### PR TITLE
Added a dev-only Labs flag switcher to Ghost Admin

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -16,6 +16,23 @@ Uses an **Ember Bridge** system for smooth migration:
 pnpm dev
 ```
 
+### Labs flag switcher
+
+Toggle Labs feature flags without leaving the screen you're on. Off by default.
+To enable it, add this to your `ghost/core/config.local.json` (gitignored) —
+nodemon picks the change up, so you only need to reload the admin:
+
+```json
+{ "labs": { "devLabsPanel": true } }
+```
+
+A pill appears bottom-right on every admin screen. `Ctrl+Shift+L` opens it,
+`Esc` closes it. Changes apply without a reload and stay in sync with
+Settings → Labs. The flag list comes from `ghost/core/core/shared/labs.js`, so
+new flags appear automatically.
+
+Development only — the code is not included in production builds.
+
 ## Testing
 
 - **Unit tests** (`pnpm test:unit`): Vitest + jsdom, colocated `*.test.ts(x)` files.

--- a/apps/admin/src/app.tsx
+++ b/apps/admin/src/app.tsx
@@ -1,8 +1,32 @@
+import { lazy, Suspense } from "react";
 import { Outlet } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { EmberProvider, EmberFallback, EmberRoot } from "./ember-bridge";
 import { AdminLayout } from "./layout/admin-layout";
 import { useEmberAuthSync, useEmberDataSync } from "./ember-bridge";
+
+/**
+ * Floating Labs flag switcher, opt in with `"labs": {"devLabsPanel": true}` in
+ * ghost/core/config.local.json.
+ *
+ * `import.meta.env.DEV` is a compile-time constant, so a production build folds
+ * this to `null` and Rollup drops the chunk — the panel is absent from dist/,
+ * not merely guarded inside it. The opt-in flag is read inside the lazy module
+ * rather than here on purpose: a hook call cannot be conditional, so reading it
+ * in this component would ship a config subscription to production and make the
+ * root re-render on config changes it otherwise ignores.
+ *
+ * The catch caps the blast radius. Nothing above App is an error boundary, so an
+ * import that fails to resolve — flags.ts throwing because labs.js moved, say —
+ * would otherwise blank the entire admin over a dev tool.
+ */
+const LabsPanel = import.meta.env.DEV
+    ? lazy(() => import("./dev-tools/labs-panel").catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error("Labs panel failed to load. The admin is unaffected.", error);
+        return { default: () => null };
+    }))
+    : null;
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -22,6 +46,7 @@ function App() {
                     <EmberRoot />
                 </>
             }
+            {LabsPanel && <Suspense fallback={null}><LabsPanel /></Suspense>}
         </EmberProvider>
     );
 }

--- a/apps/admin/src/dev-tools/labs-panel/absent-from-production-build.test.ts
+++ b/apps/admin/src/dev-tools/labs-panel/absent-from-production-build.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from 'vitest';
+import {existsSync, readFileSync, readdirSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+/**
+ * The guarantee this whole feature rests on: the Labs panel is absent from a
+ * production bundle, not merely guarded inside one. `import.meta.env.DEV` is a
+ * compile-time constant, so the ternary in app.tsx folds and Rollup drops the
+ * lazy chunk — but that is an inference about the bundler, and this asserts it.
+ *
+ * Free to run: nx.json makes admin's `test:unit` depend on `build`, so dist/ is
+ * already present (built or cache-restored) whenever this suite runs in CI. The
+ * precedent is apps/admin-toolbar, whose tests also read their build output.
+ *
+ * That dependency is what makes the result trustworthy. Run locally against a
+ * dist/ built an hour ago, this passes on stale output and says nothing about
+ * the code as it stands — build first if you are checking by hand.
+ */
+const DIST_ASSETS = join(dirname(fileURLToPath(import.meta.url)), '../../../dist/assets');
+
+/**
+ * String literals a minifier preserves, none of which appears in the admin for
+ * any other reason. The panel's flask icon would not do: it is also the real
+ * Settings nav icon, so it is present either way and would make this pass —
+ * or fail — for the wrong reason.
+ *
+ * PUBLIC_BETA_FEATURES is the most serious of the three. Its presence would mean
+ * the ?raw text of ghost/core/core/shared/labs.js had been inlined into a
+ * customer-facing bundle.
+ */
+const SENTINELS = ['ghost-labs-panel', 'PUBLIC_BETA_FEATURES', 'devLabsPanel'];
+
+describe('the dev Labs panel', () => {
+    it('leaves no trace in the production build', (context) => {
+        if (!existsSync(DIST_ASSETS)) {
+            // Skipping silently would make this a no-op in exactly the case people
+            // hit locally, so it is announced — and never skipped where it counts.
+            if (process.env.CI) {
+                throw new Error(`No build output at ${DIST_ASSETS}. This assertion cannot be skipped in CI.`);
+            }
+
+            context.skip(`no build output at ${DIST_ASSETS} — run \`pnpm build\` to check locally`);
+            return;
+        }
+
+        const scripts = readdirSync(DIST_ASSETS).filter(file => file.endsWith('.js'));
+
+        // Load-bearing, not a warm-up: with no chunks to read, the search below
+        // finds nothing and the whole assertion passes for the wrong reason.
+        expect(scripts.length).toBeGreaterThan(0);
+
+        // Every chunk, not just the entry: a regression would most likely land in
+        // a split chunk.
+        const offenders = scripts.filter((file) => {
+            const contents = readFileSync(join(DIST_ASSETS, file), 'utf8');
+
+            return SENTINELS.some(sentinel => contents.includes(sentinel));
+        });
+
+        // If this fails locally, check the shared folder before suspecting the
+        // build: vite-ember-assets.ts copies ghost/core/core/built/admin/assets
+        // into dist/assets, so a development-mode build done at any point in the
+        // past leaves a bundle there that every later build copies back in. CI
+        // builds from a clean checkout, where that folder only holds Ember output.
+        expect(offenders, 'Also check ghost/core/core/built/admin/assets for a stale development-mode bundle').toEqual([]);
+    });
+});

--- a/apps/admin/src/dev-tools/labs-panel/api.test.ts
+++ b/apps/admin/src/dev-tools/labs-panel/api.test.ts
@@ -1,0 +1,104 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {readLabs, settingsEndpoint, writeLab} from './api';
+
+function jsonResponse(body: unknown) {
+    return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve(body)
+    };
+}
+
+function settingsResponse(labs: Record<string, boolean>) {
+    return jsonResponse({
+        settings: [
+            {key: 'title', value: 'Test site'},
+            {key: 'labs', value: JSON.stringify(labs)}
+        ]
+    });
+}
+
+function stubFetch(response: unknown) {
+    const fetchMock = vi.fn(() => Promise.resolve(response));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    return fetchMock;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    window.history.pushState({}, '', '/');
+});
+
+describe('settingsEndpoint', () => {
+    it.each([
+        ['/ghost/settings', '/ghost/api/admin/settings/'],
+        ['/blog/ghost/settings', '/blog/ghost/api/admin/settings/']
+    ])('resolves %s to %s', (pathname, expected) => {
+        window.history.pushState({}, '', pathname);
+
+        expect(settingsEndpoint()).toBe(expected);
+    });
+});
+
+describe('readLabs', () => {
+    it('reads booleans out of the labs setting', async () => {
+        stubFetch(settingsResponse({tagsX: true, automations: false}));
+
+        await expect(readLabs()).resolves.toEqual({tagsX: true, automations: false});
+    });
+
+    it('throws rather than reporting an absent labs setting as no flags enabled', async () => {
+        // The write replaces the whole setting, so an empty-looking map would take
+        // every enabled flag with it on the next toggle.
+        stubFetch(jsonResponse({settings: [{key: 'title', value: 'Test site'}]}));
+
+        await expect(readLabs()).rejects.toThrow(/no labs value/);
+    });
+
+    it('throws on a response with no settings array', async () => {
+        stubFetch(jsonResponse({}));
+
+        await expect(readLabs()).rejects.toThrow(/no settings array/);
+    });
+
+    it('carries the status code so callers can tell auth from a server error', async () => {
+        stubFetch({ok: false, status: 403, statusText: 'Forbidden'});
+
+        await expect(readLabs()).rejects.toMatchObject({status: 403});
+    });
+});
+
+describe('writeLab', () => {
+    it('sends only writable flags, as a JSON string', async () => {
+        const fetchMock = stubFetch(settingsResponse({tagsX: true}));
+
+        // A read gives back the effective map: GA flags, the synthetic `members`
+        // key and config.local.json pins all ride along and must not be written.
+        await writeLab({
+            tagsX: false,
+            superEditors: true,
+            explore: true,
+            members: true,
+            devLabsPanel: true
+        }, 'tagsX', true);
+
+        const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const payload = JSON.parse(init.body as string) as {settings: {key: string; value: string}[]};
+
+        expect(payload.settings[0].key).toBe('labs');
+        expect(typeof payload.settings[0].value).toBe('string');
+        expect(JSON.parse(payload.settings[0].value)).toEqual({tagsX: true, superEditors: true});
+    });
+
+    it('returns the server map and the raw settings list', async () => {
+        stubFetch(settingsResponse({tagsX: true}));
+
+        const result = await writeLab({}, 'tagsX', true);
+
+        expect(result.labs).toEqual({tagsX: true});
+        expect(result.settings.find(setting => setting.key === 'title')).toBeTruthy();
+    });
+});

--- a/apps/admin/src/dev-tools/labs-panel/api.ts
+++ b/apps/admin/src/dev-tools/labs-panel/api.ts
@@ -1,0 +1,99 @@
+/**
+ * Admin API access for the dev Labs panel.
+ *
+ * Uses the same endpoint and payload shape as the real Labs toggle
+ * (settings/advanced/labs/feature-toggle.tsx), so there is no new API surface —
+ * writing the `labs` setting updates Ghost's settings cache immediately, which
+ * is what makes server-side labs.isSet() calls pick the change up.
+ *
+ * Reads give back the *effective* flag map, not the stored one: on both browse
+ * and edit, settings-bread-service overwrites the `labs` value with
+ * labs.getAll(), folding in GA flags, the synthetic `members` key and any
+ * config.local.json pins. That is deliberate — the switches then show what Ghost
+ * actually believes — but it is why writeLab filters before sending.
+ *
+ * Nothing here reports "no data" as "no flags enabled". A write replaces the
+ * whole setting, so an empty map that looked plausible would take every enabled
+ * flag with it on the next toggle. Every unexpected shape throws instead.
+ */
+
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {WRITABLE_FLAGS} from './flags';
+
+export type LabsSettings = Record<string, boolean>;
+
+export type SettingEntry = {key: string; value: unknown};
+
+export type WriteResult = {
+    labs: LabsSettings;
+    settings: SettingEntry[];
+};
+
+export type ApiError = Error & {status?: number};
+
+// Ghost restarting mid-request is routine in the dev stack, and an optimistic
+// switch with no in-flight indicator would sit there looking applied forever.
+const REQUEST_TIMEOUT_MS = 15000;
+
+export function settingsEndpoint(): string {
+    return `${getGhostPaths().apiRoot}/settings/`;
+}
+
+async function requestSettings(init?: RequestInit): Promise<SettingEntry[]> {
+    const response = await fetch(settingsEndpoint(), {
+        credentials: 'include',
+        headers: {'Content-Type': 'application/json'},
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        ...init
+    });
+
+    if (!response.ok) {
+        const error: ApiError = new Error(`${response.status} ${response.statusText}`);
+
+        error.status = response.status;
+        throw error;
+    }
+
+    const body = await response.json() as {settings?: SettingEntry[]};
+
+    if (!Array.isArray(body.settings)) {
+        throw new Error('Settings response had no settings array');
+    }
+
+    return body.settings;
+}
+
+function extractLabs(settings: SettingEntry[]): LabsSettings {
+    const raw = settings.find(setting => setting.key === 'labs')?.value;
+
+    if (typeof raw !== 'string') {
+        throw new Error('Settings response had no labs value');
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    return Object.fromEntries(
+        Object.entries(parsed).map(([key, value]) => [key, value === true])
+    );
+}
+
+export async function readLabs(): Promise<LabsSettings> {
+    return extractLabs(await requestSettings());
+}
+
+export async function writeLab(labs: LabsSettings, flag: string, enabled: boolean): Promise<WriteResult> {
+    // A read returns the effective map, so strip everything the allowlist would
+    // reject before echoing it back — the server filters too, but there is no
+    // reason to send GA flags and config pins it will only throw away.
+    const writable = Object.entries(labs).filter(([key]) => WRITABLE_FLAGS.has(key));
+    const next = {...Object.fromEntries(writable), [flag]: enabled};
+
+    const settings = await requestSettings({
+        method: 'PUT',
+        body: JSON.stringify({settings: [{key: 'labs', value: JSON.stringify(next)}]})
+    });
+
+    // The raw list rides along because Ember's state bridge takes the whole
+    // settings response, not just the flags.
+    return {labs: extractLabs(settings), settings};
+}

--- a/apps/admin/src/dev-tools/labs-panel/flags.test.ts
+++ b/apps/admin/src/dev-tools/labs-panel/flags.test.ts
@@ -1,0 +1,105 @@
+import {BETA_FLAGS, PRIVATE_FLAGS, WRITABLE_FLAGS, readFlagArray} from './flags';
+import {describe, expect, it} from 'vitest';
+
+/**
+ * The panel derives its flag list by parsing ghost/core/core/shared/labs.js as
+ * text, so a reformat of that file is the one change that can quietly break it.
+ * These cases are the plausible reformats — the point is that each either parses
+ * correctly or throws, and none of them silently returns a shorter list.
+ */
+const LABS_SOURCE = `
+const GA_FEATURES = [
+    'customFonts',
+    'explore'
+];
+
+const PUBLIC_BETA_FEATURES = [
+    'superEditors',
+    'editorExcerpt'
+];
+
+const PRIVATE_FEATURES = [
+    'automations',
+    'tagsX'
+];
+
+module.exports.WRITABLE_KEYS_ALLOWLIST = [...PUBLIC_BETA_FEATURES, ...PRIVATE_FEATURES];
+`;
+
+describe('readFlagArray', () => {
+    it('reads an array in the shape labs.js uses today', () => {
+        expect(readFlagArray(LABS_SOURCE, 'PUBLIC_BETA_FEATURES')).toEqual(['superEditors', 'editorExcerpt']);
+        expect(readFlagArray(LABS_SOURCE, 'PRIVATE_FEATURES')).toEqual(['automations', 'tagsX']);
+    });
+
+    it('reads double-quoted entries, so a formatter run cannot drop flags', () => {
+        const reformatted = LABS_SOURCE.replace('\'superEditors\'', '"superEditors"');
+
+        expect(readFlagArray(reformatted, 'PUBLIC_BETA_FEATURES')).toEqual(['superEditors', 'editorExcerpt']);
+    });
+
+    it('is not truncated by a bracket inside a comment', () => {
+        // The nastiest breakage: a short parse looks healthy, so the empty-list
+        // guard never fires, and the dropped flags leave the write payload.
+        const commented = LABS_SOURCE.replace('\'automations\',', '\'automations\', // [see BER-1234]');
+
+        expect(readFlagArray(commented, 'PRIVATE_FEATURES')).toEqual(['automations', 'tagsX']);
+    });
+
+    it('is not truncated by a comment containing the array terminator', () => {
+        const commented = LABS_SOURCE.replace('\'automations\',', '\'automations\', // ends with ];');
+
+        expect(readFlagArray(commented, 'PRIVATE_FEATURES')).toEqual(['automations', 'tagsX']);
+    });
+
+    it('ignores a commented-out entry rather than reading it as live', () => {
+        const commented = LABS_SOURCE.replace('    \'tagsX\'', '    // \'tagsX\'');
+
+        expect(readFlagArray(commented, 'PRIVATE_FEATURES')).toEqual(['automations']);
+    });
+
+    it('does not latch onto the spread in WRITABLE_KEYS_ALLOWLIST', () => {
+        // That line mentions both const names; matching it would yield no flags.
+        expect(readFlagArray(LABS_SOURCE, 'PRIVATE_FEATURES')).not.toHaveLength(0);
+    });
+
+    it('throws when the array is renamed away', () => {
+        expect(() => readFlagArray(LABS_SOURCE, 'RENAMED_FEATURES')).toThrow(/couldn't parse RENAMED_FEATURES/);
+    });
+
+    it('throws when a type annotation breaks the declaration shape', () => {
+        const typed = LABS_SOURCE.replace('const PRIVATE_FEATURES =', 'const PRIVATE_FEATURES: string[] =');
+
+        expect(() => readFlagArray(typed, 'PRIVATE_FEATURES')).toThrow(/couldn't parse/);
+    });
+
+    it('throws rather than returning an empty list', () => {
+        expect(() => readFlagArray('const PRIVATE_FEATURES = [];', 'PRIVATE_FEATURES')).toThrow(/couldn't parse/);
+    });
+});
+
+/**
+ * Asserted as invariants rather than as an expected list of flag names: flags
+ * graduate to GA and get deleted constantly, and a hardcoded list here would be
+ * pure churn. These catch a mis-anchored regex latching onto the wrong array.
+ */
+describe('the flags parsed from the real labs.js', () => {
+    it('finds both groups', () => {
+        expect(BETA_FLAGS.length).toBeGreaterThan(0);
+        expect(PRIVATE_FLAGS.length).toBeGreaterThan(0);
+    });
+
+    it('reads flag keys, not stray source text', () => {
+        [...BETA_FLAGS, ...PRIVATE_FLAGS].forEach((flag) => {
+            expect(flag).toMatch(/^[a-z][A-Za-z0-9]*$/);
+        });
+    });
+
+    it('keeps the two groups disjoint', () => {
+        expect(BETA_FLAGS.filter(flag => PRIVATE_FLAGS.includes(flag))).toEqual([]);
+    });
+
+    it('exposes their union as the writable set', () => {
+        expect(WRITABLE_FLAGS.size).toBe(BETA_FLAGS.length + PRIVATE_FLAGS.length);
+    });
+});

--- a/apps/admin/src/dev-tools/labs-panel/flags.ts
+++ b/apps/admin/src/dev-tools/labs-panel/flags.ts
@@ -1,0 +1,68 @@
+/**
+ * The toggleable flag list, read from Ghost's own registry instead of copied.
+ *
+ * ghost/core/core/shared/labs.js is the source of truth, but nothing exposes it
+ * to a browser: labs.getAllFlags() has no consumers, and /settings/ and /config/
+ * only report flags that have already been written — which is never the case for
+ * the flag you're about to turn on for the first time. So the panel reads the
+ * file as text through Vite's ?raw and lifts the two arrays out of it. Nothing to
+ * keep in sync here, and adding a flag to labs.js is all it takes to see it.
+ *
+ * Dev-only by construction: this module is reachable only from the DEV-guarded
+ * import in src/app.tsx, and only loaded once the opt-in flag is on, so ?raw is
+ * never resolved in a production build.
+ *
+ * GA flags are skipped deliberately — labs.getAll() forces them true and
+ * WRITABLE_KEYS_ALLOWLIST rejects them, so a switch for them would be a lie.
+ */
+
+import labsSource from '../../../../../ghost/core/core/shared/labs.js?raw';
+
+/**
+ * Pulls one flag array out of labs.js source. Exported and source-taking so the
+ * parse can be tested against reformats of labs.js without a build.
+ *
+ * Throws rather than returning [] when the parse comes up empty. An empty list
+ * is not a survivable degradation here: the panel would render "no flags",
+ * indistinguishable from a healthy install with nothing to show — and, far
+ * worse, WRITABLE_FLAGS derives from these arrays, so writeLab would strip every
+ * unparsed flag from a payload that replaces the setting wholesale. A silently
+ * half-parsed file would quietly wipe flags. Failing at import is caught by the
+ * loader in app.tsx, which logs it and renders nothing.
+ *
+ * The dangerous breakage is not an empty parse — the throw catches that — but a
+ * SHORT one, which looks healthy and takes the missing flags out of the write
+ * payload. Two realistic edits produce it, so both are handled rather than
+ * guarded: a formatter switching quote style (hence both styles match), and a
+ * comment inside the array. `[^\]]*` used to stop at the first `]`, so a single
+ * `// [see BER-1234]` truncated the list; matching lazily to the closing `];`
+ * and stripping comments first covers that and commented-out entries with it.
+ */
+export function readFlagArray(source: string, constName: string): string[] {
+    // Comments are stripped from the whole source before the array is located,
+    // not from the captured body afterwards — otherwise a comment containing the
+    // `];` terminator would still truncate the match.
+    const code = source.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    const declaration = new RegExp(`${constName}\\s*=\\s*\\[([\\s\\S]*?)\\];`).exec(code);
+    const flags = declaration ? [...declaration[1].matchAll(/['"]([^'"]+)['"]/g)].map(([, flag]) => flag) : [];
+
+    if (!flags.length) {
+        throw new Error(
+            `Labs panel: couldn't parse ${constName} out of ghost/core/core/shared/labs.js. ` +
+            'The panel derives its flag list from that file — it has probably been reformatted, ' +
+            'renamed or moved. Update readFlagArray in apps/admin/src/dev-tools/labs-panel/flags.ts.'
+        );
+    }
+
+    return flags;
+}
+
+export const BETA_FLAGS = readFlagArray(labsSource, 'PUBLIC_BETA_FEATURES');
+export const PRIVATE_FLAGS = readFlagArray(labsSource, 'PRIVATE_FEATURES');
+
+/**
+ * The same set labs.js exports as WRITABLE_KEYS_ALLOWLIST. Reads give back the
+ * *effective* flag map (GA flags, the synthetic `members` key and config.local
+ * pins folded in by settings-bread-service), none of which a write may contain.
+ */
+export const WRITABLE_FLAGS = new Set([...BETA_FLAGS, ...PRIVATE_FLAGS]);

--- a/apps/admin/src/dev-tools/labs-panel/index.tsx
+++ b/apps/admin/src/dev-tools/labs-panel/index.tsx
@@ -1,0 +1,123 @@
+/**
+ * Admin mount for the dev Labs panel — the React.lazy target used by src/app.tsx.
+ *
+ * Owns the opt-in check (`"labs": {"devLabsPanel": true}` in
+ * ghost/core/config.local.json) so that app.tsx contains nothing but a
+ * DEV-folded ternary. Reading it there would mean an unconditional hook call
+ * surviving into production.
+ *
+ * Renders nothing into the React tree: the panel is appended to document.body as
+ * a custom element so it sits above the whole admin (React screens, the Ember
+ * shell and the editor alike) without participating in any layout.
+ *
+ * Applying a flag live is the other reason this wrapper exists. Writing the
+ * setting is only half of what Settings → Labs does — the rest is patching the
+ * caches that flag-gated code reads from, and telling Ember to refetch. Without
+ * that the admin keeps rendering the old value until a reload, which is exactly
+ * the friction the panel exists to remove.
+ */
+
+import {useEffect, useRef} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
+import {configDataType, useBrowseConfig, type ConfigResponseType} from '@tryghost/admin-x-framework/api/config';
+import type {LabsPanelHandle} from './panel';
+import type {LabsSettings, SettingEntry} from './api';
+
+// admin-x-framework keeps its settings dataType private, but the query key is
+// [dataType, ...] and Settings → Labs reads `labs` from that cache. Leaving it
+// stale lets a later save there revert a flag toggled here.
+const SETTINGS_QUERY_KEY = 'SettingsResponseType';
+
+export default function LabsPanel() {
+    const client = useQueryClient();
+    const {data: config} = useBrowseConfig();
+    const enabled = config?.config.labs?.devLabsPanel === true;
+    const labs = config?.config.labs;
+    const panel = useRef<LabsPanelHandle | null>(null);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        let handle: LabsPanelHandle | null = null;
+        let cancelled = false;
+
+        /**
+         * Imported here rather than at module scope so a developer who hasn't
+         * opted in never loads the panel — nor the labs.js text that flags.ts
+         * parses, which throws by design and would otherwise put an error in the
+         * console of people who have never heard of this tool. Every remaining
+         * import in this module is type-only, so nothing else comes with it.
+         */
+        void import('./panel').then((module) => {
+            if (cancelled) {
+                return;
+            }
+
+            handle = module.mountLabsPanel({
+                onApplied: (written: LabsSettings, settings: SettingEntry[]) => {
+                    let patched = false;
+
+                    client.setQueriesData({queryKey: [configDataType]}, (current) => {
+                        const currentConfig = (current as ConfigResponseType | undefined)?.config;
+
+                        if (!currentConfig) {
+                            return current;
+                        }
+
+                        patched = true;
+                        return {config: {...currentConfig, labs: written}};
+                    });
+
+                    client.setQueriesData({queryKey: [SETTINGS_QUERY_KEY]}, current => (current ? {...current, settings} : current));
+
+                    // Throwing rather than no-oping: the caller turns this into a
+                    // "saved, but the page didn't refresh" notice with a Reload
+                    // button. Failing quietly would leave a developer staring at a
+                    // flag that reads as applied and behaves as though it isn't.
+                    if (!patched) {
+                        throw new Error('Config cache was missing or had an unexpected shape');
+                    }
+
+                    // Ember owns feature state for its own screens, so patching
+                    // the React caches alone would leave the two disagreeing.
+                    // onUpdate — not onInvalidate — because settings are mapped as
+                    // a singleton in state-bridge.js, which refuses invalidation;
+                    // onUpdate pushes the response and refetches the feature flags.
+                    //
+                    // Known limit: that refetch is a floating promise inside Ember
+                    // (state-bridge.js), so a failure there can't reach us.
+                    if (!window.EmberBridge?.state) {
+                        throw new Error('Ember bridge not ready, so Ember screens still hold the old value');
+                    }
+
+                    window.EmberBridge.state.onUpdate(SETTINGS_QUERY_KEY, {settings});
+                }
+            });
+
+            panel.current = handle;
+        }).catch((error) => {
+            // Only reachable for someone who opted in, which is the point.
+            // eslint-disable-next-line no-console
+            console.error('Labs panel failed to load.', error);
+        });
+
+        return () => {
+            cancelled = true;
+            panel.current = null;
+            handle?.unmount();
+        };
+    }, [client, enabled]);
+
+    // Closes the loop the other way. Settings → Labs patches this same config
+    // cache on every toggle (feature-toggle.tsx), so an open panel adopts the
+    // change instead of sitting on the snapshot it read when it was opened.
+    useEffect(() => {
+        if (labs) {
+            panel.current?.sync(labs);
+        }
+    }, [labs]);
+
+    return null;
+}

--- a/apps/admin/src/dev-tools/labs-panel/panel.ts
+++ b/apps/admin/src/dev-tools/labs-panel/panel.ts
@@ -1,0 +1,807 @@
+/**
+ * <ghost-labs-panel> — a floating Labs flag switcher for development.
+ *
+ * A framework-free custom element in a shadow root. It floats above the whole
+ * admin — React screens, the Ember shell and the editor alike — and the shadow
+ * root is what keeps that cheap: its styles cannot reach Ember's unlayered CSS
+ * or Shade's utilities, and neither can reach in. Building it from Shade
+ * components would mean a dev tool competing with the app it overlays for
+ * cascade and stacking, so the switch below is written by hand to match.
+ *
+ * Rows show the flag key alone. It is what you grep for and what the API takes,
+ * and it keeps every row one line high.
+ *
+ * Never registered outside development — see the import.meta.env.DEV guard at
+ * the mount site in src/app.tsx.
+ */
+
+import {BETA_FLAGS, PRIVATE_FLAGS, WRITABLE_FLAGS} from './flags';
+import {readLabs, writeLab, type ApiError, type LabsSettings, type SettingEntry} from './api';
+
+type ApplyHandler = (labs: LabsSettings, settings: SettingEntry[]) => void;
+
+const ELEMENT_NAME = 'ghost-labs-panel';
+const STORAGE_KEY = 'ghost-labs-panel';
+
+type PersistedState = {
+    open: boolean;
+    pinned: string[];
+};
+
+function readPersistedState(): PersistedState {
+    try {
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') as Partial<PersistedState>;
+
+        return {
+            open: stored.open === true,
+            pinned: Array.isArray(stored.pinned) ? stored.pinned.filter(flag => typeof flag === 'string') : []
+        };
+    } catch {
+        return {open: false, pinned: []};
+    }
+}
+
+/** Covers single quotes too, so a future single-quoted attribute can't open a hole. */
+function escapeHtml(value: string): string {
+    return value.replace(/[&<>"']/g, character => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        '\'': '&#39;'
+    }[character] as string));
+}
+
+// lucide flask-conical — the icon Settings → Labs uses in its nav.
+const FLASK_ICON = `
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" />
+        <path d="M6.453 15h11.094" />
+        <path d="M8.5 2h7" />
+    </svg>
+`;
+
+// lucide pin
+const PIN_ICON = `
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 17v5" />
+        <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+    </svg>
+`;
+
+// lucide search
+const SEARCH_ICON = `
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="m21 21-4.34-4.34" />
+        <circle cx="11" cy="11" r="8" />
+    </svg>
+`;
+
+const EASE = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+/**
+ * Events stopped at the host so nothing outside sees them.
+ *
+ * The panel is appended to document.body, so to any open dialog it is "outside" —
+ * Radix's dismissable layer listens for pointerdown on the document and closes
+ * the modal, and its focus scope would fight the search box for focus. Both of
+ * those are bubble-phase document listeners, so stopping at the host reaches
+ * them. Our own handlers are bound inside the shadow root and run before the
+ * event gets here, so containing it costs us nothing.
+ *
+ * Keys are deliberately absent: Radix binds Escape with {capture: true}, and
+ * capture runs document → host, so a bubble-phase stop here could never beat it.
+ * keydown is contained in #onKeydown instead — see the note there. keyup is not
+ * contained at all, which is fine only because nothing in the admin or Ember
+ * listens for it at document level; that is worth rechecking if this ever grows
+ * a keyup-driven behaviour.
+ */
+const CONTAINED_EVENTS = [
+    'pointerdown', 'pointerup', 'mousedown', 'mouseup', 'click', 'dblclick',
+    'touchstart', 'touchend', 'focusin', 'focusout'
+];
+
+const STYLES = `
+    :host {
+        all: initial;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        position: fixed;
+        right: 24px;
+        bottom: 24px;
+        z-index: 2147483000;
+        font-family: ui-sans-serif, -apple-system, "Segoe UI", sans-serif;
+        font-size: 12px;
+        line-height: 1.4;
+        color-scheme: light;
+
+        /* Shade's PALETTE tokens, not its semantic ones. Custom properties
+           inherit through the shadow boundary, so --color-* resolves in here.
+           The semantic tokens (--primary, --input) flip under .dark while this
+           panel stays light in both themes, so adopting those would turn the
+           "on" switch light grey against a white row. Palette tokens are
+           constants, which is what makes them safe here. */
+        --surface: var(--color-white);
+        --track: var(--color-gray-100);
+        --border: rgb(0 0 0 / 8%);
+        --divider: rgb(0 0 0 / 6%);
+        --text: var(--color-black);
+        --text-muted: #7f8b96;
+        --switch-off: var(--color-gray-200);
+        --switch-on: var(--color-black);
+        --chip-bg: #fdf2f5;
+        --chip-border: rgb(199 37 78 / 13%);
+        --chip-text: #c7254e;
+        --pill-bg: var(--color-black);
+        --pill-text: var(--color-white);
+        --shadow: 0 8px 28px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 6%);
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    }
+    * { box-sizing: border-box; }
+    button { font: inherit; cursor: pointer; }
+
+    #bubble {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 9px 15px 9px 13px;
+        border: 0;
+        border-radius: 999px;
+        background: var(--pill-bg);
+        color: var(--pill-text);
+        font-size: 13px;
+        font-weight: 500;
+        line-height: 1;
+        box-shadow: var(--shadow);
+        transition: background-color 0.15s ${EASE};
+    }
+    /* Mixed from the pill's own colour rather than a second hardcoded value, so
+       it stays a lightening of whatever --pill-bg is. */
+    #bubble:hover { background: color-mix(in oklab, var(--pill-bg), #fff 12%); }
+    /* display:block keeps the icon off the text baseline, which is what makes an
+       inline SVG sit a pixel or two low next to its label. */
+    #bubble svg { display: block; flex: none; width: 15px; height: 15px; color: rgb(255 255 255 / 65%); }
+
+    #panel {
+        display: flex;
+        flex-direction: column;
+        width: 322px;
+        max-height: min(540px, calc(100vh - 72px));
+        margin-bottom: 8px;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: var(--surface);
+        color: var(--text);
+        box-shadow: var(--shadow);
+        overflow: hidden;
+    }
+    #panel[hidden] { display: none; }
+
+    header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 14px 11px;
+    }
+    header .label {
+        color: var(--text-muted);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+    #close {
+        display: flex;
+        margin-left: auto;
+        padding: 4px;
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: var(--text-muted);
+        line-height: 0;
+    }
+    #close:hover { background: var(--track); color: var(--text); }
+    #close svg { display: block; width: 13px; height: 13px; }
+
+    #search-field {
+        position: relative;
+        display: flex;
+        align-items: center;
+        margin: 0 14px 2px;
+    }
+    #search-field > svg {
+        position: absolute;
+        left: 13px;
+        width: 14px;
+        height: 14px;
+        color: var(--text-muted);
+        pointer-events: none;
+    }
+    #search {
+        flex: 1;
+        min-width: 0;
+        padding: 8px 14px 8px 34px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: transparent;
+        color: var(--text);
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 400;
+    }
+    #search::placeholder { color: var(--text-muted); }
+    #search::-webkit-search-cancel-button { display: none; }
+    #search:focus-visible { outline: 2px solid var(--track); outline-offset: 0; }
+
+    #list { flex: 1; overflow-y: auto; padding: 6px 0; }
+    .group {
+        padding: 8px 14px 4px;
+        color: var(--text-muted);
+        font-size: 9px;
+        font-weight: 600;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+    }
+    .group + .row { border-top: 0; }
+    /* Not a <label>: clicking a row shouldn't flip a flag by accident. Only the
+       switch toggles, and only the pin button pins. */
+    .row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 9px 14px;
+    }
+    .row + .row { border-top: 1px solid var(--divider); }
+    .row:hover { background: var(--track); }
+    /* Inline-code chip: the key is a literal you paste into labs.js or a URL, so
+       it reads as code rather than as a label. Hugs its content, with the auto
+       margin pushing the pin and switch to the right edge. */
+    .row code {
+        order: 1;
+        flex: 0 1 auto;
+        min-width: 0;
+        margin-right: auto;
+        padding: 2px 6px;
+        border: 1px solid var(--chip-border);
+        border-radius: 5px;
+        background: var(--chip-bg);
+        color: var(--chip-text);
+        font-family: var(--mono);
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        opacity: 0.65;
+        transition: opacity 0.18s ${EASE};
+    }
+    .row input:checked ~ code { opacity: 1; }
+    .empty { padding: 20px 14px; color: var(--text-muted); text-align: center; }
+
+    .pin {
+        order: 2;
+        display: flex;
+        flex: none;
+        padding: 3px;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--text-muted);
+        line-height: 0;
+        opacity: 0;
+        transition: opacity 0.15s ${EASE}, color 0.15s ${EASE};
+    }
+    .pin svg { display: block; width: 13px; height: 13px; }
+    .row:hover .pin, .pin:focus-visible { opacity: 1; }
+    .pin[aria-pressed="true"] { opacity: 1; color: var(--text); }
+    .pin:hover { background: var(--divider); color: var(--text); }
+
+    /* Matches Shade's Switch, so the panel's rows read the same as Settings →
+       Labs: 28x16 track, 12px thumb, 12px travel, primary (near-black) when on. */
+    .row input {
+        order: 3;
+        appearance: none;
+        position: relative;
+        flex: none;
+        width: 28px;
+        height: 16px;
+        margin: 0;
+        border-radius: 999px;
+        background: var(--switch-off);
+        cursor: pointer;
+        transition: background-color 0.18s ${EASE};
+    }
+    .row input::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: #fff;
+        filter: drop-shadow(0 1px 2px rgb(0 0 0 / 7%));
+        transition: transform 0.18s ${EASE};
+    }
+    .row input:checked { background: var(--switch-on); }
+    .row input:checked::after { transform: translateX(12px); }
+    .row input:focus-visible { outline: 2px solid var(--text-muted); outline-offset: 2px; }
+    @media (prefers-reduced-motion: reduce) {
+        .row input, .row input::after, .row code { transition: none; }
+    }
+
+    /* Collapsed by default and slid down; adding .is-visible animates it up into
+       place. Height, padding and border all animate so the list above gives up
+       the space smoothly instead of jumping. */
+    #notice {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        max-height: 0;
+        padding: 0 16px;
+        border-top: 1px solid transparent;
+        color: var(--text-muted);
+        font-size: 11px;
+        opacity: 0;
+        overflow: hidden;
+        transform: translateY(6px);
+        pointer-events: none;
+        transition: max-height 0.22s ${EASE}, padding 0.22s ${EASE},
+                    border-top-color 0.22s ${EASE}, opacity 0.18s ${EASE},
+                    transform 0.22s ${EASE};
+    }
+    #notice.is-visible {
+        max-height: 72px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        border-top-color: var(--divider);
+        opacity: 1;
+        transform: none;
+        pointer-events: auto;
+    }
+    /* One line, always. A wrapping message shifts the button under the pointer. */
+    #notice span {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    #notice strong { color: var(--text); font-weight: 600; }
+    #notice.error { color: #d64242; }
+    #reload {
+        flex: none;
+        padding: 7px 14px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--surface);
+        color: var(--text);
+        font-size: 11px;
+        font-weight: 600;
+        line-height: 1;
+        white-space: nowrap;
+        transition: background-color 0.15s ${EASE}, border-color 0.15s ${EASE};
+    }
+    #reload:hover { background: var(--track); border-color: rgb(0 0 0 / 16%); }
+    #reload[hidden] { display: none; }
+    @media (prefers-reduced-motion: reduce) {
+        #notice { transition: none; }
+    }
+`;
+
+const TEMPLATE = `
+    <style>${STYLES}</style>
+    <section id="panel" hidden>
+        <header>
+            <span class="label">Labs</span>
+            <button id="close" type="button" aria-label="Close">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" aria-hidden="true">
+                    <path d="M18 6 6 18M6 6l12 12" />
+                </svg>
+            </button>
+        </header>
+        <div id="search-field">
+            ${SEARCH_ICON}
+            <input id="search" type="search" placeholder="Search flags…" autocomplete="off" />
+        </div>
+        <div id="list"></div>
+        <div id="notice" role="status" aria-live="polite">
+            <span id="notice-text"></span>
+            <button id="reload" type="button" hidden>Reload</button>
+        </div>
+    </section>
+    <button id="bubble" type="button" aria-label="Labs flags" aria-expanded="false" aria-controls="panel">
+        ${FLASK_ICON}<span>Labs</span>
+    </button>
+`;
+
+class GhostLabsPanel extends HTMLElement {
+    #root: ShadowRoot;
+    #state: PersistedState;
+    #labs: LabsSettings = {};
+    #query = '';
+    #error: string | null = null;
+    // Sticky: the write landed but the page couldn't be refreshed, so this page is
+    // stale until reloaded. Kept separate from #error because the remedy differs —
+    // a reload fixes this one, and must not be cleared by the next toggle.
+    #applyFailed = false;
+    #hasData = false;
+    // Serialises writes. The payload is the whole flag map, not a delta, so two
+    // overlapping writes would each build from a base the other has already moved
+    // on from and the later one would silently undo the earlier.
+    #writes: Promise<unknown> = Promise.resolve();
+    #inFlight = 0;
+    #listeners: AbortController | null = null;
+    // Applies a flag to the running admin — patching the caches flag-gated code
+    // reads from, and telling Ember. Supplied by the mount; without it a toggle
+    // would only take effect on the next reload.
+    #onApplied: ApplyHandler | null = null;
+    // Signature of the rows currently in the DOM. Rebuilding the list on every
+    // render would replace the checkbox mid-transition and kill the switch
+    // animation, so an unchanged signature updates the existing inputs in place.
+    #renderedSignature = '';
+
+    constructor() {
+        super();
+        this.#state = readPersistedState();
+        this.#root = this.attachShadow({mode: 'open'});
+        this.#root.innerHTML = TEMPLATE;
+    }
+
+    set onApplied(handler: ApplyHandler | null) {
+        this.#onApplied = handler;
+    }
+
+    /**
+     * Adopt flag state changed elsewhere — Settings → Labs, in practice.
+     *
+     * The panel holds its own snapshot and, being framework-free, subscribes to
+     * no query — so without this it only ever learns about outside changes when
+     * reopened. The wrapper watches the config cache and pushes here.
+     *
+     * Ignored while a write is in flight: the caches still hold the pre-write
+     * value then, and adopting it would flip the switch back under the pointer.
+     *
+     * A Settings toggle landing inside that window is therefore dropped, and the
+     * in-flight whole-map PUT — built without it — reverts it server-side. That
+     * is inherent to two writers sharing one setting, needs a sub-second overlap
+     * by one person in two places, and heals on the panel's next read.
+     */
+    syncLabs(labs: LabsSettings) {
+        if (this.#inFlight > 0 || !this.#hasData) {
+            return;
+        }
+
+        this.#labs = {...labs};
+        this.#render();
+    }
+
+    connectedCallback() {
+        // One controller for every listener, so disconnecting can't leave any
+        // behind and re-connecting can't double them up.
+        this.#listeners = new AbortController();
+        const {signal} = this.#listeners;
+
+        CONTAINED_EVENTS.forEach((type) => {
+            this.addEventListener(type, (event: Event) => event.stopPropagation(), {signal});
+        });
+
+        this.#element('#bubble').addEventListener('click', () => this.#setOpen(!this.#state.open), {signal});
+        this.#element('#close').addEventListener('click', () => this.#setOpen(false), {signal});
+        this.#element('#reload').addEventListener('click', () => window.location.reload(), {signal});
+
+        this.#element<HTMLInputElement>('#search').addEventListener('input', (event) => {
+            this.#query = (event.target as HTMLInputElement).value.trim().toLowerCase();
+            this.#renderList();
+        }, {signal});
+
+        this.#element('#list').addEventListener('change', (event) => {
+            const input = event.target as HTMLInputElement;
+
+            if (input.dataset.flag) {
+                this.#toggle(input.dataset.flag, input.checked);
+            }
+        }, {signal});
+
+        this.#element('#list').addEventListener('click', (event) => {
+            const pin = (event.target as HTMLElement).closest<HTMLElement>('[data-pin]');
+
+            if (pin?.dataset.pin) {
+                this.#togglePin(pin.dataset.pin);
+            }
+        }, {signal});
+
+        // Capture, not bubble: Radix's Escape handling is a capture-phase document
+        // listener, so this is the only phase from which a key originating in the
+        // panel can be kept away from it.
+        //
+        // Registration order is NOT relied on. It would put us ahead of any dialog
+        // opened after the panel mounts, but the panel now mounts asynchronously
+        // (its module is imported only once the opt-in flag reads true), so a
+        // dialog already open at that point registers first and would win. See
+        // #onKeydown for what makes the ordering irrelevant.
+        document.addEventListener('keydown', this.#onKeydown, {signal, capture: true});
+
+        this.#render();
+
+        // Only when it starts open. Closed, there is nothing on screen that could
+        // be wrong, and opening reads anyway.
+        if (this.#state.open) {
+            void this.#load();
+        }
+    }
+
+    disconnectedCallback() {
+        this.#listeners?.abort();
+        this.#listeners = null;
+    }
+
+    #onKeydown = (event: KeyboardEvent) => {
+        // Keys typed inside the panel belong to the panel. Stopping them here
+        // keeps the app's global shortcuts from firing while you type in the
+        // search box. Only propagation is stopped, so the field still gets text.
+        if (event.composedPath().includes(this)) {
+            event.stopImmediatePropagation();
+
+            // Escape additionally gets defaultPrevented, because stopping
+            // propagation only beats listeners registered after ours. Radix's
+            // DismissableLayer dismisses solely `if (!event.defaultPrevented)`,
+            // so this contains Escape whatever the registration order — which
+            // matters now that the panel mounts asynchronously and a dialog can
+            // already be open by then. Costs the search field's native
+            // Escape-clears-text, which is moot when Escape closes the panel.
+            if (event.key === 'Escape') {
+                event.preventDefault();
+            }
+        }
+
+        // Ctrl, never Cmd: ⌘L is the browser's address bar, and ⌘⇧L sits close
+        // enough to it to be worth avoiding. Ctrl+Shift+L is unclaimed on macOS.
+        if (event.key.toLowerCase() === 'l' && event.shiftKey && event.ctrlKey && !event.metaKey) {
+            event.preventDefault();
+            this.#setOpen(!this.#state.open);
+            return;
+        }
+
+        // Escape pressed elsewhere still reaches whatever else is listening: the
+        // panel is not a modal and has no claim on a key it didn't receive.
+        if (event.key === 'Escape' && this.#state.open) {
+            this.#setOpen(false);
+        }
+    };
+
+    #element<T extends HTMLElement = HTMLElement>(selector: string): T {
+        return this.#root.querySelector<T>(selector)!;
+    }
+
+    #persist() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.#state));
+        } catch {
+            // A dev tool losing its open/closed state is not worth a thrown error.
+        }
+    }
+
+    #setOpen(open: boolean) {
+        this.#state.open = open;
+        this.#persist();
+        this.#render();
+
+        if (open) {
+            this.#element('#search').focus();
+            // Refresh on open so a toggle made in Settings → Labs is reflected.
+            // Existing rows stay on screen meanwhile, so nothing flashes.
+            void this.#load();
+        } else {
+            // Send focus back where it came from rather than dropping it on body.
+            this.#element('#bubble').focus();
+        }
+    }
+
+    #togglePin(flag: string) {
+        const pinned = this.#state.pinned;
+
+        this.#state.pinned = pinned.includes(flag) ? pinned.filter(item => item !== flag) : [...pinned, flag];
+        this.#persist();
+        this.#renderList();
+    }
+
+    /**
+     * Queued behind any in-flight write, not just fired off. A read that starts
+     * before a write but resolves after it would otherwise install pre-write
+     * state, and the next toggle would persist that stale map — undoing the
+     * write it followed.
+     */
+    #load(): Promise<unknown> {
+        this.#writes = this.#writes.then(() => this.#fetchLabs());
+
+        return this.#writes;
+    }
+
+    async #fetchLabs() {
+        try {
+            this.#labs = await readLabs();
+            this.#hasData = true;
+            this.#error = null;
+        } catch (error) {
+            const status = (error as ApiError).status;
+            // Only guess at auth when the status actually says so — reading a 500
+            // or a timeout as "are you signed in?" sends you hunting in the wrong
+            // place.
+            const hint = status === 401 || status === 403 ? ' — signed in as staff?' : '';
+
+            this.#error = `Couldn't read flags${hint} (${(error as Error).message})`;
+        }
+
+        this.#render();
+    }
+
+    #toggle(flag: string, enabled: boolean) {
+        // Optimistic, so the switch feels instant. The write is queued behind any
+        // in-flight one and builds its payload from #labs at the time it runs, not
+        // from a snapshot taken now — with a whole-map payload, a stale base
+        // silently reverts whatever landed in between.
+        this.#labs = {...this.#labs, [flag]: enabled};
+        this.#error = null;
+        this.#inFlight += 1;
+        this.#render();
+
+        this.#writes = this.#writes.then(() => this.#commit(flag, enabled)).finally(() => {
+            this.#inFlight -= 1;
+        });
+    }
+
+    async #commit(flag: string, enabled: boolean) {
+        let written;
+
+        try {
+            written = await writeLab(this.#labs, flag, enabled);
+            this.#labs = written.labs;
+        } catch (error) {
+            // Revert just this flag rather than restoring a whole snapshot, which
+            // would take any concurrent change down with it.
+            this.#labs = {...this.#labs, [flag]: !enabled};
+            this.#error = `${flag} failed: ${(error as Error).message}`;
+            this.#render();
+            return;
+        }
+
+        // Applying to the live page is a separate concern from the write, and is
+        // reported as such: the flag is saved either way, so a host that can't
+        // refresh itself must not read as a failed toggle or roll the switch back.
+        try {
+            this.#onApplied?.(written.labs, written.settings);
+            this.#applyFailed = false;
+        } catch (error) {
+            this.#applyFailed = true;
+            this.#error = `${flag} saved, but this page didn't update: ${(error as Error).message}`;
+        }
+
+        this.#render();
+    }
+
+    /**
+     * One list, section headers instead of tabs — with a search box over 23 flags
+     * there is nothing for tabs to do, and searching covers every flag at once.
+     * Pinned floats to the top from either group: the point of pinning is not
+     * having to go looking for the flag you're working on.
+     */
+    #groups(): {label: string; flags: string[]}[] {
+        const matches = (flag: string) => flag.toLowerCase().includes(this.#query);
+        const available = (flags: string[]) => flags.filter(flag => matches(flag) && !this.#state.pinned.includes(flag));
+        // Pins outlive the flags they point at. One for a flag since deleted or
+        // graduated to GA would render a row the server refuses to write, so the
+        // switch would snap back with nothing said — drop it instead.
+        const pinned = this.#state.pinned.filter(flag => matches(flag) && WRITABLE_FLAGS.has(flag));
+
+        return [
+            {label: 'Pinned', flags: pinned},
+            {label: 'Beta', flags: available(BETA_FLAGS)},
+            {label: 'Private', flags: available(PRIVATE_FLAGS)}
+        ].filter(group => group.flags.length > 0);
+    }
+
+    #renderList() {
+        const list = this.#element('#list');
+
+        if (!this.#hasData) {
+            const message = this.#error ? 'Couldn’t read flags' : 'Loading…';
+
+            this.#renderedSignature = `message:${message}`;
+            list.innerHTML = `<p class="empty">${message}</p>`;
+            return;
+        }
+
+        const groups = this.#groups();
+
+        if (!groups.length) {
+            this.#renderedSignature = `empty:${this.#query}`;
+            list.innerHTML = `<p class="empty">No flag matches “${escapeHtml(this.#query)}”</p>`;
+            return;
+        }
+
+        const signature = groups.map(group => `${group.label}:${group.flags.join(',')}`).join('|');
+
+        if (signature === this.#renderedSignature) {
+            // Same rows, so keep the elements and let CSS animate the change.
+            list.querySelectorAll<HTMLInputElement>('input[data-flag]').forEach((input) => {
+                input.checked = this.#labs[input.dataset.flag!] === true;
+            });
+            return;
+        }
+
+        this.#renderedSignature = signature;
+        list.innerHTML = groups.map(group => `
+            ${group.label ? `<p class="group">${escapeHtml(group.label)}</p>` : ''}
+            ${group.flags.map((flag) => {
+                const isPinned = this.#state.pinned.includes(flag);
+
+                return `
+                    <div class="row">
+                        <input type="checkbox" role="switch" data-flag="${escapeHtml(flag)}"
+                               aria-label="${escapeHtml(flag)}" ${this.#labs[flag] ? 'checked' : ''} />
+                        <code>${escapeHtml(flag)}</code>
+                        <button class="pin" type="button" data-pin="${escapeHtml(flag)}"
+                                aria-pressed="${isPinned}" aria-label="${isPinned ? 'Unpin' : 'Pin'} ${escapeHtml(flag)}">
+                            ${PIN_ICON}
+                        </button>
+                    </div>
+                `;
+            }).join('')}
+        `).join('');
+    }
+
+    #render() {
+        const panel = this.#element('#panel');
+        const bubble = this.#element('#bubble');
+
+        panel.hidden = !this.#state.open;
+        bubble.setAttribute('aria-expanded', String(this.#state.open));
+
+        const notice = this.#element('#notice');
+        const noticeText = this.#element('#notice-text');
+
+        // The bar only ever speaks up about a problem: a toggle that applies
+        // cleanly needs no commentary, because the change is already on screen.
+        notice.classList.toggle('is-visible', this.#error !== null);
+        notice.classList.toggle('error', this.#error !== null);
+        noticeText.textContent = this.#error ?? '';
+        // The bar truncates, so keep the full text reachable on hover.
+        noticeText.title = this.#error ?? '';
+        // A reload is the remedy for a page left stale by a failed apply, and for
+        // nothing else — a failed write changed nothing to reload for.
+        this.#element('#reload').hidden = !this.#applyFailed;
+
+        this.#renderList();
+    }
+}
+
+export function defineLabsPanel() {
+    if (!customElements.get(ELEMENT_NAME)) {
+        customElements.define(ELEMENT_NAME, GhostLabsPanel);
+    }
+}
+
+export type LabsPanelHandle = {
+    /** Adopt flag state changed outside the panel. */
+    sync: (labs: LabsSettings) => void;
+    unmount: () => void;
+};
+
+export function mountLabsPanel(options: {onApplied?: ApplyHandler} = {}): LabsPanelHandle {
+    defineLabsPanel();
+
+    const element = document.createElement(ELEMENT_NAME) as GhostLabsPanel;
+
+    element.onApplied = options.onApplied ?? null;
+    document.body.appendChild(element);
+
+    return {
+        sync: labs => element.syncLabs(labs),
+        unmount: () => element.remove()
+    };
+}


### PR DESCRIPTION
## Describe the problem you are solving

Toggling a Labs flag means leaving whatever screen you're on, going to Settings, opening Labs, picking the Beta or Private tab, and finding the flag among 23 others. That's four or five clicks before you reach the switch, and the same again to get back to what you were doing. The alternative is parking a second tab there and alt-tabbing for every toggle, with the two tabs disagreeing about flag state until you reload one. Either way, you do this constantly while developing behind a flag, and twice over when comparing flag-on against flag-off.

This PR adds a floating panel available on every admin screen listing every toggleable Labs flag in one searchable list, with Beta and Private as sections rather than tabs. The flags you're working on can be pinned to the top of the list, so they're always the first thing you see. Toggling applies to the running page exactly as it does from Settings → Labs; what changes is not having to go there every single time.

It is **development-only and opt-in**, and the code is not included in production builds.

<img width="368" height="615" alt="Screenshot 2026-08-12 at 21 59 53" src="https://github.com/user-attachments/assets/e8c5a1ae-b484-4634-ba8f-8dbf01cc981e" />

## Changelog for devs

* Added a floating Labs flag switcher to Ghost Admin, available on every admin screen in development
* Added an opt-in config flag: set `"labs": {"devLabsPanel": true}` in `ghost/core/config.local.json` (gitignored, so it is off for everyone by default)
* Added flag pinning, persisted in `localStorage`, so the flags you're working on stay at the top of the list
* Added two-way sync with Settings → Labs: toggling in either place updates the other without a reload
* Added tests covering the flag-list parser, the write payload contract, and the absence of the feature from production builds

## Changelog for customers

* None. This is development tooling and is not present in a production build.

## Notes

**How to use it** (also in `apps/admin/README.md`)

1. Add to `ghost/core/config.local.json`:
   ```json
   { "labs": { "devLabsPanel": true } }
   ```
2.  Save and reload the admin (nodemon restarts Ghost for you). The pill appears bottom-right; `Ctrl+Shift+L` toggles it.

**Production absence**

`app.tsx` gates the mount on `import.meta.env.DEV`, a compile-time constant, so the branch folds and the chunk is never emitted. `absent-from-production-build.test.ts` asserts no chunk in `dist/assets` contains the panel. With the flag off, nothing loads at all — the `import()` sits behind the opt-in check.

**Why the flag list is parsed, not copied**

`flags.ts` reads `labs.js` as text via `?raw`. Nothing exposes those arrays to a browser, and `/settings/` and `/config/` only report flags already written — never the one you're about to enable. It throws rather than returning a short list, because writes replace the whole `labs` setting and a partial list would drop flags.

**What the tests cover**

The flag-list parser, the write payload contract, and production absence. Search, pinning, persistence and styling are deliberately untested — a break there is visible immediately to the only people who see it.

**Why a custom element, not Shade**

The panel overlays Ember screens and Radix portals. The shadow root gives event containment (clicking it must not dismiss an open modal), isolation from Ember's unlayered CSS, and its own stacking context. In Shade it would be a dev tool competing with the app it overlays. Cost is ~370 lines of CSS and hand-matching Shade's Switch spec.

## Technical debt

* None.

## PR Scope (mark all that apply)

- [ ] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [ ] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

_(None apply — this is development tooling with no user-facing surface.)_

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [ ] The PR is not extensive
- [x] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


