### PR TITLE
Removed unused `totalEvents` value from `EventProcessingResult`

### DIFF
--- a/ghost/core/core/server/services/email-analytics/event-processing-result.ts
+++ b/ghost/core/core/server/services/email-analytics/event-processing-result.ts
@@ -1,4 +1,4 @@
-type EventProcessingResultInput = Partial<Omit<EventProcessingResult, 'totalEvents' | 'merge'>>;
+type EventProcessingResultInput = Partial<Omit<EventProcessingResult, 'merge'>>;
 
 export class EventProcessingResult {
     // counts
@@ -34,17 +34,6 @@ export class EventProcessingResult {
         this.processingFailures = 0;
         this.emailIds = [];
         this.memberIds = [];
-    }
-
-    get totalEvents(): number {
-        return this.delivered
-            + this.opened
-            + this.temporaryFailed
-            + this.permanentFailed
-            + this.unsubscribed
-            + this.complained
-            + this.unhandled
-            + this.unprocessable;
     }
 
     merge(other: EventProcessingResultInput = {}): void {

--- a/ghost/core/test/unit/server/services/email-analytics/event-processing-result.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/event-processing-result.test.js
@@ -51,24 +51,6 @@ describe('EventProcessingResult', function () {
         assert.deepEqual(result.memberIds, [4,5]);
     });
 
-    it('has correct totalEvents value', function () {
-        const result = new EventProcessingResult({
-            delivered: 1,
-            opened: 2,
-            temporaryFailed: 3,
-            permanentFailed: 4,
-            unsubscribed: 5,
-            complained: 6,
-            unhandled: 7,
-            unprocessable: 8,
-            processingFailures: 9, // not counted
-            emailIds: [1,2,3],
-            memberIds: [4,5]
-        });
-
-        assert.equal(result.totalEvents, 36);
-    });
-
     it('resets all values', function () {
         const result = new EventProcessingResult({
             delivered: 1,


### PR DESCRIPTION
no ref

We never use this.
