### PR TITLE
Disabled compile caching by default

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -114,13 +114,6 @@ ENV GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}
 USER ghost
 ENV LD_PRELOAD=libjemalloc.so.2
 
-# Boot once to warm Node's V8 compile cache — 15-20% off every container start.
-# Must run here, as the runtime user: Node namespaces the cache directory by uid
-# (and writes entries 0600), so a cache warmed by root in an earlier stage is one
-# the runtime never looks at. Images built on top can re-run the script to cache
-# their own code, as long as they do it as the same user.
-RUN bin/warm-compile-cache.sh
-
 EXPOSE 2368
 
 CMD ["node", "index.js"]

--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -9,16 +9,11 @@
 //   e.g. bin/validate-adapters.js cache:Redis sso:ProSSO storage:S3Storage
 //
 // Adapters are named explicitly rather than read from config, which may not be
-// present at build time. Run this as the user the image runs as: the modules it
-// loads land in the V8 compile cache, which is namespaced by uid.
+// present at build time
 
-import {enableCompileCache} from 'node:module';
 import {adapterPaths} from '../core/server/services/adapter-manager/adapter-paths';
 import {baseClasses} from '../core/server/services/adapter-manager/base-classes';
 import {loadAdapterClass} from '../core/server/services/adapter-manager/utils';
-
-// No-op when NODE_COMPILE_CACHE is already set, as it is in Ghost's image.
-enableCompileCache();
 
 type AdapterType = keyof typeof baseClasses;
 


### PR DESCRIPTION
no ref
- compile-caching adds a not-insignificant amount of memory overhead for each file cached (anecdotally, ~20mb overall)
- the scripts are retained in the `bin` directory for downstream consumers who want to pre-warm the cache themselves, but for now it won't be pre-warmed by default