### PR TITLE
🎨 Improved form and container border contrast

### DIFF
--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -14,7 +14,7 @@ const cardVariants = cva(
     {
         variants: {
             variant: {
-                outline: 'rounded-xl border transition-all hover:shadow-xs',
+                outline: 'rounded-xl border border-border-default transition-all hover:shadow-xs',
                 plain: ''
             }
         },
@@ -44,7 +44,7 @@ const cardHeaderVariants = cva(
         variants: {
             variant: {
                 outline: 'p-6',
-                plain: 'border-b py-5'
+                plain: 'border-b border-border-default py-5'
             }
         },
         defaultVariants: {
@@ -98,7 +98,7 @@ const cardContentVariants = cva(
         variants: {
             variant: {
                 outline: 'p-6 pt-0',
-                plain: 'border-b'
+                plain: 'border-b border-border-default'
             }
         },
         defaultVariants: {
@@ -159,7 +159,7 @@ const EmptyCard = React.forwardRef<
 >(({className, ...props}, ref) => (
     <div
         ref={ref}
-        className={cn('flex flex-col rounded-xl border bg-card p-6 text-card-foreground transition-all hover:shadow-xs', className)}
+        className={cn('flex flex-col rounded-xl border border-border-default bg-card p-6 text-card-foreground transition-all hover:shadow-xs', className)}
         {...props}
     />
 ));

--- a/apps/shade/test/unit/components/ui/card.test.tsx
+++ b/apps/shade/test/unit/components/ui/card.test.tsx
@@ -7,7 +7,8 @@ import {
     CardFooter,
     CardTitle,
     CardDescription,
-    CardContent
+    CardContent,
+    EmptyCard
 } from '../../../../src/components/ui/card';
 import {render} from '../../utils/test-utils';
 
@@ -18,7 +19,7 @@ describe('Card Components', () => {
 
         assert.ok(card, 'Card should be rendered');
         assert.equal(card.textContent, 'Card Content', 'Card should render its content');
-        assert.ok(card.className.includes('rounded-xl border'), 'Should have outline variant styling');
+        assert.ok(card.className.includes('rounded-xl border border-border-default'), 'Should have outline variant styling');
     });
 
     it('renders Card with plain variant', () => {
@@ -34,6 +35,13 @@ describe('Card Components', () => {
         const card = screen.getByTestId('card');
 
         assert.ok(card.className.includes('custom-card-class'), 'Should have custom class');
+    });
+
+    it('renders EmptyCard with the default container border', () => {
+        render(<EmptyCard data-testid="empty-card">Empty Card</EmptyCard>);
+
+        const card = screen.getByTestId('empty-card');
+        assert.ok(card.className.includes('border border-border-default'), 'Should use the default container border');
     });
 
     it('renders CardHeader with correct styling based on Card variant', () => {
@@ -57,7 +65,7 @@ describe('Card Components', () => {
         );
 
         const header = screen.getByTestId('card-header');
-        assert.ok(header.className.includes('border-b py-5'), 'Should have plain variant styling');
+        assert.ok(header.className.includes('border-b border-border-default py-5'), 'Should have plain variant styling');
     });
 
     it('renders CardTitle with correct styling', () => {
@@ -99,7 +107,7 @@ describe('Card Components', () => {
         );
 
         const content = screen.getByTestId('card-content');
-        assert.ok(content.className.includes('border-b'), 'Should have plain variant styling');
+        assert.ok(content.className.includes('border-b border-border-default'), 'Should have plain variant styling');
     });
 
     it('renders CardFooter with correct styling based on Card variant', () => {

--- a/apps/shade/theme-variables.css
+++ b/apps/shade/theme-variables.css
@@ -39,7 +39,7 @@
     --text-tertiary: var(--color-gray-400);
     --text-inverse: var(--color-white);
     --border-subtle: var(--color-gray-200);
-    --border-default: var(--color-gray-200);
+    --border-default: var(--color-gray-300);
     --border-strong: var(--color-gray-500);
     --focus-ring: var(--color-gray-600);
     --state-info: var(--color-blue-500);

--- a/apps/shade/theme-variables.css
+++ b/apps/shade/theme-variables.css
@@ -39,7 +39,7 @@
     --text-tertiary: var(--color-gray-400);
     --text-inverse: var(--color-white);
     --border-subtle: var(--color-gray-200);
-    --border-default: var(--color-gray-300);
+    --border-default: color-mix(in oklab, var(--color-gray-200), var(--color-gray-300));
     --border-strong: var(--color-gray-500);
     --focus-ring: var(--color-gray-600);
     --state-info: var(--color-blue-500);
@@ -83,7 +83,7 @@
     --control-surface: var(--surface-elevated);
     --control-readonly-surface: var(--color-gray-50);
     --control-disabled-surface: var(--color-gray-100);
-    --control-border: var(--color-gray-300);
+    --control-border: color-mix(in oklab, var(--color-gray-200), var(--color-gray-300));
     --table-row-hover: var(--color-gray-50);
     --members-sticky-hover-bg: var(--table-row-hover);
     --mobile-navbar-height: 64px;

--- a/apps/shade/theme-variables.css
+++ b/apps/shade/theme-variables.css
@@ -83,7 +83,7 @@
     --control-surface: var(--surface-elevated);
     --control-readonly-surface: var(--color-gray-50);
     --control-disabled-surface: var(--color-gray-100);
-    --control-border: var(--color-gray-200);
+    --control-border: var(--color-gray-300);
     --table-row-hover: var(--color-gray-50);
     --members-sticky-hover-bg: var(--table-row-hover);
     --mobile-navbar-height: 64px;


### PR DESCRIPTION
## What changed

- Set Shade's light-mode `--control-border` to a 50% OKLab mix between `gray-200` and `gray-300`.
- Applied the same intermediate value to light-mode `--border-default` for bordered containers.
- Routed `Card`, `EmptyCard`, and plain-card separators through `border-border-default` explicitly.
- Kept the existing dark-mode values unchanged because they are tuned separately for dark surfaces.

The shared control token applies consistently to text inputs, textareas, selects, comboboxes, input groups, and other composed form controls. The default border token covers framed containers and dividers, while Card now opts into that semantic border deliberately.

## Why

The original gray-200 borders lacked definition, while gray-300 was visually too heavy. The midpoint preserves a quieter hierarchy while still increasing separation from white surfaces.

## Impact

This is a backward-compatible visual adjustment. No component APIs, token names, focus states, or dark-mode values change.

## Validation

- `pnpm --filter @tryghost/shade lint`
- `pnpm --filter @tryghost/shade test` — 296 tests passed
- `pnpm --filter @tryghost/shade build-storybook`
- Shade token and merge-gate scans

[DES-1474](https://linear.app/ghost/issue/DES-1474/bump-form-input-border-color-for-better-contrast)