### PR TITLE
Updated public app development commands

### DIFF
--- a/apps/admin-toolbar/README.md
+++ b/apps/admin-toolbar/README.md
@@ -13,16 +13,18 @@ run these commands from this directory:
 
 ```bash
 pnpm build    # one-off build
-pnpm dev      # watch the UMD build
-pnpm test     # build + run tests against UMD bundle
+pnpm dev      # watch and rebuild umd/admin-toolbar.min.js
+pnpm test     # build + run tests against the built bundle
 ```
 
 ## How it's served
 
 In production, the script is loaded from jsDelivr via the `adminToolbar` config
 in `defaults.json`, following the same CDN pattern as portal, comments-ui, and
-the other public apps. In development, the Docker Dockerfile overrides the URL
-to proxy through Caddy to the local vite preview server on port 4176.
+the other public apps. In development, `docker/ghost-dev/Dockerfile` overrides
+that URL to `/ghost/assets/admin-toolbar/admin-toolbar.min.js`, which the dev
+gateway serves straight off disk from this package's `umd/` directory — so the
+watcher's output is picked up on the next request.
 
 # Copyright & License
 

--- a/apps/admin-toolbar/README.md
+++ b/apps/admin-toolbar/README.md
@@ -7,9 +7,13 @@ scripts where bundle size matters more than ecosystem compatibility.
 
 ## Development
 
+Run `pnpm dev:public` from the monorepo root to start the standard development
+environment and the Admin Toolbar watcher. To work on this package by itself,
+run these commands from this directory:
+
 ```bash
 pnpm build    # one-off build
-pnpm dev      # build + preview with watch (started automatically by pnpm dev from root)
+pnpm dev      # watch the UMD build
 pnpm test     # build + run tests against UMD bundle
 ```
 

--- a/apps/announcement-bar/README.md
+++ b/apps/announcement-bar/README.md
@@ -14,9 +14,7 @@ Start Ghost with the public-app watchers enabled:
 pnpm dev:public
 ```
 
-This starts the standard development environment and the Announcement Bar
-watcher. To run only the package's build watcher, use `pnpm dev` from this
-directory.
+This starts the standard development environment and the Announcement Bar watcher. To run only the package's build watcher, use `pnpm dev` from this directory.
 
 ## Release
 
@@ -34,7 +32,7 @@ In either case, you need sufficient permissions to release `@tryghost` packages 
 2. Merge the release commit to `main`
 3. Wait until a new version of Ghost is released
 
-To use the new version of signup form in Ghost, update the version in Ghost core's default configuration (currently at `core/shared/config/default.json`)
+To use the new version of Announcement Bar in Ghost, update the version in Ghost core's default configuration (currently at `core/shared/config/default.json`)
 
 # Copyright & License 
 

--- a/apps/announcement-bar/README.md
+++ b/apps/announcement-bar/README.md
@@ -4,17 +4,19 @@
 
 ### Pre-requisites
 
-- Run `pnpm` in Ghost monorepo root
-- Run `pnpm` in this directory
+- Run `pnpm setup` in the Ghost monorepo root
 
-### Running via Ghost `pnpm dev` in root folder
+### Running via Ghost from the monorepo root
 
-Announcement Bar runs automatically when using Ghost's development command from the monorepo root:
+Start Ghost with the public-app watchers enabled:
+
 ```bash
-pnpm dev
+pnpm dev:public
 ```
 
-This starts all frontend apps (including Announcement Bar.)
+This starts the standard development environment and the Announcement Bar
+watcher. To run only the package's build watcher, use `pnpm dev` from this
+directory.
 
 ## Release
 

--- a/apps/comments-ui/README.md
+++ b/apps/comments-ui/README.md
@@ -6,14 +6,18 @@ Comments widget that is embedded at the bottom of posts in Ghost.
 
 ### Pre-requisites
 
-- Run `pnpm` in Ghost monorepo root
+- Run `pnpm setup` in the Ghost monorepo root
 
-### Running via Ghost `pnpm dev` in root folder
+### Running via Ghost from the monorepo root
 
-Comments UI runs automatically when using Ghost's development command from the monorepo root:
+Start Ghost with the public-app watchers enabled:
+
 ```bash
-pnpm dev
+pnpm dev:public
 ```
+
+This starts the standard development environment and the Comments UI watcher.
+To run only the package's build watcher, use `pnpm dev` from this directory.
 
 ## Release
 

--- a/apps/comments-ui/README.md
+++ b/apps/comments-ui/README.md
@@ -16,8 +16,7 @@ Start Ghost with the public-app watchers enabled:
 pnpm dev:public
 ```
 
-This starts the standard development environment and the Comments UI watcher.
-To run only the package's build watcher, use `pnpm dev` from this directory.
+This starts the standard development environment and the Comments UI watcher. To run only the package's build watcher, use `pnpm dev` from this directory.
 
 ## Release
 

--- a/apps/signup-form/README.md
+++ b/apps/signup-form/README.md
@@ -6,30 +6,39 @@ Embed a Ghost signup form on any site.
 
 ### Pre-requisites
 
-- Run `pnpm` in Ghost monorepo root
-- Run `pnpm` in this directory
+- Run `pnpm setup` in the Ghost monorepo root
 
-### Running via Ghost `pnpm dev` in root folder
+### Running via Ghost from the monorepo root
 
-Signup Form runs automatically when using Ghost's development command from the monorepo root:
+Start Ghost with the public-app watchers enabled:
+
 ```bash
-pnpm dev
+pnpm dev:public
 ```
 
-This starts all frontend apps (including Signup Form.)
+This starts the standard development environment and the Signup Form watcher.
 
 ### Running the standalone demo page
 
 Run `pnpm dev:standalone` (in this package folder) to start the standalone development server with HMR for testing/developing the form in isolation.
 - This serves the demo page at http://localhost:6173
 
-`pnpm dev` on its own (in this package folder) only builds `umd/signup-form.min.js` and watches for changes — it does not bind a port. The UMD is served by Caddy at http://localhost:2368/ghost/assets/signup-form/signup-form.min.js when you run `pnpm dev` from the monorepo root.
+`pnpm dev` on its own (in this package folder) only builds
+`umd/signup-form.min.js` and watches for changes — it does not bind a port. The
+UMD is served by Caddy at
+http://localhost:2368/ghost/assets/signup-form/signup-form.min.js when you run
+`pnpm dev:public` from the monorepo root.
 
 ### Using the UMD build during development
 
 Vite by default only supports HRM with an ESM output. But when loading a script on a site as a ESM module (`<script type="module" src="...">`), you don't have access to `document.currentScript` inside the script, which is required to determine the location to inject the iframe. In development mode we use a workaround for this to make the ESM HMR work. But this workaround is not suitable for production.
 
-To test the real production behaviour without this hack, you can use http://localhost:6173/preview.html (served by `pnpm dev:standalone`). The page loads the production UMD via `<script src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js">`, which is served by Caddy when `pnpm dev` is also running from the monorepo root. Both processes need to be up at the same time.
+To test the real production behaviour without this hack, you can use
+http://localhost:6173/preview.html (served by `pnpm dev:standalone`). The page
+loads the production UMD via
+`<script src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js">`,
+which is served by Caddy when `pnpm dev:public` is also running from the monorepo
+root. Both processes need to be up at the same time.
 
 ## Develop
 
@@ -42,10 +51,9 @@ Follow the instructions for the top-level repo.
 ## Test
 
 - `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-- `pnpm test:e2e` run e2e tests on Chromium
-- `pnpm test:slowmo` run e2e tests visually (headed) and slower on Chromium
-- `pnpm test:e2e:full` run e2e tests on all browsers
+- `pnpm test:acceptance` run acceptance tests on Chromium
+- `pnpm test:acceptance:slowmo` run acceptance tests visually (headed) and slower on Chromium
+- `pnpm test:acceptance:full` run acceptance tests on all configured browsers
 
 ## Release
 

--- a/apps/signup-form/README.md
+++ b/apps/signup-form/README.md
@@ -23,30 +23,13 @@ This starts the standard development environment and the Signup Form watcher.
 Run `pnpm dev:standalone` (in this package folder) to start the standalone development server with HMR for testing/developing the form in isolation.
 - This serves the demo page at http://localhost:6173
 
-`pnpm dev` on its own (in this package folder) only builds
-`umd/signup-form.min.js` and watches for changes — it does not bind a port. The
-UMD is served by Caddy at
-http://localhost:2368/ghost/assets/signup-form/signup-form.min.js when you run
-`pnpm dev:public` from the monorepo root.
+`pnpm dev` on its own (in this package folder) only builds `umd/signup-form.min.js` and watches for changes — it does not bind a port. The UMD is served by Caddy at http://localhost:2368/ghost/assets/signup-form/signup-form.min.js when you run `pnpm dev:public` from the monorepo root.
 
 ### Using the UMD build during development
 
 Vite by default only supports HRM with an ESM output. But when loading a script on a site as a ESM module (`<script type="module" src="...">`), you don't have access to `document.currentScript` inside the script, which is required to determine the location to inject the iframe. In development mode we use a workaround for this to make the ESM HMR work. But this workaround is not suitable for production.
 
-To test the real production behaviour without this hack, you can use
-http://localhost:6173/preview.html (served by `pnpm dev:standalone`). The page
-loads the production UMD via
-`<script src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js">`,
-which is served by Caddy when `pnpm dev:public` is also running from the monorepo
-root. Both processes need to be up at the same time.
-
-## Develop
-
-This is a monorepo package.
-
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm` to install top-level dependencies.
+To test the real production behaviour without this hack, you can use http://localhost:6173/preview.html (served by `pnpm dev:standalone`). The page loads the production UMD via `<script src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js">`, which is served by Caddy when `pnpm dev:public` is also running from the monorepo root. Both processes need to be up at the same time.
 
 ## Test
 

--- a/apps/sodo-search/README.md
+++ b/apps/sodo-search/README.md
@@ -4,17 +4,18 @@
 
 ### Pre-requisites
 
-- Run `pnpm` in Ghost monorepo root
-- Run `pnpm` in this directory
+- Run `pnpm setup` in the Ghost monorepo root
 
-### Running via Ghost `pnpm dev` in root folder
+### Running via Ghost from the monorepo root
 
-Sodo Search runs automatically when using Ghost's development command from the monorepo root:
+Start Ghost with the public-app watchers enabled:
+
 ```bash
-pnpm dev
+pnpm dev:public
 ```
 
-This starts all frontend apps (including Sodo Search.)
+This starts the standard development environment and the Sodo Search watcher.
+To run only the package's build watcher, use `pnpm dev` from this directory.
 
 ## Release
 

--- a/apps/sodo-search/README.md
+++ b/apps/sodo-search/README.md
@@ -14,8 +14,7 @@ Start Ghost with the public-app watchers enabled:
 pnpm dev:public
 ```
 
-This starts the standard development environment and the Sodo Search watcher.
-To run only the package's build watcher, use `pnpm dev` from this directory.
+This starts the standard development environment and the Sodo Search watcher. To run only the package's build watcher, use `pnpm dev` from this directory.
 
 ## Release
 


### PR DESCRIPTION
## Summary

- Points Announcement Bar, Comments UI, Signup Form, Sodo Search, and Admin Toolbar development at the `pnpm dev:public` root lane that actually starts their watchers.
- Distinguishes root development commands from package-local build watchers.
- Replaces Signup Form's obsolete E2E test command names with its current acceptance-test scripts.
- Fixes Admin Toolbar's "How it's served" note, which still described a `vite preview` server on port 4176 — that layer no longer exists, and the dev gateway now serves the bundle straight from the package's `umd/` directory.
- Drops Signup Form's "Develop" section, which told you to clone the repo and run `pnpm`, contradicting the `pnpm setup` pre-requisite above it.
- Corrects Announcement Bar's release note, which referred to the signup form.

## Testing

- [x] `pnpm lint:docs`
- [x] `git diff --check`
- [x] Checked every documented root and package-local command against the owning `package.json`
- [x] Checked the dev serving path against `docker/ghost-dev/Dockerfile` and `docker/dev-gateway/Caddyfile`
- [ ] App test suites not run: this changes documentation only and does not alter application code
