### PR TITLE
Added role migration helpers

### DIFF
--- a/ghost/core/core/server/data/migrations/utils/index.js
+++ b/ghost/core/core/server/data/migrations/utils/index.js
@@ -1,7 +1,8 @@
 module.exports = {
-  ...require('./migrations'),
-  ...require('./permissions'),
-  ...require('./schema'),
-  ...require('./settings'),
-  ...require('./tables'),
+    ...require('./migrations'),
+    ...require('./permissions'),
+    ...require('./roles'),
+    ...require('./schema'),
+    ...require('./settings'),
+    ...require('./tables')
 };

--- a/ghost/core/core/server/data/migrations/utils/index.js
+++ b/ghost/core/core/server/data/migrations/utils/index.js
@@ -1,8 +1,8 @@
 module.exports = {
-    ...require('./migrations'),
-    ...require('./permissions'),
-    ...require('./roles'),
-    ...require('./schema'),
-    ...require('./settings'),
-    ...require('./tables')
+  ...require('./migrations'),
+  ...require('./permissions'),
+  ...require('./roles'),
+  ...require('./schema'),
+  ...require('./settings'),
+  ...require('./tables'),
 };

--- a/ghost/core/core/server/data/migrations/utils/roles.js
+++ b/ghost/core/core/server/data/migrations/utils/roles.js
@@ -1,7 +1,7 @@
 const ObjectId = require('bson-objectid').default;
 const logging = require('@tryghost/logging');
 
-const {createTransactionalMigration} = require('./migrations');
+const { createTransactionalMigration } = require('./migrations');
 const MIGRATION_USER = 1;
 
 /**
@@ -9,32 +9,32 @@ const MIGRATION_USER = 1;
  * @param {RoleConfig} config
  */
 async function addRoleHelper(connection, config) {
-    const existingRole = await connection('roles').where({name: config.name}).first();
+  const existingRole = await connection('roles').where({ name: config.name }).first();
 
-    if (existingRole) {
-        logging.warn(`Skipping adding role: ${config.name} - role already exists`);
-        return;
-    }
+  if (existingRole) {
+    logging.warn(`Skipping adding role: ${config.name} - role already exists`);
+    return;
+  }
 
-    logging.info(`Adding role: ${config.name}`);
+  logging.info(`Adding role: ${config.name}`);
 
-    const now = connection.raw('CURRENT_TIMESTAMP');
-    const data = {
-        id: ObjectId().toHexString(),
-        ...config,
-        created_at: now,
-        updated_at: now
-    };
+  const now = connection.raw('CURRENT_TIMESTAMP');
+  const data = {
+    id: ObjectId().toHexString(),
+    ...config,
+    created_at: now,
+    updated_at: now,
+  };
 
-    if (await connection.schema.hasColumn('roles', 'created_by')) {
-        data.created_by = MIGRATION_USER;
-    }
+  if (await connection.schema.hasColumn('roles', 'created_by')) {
+    data.created_by = MIGRATION_USER;
+  }
 
-    if (await connection.schema.hasColumn('roles', 'updated_by')) {
-        data.updated_by = MIGRATION_USER;
-    }
+  if (await connection.schema.hasColumn('roles', 'updated_by')) {
+    data.updated_by = MIGRATION_USER;
+  }
 
-    await connection('roles').insert(data);
+  await connection('roles').insert(data);
 }
 
 /**
@@ -42,19 +42,19 @@ async function addRoleHelper(connection, config) {
  * @param {RoleConfig} config
  */
 async function removeRoleHelper(connection, config) {
-    const existingRole = await connection('roles').where({name: config.name}).first();
+  const existingRole = await connection('roles').where({ name: config.name }).first();
 
-    if (!existingRole) {
-        logging.warn(`Skipping removing role: ${config.name} - role does not exist`);
-        return;
-    }
+  if (!existingRole) {
+    logging.warn(`Skipping removing role: ${config.name} - role does not exist`);
+    return;
+  }
 
-    logging.info(`Removing role: ${config.name}`);
+  logging.info(`Removing role: ${config.name}`);
 
-    await connection('api_keys').where('role_id', existingRole.id).del();
-    await connection('permissions_roles').where('role_id', existingRole.id).del();
-    await connection('roles_users').where('role_id', existingRole.id).del();
-    await connection('roles').where('id', existingRole.id).del();
+  await connection('api_keys').where('role_id', existingRole.id).del();
+  await connection('permissions_roles').where('role_id', existingRole.id).del();
+  await connection('roles_users').where('role_id', existingRole.id).del();
+  await connection('roles').where('id', existingRole.id).del();
 }
 
 /**
@@ -64,14 +64,14 @@ async function removeRoleHelper(connection, config) {
  * @returns {Migration}
  */
 function addRole(config) {
-    return createTransactionalMigration(
-        async function up(connection) {
-            await addRoleHelper(connection, config);
-        },
-        async function down(connection) {
-            await removeRoleHelper(connection, config);
-        }
-    );
+  return createTransactionalMigration(
+    async function up(connection) {
+      await addRoleHelper(connection, config);
+    },
+    async function down(connection) {
+      await removeRoleHelper(connection, config);
+    },
+  );
 }
 
 /**
@@ -83,19 +83,19 @@ function addRole(config) {
  * @returns {Migration}
  */
 function removeRole(config) {
-    return createTransactionalMigration(
-        async function up(connection) {
-            await removeRoleHelper(connection, config);
-        },
-        async function down(connection) {
-            await addRoleHelper(connection, config);
-        }
-    );
+  return createTransactionalMigration(
+    async function up(connection) {
+      await removeRoleHelper(connection, config);
+    },
+    async function down(connection) {
+      await addRoleHelper(connection, config);
+    },
+  );
 }
 
 module.exports = {
-    addRole,
-    removeRole
+  addRole,
+  removeRole,
 };
 
 /**

--- a/ghost/core/core/server/data/migrations/utils/roles.js
+++ b/ghost/core/core/server/data/migrations/utils/roles.js
@@ -1,0 +1,105 @@
+const ObjectId = require('bson-objectid').default;
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('./migrations');
+const MIGRATION_USER = 1;
+
+/**
+ * @param {import('knex').Knex} connection
+ * @param {RoleConfig} config
+ */
+async function addRoleHelper(connection, config) {
+    const existingRole = await connection('roles').where({name: config.name}).first();
+
+    if (existingRole) {
+        logging.warn(`Skipping adding role: ${config.name} - role already exists`);
+        return;
+    }
+
+    logging.info(`Adding role: ${config.name}`);
+
+    const now = connection.raw('CURRENT_TIMESTAMP');
+    const data = {
+        id: ObjectId().toHexString(),
+        ...config,
+        created_at: now,
+        updated_at: now
+    };
+
+    if (await connection.schema.hasColumn('roles', 'created_by')) {
+        data.created_by = MIGRATION_USER;
+    }
+
+    if (await connection.schema.hasColumn('roles', 'updated_by')) {
+        data.updated_by = MIGRATION_USER;
+    }
+
+    await connection('roles').insert(data);
+}
+
+/**
+ * @param {import('knex').Knex} connection
+ * @param {RoleConfig} config
+ */
+async function removeRoleHelper(connection, config) {
+    const existingRole = await connection('roles').where({name: config.name}).first();
+
+    if (!existingRole) {
+        logging.warn(`Skipping removing role: ${config.name} - role does not exist`);
+        return;
+    }
+
+    logging.info(`Removing role: ${config.name}`);
+
+    await connection('api_keys').where('role_id', existingRole.id).del();
+    await connection('permissions_roles').where('role_id', existingRole.id).del();
+    await connection('roles_users').where('role_id', existingRole.id).del();
+    await connection('roles').where('id', existingRole.id).del();
+}
+
+/**
+ * Creates a migration which adds a role to the database
+ *
+ * @param {RoleConfig} config
+ * @returns {Migration}
+ */
+function addRole(config) {
+    return createTransactionalMigration(
+        async function up(connection) {
+            await addRoleHelper(connection, config);
+        },
+        async function down(connection) {
+            await removeRoleHelper(connection, config);
+        }
+    );
+}
+
+/**
+ * Creates a migration which removes a role from the database
+ *
+ * Role assignments and API keys are removed with the role and cannot be restored.
+ *
+ * @param {RoleConfig} config
+ * @returns {Migration}
+ */
+function removeRole(config) {
+    return createTransactionalMigration(
+        async function up(connection) {
+            await removeRoleHelper(connection, config);
+        },
+        async function down(connection) {
+            await addRoleHelper(connection, config);
+        }
+    );
+}
+
+module.exports = {
+    addRole,
+    removeRole
+};
+
+/**
+ * @typedef {Object} RoleConfig
+ * @prop {string} config.name
+ * @prop {string} [config.description]
+ */

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-34-25-remove-legacy-explore-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-34-25-remove-legacy-explore-integration.js
@@ -1,27 +1,28 @@
 const logging = require('@tryghost/logging');
 const ObjectID = require('bson-objectid').default;
 const {
-  createTransactionalMigration,
-  combineTransactionalMigrations,
-  createRemovePermissionMigration,
+    createTransactionalMigration,
+    combineTransactionalMigrations,
+    createRemovePermissionMigration,
+    removeRole
 } = require('../../utils');
 
 const INTEGRATION = {
-  type: 'core',
-  name: 'Ghost Explore',
-  slug: 'ghost-explore',
-  description: 'Built-in Ghost Explore integration',
+    type: 'core',
+    name: 'Ghost Explore',
+    slug: 'ghost-explore',
+    description: 'Built-in Ghost Explore integration'
 };
 
 const ROLE = {
-  name: 'Ghost Explore Integration',
-  description: 'Internal Integration for the Ghost Explore directory',
+    name: 'Ghost Explore Integration',
+    description: 'Internal Integration for the Ghost Explore directory'
 };
 
 const PERMISSION = {
-  name: 'Read explore data',
-  action: 'read',
-  object: 'explore',
+    name: 'Read explore data',
+    action: 'read',
+    object: 'explore'
 };
 
 // Mirrors the roles the permission was originally granted to in 5.3
@@ -31,113 +32,67 @@ const PERMISSION_ROLES = ['Administrator', 'Admin Integration', ROLE.name];
 // user grant would be left pointing at a deleted permission. Ghost only ever grants this
 // via roles, so there is nothing to restore on the way back down.
 const removeDirectUserGrants = createTransactionalMigration(
-  async function up(knex) {
-    const permission = await knex('permissions')
-      .where({
-        name: PERMISSION.name,
-        action_type: PERMISSION.action,
-        object_type: PERMISSION.object,
-      })
-      .first();
+    async function up(knex) {
+        const permission = await knex('permissions').where({
+            name: PERMISSION.name,
+            action_type: PERMISSION.action,
+            object_type: PERMISSION.object
+        }).first();
 
-    if (!permission) {
-      logging.warn(
-        `Skipping cleanup of direct "${PERMISSION.name}" user grants - the permission does not exist`,
-      );
-      return;
+        if (!permission) {
+            logging.warn(`Skipping cleanup of direct "${PERMISSION.name}" user grants - the permission does not exist`);
+            return;
+        }
+
+        const removed = await knex('permissions_users').where('permission_id', permission.id).del();
+        logging.info(`Removed ${removed} direct "${PERMISSION.name}" user grants`);
+    },
+    async function down() {
+        logging.info(`Skipping restore of direct "${PERMISSION.name}" user grants - Ghost only grants it via roles`);
     }
-
-    const removed = await knex('permissions_users').where('permission_id', permission.id).del();
-    logging.info(`Removed ${removed} direct "${PERMISSION.name}" user grants`);
-  },
-  async function down() {
-    logging.info(
-      `Skipping restore of direct "${PERMISSION.name}" user grants - Ghost only grants it via roles`,
-    );
-  },
 );
 
 const removeIntegration = createTransactionalMigration(
-  async function up(knex) {
-    const integration = await knex('integrations')
-      .select('id')
-      .where('slug', INTEGRATION.slug)
-      .first();
+    async function up(knex) {
+        const integration = await knex('integrations').select('id').where('slug', INTEGRATION.slug).first();
 
-    if (!integration) {
-      logging.warn(`Skipping removal of ${INTEGRATION.slug} integration - it does not exist`);
-      return;
+        if (!integration) {
+            logging.warn(`Skipping removal of ${INTEGRATION.slug} integration - it does not exist`);
+            return;
+        }
+
+        await knex('api_keys').where('integration_id', integration.id).del();
+        await knex('integrations').where('id', integration.id).del();
+        logging.info(`Removed ${INTEGRATION.slug} integration and API keys`);
+    },
+    async function down(knex) {
+        const existing = await knex('integrations').select('id').where('slug', INTEGRATION.slug).first();
+
+        if (existing) {
+            logging.warn(`Skipping restore of ${INTEGRATION.slug} integration - it already exists`);
+            return;
+        }
+
+        await knex('integrations').insert({
+            id: new ObjectID().toHexString(),
+            ...INTEGRATION,
+            created_at: knex.raw('CURRENT_TIMESTAMP'),
+            updated_at: knex.raw('CURRENT_TIMESTAMP')
+        });
+
+        // Deliberately no API key: the original secret is unrecoverable, and a rollback is
+        // about getting the schema back to what the previous version expects rather than
+        // reconnecting Explore - ghost.org stopped calling this endpoint long ago. Anyone
+        // who needs Admin API access should create a custom integration instead.
+        logging.info(`Restored ${INTEGRATION.slug} integration without an API key`);
     }
-
-    await knex('api_keys').where('integration_id', integration.id).del();
-    await knex('integrations').where('id', integration.id).del();
-    logging.info(`Removed ${INTEGRATION.slug} integration and API keys`);
-  },
-  async function down(knex) {
-    const existing = await knex('integrations')
-      .select('id')
-      .where('slug', INTEGRATION.slug)
-      .first();
-
-    if (existing) {
-      logging.warn(`Skipping restore of ${INTEGRATION.slug} integration - it already exists`);
-      return;
-    }
-
-    await knex('integrations').insert({
-      id: new ObjectID().toHexString(),
-      ...INTEGRATION,
-      created_at: knex.raw('CURRENT_TIMESTAMP'),
-      updated_at: knex.raw('CURRENT_TIMESTAMP'),
-    });
-
-    // Deliberately no API key: the original secret is unrecoverable, and a rollback is
-    // about getting the schema back to what the previous version expects rather than
-    // reconnecting Explore - ghost.org stopped calling this endpoint long ago. Anyone
-    // who needs Admin API access should create a custom integration instead.
-    logging.info(`Restored ${INTEGRATION.slug} integration without an API key`);
-  },
-);
-
-const removeRole = createTransactionalMigration(
-  async function up(knex) {
-    const role = await knex('roles').select('id').where('name', ROLE.name).first();
-
-    if (!role) {
-      logging.warn(`Skipping removal of ${ROLE.name} role - it does not exist`);
-      return;
-    }
-
-    await knex('api_keys').where('role_id', role.id).del();
-    await knex('permissions_roles').where('role_id', role.id).del();
-    await knex('roles_users').where('role_id', role.id).del();
-    await knex('roles').where('id', role.id).del();
-    logging.info(`Removed ${ROLE.name} role`);
-  },
-  async function down(knex) {
-    const existing = await knex('roles').select('id').where('name', ROLE.name).first();
-
-    if (existing) {
-      logging.warn(`Skipping restore of ${ROLE.name} role - it already exists`);
-      return;
-    }
-
-    await knex('roles').insert({
-      id: new ObjectID().toHexString(),
-      ...ROLE,
-      created_at: knex.raw('CURRENT_TIMESTAMP'),
-      updated_at: knex.raw('CURRENT_TIMESTAMP'),
-    });
-
-    logging.info(`Restored ${ROLE.name} role`);
-  },
 );
 
 // Down migrations run in reverse, so the role is restored before the permission that has
 // to be linked back to it
 module.exports = combineTransactionalMigrations(
-  removeDirectUserGrants,
-  createRemovePermissionMigration(PERMISSION, PERMISSION_ROLES),
-  removeIntegration,
-  removeRole,
+    removeDirectUserGrants,
+    createRemovePermissionMigration(PERMISSION, PERMISSION_ROLES),
+    removeIntegration,
+    removeRole(ROLE)
 );

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-34-25-remove-legacy-explore-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-34-25-remove-legacy-explore-integration.js
@@ -1,28 +1,28 @@
 const logging = require('@tryghost/logging');
 const ObjectID = require('bson-objectid').default;
 const {
-    createTransactionalMigration,
-    combineTransactionalMigrations,
-    createRemovePermissionMigration,
-    removeRole
+  createTransactionalMigration,
+  combineTransactionalMigrations,
+  createRemovePermissionMigration,
+  removeRole,
 } = require('../../utils');
 
 const INTEGRATION = {
-    type: 'core',
-    name: 'Ghost Explore',
-    slug: 'ghost-explore',
-    description: 'Built-in Ghost Explore integration'
+  type: 'core',
+  name: 'Ghost Explore',
+  slug: 'ghost-explore',
+  description: 'Built-in Ghost Explore integration',
 };
 
 const ROLE = {
-    name: 'Ghost Explore Integration',
-    description: 'Internal Integration for the Ghost Explore directory'
+  name: 'Ghost Explore Integration',
+  description: 'Internal Integration for the Ghost Explore directory',
 };
 
 const PERMISSION = {
-    name: 'Read explore data',
-    action: 'read',
-    object: 'explore'
+  name: 'Read explore data',
+  action: 'read',
+  object: 'explore',
 };
 
 // Mirrors the roles the permission was originally granted to in 5.3
@@ -32,67 +32,79 @@ const PERMISSION_ROLES = ['Administrator', 'Admin Integration', ROLE.name];
 // user grant would be left pointing at a deleted permission. Ghost only ever grants this
 // via roles, so there is nothing to restore on the way back down.
 const removeDirectUserGrants = createTransactionalMigration(
-    async function up(knex) {
-        const permission = await knex('permissions').where({
-            name: PERMISSION.name,
-            action_type: PERMISSION.action,
-            object_type: PERMISSION.object
-        }).first();
+  async function up(knex) {
+    const permission = await knex('permissions')
+      .where({
+        name: PERMISSION.name,
+        action_type: PERMISSION.action,
+        object_type: PERMISSION.object,
+      })
+      .first();
 
-        if (!permission) {
-            logging.warn(`Skipping cleanup of direct "${PERMISSION.name}" user grants - the permission does not exist`);
-            return;
-        }
-
-        const removed = await knex('permissions_users').where('permission_id', permission.id).del();
-        logging.info(`Removed ${removed} direct "${PERMISSION.name}" user grants`);
-    },
-    async function down() {
-        logging.info(`Skipping restore of direct "${PERMISSION.name}" user grants - Ghost only grants it via roles`);
+    if (!permission) {
+      logging.warn(
+        `Skipping cleanup of direct "${PERMISSION.name}" user grants - the permission does not exist`,
+      );
+      return;
     }
+
+    const removed = await knex('permissions_users').where('permission_id', permission.id).del();
+    logging.info(`Removed ${removed} direct "${PERMISSION.name}" user grants`);
+  },
+  async function down() {
+    logging.info(
+      `Skipping restore of direct "${PERMISSION.name}" user grants - Ghost only grants it via roles`,
+    );
+  },
 );
 
 const removeIntegration = createTransactionalMigration(
-    async function up(knex) {
-        const integration = await knex('integrations').select('id').where('slug', INTEGRATION.slug).first();
+  async function up(knex) {
+    const integration = await knex('integrations')
+      .select('id')
+      .where('slug', INTEGRATION.slug)
+      .first();
 
-        if (!integration) {
-            logging.warn(`Skipping removal of ${INTEGRATION.slug} integration - it does not exist`);
-            return;
-        }
-
-        await knex('api_keys').where('integration_id', integration.id).del();
-        await knex('integrations').where('id', integration.id).del();
-        logging.info(`Removed ${INTEGRATION.slug} integration and API keys`);
-    },
-    async function down(knex) {
-        const existing = await knex('integrations').select('id').where('slug', INTEGRATION.slug).first();
-
-        if (existing) {
-            logging.warn(`Skipping restore of ${INTEGRATION.slug} integration - it already exists`);
-            return;
-        }
-
-        await knex('integrations').insert({
-            id: new ObjectID().toHexString(),
-            ...INTEGRATION,
-            created_at: knex.raw('CURRENT_TIMESTAMP'),
-            updated_at: knex.raw('CURRENT_TIMESTAMP')
-        });
-
-        // Deliberately no API key: the original secret is unrecoverable, and a rollback is
-        // about getting the schema back to what the previous version expects rather than
-        // reconnecting Explore - ghost.org stopped calling this endpoint long ago. Anyone
-        // who needs Admin API access should create a custom integration instead.
-        logging.info(`Restored ${INTEGRATION.slug} integration without an API key`);
+    if (!integration) {
+      logging.warn(`Skipping removal of ${INTEGRATION.slug} integration - it does not exist`);
+      return;
     }
+
+    await knex('api_keys').where('integration_id', integration.id).del();
+    await knex('integrations').where('id', integration.id).del();
+    logging.info(`Removed ${INTEGRATION.slug} integration and API keys`);
+  },
+  async function down(knex) {
+    const existing = await knex('integrations')
+      .select('id')
+      .where('slug', INTEGRATION.slug)
+      .first();
+
+    if (existing) {
+      logging.warn(`Skipping restore of ${INTEGRATION.slug} integration - it already exists`);
+      return;
+    }
+
+    await knex('integrations').insert({
+      id: new ObjectID().toHexString(),
+      ...INTEGRATION,
+      created_at: knex.raw('CURRENT_TIMESTAMP'),
+      updated_at: knex.raw('CURRENT_TIMESTAMP'),
+    });
+
+    // Deliberately no API key: the original secret is unrecoverable, and a rollback is
+    // about getting the schema back to what the previous version expects rather than
+    // reconnecting Explore - ghost.org stopped calling this endpoint long ago. Anyone
+    // who needs Admin API access should create a custom integration instead.
+    logging.info(`Restored ${INTEGRATION.slug} integration without an API key`);
+  },
 );
 
 // Down migrations run in reverse, so the role is restored before the permission that has
 // to be linked back to it
 module.exports = combineTransactionalMigrations(
-    removeDirectUserGrants,
-    createRemovePermissionMigration(PERMISSION, PERMISSION_ROLES),
-    removeIntegration,
-    removeRole(ROLE)
+  removeDirectUserGrants,
+  createRemovePermissionMigration(PERMISSION, PERMISSION_ROLES),
+  removeIntegration,
+  removeRole(ROLE),
 );

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -317,6 +317,40 @@ async function setupSettingsDb() {
   return knex;
 }
 
+async function setupRolesDb() {
+    const knex = Knex({
+        client: 'better-sqlite3',
+        connection: {
+            filename: ':memory:'
+        },
+        useNullAsDefault: true
+    });
+
+    await knex.schema.createTable('roles', (table) => {
+        table.string('id', 24).primary();
+        table.string('name', 50).notNullable().unique();
+        table.string('description', 2000);
+        table.dateTime('created_at').notNullable();
+        table.dateTime('updated_at');
+    });
+    await knex.schema.createTable('api_keys', (table) => {
+        table.string('id', 24).primary();
+        table.string('role_id', 24);
+    });
+    await knex.schema.createTable('permissions_roles', (table) => {
+        table.string('id', 24).primary();
+        table.string('role_id', 24).notNullable();
+        table.string('permission_id', 24).notNullable();
+    });
+    await knex.schema.createTable('roles_users', (table) => {
+        table.string('id', 24).primary();
+        table.string('role_id', 24).notNullable();
+        table.string('user_id', 24).notNullable();
+    });
+
+    return knex;
+}
+
 async function runUpMigration(knex, migration) {
   // Non-transactional migrations receive a plain connection rather than a
   // transaction. Wrapping them in knex.transaction() here would also deadlock,
@@ -647,6 +681,77 @@ describe('migrations/utils/permissions', function () {
       );
     });
   });
+});
+
+describe('migrations/utils/roles', function () {
+    const role = {
+        name: 'Test Role',
+        description: 'A role used by migration utility tests'
+    };
+
+    describe('addRole', function () {
+        it('Adds a role and removes it on rollback', async function () {
+            const knex = await setupRolesDb();
+            const migration = utils.addRole(role);
+
+            assert(migration.config.transaction, 'addRole creates a transactional migration');
+
+            const runDownMigration = await runUpMigration(knex, migration);
+            const addedRole = await knex('roles').where({name: role.name}).first();
+
+            assert.equal(addedRole.description, role.description);
+
+            await runDownMigration();
+            assert.equal(await knex('roles').where({name: role.name}).first(), undefined);
+        });
+
+        it('Does not replace an existing role', async function () {
+            const knex = await setupRolesDb();
+            await knex('roles').insert({
+                id: ObjectId().toHexString(),
+                name: role.name,
+                description: 'Existing description',
+                created_at: knex.raw('CURRENT_TIMESTAMP')
+            });
+
+            await runUpMigration(knex, utils.addRole(role));
+
+            const roles = await knex('roles').where({name: role.name});
+            assert.equal(roles.length, 1);
+            assert.equal(roles[0].description, 'Existing description');
+        });
+    });
+
+    describe('removeRole', function () {
+        it('Removes the role and its relationships, then restores the role on rollback', async function () {
+            const knex = await setupRolesDb();
+            await runUpMigration(knex, utils.addRole(role));
+            const existingRole = await knex('roles').where({name: role.name}).first();
+
+            await knex('api_keys').insert({id: ObjectId().toHexString(), role_id: existingRole.id});
+            await knex('permissions_roles').insert({id: ObjectId().toHexString(), role_id: existingRole.id, permission_id: ObjectId().toHexString()});
+            await knex('roles_users').insert({id: ObjectId().toHexString(), role_id: existingRole.id, user_id: ObjectId().toHexString()});
+
+            const runDownMigration = await runUpMigration(knex, utils.removeRole(role));
+
+            assert.equal(await knex('roles').where({name: role.name}).first(), undefined);
+            assert.equal(await knex('api_keys').where({role_id: existingRole.id}).first(), undefined);
+            assert.equal(await knex('permissions_roles').where({role_id: existingRole.id}).first(), undefined);
+            assert.equal(await knex('roles_users').where({role_id: existingRole.id}).first(), undefined);
+
+            await runDownMigration();
+            const restoredRole = await knex('roles').where({name: role.name}).first();
+            assert.equal(restoredRole.description, role.description);
+        });
+
+        it('Does nothing when the role does not exist', async function () {
+            const knex = await setupRolesDb();
+
+            await runUpMigration(knex, utils.removeRole(role));
+
+            assert.equal(await knex('roles').where({name: role.name}).first(), undefined);
+        });
+    });
 });
 
 describe('migrations/utils/settings', function () {

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -318,37 +318,37 @@ async function setupSettingsDb() {
 }
 
 async function setupRolesDb() {
-    const knex = Knex({
-        client: 'better-sqlite3',
-        connection: {
-            filename: ':memory:'
-        },
-        useNullAsDefault: true
-    });
+  const knex = Knex({
+    client: 'better-sqlite3',
+    connection: {
+      filename: ':memory:',
+    },
+    useNullAsDefault: true,
+  });
 
-    await knex.schema.createTable('roles', (table) => {
-        table.string('id', 24).primary();
-        table.string('name', 50).notNullable().unique();
-        table.string('description', 2000);
-        table.dateTime('created_at').notNullable();
-        table.dateTime('updated_at');
-    });
-    await knex.schema.createTable('api_keys', (table) => {
-        table.string('id', 24).primary();
-        table.string('role_id', 24);
-    });
-    await knex.schema.createTable('permissions_roles', (table) => {
-        table.string('id', 24).primary();
-        table.string('role_id', 24).notNullable();
-        table.string('permission_id', 24).notNullable();
-    });
-    await knex.schema.createTable('roles_users', (table) => {
-        table.string('id', 24).primary();
-        table.string('role_id', 24).notNullable();
-        table.string('user_id', 24).notNullable();
-    });
+  await knex.schema.createTable('roles', (table) => {
+    table.string('id', 24).primary();
+    table.string('name', 50).notNullable().unique();
+    table.string('description', 2000);
+    table.dateTime('created_at').notNullable();
+    table.dateTime('updated_at');
+  });
+  await knex.schema.createTable('api_keys', (table) => {
+    table.string('id', 24).primary();
+    table.string('role_id', 24);
+  });
+  await knex.schema.createTable('permissions_roles', (table) => {
+    table.string('id', 24).primary();
+    table.string('role_id', 24).notNullable();
+    table.string('permission_id', 24).notNullable();
+  });
+  await knex.schema.createTable('roles_users', (table) => {
+    table.string('id', 24).primary();
+    table.string('role_id', 24).notNullable();
+    table.string('user_id', 24).notNullable();
+  });
 
-    return knex;
+  return knex;
 }
 
 async function runUpMigration(knex, migration) {
@@ -684,74 +684,88 @@ describe('migrations/utils/permissions', function () {
 });
 
 describe('migrations/utils/roles', function () {
-    const role = {
-        name: 'Test Role',
-        description: 'A role used by migration utility tests'
-    };
+  const role = {
+    name: 'Test Role',
+    description: 'A role used by migration utility tests',
+  };
 
-    describe('addRole', function () {
-        it('Adds a role and removes it on rollback', async function () {
-            const knex = await setupRolesDb();
-            const migration = utils.addRole(role);
+  describe('addRole', function () {
+    it('Adds a role and removes it on rollback', async function () {
+      const knex = await setupRolesDb();
+      const migration = utils.addRole(role);
 
-            assert(migration.config.transaction, 'addRole creates a transactional migration');
+      assert(migration.config.transaction, 'addRole creates a transactional migration');
 
-            const runDownMigration = await runUpMigration(knex, migration);
-            const addedRole = await knex('roles').where({name: role.name}).first();
+      const runDownMigration = await runUpMigration(knex, migration);
+      const addedRole = await knex('roles').where({ name: role.name }).first();
 
-            assert.equal(addedRole.description, role.description);
+      assert.equal(addedRole.description, role.description);
 
-            await runDownMigration();
-            assert.equal(await knex('roles').where({name: role.name}).first(), undefined);
-        });
-
-        it('Does not replace an existing role', async function () {
-            const knex = await setupRolesDb();
-            await knex('roles').insert({
-                id: ObjectId().toHexString(),
-                name: role.name,
-                description: 'Existing description',
-                created_at: knex.raw('CURRENT_TIMESTAMP')
-            });
-
-            await runUpMigration(knex, utils.addRole(role));
-
-            const roles = await knex('roles').where({name: role.name});
-            assert.equal(roles.length, 1);
-            assert.equal(roles[0].description, 'Existing description');
-        });
+      await runDownMigration();
+      assert.equal(await knex('roles').where({ name: role.name }).first(), undefined);
     });
 
-    describe('removeRole', function () {
-        it('Removes the role and its relationships, then restores the role on rollback', async function () {
-            const knex = await setupRolesDb();
-            await runUpMigration(knex, utils.addRole(role));
-            const existingRole = await knex('roles').where({name: role.name}).first();
+    it('Does not replace an existing role', async function () {
+      const knex = await setupRolesDb();
+      await knex('roles').insert({
+        id: ObjectId().toHexString(),
+        name: role.name,
+        description: 'Existing description',
+        created_at: knex.raw('CURRENT_TIMESTAMP'),
+      });
 
-            await knex('api_keys').insert({id: ObjectId().toHexString(), role_id: existingRole.id});
-            await knex('permissions_roles').insert({id: ObjectId().toHexString(), role_id: existingRole.id, permission_id: ObjectId().toHexString()});
-            await knex('roles_users').insert({id: ObjectId().toHexString(), role_id: existingRole.id, user_id: ObjectId().toHexString()});
+      await runUpMigration(knex, utils.addRole(role));
 
-            const runDownMigration = await runUpMigration(knex, utils.removeRole(role));
-
-            assert.equal(await knex('roles').where({name: role.name}).first(), undefined);
-            assert.equal(await knex('api_keys').where({role_id: existingRole.id}).first(), undefined);
-            assert.equal(await knex('permissions_roles').where({role_id: existingRole.id}).first(), undefined);
-            assert.equal(await knex('roles_users').where({role_id: existingRole.id}).first(), undefined);
-
-            await runDownMigration();
-            const restoredRole = await knex('roles').where({name: role.name}).first();
-            assert.equal(restoredRole.description, role.description);
-        });
-
-        it('Does nothing when the role does not exist', async function () {
-            const knex = await setupRolesDb();
-
-            await runUpMigration(knex, utils.removeRole(role));
-
-            assert.equal(await knex('roles').where({name: role.name}).first(), undefined);
-        });
+      const roles = await knex('roles').where({ name: role.name });
+      assert.equal(roles.length, 1);
+      assert.equal(roles[0].description, 'Existing description');
     });
+  });
+
+  describe('removeRole', function () {
+    it('Removes the role and its relationships, then restores the role on rollback', async function () {
+      const knex = await setupRolesDb();
+      await runUpMigration(knex, utils.addRole(role));
+      const existingRole = await knex('roles').where({ name: role.name }).first();
+
+      await knex('api_keys').insert({ id: ObjectId().toHexString(), role_id: existingRole.id });
+      await knex('permissions_roles').insert({
+        id: ObjectId().toHexString(),
+        role_id: existingRole.id,
+        permission_id: ObjectId().toHexString(),
+      });
+      await knex('roles_users').insert({
+        id: ObjectId().toHexString(),
+        role_id: existingRole.id,
+        user_id: ObjectId().toHexString(),
+      });
+
+      const runDownMigration = await runUpMigration(knex, utils.removeRole(role));
+
+      assert.equal(await knex('roles').where({ name: role.name }).first(), undefined);
+      assert.equal(await knex('api_keys').where({ role_id: existingRole.id }).first(), undefined);
+      assert.equal(
+        await knex('permissions_roles').where({ role_id: existingRole.id }).first(),
+        undefined,
+      );
+      assert.equal(
+        await knex('roles_users').where({ role_id: existingRole.id }).first(),
+        undefined,
+      );
+
+      await runDownMigration();
+      const restoredRole = await knex('roles').where({ name: role.name }).first();
+      assert.equal(restoredRole.description, role.description);
+    });
+
+    it('Does nothing when the role does not exist', async function () {
+      const knex = await setupRolesDb();
+
+      await runUpMigration(knex, utils.removeRole(role));
+
+      assert.equal(await knex('roles').where({ name: role.name }).first(), undefined);
+    });
+  });
 });
 
 describe('migrations/utils/settings', function () {


### PR DESCRIPTION
## What changed

- added reusable `addRole` and `removeRole` transactional migration helpers
- made role removal clean up related API keys, permission assignments, and user assignments before deleting the role
- updated the legacy Explore removal migration to use `removeRole`
- added focused tests for creation, idempotency, relationship cleanup, and rollback recreation

## Why

Role creation had been duplicated across migrations, while the Explore removal migration introduced the first forward role deletion. Keeping the lifecycle behavior in shared helpers makes future role migrations consistent and keeps the lossy relationship cleanup explicit in one place.

`removeRole` restores the role definition during rollback, but deliberately does not restore deleted API keys or role assignments because those relationships cannot be reconstructed safely.

## Testing

- `pnpm build`
- `pnpm test:single test/unit/server/data/migrations/utils.test.js`
- `pnpm exec vitest -c vitest.config.db.ts test/integration/migrations/migration.test.js --run`
- focused ESLint checks for changed files
- pre-commit dependency-cruiser, secret, submodule, and changeset checks
