### PR TITLE
Added error handling guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,10 @@ To contribute or add translations, see
 adding translatable product copy, see the
 [internationalization guide](practices/internationalization.md).
 
+The [error handling guide](practices/error-handling.md) explains how to design
+failure states for logs, APIs, and user interfaces without exposing raw
+technical errors.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/practices/error-handling.md
+++ b/docs/practices/error-handling.md
@@ -1,165 +1,215 @@
 # Error Handling
 
-> Our preferred fallback message is: **“An unexpected error occurred, please
-> try again.”**
+Errors are part of the product experience. Design them with the same care as
+the success and loading states around them. A person using Ghost should never
+see an error that has simply bubbled up from code.
 
-Ghost is complex software, a lot of things can go wrong, and they often do. For
-our customers and users, how we handle errors when things go wrong is a huge
-part of their experience.
+Our preferred fallback message is:
 
-Well handled errors can be a positive experience, poorly handled errors are a
-terrible experience. Therefore all errors that a user could ever see should be
-carefully crafted. Users should never see errors that have bubbled up from code.
+> An unexpected error occurred, please try again.
+
+Use that fallback when there is no safe, useful message. A specific recovery
+path is better whenever the application understands what went wrong.
 
 ## Error scenarios
 
-There are three scenarios in which a user of our systems could encounter an
-error:
+There are three places where people encounter errors:
 
-1. **Logs** - users who are accessing logs are likely technical. They're looking
-   for all the dirty details of what went wrong, so it's safe to include those
-   here. Still no one looks at logs for fun, the reader is trying to solve a
-   problem, we should try to help them.
-2. **API responses** - users who see API responses are probably developers, or
-   more technical people. As they're interacting with a technical system, there
-   is more tolerance and expectation for technical details in errors. Still,
-   when something is wrong, the aim is to inform the viewer how to solve the
-   problem.
-3. **User interfaces** - Admin, Portal, even Ghost CLI are user interfaces. The
-   users here are assumed to be non-technical, so errors here should be very
-   well considered, designed even, to tell the user what they can do next to
-   solve the problem. Technical details should be hidden unless we make
-   deliberate exceptions.
+1. **Logs** are for people investigating a failure. Include the technical detail
+   needed to find and solve the problem: the original error, stack, error ID,
+   and relevant context. Logs should still help the reader understand what to do
+   next.
+2. **API responses** are for code and developers. Return a consistent status and
+   structured error so callers can decide whether to retry, change the request,
+   or surface a failure. Include enough information to solve the problem without
+   exposing secrets or unsafe dependency details.
+3. **User interfaces** are for people trying to complete a task. Admin, Portal,
+   and Ghost CLI own the whole interaction: success, waiting, recovery, and
+   failure. Tell the person what happened in their terms and what they can do
+   next. Hide technical detail unless there is a deliberate reason to show it.
 
-For example, as a developer writing code, I make an API request to create a
-post. The API responds “error: post creation failed”. As a developer, I now
-decide what to do with that information programmatically. I can try again
-automatically, fix a bug in my code, or hunt in the logs for more detail.
+The same failure should not necessarily use the same copy in all three places.
+An API consumer may need a type and code; someone publishing a post needs to
+know whether to retry, fix an input, or get help.
 
 As a user navigating a product, I click a button to create a new post. The app
-I'm using should understand that I have no recourse. The code that handles what
-happens when this button is clicked is responsible for triggering the success
-flow, the waiting state, or an error state such as “Post could not be published,
-[retry?] or [get help]”. The Admin app is responsible for my experience, whether
-I'm succeeding, waiting, or failing. That's the UX.
+I'm using should understand that I have no technical recourse. The code handling
+that interaction is responsible for triggering the success flow, the waiting
+state, or a useful error state such as “Post could not be published” with an
+option to retry or get help. Admin is responsible for my experience whether I'm
+succeeding, waiting, or failing. That's the UX.
 
 ## Ghost's error format
 
-Since Ghost's inception, we've used our own format for displaying errors. Each
-error is made up of three main parts:
+Ghost errors have three main fields for explaining a failure:
 
-1. **Message** - the main message explaining what has gone wrong.
-2. **Context** - any details, the why or where, or the original message from a
-   third party.
-3. **Help** - either a step to take or a URL to visit to solve the problem.
+1. **`message`** is the main summary of what went wrong. It should make sense on
+   its own and describe the failed Ghost operation, not repeat a raw database,
+   JavaScript, network, or third-party error.
+2. **`context`** explains why or where the operation failed. Decode the
+   lower-level failure into useful, specific context rather than copying an
+   unknown error message. Do not include secrets, stack traces, or unsafe
+   dependency details.
+3. **`help`** tells the reader what to do next. Use a concrete next step or a
+   stable URL that explains how to solve the problem. Do not add generic help
+   text that gives the reader no useful action.
 
-### Logging
+When deliberately constructing a server error, consider all three fields. Set
+each one when it adds distinct, useful information; do not make `context` or
+`help` repeat the `message`.
 
-A properly curated error in logs gives a full message, context, and help. It has
-an ID from the API and a code, making it easier to find, and includes the stack
-trace.
+Ghost errors can also include:
 
-### API
+- `code` for a specific, stable case a caller needs to detect.
+- `property` for the input associated with a validation error.
+- `errorDetails` for structured details required by a particular caller.
+- `err` to retain the original error and stack for diagnosis.
 
-The same error returned from the API would look like this:
+### Logs
+
+A properly curated error in logs includes the full `message`, `context`, and
+`help`, where available. It also includes the original error and stack, plus an
+ID and readable code when those exist, so someone can find and diagnose the
+failure.
+
+### API responses
+
+Ghost's JSON API renderer returns an `errors` array:
 
 ```json
 {
     "errors": [{
         "message": "The email service received an error and was unable to send.",
         "context": "The email provider rejected the request.",
-        "help": "https://ghost.org/docs/newsletters/#bulk-email-configuration",
         "type": "EmailError",
+        "details": null,
+        "property": null,
+        "help": "https://ghost.org/docs/newsletters/#bulk-email-configuration",
         "code": "BULK_EMAIL_SEND_FAILED",
-        "id": "211167d0-6519-11ed-90e5-49976581c6bb",
-        "property": null
+        "id": "...",
+        "ghostErrorCode": null
     }]
 }
 ```
 
-### User interface
+The HTTP status and `type` describe the general failure. Use `code` for a
+specific case. Do not make programmatic decisions by comparing message text.
 
-The user interface should not be showing these messages. In almost all cases,
-we want to make careful choices about what we show the user, based on the error,
-the context, what recourse the user has, and what recourse the application has
-to help fix the problem.
+Unexpected errors are wrapped before the API response is rendered. The API uses
+the generic fallback for the message while retaining the original error for
+diagnosis.
 
-## Designing errors
+### User interfaces
 
-### Returning errors from the API or server
+Do not show the API response by default. Choose what to show based on the error,
+the context, what the person can do next, and what the application can do to
+recover. The UI is responsible for turning a technical failure into a designed
+experience.
 
-The `@tryghost/errors` package has tooling for creating errors in Ghost's error
-format, and where we need it we should add more. Whenever you're actively
-choosing to create an error in server-side code, it should use this format.
+## Returning errors from the server
+
+When server code deliberately creates an error, use the classes from
+`@tryghost/errors`. Choose the class that represents the failure; it supplies
+the general error type and HTTP status.
 
 ```javascript
-const ghostError = new errors.EmailError({
+throw new errors.EmailError({
     err,
-    message: tpl(messages.error),
-    context: `Email provider error ${err.error.status}: ${err.error.details}`,
+    message: tpl(messages.sendFailed),
+    context: tpl(messages.providerRejectedRequest),
     help: 'https://ghost.org/docs/newsletters/#bulk-email-configuration',
     code: 'BULK_EMAIL_SEND_FAILED'
 });
 ```
 
-- Message, context, and help are all set.
-- Context is set by actively decoding the error from the email provider.
-- We do not include the full original message from the provider; we process the
-  error into our format.
-- We add a code that is readable and searchable.
+In this example:
 
-Error strings should be kept in a `messages` object and rendered with `tpl()`.
+- `message` describes the failed Ghost operation.
+- `context` is set by actively decoding the email provider's response.
+- `help` points to the configuration needed to resolve the failure.
+- `err` retains the original provider error for logs and diagnosis.
+- `code` gives callers a readable, searchable way to identify the case.
 
-### Showing errors to users
+Pass the original failure as `err`, but do not copy raw database errors, stack
+traces, secrets, or unknown third-party responses into `message`, `context`, or
+`help`.
 
-When we are designing interactions in Admin, Portal, or any other UI, we should
-for the most part handle any and all errors and do something specific with
-them—for example retrying, or writing a custom error message to display to the
-user.
+Keep reusable server error strings in a `messages` object and render them with
+`tpl()`.
 
-Let's take an example of saving a tier. We could get any of the following errors
-from the API:
+## Showing errors in a user interface
 
-1. A validation error with specifics.
-2. Tier not found (404).
-3. A host limit error if the user has reached the maximum number of tiers.
-4. Server down for maintenance.
-5. Other genuine, specific API errors.
-6. An auth error if the user logged out in a different tab.
-7. The API might not respond at all; we could get a network or timeout error.
-8. The API could be broken and return garbage.
+Start with the action the person was trying to complete:
 
-- For case 1, we should implement all validations in the UI and show our own
-  errors. If we are getting a validation error from the API, something went very
-  wrong. We should have a special custom error message for this case, and detect
-  and fix these issues through error monitoring.
-- For cases 2–5, we may already return specific and carefully crafted errors
-  from the API. When we know this is true and can detect these based on the error
-  type, it is acceptable to display the API error if custom handling does not
-  make more sense. We need to review these regularly to ensure other messages
-  have not crept into a trusted error type.
-- Case 6 is special: the application should have a dedicated workflow for
-  logged-out users.
-- For case 7, handle errors while interacting with the API with a retry, then
-  fall back to a generic message.
-- For case 8, if we do not trust the API message, replace it with the generic
-  fallback.
+- Can the application recover or retry without asking them to do anything?
+- Is there a validation problem the UI can explain beside the relevant field?
+- Is there a dedicated workflow for the case, such as re-authentication,
+  maintenance, or a version mismatch?
+- Can the person retry safely? If so, make retrying easy.
+- If they cannot resolve it themselves, is there a useful way to get help?
 
-When we decide to show an error message to the user, we should ensure it has
-been designed.
+Write a specific message after deciding the recovery behavior. Error copy
+without a recovery path is rarely enough.
 
-If we need to show a generic error message but the underlying error has an ID
-from the server, output that error to the console.
+For example, saving a tier could fail because:
 
-## Direction
+1. The input does not pass validation.
+2. The tier no longer exists.
+3. The site has reached its tier limit.
+4. The server is down for maintenance.
+5. The API returns another known, specific error.
+6. The person logged out in another tab.
+7. The request times out or the network is unavailable.
+8. The API returns an unknown or malformed response.
 
-- Only show API errors in a UI when we are certain they are safe and useful to
-  show.
-- Reduce reliance on catch-all API error notifications in favour of custom error
-  handling and recovery for specific workflows.
-- Unify top-level error handling into a sensible system of fallbacks.
-- Never render an error that came from another part of the code we do not trust.
+Handle each group deliberately:
 
-The preferred generic fallback is:
+- **Validation:** implement expected validation in the UI and show the error
+  beside the relevant field. If normal UI input causes an API validation error,
+  treat that as a gap in the interaction and use a designed fallback.
+- **Known API failures:** handle known cases such as a missing tier, a limit, or
+  maintenance with a specific recovery path. Only show an API message when the
+  endpoint and exact error case deliberately return user-facing copy.
+- **Authentication:** use the application's dedicated logged-out or
+  re-authentication workflow.
+- **Network failures:** retry when it is safe, then show the generic fallback if
+  the request still cannot complete.
+- **Unknown failures:** do not trust the response. Show the generic fallback and
+  retain or report the underlying error for diagnosis.
 
-> An unexpected error occurred, please try again.
+Prefer an explicit decision at the workflow boundary:
+
+```javascript
+if (isKnownRecoverableError(error)) {
+    showRecoveryFor(error);
+} else if (isTrustedUserFacingError(error)) {
+    showError(error.message);
+} else {
+    showError('An unexpected error occurred, please try again.');
+}
+```
+
+Do not assume every error of a broad type is safe because one endpoint returns a
+carefully written example. Codes are more precise than message matching when a
+caller must identify a specific case.
+
+Some legacy UI paths still pass API messages through catch-all helpers such as
+Ember Admin's `showAPIError`. Treat those as existing behavior, not the pattern
+for new work. New and updated interactions should handle expected errors close
+to the workflow.
+
+Translate user-facing error copy using the
+[internationalization guide](internationalization.md).
+
+## Testing error handling
+
+Test the designed behavior at each relevant boundary:
+
+- Server tests assert the error type, HTTP status, code, and any fields the
+  caller relies on.
+- UI tests cover the expected recovery path, any deliberately trusted API
+  message, and the generic fallback for an unknown or malformed error.
+- Tests prove that raw technical errors do not reach the UI.
+
+The goal is not only to prove that an error appears. Prove that the person can
+understand what happened and take the intended next step.

--- a/docs/practices/error-handling.md
+++ b/docs/practices/error-handling.md
@@ -1,0 +1,165 @@
+# Error Handling
+
+> Our preferred fallback message is: **“An unexpected error occurred, please
+> try again.”**
+
+Ghost is complex software, a lot of things can go wrong, and they often do. For
+our customers and users, how we handle errors when things go wrong is a huge
+part of their experience.
+
+Well handled errors can be a positive experience, poorly handled errors are a
+terrible experience. Therefore all errors that a user could ever see should be
+carefully crafted. Users should never see errors that have bubbled up from code.
+
+## Error scenarios
+
+There are three scenarios in which a user of our systems could encounter an
+error:
+
+1. **Logs** - users who are accessing logs are likely technical. They're looking
+   for all the dirty details of what went wrong, so it's safe to include those
+   here. Still no one looks at logs for fun, the reader is trying to solve a
+   problem, we should try to help them.
+2. **API responses** - users who see API responses are probably developers, or
+   more technical people. As they're interacting with a technical system, there
+   is more tolerance and expectation for technical details in errors. Still,
+   when something is wrong, the aim is to inform the viewer how to solve the
+   problem.
+3. **User interfaces** - Admin, Portal, even Ghost CLI are user interfaces. The
+   users here are assumed to be non-technical, so errors here should be very
+   well considered, designed even, to tell the user what they can do next to
+   solve the problem. Technical details should be hidden unless we make
+   deliberate exceptions.
+
+For example, as a developer writing code, I make an API request to create a
+post. The API responds “error: post creation failed”. As a developer, I now
+decide what to do with that information programmatically. I can try again
+automatically, fix a bug in my code, or hunt in the logs for more detail.
+
+As a user navigating a product, I click a button to create a new post. The app
+I'm using should understand that I have no recourse. The code that handles what
+happens when this button is clicked is responsible for triggering the success
+flow, the waiting state, or an error state such as “Post could not be published,
+[retry?] or [get help]”. The Admin app is responsible for my experience, whether
+I'm succeeding, waiting, or failing. That's the UX.
+
+## Ghost's error format
+
+Since Ghost's inception, we've used our own format for displaying errors. Each
+error is made up of three main parts:
+
+1. **Message** - the main message explaining what has gone wrong.
+2. **Context** - any details, the why or where, or the original message from a
+   third party.
+3. **Help** - either a step to take or a URL to visit to solve the problem.
+
+### Logging
+
+A properly curated error in logs gives a full message, context, and help. It has
+an ID from the API and a code, making it easier to find, and includes the stack
+trace.
+
+### API
+
+The same error returned from the API would look like this:
+
+```json
+{
+    "errors": [{
+        "message": "The email service received an error and was unable to send.",
+        "context": "The email provider rejected the request.",
+        "help": "https://ghost.org/docs/newsletters/#bulk-email-configuration",
+        "type": "EmailError",
+        "code": "BULK_EMAIL_SEND_FAILED",
+        "id": "211167d0-6519-11ed-90e5-49976581c6bb",
+        "property": null
+    }]
+}
+```
+
+### User interface
+
+The user interface should not be showing these messages. In almost all cases,
+we want to make careful choices about what we show the user, based on the error,
+the context, what recourse the user has, and what recourse the application has
+to help fix the problem.
+
+## Designing errors
+
+### Returning errors from the API or server
+
+The `@tryghost/errors` package has tooling for creating errors in Ghost's error
+format, and where we need it we should add more. Whenever you're actively
+choosing to create an error in server-side code, it should use this format.
+
+```javascript
+const ghostError = new errors.EmailError({
+    err,
+    message: tpl(messages.error),
+    context: `Email provider error ${err.error.status}: ${err.error.details}`,
+    help: 'https://ghost.org/docs/newsletters/#bulk-email-configuration',
+    code: 'BULK_EMAIL_SEND_FAILED'
+});
+```
+
+- Message, context, and help are all set.
+- Context is set by actively decoding the error from the email provider.
+- We do not include the full original message from the provider; we process the
+  error into our format.
+- We add a code that is readable and searchable.
+
+Error strings should be kept in a `messages` object and rendered with `tpl()`.
+
+### Showing errors to users
+
+When we are designing interactions in Admin, Portal, or any other UI, we should
+for the most part handle any and all errors and do something specific with
+them—for example retrying, or writing a custom error message to display to the
+user.
+
+Let's take an example of saving a tier. We could get any of the following errors
+from the API:
+
+1. A validation error with specifics.
+2. Tier not found (404).
+3. A host limit error if the user has reached the maximum number of tiers.
+4. Server down for maintenance.
+5. Other genuine, specific API errors.
+6. An auth error if the user logged out in a different tab.
+7. The API might not respond at all; we could get a network or timeout error.
+8. The API could be broken and return garbage.
+
+- For case 1, we should implement all validations in the UI and show our own
+  errors. If we are getting a validation error from the API, something went very
+  wrong. We should have a special custom error message for this case, and detect
+  and fix these issues through error monitoring.
+- For cases 2–5, we may already return specific and carefully crafted errors
+  from the API. When we know this is true and can detect these based on the error
+  type, it is acceptable to display the API error if custom handling does not
+  make more sense. We need to review these regularly to ensure other messages
+  have not crept into a trusted error type.
+- Case 6 is special: the application should have a dedicated workflow for
+  logged-out users.
+- For case 7, handle errors while interacting with the API with a retry, then
+  fall back to a generic message.
+- For case 8, if we do not trust the API message, replace it with the generic
+  fallback.
+
+When we decide to show an error message to the user, we should ensure it has
+been designed.
+
+If we need to show a generic error message but the underlying error has an ID
+from the server, output that error to the console.
+
+## Direction
+
+- Only show API errors in a UI when we are certain they are safe and useful to
+  show.
+- Reduce reliance on catch-all API error notifications in favour of custom error
+  handling and recovery for specific workflows.
+- Unify top-level error handling into a sensible system of fallbacks.
+- Never render an error that came from another part of the code we do not trust.
+
+The preferred generic fallback is:
+
+> An unexpected error occurred, please try again.


### PR DESCRIPTION
## Summary

- move the public principles and UX intent of the existing error handling guide into the repository, preserving the source as a reviewable first commit
- update the guide separately against current server and UI behavior while keeping errors as a product design surface
- document the three audiences, recovery-first UI design, trusted API-message boundary, Ghost error shape, and relevant tests

## Testing

- [x] `pnpm --filter @tryghost/portal test -- errors.test.js`
- [x] `pnpm nx run ghost-admin:test -- 1 --file-path=tests/unit/services/notifications-test.js`
- [x] `pnpm lint:docs`
- [x] `git diff --check`
