### PR TITLE
Added Ghost development setup for Amp orbs

### DIFF
--- a/.agents/bin/docker
+++ b/.agents/bin/docker
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sudo --preserve-env=PUBLIC_URL /usr/bin/docker "$@"

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! amp orb service status docker >/dev/null 2>&1 || ! amp orb service status ghost >/dev/null 2>&1; then
+if ! systemctl is-active --quiet amp-svc-docker.service || ! systemctl is-active --quiet amp-svc-ghost.service; then
     amp orb services ensure
 fi

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! amp orb service status docker >/dev/null 2>&1 || ! amp orb service status ghost >/dev/null 2>&1; then
+    amp orb services ensure
+fi

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node_version="$(cat .node-version)"
+node_dir="$HOME/.local/node-v${node_version}-linux-x64"
+
+if [[ ! -x "$node_dir/bin/node" ]]; then
+    archive="/tmp/node-v${node_version}-linux-x64.tar.xz"
+    curl -fsSLo "$archive" "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.xz"
+    mkdir -p "$HOME/.local"
+    tar -xJf "$archive" -C "$HOME/.local"
+    rm -f "$archive"
+fi
+
+export PATH="$node_dir/bin:$PATH"
+corepack enable --install-directory "$node_dir/bin"
+
+profile_marker="# Ghost orb Node.js"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+    cat >> "$HOME/.bash_profile" <<EOF
+
+$profile_marker
+export PATH="$node_dir/bin:\$PATH"
+EOF
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+
+pnpm setup

--- a/.agents/setup
+++ b/.agents/setup
@@ -16,15 +16,20 @@ export PATH="$node_dir/bin:$PATH"
 corepack enable --install-directory "$node_dir/bin"
 
 profile_marker="# Ghost orb Node.js"
-if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+profile_export="export PATH=\"$node_dir/bin:\$PATH\""
+if grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+    sed -i "/^${profile_marker}$/ { n; c\\
+$profile_export
+    }" "$HOME/.bash_profile"
+else
     cat >> "$HOME/.bash_profile" <<EOF
 
 $profile_marker
-export PATH="$node_dir/bin:\$PATH"
+$profile_export
 EOF
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
+if ! /usr/bin/docker compose version >/dev/null 2>&1; then
     sudo install -m 0755 -d /etc/apt/keyrings
     sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
     sudo chmod a+r /etc/apt/keyrings/docker.asc

--- a/.agents/setup
+++ b/.agents/setup
@@ -14,6 +14,7 @@ fi
 
 export PATH="$node_dir/bin:$PATH"
 corepack enable --install-directory "$node_dir/bin"
+pnpm setup
 
 profile_marker="# Ghost orb Node.js"
 profile_export="export PATH=\"$node_dir/bin:\$PATH\""
@@ -37,5 +38,3 @@ if ! /usr/bin/docker compose version >/dev/null 2>&1; then
     sudo apt-get update
     sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 fi
-
-pnpm setup

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,16 @@
+services:
+  docker:
+    command: sudo dockerd --group root
+
+  ghost:
+    command: |
+      export PATH="$PWD/.agents/bin:$HOME/.local/node-v$(cat .node-version)-linux-x64/bin:$PATH"
+      until docker info >/dev/null 2>&1; do sleep 1; done
+      export DEV_COMPOSE_FILES="-f compose.dev.orb.yaml"
+      export GHOST_URL="$PUBLIC_URL"
+      unset PORT
+      exec pnpm dev
+    port: 2370
+    portal:
+      title: Ghost development
+      description: Full source environment with Admin HMR, backend reloads, MySQL, Redis, and Mailpit.

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -5,7 +5,15 @@ services:
   ghost:
     command: |
       export PATH="$PWD/.agents/bin:$HOME/.local/node-v$(cat .node-version)-linux-x64/bin:$PATH"
-      until docker info >/dev/null 2>&1; do sleep 1; done
+      attempts=0
+      until docker info >/dev/null 2>&1; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge 60 ]; then
+          echo "Docker did not become ready after 60 seconds" >&2
+          exit 1
+        fi
+        sleep 1
+      done
       export DEV_COMPOSE_FILES="-f compose.dev.orb.yaml"
       export GHOST_URL="$PUBLIC_URL"
       unset PORT

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ yalc.lock
 # useful for keeping local plans etc
 /ai
 
+# Amp generates thread-specific portal state at runtime
+/.amp/portals/
+
 # direnv environment loader files
 .envrc
 

--- a/compose.dev.orb.yaml
+++ b/compose.dev.orb.yaml
@@ -1,0 +1,8 @@
+services:
+  ghost-dev:
+    environment:
+      url: ${PUBLIC_URL}
+
+  ghost-dev-gateway:
+    ports: !override
+      - "2370:80"


### PR DESCRIPTION
Any future Amp thread that spawns an orb in this repo gets a fully working Ghost development environment - Node, pnpm, Docker, MySQL, Redis, Mailpit, HMR - provisioned and running automatically, with a public URL to access it. No manual setup, no SSH, no local machine required.

https://ampcode.com/what-are-orbs#what-orbs-are
