### PR TITLE
Improved internal package migration pilot safeguards

### DIFF
--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -27,8 +27,16 @@ Ghost worktree from the freshly fetched `origin/main`.
 
 Run history-changing commands individually or in a fail-fast shell. A failed
 `git worktree add` must not be followed by `git subtree add` in whichever
-checkout happens to be current. Stop if the destination branch or path already
-exists and inspect that state rather than reusing it implicitly.
+checkout happens to be current. Before choosing a branch or path, list existing
+worktrees and matching local and remote branches. Use a migration-specific slug,
+for example `codex/import-<package>-from-<source>`, rather than a generic name.
+
+If the destination branch or path already exists, stop and inspect its
+cleanliness, base, divergence, source split and attached worktree. Do not mutate,
+delete or silently reuse it. Present the evidence and ask the user whether to
+resume, preserve and supersede, or remove it when more than one choice is
+reasonable. A previous attempt can contain valid unmerged history even when its
+remote branch is gone.
 
 Before importing, record and compare the destination `HEAD` and `origin/main`;
 they must match. Recheck the first parent immediately after the subtree commit.
@@ -60,6 +68,11 @@ as evidence of continued installation needs; even then, they do not establish
 an independently supported API. Record the evidence and confidence behind the
 ownership decision; stop and ask if current support expectations remain
 unclear.
+
+Run registry-only `npm view` commands from a neutral temporary directory. A
+repository's `devEngines` policy can reject the host Node version before npm
+contacts the registry, which is unrelated to the package metadata audit. Record
+that failure separately if using a neutral directory does not resolve it.
 
 ## Produce these work products in order
 
@@ -121,6 +134,14 @@ tip, the consumer resolves the workspace package through its production import
 path, package lint and tests pass through Nx, relevant consumer tests pass, the
 full build passes, and the Ghost archive contains the internal package. Record
 the exact commit IDs and commands in the handoff.
+
+For a pilot or first use, include a structured gap report in the handoff:
+
+- `Observed`: the exact failure or ambiguity and the command/state that exposed it;
+- `Worked around`: the safe action taken, without hiding the original gap;
+- `Skill change`: the concrete instruction, preflight or script improvement;
+- `Tooling change`: anything that cannot be solved within this repository;
+- `Confidence`: high, medium or low, with unresolved evidence called out.
 
 ## 2. Merge the import without rewriting history
 

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -4,9 +4,22 @@ Read this reference before creating the Ghost import PR.
 
 ## Create package-only source history
 
-Work from an up-to-date, clean clone of the source repository. Use its actual
-default branch and a temporary branch name that cannot be confused with a
-product branch.
+Work from an up-to-date, clean, full clone of the source repository. Shallow and
+partial clones can complete `git subtree split` while still failing later when
+Ghost fetches the split, because the local source cannot serve promised objects.
+Reject them before splitting:
+
+```bash
+set -euo pipefail
+
+test "$(git rev-parse --is-shallow-repository)" = "false"
+test -z "$(git config --local --get extensions.partialClone || true)"
+```
+
+If either check fails, create a fresh full clone without `--depth`,
+`--filter` or sparse/partial clone options. Use the source's actual default
+branch and a temporary branch name that cannot be confused with a product
+branch.
 
 `git subtree split` may inspect thousands of commits and run for several
 minutes. Use `--quiet` in agent or CI-style runners so its progress stream does
@@ -41,14 +54,25 @@ excluding unrelated source-repository paths.
 
 ## Attach the history to Ghost
 
-Create or enter a dedicated Ghost worktree, then verify its branch, cleanliness,
-base and empty destination before attaching history:
+Before creating the worktree, inspect collisions rather than discovering them
+halfway through the import:
+
+```bash
+git worktree list --porcelain
+git branch --list 'codex/import-<package>*'
+git branch --remotes --list 'origin/codex/import-<package>*'
+```
+
+If a match exists, record its worktree, cleanliness, base/divergence, imported
+split and remote state. Do not delete or overwrite it without an explicit user
+decision. Otherwise create or enter a dedicated Ghost worktree, then verify its
+branch, cleanliness, base and empty destination before attaching history:
 
 ```bash
 set -euo pipefail
 
 test "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)"
-test "$(git branch --show-current)" = "codex/import-<package>"
+test "$(git branch --show-current)" = "codex/import-<package>-from-<source>"
 test -z "$(git status --porcelain)"
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 test ! -e "packages/<ghost-directory>"
@@ -88,14 +112,16 @@ git merge-base --is-ancestor "$source_split_tip" HEAD
 
 git show --no-patch --format='%H%nparents: %P%n%B' "$subtree_commit"
 git log --graph --oneline --decorate --all --max-count=40
-git log --oneline -- packages/<ghost-directory>/path/to/representative-file
+git log --full-history --oneline -- packages/<ghost-directory>/path/to/representative-file
 git log --oneline "$source_split_tip" -- path/to/representative-file
 ```
 
 The subtree commit must have two parents: its first parent must equal the
 recorded Ghost base and its second parent must equal the recorded split tip.
-Checking the prefixed destination path and unprefixed split path separately is
-more reliable around merge boundaries than relying only on `--follow`.
+Checking the prefixed destination path with `--full-history` and the unprefixed
+split path separately is more reliable around merge boundaries than relying on
+ordinary path history or `--follow`, either of which may show only the subtree
+merge.
 
 The Admin API schema migration from TryGhost/SDK is a known-good example:
 

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -58,6 +58,7 @@ Before creating the worktree, inspect collisions rather than discovering them
 halfway through the import:
 
 ```bash
+git fetch --prune origin
 git worktree list --porcelain
 git branch --list 'codex/import-<package>*'
 git branch --remotes --list 'origin/codex/import-<package>*'
@@ -105,15 +106,24 @@ source_split_tip="<recorded-source-split-tip>"
 subtree_commit=$(git rev-parse HEAD)
 ghost_parent=$(git rev-parse HEAD^1)
 imported_parent=$(git rev-parse HEAD^2)
+source_path="path/to/representative-file"
+destination_path="packages/<ghost-directory>/$source_path"
 
 test "$ghost_parent" = "$(git rev-parse origin/main)"
 test "$imported_parent" = "$source_split_tip"
 git merge-base --is-ancestor "$source_split_tip" HEAD
 
+source_history=$(git log --full-history --format=%H "$source_split_tip" -- "$source_path")
+destination_history=$(git log --full-history --format=%H -- "$destination_path")
+test -n "$source_history"
+test -n "$destination_history"
+test "$(git rev-parse "$source_split_tip:$source_path")" = \
+  "$(git rev-parse "$subtree_commit:$destination_path")"
+
 git show --no-patch --format='%H%nparents: %P%n%B' "$subtree_commit"
 git log --graph --oneline --decorate --all --max-count=40
-git log --full-history --oneline -- packages/<ghost-directory>/path/to/representative-file
-git log --oneline "$source_split_tip" -- path/to/representative-file
+git log --full-history --oneline -- "$destination_path"
+git log --full-history --oneline "$source_split_tip" -- "$source_path"
 ```
 
 The subtree commit must have two parents: its first parent must equal the
@@ -121,7 +131,9 @@ recorded Ghost base and its second parent must equal the recorded split tip.
 Checking the prefixed destination path with `--full-history` and the unprefixed
 split path separately is more reliable around merge boundaries than relying on
 ordinary path history or `--follow`, either of which may show only the subtree
-merge.
+merge. Requiring non-empty histories and equal blob IDs makes a missing or
+mismatched representative file stop the import before integration edits obscure
+the source state.
 
 The Admin API schema migration from TryGhost/SDK is a known-good example:
 


### PR DESCRIPTION
## Summary

- Harden the internal-package migration skill based on the API framework cold-start pilot.
- Reject partial or shallow source clones before history splitting, and inspect branch/worktree collisions before import.
- Add reliable history verification, neutral npm metadata checks, unique branch naming, and a structured pilot-gap handoff.

## Testing

- [x] `node --test scripts/test/check-agent-skill-links.test.js`
- [x] `pnpm lint:agent-skills`
- [x] `bash -n .agents/skills/migrate-internal-package/scripts/merge-history-pr`
- [x] `git diff --check`

## Scope

- Documentation-only skill hardening; no package migration or repository settings are changed.
