### PR TITLE
Fixed renovate config issues

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,13 +42,17 @@
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,
-    // Keep every open Renovate branch current, including updates that require
-    // human review. The shared preset uses `rebaseWhen: automerging`, which
-    // Renovate resolves to `never` whenever a package rule disables automerge.
-    // Those PRs then conflict with main indefinitely and occupy the open-PR cap
-    // until somebody manually requests a rebase. Runner scheduling below still
-    // limits when the resulting branch updates and CI runs can happen.
-    "rebaseWhen": "behind-base-branch",
+    // Branch protection does not require up-to-date branches (the required
+    // status checks ruleset has strict: false), so a green-but-behind branch
+    // is still mergeable. Rebasing on every `main` commit therefore buys
+    // nothing and costs a force-push plus a full CI re-run per branch, which
+    // is what stopped branches from ever being green *and* current inside an
+    // automerge window. "conflicted" rebases only when a branch genuinely
+    // conflicts — in practice whenever another Renovate PR lands a
+    // pnpm-lock.yaml change, which is exactly when it's needed. It also keeps
+    // needs:review PRs current, unlike the preset's "automerging", which
+    // Renovate resolves to "never" wherever a package rule disables automerge.
+    "rebaseWhen": "conflicted",
     // Soak every dependency update for 72 hours before opening a PR. This guards
     // against compromised publishes (malicious version yanked within a few hours)
     // and against unstable releases that get hotfixed shortly after publish.
@@ -82,8 +86,6 @@
     // self-hosted workflow that means a CI-storm of force-pushes across all
     // open Renovate PRs during the workday. Setting `updateNotScheduled:
     // false` keeps existing branch maintenance inside the same windows.
-    // Existing branches can still be maintained outside the normal creation
-    // schedule when the workflow switches Renovate into cap-reached mode.
     "updateNotScheduled": false,
     "schedule": [
         // Run all weekend
@@ -91,15 +93,17 @@
         // Run on weekday evenings
         "* 23 * * 1-5",
         // Run on early weekday mornings (previous day 23:00 is already
-        // covered by the evening/weekend blocks above)
-        "* 0-4 * * 1-6"
+        // covered by the evening/weekend blocks above). Extends to 05:59 to
+        // absorb GitHub Actions scheduler drift — delayed ticks were landing
+        // outside the window and doing nothing.
+        "* 0-5 * * 1-6"
     ],
     "automergeSchedule": [
         // Allow automerge all weekend
         "* * * * 0,6",
-        // Allow automerge overnight on weekday evenings (11pm-4:59am UTC)
+        // Allow automerge overnight on weekday evenings (11pm-5:59am UTC)
         "* 23 * * 1-5",
-        "* 0-4 * * 1-6"
+        "* 0-5 * * 1-6"
     ],
     // Vulnerability alerts normally bypass Renovate's PR concurrency, hourly
     // PR, and schedule limits. Let them keep doing that so security fixes can
@@ -108,7 +112,10 @@
     "vulnerabilityAlerts": {
         "schedule": ["at any time"],
         "minimumReleaseAge": "3 days",
-        "rebaseWhen": "behind-base-branch",
+        // Same reasoning as the global `rebaseWhen` above: branches don't have
+        // to be current to merge, so rebasing a security PR on every `main`
+        // commit only delays the fix behind another CI cycle.
+        "rebaseWhen": "conflicted",
         "dependencyDashboardApproval": false,
         "labels": ["dependencies", "security"]
     },

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,8 +23,11 @@ on:
     # duration, giving each merge a fresh rebase + green CI window.
     #
     # Times are UTC; matches renovate.json5's `schedule` block.
-    # Weekday early-morning window (Mon-Sat 00:00-04:59 UTC)
-    - cron: '17 0-4 * * 1-6'
+    # Weekday early-morning window (Mon-Sat 00:00-05:59 UTC). Last tick is
+    # 03:47 rather than the end of the window: Actions has been delivering
+    # these up to ~70min late, so a later cron lands outside the window and
+    # wastes the freshest-CI opportunity of the night.
+    - cron: '47 0-3 * * 1-6'
     # Weekday evening window (Mon-Fri 23:00-23:59 UTC)
     - cron: '17 23 * * 1-5'
     # Weekend - every 2h is plenty; no automerge urgency, just batch creation
@@ -38,6 +41,12 @@ on:
         required: false
         default: false
         type: boolean
+      logLevel:
+        description: 'Renovate log level for this manual run'
+        required: false
+        default: 'info'
+        type: choice
+        options: [info, debug, trace]
 
 concurrency:
   group: renovate
@@ -81,9 +90,13 @@ jobs:
       #
       # Below the cap, restrict PR creation to the number of slots left. At or
       # above the cap, or when RENOVATE_MAINTENANCE_ONLY=true, force dashboard
-      # approval for new branches/PRs while allowing existing PR branches to
-      # keep updating outside the creation schedule. That gives us "rebase and
-      # merge the 10, but create no more."
+      # approval for new branches/PRs. Existing PRs keep updating and merging
+      # on the normal schedule. That gives us "rebase and merge the 10, but
+      # create no more."
+      #
+      # Deliberately does NOT force `updateNotScheduled: true` — that overrides
+      # renovate.json5's `false` and puts a full-fleet force-push in the middle
+      # of the workday, which is exactly what #28207 removed.
       - name: Configure Renovate PR cap
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -98,19 +111,24 @@ jobs:
             PR_CAP=10
           fi
 
+          # Exclude `needs:review` PRs: Renovate cannot merge them itself, so
+          # counting them lets a handful of parked updates hold the cap shut
+          # forever — the cap is only released by Renovate merging something.
           open_count=$(gh pr list \
             --repo "${{ github.repository }}" \
             --author "app/tryghost-renovate" \
             --state open \
-            --json number --jq 'length')
+            --limit 100 \
+            --json number,labels \
+            --jq '[.[] | select(any(.labels[].name; . == "needs:review") | not)] | length')
 
-          echo "Renovate has $open_count open PRs (cap: $PR_CAP)"
+          echo "Renovate has $open_count open PRs it can merge itself (cap: $PR_CAP)"
 
           if [ "$MAINTENANCE_ONLY" = "true" ]; then
-            force='{"dependencyDashboardApproval":true,"prCreation":"approval","updateNotScheduled":true,"vulnerabilityAlerts":{"dependencyDashboardApproval":false}}'
+            force='{"dependencyDashboardApproval":true,"prCreation":"approval","vulnerabilityAlerts":{"dependencyDashboardApproval":false}}'
             echo "::notice::RENOVATE_MAINTENANCE_ONLY=true. Running in maintenance-only mode: existing PRs may update/automerge, new PRs require dashboard approval."
           elif [ "$open_count" -ge "$PR_CAP" ]; then
-            force='{"dependencyDashboardApproval":true,"prCreation":"approval","updateNotScheduled":true,"vulnerabilityAlerts":{"dependencyDashboardApproval":false}}'
+            force='{"dependencyDashboardApproval":true,"prCreation":"approval","vulnerabilityAlerts":{"dependencyDashboardApproval":false}}'
             echo "::notice::Renovate is at or above the open PR cap. Running in maintenance-only mode: existing PRs may update/automerge, new PRs require dashboard approval."
           else
             remaining=$((PR_CAP - open_count))
@@ -130,7 +148,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
         env:
-          LOG_LEVEL: debug
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_REPOSITORY_CACHE: enabled
           RENOVATE_REPOSITORIES: TryGhost/Ghost
           # Ghost is already onboarded via Mend; don't open an onboarding PR.


### PR DESCRIPTION
no ref
- switch rebaseWhen to 'conflicted', removing the consistent rebase force-push cycle that led to PRs being stuck
- widen automerge window to allow for CI re-runs
- reduce Renovate log noise by default, allow debug logging on manual runs