### PR TITLE
Updated migration checklist: you don't need to test in SQLite

### DIFF
--- a/.github/workflows/migration-review.yml
+++ b/.github/workflows/migration-review.yml
@@ -44,7 +44,6 @@ jobs:
             - [ ]  Uses the correct utils
             - [ ]  Contains a minimal changeset
             - [ ]  Does not mix DDL/DML operations
-            - [ ]  Tested in MySQL and SQLite
 
             ### Schema changes
 


### PR DESCRIPTION
no ref

Ghost [dropped SQLite in production years ago][0]. Developers don't need to test migrations with SQLite.

This change should have no user impact.

[0]: https://ghost.org/changelog/5/
