### PR TITLE
Added index to prep for automation run analytics query

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-13-16-07-33-add-automation-runs-automation-id-created-at-index.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-13-16-07-33-add-automation-runs-automation-id-created-at-index.js
@@ -1,0 +1,28 @@
+const {createNonTransactionalMigration} = require('../../utils');
+const {addIndex, dropIndex, getIndexes} = require('../../../schema/commands');
+
+const table = 'automation_runs';
+const compositeIndexColumns = ['automation_id', 'created_at'];
+const foreignKeyIndexColumns = ['automation_id'];
+const foreignKeyIndexName = 'automation_runs_automation_id_index';
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        await addIndex(table, compositeIndexColumns, knex);
+
+        // If this migration was rolled back (see `down`), we need to drop the
+        // index it created.
+        const indexes = await getIndexes(table, knex);
+        if (indexes.includes(foreignKeyIndexName)) {
+            await dropIndex(table, foreignKeyIndexColumns, knex);
+        }
+    },
+    async function down(knex) {
+        // Before this whole migration, MySQL had an implicit index on
+        // `automation_id` because it was referenced by foreign keys. Adding the
+        // composite index in `up` removes that, so we need to add it back if we
+        // reverse the migration.
+        await addIndex(table, foreignKeyIndexColumns, knex);
+        await dropIndex(table, compositeIndexColumns, knex);
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1331,7 +1331,10 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: false},
         automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', restrictDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', setNullDelete: true, index: true},
-        member_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}}
+        member_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+        '@@INDEXES@@': [
+            ['automation_id', 'created_at']
+        ]
     },
     automation_run_steps: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '205297f193a7d60b95e8ceeab3b80f4f';
+    const currentSchemaHash = 'bbded7a3841350d2d8c5856bc01c3461';
     const currentFixturesHash = 'd4c9e4fabcec3365c42d37642216021b';
     const currentSettingsHash = 'f57245b22af55ea5fc1e5e20913de9bb';
     const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1523

In [an upcoming change][0], we'll be trying to find the newest automation run per automation. This adds an index to make that query faster.

**I was lazy and did not test the performance of this migration.**

[0]: https://linear.app/ghost/issue/NY-1523