### PR TITLE
Migrated Codex documentation into the repo

### DIFF
--- a/.agents/skills/create-database-migration/SKILL.md
+++ b/.agents/skills/create-database-migration/SKILL.md
@@ -5,6 +5,11 @@ description: Create a database migration to add a table, add columns to an exist
 
 # Create Database Migration
 
+Read the canonical human guidance in
+[`docs/practices/database-migrations.md`](../../../docs/practices/database-migrations.md)
+before making a migration. This skill is the executable checklist that
+accompanies it.
+
 ## Instructions
 
 1. Create a new, empty migration file: `cd ghost/core && pnpm migrate:create <kebab-case-slug>`. IMPORTANT: do not create the migration file manually; always use this script to create the initial empty migration file. The slug must be kebab-case (e.g. `add-column-to-posts`).
@@ -12,8 +17,8 @@ description: Create a database migration to add a table, add columns to an exist
 3. Update the migration file with the changes you want to make in the database, following the existing patterns in the codebase. Where appropriate, prefer to use the utility functions in `ghost/core/core/server/data/migrations/utils/*`.
 4. Update the schema definition file in `ghost/core/core/server/data/schema/schema.js`, and make sure it aligns with the latest changes from the migration.
 5. Test the migration manually: `cd ghost/core && pnpm knex-migrator migrate --v {version directory} --force`
-6. If adding or dropping a table, update `ghost/core/core/server/data/exporter/table-lists.js` as appropriate.
-7. If adding or dropping a table, also add or remove the table name from the expected tables list in `ghost/core/test/integration/exporter/exporter.test.js`. This test has a hardcoded alphabetically-sorted array of all database tables — it runs in CI integration tests (not unit tests) and will fail if the new table is missing.
+6. If adding or dropping a table, update `ghost/core/core/server/data/exporter/table-lists.js` as appropriate. The consistency assertion in `ghost/core/test/unit/server/data/exporter/index.test.js` checks that every schema table is classified in the exporter lists.
+7. Run the focused exporter unit test when the table lists change: `cd ghost/core && pnpm test:single test/unit/server/data/exporter/index.test.js`.
 8. Run the schema integrity test, and update the hash: `cd ghost/core && pnpm test:single test/unit/server/data/schema/integrity.test.js`
 9. Run unit tests in Ghost core, and iterate until they pass: `cd ghost/core && pnpm test:unit`
 

--- a/.agents/skills/create-database-migration/SKILL.md
+++ b/.agents/skills/create-database-migration/SKILL.md
@@ -17,10 +17,12 @@ accompanies it.
 3. Update the migration file with the changes you want to make in the database, following the existing patterns in the codebase. Where appropriate, prefer to use the utility functions in `ghost/core/core/server/data/migrations/utils/*`.
 4. Update the schema definition file in `ghost/core/core/server/data/schema/schema.js`, and make sure it aligns with the latest changes from the migration.
 5. Test the migration manually: `cd ghost/core && pnpm knex-migrator migrate --v {version directory} --force`
-6. If adding or dropping a table, update `ghost/core/core/server/data/exporter/table-lists.js` as appropriate. The consistency assertion in `ghost/core/test/unit/server/data/exporter/index.test.js` checks that every schema table is classified in the exporter lists.
-7. Run the focused exporter unit test when the table lists change: `cd ghost/core && pnpm test:single test/unit/server/data/exporter/index.test.js`.
-8. Run the schema integrity test, and update the hash: `cd ghost/core && pnpm test:single test/unit/server/data/schema/integrity.test.js`
-9. Run unit tests in Ghost core, and iterate until they pass: `cd ghost/core && pnpm test:unit`
+6. Roll the migration back to test `down()`: `cd ghost/core && pnpm knex-migrator rollback --v {previous version} --force`, then migrate forward again.
+7. Run the migration integration test, which covers initialization, rollback, forward migration, and idempotency: `cd ghost/core && pnpm test:single test/integration/migrations/migration.test.js`. Migrations must pass the database-backed suites against both MySQL and SQLite.
+8. If adding or dropping a table, update `ghost/core/core/server/data/exporter/table-lists.js` as appropriate. The consistency assertion in `ghost/core/test/unit/server/data/exporter/index.test.js` checks that every schema table is classified in the exporter lists.
+9. Run the focused exporter unit test when the table lists change: `cd ghost/core && pnpm test:single test/unit/server/data/exporter/index.test.js`.
+10. Run the schema integrity test, and update the hash: `cd ghost/core && pnpm test:single test/unit/server/data/schema/integrity.test.js`
+11. Run unit tests in Ghost core, and iterate until they pass: `cd ghost/core && pnpm test:unit`
 
 ## Examples
 See [examples.md](examples.md) for example migrations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,9 @@ The [database migrations guide](practices/database-migrations.md) covers the
 current migration workflow, required schema and export updates, safety rules,
 and validation commands.
 
+The [Stripe flows guide](codebase/stripe-flows.md) describes how Stripe Connect,
+checkout sessions, and tier prices fit together.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,9 @@ and validation commands.
 The [Stripe flows guide](codebase/stripe-flows.md) describes how Stripe Connect,
 checkout sessions, and tier prices fit together.
 
+The [jobs system guide](codebase/jobs.md) explains when work runs inline or in a
+worker and how scheduled jobs behave.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,9 @@ worker and how scheduled jobs behave.
 The [site UUID guide](codebase/site-uuid.md) covers how Ghost creates, exposes,
 and protects a site's stable identifier.
 
+The [email testing guide](contributing/testing-email.md) explains local Mailpit
+capture and when external delivery configuration is needed.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,9 @@ and protects a site's stable identifier.
 The [email testing guide](contributing/testing-email.md) explains local Mailpit
 capture and when external delivery configuration is needed.
 
+The [post analytics guide](codebase/post-analytics.md) explains the sources of
+web, member, newsletter, and click data shown for posts.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,9 @@ feature-specific cache adapters.
 The [database structure guide](codebase/database.md) gives a short orientation
 to the schema and commonly referenced domain values.
 
+The [performance testing guide](contributing/performance-testing.md) covers
+focused local load tests without exposing hosted-service procedures.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,10 @@ The [error handling guide](practices/error-handling.md) explains how to design
 failure states for logs, APIs, and user interfaces without exposing raw
 technical errors.
 
+The [database migrations guide](practices/database-migrations.md) covers the
+current migration workflow, required schema and export updates, safety rules,
+and validation commands.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,9 @@ The [error handling guide](practices/error-handling.md) explains how to design
 failure states for logs, APIs, and user interfaces without exposing raw
 technical errors.
 
+The [API design guide](practices/api-design.md) documents resource envelopes,
+controller conventions, validation, permissions, caching, and compatibility.
+
 The [database migrations guide](practices/database-migrations.md) covers the
 current migration workflow, required schema and export updates, safety rules,
 and validation commands.

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,9 @@ web, member, newsletter, and click data shown for posts.
 The [internal caching guide](codebase/internal-caching.md) describes default and
 feature-specific cache adapters.
 
+The [database structure guide](codebase/database.md) gives a short orientation
+to the schema and commonly referenced domain values.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,9 @@ capture and when external delivery configuration is needed.
 The [post analytics guide](codebase/post-analytics.md) explains the sources of
 web, member, newsletter, and click data shown for posts.
 
+The [internal caching guide](codebase/internal-caching.md) describes default and
+feature-specific cache adapters.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,40 +72,27 @@ To contribute or add translations, see
 adding translatable product copy, see the
 [internationalization guide](practices/internationalization.md).
 
-The [error handling guide](practices/error-handling.md) explains how to design
-failure states for logs, APIs, and user interfaces without exposing raw
-technical errors.
+## Guides
 
-The [API design guide](practices/api-design.md) documents resource envelopes,
-controller conventions, validation, permissions, caching, and compatibility.
+Codebase guides explain how the main systems fit together:
 
-The [database migrations guide](practices/database-migrations.md) covers the
-current migration workflow, required schema and export updates, safety rules,
-and validation commands.
+- [Authentication](codebase/authentication.md)
+- [Configuration](codebase/configuration.md)
+- [Database structure](codebase/database.md)
+- [Internal caching](codebase/internal-caching.md)
+- [Jobs system](codebase/jobs.md)
+- [Post analytics](codebase/post-analytics.md)
+- [Site UUID](codebase/site-uuid.md)
+- [Stripe flows](codebase/stripe-flows.md)
 
-The [Stripe flows guide](codebase/stripe-flows.md) describes how Stripe Connect,
-checkout sessions, and tier prices fit together.
+Practice and contributor guides explain how to make and verify changes:
 
-The [jobs system guide](codebase/jobs.md) explains when work runs inline or in a
-worker and how scheduled jobs behave.
-
-The [site UUID guide](codebase/site-uuid.md) covers how Ghost creates, exposes,
-and protects a site's stable identifier.
-
-The [email testing guide](contributing/testing-email.md) explains local Mailpit
-capture and when external delivery configuration is needed.
-
-The [post analytics guide](codebase/post-analytics.md) explains the sources of
-web, member, newsletter, and click data shown for posts.
-
-The [internal caching guide](codebase/internal-caching.md) describes default and
-feature-specific cache adapters.
-
-The [database structure guide](codebase/database.md) gives a short orientation
-to the schema and commonly referenced domain values.
-
-The [performance testing guide](contributing/performance-testing.md) covers
-focused local load tests without exposing hosted-service procedures.
+- [API design](practices/api-design.md)
+- [Database migrations](practices/database-migrations.md)
+- [Email testing](contributing/testing-email.md)
+- [Error handling](practices/error-handling.md)
+- [Internationalization](practices/internationalization.md)
+- [Performance testing](contributing/performance-testing.md)
 
 ### Finding Issues to Work On
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,9 @@ checkout sessions, and tier prices fit together.
 The [jobs system guide](codebase/jobs.md) explains when work runs inline or in a
 worker and how scheduled jobs behave.
 
+The [site UUID guide](codebase/site-uuid.md) covers how Ghost creates, exposes,
+and protects a site's stable identifier.
+
 ### Finding Issues to Work On
 
 - [Good First Issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) - Great for newcomers

--- a/docs/codebase/database.md
+++ b/docs/codebase/database.md
@@ -1,0 +1,45 @@
+# Database Structure
+
+Ghost's database schema is defined in
+`ghost/core/core/server/data/schema/schema.js`.
+
+## Posts
+
+Post statuses are `draft`, `scheduled`, `published`, and `email`. Email posts are
+sent without being published on the site. Only published posts are available
+through the Content API.
+
+## Tags
+
+Tag visibility is `internal` or `public`.
+
+## Integrations
+
+Integration types are:
+
+- `internal`: private from the API.
+- `built-in`: available from the API but restricted on some plans.
+- `core`: available from the API and allowed on all plans.
+- `custom`: created by a user.
+
+## Member attribution events
+
+Member-created and subscription-created events are deleted with their member.
+Their attribution type can be `url`, `post`, `page`, `author`, or `tag`, and
+their referrer fields record the source, medium, and URL where available.
+
+The `source` on a member-created event records what created the member. Its
+values are `member`, `import`, `system`, `api`, and `admin`, and it must be set
+internally.
+
+## Link redirects and clicks
+
+`link_redirects` stores the source path, destination, and associated post for a
+tracked link. A member link-click event is stored for every click, including
+repeat clicks by the same member.
+
+## Subscriptions
+
+Subscription types are `free`, `comped`, and `paid`. Statuses are `active`,
+`expired`, and `canceled`. Paid subscriptions also record cadence, currency,
+amount, and payment-provider links.

--- a/docs/codebase/database.md
+++ b/docs/codebase/database.md
@@ -1,11 +1,14 @@
 # Database Structure
 
 Ghost's database schema is defined in
-`ghost/core/core/server/data/schema/schema.js`.
+[`schema.js`](../../ghost/core/core/server/data/schema/schema.js). It is the
+current shape expected after every migration has run. Bookshelf models in
+[`models/`](../../ghost/core/core/server/models/) define relationships and
+application behavior; do not infer those rules from the table shape alone.
 
 ## Posts
 
-Post statuses are `draft`, `scheduled`, `published`, and `email`. Email posts are
+Post statuses are `draft`, `scheduled`, `published`, and `sent`. Sent posts are
 sent without being published on the site. Only published posts are available
 through the Content API.
 
@@ -18,8 +21,8 @@ Tag visibility is `internal` or `public`.
 Integration types are:
 
 - `internal`: private from the API.
-- `built-in`: available from the API but restricted on some plans.
-- `core`: available from the API and allowed on all plans.
+- `builtin`: created as one of Ghost's built-in integrations.
+- `core`: created and managed by Ghost core.
 - `custom`: created by a user.
 
 ## Member attribution events
@@ -29,17 +32,20 @@ Their attribution type can be `url`, `post`, `page`, `author`, or `tag`, and
 their referrer fields record the source, medium, and URL where available.
 
 The `source` on a member-created event records what created the member. Its
-values are `member`, `import`, `system`, `api`, and `admin`, and it must be set
-internally.
+values are `member`, `import`, `system`, `api`, and `admin`.
 
 ## Link redirects and clicks
 
-`link_redirects` stores the source path, destination, and associated post for a
-tracked link. A member link-click event is stored for every click, including
-repeat clicks by the same member.
+`redirects` stores the source path, destination, and associated post or
+automation action for a tracked link. `members_click_events` stores every
+member click, including repeat clicks by the same member.
 
 ## Subscriptions
 
 Subscription types are `free`, `comped`, and `paid`. Statuses are `active`,
 `expired`, and `canceled`. Paid subscriptions also record cadence, currency,
 amount, and payment-provider links.
+
+For changing this structure, follow the
+[database migrations guide](../practices/database-migrations.md). Keep the
+schema definition, migration, exporter table lists, and integrity tests in sync.

--- a/docs/codebase/internal-caching.md
+++ b/docs/codebase/internal-caching.md
@@ -7,10 +7,7 @@ section of the environment configuration:
 {
     "adapters": {
         "cache": {
-            "active": "Memory",
-            "settings": {
-                "adapter": "SyncInMemory"
-            },
+            "active": "MemoryCache",
             "Redis": {
                 "host": "localhost",
                 "port": 6379,
@@ -21,18 +18,21 @@ section of the environment configuration:
                 "keyPrefix": "2368:image-sizes:",
                 "ttl": 30
             },
-            "urls": {
-                "adapter": "Redis",
-                "keyPrefix": "2368:urls:"
-            },
-            "analytics": {
-                "adapter": "Redis",
-                "keyPrefix": "2368:analytics:"
-            }
+            "gscan": {}
         }
     }
 }
 ```
 
-The active adapter provides the default cache. Named entries allow individual
-features to use a different adapter and settings.
+The active adapter provides the default cache. A named feature uses the active
+adapter unless its object includes an `adapter` override. Settings under the
+adapter's class name are shared, and the feature object can override them.
+
+Ghost includes `MemoryCache` and `Redis`. Current named caches include settings,
+image sizes, theme validation, stats, and public post and tag data; use the name
+requested by the owning service rather than inventing a second name in config.
+
+Cache adapters must extend `@tryghost/adapter-base-cache` and implement `get`,
+`set`, `reset`, and `keys`. See the
+[`cache-base` README](../../packages/adapters/cache-base/README.md) for the
+adapter contract and installation layout.

--- a/docs/codebase/internal-caching.md
+++ b/docs/codebase/internal-caching.md
@@ -1,0 +1,38 @@
+# Internal Caching
+
+Ghost supports internal cache adapters. They are configured in the `adapters`
+section of the environment configuration:
+
+```json
+{
+    "adapters": {
+        "cache": {
+            "active": "Memory",
+            "settings": {
+                "adapter": "SyncInMemory"
+            },
+            "Redis": {
+                "host": "localhost",
+                "port": 6379,
+                "password": ""
+            },
+            "imageSizes": {
+                "adapter": "Redis",
+                "keyPrefix": "2368:image-sizes:",
+                "ttl": 30
+            },
+            "urls": {
+                "adapter": "Redis",
+                "keyPrefix": "2368:urls:"
+            },
+            "analytics": {
+                "adapter": "Redis",
+                "keyPrefix": "2368:analytics:"
+            }
+        }
+    }
+}
+```
+
+The active adapter provides the default cache. Named entries allow individual
+features to use a different adapter and settings.

--- a/docs/codebase/jobs.md
+++ b/docs/codebase/jobs.md
@@ -24,6 +24,11 @@ Existing examples include:
 Prefer an existing job with similar lifecycle and failure requirements as the
 starting point for a new one.
 
+When adding a service which registers jobs, give it an explicit `init()` call
+from `ghost/core/core/boot.js`. Keep the wrapper's `init()` idempotent, but let
+boot own service construction and worker setup rather than initializing on the
+first request.
+
 ## Testing
 
 Tests for the jobs wrapper live in

--- a/docs/codebase/jobs.md
+++ b/docs/codebase/jobs.md
@@ -1,12 +1,12 @@
 # Jobs System
 
-Ghost's jobs system runs work inline or in a worker thread. Jobs can be
-scheduled, queued, or persisted so they can resume after Ghost restarts.
+Ghost's jobs system runs work inline or in a worker thread. Jobs can run once or
+on a schedule.
 
-Use inline jobs for short work which does not block the event loop. Use worker
-threads for CPU-heavy or long-running work that should not affect requests.
-Persist a job when losing it during a restart would leave Ghost in an incorrect
-state.
+Use inline jobs for short work which does not block the event loop. Inline jobs
+cannot be scheduled. Scheduled and offloaded jobs run in worker threads, so
+they must initialize their own dependencies and cannot rely on the main Ghost
+process's memory.
 
 ## Adding a job
 
@@ -17,19 +17,22 @@ events.
 
 Existing examples include:
 
-- Update checks, which run inline on a schedule.
+- Update checks, which run in a worker on a schedule.
 - Imports, which run as inline jobs.
-- Email analytics, which uses offloaded and persisted jobs.
+- Email analytics, which uses scheduled worker jobs.
 
 Prefer an existing job with similar lifecycle and failure requirements as the
 starting point for a new one.
 
 ## Testing
 
-Integration tests for the jobs system live in `ghost/core/test/integration/jobs/`.
-Tests should cover the job's result and any state that must survive a restart.
+Tests for the jobs wrapper live in
+`ghost/core/test/unit/server/services/jobs/`, with update-check integration
+coverage in `ghost/core/test/integration/jobs/`. Tests should cover the job's
+result and failure behavior.
 
 ## Scheduling
 
 The jobs system uses Bree for scheduled work. Schedules use the server's system
-timezone, so take care when a job needs to run at a specific local time.
+timezone. Offloaded jobs should have unique names, be safe to run more than
+once, and receive identifiers rather than large objects where possible.

--- a/docs/codebase/jobs.md
+++ b/docs/codebase/jobs.md
@@ -1,0 +1,35 @@
+# Jobs System
+
+Ghost's jobs system runs work inline or in a worker thread. Jobs can be
+scheduled, queued, or persisted so they can resume after Ghost restarts.
+
+Use inline jobs for short work which does not block the event loop. Use worker
+threads for CPU-heavy or long-running work that should not affect requests.
+Persist a job when losing it during a restart would leave Ghost in an incorrect
+state.
+
+## Adding a job
+
+Jobs are registered through the service in
+`ghost/core/core/server/services/jobs/`. The service is a wrapper around
+`@tryghost/job-manager` and provides Ghost's logging, configuration, models, and
+events.
+
+Existing examples include:
+
+- Update checks, which run inline on a schedule.
+- Imports, which run as inline jobs.
+- Email analytics, which uses offloaded and persisted jobs.
+
+Prefer an existing job with similar lifecycle and failure requirements as the
+starting point for a new one.
+
+## Testing
+
+Integration tests for the jobs system live in `ghost/core/test/integration/jobs/`.
+Tests should cover the job's result and any state that must survive a restart.
+
+## Scheduling
+
+The jobs system uses Bree for scheduled work. Schedules use the server's system
+timezone, so take care when a job needs to run at a specific local time.

--- a/docs/codebase/monorepo-structure.md
+++ b/docs/codebase/monorepo-structure.md
@@ -136,10 +136,13 @@ Some parts of Ghost live in separate repositories:
 - [`TryGhost/Ghost-CLI`](https://github.com/TryGhost/Ghost-CLI) installs and
   manages production Ghost sites.
 - [`TryGhost/Source`](https://github.com/TryGhost/Source),
-  [`TryGhost/Casper`](https://github.com/TryGhost/Casper), and the other
-  repositories in the [TryGhost/Themes](https://github.com/TryGhost/Themes)
-  organisation contain official themes. Some theme repositories are synced
-  copies of private source repositories.
+  [`TryGhost/Casper`](https://github.com/TryGhost/Casper), and
+  [`TryGhost/Themes`](https://github.com/TryGhost/Themes) contain official
+  themes.
+- [`TryGhost/framework`](https://github.com/TryGhost/framework) contains shared
+  Node.js packages used by Ghost.
+- [`TryGhost/SDK`](https://github.com/TryGhost/SDK) contains tools for working
+  with Ghost's APIs.
 
-Framework, SDK, and Koenig packages that previously lived in separate
-repositories are now part of this monorepo.
+Of these projects, only Koenig has moved into this monorepo. Framework and SDK
+packages still live in their own repositories.

--- a/docs/codebase/monorepo-structure.md
+++ b/docs/codebase/monorepo-structure.md
@@ -144,5 +144,5 @@ Some parts of Ghost live in separate repositories:
 - [`TryGhost/SDK`](https://github.com/TryGhost/SDK) contains tools for working
   with Ghost's APIs.
 
-Of these projects, only Koenig has moved into this monorepo. Framework and SDK
-packages still live in their own repositories.
+Of the Ghost-related projects, only Koenig has moved into this monorepo.
+Framework and SDK packages still live in their own repositories.

--- a/docs/codebase/monorepo-structure.md
+++ b/docs/codebase/monorepo-structure.md
@@ -127,3 +127,22 @@ documented in [`packages/README.md`](../../packages/README.md).
 This means a source edit may work immediately in development while a production
 build still needs `pnpm build`. Run the build when changing package exports,
 build configuration, or code included in a release artifact.
+
+## Related repositories
+
+Some parts of Ghost live in separate repositories:
+
+- [`TryGhost/Framework`](https://github.com/TryGhost/Framework) contains generic
+  pieces used across Ghost projects, such as logging and errors.
+- [`TryGhost/SDK`](https://github.com/TryGhost/SDK) contains tooling for working
+  with Ghost APIs and other companion features.
+- [`TryGhost/Koenig`](https://github.com/TryGhost/Koenig) contains the Koenig
+  editor.
+- [`TryGhost/GScan`](https://github.com/TryGhost/GScan) validates Ghost themes.
+- [`TryGhost/Ghost-CLI`](https://github.com/TryGhost/Ghost-CLI) installs and
+  manages production Ghost sites.
+- [`TryGhost/Source`](https://github.com/TryGhost/Source),
+  [`TryGhost/Casper`](https://github.com/TryGhost/Casper), and the other
+  repositories in the [TryGhost/Themes](https://github.com/TryGhost/Themes)
+  organisation contain official themes. Some theme repositories are synced
+  copies of private source repositories.

--- a/docs/codebase/monorepo-structure.md
+++ b/docs/codebase/monorepo-structure.md
@@ -132,13 +132,7 @@ build configuration, or code included in a release artifact.
 
 Some parts of Ghost live in separate repositories:
 
-- [`TryGhost/Framework`](https://github.com/TryGhost/Framework) contains generic
-  pieces used across Ghost projects, such as logging and errors.
-- [`TryGhost/SDK`](https://github.com/TryGhost/SDK) contains tooling for working
-  with Ghost APIs and other companion features.
-- [`TryGhost/Koenig`](https://github.com/TryGhost/Koenig) contains the Koenig
-  editor.
-- [`TryGhost/GScan`](https://github.com/TryGhost/GScan) validates Ghost themes.
+- [`TryGhost/gscan`](https://github.com/TryGhost/gscan) validates Ghost themes.
 - [`TryGhost/Ghost-CLI`](https://github.com/TryGhost/Ghost-CLI) installs and
   manages production Ghost sites.
 - [`TryGhost/Source`](https://github.com/TryGhost/Source),
@@ -146,3 +140,6 @@ Some parts of Ghost live in separate repositories:
   repositories in the [TryGhost/Themes](https://github.com/TryGhost/Themes)
   organisation contain official themes. Some theme repositories are synced
   copies of private source repositories.
+
+Framework, SDK, and Koenig packages that previously lived in separate
+repositories are now part of this monorepo.

--- a/docs/codebase/monorepo-structure.md
+++ b/docs/codebase/monorepo-structure.md
@@ -143,6 +143,3 @@ Some parts of Ghost live in separate repositories:
   Node.js packages used by Ghost.
 - [`TryGhost/SDK`](https://github.com/TryGhost/SDK) contains tools for working
   with Ghost's APIs.
-
-Of the Ghost-related projects, only Koenig has moved into this monorepo.
-Framework and SDK packages still live in their own repositories.

--- a/docs/codebase/post-analytics.md
+++ b/docs/codebase/post-analytics.md
@@ -1,0 +1,39 @@
+# Post Analytics
+
+Ghost provides post analytics for newsletter opens and link clicks. Summary
+information appears in the posts list, with more detail on each post's analytics
+page.
+
+## Click tracking
+
+Click tracking counts the unique members who clicked a link in an email. It does
+not combine a link across different posts and does not track clicks on the web
+version of a post.
+
+Clicks are stored in `members_click_events`. Each event refers to a row in
+`redirects`, which contains the destination. Multiple events can be recorded
+when one member clicks the same link more than once, but analytics count that
+member once.
+
+When an email is prepared, `LinkClickTrackingService` replaces a link with a
+Ghost redirect. A request to `/r/{redirectId}?m={memberUuid}` records the event
+and redirects the member to the destination.
+
+Click tracking can be disabled in Admin or with the `email_track_clicks`
+setting.
+
+## Email analytics
+
+Ghost uses Mailgun's Events API to collect newsletter delivery, open, and
+failure data. Aggregates are stored on `emails`, with recipient-level data in
+`email_recipients`.
+
+“Sent” and “delivered” are different. Sent means Ghost processed the email
+batch. Delivered means Ghost received a delivery event from Mailgun.
+
+The email analytics job polls Mailgun regularly. It fetches recent events first,
+then uses a delayed missing-events pass because Mailgun events do not always
+arrive in order. Progress is stored so the job can continue from its previous
+position.
+
+Email analytics can be disabled with the `emailAnalytics` configuration.

--- a/docs/codebase/post-analytics.md
+++ b/docs/codebase/post-analytics.md
@@ -1,8 +1,12 @@
 # Post Analytics
 
-Ghost provides post analytics for newsletter opens and link clicks. Summary
-information appears in the posts list, with more detail on each post's analytics
-page.
+Ghost provides post analytics for web traffic, member growth, newsletter opens,
+and link clicks. Summary information appears in the posts list, with more detail
+on each post's analytics page.
+
+Web traffic comes from Ghost's Tinybird integration. Member and revenue
+attribution comes from Ghost's event data. Newsletter analytics uses the local
+email, recipient, redirect, and click-event tables.
 
 ## Click tracking
 
@@ -18,6 +22,9 @@ member once.
 When an email is prepared, `LinkClickTrackingService` replaces a link with a
 Ghost redirect. A request to `/r/{redirectId}?m={memberUuid}` records the event
 and redirects the member to the destination.
+
+The implementation lives in
+[`services/link-tracking/`](../../ghost/core/core/server/services/link-tracking/).
 
 Click tracking can be disabled in Admin or with the `email_track_clicks`
 setting.
@@ -36,4 +43,9 @@ then uses a delayed missing-events pass because Mailgun events do not always
 arrive in order. Progress is stored so the job can continue from its previous
 position.
 
-Email analytics can be disabled with the `emailAnalytics` configuration.
+Email analytics can be disabled with `emailAnalytics.enabled`. The service and
+its scheduled jobs live in
+[`services/email-analytics/`](../../ghost/core/core/server/services/email-analytics/).
+
+The endpoints that combine web, member, and newsletter figures use
+[`posts-stats-service.js`](../../ghost/core/core/server/services/stats/posts-stats-service.js).

--- a/docs/codebase/site-uuid.md
+++ b/docs/codebase/site-uuid.md
@@ -1,15 +1,14 @@
 # Site UUID
 
 Each Ghost site has a `site_uuid` in its settings table. It is a unique site
-identifier which is safe to expose publicly. It is used when Ghost talks to
-shared services such as Tinybird, where records need to be associated with the
-correct site.
+identifier exposed by Ghost's public site configuration. Ghost uses it to keep
+site data separate when talking to services such as Tinybird.
 
 ## Generation
 
-On first boot, Ghost uses the configured `site_uuid` when it is a valid UUID.
-Otherwise it generates a random UUID. The resulting value is stored as the
-`site_uuid` setting.
+When the setting is first created, Ghost uses the configured `site_uuid` when it
+is a valid UUID. Otherwise it generates a random UUID. The value is normalized
+to lowercase before it is stored.
 
 The value is immutable. It cannot be changed through the Admin API or a JSON
 import. To choose it, configure `site_uuid` before the site's first boot.
@@ -25,3 +24,8 @@ Read the stored value inside Ghost with:
 ```js
 settingsCache.get('site_uuid')
 ```
+
+Generation is implemented in
+[`settings-utils.js`](../../ghost/core/core/server/services/settings/settings-utils.js),
+and the boot-time check is in
+[`settings-service.js`](../../ghost/core/core/server/services/settings/settings-service.js).

--- a/docs/codebase/site-uuid.md
+++ b/docs/codebase/site-uuid.md
@@ -1,0 +1,27 @@
+# Site UUID
+
+Each Ghost site has a `site_uuid` in its settings table. It is a unique site
+identifier which is safe to expose publicly. It is used when Ghost talks to
+shared services such as Tinybird, where records need to be associated with the
+correct site.
+
+## Generation
+
+On first boot, Ghost uses the configured `site_uuid` when it is a valid UUID.
+Otherwise it generates a random UUID. The resulting value is stored as the
+`site_uuid` setting.
+
+The value is immutable. It cannot be changed through the Admin API or a JSON
+import. To choose it, configure `site_uuid` before the site's first boot.
+
+On later boots, Ghost compares a configured `site_uuid` with the stored setting.
+If they differ, Ghost stops with a `SITE_UUID_MISMATCH` error to prevent the site
+from running under the wrong identity.
+
+## Usage
+
+Read the stored value inside Ghost with:
+
+```js
+settingsCache.get('site_uuid')
+```

--- a/docs/codebase/stripe-flows.md
+++ b/docs/codebase/stripe-flows.md
@@ -3,15 +3,18 @@
 ## Stripe Connect
 
 Ghost has a Stripe Connect integration. The client ID is part of the Ghost
-codebase, allowing any Ghost instance to start the OAuth flow.
+codebase, allowing any Ghost instance served over HTTPS to start the OAuth flow.
 
 1. The user selects **Connect with Stripe** in Ghost Admin and is redirected to
    Stripe.
 2. Stripe redirects the user to `stripe.ghost.org` after authorization.
 3. `stripe.ghost.org` exchanges the authorization code for the account's public
    and secret keys.
-4. The connection data is encoded and returned to the user.
-5. Ghost decodes and stores the connection data to complete the connection.
+4. The connection data and OAuth state are encoded and returned to Ghost.
+5. Ghost checks the state, decodes the data, and stores the connection settings.
+
+This flow is implemented in
+[`services/members/stripe-connect.js`](../../ghost/core/core/server/services/members/stripe-connect.js).
 
 ## Stripe Checkout
 
@@ -29,3 +32,6 @@ codebase, allowing any Ghost instance to start the OAuth flow.
 1. Ghost receives a request to create a tier with monthly and yearly prices.
 2. Ghost creates the corresponding Stripe Product and Prices.
 3. Ghost stores their details in the database.
+
+The checkout and tier price flows are implemented by
+[`payments-service.js`](../../ghost/core/core/server/services/members/members-api/services/payments-service.js).

--- a/docs/codebase/stripe-flows.md
+++ b/docs/codebase/stripe-flows.md
@@ -1,0 +1,31 @@
+# Stripe Flows
+
+## Stripe Connect
+
+Ghost has a Stripe Connect integration. The client ID is part of the Ghost
+codebase, allowing any Ghost instance to start the OAuth flow.
+
+1. The user selects **Connect with Stripe** in Ghost Admin and is redirected to
+   Stripe.
+2. Stripe redirects the user to `stripe.ghost.org` after authorization.
+3. `stripe.ghost.org` exchanges the authorization code for the account's public
+   and secret keys.
+4. The connection data is encoded and returned to the user.
+5. Ghost decodes and stores the connection data to complete the connection.
+
+## Stripe Checkout
+
+1. Ghost receives a request to create a checkout session for a tier and billing
+   cadence.
+2. Ghost checks that the tier is not archived.
+3. Ghost looks for the Stripe Price associated with the tier and cadence.
+4. Ghost checks the price against Stripe.
+5. If needed, Ghost creates the Stripe Product and Price and stores them
+   locally.
+6. Ghost creates a Stripe Checkout Session with that price.
+
+## Creating a tier
+
+1. Ghost receives a request to create a tier with monthly and yearly prices.
+2. Ghost creates the corresponding Stripe Product and Prices.
+3. Ghost stores their details in the database.

--- a/docs/codebase/stripe-flows.md
+++ b/docs/codebase/stripe-flows.md
@@ -8,15 +8,16 @@ codebase, allowing any Ghost instance served over HTTPS to start the OAuth flow.
 1. The user selects **Connect with Stripe** in Ghost Admin and is redirected to
    Stripe.
 2. Stripe redirects the user to `stripe.ghost.org` after authorization.
-3. `stripe.ghost.org` exchanges the authorization code for the account's public
-   and secret keys.
-4. The connection data and OAuth state are encoded and returned to Ghost.
-5. Ghost checks the state, decodes the data, and stores the connection settings.
+3. `stripe.ghost.org` exchanges the authorization code and returns a
+   base64-encoded payload containing `s`, `p`, `a`, `l`, `n`, and `i`. The `a`
+   value is Stripe's OAuth `access_token`, not the account's secret key.
+4. Ghost validates the state in `s`, then maps and stores the connection
+   settings.
 
 This flow is implemented in
 [`services/members/stripe-connect.js`](../../ghost/core/core/server/services/members/stripe-connect.js).
 
-## Stripe Checkout
+## Stripe subscription checkout
 
 1. Ghost receives a request to create a checkout session for a tier and billing
    cadence.

--- a/docs/contributing/performance-testing.md
+++ b/docs/contributing/performance-testing.md
@@ -6,26 +6,19 @@ tools commonly used with Ghost are `loadtest` for a simple endpoint and
 
 ## loadtest
 
-Install `loadtest` globally, then specify the total requests and concurrency:
+Run `loadtest` with pnpm and specify the total requests and concurrency:
 
 ```bash
-npm install -g loadtest
-loadtest -n 500 -c 5 http://localhost:2368/
+pnpm dlx loadtest -n 500 -c 5 http://localhost:2368/
 ```
 
 It can also run at a fixed request rate for a duration:
 
 ```bash
-loadtest -t 30 --rps 50 http://localhost:2368/
+pnpm dlx loadtest -t 30 --rps 50 http://localhost:2368/
 ```
 
 ## Artillery
-
-Install Artillery globally:
-
-```bash
-npm install -g artillery@latest
-```
 
 Artillery uses a YAML test definition and supports phased rates, several
 requests in one flow, and processor functions for variable input:
@@ -47,7 +40,7 @@ scenarios:
 Run it with:
 
 ```bash
-artillery run load-test.yml
+pnpm dlx artillery run load-test.yml
 ```
 
 ## Getting useful results
@@ -60,3 +53,11 @@ uncached requests.
 Local testing starts at [http://localhost:2368](http://localhost:2368). Local
 hardware and production hosting differ, but local results can still show whether
 a change improves or degrades a focused workflow.
+
+Only send load to a system you own or have explicit permission to test. The
+public repository does not document production or hosted-service load-testing
+procedures.
+
+See the [`loadtest` README](https://github.com/alexfernandez/loadtest) and
+[Artillery documentation](https://www.artillery.io/docs/get-started/core-concepts)
+for the current command and scenario options.

--- a/docs/contributing/performance-testing.md
+++ b/docs/contributing/performance-testing.md
@@ -1,0 +1,62 @@
+# Load Testing and Benchmarking
+
+Performance testing is important for high-volume or intensive workflows. Two
+tools commonly used with Ghost are `loadtest` for a simple endpoint and
+`artillery` for multi-step or variable traffic.
+
+## loadtest
+
+Install `loadtest` globally, then specify the total requests and concurrency:
+
+```bash
+npm install -g loadtest
+loadtest -n 500 -c 5 http://localhost:2368/
+```
+
+It can also run at a fixed request rate for a duration:
+
+```bash
+loadtest -t 30 --rps 50 http://localhost:2368/
+```
+
+## Artillery
+
+Install Artillery globally:
+
+```bash
+npm install -g artillery@latest
+```
+
+Artillery uses a YAML test definition and supports phased rates, several
+requests in one flow, and processor functions for variable input:
+
+```yaml
+config:
+  target: "http://localhost:2368"
+  phases:
+    - duration: 15
+      arrivalRate: 50
+
+scenarios:
+  - name: "Home page"
+    flow:
+      - get:
+          url: "/"
+```
+
+Run it with:
+
+```bash
+artillery run load-test.yml
+```
+
+## Getting useful results
+
+Request pooling, keep-alive, timeouts, concurrency, cookies, and headers can all
+change the result. Match them to the behavior being investigated. Ghost caches
+public content, so decide whether the test is intended to measure cached or
+uncached requests.
+
+Local testing starts at [http://localhost:2368](http://localhost:2368). Local
+hardware and production hosting differ, but local results can still show whether
+a change improves or degrades a focused workflow.

--- a/docs/contributing/testing-email.md
+++ b/docs/contributing/testing-email.md
@@ -2,36 +2,24 @@
 
 ## Local email
 
-Install MailDev globally:
+The normal development environment starts Mailpit with Ghost. Run:
 
 ```bash
-npm install -g maildev
-maildev
+pnpm dev
 ```
 
-MailDev starts an SMTP server and a web interface at
-[http://localhost:1080](http://localhost:1080). Configure Ghost to send mail to
-the local SMTP server:
-
-```json
-{
-    "mail": {
-        "transport": "SMTP",
-        "options": {
-            "host": "localhost",
-            "port": 1025
-        }
-    }
-}
-```
-
-Emails sent by Ghost will appear in the MailDev interface rather than being
-delivered.
+Emails sent by the development site are captured at
+[http://localhost:8025](http://localhost:8025) rather than delivered. The Docker
+development configuration connects Ghost to Mailpit automatically.
 
 ## Testing with Mailgun
 
-For testing real delivery, create a Mailgun account and configure Ghost with
-the SMTP credentials for a Mailgun domain. Sandbox domains only send to
-authorized recipients, which must be added and verified in Mailgun first.
+For testing transactional email delivery, configure Ghost's `mail` setting with
+an SMTP provider. For testing newsletter delivery, configure the separate
+Mailgun settings used by Ghost's bulk email service. Mailgun sandbox domains
+only send to recipients that have been added and verified in Mailgun.
 
 Keep credentials in your local configuration and do not commit them.
+
+Most development does not need real delivery. Use Mailpit unless the behavior
+being tested depends on the external provider.

--- a/docs/contributing/testing-email.md
+++ b/docs/contributing/testing-email.md
@@ -1,0 +1,37 @@
+# Receiving and Testing Emails
+
+## Local email
+
+Install MailDev globally:
+
+```bash
+npm install -g maildev
+maildev
+```
+
+MailDev starts an SMTP server and a web interface at
+[http://localhost:1080](http://localhost:1080). Configure Ghost to send mail to
+the local SMTP server:
+
+```json
+{
+    "mail": {
+        "transport": "SMTP",
+        "options": {
+            "host": "localhost",
+            "port": 1025
+        }
+    }
+}
+```
+
+Emails sent by Ghost will appear in the MailDev interface rather than being
+delivered.
+
+## Testing with Mailgun
+
+For testing real delivery, create a Mailgun account and configure Ghost with
+the SMTP credentials for a Mailgun domain. Sandbox domains only send to
+authorized recipients, which must be added and verified in Mailgun first.
+
+Keep credentials in your local configuration and do not commit them.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -29,7 +29,8 @@ Put tests as close as possible to the code and behavior under test:
 - **Ghost Core server E2E tests** exercise the server, frontend rendering,
   webhooks, and APIs against a running Ghost instance and test database. They
   live under `ghost/core/test/e2e-*/`. These are Vitest suites, not browser
-  tests.
+  tests. See the [Ghost Core E2E guide](../../ghost/core/test/README.md) for the
+  request agents, fixtures, mocks, and snapshot helpers.
 - **App acceptance tests** exercise an individual app through its UI. The
   framework and command vary by app, so use that workspace's
   `test:acceptance` target.

--- a/docs/practices/api-design.md
+++ b/docs/practices/api-design.md
@@ -1,0 +1,169 @@
+# API Design
+
+Ghost's APIs are mature and widely used. There is no need for a wholesale
+redesign; we should follow the established principles and patterns carefully,
+and add new patterns only when existing ones do not serve API consumers.
+
+## Principles
+
+### Postel's Law
+
+> Be conservative in what you send, and liberal in what you accept.
+
+Ghost APIs are used by many different clients. Be flexible and permissive about
+useful input while keeping responses specific and predictable.
+
+Being liberal in what we accept does not mean accepting arbitrary properties.
+For example, a client should be able to pass a resource returned by `read` back
+to `edit`; known non-writable fields can be ignored. A misspelled field such as
+`member: {naem: "John"}` is not useful input and should produce an error rather
+than being silently ignored.
+
+### Hyrum's Law
+
+> With a sufficient number of users of an API, every observable behaviour will
+> be depended on by somebody.
+
+Every detail can become part of the API contract. Ask “should we add this?” and
+weigh the value of new behavior against its long-term compatibility and
+maintenance cost.
+
+Good API design balances these principles: preserve useful flexibility for
+clients without making outputs or behavior accidental and unpredictable.
+
+### API maturity
+
+Ghost's APIs are around level 2 of the Richardson and Amundsen maturity models.
+Ghost borrowed heavily from JSON:API when standardising its APIs, but did not
+adopt its hypermedia concepts. When improving APIs, focus on useful affordances
+for consumers rather than API aesthetics alone.
+
+## Patterns
+
+The foundation of Ghost's HTTP API is to follow RESTful principles. REST and
+JSON:API provide useful CRUD patterns for top-level resources such as posts and
+members, although less standard operations such as file uploads and bulk changes
+need additional patterns.
+
+The following conventions should hold:
+
+- Use HTTP methods according to the action being taken.
+- Define endpoints as resources or nouns.
+- Request and response bodies represent the resource under a top-level key:
+
+  ```json
+  {
+      "members": [],
+      "meta": {}
+  }
+  ```
+
+- Resource bodies use a top-level key containing an array, including singular
+  requests. Settings are an exception because the key-value pairs are the list
+  of resources.
+- Responses can include a top-level `meta` key for additional information.
+- Pagination metadata follows this shape:
+
+  ```json
+  {
+      "page": 3,
+      "prev": 2,
+      "next": 4,
+      "limit": 15,
+      "total": 38,
+      "pages": 3
+  }
+  ```
+
+- Use `snake_case` for API resource names and keys.
+
+### Working with files
+
+File endpoints such as `/images/upload` break the normal noun-only pattern. A
+file-interaction convention using an action such as `upload` has become
+established and should remain limited to file operations rather than being
+copied for ordinary data interactions.
+
+### Bulk endpoints
+
+Ghost uses `/bulk` as a nested resource for some bulk operations, such as
+`/members/bulk`. Define the request body and client behavior carefully before
+adding another bulk endpoint.
+
+## Conventions
+
+### Function signatures and API calls
+
+The HTTP API should map closely to the SDK and internal package APIs, including
+function signatures and parameters. For example, a client call such as
+`api.posts.browse({filter, fields})` maps those options to a `GET` request for
+the posts resource with `filter` and `fields` query parameters.
+
+### Graceful passing of objects
+
+Internal and HTTP APIs should return and accept a common resource format. A
+caller should be able to pass the result of `read` or `GET` directly to the
+corresponding `edit` or `PUT` operation without first removing read-only fields.
+
+### Caching and cache invalidation
+
+API endpoints use middleware to set `Cache-Control`. Design every response on
+the assumption that a greedy cache can exist in front of Ghost.
+
+Mutation responses can include an `X-Cache-Invalidate` header telling clients
+which paths need to be purged. Cache behavior must be deliberate for every API
+response.
+
+### Allowlist resource properties
+
+Prefer allowlists for API resource properties. Use the allowlist to ignore known
+but non-writable input properties while stripping properties that should not be
+sent in responses. Do not rely on a blocklist that must be updated every time a
+new internal property is added.
+
+## Settings
+
+Do not add new object values to the settings table. Settings values can be a
+string, number, boolean, or an array of values of the same type. The existing
+`labs` object is a special case and should not be used as precedent.
+
+Settings keys:
+
+- Use `snake_case`.
+- Be descriptive and unique.
+- Match the name exposed by the API where the key is public.
+
+The `type` field declares the type stored in `value`. The `group` field collects
+settings that are fetched and updated together and implies their API exposure:
+
+- `site` settings are available to the Admin and Content Settings APIs.
+- `core` settings are not available through an API.
+- Other groups are available through the Admin Settings API.
+
+Settings flags can make a setting public, read-only, or both.
+
+## Permissions
+
+Permission checks run after input serialization and before the controller query.
+Permissions are associated with a resource name (`docName`) and method, with
+their role assignments stored in the permissions and roles tables.
+
+An endpoint's permission configuration can be:
+
+- An object using the database permission, with optional overrides for `method`,
+  `docName`, and writable `unsafeAttrs`.
+- `true` to use the database permission.
+- `false` to skip the permission stage.
+- A function for exceptional custom logic. It should throw a
+  `NoPermissionError` to deny access and should not replace normal permission
+  configuration without a specific reason.
+
+Adding or changing a database-backed permission requires updates to fixtures, a
+database migration, fixture tests, and the database integrity hash.
+
+## Future design
+
+Ghost's API design can continue to evolve. REST can produce awkward affordances
+for actions: publishing a post is a `PUT` to `/posts/:id/` and looks the same as
+changing its title. New patterns should solve a demonstrated consumer problem
+without discarding the compatibility and consistency of the existing APIs.

--- a/docs/practices/api-design.md
+++ b/docs/practices/api-design.md
@@ -52,8 +52,8 @@ The following conventions should hold:
   ```
 
 - Resource bodies use a top-level key containing an array, including singular
-  requests. Settings are an exception because the key-value pairs are the list
-  of resources.
+  requests. Settings use the same shape, with each key-value pair represented
+  as a resource in the array.
 - Responses can include a top-level `meta` key for additional information.
 - Pagination metadata is nested under `meta.pagination`:
 

--- a/docs/practices/api-design.md
+++ b/docs/practices/api-design.md
@@ -1,8 +1,8 @@
 # API Design
 
 Ghost's APIs are mature and widely used. There is no need for a wholesale
-redesign; we should follow the established principles and patterns carefully,
-and add new patterns only when existing ones do not serve API consumers.
+redesign; follow the established principles and patterns carefully, and add new
+patterns only when existing ones do not serve API consumers.
 
 ## Principles
 
@@ -10,11 +10,11 @@ and add new patterns only when existing ones do not serve API consumers.
 
 > Be conservative in what you send, and liberal in what you accept.
 
-Ghost APIs are used by many different clients. Be flexible and permissive about
+Ghost APIs are used by many different apps and integrations. Be flexible about
 useful input while keeping responses specific and predictable.
 
 Being liberal in what we accept does not mean accepting arbitrary properties.
-For example, a client should be able to pass a resource returned by `read` back
+For example, a caller should be able to pass a resource returned by `read` back
 to `edit`; known non-writable fields can be ignored. A misspelled field such as
 `member: {naem: "John"}` is not useful input and should produce an error rather
 than being silently ignored.
@@ -29,21 +29,14 @@ weigh the value of new behavior against its long-term compatibility and
 maintenance cost.
 
 Good API design balances these principles: preserve useful flexibility for
-clients without making outputs or behavior accidental and unpredictable.
-
-### API maturity
-
-Ghost's APIs are around level 2 of the Richardson and Amundsen maturity models.
-Ghost borrowed heavily from JSON:API when standardising its APIs, but did not
-adopt its hypermedia concepts. When improving APIs, focus on useful affordances
-for consumers rather than API aesthetics alone.
+callers without making outputs or behavior accidental and unpredictable.
 
 ## Patterns
 
-The foundation of Ghost's HTTP API is to follow RESTful principles. REST and
-JSON:API provide useful CRUD patterns for top-level resources such as posts and
-members, although less standard operations such as file uploads and bulk changes
-need additional patterns.
+Ghost's HTTP APIs follow RESTful principles. REST and JSON:API provide useful
+CRUD patterns for top-level resources such as posts and members, although less
+standard operations such as file uploads and bulk changes need additional
+patterns.
 
 The following conventions should hold:
 
@@ -62,16 +55,21 @@ The following conventions should hold:
   requests. Settings are an exception because the key-value pairs are the list
   of resources.
 - Responses can include a top-level `meta` key for additional information.
-- Pagination metadata follows this shape:
+- Pagination metadata is nested under `meta.pagination`:
 
   ```json
   {
-      "page": 3,
-      "prev": 2,
-      "next": 4,
-      "limit": 15,
-      "total": 38,
-      "pages": 3
+      "members": [],
+      "meta": {
+          "pagination": {
+              "page": 3,
+              "prev": 2,
+              "next": null,
+              "limit": 15,
+              "total": 38,
+              "pages": 3
+          }
+      }
   }
   ```
 
@@ -86,8 +84,8 @@ copied for ordinary data interactions.
 
 ### Bulk endpoints
 
-Ghost uses `/bulk` as a nested resource for some bulk operations, such as
-`/members/bulk`. Define the request body and client behavior carefully before
+Ghost uses `/bulk` as a nested resource for bulk operations such as
+`/members/bulk`. Define the request body and app behavior carefully before
 adding another bulk endpoint.
 
 ## Conventions
@@ -95,7 +93,7 @@ adding another bulk endpoint.
 ### Function signatures and API calls
 
 The HTTP API should map closely to the SDK and internal package APIs, including
-function signatures and parameters. For example, a client call such as
+function signatures and parameters. For example, a call such as
 `api.posts.browse({filter, fields})` maps those options to a `GET` request for
 the posts resource with `filter` and `fields` query parameters.
 
@@ -110,7 +108,7 @@ corresponding `edit` or `PUT` operation without first removing read-only fields.
 API endpoints use middleware to set `Cache-Control`. Design every response on
 the assumption that a greedy cache can exist in front of Ghost.
 
-Mutation responses can include an `X-Cache-Invalidate` header telling clients
+Mutation responses can include an `X-Cache-Invalidate` header telling callers
 which paths need to be purged. Cache behavior must be deliberate for every API
 response.
 
@@ -123,9 +121,9 @@ new internal property is added.
 
 ## Settings
 
-Do not add new object values to the settings table. Settings values can be a
-string, number, boolean, or an array of values of the same type. The existing
-`labs` object is a special case and should not be used as precedent.
+Settings values can be strings, numbers, booleans, arrays, or objects. Object
+settings are used for a small number of structured values and should not be the
+default for new settings.
 
 Settings keys:
 
@@ -134,13 +132,9 @@ Settings keys:
 - Match the name exposed by the API where the key is public.
 
 The `type` field declares the type stored in `value`. The `group` field collects
-settings that are fetched and updated together and implies their API exposure:
-
-- `site` settings are available to the Admin and Content Settings APIs.
-- `core` settings are not available through an API.
-- Other groups are available through the Admin Settings API.
-
-Settings flags can make a setting public, read-only, or both.
+settings that are fetched and updated together. Groups and flags control which
+settings are exposed through the Admin and Content APIs, so follow an existing
+setting with the same intended exposure.
 
 ## Permissions
 

--- a/docs/practices/database-migrations.md
+++ b/docs/practices/database-migrations.md
@@ -107,8 +107,8 @@ pnpm test:single test/integration/migrations/migration.test.js
 ```
 
 Add focused tests for any non-trivial transformation, then run the affected Core
-tests. The migration review checklist requires verification with both MySQL and
-SQLite because Knex and the database engines do not always behave identically.
+tests. CI runs the database-backed Core suites with both MySQL and SQLite
+because Knex and the database engines do not always behave identically.
 
 ### Reviewing
 

--- a/docs/practices/database-migrations.md
+++ b/docs/practices/database-migrations.md
@@ -38,7 +38,7 @@ The slug must be kebab-case, for example `add-column-to-posts`. The script:
 
 - Places the file in the next minor-version folder under
   `core/server/data/migrations/versions/`.
-- Bumps the Ghost Core package to the target minor release candidate when
+- Bumps the Ghost Core and Admin packages to the target minor release candidate when
   needed so `knex-migrator` will run the new version folder.
 
 Always use this command rather than creating or naming the file manually. It

--- a/docs/practices/database-migrations.md
+++ b/docs/practices/database-migrations.md
@@ -31,22 +31,28 @@ Create a migration file from `ghost/core`:
 
 ```bash
 cd ghost/core
-yarn migrate:create <slug>
+pnpm migrate:create <slug>
 ```
 
 The slug must be kebab-case, for example `add-column-to-posts`. The script:
 
 - Places the file in the next minor-version folder under
   `core/server/data/migrations/versions/`.
-- Bumps the Ghost Core and Admin package versions to the next release candidate
-  when this is the first migration since the last release.
+- Bumps the Ghost Core package to the target minor release candidate when
+  needed so `knex-migrator` will run the new version folder.
+
+Always use this command rather than creating or naming the file manually. It
+compares the current package version with the latest published Ghost tag to
+avoid placing a migration in a version that has already shipped. CI repeats
+these version and placement checks with
+[`scripts/check-migration-integrity.cjs`](../../scripts/check-migration-integrity.cjs).
 
 ### Writing the migration
 
 1. Open the generated migration file in
    `core/server/data/migrations/versions/`.
 2. Add the database changes, using similar existing migrations as examples.
-3. Run the migration with `yarn knex-migrator migrate` while following the
+3. Run the migration with `pnpm knex-migrator migrate` while following the
    iteration guidance below.
 4. For schema changes, update `core/server/data/schema/schema.js` to match.
 5. Update the schema integrity tests and any other affected tests.
@@ -69,8 +75,9 @@ During development, run migrations with Ghost's custom
 [`knex-migrator`](https://github.com/TryGhost/knex-migrator):
 
 ```bash
-yarn knex-migrator migrate
-yarn knex-migrator rollback
+cd ghost/core
+pnpm knex-migrator migrate --v <version-directory> --force
+pnpm knex-migrator rollback --v <previous-version> --force
 ```
 
 `migrate` calls the migration's `up()` method and `rollback` calls its `down()`
@@ -82,9 +89,26 @@ state that existed before `up()`.
 Test migrations against both MySQL and SQLite because Knex can behave
 differently between database clients.
 
-Migration tests should cover idempotency. A simple manual check is to run the
-migration, remove its row from the `migrations` table, and start Ghost again. It
-should start with a warning rather than fail.
+Run the schema integrity test after changing `schema.js`, fixtures, default
+settings, or default routes. Update only the expected hash for the change you
+made:
+
+```bash
+cd ghost/core
+pnpm test:single test/unit/server/data/schema/integrity.test.js
+```
+
+Run the migration integration test to exercise initialization, rollback,
+forward migration, and idempotency:
+
+```bash
+cd ghost/core
+pnpm test:single test/integration/migrations/migration.test.js
+```
+
+Add focused tests for any non-trivial transformation, then run the affected Core
+tests. The migration review checklist requires verification with both MySQL and
+SQLite because Knex and the database engines do not always behave identically.
 
 ### Reviewing
 
@@ -118,6 +142,11 @@ Examples include:
 Schema changes, index changes, and data updates can be expensive on large
 tables. Consider how the migration behaves with a large dataset and remember
 that migrations block Ghost from booting until they finish.
+
+Avoid unbounded loops and mass updates. Batch large data changes, and do not mix
+DDL and DML operations in the same migration. Performance measured against a
+small local database is not evidence that a migration is safe for large sites;
+flag uncertain changes explicitly for reviewer attention.
 
 ### Idempotency
 
@@ -153,6 +182,12 @@ Use the helpers in
 [`core/server/data/migrations/utils/`](../../ghost/core/core/server/data/migrations/utils/)
 wherever possible. They contain tested implementations of common operations,
 including idempotency and logging protections.
+
+Choose the wrapper that matches the operation. DML normally uses
+`createTransactionalMigration`; many DDL operations require
+`createNonTransactionalMigration` or a focused schema helper such as
+`addTable` or `createAddColumnMigration`. Copy a recent comparable migration
+rather than assuming every operation has the same transaction behavior.
 
 ### Migrations are immutable
 

--- a/docs/practices/database-migrations.md
+++ b/docs/practices/database-migrations.md
@@ -1,0 +1,171 @@
+# Database Migrations
+
+## Why might I need a migration?
+
+Database migrations transform the state of Ghost's database when Ghost boots.
+For example, a migration may:
+
+- Add a table.
+- Add a column to a table.
+- Add user permissions.
+- Manipulate existing data.
+
+> Migrations are dangerous and need to be treated with a great deal of care.
+> This is one of the places where a mistake can cause widespread damage.
+
+## How to write a migration
+
+### Planning
+
+Migrations should be carefully planned and written as one of the first steps in
+feature development. This allows more time for feedback during review. They
+should not be rushed.
+
+Before writing the migration, be clear about the expected schema, including the
+tables and columns that are needed and the naming they will use. For data
+migrations, understand the size and shape of the existing data first.
+
+### Creating the migration file
+
+Create a migration file from `ghost/core`:
+
+```bash
+cd ghost/core
+yarn migrate:create <slug>
+```
+
+The slug must be kebab-case, for example `add-column-to-posts`. The script:
+
+- Places the file in the next minor-version folder under
+  `core/server/data/migrations/versions/`.
+- Bumps the Ghost Core and Admin package versions to the next release candidate
+  when this is the first migration since the last release.
+
+### Writing the migration
+
+1. Open the generated migration file in
+   `core/server/data/migrations/versions/`.
+2. Add the database changes, using similar existing migrations as examples.
+3. Run the migration with `yarn knex-migrator migrate` while following the
+   iteration guidance below.
+4. For schema changes, update `core/server/data/schema/schema.js` to match.
+5. Update the schema integrity tests and any other affected tests.
+
+#### Types of migration
+
+Migration pull requests generally contain one of two types of change:
+
+- **DDL (data definition language)** migrations change the database schema.
+  They require a migration for existing databases and a matching update to
+  `schema.js`. New tables must also be added to the export list, and the schema
+  integrity hash must be updated.
+- **DML (data manipulation language)** migrations change data already stored in
+  the tables. They generally require only the migration itself and focused
+  tests.
+
+### Iterating
+
+During development, run migrations with Ghost's custom
+[`knex-migrator`](https://github.com/TryGhost/knex-migrator):
+
+```bash
+yarn knex-migrator migrate
+yarn knex-migrator rollback
+```
+
+`migrate` calls the migration's `up()` method and `rollback` calls its `down()`
+method. You can use this workflow to iterate while `down()` restores the same
+state that existed before `up()`.
+
+### Testing
+
+Test migrations against both MySQL and SQLite because Knex can behave
+differently between database clients.
+
+Migration tests should cover idempotency. A simple manual check is to run the
+migration, remove its row from the `migrations` table, and start Ghost again. It
+should start with a warning rather than fail.
+
+### Reviewing
+
+Review migrations for three primary concerns:
+
+- **Correctness:** does the migration make the intended change?
+- **Performance:** does it complete in a safe amount of time?
+- **Safety:** does it protect against missing or invalid data?
+
+Migration pull requests should contain as few changes as possible: only the
+migration and the updates required for Ghost and its tests to continue working.
+A workflow adds a [migration review checklist](../../.github/workflows/migration-review.yml)
+to pull requests containing migrations.
+
+All migrations require review. Compare the implementation with the intended
+schema or feature design, and give changes to large or frequently updated tables
+additional performance scrutiny.
+
+The best place to start is an existing migration that performs a similar change.
+Examples include:
+
+- [Adding a table](https://github.com/TryGhost/Ghost/pull/16150/files)
+- [Adding and populating columns](https://github.com/TryGhost/Ghost/pull/15855/files)
+- [Adding a setting](https://github.com/TryGhost/Ghost/pull/15705/files)
+- [Manipulating data](https://github.com/TryGhost/Ghost/pull/15952/files)
+
+## Rules
+
+### Performance
+
+Schema changes, index changes, and data updates can be expensive on large
+tables. Consider how the migration behaves with a large dataset and remember
+that migrations block Ghost from booting until they finish.
+
+### Idempotency
+
+It must be safe to run a migration twice. A migration may stop partway through
+because of an external failure, and rerunning it must not leave the database in
+an invalid state.
+
+### Be minimal
+
+Keep migration pull requests small. Mistakes are easier to miss when the
+migration is buried in a large change.
+
+### Be defensive
+
+Protect against missing or unexpected data. If a migration crashes, Ghost
+cannot boot.
+
+### Log every code path
+
+Log what every code path and early return did so a migration can be diagnosed
+after it runs.
+
+### Do not use the model layer
+
+Migrations run against the database state from an older Ghost version, but the
+model layer comes from the version being installed. A later model change can
+therefore break an older migration. Use the migration's database transaction
+and migration utilities directly instead.
+
+### Use migration utilities
+
+Use the helpers in
+[`core/server/data/migrations/utils/`](../../ghost/core/core/server/data/migrations/utils/)
+wherever possible. They contain tested implementations of common operations,
+including idempotency and logging protections.
+
+### Migrations are immutable
+
+Once a migration is in `main`, it is final except for very limited bug or
+performance fixes. Create another migration when a later change is needed.
+Changing or removing a migration after it has run leaves different environments
+in different database states and can break migration tracking.
+
+For example, if a column needs to be renamed after its migration reaches `main`,
+make the original migration a no-op only when necessary for a fix, then add new
+migrations that create the correct column and remove the old one if it exists.
+
+### Versioning
+
+Migrations must preserve Ghost's version update policy: users must be able to
+update from the last patch release in any supported major version.

--- a/ghost/core/test/README.md
+++ b/ghost/core/test/README.md
@@ -1,8 +1,9 @@
 # Ghost Core End-to-End Tests
 
-Ghost Core's end-to-end framework provides one place to access request agents,
-fixtures, mocks, and snapshot matchers. Tests use it by requiring
-`test/utils/e2e-framework.js`.
+Ghost Core's server end-to-end framework provides one place to access request
+agents, fixtures, mocks, and snapshot matchers. These are Vitest suites which
+exercise Ghost directly; they are separate from the Playwright browser suite in
+the repository's `e2e/` directory.
 
 ```js
 const {agentProvider, fixtureManager, mockManager, matchers} =
@@ -25,10 +26,10 @@ add focused assertions for important behavior such as ordering and side effects.
 
 ## Fixtures
 
-Use `fixtureManager.init()` to insert fixture tasks in a known state. Basic
-fixtures such as roles, permissions, and the owner are already available.
-Named tasks add the data required by a test; for example, `users` creates a
-staff user for each role and `users:inactive` adds an inactive user.
+Use `fixtureManager.init()` to insert fixture tasks in a known state. The
+framework includes the owner fixture by default. Named tasks add the data
+required by a test; for example, `users` creates staff users for each role and
+`users:inactive` adds an inactive user.
 
 Older tests may use `localUtils.doAuth()` or `testUtils.setup()`, but new
 end-to-end tests should use the fixture manager and request agents.
@@ -41,6 +42,24 @@ after each test.
 
 The webhook mock receiver follows the same pattern for outgoing webhooks.
 
+Real network access is disabled when the framework boots. Use a focused mock or
+an existing `mockManager` helper for external services.
+
+## Snapshots
+
+Request agents provide `matchBodySnapshot()` and `matchHeaderSnapshot()`. Use
+the most specific matcher available for values that change between runs, such
+as object IDs, UUIDs, dates, ETags, and resource locations.
+
+To update a snapshot for one test, run:
+
+```bash
+SNAPSHOT_UPDATE=1 pnpm test:single test/e2e-api/path/to/test.test.js
+```
+
+Review every changed `.snap` file before committing it. A generated snapshot is
+not proof that the response is correct.
+
 ## Test style
 
 - Keep tests fast and make only the requests needed for the behavior.
@@ -48,3 +67,17 @@ The webhook mock receiver follows the same pattern for outgoing webhooks.
 - Test side effects as well as the response.
 - Give tests names that remain clear in snapshot files.
 - Do not use the old test utilities in new tests.
+
+## Running the tests
+
+From `ghost/core`:
+
+```bash
+pnpm test:e2e
+pnpm test:single test/e2e-api/path/to/test.test.js
+```
+
+The main groups are `test/e2e-api/`, `test/e2e-frontend/`,
+`test/e2e-webhooks/`, `test/e2e-server/`, and `test/e2e-isolated/`. Start from a
+nearby test in the same group because boot options, agent choice, and cleanup
+requirements vary by boundary.

--- a/ghost/core/test/README.md
+++ b/ghost/core/test/README.md
@@ -29,7 +29,7 @@ add focused assertions for important behavior such as ordering and side effects.
 Use `fixtureManager.init()` to insert fixture tasks in a known state. The
 framework includes the owner fixture by default. Named tasks add the data
 required by a test; for example, `users` creates staff users for each role and
-`users:inactive` adds an inactive user.
+`user:inactive` adds an inactive user.
 
 Older tests may use `localUtils.doAuth()` or `testUtils.setup()`, but new
 end-to-end tests should use the fixture manager and request agents.
@@ -78,6 +78,7 @@ pnpm test:single test/e2e-api/path/to/test.test.js
 ```
 
 The main groups are `test/e2e-api/`, `test/e2e-frontend/`,
-`test/e2e-webhooks/`, `test/e2e-server/`, and `test/e2e-isolated/`. Start from a
-nearby test in the same group because boot options, agent choice, and cleanup
-requirements vary by boundary.
+`test/e2e-webhooks/`, and `test/e2e-server/`. Isolated tests use an
+`.isolated.test.js` or `.isolated.test.ts` suffix inside `test/e2e-server/`.
+Start from a nearby test in the same group because boot options, agent choice,
+and cleanup requirements vary by boundary.

--- a/ghost/core/test/README.md
+++ b/ghost/core/test/README.md
@@ -1,0 +1,50 @@
+# Ghost Core End-to-End Tests
+
+Ghost Core's end-to-end framework provides one place to access request agents,
+fixtures, mocks, and snapshot matchers. Tests use it by requiring
+`test/utils/e2e-framework.js`.
+
+```js
+const {agentProvider, fixtureManager, mockManager, matchers} =
+    require('../utils/e2e-framework');
+
+const agent = await agentProvider.getAdminAPIAgent();
+await fixtureManager.init('members');
+await agent.loginAsOwner();
+```
+
+## Request agents
+
+The framework provides agents for the Admin, Content, and Members APIs. Agents
+boot Ghost with suitable defaults, reset the database, configure the API base
+path, and provide authentication helpers.
+
+Requests use async/await. Assert the response status, body, and relevant headers.
+Use the snapshot matchers for generated IDs, dates, ETags, and locations, and
+add focused assertions for important behavior such as ordering and side effects.
+
+## Fixtures
+
+Use `fixtureManager.init()` to insert fixture tasks in a known state. Basic
+fixtures such as roles, permissions, and the owner are already available.
+Named tasks add the data required by a test; for example, `users` creates a
+staff user for each role and `users:inactive` adds an inactive user.
+
+Older tests may use `localUtils.doAuth()` or `testUtils.setup()`, but new
+end-to-end tests should use the fixture manager and request agents.
+
+## Mocks
+
+`mockManager` handles external effects. Use `mockManager.mockMail()` to inspect
+outgoing email and match HTML, plain text, and metadata snapshots. Restore mocks
+after each test.
+
+The webhook mock receiver follows the same pattern for outgoing webhooks.
+
+## Test style
+
+- Keep tests fast and make only the requests needed for the behavior.
+- Use `expectEmptyBody` for responses such as `204`.
+- Test side effects as well as the response.
+- Give tests names that remain clear in snapshot files.
+- Do not use the old test utilities in new tests.

--- a/ghost/core/test/README.md
+++ b/ghost/core/test/README.md
@@ -9,9 +9,13 @@ the repository's `e2e/` directory.
 const {agentProvider, fixtureManager, mockManager, matchers} =
     require('../utils/e2e-framework');
 
-const agent = await agentProvider.getAdminAPIAgent();
-await fixtureManager.init('members');
-await agent.loginAsOwner();
+let agent;
+
+beforeAll(async function () {
+    agent = await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('members');
+    await agent.loginAsOwner();
+});
 ```
 
 ## Request agents


### PR DESCRIPTION
## Summary

- Migrates the remaining durable Codex engineering guidance into the codebase documentation, including database migrations, API design, database structure, caching, jobs, email testing, analytics, Stripe flows, site identity, Core E2E tests, and performance testing.
- Preserves each source migration and its code-verified correction as separate commits so reviewers can distinguish the original guidance from factual updates.
- Updates the documentation index, while leaving obsolete, historical, and non-public operational material out of the public guides.

## Follow-up

- Public app release documentation corrections have been separated for a later PR.

## Testing

- [x] `pnpm lint:docs`
- [x] Checked local links in all changed Markdown files
- [x] `git diff --check origin/main...HEAD`
