### PR TITLE
🐛 Stopped automation runs when member unsubscribes

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -177,14 +177,8 @@ const processStep = async ({
             break;
         case 'send_email': {
             if (!hasUpdatesAndAnnouncementsEnabled(member)) {
-                logging.info({
-                    system: {
-                        event: 'automations.poll.skipped_unsubscribed_member',
-                        member_id: step.member_id,
-                        step_id: step.id
-                    }
-                }, `[AUTOMATIONS] Member ${step.member_id} for step ${step.id} has unsubscribed from emails. Fast-finishing this step`);
-                break;
+                await automationsApi.markStepTerminal(step, 'member unsubscribed');
+                return null;
             }
             memberWelcomeEmailService.init();
             const trackClicks = labs.isSet('automationAnalytics') && Boolean(settingsCache.get('email_track_clicks'));

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -265,11 +265,9 @@ describe('automations poll', function () {
         sinon.assert.calledOnceWithExactly(automationsApi.markStepTerminal, step, 'member changed status');
     });
 
-    it('skips sending email if the member unsubscribed from updates & announcements', async function () {
-        const nextReadyAt = new Date(Date.now() + 60 * 1000);
+    it('ends the automation run if the member unsubscribed from updates & announcements', async function () {
         const step = buildEmailStep();
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
-        automationsApi.finishStepAndEnqueueNext.resolves(nextReadyAt);
         Member.findOne.resolves(buildMember({enable_updates_and_announcements: false}));
 
         await poll(options);
@@ -277,9 +275,9 @@ describe('automations poll', function () {
         sinon.assert.notCalled(memberWelcomeEmailService.init);
         sinon.assert.notCalled(memberWelcomeEmailService.api.sendAutomationEmail);
         sinon.assert.notCalled(automationsApi.recordEmailSent);
-        sinon.assert.notCalled(automationsApi.markStepTerminal);
-        sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
-        sinon.assert.calledOnceWithExactly(options.enqueueAnotherPollAt, nextReadyAt);
+        sinon.assert.calledOnceWithExactly(automationsApi.markStepTerminal, step, 'member unsubscribed');
+        sinon.assert.notCalled(automationsApi.finishStepAndEnqueueNext);
+        sinon.assert.notCalled(options.enqueueAnotherPollAt);
     });
 
     it('sends email if updates & announcements is unset and the member has newsletter subscriptions', async function () {
@@ -297,11 +295,9 @@ describe('automations poll', function () {
         sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
     });
 
-    it('skips sending email if updates & announcements is unset and the member has no newsletter subscriptions', async function () {
-        const nextReadyAt = new Date(Date.now() + 60 * 1000);
+    it('ends the automation run if updates & announcements is unset and the member has no newsletter subscriptions', async function () {
         const step = buildEmailStep();
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
-        automationsApi.finishStepAndEnqueueNext.resolves(nextReadyAt);
         Member.findOne.resolves(buildMember({
             enable_updates_and_announcements: null,
             newsletters: []
@@ -312,9 +308,9 @@ describe('automations poll', function () {
         sinon.assert.notCalled(memberWelcomeEmailService.init);
         sinon.assert.notCalled(memberWelcomeEmailService.api.sendAutomationEmail);
         sinon.assert.notCalled(automationsApi.recordEmailSent);
-        sinon.assert.notCalled(automationsApi.markStepTerminal);
-        sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
-        sinon.assert.calledOnceWithExactly(options.enqueueAnotherPollAt, nextReadyAt);
+        sinon.assert.calledOnceWithExactly(automationsApi.markStepTerminal, step, 'member unsubscribed');
+        sinon.assert.notCalled(automationsApi.finishStepAndEnqueueNext);
+        sinon.assert.notCalled(options.enqueueAnotherPollAt);
     });
 
     it('gift members run through paid automations', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1527

Before this change, if a member unsubscribed from automation emails, `send_email` steps would be no-ops. Every step would run, but emails wouldn't be sent.

After this change, the automation is stopped.

## Manual test

In addition to automated tests, I also did a manual test.

1. I set up an automation with 3 emails separated by 1 day waits. (I configured things so that 1 day got shortened to 15 seconds, for testing.)
2. I signed up and verified that I got the first email.
3. I unsubscribed.
4. After ~15 seconds, I got no email. And the data in the database looked correct.

Screencast (no audio):

https://github.com/user-attachments/assets/6f1e6512-093d-4bfe-bfc3-24a353bc632f