### PR TITLE
Documented the koenig package APIs

### DIFF
--- a/.changeset/common-squids-argue.md
+++ b/.changeset/common-squids-argue.md
@@ -1,0 +1,15 @@
+---
+"@tryghost/kg-utils": patch
+"@tryghost/kg-unsplash-selector": patch
+"@tryghost/kg-markdown-html-renderer": patch
+"@tryghost/kg-lexical-html-renderer": patch
+"@tryghost/kg-html-to-lexical": patch
+"@tryghost/kg-default-transforms": patch
+"@tryghost/kg-default-nodes": patch
+"@tryghost/kg-default-cards": patch
+"@tryghost/kg-converters": patch
+"@tryghost/kg-clean-basic-html": patch
+"@tryghost/kg-card-factory": patch
+---
+
+Documented the package API and corrected the development instructions in the README

--- a/.changeset/olive-regions-stop.md
+++ b/.changeset/olive-regions-stop.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/koenig-lexical": patch
+---
+
+Added a package description for npm

--- a/koenig/README.md
+++ b/koenig/README.md
@@ -90,8 +90,10 @@ edit/run/test loop against ghost/core.
 
 - kg-* Node libraries share a Vitest base config —
   [vitest.shared.ts](./vitest.shared.ts) (`createKoenigVitestConfig`). Run
-  `pnpm test:unit` in the package, or `pnpm test` for the full gate (types +
-  coverage thresholds + lint).
+  `pnpm test:unit` in the package for unit tests, `pnpm test:types` for type
+  checks, and `pnpm lint` for lint. `pnpm test` runs the package's configured
+  test suites and enforces coverage thresholds; packages with a `posttest`
+  hook also run lint automatically.
 - `koenig-lexical` has Vitest unit tests and a large Playwright browser
   acceptance suite: `pnpm test:unit`, `pnpm test:acceptance` (headless by default;
   `:headed`, `:report`, and `test:slowmo` variants for debugging). See

--- a/koenig/kg-card-factory/README.md
+++ b/koenig/kg-card-factory/README.md
@@ -1,38 +1,40 @@
 # Koenig Card Factory
 
+Card definition factory for Ghost's Mobiledoc renderer.
+
+> Legacy: this package supports posts that have never been converted from
+> Mobiledoc. New editor work belongs in the Lexical packages.
+
 ## Install
-
-`npm install @tryghost/kg-card-factory --save`
-
-or
 
 `npm install @tryghost/kg-card-factory`
 
-
 ## Usage
 
+```js
+import {CardFactory} from '@tryghost/kg-card-factory';
+
+const factory = new CardFactory({siteUrl: 'https://example.com'});
+const card = factory.createCard(cardDefinition);
+```
+
+Options passed to the factory are merged into the render options of every card
+it creates, with per-render options taking precedence.
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-card-factory`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
-## Run
-
-- `pnpm dev`
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-
-
-
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
 # Copyright & License
 

--- a/koenig/kg-card-factory/README.md
+++ b/koenig/kg-card-factory/README.md
@@ -34,7 +34,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-card-factory/package.json
+++ b/koenig/kg-card-factory/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-card-factory",
   "version": "5.2.3",
+  "description": "Card definition factory for Ghost's Mobiledoc renderer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-clean-basic-html/README.md
+++ b/koenig/kg-clean-basic-html/README.md
@@ -1,38 +1,45 @@
 # Koenig Clean Basic Html
 
+Sanitises and normalises the basic HTML snippets used in Ghost's editor cards, such as captions.
+
 ## Install
-
-`npm install @tryghost/kg-clean-basic-html --save`
-
-or
 
 `npm install @tryghost/kg-clean-basic-html`
 
-
 ## Usage
 
+```js
+import {cleanBasicHtml} from '@tryghost/kg-clean-basic-html';
+
+cleanBasicHtml('  <p>Hello <b>world</b></p>&nbsp; ');
+// '<p>Hello <b>world</b></p>'
+```
+
+In the browser the document is taken from the global `document`. In Node you
+must supply one, or the call throws:
+
+```js
+import {JSDOM} from 'jsdom';
+
+cleanBasicHtml(html, {
+    createDocument: htmlString => new JSDOM(htmlString).window.document
+});
+```
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-clean-basic-html`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
-## Run
-
-- `pnpm dev`
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-
-
-
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
 # Copyright & License
 

--- a/koenig/kg-clean-basic-html/README.md
+++ b/koenig/kg-clean-basic-html/README.md
@@ -39,7 +39,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-clean-basic-html/package.json
+++ b/koenig/kg-clean-basic-html/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-clean-basic-html",
   "version": "4.3.3",
+  "description": "Sanitises and normalises the basic HTML snippets used in Ghost's editor cards",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-converters/README.md
+++ b/koenig/kg-converters/README.md
@@ -32,7 +32,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-converters/README.md
+++ b/koenig/kg-converters/README.md
@@ -1,35 +1,39 @@
 # Koenig Converters
 
-Functions for converting between serialized Lexical and Mobiledoc formats
+Converts between the serialized Mobiledoc and Lexical formats.
 
 ## Install
-
-`npm install @tryghost/kg-converters --save`
-
-or
 
 `npm install @tryghost/kg-converters`
 
 ## Usage
 
+```js
+import {mobiledocToLexical, lexicalToMobiledoc} from '@tryghost/kg-converters';
+
+const lexical = mobiledocToLexical(serializedMobiledoc);
+const mobiledoc = lexicalToMobiledoc(serializedLexical);
+```
+
+Both take and return serialized JSON strings. Mobiledoc cards are carried
+across as Lexical nodes of the same name, so a round trip preserves cards that
+both formats know about.
 
 ## Develop
 
-This is a monorepo package.
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-converters`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
-
-
-# Copyright & License 
+# Copyright & License
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](https://github.com/TryGhost/Ghost/blob/main/LICENSE).

--- a/koenig/kg-converters/package.json
+++ b/koenig/kg-converters/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-converters",
   "version": "1.2.4",
+  "description": "Converts between serialized Mobiledoc and Lexical formats for Ghost's editor",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-default-cards/README.md
+++ b/koenig/kg-default-cards/README.md
@@ -19,9 +19,9 @@ cards.map(card => card.name);
 ```
 
 Each card exposes `name`, `type` and a `render` function, ready to hand to the
-Mobiledoc renderer, plus the URL transform helpers (`absoluteToRelative`,
-`relativeToAbsolute`, `toTransformReady`) that Ghost applies when storing and
-serving content.
+Mobiledoc renderer. Cards that contain URLs also expose the relevant transform
+helpers (`absoluteToRelative`, `relativeToAbsolute`, `toTransformReady`) that
+Ghost applies when storing and serving content.
 
 ## Develop
 

--- a/koenig/kg-default-cards/README.md
+++ b/koenig/kg-default-cards/README.md
@@ -36,7 +36,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-default-cards/README.md
+++ b/koenig/kg-default-cards/README.md
@@ -1,38 +1,42 @@
 # Koenig Default Cards
 
+Mobiledoc card definitions for Ghost's editor.
+
+> Legacy: this package supports posts that have never been converted from
+> Mobiledoc. New editor work belongs in the Lexical packages.
+
 ## Install
-
-`npm install @tryghost/kg-default-cards --save`
-
-or
 
 `npm install @tryghost/kg-default-cards`
 
-
 ## Usage
 
+```js
+import {cards} from '@tryghost/kg-default-cards';
+
+cards.map(card => card.name);
+// ['bookmark', 'code', 'email', 'email-cta', 'embed', ...]
+```
+
+Each card exposes `name`, `type` and a `render` function, ready to hand to the
+Mobiledoc renderer, plus the URL transform helpers (`absoluteToRelative`,
+`relativeToAbsolute`, `toTransformReady`) that Ghost applies when storing and
+serving content.
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-default-cards`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
-## Run
-
-- `pnpm dev`
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-
-
-
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
 # Copyright & License
 

--- a/koenig/kg-default-cards/package.json
+++ b/koenig/kg-default-cards/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-default-cards",
   "version": "10.3.4",
+  "description": "Mobiledoc card definitions for Ghost's editor",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-default-nodes/README.md
+++ b/koenig/kg-default-nodes/README.md
@@ -1,43 +1,47 @@
 # Koenig Default Nodes
 
-Lexical node definitions for the default nodes used in Ghost&#39;s Koenig editor
+Lexical node definitions for all of Ghost's cards, including each node's HTML renderer. This is the single source of truth for node rendering — both the editor and the server render through it.
 
 ## Install
-
-`npm install @tryghost/kg-default-nodes --save`
-
-or
 
 `npm install @tryghost/kg-default-nodes`
 
 ## Usage
 
+```js
+const {DEFAULT_NODES, DEFAULT_CONFIG} = require('@tryghost/kg-default-nodes');
+
+const editor = createHeadlessEditor({
+    nodes: [HeadingNode, LinkNode, ListNode, ListItemNode, QuoteNode, ...DEFAULT_NODES],
+    html: DEFAULT_CONFIG.html
+});
+```
+
+`DEFAULT_NODES` covers Ghost's own cards, so pair it with the base Lexical
+nodes your content needs. `DEFAULT_CONFIG.html` supplies the import serializers
+that keep pasted HTML mapping onto the right nodes.
+
+Individual nodes are exported by name (`ImageNode`, `CalloutNode`, and so on)
+when you need a subset rather than the full set.
+
+This package must stay browser-safe: it runs inside the editor as well as on
+the server.
 
 ## Develop
 
-This is a monorepo package.
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-default-nodes`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
-
-## Running in Ghost Admin
-In order to run local changes, perform the following:
-This package is part of the Ghost monorepo workspace — `ghost/core` resolves
-it via `workspace:` automatically, so local changes are picked up with no
-linking. Run `pnpm dev` in this package for a rebuild-on-change watcher.
-
-`kg-lexical-html-renderer` must also be linked when linking this package as they are codependencies.
-
-
-# Copyright & License 
+# Copyright & License
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](https://github.com/TryGhost/Ghost/blob/main/LICENSE).

--- a/koenig/kg-default-nodes/README.md
+++ b/koenig/kg-default-nodes/README.md
@@ -9,10 +9,11 @@ Lexical node definitions for all of Ghost's cards, including each node's HTML re
 ## Usage
 
 ```js
+const {createEditor} = require('lexical');
 const {DEFAULT_NODES, DEFAULT_CONFIG} = require('@tryghost/kg-default-nodes');
 
-const editor = createHeadlessEditor({
-    nodes: [HeadingNode, LinkNode, ListNode, ListItemNode, QuoteNode, ...DEFAULT_NODES],
+const editor = createEditor({
+    nodes: DEFAULT_NODES,
     html: DEFAULT_CONFIG.html
 });
 ```
@@ -40,7 +41,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-default-nodes/package.json
+++ b/koenig/kg-default-nodes/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-default-nodes",
   "version": "2.1.5",
+  "description": "Lexical node definitions and HTML renderers for Ghost's Koenig editor cards",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-default-transforms/README.md
+++ b/koenig/kg-default-transforms/README.md
@@ -33,7 +33,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-default-transforms/README.md
+++ b/koenig/kg-default-transforms/README.md
@@ -1,35 +1,40 @@
 # Koenig Default Transforms
 
-Default Lexical Node transforms used across our Koenig packages
+Lexical node transforms shared between the editor and the server, such as denesting and list merging.
 
 ## Install
-
-`npm install @tryghost/kg-default-transforms --save`
-
-or
 
 `npm install @tryghost/kg-default-transforms`
 
 ## Usage
 
+```js
+const {registerDefaultTransforms} = require('@tryghost/kg-default-transforms');
+
+const teardown = registerDefaultTransforms(editor);
+```
+
+Returns a teardown function that unregisters every transform it added.
+
+Individual transforms are also exported by name for cases that need a subset.
+`registerRemoveAtLinkNodesTransform` is deliberately not part of the defaults —
+it is only wanted when rendering.
 
 ## Develop
 
-This is a monorepo package.
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-default-transforms`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
-
-
-# Copyright & License 
+# Copyright & License
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](https://github.com/TryGhost/Ghost/blob/main/LICENSE).

--- a/koenig/kg-default-transforms/package.json
+++ b/koenig/kg-default-transforms/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-default-transforms",
   "version": "1.3.3",
+  "description": "Shared Lexical node transforms for Ghost's Koenig editor",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-html-to-lexical/README.md
+++ b/koenig/kg-html-to-lexical/README.md
@@ -1,34 +1,37 @@
 # Html To Lexical
 
-Convert HTML strings into Lexical editor state objects
+Converts HTML strings into Lexical editor state, used by imports and the Admin API's `?source=html` option.
 
 ## Install
-
-`npm install @tryghost/kg-html-to-lexical --save`
-
-or
 
 `npm install @tryghost/kg-html-to-lexical`
 
 ## Usage
 
+```js
+const {htmlToLexical} = require('@tryghost/kg-html-to-lexical');
+
+const state = htmlToLexical('<p>Hello <strong>world</strong></p>');
+// {root: {children: [...], type: 'root', ...}}
+```
+
+Returns a serializable editor state object, not a string — `JSON.stringify` it
+before storing. Runs headlessly via JSDOM, so it works server-side.
 
 ## Develop
 
-This is a monorepo package.
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-html-to-lexical`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-
-
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
 # Copyright & License
 

--- a/koenig/kg-html-to-lexical/README.md
+++ b/koenig/kg-html-to-lexical/README.md
@@ -31,7 +31,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-html-to-lexical/package.json
+++ b/koenig/kg-html-to-lexical/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-html-to-lexical",
   "version": "1.3.3",
+  "description": "Converts HTML strings into Lexical editor state for Ghost",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-lexical-html-renderer/README.md
+++ b/koenig/kg-lexical-html-renderer/README.md
@@ -62,7 +62,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-lexical-html-renderer/README.md
+++ b/koenig/kg-lexical-html-renderer/README.md
@@ -1,21 +1,16 @@
 # Koenig Lexical Html Renderer
 
-Renders a lexical editor state string to a HTML string.
+Renders a serialized Lexical editor state to an HTML string.
 
 This library differs from Lexical's own [lexical-html](https://github.com/facebook/lexical/tree/main/packages/lexical-html) package in a few ways:
 
-1. it's output target is not an editor but rendered web pages or emails which means the handling of nodes (especially custom DecoratorNodes) will differ to the node's built-in editor-focused rendering
+1. its output target is not an editor but rendered web pages or emails, which means the handling of nodes (especially custom DecoratorNodes) will differ from the node's built-in editor-focused rendering
 2. render output will vary based on supplied options and targets, e.g. when rendering for email the output may use `<table>` elements in place of modern HTML structure
-3. it's primary usage environment is server-side
+3. its primary usage environment is server-side
 
 ## Install
 
-`npm install @tryghost/kg-lexical-html-renderer --save`
-
-or
-
 `npm install @tryghost/kg-lexical-html-renderer`
-
 
 ## Usage
 
@@ -29,6 +24,8 @@ const lexicalState = '{...}';
 const html = await renderer.render(lexicalState);
 ```
 
+`render()` is async and returns a string.
+
 Options can be passed in as the second argument to `.render()`.
 
 ```js
@@ -39,29 +36,33 @@ const html = await renderer.render(lexicalState, {target: 'email'});
 | -------- | ------ |
 | `target` | `'html'` (default), `'email'` |
 
+Options are passed through to each node's renderer in `kg-default-nodes`,
+which accepts further keys — `siteUrl`, `postUrl`, `imageOptimization` and
+others — for URL resolution and image handling.
+
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-lexical-html-renderer`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
+`ghost/core` resolves this package via a `source` export condition pointing at
+`src/`, so a change here is picked up by a running Ghost dev server without a
+rebuild. Run `pnpm dev` for a watching `tsc` build when you need the compiled
+output.
 
+Changes usually need to be made alongside
+[kg-default-nodes](../kg-default-nodes), which owns the per-node rendering this
+package drives.
+
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-
-
-## Running in Ghost Admin
-In order to run local changes, perform the following:
-This package is part of the Ghost monorepo workspace — `ghost/core` resolves
-it via `workspace:` automatically, so local changes are picked up with no
-linking. Run `pnpm dev` in this package for a rebuild-on-change watcher.
-
-`kg-default-nodes` must also be linked when linking this package as they are codependencies.
-
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
 # Copyright & License
 

--- a/koenig/kg-lexical-html-renderer/package.json
+++ b/koenig/kg-lexical-html-renderer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-lexical-html-renderer",
   "version": "1.4.3",
+  "description": "Renders serialized Lexical state to front-end or email HTML for Ghost",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-markdown-html-renderer/README.md
+++ b/koenig/kg-markdown-html-renderer/README.md
@@ -1,38 +1,45 @@
 # Koenig Markdown Html Renderer
 
+Markdown to HTML rendering for Ghost's markdown card.
+
 ## Install
-
-`npm install @tryghost/kg-markdown-html-renderer --save`
-
-or
 
 `npm install @tryghost/kg-markdown-html-renderer`
 
-
 ## Usage
 
+```js
+import {render} from '@tryghost/kg-markdown-html-renderer';
+
+render('# Hello');
+// '<h1 id="hello">Hello</h1>\n'
+```
+
+Headings are given generated ids. Pass `{ghostVersion: '3.0'}` to get the
+pre-4.0 slug format, which older content's anchor links depend on:
+
+```js
+render('## Hello, World!');
+// '<h2 id="hello-world">Hello, World!</h2>\n'
+
+render('## Hello, World!', {ghostVersion: '3.0'});
+// '<h2 id="helloworld">Hello, World!</h2>\n'
+```
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-markdown-html-renderer`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
-## Run
-
-- `pnpm dev`
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
-
-
-
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
 # Copyright & License
 

--- a/koenig/kg-markdown-html-renderer/README.md
+++ b/koenig/kg-markdown-html-renderer/README.md
@@ -39,7 +39,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-markdown-html-renderer/package.json
+++ b/koenig/kg-markdown-html-renderer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-markdown-html-renderer",
   "version": "7.2.3",
+  "description": "Markdown to HTML rendering for Ghost's markdown card",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/kg-unsplash-selector/README.md
+++ b/koenig/kg-unsplash-selector/README.md
@@ -1,32 +1,51 @@
 # Unsplash Selector
 
-Unsplash Selector in React
+React Unsplash image picker used by Ghost's Koenig editor and Admin.
 
-## Development
+## Install
 
-### Pre-requisites
+`npm install @tryghost/kg-unsplash-selector`
 
-- Run `pnpm install` in the Ghost monorepo root
+## Usage
 
-### Running the development version
+```jsx
+import {UnsplashSearchModal} from '@tryghost/kg-unsplash-selector';
 
-Run `pnpm dev` to start the development server to test/develop the settings standalone. This will generate a demo site from the `index.html` file which renders the app and makes it available on http://localhost:5173
-To Run it in-memory, meaning the app will run in memory and not make any requests to the Unsplash API, run `VITE_APP_TESTING=true pnpm dev`
+<UnsplashSearchModal
+    unsplashProviderConfig={unsplashConfig}
+    onClose={() => setOpen(false)}
+    onImageInsert={image => insert(image)}
+/>
+```
+
+Passing `null` as `unsplashProviderConfig` swaps in an in-memory provider that
+serves fixtures instead of calling the Unsplash API, which is what the
+standalone dev server uses.
 
 ## Develop
 
-This is a monorepo package.
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-unsplash-selector`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
+Run `pnpm dev` to start a standalone development server, which renders the
+picker from `index.html` at http://localhost:5173. To develop without making
+requests to the Unsplash API, run `VITE_APP_TESTING=true pnpm dev` to serve
+in-memory fixtures instead.
 
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test:acceptance` runs acceptance tests
-- `pnpm test:unit` runs unit tests
-- `pnpm test:acceptance path/to/test` runs a specific test
-- `pnpm test:acceptance:slowmo` runs acceptance tests in slow motion and headed mode, useful for debugging and developing tests
+- `pnpm test:unit` runs the unit tests
+- `pnpm test:acceptance` runs the Playwright acceptance tests
+- `pnpm test:acceptance <path>` runs a single acceptance test
+- `pnpm test:acceptance:slowmo` runs them headed and slowed down, for debugging
+- `pnpm test:acceptance:full` runs them against all configured browsers
+- `pnpm test` runs unit and acceptance tests
+
+# Copyright & License
+
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](https://github.com/TryGhost/Ghost/blob/main/LICENSE).

--- a/koenig/kg-unsplash-selector/package.json
+++ b/koenig/kg-unsplash-selector/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-unsplash-selector",
   "version": "0.4.3",
+  "description": "React Unsplash image picker for Ghost's Koenig editor",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/koenig/kg-utils/README.md
+++ b/koenig/kg-utils/README.md
@@ -1,39 +1,48 @@
 # Koenig Utils
 
+Small shared utilities used across the Koenig packages.
+
 ## Install
-
-`npm install @tryghost/kg-utils --save`
-
-or
 
 `npm install @tryghost/kg-utils`
 
-
 ## Usage
 
+```js
+import {slugify} from '@tryghost/kg-utils';
+
+slugify('My Post Title!');
+// 'my-post-title'
+```
+
+`slugify` accepts `{ghostVersion, type}`, both of which select a slug format
+rather than changing the input. `ghostVersion` defaults to `'4.0'`; passing an
+earlier version reproduces the pre-4.0 format, which older content's anchor
+links depend on:
+
+```js
+slugify('Ünïcödé Tïtlé');
+// '%C3%BCn%C3%AFc%C3%B6d%C3%A9-t%C3%AFtl%C3%A9'
+
+slugify('Ünïcödé Tïtlé', {ghostVersion: '3.0'});
+// '-n-c-d-t-tl-'
+```
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
+and resolves through the pnpm workspace — there is no linking or per-package
+install step. Run `pnpm setup` in the monorepo root, then work in
+`koenig/kg-utils`.
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` from the Ghost monorepo root.
-
-
-## Run
-
-- `pnpm dev`
-
+See the [Koenig README](../README.md) for the shared build, test and release
+workflow.
 
 ## Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
+- `pnpm test:unit` runs the unit tests
+- `pnpm test` runs the full gate: types, coverage thresholds and lint
 
-
-
-
-# Copyright & License 
+# Copyright & License
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](https://github.com/TryGhost/Ghost/blob/main/LICENSE).

--- a/koenig/kg-utils/README.md
+++ b/koenig/kg-utils/README.md
@@ -41,7 +41,8 @@ workflow.
 ## Test
 
 - `pnpm test:unit` runs the unit tests
-- `pnpm test` runs the full gate: types, coverage thresholds and lint
+- `pnpm test` runs the unit and type tests, including coverage thresholds
+- `pnpm lint` runs the lint checks
 
 # Copyright & License
 

--- a/koenig/kg-utils/package.json
+++ b/koenig/kg-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/kg-utils",
   "version": "1.1.3",
+  "description": "Shared utilities for Ghost's Koenig editor packages",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",

--- a/koenig/koenig-lexical/package.json
+++ b/koenig/koenig-lexical/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/koenig-lexical",
   "version": "1.9.1",
+  "description": "Ghost's Lexical-based rich text post editor",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",


### PR DESCRIPTION
## Summary

Brings the Koenig package READMEs up to date and documents each package's API.

The Develop sections described a standalone repo with lerna, which predates these packages moving into the monorepo. Most packages had an empty `## Usage` heading and no `description` in `package.json`, so their npm pages showed just a name.

## What changed

- Develop sections now describe the pnpm workspace setup, and link to the [Koenig README](koenig/README.md) for the shared build, test and release workflow
- Usage examples added for the nine packages that had none
- `description` added to twelve `package.json` files
- Dropped the `## Run` sections from four packages where `pnpm dev` is a placeholder script
- `kg-lexical-html-renderer`: tidied the "Running in Ghost Admin" section, which had linking instructions left over from before the monorepo move

`kg-simplemde` is unchanged — it's a vendored fork with its own upstream README.

## Notes on the examples

Each example was run against the built package. A few details worth flagging, since they're easy to miss from the type signatures:

- `cleanBasicHtml` needs a `createDocument` option in Node, so the example shows the JSDOM form
- `kg-html-to-lexical`'s ESM build doesn't load in plain Node, so its example uses `require`
- `ghostVersion` in `kg-utils` and `kg-markdown-html-renderer` affects heading/slug generation, which the examples show

## Testing

- [x] every code block run against the built package
- [x] `lint` and `test:unit` on the touched packages
- [x] `pnpm lint:docs`
- [x] `node scripts/change-check.js`

## Release impact

12 patch releases, one per package with a change to a published file. No code changes.
