### PR TITLE
Stopped documentation-only changes from running code tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,9 @@ jobs:
               - '.github/workflows/ci.yml'
             core:
               - *shared
-              # Repository documentation and ownership metadata do not affect
-              # Ghost runtime behaviour, even though they live in .github.
-              - '!.github/**/*.md'
+              # Documentation and ownership metadata do not affect Ghost
+              # runtime behaviour, even when they live inside a project root.
+              - '!**/*.md'
               - '!.github/CODEOWNERS'
               - 'ghost/**'
               - '!ghost/core/core/server/data/tinybird/**'
@@ -234,6 +234,18 @@ jobs:
       - name: Determine Affected Projects
         id: affected
         run: |
+          # Nx treats README files as project inputs. Avoid populating code-test
+          # matrices when every changed file is documentation.
+          if [[ "${{ env.IS_TAG }}" != 'true' && "${{ steps.changed.outputs.any-code }}" != 'true' ]]; then
+            echo 'affected_projects=[]' >> "$GITHUB_OUTPUT"
+            echo 'affected_projects_str=' >> "$GITHUB_OUTPUT"
+            echo 'unit_test_projects_str=' >> "$GITHUB_OUTPUT"
+            echo 'affected_i18n_projects=' >> "$GITHUB_OUTPUT"
+            echo 'affected_playwright_projects=[]' >> "$GITHUB_OUTPUT"
+            echo 'publish_public_apps_matrix=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # if the ci files have changed or we're in a tag, ensure we don't just look at affected
           # projects and we run the necessary jobs on all projects
           AFFECTED_ARG="--affected"


### PR DESCRIPTION
## Summary

- Stops documentation-only changes from running Nx lint, unit, acceptance, legacy, Admin build, and browser E2E lanes.
- Excludes Markdown from the Core path filter and reuses the existing `any-code` result to leave affected-project matrices empty for Markdown-only changes.
- Keeps normal CI for mixed changes and all `package.json` updates, including description-only changes such as #29984.

## Testing

- [x] `pnpm lint:docs`
- [x] Parsed `.github/workflows/ci.yml` as YAML
- [x] `git diff --check`
