### PR TITLE
🐛 Fixed newsletters left pending after interrupted scheduling

### DIFF
--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -146,7 +146,8 @@ class EmailServiceWrapper {
             sendingService,
             models: {
                 Email,
-                EmailBatch
+                EmailBatch,
+                EmailRecipient
             },
             settingsCache,
             emailRenderer,

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -48,6 +48,7 @@ class EmailService {
     #emailAnalyticsJobs;
     #domainWarmingService;
     #config;
+    #serviceStartedAt;
 
     /**
      *
@@ -56,7 +57,8 @@ class EmailService {
      * @param {SendingService} dependencies.sendingService
      * @param {object} dependencies.models
      * @param {object} dependencies.models.Email
-     * @param {object} [dependencies.models.EmailBatch] - Required for resumeInterruptedSends breadcrumbs
+     * @param {object} [dependencies.models.EmailBatch] - Required for resumeInterruptedSends breadcrumbs and pending recovery
+     * @param {object} [dependencies.models.EmailRecipient] - Required for fail-closed pending recovery
      * @param {object} dependencies.settingsCache
      * @param {EmailRenderer} dependencies.emailRenderer
      * @param {EmailSegmenter} dependencies.emailSegmenter
@@ -93,6 +95,7 @@ class EmailService {
         this.#emailAnalyticsJobs = emailAnalyticsJobs;
         this.#domainWarmingService = domainWarmingService;
         this.#config = config;
+        this.#serviceStartedAt = new Date().toISOString();
     }
 
     /**
@@ -180,6 +183,7 @@ class EmailService {
             post_id: post.id,
             newsletter_id: newsletter.id,
             status: 'pending',
+            error: null,
             submitted_at: new Date(),
             track_opens: !!this.#settingsCache.get('email_track_opens'),
             track_clicks: !!this.#settingsCache.get('email_track_clicks'),
@@ -215,9 +219,13 @@ class EmailService {
 
     /**
      * Boot-time scanner: resumes newsletter emails left in `submitting` after a
-     * previous container's interrupted send. Iterates sequentially; one failure
-     * does not skip others. Rows older than the configured max-age are flipped
-     * to `failed` (not resumed) so stale content does not get sent to current members.
+     * previous container's interrupted send. It also performs a boot-only pass
+     * for `pending` rows that were persisted before this service started, so a
+     * crash between persistence and job scheduling can be safely returned to the
+     * normal CAS-protected scheduling path.
+     * Iterates sequentially; one failure does not skip others. Rows older than
+     * the configured max-age are flipped to `failed` (not resumed) so stale
+     * content does not get sent to current members.
      */
     async resumeInterruptedSends() {
         const maxAgeMs = this.#config?.get?.('bulkEmail:resumeMaxAgeMs') ?? DEFAULT_RESUME_MAX_AGE_MS;
@@ -250,9 +258,6 @@ class EmailService {
             filter: `status:submitting+created_at:>'${cutoffIso}'`
         });
         const list = emails.models || emails;
-        if (staleList.length === 0 && list.length === 0) {
-            return;
-        }
         if (list.length > 0) {
             logging.info(`Email resume: found ${list.length} email(s) in submitting status within max age (${maxAgeMs}ms)`);
         }
@@ -262,6 +267,33 @@ class EmailService {
                 await this.#resumeOneEmail(email);
             } catch (e) {
                 logging.error(e);
+            }
+        }
+
+        // A fresh submitting row may have just been atomically moved to pending
+        // and scheduled above. Do not let the pending pass enqueue it again
+        // before its normal job has materialized batches/recipients. Skipping a
+        // raced status change is deliberately conservative; the normal CAS is
+        // still the final deduplication authority.
+        const submittingEmailIds = new Set(list.map(email => email.id));
+
+        const pendingEmails = await this.#models.Email.findAll({
+            filter: `status:pending+created_at:>'${cutoffIso}'+created_at:<'${this.#serviceStartedAt}'`
+        });
+        const pendingList = pendingEmails.models || pendingEmails;
+        if (pendingList.length > 0) {
+            logging.info('Email resume: found pending email(s) eligible for boot recovery');
+        }
+
+        for (const email of pendingList) {
+            if (submittingEmailIds.has(email.id)) {
+                logging.info(`Email resume: ${email.id} skipped because submitting recovery ran this boot`);
+                continue;
+            }
+            try {
+                await this.#resumePendingEmail(email, cutoffIso);
+            } catch {
+                logging.warn(`Email resume: ${email.id} skipped because pending recovery failed`);
             }
         }
 
@@ -306,6 +338,86 @@ class EmailService {
         logging.warn(`Email resume: scheduling ${email.id} for re-send ${JSON.stringify(breadcrumb)}`);
 
         // Skip checkLimits — this email already passed limits when first sent.
+        this.#batchSendingService.scheduleEmail(email);
+    }
+
+    async #resumePendingEmail(email, cutoffIso) {
+        if (email.get('status') !== 'pending') {
+            logging.info(`Email resume: ${email.id} skipped because status is not pending`);
+            return;
+        }
+
+        const createdAt = new Date(email.get('created_at')).getTime();
+        const serviceStartedAt = new Date(this.#serviceStartedAt).getTime();
+        const resumeCutoffAt = new Date(cutoffIso).getTime();
+        if (!Number.isFinite(createdAt) || createdAt <= resumeCutoffAt || createdAt >= serviceStartedAt) {
+            logging.info(`Email resume: ${email.id} skipped because created_at is outside the recovery window`);
+            return;
+        }
+
+        const emailCount = Number(email.get('email_count'));
+        const deliveredCount = email.get('delivered_count');
+        const failedCount = email.get('failed_count');
+        const error = email.get('error');
+
+        if (!Number.isFinite(emailCount) || emailCount <= 0) {
+            logging.info(`Email resume: ${email.id} skipped because email_count is not positive`);
+            return;
+        }
+        if (!Number.isFinite(deliveredCount) || deliveredCount !== 0 || !Number.isFinite(failedCount) || failedCount !== 0) {
+            logging.info(`Email resume: ${email.id} skipped because delivery counters are non-zero`);
+            return;
+        }
+        if (error !== null && error !== '') {
+            logging.info(`Email resume: ${email.id} skipped because error is set`);
+            return;
+        }
+
+        const post = await email.getLazyRelation('post');
+        const postStatus = post ? post.get('status') : null;
+        if (postStatus !== 'published' && postStatus !== 'sent') {
+            logging.info(`Email resume: ${email.id} skipped because parent post is not sendable`);
+            return;
+        }
+
+        const newsletter = await email.getLazyRelation('newsletter');
+        const newsletterStatus = newsletter ? newsletter.get('status') : null;
+        if (newsletterStatus !== 'active') {
+            logging.info(`Email resume: ${email.id} skipped because newsletter is not active`);
+            return;
+        }
+
+        const models = /** @type {any} */ (this.#models);
+        const emailBatchModel = models.EmailBatch;
+        const emailRecipientModel = models.EmailRecipient;
+        if (!emailBatchModel || !emailRecipientModel) {
+            logging.warn(`Email resume: ${email.id} skipped because required recovery models are unavailable`);
+            return;
+        }
+
+        try {
+            const existingBatch = await emailBatchModel.findOne({email_id: email.id}, {require: false});
+            if (existingBatch) {
+                logging.info(`Email resume: ${email.id} skipped because a batch already exists`);
+                return;
+            }
+        } catch {
+            logging.warn(`Email resume: ${email.id} skipped because batch lookup failed`);
+            return;
+        }
+
+        try {
+            const existingRecipient = await emailRecipientModel.findOne({email_id: email.id}, {require: false});
+            if (existingRecipient) {
+                logging.info(`Email resume: ${email.id} skipped because a recipient already exists`);
+                return;
+            }
+        } catch {
+            logging.warn(`Email resume: ${email.id} skipped because recipient lookup failed`);
+            return;
+        }
+
+        logging.warn(`Email resume: scheduling pending email ${email.id} for boot recovery`);
         this.#batchSendingService.scheduleEmail(email);
     }
 
@@ -362,7 +474,9 @@ class EmailService {
 
         // Change email status back to 'pending' before scheduling
         // so we have a immediate response when retrying an email (schedule can take a while to kick off sometimes)
-        await email.save({status: 'pending'}, {patch: true});
+        // Clear the old failure before re-queuing so a crash before the job runs
+        // leaves a pending row eligible for the same fail-closed boot recovery as a new email.
+        await email.save({status: 'pending', error: null}, {patch: true});
 
         this.#batchSendingService.scheduleEmail(email);
         return email;

--- a/ghost/core/test/integration/services/email-service/resume-interrupted-sends.test.js
+++ b/ghost/core/test/integration/services/email-service/resume-interrupted-sends.test.js
@@ -86,6 +86,79 @@ describe('Resume interrupted sends', function () {
         sinon.assert.calledOnce(mailgunStub);
     });
 
+    it('resumes a pending email after boot recovery when batch and recipient rows were lost', async function () {
+        configUtils.set('bulkEmail:batchSize', 100);
+        configUtils.set('bulkEmail:resumeMaxAgeMs', 48 * 60 * 60 * 1000);
+
+        const {emailModel} = await sendEmail(agent);
+        assert.equal(emailModel.get('error'), null, 'freshly persisted email must have a concrete empty error state');
+        const originalBatches = (await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`})).models;
+        const originalRecipients = (await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'`})).models;
+        assert.ok(originalBatches.length > 0, 'expected original email batches to exist');
+        assert.ok(originalRecipients.length > 0, 'expected original email recipients to exist');
+
+        for (const recipient of originalRecipients) {
+            await recipient.destroy();
+        }
+        for (const batch of originalBatches) {
+            await batch.destroy();
+        }
+
+        await emailModel.save({
+            status: 'pending',
+            delivered_count: 0,
+            failed_count: 0,
+            error: null,
+            created_at: new Date(Date.now() - 60 * 60 * 1000)
+        }, {patch: true, autoRefresh: false});
+
+        const mailgunStub = mockManager.getMailgunCreateMessageStub();
+        mailgunStub.resetHistory();
+
+        const completedPromise = jobManager.awaitCompletion('batch-sending-service-job');
+        await emailService.service.resumeInterruptedSends();
+        await completedPromise;
+
+        await emailModel.refresh();
+        assert.equal(emailModel.get('status'), 'submitted', 'email should be re-submitted after boot recovery');
+        sinon.assert.calledOnce(mailgunStub);
+
+        const recreatedBatches = (await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`})).models;
+        const recreatedRecipients = (await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'`})).models;
+        assert.ok(recreatedBatches.length > 0, 'expected batches to be recreated during recovery');
+        assert.ok(recreatedRecipients.length > 0, 'expected recipients to be recreated during recovery');
+        assert.ok(recreatedBatches.some((/** @type {any} */ batch) => !originalBatches.some((/** @type {any} */ original) => original.id === batch.id)), 'expected freshly recreated batch rows');
+        assert.ok(recreatedRecipients.some((/** @type {any} */ recipient) => !originalRecipients.some((/** @type {any} */ original) => original.id === recipient.id)), 'expected freshly recreated recipient rows');
+    });
+
+    it('rejects a pending row when batches or recipients already exist', async function () {
+        configUtils.set('bulkEmail:batchSize', 100);
+        configUtils.set('bulkEmail:resumeMaxAgeMs', 48 * 60 * 60 * 1000);
+
+        const {emailModel} = await sendEmail(agent);
+        const mailgunStub = mockManager.getMailgunCreateMessageStub();
+        mailgunStub.resetHistory();
+
+        await emailModel.save({
+            status: 'pending',
+            delivered_count: 0,
+            failed_count: 0,
+            error: null,
+            created_at: new Date(Date.now() - 60 * 60 * 1000)
+        }, {patch: true, autoRefresh: false});
+
+        const recipients = (await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'`})).models;
+        const batches = (await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`})).models;
+        assert.ok(recipients.length > 0, 'expected at least one recipient in the seeded email');
+        assert.ok(batches.length > 0, 'expected at least one batch in the seeded email');
+
+        await emailService.service.resumeInterruptedSends();
+
+        await emailModel.refresh();
+        assert.equal(emailModel.get('status'), 'pending', 'email should remain pending when recovery is blocked');
+        sinon.assert.notCalled(mailgunStub);
+    });
+
     it('marks email as failed when an orphan submitting batch is encountered', async function () {
         // Same setup, but this time one of the batches is left as `submitting` — the orphan
         // state a crashed worker leaves behind. The (b) short-circuit fix should refuse to

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -14,6 +14,8 @@ describe('Email Service', function () {
     let scheduleRecurringNewslettersJob;
     let domainWarmingService;
     let getMembersCount;
+    /** @type {{restore: () => void} | undefined} */
+    let testClock;
 
     beforeEach(function () {
         memberCount = 123;
@@ -117,6 +119,10 @@ describe('Email Service', function () {
     });
 
     afterEach(function () {
+        if (testClock) {
+            testClock.restore();
+            testClock = undefined;
+        }
         sinon.restore();
     });
 
@@ -305,6 +311,7 @@ describe('Email Service', function () {
             assert.equal(email.get('newsletter_id'), post.get('newsletter').id);
             assert.equal(email.get('post_id'), post.id);
             assert.equal(email.get('status'), 'pending');
+            assert.equal(email.get('error'), null);
             assert.equal(email.get('source'), post.get('mobiledoc'));
             assert.equal(email.get('source_type'), 'mobiledoc');
             sinon.assert.calledOnce(scheduleRecurringNewslettersJob);
@@ -541,6 +548,8 @@ describe('Email Service', function () {
 
             await service.retryEmail(email);
             sinon.assert.calledOnce(scheduleEmail);
+            assert.equal(email.get('status'), 'pending');
+            assert.equal(email.get('error'), null);
         });
 
         it('Does not schedule email again if draft', async function () {
@@ -584,16 +593,320 @@ describe('Email Service', function () {
     });
 
     describe('resumeInterruptedSends', function () {
-        // Mock factory that mimics the scanner's filter semantics: the scanner runs two
-        // findAll queries, one for stale rows (`created_at:<...`) and one for fresh rows
-        // (`created_at:>...`). For tests that don't care about the stale path, this
-        // returns the given emails for the fresh query and an empty list for stale.
+        // Mock factory that mimics the scanner's filter semantics: it queries stale and
+        // fresh `submitting` rows plus bounded `pending` rows. For legacy submitting tests,
+        // return the given emails for non-stale filters and an empty list for stale.
         const filterAwareFindAll = emails => async ({filter}) => {
             if (filter.includes('created_at:<')) {
                 return {models: []};
             }
             return {models: emails};
         };
+
+        const buildPendingRecoveryService = (/** @type {any} */ {
+            pendingEmails = [],
+            submittingEmails = [],
+            emailBatchFindOne,
+            emailRecipientFindOne,
+            omitEmailBatchModel = false,
+            omitEmailRecipientModel = false,
+            updateStatusLock,
+            config = {}
+        } = {}) => {
+            const capturedFilters = [];
+            const localScheduleEmail = sinon.stub().returns();
+            const localUpdateStatusLock = updateStatusLock ?? sinon.stub().resolves(createModel({}));
+            const models = /** @type {any} */ ({
+                Email: {
+                    findAll: async (/** @type {{filter: string}} */ query) => {
+                        const {filter} = query;
+                        capturedFilters.push(filter);
+                        if (filter.includes('status:submitting')) {
+                            if (filter.includes('created_at:<')) {
+                                return {models: []};
+                            }
+                            return {models: submittingEmails};
+                        }
+                        if (filter.includes('status:pending')) {
+                            return {models: pendingEmails};
+                        }
+                        return {models: []};
+                    }
+                }
+            });
+
+            if (!omitEmailBatchModel) {
+                models.EmailBatch = typeof emailBatchFindOne === 'function'
+                    ? {findOne: emailBatchFindOne}
+                    : createModelClass({findOne: emailBatchFindOne ?? null});
+            }
+            if (!omitEmailRecipientModel) {
+                models.EmailRecipient = typeof emailRecipientFindOne === 'function'
+                    ? {findOne: emailRecipientFindOne}
+                    : createModelClass({findOne: emailRecipientFindOne ?? null});
+            }
+
+            const localService = new EmailService({
+                emailSegmenter: {getMembersCount: () => Promise.resolve(0)},
+                limitService: {isLimited: () => false, errorIfIsOverLimit: () => {}, errorIfWouldGoOverLimit: () => {}},
+                verificationTrigger: {checkVerificationRequired: () => Promise.resolve(false)},
+                models,
+                batchSendingService: {
+                    scheduleEmail: localScheduleEmail,
+                    updateStatusLock: localUpdateStatusLock
+                },
+                settingsCache,
+                emailRenderer,
+                membersRepository,
+                sendingService,
+                emailAnalyticsJobs: {scheduleRecurringNewslettersJob},
+                domainWarmingService,
+                config
+            });
+
+            return {capturedFilters, localScheduleEmail, localService};
+        };
+
+        const createPendingEmail = ({
+            id,
+            created_at,
+            status = 'pending',
+            email_count = 1,
+            delivered_count = 0,
+            failed_count = 0,
+            error = '',
+            postStatus = 'published',
+            newsletterStatus = 'active'
+        }) => createModel({
+            id,
+            status,
+            created_at,
+            email_count,
+            delivered_count,
+            failed_count,
+            error,
+            post: createModel({status: postStatus}),
+            newsletter: createModel({status: newsletterStatus})
+        });
+
+        it('Resumes a valid pending email created before service start and ignores current-process rows', async function () {
+            testClock = sinon.useFakeTimers({now: new Date('2025-01-01T12:00:00Z')});
+
+            const priorProcessEmail = createPendingEmail({
+                id: 'prior-process',
+                created_at: new Date('2025-01-01T11:55:00Z')
+            });
+            const currentProcessEmail = createPendingEmail({
+                id: 'current-process',
+                created_at: new Date('2025-01-01T12:00:01Z')
+            });
+
+            const {capturedFilters, localScheduleEmail, localService} = buildPendingRecoveryService({
+                pendingEmails: [priorProcessEmail, currentProcessEmail]
+            });
+
+            await localService.resumeInterruptedSends();
+
+            sinon.assert.calledOnce(localScheduleEmail);
+            sinon.assert.calledWithExactly(localScheduleEmail, priorProcessEmail);
+            assert.ok(capturedFilters.some(filter => filter.includes('status:pending') && filter.includes("created_at:>'2024-12-31T12:00:00.000Z'") && filter.includes("created_at:<'2025-01-01T12:00:00.000Z'")), `expected pending recovery filter to include both cutoff and boot timestamp, got: ${capturedFilters.join(' | ')}`);
+        });
+
+        it('Does not reschedule a submitting email through the pending pass in the same boot', async function () {
+            testClock = sinon.useFakeTimers({now: new Date('2025-01-01T12:00:00Z')});
+
+            const email = createPendingEmail({
+                id: 'same-boot-submitting-email',
+                status: 'submitting',
+                created_at: new Date('2025-01-01T11:55:00Z')
+            });
+            const updateStatusLock = sinon.stub().callsFake(async (_Model, _emailId, status) => {
+                await email.save({status});
+                return email;
+            });
+            const {localScheduleEmail, localService} = buildPendingRecoveryService({
+                submittingEmails: [email],
+                pendingEmails: [email],
+                updateStatusLock
+            });
+
+            await localService.resumeInterruptedSends();
+
+            sinon.assert.calledOnce(localScheduleEmail);
+            sinon.assert.calledWithExactly(localScheduleEmail, email);
+            sinon.assert.calledOnce(updateStatusLock);
+        });
+
+        it('Fails closed for invalid pending candidates', async function () {
+            testClock = sinon.useFakeTimers({now: new Date('2025-01-01T12:00:00Z')});
+
+            const cases = [
+                {
+                    name: 'current-process timestamp',
+                    email: createPendingEmail({
+                        id: 'current-process',
+                        created_at: new Date('2025-01-01T12:00:01Z')
+                    })
+                },
+                {
+                    name: 'out-of-window',
+                    email: createPendingEmail({
+                        id: 'out-of-window',
+                        created_at: new Date('2024-12-30T12:00:00Z')
+                    })
+                },
+                {
+                    name: 'zero/nonpositive audience',
+                    email: createPendingEmail({
+                        id: 'zero-audience',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        email_count: 0
+                    })
+                },
+                {
+                    name: 'error',
+                    email: createPendingEmail({
+                        id: 'with-error',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        error: 'boom'
+                    })
+                },
+                {
+                    name: 'nonzero delivered count',
+                    email: createPendingEmail({
+                        id: 'delivered-count',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        delivered_count: 1
+                    })
+                },
+                {
+                    name: 'nonzero failed count',
+                    email: createPendingEmail({
+                        id: 'failed-count',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        failed_count: 1
+                    })
+                },
+                {
+                    name: 'non-finite delivered count',
+                    email: createPendingEmail({
+                        id: 'non-finite-delivered-count',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        delivered_count: Number.NaN
+                    })
+                },
+                {
+                    name: 'invalid error state',
+                    email: createPendingEmail({
+                        id: 'invalid-error-state',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        error: /** @type {any} */ (false)
+                    })
+                },
+                {
+                    name: 'missing error state',
+                    email: createModel({
+                        id: 'missing-error-state',
+                        status: 'pending',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        email_count: 1,
+                        delivered_count: 0,
+                        failed_count: 0,
+                        post: createModel({status: 'published'}),
+                        newsletter: createModel({status: 'active'})
+                    })
+                },
+                {
+                    name: 'non-pending status',
+                    email: createPendingEmail({
+                        id: 'wrong-status',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        status: 'submitting'
+                    })
+                },
+                {
+                    name: 'existing batch',
+                    email: createPendingEmail({
+                        id: 'existing-batch',
+                        created_at: new Date('2025-01-01T11:00:00Z')
+                    }),
+                    emailBatchFindOne: {id: 'batch-1'}
+                },
+                {
+                    name: 'existing recipient',
+                    email: createPendingEmail({
+                        id: 'existing-recipient',
+                        created_at: new Date('2025-01-01T11:00:00Z')
+                    }),
+                    emailRecipientFindOne: {id: 'recipient-1'}
+                },
+                {
+                    name: 'batch lookup failure',
+                    email: createPendingEmail({
+                        id: 'batch-lookup-failure',
+                        created_at: new Date('2025-01-01T11:00:00Z')
+                    }),
+                    emailBatchFindOne: async () => {
+                        throw new Error('batch lookup unavailable');
+                    }
+                },
+                {
+                    name: 'recipient lookup failure',
+                    email: createPendingEmail({
+                        id: 'recipient-lookup-failure',
+                        created_at: new Date('2025-01-01T11:00:00Z')
+                    }),
+                    emailRecipientFindOne: async () => {
+                        throw new Error('recipient lookup unavailable');
+                    }
+                },
+                {
+                    name: 'missing batch model',
+                    email: createPendingEmail({
+                        id: 'missing-batch-model',
+                        created_at: new Date('2025-01-01T11:00:00Z')
+                    }),
+                    omitEmailBatchModel: true
+                },
+                {
+                    name: 'missing recipient model',
+                    email: createPendingEmail({
+                        id: 'missing-recipient-model',
+                        created_at: new Date('2025-01-01T11:00:00Z')
+                    }),
+                    omitEmailRecipientModel: true
+                },
+                {
+                    name: 'unsendable post',
+                    email: createPendingEmail({
+                        id: 'draft-post',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        postStatus: 'draft'
+                    })
+                },
+                {
+                    name: 'inactive newsletter',
+                    email: createPendingEmail({
+                        id: 'inactive-newsletter',
+                        created_at: new Date('2025-01-01T11:00:00Z'),
+                        newsletterStatus: 'archived'
+                    })
+                }
+            ];
+
+            for (const testCase of cases) {
+                const {localScheduleEmail, localService} = buildPendingRecoveryService({
+                    pendingEmails: [testCase.email],
+                    emailBatchFindOne: testCase.emailBatchFindOne,
+                    emailRecipientFindOne: testCase.emailRecipientFindOne,
+                    omitEmailBatchModel: testCase.omitEmailBatchModel ?? false,
+                    omitEmailRecipientModel: testCase.omitEmailRecipientModel ?? false
+                });
+
+                await localService.resumeInterruptedSends();
+                assert.equal(localScheduleEmail.callCount, 0, testCase.name);
+            }
+        });
 
         it('Per-email try/catch: one bad email does not skip the others', async function () {
             const errorLog = sinon.stub(logging, 'error');
@@ -770,7 +1083,7 @@ describe('Email Service', function () {
             await localService.resumeInterruptedSends();
             const after = Date.now();
 
-            assert.equal(capturedFilters.length, 2);
+            assert.equal(capturedFilters.length, 3);
             // Both filters carry the same cutoff timestamp — extract it from one.
             const match = capturedFilters[0].match(/created_at:[<>]'([^']+)'/);
             assert.ok(match, `expected ISO cutoff in filter, got: ${capturedFilters[0]}`);


### PR DESCRIPTION
## Why

Closes #29987.

This extends the boot-time recovery introduced in #27822. That recovery handles email rows left in `submitting` during an interrupted send, but a process can also stop after a new email has been persisted as `pending` and before its background job is scheduled. In that case, the row has no materialized batches or recipients and the existing boot scanner does not revisit it.

## What changed

- Add a narrow boot-only recovery pass for recent, pre-boot `pending` email rows.
- Require a sendable post, active newsletter, positive email count, zero delivery counters, a clear error state, and no materialized batch or recipient rows.
- Keep the existing normal status lock as the final deduplication authority.
- Skip all rows that do not meet the predicate rather than attempting a broad retry.
- Preserve eligibility for a newly created or manually retried row by persisting `error: null` when it is placed in `pending`.

## Safety and compatibility

This does not change the normal send path or broadly resend pending newsletters. It only re-enters the existing scheduling path for the narrowly identified persistence-before-scheduling crash window. Existing `submitting` recovery remains unchanged.

## Testing

- [x] Focused EmailService unit tests — 49 passing
- [x] Focused `resume-interrupted-sends` integration test — 5 passing
- [ ] Repository `pnpm check` — run locally, but not green because four unrelated Ghost Core tests timed out and three unrelated Koenig browser tests failed. The four Ghost Core files passed when rerun individually.
- [ ] CI

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written automated tests to prove the change works
