### PR TITLE
🐛 Fixed dynamic routes with file extensions returning 404

### DIFF
--- a/ghost/core/core/frontend/services/routing/registry.js
+++ b/ghost/core/core/frontend/services/routing/registry.js
@@ -28,6 +28,8 @@ class Registry {
         this.routes = [];
         /** @type {Object<string, ParentRouter>} */
         this.routers = {};
+        /** @type {Set<string>|null} */
+        this.routeExtensions = null;
     }
 
     /**
@@ -37,6 +39,7 @@ class Registry {
      */
     setRoute(routerName, route) {
         this.routes.push({route: route, from: routerName});
+        this.routeExtensions = null;
     }
 
     /**
@@ -135,10 +138,32 @@ class Registry {
     }
 
     /**
+     * File extensions (with leading dot, lowercase) that appear in registered
+     * route definitions, e.g. `.html` from a `/{slug}.html/` collection
+     * permalink. Used to keep extension-bearing dynamic routes reachable when
+     * request paths with extensions are otherwise treated as static files.
+     *
+     * @returns {Set<string>}
+     */
+    getRouteExtensions() {
+        if (this.routeExtensions === null) {
+            this.routeExtensions = new Set();
+            for (const {route} of this.routes) {
+                for (const [, extension] of route.matchAll(/\.([a-z0-9]+)(?=\/|$)/gi)) {
+                    this.routeExtensions.add(`.${extension.toLowerCase()}`);
+                }
+            }
+        }
+
+        return this.routeExtensions;
+    }
+
+    /**
      * @description Reset all routes.
      */
     resetAllRoutes() {
         this.routes = [];
+        this.routeExtensions = null;
     }
 
     /**

--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const config = require('../../../shared/config');
 const themeEngine = require('../../services/theme-engine');
+const routingRegistry = require('../../services/routing/registry');
 const express = require('../../../shared/express');
 const AASA_PATH = '/.well-known/apple-app-site-association';
 
@@ -123,6 +124,13 @@ function staticTheme() {
         }
 
         if (isDeniedFile(normalizedPath)) {
+            return next();
+        }
+
+        // An extension used by a registered dynamic route (e.g. `.html` from a
+        // `/{slug}.html/` collection permalink) is not a static file request,
+        // so fall through and let the dynamic router serve it.
+        if (routingRegistry.getRouteExtensions().has(path.extname(normalizedPath))) {
             return next();
         }
 

--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -128,10 +128,12 @@ function staticTheme() {
         }
 
         // An extension used by a registered dynamic route (e.g. `.html` from a
-        // `/{slug}.html/` collection permalink) is not a static file request,
-        // so fall through and let the dynamic router serve it.
+        // `/{slug}.html/` collection permalink) may be a dynamic URL rather
+        // than a static file. Serve a matching theme file when one exists,
+        // but let a miss fall through to the dynamic router instead of
+        // terminating it as a static 404.
         if (routingRegistry.getRouteExtensions().has(path.extname(normalizedPath))) {
-            return next();
+            return forwardToExpressStatic(req, res, next, {fallthrough: true});
         }
 
         return forwardToExpressStatic(req, res, next);

--- a/ghost/core/test/unit/frontend/services/routing/registry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/registry.test.js
@@ -185,4 +185,46 @@ describe('UNIT: services/routing/registry', function () {
             assert.equal(registry.getRouter('a'), undefined);
         });
     });
+
+    describe('fn: getRouteExtensions', function () {
+        it('returns an empty set when no routes are registered', function () {
+            assert.equal(registry.getRouteExtensions().size, 0);
+        });
+
+        it('returns the extension of a collection permalink route', function () {
+            registry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
+
+            assert.equal(registry.getRouteExtensions().has('.html'), true);
+        });
+
+        it('returns the extension of a literal route', function () {
+            registry.setRoute('StaticRoutesRouter', '/custom.xml/');
+
+            assert.equal(registry.getRouteExtensions().has('.xml'), true);
+        });
+
+        it('ignores routes without extensions', function () {
+            registry.setRoute('CollectionRouter', '/:slug/');
+            registry.setRoute('TaxonomyRouter', '/category/:slug/');
+
+            assert.equal(registry.getRouteExtensions().size, 0);
+        });
+
+        it('is cleared by resetAllRoutes', function () {
+            registry.setRoute('CollectionRouter', '/:slug.html/');
+            assert.equal(registry.getRouteExtensions().has('.html'), true);
+
+            registry.resetAllRoutes();
+
+            assert.equal(registry.getRouteExtensions().size, 0);
+        });
+
+        it('picks up routes registered after a previous read', function () {
+            assert.equal(registry.getRouteExtensions().size, 0);
+
+            registry.setRoute('CollectionRouter', '/:slug.html/');
+
+            assert.equal(registry.getRouteExtensions().has('.html'), true);
+        });
+    });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 const express = require('../../../../../core/shared/express');
 const themeEngine = require('../../../../../core/frontend/services/theme-engine');
+const routingRegistry = require('../../../../../core/frontend/services/routing/registry');
 const staticTheme = require('../../../../../core/frontend/web/middleware/static-theme');
 
 describe('staticTheme', function () {
@@ -536,6 +537,65 @@ describe('staticTheme', function () {
             const options = expressStaticStub.firstCall.args[1];
             assert(_.isPlainObject(options));
             assert('maxAge' in options);
+            assert.equal(options.fallthrough, false);
+        });
+    });
+
+    describe('dynamic routes with file extensions', function () {
+        afterEach(function () {
+            routingRegistry.resetAllRoutes();
+        });
+
+        it('should skip when the extension is used by a registered dynamic route', async function () {
+            routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
+            req.path = '/finance/my-post.html/';
+
+            await callStaticTheme();
+            sinon.assert.notCalled(expressStaticStub);
+        });
+
+        it('should skip when the extension is used by a registered dynamic route, without trailing slash', async function () {
+            routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
+            req.path = '/finance/my-post.html';
+
+            await callStaticTheme();
+            sinon.assert.notCalled(expressStaticStub);
+        });
+
+        it('should skip for a custom route with a literal extension', async function () {
+            routingRegistry.setRoute('StaticRoutesRouter', '/custom.xml/');
+            req.path = '/custom.xml';
+
+            await callStaticTheme();
+            sinon.assert.notCalled(expressStaticStub);
+        });
+
+        it('should NOT skip in /assets/ even when the extension is used by a dynamic route', async function () {
+            routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
+            req.path = '/assets/snippet.html';
+
+            await callStaticTheme();
+            sinon.assert.called(expressStaticStub);
+        });
+
+        it('should NOT skip when no dynamic route uses the extension', async function () {
+            routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
+            req.path = '/style.css';
+
+            await callStaticTheme();
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, false);
+        });
+
+        it('should NOT skip when no dynamic routes are registered', async function () {
+            req.path = '/finance/my-post.html/';
+
+            await callStaticTheme();
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
             assert.equal(options.fallthrough, false);
         });
     });

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -546,36 +546,64 @@ describe('staticTheme', function () {
             routingRegistry.resetAllRoutes();
         });
 
-        it('should skip when the extension is used by a registered dynamic route', async function () {
+        it('should set fallthrough to true when the extension is used by a registered dynamic route', async function () {
             routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
             req.path = '/finance/my-post.html/';
 
             await callStaticTheme();
-            sinon.assert.notCalled(expressStaticStub);
+            // express.static is still consulted, so an existing theme file
+            // sharing the extension (e.g. legal.html) is served; a miss falls
+            // through to the dynamic router instead of erroring
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should skip when the extension is used by a registered dynamic route, without trailing slash', async function () {
+        it('should set fallthrough to true when the extension is used by a registered dynamic route, without trailing slash', async function () {
             routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
             req.path = '/finance/my-post.html';
 
             await callStaticTheme();
-            sinon.assert.notCalled(expressStaticStub);
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should skip for a custom route with a literal extension', async function () {
+        it('should set fallthrough to true for a custom route with a literal extension', async function () {
             routingRegistry.setRoute('StaticRoutesRouter', '/custom.xml/');
             req.path = '/custom.xml';
 
             await callStaticTheme();
-            sinon.assert.notCalled(expressStaticStub);
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should NOT skip in /assets/ even when the extension is used by a dynamic route', async function () {
+        it('should set fallthrough to true for a static file that shares an extension but matches no route', async function () {
+            routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
+            req.path = '/legal.html';
+
+            await callStaticTheme();
+            // express.static serves the file when it exists; only a miss
+            // falls through to dynamic routing
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
+        });
+
+        it('should keep fallthrough false in /assets/ even when the extension is used by a dynamic route', async function () {
             routingRegistry.setRoute('CollectionRouter', '/:primary_tag/:slug.html/:options(edit)?/');
             req.path = '/assets/snippet.html';
 
             await callStaticTheme();
             sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, false);
         });
 
         it('should NOT skip when no dynamic route uses the extension', async function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/29991

## Problem

Since the static-theme middleware started passing `fallthrough: false` to `express.static` (336f1e7599), every request path with a file extension is terminated in static file serving when no matching theme file exists. That also swallows requests to dynamic routes whose definitions legitimately contain an extension, such as a collection permalink of `/{slug}.html/` used by sites that preserved legacy URLs after migrating from other platforms.

The result is internally inconsistent: `route-settings/validate.js` accepts the permalink, the URL service generates `/{slug}.html/` URLs everywhere (post cards, sitemap, canonical tags), the collection router mounts a matching Express route, and then the static-theme middleware 404s every request to those URLs with a plain-text `File not found` before routing runs. The same routes file works on Ghost 5.

## Solution

The routing registry now exposes `getRouteExtensions()`, the set of file extensions (e.g. `.html`) that appear in registered route definitions, computed lazily and invalidated on `setRoute`/`resetAllRoutes`. The static-theme middleware checks it after the existing allow/deny checks: a request whose extension is used by a registered dynamic route is served by `express.static` with `fallthrough: true`, so an existing theme file that shares the extension is served exactly as before, and only a miss falls through to the dynamic router instead of being terminated as a static 404.

Scope is deliberately narrow:

- Sites whose routes contain no extensions keep the current behaviour exactly (missing static files still get an immediate plain-text 404, per the intent of 336f1e7599).
- Real theme files keep being served even when they share an extension with a dynamic route (e.g. a root-level `legal.html` alongside a `/{slug}.html/` permalink), matching Ghost 5 semantics.
- Paths under `/assets/` are unaffected; `isAllowedFile` is checked first, so `/assets/*.html` files are still served statically with the existing hard-404 behaviour.
- The check reuses the already-normalized, lowercased path, so it composes with the existing URL-encoding and path-traversal handling.

Verified end-to-end on a Ghost 6.57.1 install with a `/{primary_tag}/{slug}.html/` collection permalink: posts render again, the no-trailing-slash variant 301s to the canonical URL, sitemaps and taxonomies are unaffected, and a missing `.css` file still returns the plain-text 404.

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
