### PR TITLE
Changed CodeRabbit to prioritise important feedback

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,8 +10,8 @@ reviews:
   poem: false
   auto_review:
     ignore_usernames:
-      - tryghost-renovate
-      - dependabot
+      - tryghost-renovate[bot]
+      - dependabot[bot]
   pre_merge_checks:
     docstrings:
       mode: "off"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,11 +1,17 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  profile: quiet
+  review_details: true
   high_level_summary: false
   collapse_walkthrough: false
   changed_files_summary: false
   sequence_diagrams: false
   estimate_code_review_effort: false
   poem: false
+  auto_review:
+    ignore_usernames:
+      - tryghost-renovate
+      - dependabot
   pre_merge_checks:
     docstrings:
       mode: "off"


### PR DESCRIPTION
## Summary

- trial CodeRabbit's `quiet` review profile to prioritise important findings
- enable `review_details` so ignored files, context, suppressions, and tool contributions can be audited
- explicitly exclude Renovate and Dependabot PRs, matching their existing observed review behaviour

## Context

This is a small, non-blocking experiment based on three months of Ghost review data:

- review-body nitpicks represented 517 of 1,692 captured feedback items (30.6%)
- in the weighted adjudicated sample, 77.5% of nitpicks were ignored and 12.2% led to a matching code change
- 284 Renovate and three Dependabot PRs had no CodeRabbit artifact already

The change does not enable request changes, add path instructions, or map additional documentation. Those remain separate measured experiments.

## Measurement and rollback

`review_details` will expose the evidence needed to compare this trial with the fixed baseline. We'll monitor finding volume, Major/Critical yield, validity, action, and CI duplication. The profile can be reverted independently if important feedback drops.

## Testing

- [x] `.coderabbit.yaml` validated against CodeRabbit's live v2 schema
- [x] Ghost pre-commit hooks
- [x] `git diff --check`
