### PR TITLE
Updated commit message guidance

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -14,7 +14,8 @@ Use this skill whenever the user asks you to create a git commit for the current
    - `git diff`
    - `git log -5 --oneline`
 2. Only stage files relevant to the requested change. Do not include unrelated untracked files, generated files, or likely-local artifacts.
-3. Always follow Ghost's commit conventions (see below) for commit messages
+3. Read and follow `docs/contributing/workflow.md#commit-messages`. It is the
+   source of truth for Ghost's commit conventions.
 4. Run `git status --short` after committing and confirm the result.
 
 ## Important
@@ -23,39 +24,13 @@ Use this skill whenever the user asks you to create a git commit for the current
 - If there are no relevant changes, do not create an empty commit
 - If hooks fail, fix the issue and create a new commit. Never bypass hooks.
 
-## Commit message format
+## Agent-specific guidance
 
-We have a handful of simple standards for commit messages which help us to generate readable changelogs. Please follow this wherever possible and mention the associated issue number.
-
-- **1st line:** Max 80 character summary
-   - Written in past tense e.g. “Fixed the thing” not “Fixes the thing”
-   - Start with one of: Fixed, Changed, Updated, Improved, Added, Removed, Reverted, Moved, Released, Bumped, Cleaned
-- **2nd line:** [Always blank]
-- **3rd line:** `ref <issue link>`, `fixes <issue link>`, `closes <issue link>` or blank
-- **4th line:** Why this change was made - the code includes the what, the commit message should describe the context of why - why this, why now, why not something else?
-
-If your change is **user-facing** please prepend the first line of your commit with **an emoji**.
-
-Because emoji commits are the release notes, it's important that anything that gets an emoji is a user-facing change that's significant and relevant for end-users to see.
-
-The first line of an emoji commit message should be from the perspective of the user. For example, 🐛 Fixed a race condition in the members service is technical and tells the user nothing, but 🐛 Fixed a bug causing active members to lose access to paid content tells the user reading the release notes “oh yeah, they fixed that bug I kept hitting.”
-
-###  Main emojis we are using:
-
-- ✨ Feature
-- 🎨 Improvement / change
-- 🐛 Bug Fix
-- 🌐 i18n (translation) submissions
-- 💡 Anything else flagged to users or whoever is writing release notes
-
-### Example
-
-```
-✨ Added config flag for disabling page analytics
-
-ref https://linear.app/tryghost/issue/ENG-1234/
-
-- analytics are brand new under development, therefore they need to be behind a flag
-- not using the developerExperiments flag as that is already in wide use and we aren't ready to deploy this anywhere yet
-- using the term `pageAnalytics` as this was discussed as best reflecting what this does
-```
+- Treat the pull request title and final squash commit as the durable mainline
+  history. Intermediate commits should still be clear and focused, but hook
+  warnings are advisory.
+- Decide whether a change is significant and user-facing from the diff and task
+  context before adding a release-note emoji. Do not add one merely to silence
+  a warning.
+- Do not invent an issue relationship. Use the real issue URL when one exists;
+  otherwise follow the documented `no ref` or blank-line options.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -14,7 +14,7 @@ Use this skill whenever the user asks you to create a git commit for the current
    - `git diff`
    - `git log -5 --oneline`
 2. Only stage files relevant to the requested change. Do not include unrelated untracked files, generated files, or likely-local artifacts.
-3. Read and follow `docs/contributing/workflow.md#commit-messages`. It is the
+3. Read and follow `.github/CONTRIBUTING.md#commit-messages`. It is the
    source of truth for Ghost's commit conventions.
 4. Run `git status --short` after committing and confirm the result.
 
@@ -23,14 +23,3 @@ Use this skill whenever the user asks you to create a git commit for the current
 - Keep commits focused and avoid bundling unrelated changes
 - If there are no relevant changes, do not create an empty commit
 - If hooks fail, fix the issue and create a new commit. Never bypass hooks.
-
-## Agent-specific guidance
-
-- Treat the pull request title and final squash commit as the durable mainline
-  history. Intermediate commits should still be clear and focused, but hook
-  warnings are advisory.
-- Decide whether a change is significant and user-facing from the diff and task
-  context before adding a release-note emoji. Do not add one merely to silence
-  a warning.
-- Do not invent an issue relationship. Use the real issue URL when one exists;
-  otherwise follow the documented `no ref` or blank-line options.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,34 +22,9 @@ Discuss new features and substantial product or architectural changes in the
 
 ## Commit Messages
 
-We have a handful of simple standards for commit messages which help us to generate readable changelogs. Please follow this wherever possible and mention the associated issue number.
-
-- **1st line:** Max 80 character summary
-   - Written in past tense e.g. “Fixed the thing” not “Fixes the thing”
-   - Start with one of: Fixed, Changed, Updated, Improved, Added, Removed, Reverted, Moved, Released, Bumped, Cleaned
-- **2nd line:** [Always blank]
-- **3rd line:** `ref <issue link>`, `fixes <issue link>`, `closes <issue link>` or blank
-- **4th line:** Why this change was made - the code includes the what, the commit message should describe the context of why - why this, why now, why not something else?
-
-If your change is **user-facing** please prepend the first line of your commit with **an emoji key**. If the commit is for an alpha feature, no emoji is needed. We are following [gitmoji](https://gitmoji.carloscuesta.me/).
-
-**Main emojis we are using:**
-
-- ✨ Feature
-- 🎨 Improvement / change
-- 🐛 Bug Fix
-- 🌐 i18n (translation) submissions  [[See Translating Ghost docs for more detail](../docs/contributing/translating-ghost.md)]
-- 💡 Anything else flagged to users or whoever is writing release notes
-
-Good commit message examples: [new feature](https://github.com/TryGhost/Ghost/commit/61db6defde3b10a4022c86efac29cf15ae60983f), [bug fix](https://github.com/TryGhost/Ghost/commit/6ef835bb5879421ae9133541ebf8c4e560a4a90e) and [translation](https://github.com/TryGhost/Ghost/commit/83904c1611ae7ab3257b3b7d55f03e50cead62d7).
-
-**Bumping @tryghost dependencies**
-
-When bumping `@tryghost/*` dependencies, the first line should follow the above format and say what has changed, not say what has been bumped.
-
-There is no need to include what modules have changed in the commit message, as this is _very_ clear from the contents of the commit. The commit should focus on surfacing the underlying changes from the dependencies - what actually changed as a result of this dependency bump?
-
-[Good example](https://github.com/TryGhost/Ghost/commit/95751a0e5fb719bb5bca74cb97fb5f29b225094f)
+Follow the [commit message guidance](../docs/contributing/workflow.md#commit-messages).
+The subject conventions matter most for pull request titles and squash commits;
+the local hook gives best-effort feedback on intermediate commits.
 
 ## Changesets
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,9 +58,7 @@ need an emoji until it becomes user-facing.
 
 - ✨ Feature
 - 🎨 Improvement or change
-- 💄 UI or styling improvement
 - 🐛 Bug fix
-- 🔒 Security improvement
 - 💡 Other noteworthy user-facing change
 
 Use 🌐 for [translation submissions](../docs/contributing/translating-ghost.md).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,9 +22,61 @@ Discuss new features and substantial product or architectural changes in the
 
 ## Commit Messages
 
-Follow the [commit message guidance](../docs/contributing/workflow.md#commit-messages).
-The subject conventions matter most for pull request titles and squash commits;
-the local hook gives best-effort feedback on intermediate commits.
+We have a handful of simple standards for commit messages which keep the main
+branch readable and generate useful release notes. They matter most for pull
+request titles and squash commits; follow them for intermediate commits where
+practical.
+
+```text
+<optional release-note emoji> <past-tense summary, at most 80 characters>
+
+<optional issue relationship, or "no ref">
+
+<why this change was made>
+```
+
+- Start the summary with `Fixed`, `Changed`, `Updated`, `Improved`, `Added`,
+  `Removed`, `Reverted`, `Moved`, `Released`, `Bumped`, or `Cleaned`.
+- Keep the second line blank.
+- When an issue exists, use a supported relationship followed by its URL, such
+  as `ref <issue URL>`, `fixes <issue URL>`, or `closes <issue URL>`. Use
+  `no ref` when it is useful to state explicitly that there is no issue, or
+  leave this line blank.
+- Explain the context in the body: why this change, why now, and why this
+  approach. The diff already describes what changed.
+
+The local hook warns about most deviations without blocking the commit. It
+does require the common invalid forms `refs ...` and `ref: ...` to be corrected
+to a supported relationship such as `ref ...`.
+
+### Release-note emojis
+
+A leading release-note emoji opts the squash commit into generated release
+notes. Add one only for a significant change that is relevant to users, and
+write the summary from their perspective. Alpha or experimental work does not
+need an emoji until it becomes user-facing.
+
+- ✨ Feature
+- 🎨 Improvement or change
+- 💄 UI or styling improvement
+- 🐛 Bug fix
+- 🔒 Security improvement
+- 💡 Other noteworthy user-facing change
+
+Use 🌐 for [translation submissions](../docs/contributing/translating-ghost.md).
+Translation commits are not selected for generated release notes by that emoji
+alone.
+
+Good final commit examples include a [new feature](https://github.com/TryGhost/Ghost/commit/61db6defde3b10a4022c86efac29cf15ae60983f),
+a [bug fix](https://github.com/TryGhost/Ghost/commit/6ef835bb5879421ae9133541ebf8c4e560a4a90e),
+and a [translation](https://github.com/TryGhost/Ghost/commit/83904c1611ae7ab3257b3b7d55f03e50cead62d7).
+
+**Bumping @tryghost dependencies**
+
+When bumping `@tryghost/*` dependencies, describe the user-visible result rather
+than which packages were bumped. The diff already shows the package changes;
+the message should explain what changed because of them. See this
+[good example](https://github.com/TryGhost/Ghost/commit/95751a0e5fb719bb5bca74cb97fb5f29b225094f).
 
 ## Changesets
 

--- a/.github/hooks/commit-msg.bash
+++ b/.github/hooks/commit-msg.bash
@@ -79,19 +79,6 @@ if [ -z "$body" ]; then
     echo -e "The body should explain: why this, why now, why not something else?"
 fi
 
-# Check for emoji in user-facing changes
-if [[ "$subject" =~ ^[^[:space:]]*[[:space:]] ]]; then
-    first_word="${subject%% *}"
-    # Emoji are multi-byte (non-ASCII), so detect them by stripping every ASCII
-    # byte and seeing if anything is left. The previous check tested the first word
-    # against [[:punct:]], which never matches an emoji — so the warning fired on
-    # *every* correctly-prefixed commit (🐛, ✨, …) and passed on plain ASCII.
-    if [[ -z "$(printf '%s' "$first_word" | LC_ALL=C tr -d '\000-\177')" ]]; then
-        echo -e "${yellow}Warning: User-facing changes should start with an emoji${no_color}"
-        echo -e "Common emojis: ✨ (Feature), 🎨 (Improvement), 🐛 (Bug Fix), 🌐 (i18n), 💡 (User-facing)"
-    fi
-fi
-
 # Check for past tense verbs in subject
 past_tense_words="Fixed|Changed|Updated|Improved|Added|Removed|Reverted|Moved|Released|Bumped|Cleaned"
 if ! echo "$subject" | grep -iE "$past_tense_words" > /dev/null; then

--- a/.github/hooks/commit-msg.bash
+++ b/.github/hooks/commit-msg.bash
@@ -79,6 +79,20 @@ if [ -z "$body" ]; then
     echo -e "The body should explain: why this, why now, why not something else?"
 fi
 
+# Give concise release-note guidance. Whether a change is user-facing requires
+# human judgment, so these notices are informative rather than enforcement.
+first_word="${subject%% *}"
+supported_emojis="✨ 🎨 💄 🐛 🔒 💡 🌐"
+
+if [[ "$first_word" =~ ^(✨|🎨|💄|🐛|🔒|💡|🌐)$ ]]; then
+    echo -e "${yellow}Notice: Keep the emoji only for a significant user-facing PR title or squash commit.${no_color}"
+elif [[ -n "$(printf '%s' "$first_word" | LC_ALL=C tr -d '\000-\177')" ]]; then
+    echo -e "${yellow}Warning: Unsupported leading emoji. Use one of: ${supported_emojis}${no_color}"
+    echo -e "Emoji selection only matters for user-facing PR titles and squash commits."
+else
+    echo -e "${yellow}Notice: If this is a significant user-facing PR title or squash commit, add one of: ${supported_emojis}${no_color}"
+fi
+
 # Check for past tense verbs in subject
 past_tense_words="Fixed|Changed|Updated|Improved|Added|Removed|Reverted|Moved|Released|Bumped|Cleaned"
 if ! echo "$subject" | grep -iE "$past_tense_words" > /dev/null; then

--- a/.github/hooks/commit-msg.bash
+++ b/.github/hooks/commit-msg.bash
@@ -82,15 +82,15 @@ fi
 # Give concise release-note guidance. Whether a change is user-facing requires
 # human judgment, so these notices are informative rather than enforcement.
 first_word="${subject%% *}"
-supported_emojis="✨ 🎨 💄 🐛 🔒 💡 🌐"
+contributor_emojis="✨ 🎨 🐛 🌐 💡"
 
-if [[ "$first_word" =~ ^(✨|🎨|💄|🐛|🔒|💡|🌐)$ ]]; then
+if [[ "$first_word" =~ ^(✨|🎨|🐛|🌐|💡|🔒)$ ]]; then
     echo -e "${yellow}Notice: Keep the emoji only for a significant user-facing PR title or squash commit.${no_color}"
 elif [[ -n "$(printf '%s' "$first_word" | LC_ALL=C tr -d '\000-\177')" ]]; then
-    echo -e "${yellow}Warning: Unsupported leading emoji. Use one of: ${supported_emojis}${no_color}"
+    echo -e "${yellow}Warning: Unsupported leading emoji. Use one of: ${contributor_emojis}${no_color}"
     echo -e "Emoji selection only matters for user-facing PR titles and squash commits."
 else
-    echo -e "${yellow}Notice: If this is a significant user-facing PR title or squash commit, add one of: ${supported_emojis}${no_color}"
+    echo -e "${yellow}Notice: If this is a significant user-facing PR title or squash commit, add one of: ${contributor_emojis}${no_color}"
 fi
 
 # Check for past tense verbs in subject

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,11 @@ skill without duplicating it. Run `pnpm lint:agent-skills` to verify every
 repository skill is linked correctly; CI runs the same check.
 
 ### Commit Messages
-When the user asks you to create a commit or draft a commit message, load and follow the `commit` skill from `.agents/skills/commit`.
+When the user asks you to create a commit or draft a commit message, load and
+follow the `commit` skill from `.agents/skills/commit`. Read the canonical
+[commit message guidelines](.github/CONTRIBUTING.md#commit-messages), and apply
+the subject convention carefully to PR titles and proposed squash commits.
+Local hook notices on intermediate commits are best-effort guidance.
 
 ### ESLint Config
 Source of truth: two internal config packages — [`@internal/cfg-eslint`](configs/eslint/index.mjs) (shared rule atoms + the `nodeLibConfig` factory for Node libs) and [`@internal/cfg-eslint-react`](configs/eslint-react/index.mjs) (the `reactAppConfig` factory for every `apps/*` workspace). Both factories are synchronous and have full JSDoc with `@example`s; hover the call site in your editor. Consume them by name — declare the package as a `workspace:*` devDependency.

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -76,63 +76,7 @@ not affect a publishable package do not need one.
 
 ## Commit Messages
 
-These conventions keep the main branch readable and generate useful release
-notes. They matter most for the pull request title and the squash commit that
-lands on `main`. Use them for intermediate commits where practical; the local
-commit hook provides best-effort feedback while work is in progress.
-
-Write the final commit message in this form:
-
-```text
-<optional release-note emoji> <past-tense summary, at most 80 characters>
-
-<optional issue relationship, or "no ref">
-
-<why this change was made>
-```
-
-- Start the summary with `Fixed`, `Changed`, `Updated`, `Improved`, `Added`,
-  `Removed`, `Reverted`, `Moved`, `Released`, `Bumped`, or `Cleaned`.
-- Keep the second line blank.
-- When an issue exists, use a supported relationship followed by its URL, such
-  as `ref <issue URL>`, `fixes <issue URL>`, or `closes <issue URL>`. Use
-  `no ref` when it is useful to state explicitly that there is no issue, or
-  leave this line blank.
-- Explain the context in the body: why this change, why now, and why this
-  approach. The diff already describes what changed.
-
-The local hook warns about most deviations without blocking the commit. It
-does require the common invalid forms `refs ...` and `ref: ...` to be corrected
-to a supported relationship such as `ref ...`.
-
-### Release-note emojis
-
-A leading release-note emoji opts the squash commit into generated release
-notes. Add one only for a significant change that is relevant to users, and
-write the summary from their perspective. Alpha or experimental work does not
-need an emoji until it becomes user-facing.
-
-- ✨ Feature
-- 🎨 Improvement or change
-- 💄 UI or styling improvement
-- 🐛 Bug fix
-- 🔒 Security improvement
-- 💡 Other noteworthy user-facing change
-
-Use 🌐 for [translation submissions](translating-ghost.md). Translation commits
-are not selected for generated release notes by that emoji alone.
-
-Good final commit examples include a [new feature](https://github.com/TryGhost/Ghost/commit/61db6defde3b10a4022c86efac29cf15ae60983f),
-a [bug fix](https://github.com/TryGhost/Ghost/commit/6ef835bb5879421ae9133541ebf8c4e560a4a90e),
-and a [translation](https://github.com/TryGhost/Ghost/commit/83904c1611ae7ab3257b3b7d55f03e50cead62d7).
-
-**Bumping @tryghost dependencies**
-
-When bumping `@tryghost/*` dependencies, the first line should follow the above format and say what has changed, not say what has been bumped.
-
-There is no need to include what modules have changed in the commit message, as this is _very_ clear from the contents of the commit. The commit should focus on surfacing the underlying changes from the dependencies - what actually changed as a result of this dependency bump?
-
-[Good example](https://github.com/TryGhost/Ghost/commit/95751a0e5fb719bb5bca74cb97fb5f29b225094f)
+Follow the canonical [commit message guidelines](../../.github/CONTRIBUTING.md#commit-messages).
 
 
 ## Publish the branch

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -76,26 +76,55 @@ not affect a publishable package do not need one.
 
 ## Commit Messages
 
-We have a handful of simple standards for commit messages which help us to generate readable changelogs. Please follow this wherever possible and mention the associated issue number.
+These conventions keep the main branch readable and generate useful release
+notes. They matter most for the pull request title and the squash commit that
+lands on `main`. Use them for intermediate commits where practical; the local
+commit hook provides best-effort feedback while work is in progress.
 
-- **1st line:** Max 80 character summary
-   - Written in past tense e.g. “Fixed the thing” not “Fixes the thing”
-   - Start with one of: Fixed, Changed, Updated, Improved, Added, Removed, Reverted, Moved, Released, Bumped, Cleaned
-- **2nd line:** [Always blank]
-- **3rd line:** `ref <issue link>`, `fixes <issue link>`, `closes <issue link>` or blank
-- **4th line:** Why this change was made - the code includes the what, the commit message should describe the context of why - why this, why now, why not something else?
+Write the final commit message in this form:
 
-If your change is **user-facing** please prepend the first line of your commit with **an emoji key**. If the commit is for an alpha feature, no emoji is needed. We are following [gitmoji](https://gitmoji.carloscuesta.me/).
+```text
+<optional release-note emoji> <past-tense summary, at most 80 characters>
 
-**Main emojis we are using:**
+<optional issue relationship, or "no ref">
+
+<why this change was made>
+```
+
+- Start the summary with `Fixed`, `Changed`, `Updated`, `Improved`, `Added`,
+  `Removed`, `Reverted`, `Moved`, `Released`, `Bumped`, or `Cleaned`.
+- Keep the second line blank.
+- When an issue exists, use a supported relationship followed by its URL, such
+  as `ref <issue URL>`, `fixes <issue URL>`, or `closes <issue URL>`. Use
+  `no ref` when it is useful to state explicitly that there is no issue, or
+  leave this line blank.
+- Explain the context in the body: why this change, why now, and why this
+  approach. The diff already describes what changed.
+
+The local hook warns about most deviations without blocking the commit. It
+does require the common invalid forms `refs ...` and `ref: ...` to be corrected
+to a supported relationship such as `ref ...`.
+
+### Release-note emojis
+
+A leading release-note emoji opts the squash commit into generated release
+notes. Add one only for a significant change that is relevant to users, and
+write the summary from their perspective. Alpha or experimental work does not
+need an emoji until it becomes user-facing.
 
 - ✨ Feature
-- 🎨 Improvement / change
-- 🐛 Bug Fix
-- 🌐 i18n (translation) submissions  [[See Translating Ghost docs for more detail](translating-ghost.md)]
-- 💡 Anything else flagged to users or whoever is writing release notes
+- 🎨 Improvement or change
+- 💄 UI or styling improvement
+- 🐛 Bug fix
+- 🔒 Security improvement
+- 💡 Other noteworthy user-facing change
 
-Good commit message examples: [new feature](https://github.com/TryGhost/Ghost/commit/61db6defde3b10a4022c86efac29cf15ae60983f), [bug fix](https://github.com/TryGhost/Ghost/commit/6ef835bb5879421ae9133541ebf8c4e560a4a90e) and [translation](https://github.com/TryGhost/Ghost/commit/83904c1611ae7ab3257b3b7d55f03e50cead62d7).
+Use 🌐 for [translation submissions](translating-ghost.md). Translation commits
+are not selected for generated release notes by that emoji alone.
+
+Good final commit examples include a [new feature](https://github.com/TryGhost/Ghost/commit/61db6defde3b10a4022c86efac29cf15ae60983f),
+a [bug fix](https://github.com/TryGhost/Ghost/commit/6ef835bb5879421ae9133541ebf8c4e560a4a90e),
+and a [translation](https://github.com/TryGhost/Ghost/commit/83904c1611ae7ab3257b3b7d55f03e50cead62d7).
 
 **Bumping @tryghost dependencies**
 

--- a/scripts/lib/release-notes.js
+++ b/scripts/lib/release-notes.js
@@ -5,7 +5,7 @@ const ROOT = resolve(import.meta.dirname, '../..');
 const REPO_URL = 'https://github.com/TryGhost/Ghost';
 
 // Emoji priority order (lowest index = lowest priority, sorted descending)
-const EMOJI_ORDER = ['💡', '🐛', '🎨', '💄', '✨', '🔒'];
+const EMOJI_ORDER = ['💡', '🐛', '🎨', '✨', '🔒'];
 
 // User-facing emojis — only these are included in release notes
 const USER_FACING_EMOJIS = new Set(EMOJI_ORDER);


### PR DESCRIPTION
## Summary

- Keeps the long-standing commit guidelines canonical in `.github/CONTRIBUTING.md`, with the newer workflow guide and agent guidance linking back to them.
- Clarifies that the conventions matter primarily for PR titles and squash commits, while local hook feedback is best effort.
- Replaces the misleading emoji check with concise guidance for supported, absent, and unsupported emojis while preserving the deliberate `refs`/`ref:` correction.
- Retains `🔒` as an intentionally undocumented security-release marker and retires the obsolete `💄` marker from release-note generation.

## Testing

- [x] `pnpm lint:docs`
- [x] `bash -n .github/hooks/commit-msg.bash`
- [x] `node --check scripts/lib/release-notes.js`
- [x] `git diff --check`
- [x] Manual hook checks: supported, absent, unsupported, and private security emojis
