### PR TITLE
Moved E2E guidance into codebase docs

### DIFF
--- a/apps/ember-admin/README.md
+++ b/apps/ember-admin/README.md
@@ -6,53 +6,31 @@ This is the home of the Ember.js-based Admin app that ships with [Ghost](https:/
 
 ### Running tests in the browser
 
-Run all tests in the browser by running `pnpm dev` in the Ghost monorepo and visiting http://localhost:4200/tests. The code is hotloaded on change and you can filter which tests to run.
-
-[Testing public documentation](https://ghost.notion.site/Testing-Ember-560cec6700fc4d37a58b3ba9febb4b4b)
-
----
+Run `pnpm dev` from the repository root, then visit
+[http://localhost:4200/tests](http://localhost:4200/tests). The code reloads on
+change and the browser runner can filter the tests.
 
 Tip: You can use `this.timeout(0); await this.pauseTest();` in your tests to temporarily pause the execution of browser tests. Use the browser console to inspect and debug the DOM, then resume tests by running `resumeTest()` directly in the browser console ([docs](https://guides.emberjs.com/v3.28.0/testing/testing-application/#toc_debugging-your-tests))
 
-
 ### Running tests in the CLI
 
-To build and run tests in the CLI, you can use:
+Run Ember Admin tests through Nx from the repository root so the required
+dependencies are built first:
 
 ```bash
-TZ=UTC pnpm test
+pnpm nx run ghost-admin:test
 ```
-_Note the `TZ=UTC` environment variable which is currently required to get tests working if your system timezone doesn't match UTC._
 
----
-
-However, this is very slow when writing tests, as it requires the app to be rebuilt on every change. Instead, create a separate watching build with:
+To run one file, pass the required parallel value before the Ember Exam
+arguments:
 
 ```bash
-pnpm build --environment=test -w -o="dist-test"
+pnpm nx run ghost-admin:test -- 1 \
+  --file-path=tests/acceptance/editor/publish-flow-test.js
 ```
 
-Then run tests with:
-
-```bash
-TZ=UTC pnpm test 1 --reporter dot --path="dist-test"
-```
-
-The `--reporter dot` shows a dot (`.`) for every successful test, and `F` for every failed test. It renders the output of the failed tests only.
-
----
-
-To run a specific test file:
-```bash
-TZ=UTC pnpm test 1 --reporter dot --path="dist-test" -mp=tests/unit/helpers/gh-count-characters-test.js
-```
-
----
-
-To have a full list of the available options, run
-```bash
-ember exam --help
-```
+For more detail, see the
+[testing guide](../../docs/contributing/testing.md#run-ember-admin-tests).
 
 # Copyright & License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ Practice and contributor guides explain how to make and verify changes:
 
 - [API design](practices/api-design.md)
 - [Database migrations](practices/database-migrations.md)
+- [Browser E2E testing](contributing/e2e-testing.md)
 - [Email testing](contributing/testing-email.md)
 - [Error handling](practices/error-handling.md)
 - [Internationalization](practices/internationalization.md)

--- a/docs/contributing/e2e-testing.md
+++ b/docs/contributing/e2e-testing.md
@@ -1,16 +1,19 @@
-# E2E Test Writing Guide
+# Writing Browser E2E Tests
 
-Worked examples for writing E2E tests in `/e2e/` with TypeScript and Playwright.
+Ghost's browser end-to-end tests live in `/e2e/` and use TypeScript and
+Playwright to verify complete journeys across Ghost Admin and the public site.
+This guide explains how to write and structure them.
 
-This guide covers *how to build the pieces* — page objects, common interaction
-patterns, and selector discovery. It deliberately does not repeat what is
-already documented elsewhere:
+For related guidance:
 
 | For | Read |
 | --- | --- |
-| Running tests, dev/build modes, debugging, folder layout, test isolation, fixtures | [README.md](../README.md) |
-| Rules, locator priority, AAA structure, DO/DON'T, validation checklist | [AGENTS.md](../AGENTS.md) |
-| Available factories and how to add one | [data-factory/README.md](../data-factory/README.md) |
+| Choosing between unit, integration, acceptance, and E2E tests | [Testing Ghost](testing.md) |
+| Running E2E tests, infrastructure modes, debugging, isolation, and fixtures | [E2E workspace README](../../e2e/README.md) |
+| Available factories and how to add one | [Data factory README](../../e2e/data-factory/README.md) |
+
+Workspace command examples start from the repository root and change into
+`e2e/`.
 
 ## Conventions
 
@@ -22,8 +25,8 @@ already documented elsewhere:
 - Page objects: `<feature>-page.ts` — `login-page.ts`, `admin-page.ts`
 - Class names stay PascalCase: `login-page.ts` exports `class LoginPage`
 
-**Import through the `@/` path aliases**, never relative paths. The aliases are
-defined in `tsconfig.json`:
+In tests, import shared helpers and page objects through the `@/` path aliases
+defined in `e2e/tsconfig.json`:
 
 ```typescript
 import {expect, test} from '@/helpers/playwright';
@@ -31,6 +34,20 @@ import {LoginPage, PostsPage} from '@/admin-pages';
 import {createPostFactory} from '@/data-factory';
 import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 ```
+
+Page-object modules use relative imports for nearby base classes and sibling
+modules where appropriate.
+
+Use Arrange–Act–Assert as a readability heuristic: set up the scenario,
+perform the behaviour under test, then verify the outcome. Make the phases
+clear through structure and naming; add comments only when the boundary would
+otherwise be unclear. Keep each test focused on one scenario and write its name
+and flow so that someone without detailed knowledge of the implementation can
+understand the behaviour being checked.
+
+Use factories for test data. Keep their defaults for data that does not affect
+the scenario, and only override the values needed for the behaviour and
+assertions in that test.
 
 ## Page Object Pattern
 
@@ -67,7 +84,7 @@ export class FeaturePage extends AdminPage {
         // 2. Labels for form elements
         this.nameInput = page.getByLabel('Name');
 
-        // 3. Text content (for unique text)
+        // 3. Text content when the text is unique
         this.statusMessage = page.getByText('Saved');
 
         // 4. Stable test IDs when semantic locators are unavailable
@@ -189,14 +206,8 @@ await page.keyboard.type('Hello World');
 
 ## Ghost-Specific Patterns
 
-### Common Selectors
-- Navigation: `data-test-nav="[section]"`
-- Buttons: `data-test-button="[action]"`
-- Modals: `[role="dialog"]`
-- Loading states: `.gh-loading-spinner`
-
-Ember Admin uses `data-test-*` attributes; the React Admin apps use
-`data-testid`. Prefer a role or label over either where one exists.
+Ember Admin commonly uses `data-test-*` attributes and the React Admin apps use
+`data-testid`. Prefer a role, label, or unique visible text where one exists.
 
 ### Admin URLs
 - Editor: `/ghost/#/editor/post/[id]`
@@ -204,38 +215,31 @@ Ember Admin uses `data-test-*` attributes; the React Admin apps use
 - Settings: `/ghost/#/settings`
 - Members: `/ghost/#/members`
 
-## Using Playwright MCP for Page Object Discovery
+## Discovering Locators
 
-When creating new Page Objects or discovering selectors for unfamiliar UI:
+When creating a Page Object for unfamiliar UI, preserve the test environment
+after a run and inspect the rendered page with Playwright Inspector or browser
+developer tools.
 
-### 1. Start Ghost with Preserved Environment
+### Preserve the test environment
+
 ```bash
+cd e2e
+
 # Start Ghost and keep it running
 PRESERVE_ENV=true pnpm test
 
 # The test will output the Ghost instance URL (usually http://localhost:2369)
 ```
 
-### 2. Use Playwright MCP to Explore
-```javascript
-// Navigate to the Ghost instance
-mcp__playwright__browser_navigate({url: "http://localhost:2369/ghost"})
+The test output provides the preserved Ghost instance URL, usually
+`http://localhost:2369`. Open that URL, exercise the interaction, and inspect
+the accessibility tree and relevant attributes.
 
-// Capture the current DOM structure
-mcp__playwright__browser_snapshot()
-
-// Interact with elements to discover selectors
-mcp__playwright__browser_click({element: "Button description", ref: "selector-from-snapshot"})
-
-// Take screenshots for reference
-mcp__playwright__browser_take_screenshot({filename: "feature-state.png"})
-```
-
-### 3. Extract Selectors for Page Objects
-Based on your exploration, create the Page Object with discovered selectors:
-- Note the element references from snapshots
-- Identify the best selector strategy (role, label, text, testId)
-- Test interactions before finalizing the Page Object
+Choose the locator using the priority above and verify the interaction before
+adding it to the Page Object. If the UI has no reliable semantic locator, add a
+stable test ID to the product code rather than coupling the test to styling or
+DOM position.
 
 ## Test Template
 
@@ -257,4 +261,15 @@ test.describe('Ghost Admin - Feature', () => {
         await expect(featurePage.statusMessage).toBeVisible();
     });
 });
+```
+
+After changing E2E tests, run the focused test as well as the workspace lint
+and type checks:
+
+```bash
+cd e2e
+
+pnpm test tests/admin/signin.test.ts
+pnpm lint
+pnpm test:types
 ```

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -35,7 +35,8 @@ Put tests as close as possible to the code and behavior under test:
   framework and command vary by app, so use that workspace's
   `test:acceptance` target.
 - **Browser E2E tests** use Playwright to cover complete journeys across Ghost
-  Admin and the public site. They live in `e2e/`.
+  Admin and the public site. They live in `e2e/`. See
+  [Writing Browser E2E Tests](e2e-testing.md) for conventions and examples.
 - **Ember Admin tests** cover the legacy Ember application in
   `apps/ember-admin/` and run through Ember Exam via Nx.
 
@@ -112,16 +113,19 @@ pnpm dev
 pnpm test:e2e
 ```
 
-Run a specific file or match a test title by passing Playwright arguments:
+Run a specific file or match a test title by passing Playwright arguments. For
+example, the first command runs the existing Admin sign-in test:
 
 ```bash
-pnpm test:e2e tests/admin/posts.spec.ts
+pnpm test:e2e tests/admin/signin.test.ts
 pnpm test:e2e --grep "publish a post"
 ```
 
 Use `pnpm test:e2e:debug` for Ghost E2E debug logs. See the
-[browser E2E guide](../../e2e/README.md) for infrastructure modes, test
-isolation, fixtures, selectors, and debugging.
+[E2E workspace README](../../e2e/README.md) for infrastructure modes, test
+isolation, fixtures, and debugging, and
+[Writing Browser E2E Tests](e2e-testing.md) for test conventions, selectors,
+and Page Objects.
 
 ## Run Ember Admin Tests
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,165 +1,37 @@
 # AGENTS.md
 
-E2E testing guidance for AI assistants (Claude, Codex, etc.) working with Ghost tests.
+Read the canonical human documentation before changing this workspace:
 
-**IMPORTANT**: `README.md` is the canonical human documentation for E2E testing.
-When creating or modifying E2E tests, follow it first. Use
-`./.claude/E2E_TEST_WRITING_GUIDE.md` for additional agent-oriented examples.
+- [Writing Browser E2E Tests](../docs/contributing/e2e-testing.md) covers test
+  structure, Page Objects, locator priority, waiting, and validation.
+- The [E2E workspace README](./README.md) covers infrastructure modes,
+  fixtures, isolation, commands, and troubleshooting.
+- The [data factory README](./data-factory/README.md) covers test-data helpers.
 
-## Critical Rules
-1. **Always use pnpm**, never npm
-2. **Always run after changes**: `pnpm lint` and `pnpm test:types`
-3. **Prefer semantic locators**, then stable test IDs
-4. **Keep reusable UI structure and interactions in Page Objects**
-5. **Avoid selectors coupled to styling or DOM position**
-6. **Prefer clear names and structure over explanatory comments**; add a
-   comment when an AAA boundary would otherwise be unclear
+## Required workflow
 
-## Running E2E Tests
+- Always use `pnpm`, never npm or Yarn.
+- Import shared test helpers through the `@/` aliases documented in the writing
+  guide.
+- After changing E2E tests, run the focused test, `pnpm lint`, and
+  `pnpm test:types` from this workspace.
+- After changing the data factory, also run `pnpm build`.
+- Update the canonical human guide when a shared E2E convention changes. Do not
+  create or rely on tool-specific copies of the guidance.
 
-For normal development, start `pnpm dev` before running E2E tests. The runner
-auto-detects whether the Admin dev server is reachable at
-`http://127.0.0.1:5174`: when it is, tests use **dev mode**, which is the fastest
-feedback loop and does not require a prebuilt Ghost E2E image.
+## Playwright MCP
 
-The suite also supports **build mode** for local CI-like testing without dev
-servers. Build mode requires a prepared `ghost-e2e:local` image; follow the
-commands in the canonical README's [Build Mode](./README.md#build-mode-prebuilt-image)
-section. If `Build image not found: ghost-e2e:local` appears unexpectedly, either
-start `pnpm dev` to use dev mode or prepare the build-mode image.
+When discovering selectors or building a Page Object, use Playwright MCP when
+it is available:
 
-```bash
-# Terminal 1 (or background): Start dev environment from the repo root
-pnpm dev
+- Run a focused test with `PRESERVE_ENV=true` and use the instance URL printed
+  by the test runner.
+- Navigate to that instance and take an accessibility snapshot before choosing
+  locators.
+- Exercise the interaction to verify the locator and capture a screenshot when
+  the rendered state is useful context.
+- Follow the locator priority in the E2E writing guide; do not copy generated
+  selectors without checking that they are stable.
 
-# Wait for the admin dev server to be reachable (http://127.0.0.1:5174)
-
-# Terminal 2: Run e2e tests from the e2e/ directory
-pnpm test                                       # Run all tests
-pnpm test tests/path/to/test.ts                 # Run specific test
-pnpm lint                                       # Required after writing tests
-pnpm test:types                                 # Check TypeScript errors
-pnpm build                                      # Required after factory changes
-pnpm test --debug                               # See browser during execution, for debugging
-PRESERVE_ENV=true pnpm test                     # Debug failed tests (keeps containers)
-```
-## Test Structure
-
-### Naming Conventions
-- **Test suites**: `Ghost Admin - Feature` or `Ghost Public - Feature`
-- **Test names**: `what is tested - expected outcome` (lowercase)
-- **One test = one scenario** (never mix multiple scenarios)
-
-### AAA Pattern
-```typescript
-test('action performed - expected result', async ({page}) => {
-    const analyticsPage = new AnalyticsGrowthPage(page);
-    const postFactory = createPostFactory(page.request);
-    const post = await postFactory.create({status: 'published'});
-
-    await analyticsPage.goto();
-    await analyticsPage.topContent.postsButton.click();
-
-    await expect(analyticsPage.topContent.contentCard).toContainText('No conversions');
-});
-```
-
-## Page Objects
-
-### Structure
-```typescript
-export class AnalyticsPage extends AdminPage {
-    // Public readonly locators only
-    public readonly saveButton = this.page.getByRole('button', {name: 'Save'});
-    public readonly emailInput = this.page.getByLabel('Email');
-
-    // Semantic action methods
-    async saveSettings() {
-        await this.saveButton.click();
-    }
-}
-```
-
-### Rules
-- Put reusable page and major-component behavior in `helpers/pages/`
-- Direct semantic locators are acceptable for small, one-off test interactions or assertions
-- Expose locators as `public readonly` when used with assertions
-- Methods use semantic names (`login()` not `clickLoginButton()`)
-- Use `waitFor()` for guards, never `expect()` in page objects
-- Keep all assertions in test files
-
-## Locators (Strict Priority)
-
-1. **Semantic** (always prefer):
-   - `getByRole('button', {name: 'Save'})`
-   - `getByLabel('Email')`
-   - `getByText('Success')`
-
-2. **Test IDs** (when semantic unavailable):
-   - `getByTestId('analytics-card')`
-   - Suggest adding `data-testid` to Ghost codebase when needed
-
-3. **Structural fallback**: stable attributes when semantic locators are unavailable
-
-Avoid XPath, `nth-child`, styling classes, and other selectors coupled to DOM
-position or presentation. Keep necessary structural selectors in Page Objects where
-practical.
-
-### Playwright MCP Usage
-- Use `mcp__playwright__browser_snapshot` to find elements
-- Use `mcp__playwright__browser_click` with semantic descriptions
-- If no good locator exists, suggest `data-testid` addition to Ghost
-
-## Test Data
-
-### Factory Pattern (Required)
-```typescript
-import {createPostFactory} from '@/data-factory';
-
-const postFactory = createPostFactory(page.request);
-const post = await postFactory.create({title: 'Test Post'});
-```
-
-Import through the `@/` path aliases in `tsconfig.json` (`@/data-factory`,
-`@/helpers/playwright`, `@/admin-pages`), never relative paths.
-
-## Best Practices
-
-### DO ✅
-- Use `usePerTestIsolation()` from `@/helpers/playwright/isolation` if a file needs per-test isolation
-- Treat `config` and `labs` as environment-identity inputs: changing them should be an intentional part of test setup
-- Use `resetEnvironment()` only in `beforeEach` hooks when you need a forced recycle inside per-file mode
-- Keep `stripeEnabled` tests in per-test mode; the fixture forces this automatically
-- Use factories for all test data
-- Use Playwright's auto-waiting
-- Run tests multiple times to ensure stability
-- Use `test.only()` for debugging single tests
-
-### DON'T ❌
-- Use `test.describe.parallel(...)` or `test.describe.serial(...)` in e2e tests
-- Use nested `test.describe.configure({mode: ...})` (mode toggles are root-level only)
-- Call `resetEnvironment()` after resolving `baseURL`, `page`, `pageWithAuthenticatedUser`, or `ghostAccountOwner`
-- Hard-coded waits (`waitForTimeout`)
-- networkidle in waits (`networkidle`)
-- Test dependencies (Test B needs Test A)
-- Direct database manipulation
-- Multiple scenarios in one test
-- Assertions in page objects
-- Manual login (auto-authenticated via fixture)
-
-## Project Structure
-- `tests/admin/` - Admin area tests
-- `tests/public/` - Public site tests
-- `helpers/pages/` - Page objects
-- `helpers/environment/` - Container management
-- `data-factory/` - Test data factories
-
-## Validation Checklist
-After writing tests, verify:
-1. Test passes: `pnpm test path/to/test.ts`
-2. Linting passes: `pnpm lint`
-3. Types check: `pnpm test:types`
-4. Follows AAA pattern with clear sections
-5. Uses Page Objects for reusable UI behavior
-6. Prefers semantic locators, then stable test IDs
-7. Has no hard-coded waits or selectors coupled to styling/DOM position
+If Playwright MCP is unavailable, use Playwright Inspector or browser developer
+tools as described in the writing guide.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -87,8 +87,8 @@ pnpm --filter @tryghost/e2e preflight:build
 ### Running Specific Tests
 
 ```bash
-# Specific test file
-pnpm test specific/folder/testfile.spec.ts
+# Run the Admin sign-in test
+pnpm test tests/admin/signin.test.ts
 
 # Matching a pattern
 pnpm test --grep "homepage"
@@ -99,6 +99,11 @@ pnpm test --debug
 
 ## Tests Development
 
+See [Writing Browser E2E Tests](../docs/contributing/e2e-testing.md) for the
+canonical conventions, Page Object pattern, locator priority, waiting patterns,
+and worked examples. This README covers the local workspace, infrastructure,
+fixtures, and commands.
+
 The test suite is organized into separate directories for different areas/functions:
 
 ### **Current Test Suites**
@@ -107,16 +112,6 @@ The test suite is organized into separate directories for different areas/functi
 - `tests/portal/` - Portal member journey tests
 
 We can decide whether to add additional sub-folders as we add more tests.
-
-Filenames are kebab-case — `eslint.config.js` enforces this. Test files end in
-`.test.ts` and are named after the behaviour under test, not the page:
-
-```text
-tests/admin/
-├── signin.test.ts
-├── two-factor-auth.test.ts
-└── whats-new.test.ts
-```
 
 Project folder structure can be seen below:
 
@@ -147,88 +142,6 @@ e2e/
 ├── package.json                # Dependencies and scripts
 └── tsconfig.json               # TypeScript configuration and path aliases
 ```
-
-### Writing Tests
-
-Tests use [Playwright Test](https://playwright.dev/docs/writing-tests). Use
-Arrange–Act–Assert (AAA) as a readability heuristic: set up the scenario, perform
-the behavior under test, then verify the outcome. Keep those phases clear through
-test structure and naming; comments are only useful when the boundaries would
-otherwise be unclear.
-
-Import through the `@/` path aliases defined in `tsconfig.json`, not relative paths:
-
-```typescript
-import {expect, test} from '@/helpers/playwright';
-import {HomePage} from '@/public-pages';
-
-test.describe('Ghost Homepage', () => {
-    test('loads correctly', async ({page}) => {
-        const homePage = new HomePage(page);
-
-        await homePage.goto();
-
-        await expect(homePage.title).toBeVisible();
-    });
-});
-```
-
-### Using Page Objects
-
-Page Objects are the default home for reusable knowledge about a page or major UI
-component. They encapsulate locators, readiness guards, and semantic interactions
-so tests can describe behavior rather than DOM structure. Assertions stay in test
-files.
-
-Prefer an existing Page Object when a test exercises reusable UI behavior. A direct
-semantic locator in a test is acceptable for a small, one-off assertion or
-interaction when creating a Page Object would add indirection without reuse.
-Structural selectors sometimes remain necessary for iframes, editor internals,
-generated theme markup, and elements without an accessible role. Keep those inside
-Page Objects where practical and prefer, in order:
-
-1. Accessible roles, labels, and visible text
-2. Stable test IDs
-3. Stable structural selectors when no semantic locator exists
-
-Avoid selectors coupled to visual styling, DOM position, or incidental class names.
-See [Playwright's locator guidance](https://playwright.dev/docs/locators) and
-[Martin Fowler's Page Object description](https://martinfowler.com/bliki/PageObject.html)
-for background.
-
-Admin page objects extend `AdminPage`, public and portal ones extend `BasePage`.
-The base class supplies `goto()`, `refresh()` and `pressKey()`, so a subclass
-only sets its own `pageUrl` and locators:
-
-```typescript
-// helpers/pages/admin/login-page.ts
-import {AdminPage} from './admin-page';
-import type {Locator, Page} from '@playwright/test';
-
-export class LoginPage extends AdminPage {
-    readonly emailAddressField: Locator;
-    readonly passwordField: Locator;
-    readonly signInButton: Locator;
-
-    constructor(page: Page) {
-        super(page);
-        this.pageUrl = '/ghost/#/signin';
-
-        this.emailAddressField = page.getByRole('textbox', {name: 'Email address'});
-        this.passwordField = page.getByRole('textbox', {name: 'Password'});
-        this.signInButton = page.getByRole('button', {name: 'Sign in →'});
-    }
-
-    async signIn(email: string, password: string) {
-        await this.emailAddressField.fill(email);
-        await this.passwordField.fill(password);
-        await this.signInButton.click();
-    }
-}
-```
-
-For worked examples of modals, iframes, and discovering selectors for new page
-objects, see the [test writing guide](./.claude/E2E_TEST_WRITING_GUIDE.md).
 
 ### Global Setup and Teardown
 


### PR DESCRIPTION
## Summary

- Moves browser E2E writing guidance out of a tool-specific directory and into the canonical codebase documentation.
- Keeps workspace setup and infrastructure in the E2E README, shared conventions in the writing guide, and Playwright MCP instructions in agent guidance.
- Removes the final repository dependency on the retired Codex testing pages and aligns Ember Admin testing commands with the supported Nx flow.

## Testing

- [x] `pnpm nx run ghost-admin:test -- 1 --file-path=tests/acceptance/editor/publish-flow-test.js`
- [x] `pnpm --filter @tryghost/e2e lint` (14 pre-existing warnings, no errors)
- [x] `git diff --check origin/main...HEAD`
