### PR TITLE
🐛 Improved toggle card accessibility for screen readers

### DIFF
--- a/.changeset/toggle-card-a11y.md
+++ b/.changeset/toggle-card-a11y.md
@@ -1,0 +1,6 @@
+---
+"@tryghost/kg-default-nodes": patch
+"@tryghost/kg-default-cards": patch
+---
+
+Improved toggle card accessibility for screen readers (aria-expanded, hidden collapsed content).

--- a/ghost/core/core/frontend/src/cards/css/toggle.css
+++ b/ghost/core/core/frontend/src/cards/css/toggle.css
@@ -10,7 +10,7 @@
     padding: 1.2em;
 }
 
-.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content{
+.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content {
     height: 0;
     overflow: hidden;
     transition: opacity .5s ease, top .35s ease;
@@ -74,6 +74,11 @@
     background: none;
     border: 0;
     cursor: pointer;
+}
+
+.kg-toggle-card-icon:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
 }
 
 .kg-toggle-heading svg {

--- a/ghost/core/core/frontend/src/cards/js/toggle.js
+++ b/ghost/core/core/frontend/src/cards/js/toggle.js
@@ -1,18 +1,89 @@
-(function() {
-    const toggleHeadingElements = document.getElementsByClassName("kg-toggle-heading");
+(function () {
+    const toggleCards = document.querySelectorAll('.kg-toggle-card');
 
-    const toggleFn = function(event) {
-        const targetElement = event.target;
-        const parentElement = targetElement.closest('.kg-toggle-card');
-        var toggleState = parentElement.getAttribute("data-kg-toggle-state");
-        if (toggleState === 'close') {
-            parentElement.setAttribute('data-kg-toggle-state', 'open');
-        } else {
-            parentElement.setAttribute('data-kg-toggle-state', 'close');
+    const setExpandedState = function (card, isOpen) {
+        const button = card.querySelector('.kg-toggle-card-icon');
+        const content = card.querySelector('.kg-toggle-content');
+
+        card.setAttribute('data-kg-toggle-state', isOpen ? 'open' : 'close');
+
+        if (button) {
+            button.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+
+            // When aria-labelledby is present, aria-expanded conveys state with the heading name.
+            // Otherwise keep a clear Expand/Collapse label for older markup.
+            if (!button.getAttribute('aria-labelledby')) {
+                button.setAttribute('aria-label', isOpen ? 'Collapse content' : 'Expand content');
+            }
+        }
+
+        if (content) {
+            if (isOpen) {
+                content.removeAttribute('hidden');
+                content.removeAttribute('aria-hidden');
+                content.removeAttribute('inert');
+            } else {
+                // Use hidden so collapsed content is not exposed to assistive tech.
+                // aria-hidden + inert cover older markup and browsers without full hidden support.
+                content.setAttribute('hidden', '');
+                content.setAttribute('aria-hidden', 'true');
+                content.setAttribute('inert', '');
+            }
         }
     };
 
-    for (let i = 0; i < toggleHeadingElements.length; i++) {
-        toggleHeadingElements[i].addEventListener('click', toggleFn, false);
+    const toggleFn = function (event) {
+        const targetElement = event.target;
+        const parentElement = targetElement.closest('.kg-toggle-card');
+
+        if (!parentElement) {
+            return;
+        }
+
+        const isClosed = parentElement.getAttribute('data-kg-toggle-state') === 'close';
+        setExpandedState(parentElement, isClosed);
+    };
+
+    for (let i = 0; i < toggleCards.length; i++) {
+        const card = toggleCards[i];
+        const heading = card.querySelector('.kg-toggle-heading');
+        const button = card.querySelector('.kg-toggle-card-icon');
+        const content = card.querySelector('.kg-toggle-content');
+        const headingText = card.querySelector('.kg-toggle-heading-text');
+
+        if (content) {
+            const contentId = `kg-toggle-content-${i}`;
+            content.id = contentId;
+
+            if (button) {
+                button.setAttribute('aria-controls', contentId);
+                button.setAttribute('type', 'button');
+            }
+        }
+
+        if (headingText && button) {
+            const headingId = `kg-toggle-heading-${i}`;
+            headingText.id = headingId;
+            // Prefer the heading text as the accessible name so the control is announced
+            // with the section title plus expanded/collapsed state via aria-expanded.
+            button.setAttribute('aria-labelledby', headingId);
+            button.removeAttribute('aria-label');
+        }
+
+        if (button) {
+            const svg = button.querySelector('svg');
+            if (svg) {
+                svg.setAttribute('aria-hidden', 'true');
+                svg.setAttribute('focusable', 'false');
+            }
+        }
+
+        const isOpen = card.getAttribute('data-kg-toggle-state') === 'open';
+        setExpandedState(card, isOpen);
+
+        // Preserve mouse activation on the whole heading; keyboard users activate via the button.
+        if (heading) {
+            heading.addEventListener('click', toggleFn, false);
+        }
     }
 })();

--- a/koenig/kg-default-cards/src/cards/toggle.ts
+++ b/koenig/kg-default-cards/src/cards/toggle.ts
@@ -19,11 +19,11 @@ const toggleCard: Card = {
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">{{{heading}}}</h4>
-                    <button class="kg-toggle-card-icon">
-                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
+                    <button class="kg-toggle-card-icon" type="button" aria-expanded="false" aria-label="Expand content">
+                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
                     </button>
                 </div>
-                <div class="kg-toggle-content">{{{content}}}</div>
+                <div class="kg-toggle-content" hidden aria-hidden="true" inert>{{{content}}}</div>
             </div>
         `;
 

--- a/koenig/kg-default-cards/test/cards/toggle.test.ts
+++ b/koenig/kg-default-cards/test/cards/toggle.test.ts
@@ -13,7 +13,7 @@ describe('Toggle card', function () {
                 }
             };
 
-            expect(serializer.serialize(card.render(opts))).toBe('<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content">This is toggle content</div></div>');
+            expect(serializer.serialize(card.render(opts))).toBe('<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon" type="button" aria-expanded="false" aria-label="Expand content"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content" hidden aria-hidden="true" inert>This is toggle content</div></div>');
         });
     });
 

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
@@ -16,13 +16,13 @@ function cardTemplate({node}: {node: ToggleNodeData}) {
         <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
             <div class="kg-toggle-heading">
                 <h4 class="kg-toggle-heading-text">${node.heading}</h4>
-                <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
-                    <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <button class="kg-toggle-card-icon" type="button" aria-expanded="false" aria-label="Expand content">
+                    <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                         <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                     </svg>
                 </button>
             </div>
-            <div class="kg-toggle-content">${node.content}</div>
+            <div class="kg-toggle-content" hidden aria-hidden="true" inert>${node.content}</div>
         </div>
         `
     );

--- a/koenig/kg-default-nodes/test/nodes/toggle.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/toggle.test.ts
@@ -174,13 +174,13 @@ describe('ToggleNode', function () {
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">Heading</h4>
-                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
-                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <button class="kg-toggle-card-icon" type="button" aria-expanded="false" aria-label="Expand content">
+                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                             <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                         </svg>
                     </button>
                 </div>
-                <div class="kg-toggle-content">Content</div>
+                <div class="kg-toggle-content" hidden="" aria-hidden="true" inert="">Content</div>
             </div>
             `);
         }));
@@ -221,7 +221,7 @@ describe('ToggleNode', function () {
     describe('importDOM', function () {
         it('parses toggle card', editorTest(function () {
             const document = createDocument(html`
-                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon" aria-label="Expand toggle to read content"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content">Content</div></div>
+                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon" type="button" aria-expanded="false" aria-label="Expand content"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content" hidden aria-hidden="true" inert>Content</div></div>
             `);
             const nodes = $generateNodesFromDOM(editor, document) as ToggleNode[];
             expect(nodes.length).toBe(1);

--- a/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
@@ -30,15 +30,17 @@ describe('renderers/toggle-renderer', function () {
                         <h4 class="kg-toggle-heading-text">Toggle Heading</h4>
                         <button
                             class="kg-toggle-card-icon"
-                            aria-label="Expand toggle to read content">
-                            <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            type="button"
+                            aria-expanded="false"
+                            aria-label="Expand content">
+                            <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <path
                                     class="cls-1"
                                     d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                             </svg>
                         </button>
                     </div>
-                    <div class="kg-toggle-content">Collapsible content</div>
+                    <div class="kg-toggle-content" hidden="" aria-hidden="true" inert="">Collapsible content</div>
                 </div>
             `);
         });


### PR DESCRIPTION
## Summary
- Fixes expand/collapse a11y for published `kg-toggle-card` content: `aria-expanded`, `aria-controls`, and a clear accessible name on the toggle button
- Hides collapsed content from assistive tech with `hidden` / `aria-hidden` / `inert`, synced by frontend JS with `data-kg-toggle-state`
- Updates both card renderers (`kg-default-cards` and `kg-default-nodes`) and unit tests for consistent markup

Fixes #27462

## Test plan
- [ ] Publish a post with one or more Toggle cards; confirm collapsed body is not read by VoiceOver/NVDA until expanded
- [ ] Confirm the toggle control announces expanded/collapsed state and can be activated with keyboard (Enter/Space on the button)
- [ ] Confirm clicking the heading still expands/collapses
- [ ] Confirm email render still shows heading + content (always expanded)
- [ ] Run `pnpm exec vitest run test/cards/toggle.test.ts` in `koenig/kg-default-cards`
- [ ] Run `pnpm exec vitest run test/renderers/toggle-renderer.test.ts test/nodes/toggle.test.ts` in `koenig/kg-default-nodes`