### PR TITLE
Improved CodeRabbit's Ghost review context

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,10 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   profile: quiet
+  request_changes_workflow: false
   review_details: true
+  review_status: true
+  review_progress: true
   high_level_summary: false
   collapse_walkthrough: false
   changed_files_summary: false
@@ -9,9 +12,17 @@ reviews:
   estimate_code_review_effort: false
   poem: false
   auto_review:
+    enabled: true
+    drafts: false
     ignore_usernames:
       - tryghost-renovate[bot]
       - dependabot[bot]
+  path_filters:
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/built/**"
+    - "!**/umd/**"
+    - "!**/coverage/**"
   pre_merge_checks:
     docstrings:
       mode: "off"
@@ -37,6 +48,16 @@ reviews:
           a tool/config file, under scripts/ or docker/, or generated/vendored code.
           Modifying pre-existing JS files never fails this check.
   path_instructions:
+    - path: "**/*"
+      instructions: |
+        Prioritise concrete correctness, security, data-integrity, compatibility,
+        and regression risks. Explain the failure mode and point to the affected
+        code. Do not report formatting, naming, import ordering, type errors, or
+        other findings already owned by configured static tools or failing GitHub
+        checks. Do not request speculative abstractions, broad refactors, generic
+        documentation, or tests unrelated to changed behaviour. Treat nearby
+        AGENTS.md files and mapped codebase documentation as authoritative; do not
+        enforce proposals, plans, or historical guidance as current policy.
     - path: "**/*.{ts,tsx,mts,cts}"
       instructions: |
         Review lens: "where does this data become trusted?"
@@ -63,3 +84,129 @@ reviews:
         exempt areas.
         If the PR adds or changes a runtime boundary (parsing HTTP input, JSON, config,
         external responses), suggest validating it — ideally with TS + Zod.
+    - path: "ghost/core/core/server/api/**"
+      instructions: |
+        Review API contract semantics: authentication and permissions, validation at
+        untrusted boundaries, writable-field allowlists, accidental response-data
+        exposure, stable error codes/statuses, pagination/filter consistency, cache
+        invalidation, and compatibility with existing clients. Require tests only for
+        changed behaviour or a credible regression path. Do not repeat endpoint
+        complexity, filenames, typing, or other ESLint/schema failures.
+    - path: "ghost/core/core/server/services/**"
+      instructions: |
+        Review new or changed service boundaries for explicit dependency ownership,
+        deterministic/idempotent initialisation, boot ordering, transaction and event
+        semantics, cache coherence, and restart/multi-instance safety. New standalone
+        services default to TypeScript; extending an existing JavaScript service is an
+        accepted exception. Do not enforce unapproved repository, ORM, or dependency-
+        injection proposals as current architecture.
+    - path: "ghost/core/core/server/data/{migrations,schema}/**"
+      instructions: |
+        Review migration safety beyond lint: schema and migration parity, existing-data
+        shape and volume, deploy/rollback compatibility, transaction and locking risk,
+        idempotency, export/integrity updates, and preservation of constraints/defaults.
+        Do not duplicate migration filename, loop, schema-field, or integrity-check CI.
+    - path: "packages/**"
+      instructions: |
+        Review package boundaries and production consumption: minimal explicit exports,
+        declared runtime dependencies, source-condition versus built-output parity,
+        copied runtime assets, ESM/NodeNext compatibility, and consumer-facing release
+        impact. Respect ghostPackage migration/exempt metadata and public/browser/test-
+        only exceptions. Do not repeat fields enforced by lint:packages or changeset CI.
+    - path: "apps/{admin,activitypub,admin-x-framework,shade}/**/*.{ts,tsx}"
+      instructions: |
+        Review Admin UI for existing Shade reuse, correct component layer, semantic
+        tokens, accessible interaction states, and whole-sentence translations. New UI
+        that depends on backend settings, endpoints, or config must feature-detect old
+        backend support and cover the not-yet-deployed backend case. Do not apply these
+        rules to independent public UMD apps. Do not repeat ESLint/Tailwind findings.
+    - path: "apps/{portal,comments-ui,signup-form,sodo-search,announcement-bar}/**/*.{js,jsx,ts,tsx}"
+      instructions: |
+        These are independent public UMD/CDN surfaces, not embedded Shade apps. Review
+        backwards-compatible browser behaviour, bundle/runtime assumptions, accessible
+        recovery states, namespace-correct whole-sentence translations, and safe
+        handling of server-provided data. Do not request Shade adoption or Admin-only
+        Tailwind conventions.
+    - path: "e2e/tests/**/*.ts"
+      instructions: |
+        Review semantic E2E quality that static checks miss: test the user-visible
+        integration at the lowest useful layer; prefer web-first assertions and
+        semantic locators; keep reusable interactions in page objects and assertions in
+        tests; avoid hard waits and networkidle; use factories and preserve isolation.
+        Per-file environment reuse is the default, so request per-test isolation only
+        for state-heavy cases that genuinely need it. A direct semantic locator is fine
+        for a small one-off assertion. Do not repeat Playwright ESLint or CI failures.
+    - path: "e2e/helpers/**/*.ts"
+      instructions: |
+        Review fixture/page-object lifecycle, concurrency, reset timing, reusable
+        readiness guards, and stable public locators. Page objects may use necessary
+        structural selectors for iframe/editor/theme internals but must not contain
+        business assertions. Preserve the documented per-file/per-test isolation model.
+    - path: "**/*.{test,spec}.{js,jsx,ts,tsx}"
+      instructions: |
+        Review whether tests prove changed behaviour, meaningful error/edge paths, and
+        externally observable contracts without coupling to implementation details.
+        Prefer the lowest useful test layer. Do not demand broad E2E coverage for
+        isolated logic or repeat test-run failures already visible in GitHub checks.
+    - path: "docs/**/*.md"
+      instructions: |
+        Check technical claims, paths, commands, and declared authority/status against
+        the current repository. Flag contradictions and stale instructions with a
+        concrete source of truth. Do not demand generic tutorial expansion or enforce
+        proposal language on production code.
+  tools:
+    eslint:
+      enabled: true
+    oxc:
+      enabled: true
+    stylelint:
+      enabled: true
+    emberTemplateLint:
+      enabled: true
+    actionlint:
+      enabled: true
+    zizmor:
+      enabled: true
+    yamllint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    opengrep:
+      enabled: true
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    osvScanner:
+      enabled: true
+    github-checks:
+      enabled: true
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - files: "docs/practices/api-design.md"
+        applyTo: "ghost/core/core/server/api/**,packages/admin-api-schema/**"
+      - files: "docs/practices/database-migrations.md"
+        applyTo: "ghost/core/core/server/data/migrations/**,ghost/core/core/server/data/schema/**"
+      - files: "docs/practices/error-handling.md"
+        applyTo: "ghost/core/core/server/**,apps/**/*.{js,jsx,ts,tsx}"
+      - files: "docs/practices/internationalization.md"
+        applyTo: "apps/**/*.{js,jsx,ts,tsx},packages/i18n/**"
+      - files: "docs/contributing/testing.md"
+        applyTo: "**/*.{js,jsx,ts,tsx}"
+      - files: "docs/codebase/monorepo-structure.md"
+        applyTo: "package.json,pnpm-workspace.yaml,nx.json,apps/**,packages/**,ghost/core/**,koenig/**"
+      - files: "docs/codebase/configuration.md"
+        applyTo: "ghost/core/core/shared/config/**,ghost/core/config*.json*"
+      - files: "docs/codebase/internal-caching.md"
+        applyTo: "ghost/core/core/server/**"
+      - files: "docs/codebase/jobs.md"
+        applyTo: "ghost/core/core/server/services/**"
+      - files: "packages/README.md"
+        applyTo: "packages/**"
+      - files: "apps/shade/AGENTS.md"
+        applyTo: "apps/admin/**,apps/activitypub/**,apps/admin-x-framework/**,apps/shade/**"
+      - files: "e2e/README.md,e2e/AGENTS.md"
+        applyTo: "e2e/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
     enabled: true
     drafts: false
     ignore_usernames:
-      - tryghost-renovate[bot]
+      - app/tryghost-renovate
       - dependabot[bot]
   path_filters:
     - "!**/dist/**"
@@ -142,7 +142,7 @@ reviews:
         readiness guards, and stable public locators. Page objects may use necessary
         structural selectors for iframe/editor/theme internals but must not contain
         business assertions. Preserve the documented per-file/per-test isolation model.
-    - path: "**/*.{test,spec}.{js,jsx,ts,tsx}"
+    - path: "**/*{.,-}{test,spec}.{js,jsx,ts,tsx}"
       instructions: |
         Review whether tests prove changed behaviour, meaningful error/edge paths, and
         externally observable contracts without coupling to implementation details.
@@ -195,13 +195,13 @@ knowledge_base:
       - files: "docs/practices/internationalization.md"
         applyTo: "apps/**/*.{js,jsx,ts,tsx},packages/i18n/**"
       - files: "docs/contributing/testing.md"
-        applyTo: "**/*.{js,jsx,ts,tsx}"
+        applyTo: "**/{test,tests}/**,**/*{.,-}{test,spec}.{js,jsx,ts,tsx}"
       - files: "docs/codebase/monorepo-structure.md"
         applyTo: "package.json,pnpm-workspace.yaml,nx.json,apps/**,packages/**,ghost/core/**,koenig/**"
       - files: "docs/codebase/configuration.md"
         applyTo: "ghost/core/core/shared/config/**,ghost/core/config*.json*"
       - files: "docs/codebase/internal-caching.md"
-        applyTo: "ghost/core/core/server/**"
+        applyTo: "ghost/core/core/server/adapters/cache/**,ghost/core/core/server/adapters/lib/redis/**,ghost/core/core/server/**/*cache*.{js,ts},ghost/core/core/shared/config/**,packages/adapters/cache-base/**"
       - files: "docs/codebase/jobs.md"
         applyTo: "ghost/core/core/server/services/**"
       - files: "packages/README.md"


### PR DESCRIPTION
## Context

Ghost's CodeRabbit configuration had started growing from isolated rules while most of the repository's established conventions were still unavailable to reviews. That makes a slow one-variable configuration trial impractical and risks producing inconsistent feedback between subsystems.

## Summary

- maps current codebase documentation to the source trees it governs, while retaining automatic `AGENTS.md` discovery
- adds focused semantic review guidance for APIs, services, migrations, packages, Admin/Shade, public apps, E2E, tests, and docs
- explicitly enables Ghost-relevant static/security tools and tells the AI review not to repeat lint or failing GitHub checks
- excludes generated build output and keeps dependency-bot/draft review behaviour explicit
- keeps general review comments non-blocking while preserving the existing TypeScript/Zod pre-merge checks

The rules deliberately exclude proposals and historical guidance from enforcement. They also distinguish embedded Admin apps from the independent public UMD apps, and preserve documented exceptions for existing JavaScript, package migrations, and E2E isolation.

## Testing

- [x] validated `.coderabbit.yaml` against the live CodeRabbit v2 JSON schema (Draft 2020-12)
- [x] `git diff --check`
- [x] verified every mapped guideline file and principal source scope exists on current `main`

## Monitoring

This becomes a new holistic intervention boundary in the existing CodeRabbit review-research dataset. Review volume, severity, validity, author action, CI duplication, and subsystem yield will be monitored after merge; noisy or inaccurate rules should be narrowed or removed from evidence rather than allowed to accumulate.
