### PR TITLE
Fixed the boot benchmark failing on a missing card asset manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,6 +566,14 @@ jobs:
       - name: Build TS code
         run: pnpm nx run-many -t build:tsc
 
+      # Boot reads the card asset manifest, which is written at build time. The
+      # test targets declare build:assets in their nx dependsOn (ghost/core's
+      # package.json); this job boots via raw `node index.js`, so there's no
+      # target to inherit it from. Outside the measured command, so it doesn't
+      # affect the series.
+      - name: Build assets
+        run: pnpm --filter ghost run build:assets
+
       - name: Run hyperfine on boot
         working-directory: ghost/core
         run: hyperfine --show-output --warmup 3 'GHOST_CI_SHUTDOWN_AFTER_BOOT=1 node index.js' --export-json boot-perf.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,11 +566,6 @@ jobs:
       - name: Build TS code
         run: pnpm nx run-many -t build:tsc
 
-      # Boot reads the card asset manifest, which is written at build time. The
-      # test targets declare build:assets in their nx dependsOn (ghost/core's
-      # package.json); this job boots via raw `node index.js`, so there's no
-      # target to inherit it from. Outside the measured command, so it doesn't
-      # affect the series.
       - name: Build assets
         run: pnpm --filter ghost run build:assets
 


### PR DESCRIPTION
`job_perf-tests` has been red on `main` since cbe73b18a43c5dee490427a83c4da007575fe1be ([#29659](https://github.com/TryGhost/Ghost/pull/29659)) — e.g. [this run](https://github.com/TryGhost/Ghost/actions/runs/32003364465/job/95319486327):

```
InternalServerError: Could not use the card asset manifest at .../core/frontend/public/cards.manifest.json
  ENOENT: no such file or directory
  at CardAssets.readManifest (core/frontend/services/assets-minification/card-assets.js:69)
```

That commit moved card minification from request time to build time and made `cards.manifest.json` a hard boot requirement (it's constructed eagerly from `core/bridge.js`). The job only ran `build:tsc`, so the manifest never existed and boot exited 2, failing hyperfine.

Every other Ghost-booting job already gets the manifest: the test jobs through their nx `dependsOn: ["build:assets", ...]`, the production-image benchmark through `Dockerfile.production`, and `job_ghost-cli` through the packed archive from `job_pack`. This job boots via raw `node index.js`, so there's no target to inherit it from — it has to build the assets itself.

`pnpm --filter ghost run build:assets` is the same invocation already used in `job_pack` and `Dockerfile.production`, rather than a narrower `build:assets:cards`, so the "make the tree bootable" step stays one greppable string across all three call sites.

### Benchmark impact

The step is a separate `run:`, outside the measured command, so it isn't in the hyperfine sample.

Worth flagging for whoever reads the chart: the series has a gap since 17 Aug, and the first green run will likely show a small step up. That's real product behaviour from #29659 — a 53KB `readFileSync` + `JSON.parse` at boot, plus the content-based asset hashing default flip — not environment drift from this change.

### Verification

Locally, on this branch:

- `pnpm --filter ghost run build:assets` → writes `cards.manifest.json` at exactly the path `card-assets.js` reads (`publicFilePath`).
- `GHOST_CI_SHUTDOWN_AFTER_BOOT=1 node index.js` → exit 0, "Ghost booted in 3.354s".
- Same boot with the manifest removed → exit 2 with the identical ENOENT, matching CI.

No other job in `ci.yml` (or any other workflow) boots Ghost from source, so this is the only place that needed it.
