### PR TITLE
Updated Koenig Lexical agent guidance

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -16,7 +16,11 @@ Use this skill whenever the user asks you to create a git commit for the current
 2. Only stage files relevant to the requested change. Do not include unrelated untracked files, generated files, or likely-local artifacts.
 3. Read and follow `.github/CONTRIBUTING.md#commit-messages`. It is the
    source of truth for Ghost's commit conventions.
-4. Run `git status --short` after committing and confirm the result.
+4. For publishable packages, check whether a release intent is required. A
+   package `README.md` is published and requires a release; repository-only
+   Markdown such as `AGENTS.md`, `CLAUDE.md`, changelogs, and package-local
+   `docs/` does not.
+5. Run `git status --short` after committing and confirm the result.
 
 ## Important
 - Do not push to remote unless the user explicitly asks

--- a/.changeset/loose-pans-argue.md
+++ b/.changeset/loose-pans-argue.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/koenig-lexical": patch
+---
+
+Updated Koenig Lexical testing documentation.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,6 +90,10 @@ This records which packages changed and the bump type (patch / minor / major); t
 pnpm change --bump none
 ```
 
+A package `README.md` is published with the package and requires a release.
+Repository-only Markdown such as `AGENTS.md`, `CLAUDE.md`, changelogs, and
+package-local `docs/` does not.
+
 CI enforces this — the **Check app version bump** job fails a pull request that affects a publishable package without a covering changeset. The pre-commit hook prints a non-blocking reminder locally, and `pnpm change status` shows what's currently pending.
 
 For more detail, see the [contribution workflow](../docs/contributing/workflow.md).

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -63,6 +63,10 @@ Choose patch, minor, or major according to the package's public compatibility
 impact. The summary becomes the changelog entry, so describe the result for the
 package's consumers.
 
+A package `README.md` is included when the package is published, so changing it
+requires a release. Repository-only Markdown such as `AGENTS.md`, `CLAUDE.md`,
+changelogs, and files under a package's `docs/` directory does not.
+
 If a changed publishable package genuinely requires no release—for example, a
 test-only or internal tooling change—record that explicitly:
 

--- a/koenig/koenig-lexical/AGENTS.md
+++ b/koenig/koenig-lexical/AGENTS.md
@@ -1,26 +1,17 @@
-# Koenig Lexical Test Guide
+# Koenig Lexical agent guidance
 
-## Test Commands
+Read the [`README.md`](./README.md), especially its development, testing, and
+editor-integration sections, before changing this package.
 
-### Unit Tests
-```bash
-pnpm test:unit          # Run unit tests once
-pnpm test:unit:watch    # Run unit tests in watch mode
-```
+## Required workflow
 
-### Acceptance Tests (Playwright)
-```bash
-pnpm test:acceptance           # Run Playwright tests (headless, list reporter)
-pnpm test:acceptance:quiet     # Minimal output, failures only
-pnpm test:acceptance:headed    # Run with browser UI visible
-pnpm test:acceptance:report    # Run with HTML report
-pnpm test:slowmo               # Slow motion + UI
-```
-
-### All Tests
-```bash
-pnpm test               # Run unit + acceptance tests, then lint
-```
+- Always use `pnpm`.
+- These Playwright tests are package-level acceptance tests. Ghost's browser
+  E2E suite lives in the repository-level `e2e/` workspace.
+- Use `pnpm test:unit:watch` for focused unit-test development and
+  `pnpm test:acceptance:quiet` when concise acceptance-test output is useful.
+- Run the relevant focused tests while iterating, then run `pnpm test` and
+  `pnpm lint` before submitting changes.
 
 ## AI-Friendly Testing
 
@@ -31,30 +22,8 @@ The test runner has been configured to work well with AI agents:
 - **Clean exit**: Tests complete without hanging processes or opening browsers
 - **Clear output**: List reporter provides clear pass/fail information
 
-## Human-Friendly Testing
-
-For debugging and development:
-
-- Use `pnpm test:acceptance:headed` to see the browser UI
-- Use `pnpm test:acceptance:report` to generate an HTML report
-- Use `pnpm test:slowmo` for slow-motion debugging
-
-## Environment Variables
-
-- `PLAYWRIGHT_HEADED=true` - Show browser UI
-- `PLAYWRIGHT_HTML_REPORT=true` - Generate HTML report
-- `PLAYWRIGHT_SLOWMO=100` - Slow motion delay (ms)
-
-## Test Structure
-
-- `test/unit/` - Unit tests (Vitest)
-- `test/e2e/` - Package-level acceptance tests (Playwright,
-  `test:acceptance` target); Ghost's end-to-end suite lives in the repository's
-  top-level `e2e/` directory
-- `test/utils/` - Shared test utilities
-
-## Development Workflow
-
-1. Run unit tests during development: `pnpm test:unit:watch`
-2. Run acceptance tests before committing: `pnpm test:acceptance`
-3. Use headed mode for debugging: `pnpm test:acceptance:headed`
+- Use `pnpm test:acceptance:headed`, `pnpm test:acceptance --ui`, or
+  `pnpm test:slowmo` only when interactive debugging is useful; do not leave a
+  browser or report server running after validation.
+- Update the README when the package's shared commands or testing workflow
+  changes; do not duplicate that guidance here.

--- a/koenig/koenig-lexical/README.md
+++ b/koenig/koenig-lexical/README.md
@@ -76,6 +76,9 @@ We use [Vitest](https://vitest.dev) for unit tests and
 end-to-end test suite lives in the repository's top-level
 [`e2e/`](../../e2e/) directory.
 
+Package tests live in `test/unit/` and `test/e2e/`, with shared test helpers in
+`test/utils/`.
+
 - `pnpm test` runs all tests and exits
 - `pnpm test:unit` runs unit tests
 - `pnpm test:unit:watch` runs unit tests and starts a test watcher that re-runs tests on file changes
@@ -88,6 +91,12 @@ end-to-end test suite lives in the repository's top-level
   in watch mode for exploring and re-running acceptance tests
 - `pnpm test:slowmo` runs headed acceptance tests with a 100ms delay between
   instructions (some tests may fail or time out due to the added delays)
+
+The acceptance-test commands use these environment variables:
+
+- `PLAYWRIGHT_HEADED=true` shows the browser UI.
+- `PLAYWRIGHT_HTML_REPORT=true` generates an HTML report.
+- `PLAYWRIGHT_SLOWMO=100` adds a delay in milliseconds between browser actions.
 
 Before tests are started we build a version of the demo app that is used for the unit tests.
 


### PR DESCRIPTION
## Summary

- Keeps Koenig Lexical's AI-specific test-running guidance in `AGENTS.md` while routing shared commands and test structure to the package README.
- Restores the supported Playwright environment variables and records a patch release because the README is published with the package.
- Documents and reinforces the existing rule that package READMEs require release intent while repository-only agent documentation does not.

## Testing

- [x] `node --test scripts/test/change-check.test.js scripts/test/check-agent-guidance.test.js`
- [x] `pnpm lint:docs`
- [x] `pnpm lint:agent-skills`
- [x] `pnpm change status`
- [x] `git diff --check origin/main...HEAD`
