### PR TITLE
Expanded database codebase documentation

### DIFF
--- a/docs/codebase/database.md
+++ b/docs/codebase/database.md
@@ -6,6 +6,9 @@ current shape expected after every migration has run. Bookshelf models in
 [`models/`](../../ghost/core/core/server/models/) define relationships and
 application behavior; do not infer those rules from the table shape alone.
 
+The sections below are domain maps, not a replacement for the schema. They
+explain why related tables exist and where to start when changing them.
+
 ## Posts
 
 Post statuses are `draft`, `scheduled`, `published`, and `sent`. Sent posts are
@@ -33,6 +36,68 @@ their referrer fields record the source, medium, and URL where available.
 
 The `source` on a member-created event records what created the member. Its
 values are `member`, `import`, `system`, `api`, and `admin`.
+
+## Members
+
+`members` is the central record for a reader. It stores identity, status,
+profile information, email engagement totals, and communication preferences.
+Related data is separated by responsibility:
+
+| Responsibility | Tables |
+| --- | --- |
+| Labels | `labels`, `members_labels` |
+| Custom fields | `members_custom_fields`, `members_custom_field_values` |
+| Newsletter subscriptions | `newsletters`, `members_newsletters` |
+| Tiers and access | `products`, `members_products`, `subscriptions` |
+| Stripe state | `members_stripe_customers`, `members_stripe_customers_subscriptions`, `members_current_subscription`, `stripe_products`, `stripe_prices` |
+| Offers | `offers`, `offer_redemptions` |
+| Lifecycle and attribution history | the `members_*_events` tables |
+
+`labels` has a many-to-many relationship with `members` through
+`members_labels`. Newsletter subscriptions use the same pattern through
+`members_newsletters`. Custom-field definitions are stored once in
+`members_custom_fields`; `members_custom_field_values` stores the values a
+member has supplied.
+
+Ghost keeps a provider-independent subscription in `subscriptions`. The Stripe
+tables cache the provider records needed to synchronize paid membership state.
+`members_current_subscription` is the one-row-per-member lookup used to expose
+the resolved Stripe subscription in Admin and member filtering. Read the member
+model, the resolved-subscription view, and the Stripe service as well as the
+schema before changing these relationships.
+
+The event tables are append-oriented history used for attribution, analytics,
+and changes to member or subscription state. They are not alternative sources
+of truth for the current member record.
+
+## Newsletters and email
+
+A newsletter send is represented across four main tables:
+
+| Table | Purpose |
+| --- | --- |
+| `emails` | One send for one post, including rendered content, recipient filter, aggregate counts, tracking options, and overall status |
+| `email_batches` | Provider submissions for an email, including the member segment, provider identifier, status, and batch-level errors |
+| `email_recipients` | The recipients selected for a send, their batch, a snapshot of member identity, and processing/delivery/open/failure timestamps |
+| `email_recipient_failures` | Structured temporary or permanent delivery failure information for a recipient |
+
+This split answers three different questions: `emails` records what Ghost sent,
+`email_batches` records how it was submitted to the provider, and
+`email_recipients` records who was included and what happened to each delivery.
+Do not reconstruct a historical recipient list from current member or segment
+state; the recipient rows are the send-time record.
+
+`posts.newsletter_id` and `emails.newsletter_id` associate the content and send
+with a newsletter. The `newsletters` table owns newsletter identity, sender
+configuration, subscription defaults, and presentation settings.
+
+`email_spam_complaint_events` records complaint events associated with a member
+and email. Member rows also cache aggregate engagement values for browsing and
+filtering; the per-send and per-recipient tables remain the detailed record.
+
+Automated emails use a separate set of `automation_*`,
+`welcome_email_automation_*`, and `automated_email_recipients` tables. They do
+not create newsletter `emails` and `email_recipients` rows.
 
 ## Link redirects and clicks
 

--- a/docs/codebase/database.md
+++ b/docs/codebase/database.md
@@ -114,3 +114,5 @@ amount, and payment-provider links.
 For changing this structure, follow the
 [database migrations guide](../practices/database-migrations.md). Keep the
 schema definition, migration, exporter table lists, and integrity tests in sync.
+For initial data and settings defaults, see the
+[schema and default data guide](../../ghost/core/core/server/data/schema/README.md).

--- a/ghost/core/core/server/data/schema/README.md
+++ b/ghost/core/core/server/data/schema/README.md
@@ -1,0 +1,87 @@
+# Schema and default data
+
+This directory defines the database shape and the records a new Ghost database
+starts with.
+
+## Sources of truth
+
+- `schema.js` is the final table and index structure expected after every
+  migration has run.
+- `fixtures/fixtures.json` contains durable records and relationships required
+  by a new site, including roles, permissions, the owner, starter content,
+  tiers, and a newsletter.
+- `default-settings/default-settings.json` defines the settings a site starts
+  with, grouped by responsibility.
+
+The initialization migrations create the tables and then use the fixture
+manager to add missing fixture records. The settings model flattens the grouped
+default-settings file and inserts settings missing from the database. Some
+values, such as signing keys and secrets, are generated when the defaults are
+populated rather than stored in the JSON file.
+
+Fixtures and default settings are different mechanisms. Fixtures create model
+records and relationships; default settings describe rows in the `settings`
+table.
+
+## Fixtures
+
+Fixture entries are added through their Bookshelf models. The fixture manager
+checks for an existing record before inserting it, adds roles and the owner
+before dependent records, and then creates the declared relationships.
+
+Use fixtures only for records every new Ghost installation requires. Sample
+development data belongs in the data generator, not in `fixtures.json`.
+
+When changing fixtures:
+
+1. Update `fixtures/fixtures.json`.
+2. Add a database migration when existing installations need the same change.
+3. Update affected models, exporter lists, and tests.
+4. Run the schema integrity test documented in the
+   [database migrations guide](../../../../../../docs/practices/database-migrations.md).
+
+## Default settings
+
+The top-level keys in `default-settings/default-settings.json` become setting
+groups. Each setting has a `defaultValue` and `type`, and may also declare
+validation and flags. The settings model adds the group and key when it
+flattens the file.
+
+Supported setting types include `string`, `number`, `boolean`, `array`, and
+`object`. Values are stored in the database in the representation expected by
+the settings model and cache.
+
+The flags used by settings migrations are:
+
+- `PUBLIC`: identifies a setting intended for a public settings surface.
+- `RO`: identifies a read-only setting.
+- `PUBLIC,RO`: applies both flags.
+
+Flags are part of the setting's stored contract, but each API surface still
+controls which settings it selects and how they may be changed. Check the
+relevant endpoint and serializer rather than assuming the flag alone grants
+access.
+
+The `core` group is restricted to internal access. Other groups organize
+settings that are commonly read or edited together; they do not by themselves
+make a setting public.
+
+When adding or changing a default setting:
+
+1. Update `default-settings/default-settings.json` for new installations.
+2. Add a migration for existing installations. Use the settings migration
+   utilities rather than inserting a row by hand.
+3. Update validation, API serializers, and tests when the setting's behaviour
+   requires it.
+4. Run the schema integrity test.
+
+Do not put environment-specific configuration in default settings. Runtime
+configuration belongs in Ghost's configuration system; see the
+[configuration guide](../../../../../../docs/codebase/configuration.md).
+
+## Schema changes
+
+Changing `schema.js` alone does not update an existing database. Every schema
+change needs a migration that moves an installed database to the new shape.
+Follow the [database migrations guide](../../../../../../docs/practices/database-migrations.md)
+for generation, iteration, testing, and review requirements.


### PR DESCRIPTION
## Summary

- document the current members, newsletters, and email database domains from the schema, models, and services
- add nearby guidance for schema definitions, fixtures, and default settings
- clarify when database changes require migrations and link the existing migration guide

## Testing

- [x] `pnpm lint:docs`
- [x] `git diff --check`
