### PR TITLE
Fixed documentation changes running core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,6 @@ jobs:
               - '.github/workflows/ci.yml'
             core:
               - *shared
-              # Documentation and ownership metadata do not affect Ghost
-              # runtime behaviour, even when they live inside a project root.
-              - '!**/*.md'
               - '!.github/CODEOWNERS'
               - 'ghost/**'
               - '!ghost/core/core/server/data/tinybird/**'
@@ -192,6 +189,10 @@ jobs:
               - '!koenig/kg-unsplash-selector/**'
               - '!koenig/kg-simplemde/**'
               - '!koenig/*/test/**'
+              # Documentation does not affect Ghost runtime behaviour, even
+              # when it lives inside a project root. Keep this after every
+              # positive pattern so micromatch cannot add Markdown files back.
+              - '!**/*.md'
             unit-test-globals:
               - 'vitest.config.mjs'
             core-unit-test-globals:

--- a/scripts/test/ci-path-filters.test.js
+++ b/scripts/test/ci-path-filters.test.js
@@ -1,0 +1,28 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert';
+import {readFile} from 'node:fs/promises';
+import yaml from 'js-yaml';
+
+async function getFilterPatterns(filterName) {
+    const workflow = yaml.load(await readFile(new URL('../../.github/workflows/ci.yml', import.meta.url), 'utf8'));
+    const filterStep = workflow.jobs.job_setup.steps.find(step => step.id === 'changed');
+    const filters = yaml.load(filterStep.with.filters);
+
+    return filters[filterName].flat(Infinity);
+}
+
+describe('CI path filters', () => {
+    it('excludes Markdown after all positive core patterns', async () => {
+        const patterns = await getFilterPatterns('core');
+        const markdownExclusion = patterns.indexOf('!**/*.md');
+        const positivePatterns = patterns
+            .map((pattern, index) => ({pattern, index}))
+            .filter(({pattern}) => !pattern.startsWith('!'));
+
+        assert.notStrictEqual(markdownExclusion, -1);
+        assert.ok(
+            positivePatterns.every(({index}) => index < markdownExclusion),
+            'Markdown exclusions must follow positive patterns so later patterns cannot add docs back'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Prevent Markdown-only changes inside `ghost/**` or `koenig/**` from triggering the Core acceptance and legacy test jobs.
- Keep the broad Markdown exclusion after all positive Core patterns because Micromatch allows later positive patterns to add excluded files back.
- Add a regression test that parses the real workflow and enforces the required ordering.

## Context

PR #30006 changed only Markdown, but `ghost/core/core/server/data/schema/README.md` was classified as both documentation and Core code. That caused the MySQL and SQLite acceptance and legacy suites to run unnecessarily.

## Testing

- [x] `pnpm --filter @internal/scripts test` — 89 tests passed
- [x] `pnpm --filter @internal/scripts lint`
- [x] Manual Micromatch check using the version installed by the workflow dependency: the PR #30006 file set matched Core before the reorder and no longer matches afterward
- [ ] `pnpm check` — lint passed, but the full parallel test graph encountered unrelated timeouts in Portal, Core, Koenig, and Admin
