### PR TITLE
Improved automation canvas viewport constraints

### DIFF
--- a/apps/admin/src/automations/components/canvas/automation-canvas.tsx
+++ b/apps/admin/src/automations/components/canvas/automation-canvas.tsx
@@ -19,6 +19,8 @@ import {isEmptyEmailLexical} from '@/automations/utils';
 import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 import {useLocation, useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import type {EmailModalMode} from '@/automations/components/types';
+import {CANVAS_ZOOM_CONFIG, useCanvasViewport} from './use-canvas-viewport';
+import type {CanvasContentBounds} from './use-canvas-viewport';
 
 const NODE_X = 0;
 const NODE_WIDTH = 256;
@@ -33,9 +35,6 @@ const EMAIL_NODE_WITH_STATS_HEIGHT = 133;
 const INITIAL_VIEWPORT_Y = 40;
 // Rendered height of the tail node (h-12) — used to derive the content's bottom edge for the pan bound.
 const TAIL_NODE_HEIGHT = 48;
-// The default view is as close as you need, so zoom only goes out from there.
-const MIN_ZOOM = 0.5;
-const MAX_ZOOM = 1;
 const NODE_ENTER_ANIMATION_DURATION = 250;
 const DISABLED_REASON = 'Maximum steps added';
 const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
@@ -174,9 +173,7 @@ type BuildGraphParams = {
     selectedStepId: string | null;
 }
 
-type ContentBounds = {left: number; right: number; bottom: number};
-
-const buildGraph = ({actionErrors, automation, automationAnalyticsEnabled, disabled, onDelete, onEditEmailBody, onPick, onPreviewEmail, onSelectStep, newStepId, selectedStepId}: BuildGraphParams): { nodes: AutomationFlowNode[]; edges: Edge[]; contentBounds: ContentBounds } => {
+const buildGraph = ({actionErrors, automation, automationAnalyticsEnabled, disabled, onDelete, onEditEmailBody, onPick, onPreviewEmail, onSelectStep, newStepId, selectedStepId}: BuildGraphParams): { nodes: AutomationFlowNode[]; edges: Edge[]; contentBounds: CanvasContentBounds } => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,
@@ -261,7 +258,7 @@ const buildGraph = ({actionErrors, automation, automationAnalyticsEnabled, disab
     // Content bounds in flow coordinates, derived from node positions so the pan bound keeps
     // working if the graph ever grows wider (e.g. branching).
     const xs = nodes.map(node => node.position.x);
-    const contentBounds: ContentBounds = {
+    const contentBounds: CanvasContentBounds = {
         left: Math.min(...xs),
         right: Math.max(...xs) + NODE_WIDTH,
         bottom: cursorY + TAIL_NODE_HEIGHT
@@ -307,24 +304,6 @@ const getInitialViewport = (canvasWidth: number): { x: number; y: number; zoom: 
     y: INITIAL_VIEWPORT_Y,
     zoom: 1
 });
-
-// Bounds panning so the viewport center always stays over the content — panning stops when a
-// content edge reaches the center of the screen, so the flow can never be lost off screen at any
-// viewport size or zoom. The bottom bound also contains the initial top-anchored viewport, so
-// short flows load at the top and can't be pushed above it.
-const panTranslateExtent = (
-    content: ContentBounds,
-    size: {width: number; height: number},
-    zoom: number
-): [[number, number], [number, number]] => {
-    const halfWidth = size.width / (2 * zoom);
-    const halfHeight = size.height / (2 * zoom);
-    const initialVisibleBottom = (size.height - INITIAL_VIEWPORT_Y) / zoom;
-    return [
-        [content.left - halfWidth, -halfHeight],
-        [content.right + halfWidth, Math.max(content.bottom + halfHeight, initialVisibleBottom)]
-    ];
-};
 
 type AutomationCanvasProps = {
     actionErrors?: Record<string, string>;
@@ -506,28 +485,10 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
         });
     }, [actionErrors, automation, automationAnalyticsEnabled, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handlePick, handleRequestDelete, newStepId, selectedStepId]);
 
-    // Canvas size and zoom feed the pan bound. Size is measured via callback ref — the canvas node
-    // only exists once loading/error states clear, so a mount-time effect would never see it.
-    const [canvasSize, setCanvasSize] = useState({width: 0, height: 0});
-    const [zoom, setZoom] = useState(1);
-    const observerRef = useRef<ResizeObserver | null>(null);
-    const measureCanvas = useCallback((el: HTMLDivElement | null) => {
-        observerRef.current?.disconnect();
-        if (!el) {
-            observerRef.current = null;
-            return;
-        }
-        const update = () => setCanvasSize({width: el.clientWidth, height: el.clientHeight});
-        update();
-        observerRef.current = new ResizeObserver(update);
-        observerRef.current.observe(el);
-    }, []);
-
-    // Unbounded until the canvas is measured — a zero-size extent would lock panning entirely.
-    const translateExtent = useMemo(
-        () => (graph && canvasSize.width ? panTranslateExtent(graph.contentBounds, canvasSize, zoom) : undefined),
-        [graph, canvasSize, zoom]
-    );
+    const viewport = useCanvasViewport<AutomationFlowNode, Edge>({
+        contentBounds: graph?.contentBounds,
+        initialViewport: initialViewport.current
+    });
 
     const clearDetail = useCallback(() => {
         setSelectedStep(null);
@@ -595,27 +556,27 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
     }
 
     return (
-        <div ref={measureCanvas} className='relative flex-1 overflow-hidden bg-background' data-testid='automation-canvas'>
+        <div ref={viewport.measureCanvas} className='relative flex-1 overflow-hidden bg-background' data-testid='automation-canvas'>
             <ReactFlow
                 className='[--xy-background-color:var(--color-grey-50)] [--xy-background-pattern-color:var(--color-grey-500)] [--xy-edge-stroke:var(--color-grey-300)] dark:[--xy-background-color:var(--background)] dark:[--xy-background-pattern-color:var(--color-grey-900)] dark:[--xy-edge-stroke:var(--color-grey-800)]'
                 defaultViewport={initialViewport.current}
                 edges={graph.edges}
                 edgesFocusable={false}
                 edgeTypes={edgeTypes}
-                maxZoom={MAX_ZOOM}
-                minZoom={MIN_ZOOM}
+                maxZoom={CANVAS_ZOOM_CONFIG.maxZoom}
+                minZoom={CANVAS_ZOOM_CONFIG.minZoom}
                 nodes={graph.nodes}
                 nodesConnectable={false}
                 nodesDraggable={false}
                 nodesFocusable={false}
                 nodeTypes={nodeTypes}
                 proOptions={{hideAttribution: true}}
-                translateExtent={translateExtent}
+                translateExtent={viewport.translateExtent}
                 zoomOnDoubleClick={false}
                 zoomOnScroll={false}
                 panOnScroll
-                onInit={instance => setZoom(instance.getViewport().zoom)}
-                onMove={(_, viewport) => setZoom(viewport.zoom)}
+                onInit={viewport.onInit}
+                onMove={viewport.onMove}
                 onNodeClick={(event, node) => {
                     if (event.button !== 0) {
                         return;

--- a/apps/admin/src/automations/components/canvas/controls.tsx
+++ b/apps/admin/src/automations/components/canvas/controls.tsx
@@ -3,9 +3,9 @@ import React, {useState} from 'react';
 import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {Controls, useReactFlow, useViewport} from '@xyflow/react';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
+import {CANVAS_ZOOM_CONFIG} from './use-canvas-viewport';
 
 const VIEWPORT_ANIMATION_DURATION = 180;
-const ZOOM_PRESETS = [1.5, 1, 0.75, 0.5, 0.25];
 
 export const AutomationCanvasControls: React.FC = () => {
     const [open, setOpen] = useState(false);
@@ -36,6 +36,7 @@ export const AutomationCanvasControls: React.FC = () => {
             <Button
                 aria-label='Zoom out'
                 className='rounded-sm text-text-secondary hover:text-foreground'
+                disabled={zoom <= CANVAS_ZOOM_CONFIG.minZoom}
                 size='icon'
                 title='Zoom out'
                 type='button'
@@ -56,7 +57,7 @@ export const AutomationCanvasControls: React.FC = () => {
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align='center' className='w-40' side='top' sideOffset={12}>
-                    {ZOOM_PRESETS.map((preset) => {
+                    {CANVAS_ZOOM_CONFIG.presets.map((preset) => {
                         const presetPercent = Math.round(preset * 100);
                         const isSelected = Math.abs(zoom - preset) < 0.01;
                         return (
@@ -79,6 +80,7 @@ export const AutomationCanvasControls: React.FC = () => {
             <Button
                 aria-label='Zoom in'
                 className='rounded-sm text-text-secondary hover:text-foreground'
+                disabled={zoom >= CANVAS_ZOOM_CONFIG.maxZoom}
                 size='icon'
                 title='Zoom in'
                 type='button'

--- a/apps/admin/src/automations/components/canvas/use-canvas-viewport.ts
+++ b/apps/admin/src/automations/components/canvas/use-canvas-viewport.ts
@@ -1,0 +1,117 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import type {CoordinateExtent, Edge, Node, OnInit, OnMove, ReactFlowInstance, Viewport} from '@xyflow/react';
+
+export type CanvasContentBounds = {
+    left: number;
+    right: number;
+    bottom: number;
+};
+
+export const CANVAS_ZOOM_CONFIG = {
+    minZoom: 0.5,
+    maxZoom: 1,
+    presets: [1, 0.75, 0.5]
+} as const;
+
+// Keep the viewport center over the content. Each content edge can move as far as the center of
+// the canvas, while short flows retain their initial top-anchored position.
+const getPanTranslateExtent = (
+    content: CanvasContentBounds,
+    size: {width: number; height: number},
+    viewport: Pick<Viewport, 'y' | 'zoom'>
+): CoordinateExtent => {
+    const halfWidth = size.width / (2 * viewport.zoom);
+    const halfHeight = size.height / (2 * viewport.zoom);
+    const initialVisibleBottom = (size.height - viewport.y) / viewport.zoom;
+
+    return [
+        [content.left - halfWidth, -halfHeight],
+        [content.right + halfWidth, Math.max(content.bottom + halfHeight, initialVisibleBottom)]
+    ];
+};
+
+const constrainViewport = (viewport: Viewport, size: {width: number; height: number}, extent: CoordinateExtent): Viewport => ({
+    x: Math.min(Math.max(viewport.x, size.width - (extent[1][0] * viewport.zoom)), -extent[0][0] * viewport.zoom),
+    y: Math.min(Math.max(viewport.y, size.height - (extent[1][1] * viewport.zoom)), -extent[0][1] * viewport.zoom),
+    zoom: viewport.zoom
+});
+
+export const useCanvasViewport = <NodeType extends Node = Node, EdgeType extends Edge = Edge>({contentBounds, initialViewport}: {
+    contentBounds?: CanvasContentBounds;
+    initialViewport: Viewport;
+}) => {
+    const [canvasSize, setCanvasSize] = useState({width: 0, height: 0});
+    const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance<NodeType, EdgeType> | null>(null);
+    const [zoom, setZoom] = useState(initialViewport.zoom);
+    const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+    const measureCanvas = useCallback((element: HTMLDivElement | null) => {
+        resizeObserverRef.current?.disconnect();
+
+        if (!element) {
+            resizeObserverRef.current = null;
+            return;
+        }
+
+        const update = () => {
+            const nextSize = {width: element.clientWidth, height: element.clientHeight};
+            setCanvasSize(currentSize => (
+                currentSize.width === nextSize.width && currentSize.height === nextSize.height
+                    ? currentSize
+                    : nextSize
+            ));
+        };
+
+        update();
+        const observer = new ResizeObserver(update);
+        observer.observe(element);
+        resizeObserverRef.current = observer;
+    }, []);
+
+    const translateExtent = useMemo(() => (
+        contentBounds && canvasSize.width && canvasSize.height
+            ? getPanTranslateExtent(contentBounds, canvasSize, {y: initialViewport.y, zoom})
+            : undefined
+    ), [canvasSize, contentBounds, initialViewport.y, zoom]);
+
+    const onInit = useCallback<OnInit<NodeType, EdgeType>>((instance) => {
+        setReactFlowInstance(instance);
+        setZoom(instance.getViewport().zoom);
+    }, []);
+
+    const onMove = useCallback<OnMove>((_, viewport) => {
+        setZoom(viewport.zoom);
+    }, []);
+
+    const contentBottom = contentBounds?.bottom;
+    const contentLeft = contentBounds?.left;
+    const contentRight = contentBounds?.right;
+
+    useEffect(() => {
+        if (!reactFlowInstance || !canvasSize.width || !canvasSize.height || contentBottom === undefined || contentLeft === undefined || contentRight === undefined) {
+            return;
+        }
+
+        // React Flow applies a new translateExtent to future interactions but does not constrain
+        // the current transform. Clamp it explicitly after the canvas or graph shrinks. Zoom
+        // changes already pass through React Flow's constraint path.
+        const currentViewport = reactFlowInstance.getViewport();
+        const nextExtent = getPanTranslateExtent({
+            bottom: contentBottom,
+            left: contentLeft,
+            right: contentRight
+        }, canvasSize, {y: initialViewport.y, zoom: currentViewport.zoom});
+        const nextViewport = constrainViewport(currentViewport, canvasSize, nextExtent);
+
+        if (nextViewport.x !== currentViewport.x || nextViewport.y !== currentViewport.y) {
+            void reactFlowInstance.setViewport(nextViewport);
+        }
+    }, [canvasSize.height, canvasSize.width, contentBottom, contentLeft, contentRight, initialViewport.y, reactFlowInstance]);
+
+    return {
+        measureCanvas,
+        onInit,
+        onMove,
+        translateExtent
+    };
+};

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -123,6 +123,8 @@ const mockEditMutation = {
 };
 const mockReactFlow = {
     fitView: vi.fn(),
+    getViewport: vi.fn(() => ({x: 0, y: 0, zoom: mockViewportZoom})),
+    setViewport: vi.fn(),
     zoomIn: vi.fn(),
     zoomOut: vi.fn(),
     zoomTo: vi.fn()
@@ -168,6 +170,8 @@ type StubReactFlowProps = {
     edgeTypes?: Record<string, React.ComponentType<EdgeRenderProps>>;
     onNodeClick?: (event: React.MouseEvent<HTMLDivElement>, node: StubNode) => void;
     onNodeDoubleClick?: (event: React.MouseEvent<HTMLDivElement>, node: StubNode) => void;
+    onInit?: (instance: typeof mockReactFlow) => void;
+    onMove?: (event: MouseEvent | TouchEvent | null, viewport: {x: number; y: number; zoom: number}) => void;
     onPaneClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
     zoomOnDoubleClick?: boolean;
 };
@@ -178,8 +182,13 @@ vi.mock('@xyflow/react', async () => {
     const actual = await vi.importActual<typeof import('@xyflow/react')>('@xyflow/react');
     return {
         ...actual,
-        ReactFlow: ({nodes, edges, children, className, nodeTypes, edgeTypes, onNodeClick, onNodeDoubleClick, onPaneClick, zoomOnDoubleClick}: StubReactFlowProps) => (
-            <div className={className} data-testid='react-flow-mock' data-zoom-on-double-click={String(zoomOnDoubleClick)} onClick={onPaneClick}>
+        ReactFlow: ({nodes, edges, children, className, nodeTypes, edgeTypes, onInit, onNodeClick, onNodeDoubleClick, onPaneClick, zoomOnDoubleClick}: StubReactFlowProps) => {
+            React.useEffect(() => {
+                onInit?.(mockReactFlow);
+            }, [onInit]);
+
+            return (
+                <div className={className} data-testid='react-flow-mock' data-zoom-on-double-click={String(zoomOnDoubleClick)} onClick={onPaneClick}>
                 {nodes.map((node) => {
                     const nodeType = node.type ?? 'default';
                     const Custom = nodeTypes?.[nodeType];
@@ -223,8 +232,9 @@ vi.mock('@xyflow/react', async () => {
                     })}
                 </ul>
                 {children}
-            </div>
-        ),
+                </div>
+            );
+        },
         Background: () => null,
         Controls: ({children, className, showFitView, showInteractive, showZoom, style}: {children?: React.ReactNode; className?: string; showFitView?: boolean; showInteractive?: boolean; showZoom?: boolean; style?: React.CSSProperties}) => (
             <div
@@ -355,6 +365,9 @@ describe('AutomationEditor', () => {
         });
         mockEditMutation.mutate.mockReset();
         mockReactFlow.fitView.mockReset();
+        mockReactFlow.getViewport.mockReset();
+        mockReactFlow.getViewport.mockImplementation(() => ({x: 0, y: 0, zoom: mockViewportZoom}));
+        mockReactFlow.setViewport.mockReset();
         mockReactFlow.zoomIn.mockReset();
         mockReactFlow.zoomOut.mockReset();
         mockReactFlow.zoomTo.mockReset();
@@ -847,10 +860,11 @@ describe('AutomationEditor', () => {
         expect(controls).toHaveClass('overflow-hidden', 'rounded-md');
         expect(screen.getByRole('button', {name: 'Zoom out'})).toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Zoom level 100%'})).toHaveTextContent('100%');
-        expect(screen.getByRole('button', {name: 'Zoom in'})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Zoom in'})).toBeDisabled();
     });
 
     it('animates viewport changes from the custom canvas controls', () => {
+        mockViewportZoom = 0.75;
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},
             isLoading: false,
@@ -878,11 +892,11 @@ describe('AutomationEditor', () => {
 
         fireEvent.pointerDown(screen.getByRole('button', {name: 'Zoom level 75%'}), {button: 0, ctrlKey: false});
 
-        expect(screen.getByRole('menuitem', {name: '150%'})).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', {name: '150%'})).not.toBeInTheDocument();
         expect(screen.getByRole('menuitem', {name: '100%'})).toBeInTheDocument();
         expect(screen.getByRole('menuitem', {name: '75%'})).toBeInTheDocument();
         expect(screen.getByRole('menuitem', {name: '50%'})).toBeInTheDocument();
-        expect(screen.getByRole('menuitem', {name: '25%'})).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', {name: '25%'})).not.toBeInTheDocument();
         expect(screen.getByRole('menuitem', {name: 'Fit to view'})).toBeInTheDocument();
         expect(screen.getByRole('menuitem', {name: '75%'}).querySelector('svg')).toBeInTheDocument();
     });
@@ -897,14 +911,41 @@ describe('AutomationEditor', () => {
         renderEditor();
 
         fireEvent.pointerDown(screen.getByRole('button', {name: 'Zoom level 100%'}), {button: 0, ctrlKey: false});
-        fireEvent.click(screen.getByRole('menuitem', {name: '150%'}));
+        fireEvent.click(screen.getByRole('menuitem', {name: '75%'}));
 
-        expect(mockReactFlow.zoomTo).toHaveBeenCalledWith(1.5, {duration: 180});
+        expect(mockReactFlow.zoomTo).toHaveBeenCalledWith(0.75, {duration: 180});
 
         fireEvent.pointerDown(screen.getByRole('button', {name: 'Zoom level 100%'}), {button: 0, ctrlKey: false});
         fireEvent.click(screen.getByRole('menuitem', {name: 'Fit to view'}));
 
         expect(mockReactFlow.fitView).toHaveBeenCalledWith({duration: 180});
+    });
+
+    it('re-constrains the viewport when deleting a step shrinks the graph', async () => {
+        const clientWidthSpy = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(1000);
+        const clientHeightSpy = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(800);
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        try {
+            renderEditor();
+            await waitFor(() => expect(mockReactFlow.setViewport).toHaveBeenCalled());
+            mockReactFlow.setViewport.mockClear();
+            // This is the bottom-most valid viewport for the original two-step graph. Once one
+            // step is deleted, it falls outside the shorter graph's new translate extent.
+            mockReactFlow.getViewport.mockReturnValue({x: 372, y: -188, zoom: 1});
+
+            fireEvent.click(screen.getByRole('button', {name: 'Wait: 1 day'}));
+            fireEvent.click(within(screen.getByRole('complementary', {name: 'Step details'})).getByRole('button', {name: 'Delete step'}));
+
+            await waitFor(() => expect(mockReactFlow.setViewport).toHaveBeenCalledWith({x: 372, y: -8, zoom: 1}));
+        } finally {
+            clientWidthSpy.mockRestore();
+            clientHeightSpy.mockRestore();
+        }
     });
 
     it('opens a read-only sidebar for the trigger step', () => {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/29962

- re-constrained the current viewport when graph or canvas bounds shrink
- kept zoom presets and controls within the configured zoom limits
- extracted viewport measurement and constraint handling into a shared hook