### PR TITLE
Removed stale ignoreDeps from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,64 +124,25 @@
     },
     "ignoreDeps": [
         // https://github.com/TryGhost/Ghost/commit/2b9e494dfcb95c40f596ccf54ec3151c25d53601
-        // `got` 10.x has a Node 10 bug that makes it pretty much unusable for now
-        "got",
-        // https://github.com/TryGhost/Ghost/commit/2b9e494dfcb95c40f596ccf54ec3151c25d53601
-        // `intl-messageformat` 6.0.0 introduced a breaking change in terms of
-        // escaping that would be pretty difficult to fix for now
+        // Theme i18n ({{t}} helper) is on intl-messageformat 5.x. 6.0.0 changed
+        // message escaping from `\` to ICU apostrophe quoting, which changes the
+        // output of existing theme locale strings; needs a deliberate migration.
         "intl-messageformat",
-        // https://github.com/TryGhost/Ghost/commit/b2fa84c7ff9bf8e21b0791f268f57e92759a87b1
-        // no reason given
-        "moment",
-        // https://github.com/TryGhost/Ghost/pull/10672
-        // https://github.com/TryGhost/Ghost/issues/10870
-        "moment-timezone",
-        // https://github.com/TryGhost/Admin/pull/1111/files
-        // Ignored because of a mobiledoc-kit issue but that's now in koenig, can probably be cleaned up
-        "simple-dom",
-        // https://github.com/TryGhost/Admin/pull/1111/files
-        // https://github.com/TryGhost/Ghost/pull/10672
-        // These have been ignored since forever
-        "ember-drag-drop",
-        "normalize.css",
-        "validator",
 
-        // https://github.com/TryGhost/Ghost/commit/7ebf2891b7470a1c2ffeddefb2fe5e7a57319df3
-        // Changed how modules are loaded, caused a weird error during render
-        "@embroider/macros",
-
-        // https://github.com/TryGhost/Ghost/commit/a10ad3767f60ed2c8e56feb49e7bf83d9618b2ab
-        // Caused linespacing issues in the editor, but now it's used in different places
-        // So not sure if it's relevant - soon we will finish switching to react-codemirror
+        // codemirror 6 is a rewrite of the 5.x API. @tryghost/kg-simplemde (the
+        // Koenig markdown card) is built on 5.x and is not being ported. Also
+        // covers the `codemirror@<5.58.2` pnpm override key.
         "codemirror",
-
-        // https://github.com/TryGhost/Ghost/commit/3236891b80988924fbbdb625d30cb64a7bf2afd1
-        // ember-cli-code-coverage@2.0.0 broke our code coverage
-        "ember-cli-code-coverage",
-        // https://github.com/TryGhost/Ghost/commit/1382e34e42a513c201cb957b7f843369a2ce1b63
-        // ember-cli-terser@4.0.2 has a regression that breaks our sourcemaps
-        "ember-cli-terser",
-
-        // https://linear.app/ghost/issue/PLA-56
-        // Deprecated (per-method lodash packages are EOL); last real release is
-        // 4.5.0 (2019). The flagged "4.18.0 [SECURITY]" bump does not exist, so
-        // Renovate can't remediate it. It's transitive-only — we never call
-        // `_.template` ourselves — and only reachable via frozen Ember build
-        // tooling (broccoli-templater, sourcemap-validator) plus old @tryghost/*
-        // packages, so it can't be removed from the tree here. Ignore it to stop
-        // the unactionable dashboard noise.
-        "lodash.template",
 
         // https://linear.app/ghost/issue/PLA-78
         // https://github.com/TryGhost/Ghost/pull/28180
-        // knex 2.5.x breaks migrations: 2.5.0's password-masking mutates the
-        // shared `config.get('database')` object, which we hand to BOTH knex()
-        // and knex-migrator. With core ahead of knex-migrator's pinned knex
-        // (2.4.2), the password is stripped before knex-migrator connects →
-        // "Access denied (using password: NO)". 2.x is EOL; the real move is
-        // knex 3.x, gated on publishing a knex-3 knex-migrator
-        // (TryGhost/knex-migrator#86, unreleased), bumped in lockstep with core.
-        // Ignore until we do that coordinated upgrade.
+        // ghost/core is pinned to knex 2.4.2 and knex-migrator's knex is pinned
+        // back to the same version via the `knex-migrator>knex` pnpm override
+        // (knex-migrator 5.4.x bundles knex 3.x). Migrations are built with
+        // core's query builder and executed by knex-migrator's, so the two must
+        // move together; 2.5.x also strips the password from the shared
+        // `config.get('database')` object before knex-migrator connects. Ignore
+        // until core moves to knex 3.x in one coordinated upgrade.
         "knex",
         // Same PLA-78 pin, but Renovate treats the pnpm override key
         // `knex-migrator>knex` as its own dependency name, so the plain "knex"


### PR DESCRIPTION
no ref

Most of the `ignoreDeps` entries in `.github/renovate.json5` dated from 2019–2020 and their reasons no longer hold, so they were either silently holding back updates or doing nothing. This prunes the list to entries with a live reason and refreshes the kept comments. No dependency versions change in this PR — Renovate will open the usual PRs for anything newly unignored.

### Removed

| Entry | Why it was ignored | Why that's stale |
| --- | --- | --- |
| `got` | got 10.x had a Node 10 bug (2020) | ghost/core is on got 13.0.0, Node 22; got 15 exists |
| `moment` | no reason recorded (2020) | whole tree is already forced to 2.30.1 (latest; moment is maintenance-only) via the pnpm override — the ignore only blocked core's stale `2.24.0` declaration from catching up |
| `moment-timezone` | #10870: 0.5.24 changed `format()` output in a regression test (2019) | issue closed 2021; we're on 0.5.45. The ignore was freezing IANA tz data at Feb 2024 — 0.5.46–0.6.3 are all TZDB updates (0.6.0 is TypeScript-types-only breaking) |
| `simple-dom` | mobiledoc-kit issue in Admin (2019) | mobiledoc-kit is gone from Admin; 1.4.0 is still the latest release, so the entry is a no-op |
| `validator` | 2019 Renovate onboarding carry-over, no reason | catalog is held at 13.12.0 vs 13.15.35 for core, admin and shade |
| `ember-drag-drop`, `normalize.css`, `@embroider/macros`, `ember-cli-code-coverage`, `ember-cli-terser` | Ember admin build/runtime regressions | only declared in `apps/ember-admin`, which is frozen wholesale via `ignorePaths` (`apps/ember-admin/**`) — the entries are dead |
| `lodash.template` | "4.18.0 [SECURITY] doesn't exist, Renovate can't remediate" | 4.18.1 exists and the lockfile already resolves it; it's transitive-only, so Renovate never proposes it anyway |

### Kept

| Entry | Current reason |
| --- | --- |
| `intl-messageformat` | Theme i18n (`{{t}}`) is on 5.4.3; 6.0.0 changed escaping from `\` to ICU apostrophe quoting, which changes output of existing theme locale strings. Needs a deliberate migration. |
| `codemirror` | `@tryghost/kg-simplemde` (Koenig markdown card) is built on the 5.x API; 6 is a rewrite. Also matches the `codemirror@<5.58.2` pnpm override key. |
| `knex`, `knex-migrator>knex` | Core is pinned to knex 2.4.2 and knex-migrator's knex is pinned back to match via the pnpm override; the two must move to 3.x together. Comment refreshed — it no longer claims a knex-3 knex-migrator is unreleased (5.4.x ships one). |
| `path-to-regexp` | Express 4 needs the 0.1 line; the override must not leave it. Unchanged. |

### Verification

- Config parses as JSON5; `ignoreDeps` now = `intl-messageformat, codemirror, knex, knex-migrator>knex, path-to-regexp`.
- Locations checked with `grep` across all workspace `package.json`/`pnpm-workspace.yaml`, `pnpm why`, `npm view`, and the linked commits/issues.
