### PR TITLE
Changed theme settings dialogs to controlled components

### DIFF
--- a/apps/admin/src/settings/app/components/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme-modal.tsx
@@ -1,9 +1,8 @@
 import AdvancedThemeSettings from './theme/advanced-theme-settings';
 import InvalidThemeModal, {type FatalErrors} from './theme/invalid-theme-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import OfficialThemes from './theme/official-themes';
 import React, {useEffect, useState} from 'react';
-import ThemeInstalledModal from './theme/theme-installed-modal';
+import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme/theme-installed-modal';
 import ThemePreview from './theme/theme-preview';
 import {Button, Dropzone, LoadingIndicator, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {type InstalledTheme, type Theme, type ThemesInstallResponseType, isDefaultOrLegacyTheme, useActivateTheme, useBrowseThemes, useInstallTheme, useUploadTheme} from '@tryghost/admin-x-framework/api/themes';
@@ -59,6 +58,8 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
 
     const [uploadConfig, setUploadConfig] = useState<{enabled: boolean; error?: string} | undefined>();
     const [isUploading, setUploading] = useState(false);
+    const [uploadErrors, setUploadErrors] = useState<FatalErrors | null>(null);
+    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
 
     useEffect(() => {
         const checkUploadLimit = async () => {
@@ -155,17 +156,7 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
         }
 
         if (fatalErrors && !data) {
-            const title = 'Theme not uploaded';
-            const prompt = <>This theme couldn&apos;t be uploaded because Ghost found a blocking validation error. Fix the issue below and upload the theme again.</>;
-            NiceModal.show(InvalidThemeModal, {
-                title,
-                prompt,
-                fatalErrors,
-                onRetry: async (invalidThemeModal) => {
-                    invalidThemeModal?.remove();
-                    handleUpload();
-                }
-            });
+            setUploadErrors(fatalErrors);
         }
 
         if (!data) {
@@ -200,11 +191,11 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
             }
         }
 
-        NiceModal.show(ThemeInstalledModal, {
+        setInstalledModal({
             title,
             prompt,
             installedTheme: uploadedTheme,
-            onActivate: onActivate
+            onActivate
         });
     };
 
@@ -269,6 +260,19 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
                 </TabsList>
             </Tabs>
         </div>
+        {uploadErrors && (
+            <InvalidThemeModal
+                fatalErrors={uploadErrors}
+                prompt={<>This theme couldn&apos;t be uploaded because Ghost found a blocking validation error. Fix the issue below and upload the theme again.</>}
+                title='Theme not uploaded'
+                onClose={() => setUploadErrors(null)}
+                onRetry={async () => {
+                    setUploadErrors(null);
+                    handleUpload();
+                }}
+            />
+        )}
+        {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
     </>);
 };
 
@@ -302,6 +306,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
     const [isInstalling, setInstalling] = useState(false);
     const [installedFromMarketplace, setInstalledFromMarketplace] = useState(false);
     const [isMounted, setIsMounted] = useState(false);
+    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
     const {updateRoute} = useSettingsNavigation();
 
     const {data: {themes} = {}} = useBrowseThemes();
@@ -491,7 +496,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                 installedTheme = newlyInstalledTheme;
             }
 
-            NiceModal.show(ThemeInstalledModal, {
+            setInstalledModal({
                 title,
                 prompt,
                 installedTheme: installedTheme!,
@@ -552,6 +557,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                     }
                 </div>
             </div>
+            {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
         </SettingsModal>
     );
 };

--- a/apps/admin/src/settings/app/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/advanced-theme-settings.tsx
@@ -1,6 +1,5 @@
 import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
-import NiceModal from '@ebay/nice-modal-react';
-import React from 'react';
+import React, {useState} from 'react';
 import useCustomFonts from '@/settings/app/hooks/use-custom-fonts';
 import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
@@ -60,6 +59,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     const {route, updateRoute} = useSettingsNavigation();
     const {checkThemeLimitError} = useCheckThemeLimitError();
     const {confirm, showLimit} = useConfirmation();
+    const [activationErrors, setActivationErrors] = useState<FatalErrors | null>(null);
 
     const handleActivate = async () => {
         try {
@@ -73,19 +73,8 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
             } else {
                 handleError(e);
             }
-            const title = 'Theme not activated';
-            const prompt = <>This theme couldn&apos;t be activated because Ghost found a blocking validation error. Fix the issue below and try again.</>;
-
             if (fatalErrors) {
-                NiceModal.show(InvalidThemeModal, {
-                    title,
-                    prompt,
-                    fatalErrors,
-                    onRetry: async (modal) => {
-                        modal?.remove();
-                        handleActivate();
-                    }
-                });
+                setActivationErrors(fatalErrors);
             }
         }
     };
@@ -172,6 +161,18 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
                     )}
                 </DropdownMenuContent>
             </DropdownMenu>
+            {activationErrors && (
+                <InvalidThemeModal
+                    fatalErrors={activationErrors}
+                    prompt={<>This theme couldn&apos;t be activated because Ghost found a blocking validation error. Fix the issue below and try again.</>}
+                    title='Theme not activated'
+                    onClose={() => setActivationErrors(null)}
+                    onRetry={async () => {
+                        setActivationErrors(null);
+                        handleActivate();
+                    }}
+                />
+            )}
         </div>
     );
 };

--- a/apps/admin/src/settings/app/components/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/invalid-theme-modal.tsx
@@ -2,6 +2,7 @@ import React, {type ReactNode} from 'react';
 import {ConfirmationModalContent} from '@/settings/app/components/confirmation-modal';
 import {ErrorTextCard, type FatalErrors, ThemeValidationDetailsDisclosure, ValidationProblemCard, getIssuesFromFatalErrors} from './theme-validation-details';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {formatNumber} from '@tryghost/shade/utils';
 
 export type {FatalErrors} from './theme-validation-details';
 
@@ -20,11 +21,11 @@ const InvalidThemeModal: React.FC<InvalidThemeModalProps & {onClose: () => void}
     const defaultOpen = validationDetailsDefaultOpen ?? configData?.config?.environment === 'development';
     const {blockingProblems, secondaryProblems, stringErrors} = getIssuesFromFatalErrors(fatalErrors);
     const blockingIssueCount = blockingProblems.length + stringErrors.length;
-    const promptText = prompt ?? <>Ghost found {blockingIssueCount === 1 ? 'a blocking validation error' : `${blockingIssueCount} blocking validation errors`} and did not save your theme. Fix {blockingIssueCount === 1 ? 'the issue' : 'the issues'} below and try again.</>;
+    const promptText = prompt ?? <>Ghost found {blockingIssueCount === 1 ? 'a blocking validation error' : `${formatNumber(blockingIssueCount)} blocking validation errors`} and did not save your theme. Fix {blockingIssueCount === 1 ? 'the issue' : 'the issues'} below and try again.</>;
 
     return <ConfirmationModalContent
         cancelLabel='Close'
-        okLabel={'Retry'}
+        okLabel={onRetry ? 'Retry' : ''}
         okVariant='default'
         prompt={<>
             <div className='space-y-5'>

--- a/apps/admin/src/settings/app/components/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/invalid-theme-modal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode} from 'react';
 import {ConfirmationModalContent} from '@/settings/app/components/confirmation-modal';
 import {ErrorTextCard, type FatalErrors, ThemeValidationDetailsDisclosure, ValidationProblemCard, getIssuesFromFatalErrors} from './theme-validation-details';
@@ -6,22 +5,22 @@ import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 
 export type {FatalErrors} from './theme-validation-details';
 
-const InvalidThemeModal: React.FC<{
+export type InvalidThemeModalProps = {
     title: string
-    prompt: ReactNode
+    prompt?: ReactNode
     fatalErrors?: FatalErrors;
     validationDetailsDefaultOpen?: boolean;
     onRetry?: (modal?: {
         remove: () => void;
     }) => void | Promise<void>;
-}> = ({title, prompt, fatalErrors, validationDetailsDefaultOpen, onRetry}) => {
+};
+
+const InvalidThemeModal: React.FC<InvalidThemeModalProps & {onClose: () => void}> = ({title, prompt, fatalErrors, validationDetailsDefaultOpen, onRetry, onClose}) => {
     const {data: configData} = useBrowseConfig();
     const defaultOpen = validationDetailsDefaultOpen ?? configData?.config?.environment === 'development';
     const {blockingProblems, secondaryProblems, stringErrors} = getIssuesFromFatalErrors(fatalErrors);
     const blockingIssueCount = blockingProblems.length + stringErrors.length;
     const promptText = prompt ?? <>Ghost found {blockingIssueCount === 1 ? 'a blocking validation error' : `${blockingIssueCount} blocking validation errors`} and did not save your theme. Fix {blockingIssueCount === 1 ? 'the issue' : 'the issues'} below and try again.</>;
-
-    const modal = useModal();
 
     return <ConfirmationModalContent
         cancelLabel='Close'
@@ -48,10 +47,9 @@ const InvalidThemeModal: React.FC<{
         </>}
         stickyFooter={true}
         title={title}
-        visible={modal.visible}
         onOk={onRetry}
-        onRemove={() => modal.remove()}
+        onRemove={onClose}
     />;
 };
 
-export default NiceModal.create(InvalidThemeModal);
+export default InvalidThemeModal;

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -1,12 +1,11 @@
 import CodeMirror, {EditorView} from '@uiw/react-codemirror';
 import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import ThemeEditorConfirmModal from './theme-editor-confirm-modal';
 import ThemeEditorInputModal from './theme-editor-input-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
 import ThemeFileTree from './theme-file-tree';
-import ThemeInstalledModal from './theme-installed-modal';
+import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme-installed-modal';
 import {TextWrap, Undo2} from 'lucide-react';
 import {
     cloneThemeFiles,
@@ -249,6 +248,10 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const [isSaving, setIsSaving] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
+    const [confirmRequest, setConfirmRequest] = useState<{props: ThemeEditorConfirmModalProps; resolve: (result: boolean) => void} | null>(null);
+    const [inputRequest, setInputRequest] = useState<{props: ThemeEditorInputModalProps; resolve: (result: string | null) => void} | null>(null);
+    const [saveErrors, setSaveErrors] = useState<FatalErrors | null>(null);
+    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
     const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | typeof oneDark | typeof editorSelectionTheme | typeof EditorView.lineWrapping | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
 
     useEffect(() => {
@@ -369,42 +372,16 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         };
     }, [isTextWrapEnabled, selectedFile]);
 
-    const requestConfirmation = async ({
-        title,
-        prompt,
-        cancelLabel,
-        okLabel,
-        okVariant
-    }: ThemeEditorConfirmModalProps) => {
-        const confirmed = await NiceModal.show(ThemeEditorConfirmModal, {
-            title,
-            prompt,
-            cancelLabel,
-            okLabel,
-            okVariant
-        }) as boolean | undefined;
-
-        return Boolean(confirmed);
+    const requestConfirmation = (props: ThemeEditorConfirmModalProps) => {
+        return new Promise<boolean>((resolve) => {
+            setConfirmRequest({props, resolve});
+        });
     };
 
-    const requestInput = async ({
-        title,
-        prompt,
-        fieldTitle,
-        initialValue,
-        placeholder,
-        cancelLabel,
-        okLabel
-    }: ThemeEditorInputModalProps) => {
-        return await NiceModal.show(ThemeEditorInputModal, {
-            title,
-            prompt,
-            fieldTitle,
-            initialValue,
-            placeholder,
-            cancelLabel,
-            okLabel
-        }) as string | null;
+    const requestInput = (props: ThemeEditorInputModalProps) => {
+        return new Promise<string | null>((resolve) => {
+            setInputRequest({props, resolve});
+        });
     };
 
     const closeEditor = async () => {
@@ -781,10 +758,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
 
             if (!response.ok) {
                 if (response.status === 422 && data?.errors) {
-                    NiceModal.show(InvalidThemeModal, {
-                        title: 'Theme not saved',
-                        fatalErrors: data.errors as FatalErrors
-                    });
+                    setSaveErrors(data.errors as FatalErrors);
                     return;
                 }
 
@@ -812,7 +786,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             await queryClient.invalidateQueries({queryKey: ['ThemesResponseType']});
 
             if (isSaveAs || uploadedTheme.errors?.length || uploadedTheme.warnings?.length) {
-                NiceModal.show(ThemeInstalledModal, {
+                setInstalledModal({
                     title: isSaveAs ? 'Theme saved' : 'Theme updated',
                     prompt: <><strong>{uploadedTheme.name}</strong> saved successfully.</>,
                     installedTheme: uploadedTheme
@@ -838,7 +812,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
 
     const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
 
-    return (
+    return (<>
         <div
             aria-label={`Edit theme ${themeName}`}
             aria-modal='true'
@@ -967,7 +941,27 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
 
             </div>
         </div>
-    );
+        {confirmRequest && (
+            <ThemeEditorConfirmModal
+                {...confirmRequest.props}
+                onResolve={(result) => {
+                    setConfirmRequest(null);
+                    confirmRequest.resolve(result);
+                }}
+            />
+        )}
+        {inputRequest && (
+            <ThemeEditorInputModal
+                {...inputRequest.props}
+                onResolve={(result) => {
+                    setInputRequest(null);
+                    inputRequest.resolve(result);
+                }}
+            />
+        )}
+        {saveErrors && <InvalidThemeModal fatalErrors={saveErrors} title='Theme not saved' onClose={() => setSaveErrors(null)} />}
+        {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
+    </>);
 };
 
 export default ThemeCodeEditorModal;

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -1,6 +1,6 @@
 import CodeMirror, {EditorView} from '@uiw/react-codemirror';
 import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import ThemeEditorConfirmModal from './theme-editor-confirm-modal';
 import ThemeEditorInputModal from './theme-editor-input-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
@@ -26,6 +26,7 @@ import {toast} from 'sonner';
 import {useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tanstack/react-query';
+import {formatNumber} from '@tryghost/shade/utils';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import type {SelectedNode} from './theme-file-tree';
 import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
@@ -184,6 +185,16 @@ type UploadSizeLimitError = {
     };
 };
 
+type ThemeEditorDialogRequest = {
+    type: 'confirmation';
+    props: ThemeEditorConfirmModalProps;
+    resolve: (result: boolean) => void;
+} | {
+    type: 'input';
+    props: ThemeEditorInputModalProps;
+    resolve: (result: string | null) => void;
+};
+
 const UPLOAD_SIZE_LIMIT_TITLES: Record<string, string> = {
     COMPRESSED_TOO_LARGE: 'Theme too large to upload',
     ENTRY_TOO_LARGE: 'File too large',
@@ -248,8 +259,8 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const [isSaving, setIsSaving] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
-    const [confirmRequest, setConfirmRequest] = useState<{props: ThemeEditorConfirmModalProps; resolve: (result: boolean) => void} | null>(null);
-    const [inputRequest, setInputRequest] = useState<{props: ThemeEditorInputModalProps; resolve: (result: string | null) => void} | null>(null);
+    const [dialogRequest, setDialogRequest] = useState<ThemeEditorDialogRequest | null>(null);
+    const dialogRequestRef = useRef<ThemeEditorDialogRequest | null>(null);
     const [saveErrors, setSaveErrors] = useState<FatalErrors | null>(null);
     const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
     const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | typeof oneDark | typeof editorSelectionTheme | typeof EditorView.lineWrapping | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
@@ -372,17 +383,45 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         };
     }, [isTextWrapEnabled, selectedFile]);
 
+    const cancelPendingDialogRequest = useCallback(() => {
+        const request = dialogRequestRef.current;
+
+        if (!request) {
+            return;
+        }
+
+        dialogRequestRef.current = null;
+
+        if (request.type === 'confirmation') {
+            request.resolve(false);
+        } else {
+            request.resolve(null);
+        }
+    }, []);
+
     const requestConfirmation = (props: ThemeEditorConfirmModalProps) => {
+        cancelPendingDialogRequest();
+
         return new Promise<boolean>((resolve) => {
-            setConfirmRequest({props, resolve});
+            const request: ThemeEditorDialogRequest = {type: 'confirmation', props, resolve};
+            dialogRequestRef.current = request;
+            setDialogRequest(request);
         });
     };
 
     const requestInput = (props: ThemeEditorInputModalProps) => {
+        cancelPendingDialogRequest();
+
         return new Promise<string | null>((resolve) => {
-            setInputRequest({props, resolve});
+            const request: ThemeEditorDialogRequest = {type: 'input', props, resolve};
+            dialogRequestRef.current = request;
+            setDialogRequest(request);
         });
     };
+
+    useEffect(() => {
+        return () => cancelPendingDialogRequest();
+    }, [cancelPendingDialogRequest]);
 
     const closeEditor = async () => {
         if (changes.length > 0) {
@@ -407,15 +446,28 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     // each render — using a ref decouples that churn from the global listener.
     const handleSaveRef = useRef<() => void>(() => {});
 
+    const hasOpenDialog = Boolean(dialogRequest || saveErrors || installedModal);
+
     useEffect(() => {
         const handleKeydown = (event: KeyboardEvent) => {
             if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
                 event.preventDefault();
+
+                if (hasOpenDialog) {
+                    event.stopPropagation();
+                    event.stopImmediatePropagation();
+                    return;
+                }
+
                 void handleSaveRef.current();
                 return;
             }
 
             if (event.key !== 'Escape') {
+                return;
+            }
+
+            if (hasOpenDialog) {
                 return;
             }
 
@@ -429,7 +481,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         return () => {
             window.removeEventListener('keydown', handleKeydown, true);
         };
-    }, []);
+    }, [hasOpenDialog]);
 
     const ensurePathExpanded = (path: string) => {
         setExpandedDirectories((current) => {
@@ -622,7 +674,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
 
         const confirmed = await requestConfirmation({
             title: 'Delete folder',
-            prompt: <>Delete {matchingPaths.length} file{matchingPaths.length === 1 ? '' : 's'} from <strong>{selectedNode.path}</strong>?</>,
+            prompt: <>Delete {formatNumber(matchingPaths.length)} file{matchingPaths.length === 1 ? '' : 's'} from <strong>{selectedNode.path}</strong>?</>,
             okLabel: 'Delete',
             okVariant: 'destructive'
         });
@@ -705,7 +757,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         const themeExists = themesData?.themes.some(theme => theme.name === nextThemeName) || false;
         const confirmMessage = isSaveAs
             ? `Save your edits as "${nextThemeName}"?`
-            : `Upload ${changes.length} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
+            : `Upload ${formatNumber(changes.length)} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
 
         const confirmedSave = await requestConfirmation({
             title: isSaveAs ? 'Save theme as new copy' : 'Update theme',
@@ -941,21 +993,31 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
 
             </div>
         </div>
-        {confirmRequest && (
+        {dialogRequest?.type === 'confirmation' && (
             <ThemeEditorConfirmModal
-                {...confirmRequest.props}
+                {...dialogRequest.props}
                 onResolve={(result) => {
-                    setConfirmRequest(null);
-                    confirmRequest.resolve(result);
+                    if (dialogRequestRef.current !== dialogRequest) {
+                        return;
+                    }
+
+                    dialogRequestRef.current = null;
+                    setDialogRequest(null);
+                    dialogRequest.resolve(result);
                 }}
             />
         )}
-        {inputRequest && (
+        {dialogRequest?.type === 'input' && (
             <ThemeEditorInputModal
-                {...inputRequest.props}
+                {...dialogRequest.props}
                 onResolve={(result) => {
-                    setInputRequest(null);
-                    inputRequest.resolve(result);
+                    if (dialogRequestRef.current !== dialogRequest) {
+                        return;
+                    }
+
+                    dialogRequestRef.current = null;
+                    setDialogRequest(null);
+                    dialogRequest.resolve(result);
                 }}
             />
         )}

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-editor-confirm-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-editor-confirm-modal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React from 'react';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import type {ButtonProps} from '@tryghost/shade/components';
@@ -11,20 +10,14 @@ export type ThemeEditorConfirmModalProps = {
     okVariant?: ButtonProps['variant'];
 };
 
-const ThemeEditorConfirmModal = NiceModal.create<ThemeEditorConfirmModalProps>(({
+const ThemeEditorConfirmModal: React.FC<ThemeEditorConfirmModalProps & {onResolve: (result: boolean) => void}> = ({
     title,
     prompt,
     cancelLabel = 'Cancel',
     okLabel = 'OK',
-    okVariant = 'default'
+    okVariant = 'default',
+    onResolve
 }) => {
-    const modal = useModal();
-
-    const closeWithResult = (result: boolean) => {
-        modal.resolve(result);
-        modal.remove();
-    };
-
     return (
         <SettingsModal
             backDropClick={false}
@@ -34,14 +27,15 @@ const ThemeEditorConfirmModal = NiceModal.create<ThemeEditorConfirmModalProps>((
             testId='theme-editor-confirm-modal'
             title={title}
             width={540}
-            onCancel={() => closeWithResult(false)}
-            onOk={() => closeWithResult(true)}
+            onCancel={() => onResolve(false)}
+            onClose={() => onResolve(false)}
+            onOk={() => onResolve(true)}
         >
             <div className='py-4'>
                 {prompt}
             </div>
         </SettingsModal>
     );
-});
+};
 
 export default ThemeEditorConfirmModal;

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-editor-input-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-editor-input-modal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import {Field, FieldLabel, Input} from '@tryghost/shade/components';
 import {SettingsModal} from '@tryghost/shade/patterns';
@@ -13,22 +12,17 @@ export type ThemeEditorInputModalProps = {
     okLabel?: string;
 };
 
-const ThemeEditorInputModal = NiceModal.create<ThemeEditorInputModalProps>(({
+const ThemeEditorInputModal: React.FC<ThemeEditorInputModalProps & {onResolve: (result: string | null) => void}> = ({
     title,
     prompt,
     fieldTitle,
     initialValue,
     placeholder,
     cancelLabel = 'Cancel',
-    okLabel = 'Continue'
+    okLabel = 'Continue',
+    onResolve
 }) => {
-    const modal = useModal();
     const [value, setValue] = useState(initialValue);
-
-    const closeWithResult = (result: string | null) => {
-        modal.resolve(result);
-        modal.remove();
-    };
 
     return (
         <SettingsModal
@@ -39,8 +33,9 @@ const ThemeEditorInputModal = NiceModal.create<ThemeEditorInputModalProps>(({
             testId='theme-editor-input-modal'
             title={title}
             width={540}
-            onCancel={() => closeWithResult(null)}
-            onOk={() => closeWithResult(value)}
+            onCancel={() => onResolve(null)}
+            onClose={() => onResolve(null)}
+            onOk={() => onResolve(value)}
         >
             <div className='flex flex-col gap-4 py-4'>
                 {prompt}
@@ -51,6 +46,6 @@ const ThemeEditorInputModal = NiceModal.create<ThemeEditorInputModalProps>(({
             </div>
         </SettingsModal>
     );
-});
+};
 
 export default ThemeEditorInputModal;

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-installed-modal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode} from 'react';
 import useCustomFonts from '@/settings/app/hooks/use-custom-fonts';
 import {ConfirmationModalContent} from '@/settings/app/components/confirmation-modal';
@@ -9,13 +8,15 @@ import {toast} from 'sonner';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
-const ThemeInstalledModal: React.FC<{
+export type ThemeInstalledModalProps = {
     title: string
     prompt: ReactNode
     installedTheme: InstalledTheme;
     validationDetailsDefaultOpen?: boolean;
     onActivate?: () => void;
-}> = ({title, installedTheme, validationDetailsDefaultOpen, onActivate}) => {
+};
+
+const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & {onClose: () => void}> = ({title, installedTheme, validationDetailsDefaultOpen, onActivate, onClose}) => {
     const {mutateAsync: activateTheme} = useActivateTheme();
     const {refreshActiveThemeData} = useCustomFonts();
     const handleError = useHandleError();
@@ -46,8 +47,6 @@ const ThemeInstalledModal: React.FC<{
         </>
     );
 
-    const modal = useModal();
-
     return <ConfirmationModalContent
         cancelLabel='Close'
         okLabel={okLabel}
@@ -75,7 +74,6 @@ const ThemeInstalledModal: React.FC<{
         </>}
         stickyFooter={true}
         title={modalTitle}
-        visible={modal.visible}
         onOk={async (activateModal) => {
             if (!installedTheme.active) {
                 try {
@@ -91,8 +89,8 @@ const ThemeInstalledModal: React.FC<{
             onActivate?.();
             activateModal?.remove();
         }}
-        onRemove={() => modal.remove()}
+        onRemove={onClose}
     />;
 };
 
-export default NiceModal.create(ThemeInstalledModal);
+export default ThemeInstalledModal;

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-installed-modal.tsx
@@ -84,6 +84,7 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & {onClose: () => v
                     toast.success('Theme activated', {description: <div><span className='capitalize'>{updatedTheme.name}</span> is now your active theme.</div>});
                 } catch (e) {
                     handleError(e);
+                    return;
                 }
             }
             onActivate?.();

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -145,6 +145,48 @@ describe("Theme settings", () => {
         expect(uploadApi.requests).toHaveLength(1);
     });
 
+    it("reports blocking upload errors and retries the upload from the error dialog", async () => {
+        fakeThemeWorld();
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing index.hbs" }],
+        }, { status: 422 });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
+
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "theme.zip", { type: "application/zip" }));
+
+        const errorModal = settingsScreen.confirmationModal();
+        await expect.element(errorModal).toHaveTextContent("Theme not uploaded");
+        await expect.element(errorModal).toHaveTextContent("Missing index.hbs");
+        expect(uploadApi.requests).toHaveLength(1);
+
+        await errorModal.getByRole("button", { name: "Retry" }).click();
+        await expect.element(page.getByText("Click to select or drag & drop zip file", { exact: true })).toBeVisible();
+        await expect(page.getByText("Theme not uploaded")).toHaveCount(0);
+    });
+
+    it("reports blocking activation errors for an installed theme", async () => {
+        fakeThemeWorld();
+        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", {
+            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing post.hbs" }],
+        }, { status: 422 });
+        await renderAdminApp("/settings/design/change-theme");
+
+        const modal = settingsScreen.themeModal();
+        await modal.getByRole("tab", { name: "Installed" }).click();
+        await installedTheme("casper").getByRole("button", { name: "Activate" }).click();
+
+        const errorModal = settingsScreen.confirmationModal();
+        await expect.element(errorModal).toHaveTextContent("Theme not activated");
+        await expect.element(errorModal).toHaveTextContent("Missing post.hbs");
+        expect(activateApi.requests).toHaveLength(1);
+
+        await errorModal.getByRole("button", { name: "Close" }).click();
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(modal).toBeVisible();
+    });
+
     it("prevents uploading an archive over a built-in theme", async () => {
         fakeThemeWorld();
         const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "source" })] });
@@ -216,6 +258,27 @@ describe("Theme settings", () => {
 
         await expect.element(settingsScreen.errorToast()).toHaveTextContent(/partials\/huge\.hbs/);
         await expect.element(settingsScreen.errorToast()).toHaveTextContent(/1\.0 MB/);
+    });
+
+    it("keeps the code editor open and reports blocking validation errors on save", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing default.hbs" }],
+        }, { status: 422 });
+        await renderAdminApp("/settings/theme/edit/edition");
+
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+
+        const errorModal = settingsScreen.confirmationModal();
+        await expect.element(errorModal).toHaveTextContent("Theme not saved");
+        await expect.element(errorModal).toHaveTextContent("Missing default.hbs");
+        await errorModal.getByRole("button", { name: "Close" }).click();
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
     });
 
     it("requires built-in themes to be saved under a valid new name", async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -145,6 +145,28 @@ describe("Theme settings", () => {
         expect(uploadApi.requests).toHaveLength(1);
     });
 
+    it("keeps the installed-theme dialog open when activation fails", async () => {
+        fakeThemeWorld();
+        const uploaded = theme({ name: "mytheme" });
+        fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
+        const activateApi = fakeAdminEndpoint("PUT", "/themes/mytheme/activate/", {
+            errors: [{ message: "Theme activation failed" }],
+        }, { status: 422 });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
+
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+
+        const installedModal = settingsScreen.confirmationModal();
+        await installedModal.getByRole("button", { name: "Activate theme" }).click();
+
+        await expect.element(installedModal).toBeVisible();
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent("Theme activation failed");
+        await expect.poll(currentRoute).toBe("/settings/design/change-theme");
+        expect(activateApi.requests).toHaveLength(1);
+    });
+
     it("reports blocking upload errors and retries the upload from the error dialog", async () => {
         fakeThemeWorld();
         const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", {
@@ -232,6 +254,9 @@ describe("Theme settings", () => {
         const editor = await editorTextbox();
         await editor.fill('{"name":"edition","version":"1.0.0"}\n');
         window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true, bubbles: true, cancelable: true }));
+        await expect.element(settingsScreen.themeEditorConfirmModal()).toBeVisible();
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true, bubbles: true, cancelable: true }));
+        await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(1);
         await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
 
         await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
@@ -276,7 +301,8 @@ describe("Theme settings", () => {
         const errorModal = settingsScreen.confirmationModal();
         await expect.element(errorModal).toHaveTextContent("Theme not saved");
         await expect.element(errorModal).toHaveTextContent("Missing default.hbs");
-        await errorModal.getByRole("button", { name: "Close" }).click();
+        await expect(errorModal.getByRole("button", { name: "Retry" })).toHaveCount(0);
+        await userEvent.keyboard("{Escape}");
         await expect(settingsScreen.confirmationModal()).toHaveCount(0);
         await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
     });
@@ -409,7 +435,8 @@ describe("Theme settings", () => {
         await editor.fill('{"name":"edition","version":"1.0.0"}\n');
         await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
         await expect.element(settingsScreen.themeEditorConfirmModal()).toHaveTextContent(/unsaved theme changes/i);
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Cancel" }).click();
+        await userEvent.keyboard("{Escape}");
+        await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(0);
         await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
         await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
         await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Discard changes" }).click();


### PR DESCRIPTION
no ref

The invalid-theme, theme-installed, theme-editor confirm and theme-editor input dialogs were the remaining `NiceModal.create` dialogs in the theme settings area. They now render in-tree from the component that opens them: the two `ConfirmationModalContent` dialogs take an `onClose` prop, and the two promise-style editor dialogs take an `onResolve` prop, with the code editor keeping its await-based `requestConfirmation`/`requestInput` helpers via a small pending-request state instead of `NiceModal.show`.

The theme code editor's dialogs are rendered as fragment siblings of its dark, backdrop-blurred root so they keep the same theme and stacking they had when NiceModal rendered them at the provider.

## Verification

- `pnpm test:acceptance src/settings/site/theme.acceptance.test.tsx` — 28/28 (three new tests: blocking upload errors + retry, blocking activation errors from the installed list, blocking validation errors when saving from the code editor; the installed/success, confirm and input dialogs were already covered)
- `tsc --noEmit` and eslint clean on `apps/admin`