### PR TITLE
Changed membership settings dialogs to controlled components

### DIFF
--- a/apps/admin/src/settings/app/components/settings/email/emails.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/emails.tsx
@@ -2,7 +2,6 @@ import DefaultRecipients from './default-recipients';
 import EnableNewsletters from './enable-newsletters';
 import MailGun from './mailgun';
 import NewslettersTabContent, {type NewslettersFilter} from './newsletters/newsletters-tab-content';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef, useState} from 'react';
 import SearchableSection from '@/settings/app/components/searchable-section';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
@@ -26,8 +25,9 @@ export const searchKeywords = {
 };
 
 const TransactionalTabContent: React.FC = () => {
+    const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
     const openCustomizeModal = () => {
-        NiceModal.show(WelcomeEmailCustomizeModal);
+        setIsCustomizeOpen(true);
     };
 
     return (
@@ -52,6 +52,7 @@ const TransactionalTabContent: React.FC = () => {
                 </ActionListItemContent>
                 <ActionListItemActions><Button className='h-auto p-0 font-bold text-green hover:text-green/90 hover:no-underline' type='button' variant='link' onClick={openCustomizeModal}>Edit</Button></ActionListItemActions>
             </ActionListItem>
+            {isCustomizeOpen && <WelcomeEmailCustomizeModal onClose={() => setIsCustomizeOpen(false)} />}
         </ActionList>
     );
 };

--- a/apps/admin/src/settings/app/components/settings/membership/custom-fields.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/custom-fields.tsx
@@ -1,6 +1,5 @@
 import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
 import CustomFieldModal from './custom-fields/custom-field-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
@@ -13,6 +12,7 @@ import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tryghost/admin-x-framework';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {DialogPortal} from '@/settings/app/components/providers/dialog-portal';
 
 // How many fields render before the list collapses behind "Show all" — the
 // recommendations list's preview size.
@@ -189,7 +189,8 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
         previousCounts.current = {active: activeFields.length, archived: archivedFields.length};
     }, [activeFields.length, archivedFields.length]);
 
-    const openModal = (field?: MemberCustomField) => NiceModal.show(CustomFieldModal, {field});
+    const [editingField, setEditingField] = useState<{field?: MemberCustomField} | null>(null);
+    const openModal = (field?: MemberCustomField) => setEditingField({field});
 
     /**
      * Applied to the whole list rather than the active tab: a reorder names every
@@ -241,6 +242,7 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
                     <TabsContent value='archived-fields'><FieldList fields={archivedFields} openModal={openModal} showAll={showAllArchived} onShowAll={() => setShowAllArchived(true)} /></TabsContent>
                 </Tabs>
             )}
+            {editingField && <DialogPortal><CustomFieldModal field={editingField.field} onClose={() => setEditingField(null)} /></DialogPortal>}
         </TopLevelGroup>
     );
 };

--- a/apps/admin/src/settings/app/components/settings/membership/custom-fields/custom-field-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/custom-fields/custom-field-modal.tsx
@@ -1,5 +1,5 @@
+import React from 'react';
 import {CustomFieldTypeOption} from '@/shared/member-custom-fields/custom-field-type-option';
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Field, FieldDescription, FieldError, FieldGroup, FieldLabel, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {SettingsModal} from '@tryghost/shade/patterns';
@@ -12,8 +12,7 @@ import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-cus
 
 const userTypeById = (id: string) => memberCustomFieldUserTypes.find(userType => userType.id === id) || memberCustomFieldUserTypes[0];
 
-const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field}) => {
-    const modal = useModal();
+const CustomFieldModal: React.FC<{field?: MemberCustomField; onClose: () => void}> = ({field, onClose}) => {
     const {confirm} = useConfirmation();
     const {mutateAsync: createField} = useCreateMemberCustomField();
     const {mutateAsync: editField} = useEditMemberCustomField();
@@ -68,7 +67,7 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
     // newsletters pattern) — they change what every collection surface shows.
     const archiveButton = (
         <Button className='text-destructive hover:text-destructive' size='sm' type='button' variant='ghost' onClick={() => {
-            modal.remove();
+            onClose();
             confirm({
                 title: 'Archive custom field',
                 prompt: <>
@@ -96,7 +95,7 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
 
     const reactivateButton = (
         <Button className='text-green hover:text-green' size='sm' type='button' variant='ghost' onClick={() => {
-            modal.remove();
+            onClose();
             confirm({
                 title: 'Reactivate custom field',
                 prompt: <>
@@ -128,7 +127,7 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
     // two-step (only archived fields can be deleted). A visible red button
     // would put irreversible data loss on equal footing with Save.
     const confirmDeleteField = () => {
-        modal.remove();
+        onClose();
         confirm({
             title: 'Delete custom field',
             prompt: <><strong>{field!.name}</strong> and every value collected from your members will be permanently deleted from the database. This can&rsquo;t be undone.</>,
@@ -174,10 +173,11 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
             testId='custom-field-modal'
             title={isEdit ? 'Edit custom field' : 'Add custom field'}
             topRightContent={isArchived ? archivedFieldMenu : undefined}
+            onClose={onClose}
             onOk={async () => {
                 try {
                     if (await handleSave()) {
-                        modal.remove();
+                        onClose();
                     }
                 } catch {
                     // useForm has already passed the error to onSaveError, which
@@ -208,6 +208,6 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
             </FieldGroup>
         </SettingsModal>
     );
-});
+};
 
 export default CustomFieldModal;

--- a/apps/admin/src/settings/app/components/settings/membership/member-emails.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/member-emails.tsx
@@ -1,8 +1,7 @@
-import NiceModal from '@ebay/nice-modal-react';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import WelcomeEmailCustomizeModal from './member-emails/welcome-email-customize-modal';
-import WelcomeEmailModal from './member-emails/welcome-email-modal';
+import WelcomeEmailModal, {type WelcomeEmailModalProps} from './member-emails/welcome-email-modal';
 import useQueryParams from '@/settings/app/hooks/use-query-params';
 import {APIError} from '@tryghost/admin-x-framework/errors';
 import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Switch} from '@tryghost/shade/components';
@@ -17,6 +16,7 @@ import {useGlobalData} from '@/settings/app/components/providers/global-data-pro
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import {DialogPortal} from '@/settings/app/components/providers/dialog-portal';
 
 const EmailPreviewRow: React.FC<{
     automatedEmail: AutomatedEmail,
@@ -251,6 +251,9 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
     };
 
+    const [editingEmail, setEditingEmail] = useState<WelcomeEmailModalProps | null>(null);
+    const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
+
     // Handle Edit button click - creates inactive row if needed, then opens modal
     const handleEditClick = async (emailType: 'free' | 'paid') => {
         const existing = automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS[emailType]);
@@ -264,13 +267,13 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 const result = await createAutomatedEmail(emailType, 'inactive');
                 const newEmail = result?.automated_emails?.[0];
                 if (newEmail) {
-                    NiceModal.show(WelcomeEmailModal, {emailType, automatedEmail: newEmail});
+                    setEditingEmail({emailType, automatedEmail: newEmail});
                 }
             } catch (e) {
                 handleError(e);
             }
         } else {
-            NiceModal.show(WelcomeEmailModal, {emailType, automatedEmail: existing});
+            setEditingEmail({emailType, automatedEmail: existing});
         }
     };
 
@@ -286,7 +289,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     size='sm'
                     type='button'
                     variant='ghost'
-                    onClick={() => NiceModal.show(WelcomeEmailCustomizeModal)}
+                    onClick={() => setIsCustomizeOpen(true)}
                 >
                     Customize
                 </Button>
@@ -311,6 +314,12 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 onPaidEdit={() => handleEditClick('paid')}
                 onPaidToggle={() => handleToggle('paid')}
             />
+            {editingEmail && (
+                <DialogPortal>
+                    <WelcomeEmailModal key={editingEmail.automatedEmail.id} {...editingEmail} onClose={() => setEditingEmail(null)} />
+                </DialogPortal>
+            )}
+            {isCustomizeOpen && <WelcomeEmailCustomizeModal onClose={() => setIsCustomizeOpen(false)} />}
         </TopLevelGroup>
     );
 };

--- a/apps/admin/src/settings/app/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -1,7 +1,6 @@
 import EmailDesignModal from '@/settings/app/components/settings/email-design/email-design-modal';
 import EmailPreview from '@/settings/app/components/settings/email-design/email-preview';
 import HeaderImageField from '@/settings/app/components/settings/email-design/header-image-field';
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import ShowBadgeField from '@/settings/app/components/settings/email-design/show-badge-field';
 import WelcomeEmailPreviewContent from '@/settings/app/components/settings/email-design/welcome-email-preview-content';
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
@@ -333,8 +332,7 @@ const normalizeSenderValue = (value: string | null | undefined) => {
     return trimmed || null;
 };
 
-const WelcomeEmailCustomizeModal = NiceModal.create(() => {
-    const modal = useModal();
+const WelcomeEmailCustomizeModal: React.FC<{onClose: () => void}> = ({onClose}) => {
     const {siteData, settings: globalSettings, config} = useGlobalData();
     const [siteTitle, defaultEmailAddress, icon, supportEmailAddress] = getSettingValues<string>(
         globalSettings,
@@ -510,10 +508,6 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         }));
     }, [updateForm]);
 
-    const handleClose = useCallback(() => {
-        modal.hide();
-    }, [modal]);
-
     const fetchErrorMessage = 'Unable to load email design settings. Please try again.';
     const modalOkProps = hasSaveError ? {
         ...okProps,
@@ -524,14 +518,9 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     return (
         <EmailDesignProvider accentColor={siteData.accent_color} settings={designSettings} onSettingsChange={handleDesignChange}>
             <EmailDesignModal
-                afterClose={() => {
-                    modal.resolveHide();
-                    modal.remove();
-                }}
                 dirty={saveState === 'unsaved'}
                 isLoading={isLoading || isError}
                 okProps={modalOkProps}
-                open={modal.visible}
                 preview={isError ? (
                     <ErrorState message={fetchErrorMessage} />
                 ) : (
@@ -574,11 +563,12 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                 }
                 testId="welcome-email-customize-modal"
                 title="Welcome emails"
-                onClose={handleClose}
+                open
+                onClose={onClose}
                 onSave={() => handleSave({fakeWhenUnchanged: true})}
             />
         </EmailDesignProvider>
     );
-});
+};
 
 export default WelcomeEmailCustomizeModal;

--- a/apps/admin/src/settings/app/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
@@ -90,15 +89,14 @@ const EmailPreviewBody: React.FC<EmailPreviewBodyProps> = ({children, className}
     </div>
 );
 
-interface WelcomeEmailModalProps {
+export interface WelcomeEmailModalProps {
     emailType: 'free' | 'paid';
     automatedEmail: AutomatedEmail;
 }
 
 type PreviewMode = 'edit' | 'preview';
 
-const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType = 'free', automatedEmail}) => {
-    const modal = useModal();
+const WelcomeEmailModal: React.FC<WelcomeEmailModalProps & {onClose: () => void}> = ({emailType = 'free', automatedEmail, onClose}) => {
     const {settings: globalSettings, config} = useGlobalData();
     const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'support_email_address']);
     const {updateRoute} = useSettingsNavigation();
@@ -144,10 +142,8 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const isDirty = saveState === 'unsaved';
 
     const handleClose = useCallback(() => {
-        confirm(isDirty, () => {
-            modal.remove();
-        });
-    }, [confirm, modal, isDirty]);
+        confirm(isDirty, onClose);
+    }, [confirm, onClose, isDirty]);
 
     const handleSaveRef = useRef(handleSave);
     useEffect(() => {
@@ -216,6 +212,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             size='full'
             testId='welcome-email-modal'
             width='full'
+            onClose={onClose}
         >
             <EmailPreviewModalContent
                 centeredHeaderContent={
@@ -331,6 +328,6 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             <DirtyConfirmDialog {...dialogProps} />
         </SettingsModal>
     );
-});
+};
 
 export default WelcomeEmailModal;

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -244,10 +244,8 @@ describe("Custom fields", () => {
         await expect(rows).toHaveCount(7);
         await expect.element(rows.last()).toHaveTextContent("Newest");
 
-        // Wait for the modal to finish closing (Save holds it open ~500ms for
-        // its saving state). Ending the test earlier leaves that removal
-        // pending, and it would fire into the NEXT test's freshly-opened
-        // modal — NiceModal keys modals by component and dispatches globally.
+        // Save holds the modal open for its ~500ms saving state. Verify the
+        // async save has completed and the parent-controlled modal unmounts.
         await expect(modal).toHaveCount(0);
     });
 


### PR DESCRIPTION
no ref

Uses the settings `DialogPortal` from #30014.

The custom field, welcome email and welcome email customize dialogs were the last `NiceModal.create` dialogs in the membership and email settings areas. They now take an `onClose` prop and are rendered by the component that opens them: the two `SettingsModal` dialogs through the settings dialog portal so they paint above the settings chrome, and the customize dialog directly, since its `EmailDesignModal` is already a portalled Shade `Dialog`.

With these converted (plus #30014 and #30015), no settings dialog is created or shown through NiceModal any more, which clears the way to remove the provider, the dependency and the compatibility bridges.

## Verification

- `pnpm test:acceptance src/settings/membership src/settings/email` — 114/114 (custom fields, welcome emails and the customize dialog already had thorough coverage; the welcome-email save test is what caught the stacking-context problem the portal fixes)
- `tsc --noEmit` and eslint clean on `apps/admin`