### PR TITLE
Removed superEditors labs flag

### DIFF
--- a/apps/admin/src/settings/advanced/labs/beta-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/beta-features.tsx
@@ -93,16 +93,6 @@ const BetaFeatures: React.FC = () => {
           />
         ) : null}
         <LabItem
-          action={<FeatureToggle flag="superEditors" />}
-          detail={
-            <>
-              Allows newly-assigned editors to manage members and comments in addition to regular
-              roles.
-            </>
-          }
-          title="Enhanced Editor role (beta)"
-        />
-        <LabItem
           action={<FeatureToggle flag="editorExcerpt" />}
           detail={<>Adds the excerpt input below the post title in the editor</>}
           title="Show post excerpt inline"

--- a/apps/admin/src/settings/general/invite-user-modal.tsx
+++ b/apps/admin/src/settings/general/invite-user-modal.tsx
@@ -20,7 +20,7 @@ import { useAddInvite, useBrowseInvites } from '@tryghost/admin-x-framework/api/
 import { useBrowseRoles } from '@tryghost/admin-x-framework/api/roles';
 import { useBrowseUsers } from '@tryghost/admin-x-framework/api/users';
 import { useEffect, useState } from 'react';
-import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
 
 type RoleType = 'administrator' | 'editor' | 'author' | 'contributor' | 'super editor';
@@ -36,7 +36,6 @@ function InviteUserModal() {
   const limiter = useLimiter();
 
   const { updateRoute } = useSettingsNavigation();
-  const editorBeta = useFeatureFlag('superEditors');
   const [email, setEmail] = useState<string>('');
   const [saveState, setSaveState] = useState<'saving' | 'saved' | 'error' | ''>('');
   const [role, setRole] = useState<RoleType>('contributor');
@@ -170,7 +169,7 @@ function InviteUserModal() {
     }
   };
 
-  const roleOptions = [
+  const roleOptions: { hint: string; label: string; value: RoleType }[] = [
     {
       hint: 'Can create and edit their own posts, but cannot publish. An Editor needs to approve and publish for them.',
       label: 'Contributor',
@@ -182,9 +181,9 @@ function InviteUserModal() {
       value: 'author',
     },
     {
-      hint: 'Can invite and manage other Authors and Contributors, as well as edit and publish any posts on the site.',
+      hint: 'Can invite and manage other Authors and Contributors, as well as edit and publish any posts on the site. Can manage members and moderate comments.',
       label: 'Editor',
-      value: 'editor',
+      value: 'super editor',
     },
     {
       hint: 'Trusted staff user who should be able to manage all content and users, as well as site settings and options.',
@@ -193,26 +192,8 @@ function InviteUserModal() {
     },
   ];
 
-  // If the editor beta is enabled, replace the editor role option with super editor options.
-  // This gets a little weird, because we aren't changing what is actually assigned based on the toggle.
-  // So, a site could have the editor beta enabled, but that doesn't automatically convert their editors.
-  // (Editors can be up/downgraded by reassigning them in this modal.  For 6.0, we should decide whether
-  // the old editors are going away or whether both roles are staying, and tidy this up then.)
-
-  if (editorBeta) {
-    roleOptions[2] = {
-      hint: 'Can invite and manage other Authors and Contributors, as well as edit and publish any posts on the site. Can manage members and moderate comments.',
-      label: 'Editor (beta mode)',
-      value: 'super editor',
-    };
-  }
   const allowedRoleOptions = roleOptions.filter((option) => {
-    return assignableRoles.some((r) => {
-      return (
-        r.name === option.label ||
-        (r.name === 'Super Editor' && option.label === 'Editor (beta mode)')
-      );
-    });
+    return assignableRoles.some((r) => r.name.toLowerCase() === option.value);
   });
 
   if (errors.email) {

--- a/apps/admin/src/settings/general/staff-roles.acceptance.test.tsx
+++ b/apps/admin/src/settings/general/staff-roles.acceptance.test.tsx
@@ -43,7 +43,7 @@ describe('Staff roles', () => {
     const owner = user('Owner');
     const author = user('Author');
     const { boot } = fakeStaffWorld({ currentUser: owner, users: [owner, author] });
-    const edited = { ...author, roles: [role('Editor')] };
+    const edited = { ...author, roles: [role('Super Editor')] };
     const editApi = fakeAdminEndpoint('PUT', `/users/${author.id}/?include=roles`, {
       users: [edited],
     });
@@ -56,7 +56,7 @@ describe('Staff roles', () => {
 
     await expect.element(modal.getByRole('button', { name: 'Saved' })).toBeVisible();
     expect(editApi.lastRequest?.body).toMatchObject({
-      users: [{ id: author.id, roles: [{ id: role('Editor').id, name: 'Editor' }] }],
+      users: [{ id: author.id, roles: [{ id: role('Super Editor').id, name: 'Super Editor' }] }],
     });
     await modal.getByRole('button', { name: 'Close' }).click();
 

--- a/apps/admin/src/settings/general/staff.test-helpers.ts
+++ b/apps/admin/src/settings/general/staff.test-helpers.ts
@@ -49,6 +49,7 @@ export function invite(overrides: Partial<StaffInvite> = {}): StaffInvite {
 export const allRoles = (): StaffRole[] => [
   role('Administrator'),
   role('Editor'),
+  role('Super Editor'),
   role('Author'),
   role('Contributor'),
   role('Owner'),

--- a/apps/admin/src/settings/general/users/role-selector.tsx
+++ b/apps/admin/src/settings/general/users/role-selector.tsx
@@ -10,16 +10,14 @@ import {
 } from '@tryghost/shade/components';
 import { type User, isOwnerUser } from '@tryghost/admin-x-framework/api/users';
 import { useBrowseRoles } from '@tryghost/admin-x-framework/api/roles';
-import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 
 const RoleSelector: React.FC<{ user: User; setUserData: (user: User) => void }> = ({
   user,
   setUserData,
 }) => {
   const { data: { roles } = {} } = useBrowseRoles();
-  const editorBeta = useFeatureFlag('superEditors');
 
-  let optionsArray = [
+  const optionsArray = [
     {
       hint: 'Can write and edit their own posts, but cannot publish them.',
       label: 'Contributor',
@@ -31,9 +29,9 @@ const RoleSelector: React.FC<{ user: User; setUserData: (user: User) => void }> 
       value: 'author',
     },
     {
-      hint: 'Can edit and publish any posts, and manage Authors and Contributors.',
+      hint: 'Can invite and manage other Authors and Contributors, as well as edit and publish any posts on the site. Can manage members and moderate comments.',
       label: 'Editor',
-      value: 'editor',
+      value: 'super editor',
     },
     {
       hint: 'Trusted user who has full access to all content, settings, and user management.',
@@ -41,21 +39,6 @@ const RoleSelector: React.FC<{ user: User; setUserData: (user: User) => void }> 
       value: 'administrator',
     },
   ];
-  // if the editor beta is enabled, replace the editor role with super editor
-  if (editorBeta) {
-    optionsArray = optionsArray.map((option) => {
-      if (option.value === 'editor') {
-        return {
-          ...option,
-          label: 'Editor (beta mode)',
-          value: 'super editor',
-          hint: 'Can invite and manage other Authors and Contributors, as well as edit and publish any posts on the site. Can manage members and moderate comments.',
-        };
-      }
-      return option;
-    });
-  }
-
   if (isOwnerUser(user)) {
     const ownerOption = {
       label: 'Owner',
@@ -88,9 +71,8 @@ const RoleSelector: React.FC<{ user: User; setUserData: (user: User) => void }> 
   }
 
   const selectedRoleValue = user.roles[0].name.toLowerCase();
-  const selectedRoleLabel = optionsArray.find(
-    (option) => option.value.toLowerCase() === selectedRoleValue,
-  )?.label;
+  const selectedRoleLabel =
+    optionsArray.find((option) => option.value === selectedRoleValue)?.label ?? user.roles[0].name;
 
   return (
     <Field>

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -30,7 +30,7 @@ const messages = {
 const GA_FEATURES = ['automationAnalytics'];
 
 // These features are considered publicly available and can be enabled/disabled by users
-const PUBLIC_BETA_FEATURES = ['superEditors', 'editorExcerpt', 'additionalPaymentMethods'];
+const PUBLIC_BETA_FEATURES = ['editorExcerpt', 'additionalPaymentMethods'];
 
 // These features are considered private they live in the private tab of the labs settings page
 // Which is only visible if the developer experiments flag is enabled

--- a/packages/testing/test-data/src/fixtures/data/labs.ts
+++ b/packages/testing/test-data/src/fixtures/data/labs.ts
@@ -4,7 +4,6 @@
  * both places at once (the admin client reads labs from settings AND config).
  */
 export const labsDefaults: Record<string, boolean> = {
-  superEditors: false,
   editorExcerpt: false,
   additionalPaymentMethods: false,
 };

--- a/packages/testing/test-data/test/fixtures.test.ts
+++ b/packages/testing/test-data/test/fixtures.test.ts
@@ -12,24 +12,25 @@ function getLabs(response: ReturnType<typeof settingsResponse>): Record<string, 
 describe('boot fixtures', () => {
   it('defaults labs flags to off in settings and config', () => {
     expect(getLabs(settingsResponse())).toEqual({
-      superEditors: false,
       editorExcerpt: false,
       additionalPaymentMethods: false,
     });
     expect(configResponse().config.labs).toEqual({
-      superEditors: false,
       editorExcerpt: false,
       additionalPaymentMethods: false,
     });
   });
 
   it('merges labs overrides without mutating the canned data', () => {
-    const overridden = settingsResponse({ labs: { superEditors: true } });
+    const overridden = settingsResponse({ labs: { editorExcerpt: true } });
 
-    expect(getLabs(overridden)).toMatchObject({ superEditors: true, editorExcerpt: false });
-    expect(getLabs(settingsResponse())).toMatchObject({ superEditors: false });
-    expect(configResponse({ labs: { superEditors: true } }).config.labs).toMatchObject({
-      superEditors: true,
+    expect(getLabs(overridden)).toMatchObject({
+      editorExcerpt: true,
+      additionalPaymentMethods: false,
+    });
+    expect(getLabs(settingsResponse())).toMatchObject({ editorExcerpt: false });
+    expect(configResponse({ labs: { editorExcerpt: true } }).config.labs).toMatchObject({
+      editorExcerpt: true,
     });
   });
 


### PR DESCRIPTION
no ref

The enhanced Editor role ("Super Editor") has been in public beta long enough to treat as GA, so this removes the `superEditors` labs flag.

- Dropped `superEditors` from `PUBLIC_BETA_FEATURES` in `ghost/core/core/shared/labs.js` and removed the "Enhanced Editor role (beta)" toggle from Settings → Labs.
- Staff invite modal and user role selector now always offer the Super Editor role under the "Editor" label (previously the flag-on behaviour, labelled "Editor (beta mode)"). Hint copy matches the beta text.
- Existing users on the legacy `Editor` role are untouched; the role selector falls back to their current role name so the field is never blank.
- Removed the flag from `@tryghost/test-data` labs defaults; updated staff acceptance tests so choosing "Editor" asserts the Super Editor role assignment.

Verified: `apps/admin` typecheck + eslint clean, `pnpm test:acceptance src/settings/general/staff src/settings/permissions` (45 passing), `ghost/core` `test/unit/shared/labs.test.js` passing, `packages/testing/test-data` tests passing.
