### PR TITLE
Added a members list column for each custom field filtered on

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -160,6 +160,61 @@ export const memberCustomFieldParts = <T extends FieldType>(type: T): MemberCust
     return partKeys.map(key => ({key, label: labels[key]}));
 };
 
+/**
+ * A value as the record of parts a composite reads from, and nothing otherwise.
+ *
+ * A predicate rather than an assertion: the same checks either way, but this one hands
+ * the narrowing to the compiler rather than overriding it, so a formatter below cannot be
+ * reached by a value nobody looked at.
+ */
+const isPartRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * How each composite type reads as one line. Written per type rather than walked from
+ * `subFieldsOf`, because where a part sits in the sentence is a fact about how the value
+ * reads, not one the value schema can supply — an address fuses state and postal code the
+ * way people write them. A part added upstream stays out of the line until someone decides
+ * where it belongs.
+ *
+ * Total over the field types, the way the presentation catalog above is: a type added
+ * upstream fails to compile here until someone has decided how its value reads, rather
+ * than reaching every surface as a blank cell. A scalar declares `undefined`, which is
+ * how "its value is already a line" is said.
+ */
+const compositeValueFormatters: {
+    [T in FieldType]: [PartsOf<T>] extends [never] ? undefined : (value: Record<string, unknown>) => string
+} = {
+    short_text: undefined,
+    long_text: undefined,
+    address: (value) => {
+        const {line1, line2, city, state, postal_code: postalCode, country} = value;
+        const statePostal = [state, postalCode].filter(Boolean).join(' ');
+        return [line1, line2, city, statePostal, country].filter(Boolean).join(', ');
+    }
+};
+
+/**
+ * A member's value for one field as a single readable line: the string itself for a
+ * scalar, and for a composite its parts joined the way that type reads — e.g.
+ * "1 Main St, 12 apt B, New York, NY 00001, US". Missing parts drop out, so a partial
+ * value still reads naturally.
+ *
+ * Empty string for a value that is not the shape its type declares: the type decides
+ * which shape is readable, so a composite reads only from its parts and a scalar only
+ * from text. Callers own their own placeholder, since "no value" reads differently in a
+ * table cell than in a detail row.
+ */
+export const formatMemberCustomFieldValue = (type: FieldType, value: unknown): string => {
+    const formatComposite = compositeValueFormatters[type];
+
+    if (formatComposite) {
+        return isPartRecord(value) ? formatComposite(value) : '';
+    }
+
+    return typeof value === 'string' ? value : '';
+};
+
 export interface MemberCustomFieldsResponseType {
     meta?: Meta;
     members_custom_fields: MemberCustomField[];

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -1,4 +1,4 @@
-import {type FieldTypePresentation, type MemberCustomField, memberCustomFieldCsvColumns, memberCustomFieldParts} from '../../../src/api/member-custom-fields';
+import {type FieldTypePresentation, type MemberCustomField, formatMemberCustomFieldValue, memberCustomFieldCsvColumns, memberCustomFieldParts} from '../../../src/api/member-custom-fields';
 
 // Compile-time cases: the build failing is the assertion. Each `@ts-expect-error` fails the
 // build if the case it names stops being an error. Declared on one line each, because the
@@ -96,6 +96,42 @@ describe('member custom fields api helpers', () => {
                 {key: 'postal_code', label: 'Postal code'},
                 {key: 'country', label: 'Country'}
             ]);
+        });
+    });
+
+    describe('formatMemberCustomFieldValue', () => {
+        it('returns a scalar value as it stands', () => {
+            expect(formatMemberCustomFieldValue('short_text', 'Editor')).toBe('Editor');
+            expect(formatMemberCustomFieldValue('long_text', 'A longer note')).toBe('A longer note');
+        });
+
+        it('formats a full address as one readable line', () => {
+            expect(formatMemberCustomFieldValue('address', {line1: '1 Main St', line2: '12 apt B', city: 'New York', state: 'NY', postal_code: '00001', country: 'US'}))
+                .toBe('1 Main St, 12 apt B, New York, NY 00001, US');
+        });
+
+        it('pairs state and postal code, and drops missing parts cleanly', () => {
+            expect(formatMemberCustomFieldValue('address', {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}))
+                .toBe('1 Main St, Berlin, 10115, DE');
+            expect(formatMemberCustomFieldValue('address', {city: 'Berlin'})).toBe('Berlin');
+        });
+
+        // A surface renders its own placeholder, so every unreadable value has to reduce to
+        // the same empty string rather than leaking a raw object or the word "undefined".
+        it('formats an empty or unreadable value as an empty string', () => {
+            expect(formatMemberCustomFieldValue('address', {})).toBe('');
+            expect(formatMemberCustomFieldValue('address', null)).toBe('');
+            expect(formatMemberCustomFieldValue('address', undefined)).toBe('');
+            expect(formatMemberCustomFieldValue('address', ['a', 'b'])).toBe('');
+            // A composite type from a later build: no formatter, so no line.
+            expect(formatMemberCustomFieldValue('unheard_of' as MemberCustomField['type'], {line1: '1 Main St'})).toBe('');
+        });
+
+        // The type decides which shape is readable, so a value of the other shape is not
+        // read at all rather than being coerced into a line that misrepresents it.
+        it('reads only the shape its type declares', () => {
+            expect(formatMemberCustomFieldValue('address', '1 Main St, Berlin')).toBe('');
+            expect(formatMemberCustomFieldValue('short_text', {line1: '1 Main St'})).toBe('');
         });
     });
 });

--- a/apps/admin/src/members/components/members-filters.tsx
+++ b/apps/admin/src/members/components/members-filters.tsx
@@ -9,6 +9,7 @@ import {
     toOfferFilterDisplayValues,
     useMemberFilterFields
 } from '@/members/use-member-filter-fields';
+import {CUSTOM_FIELDS_PREFIX} from '@/members/member-fields';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
@@ -104,8 +105,8 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const referencedCustomFieldKeys = useMemo(() => new Set(
         filters
             .map(filter => filter.field)
-            .filter(field => field.startsWith('custom_field.'))
-            .map(field => field.slice('custom_field.'.length))
+            .filter(field => field.startsWith(CUSTOM_FIELDS_PREFIX))
+            .map(field => field.slice(CUSTOM_FIELDS_PREFIX.length))
             .filter(Boolean)
     ), [filters]);
     // Only when the current filter references a custom field do we also pull the archived

--- a/apps/admin/src/members/components/members-list-item.tsx
+++ b/apps/admin/src/members/components/members-list-item.tsx
@@ -4,8 +4,7 @@ import {Avatar, TableCell, TableRow} from '@tryghost/shade/components';
 import {type Member} from '@tryghost/admin-x-framework/api/members';
 import {buildMemberDetailPath} from '@/members/member-detail-hash';
 import {cn, formatPercentage} from '@tryghost/shade/utils';
-import {getActiveColumnValue} from '@/members/member-query-params';
-import type {ActiveColumn} from '@/members/member-query-params';
+import type {MemberActiveColumn} from '@/members/member-query-params';
 import {forwardRef, type CSSProperties} from 'react';
 import type {MemberTableColumnStyles} from './member-table-layout';
 
@@ -179,11 +178,11 @@ function MembersListItemDynamicColumn({
     member,
     timezone
 }: {
-    column: ActiveColumn;
+    column: MemberActiveColumn;
     member: Member;
     timezone: string;
 }) {
-    const value = getActiveColumnValue(column, member, timezone);
+    const value = column.getValue(member, timezone);
 
     if (!value) {
         return (
@@ -207,7 +206,7 @@ function MembersListItemDynamicColumn({
 
 interface MembersListItemProps {
     item: Member;
-    activeColumns: ActiveColumn[];
+    activeColumns: MemberActiveColumn[];
     backPath?: string;
     columnStyles: MemberTableColumnStyles;
     showPinnedEdge: boolean;

--- a/apps/admin/src/members/components/members-list-item.tsx
+++ b/apps/admin/src/members/components/members-list-item.tsx
@@ -192,9 +192,13 @@ function MembersListItemDynamicColumn({
 
     return (
         <div className="min-w-0">
-            <div className="truncate text-base">{value.text}</div>
+            {/* A dynamic column holds whatever a publisher collected, so its value has no
+                length a column width can be sized to — an address routinely outruns the
+                cell. The native title is the fallback for reading one in full: no cost per
+                row, which a tooltip component would have across a virtualised list. */}
+            <div className="truncate text-base" title={value.text}>{value.text}</div>
             {value.subtext && (
-                <div className="truncate text-base text-muted-foreground">
+                <div className="truncate text-base text-muted-foreground" title={value.subtext}>
                     {value.subtext}
                 </div>
             )}

--- a/apps/admin/src/members/components/members-list.tsx
+++ b/apps/admin/src/members/components/members-list.tsx
@@ -6,7 +6,7 @@ import {Table, TableBody, TableCell, TableRow} from '@tryghost/shade/components'
 import {buildMemberDetailPath} from '@/members/member-detail-hash';
 import {forwardRef, useEffect, useMemo, useRef, useState} from 'react';
 import {getMemberTableLayout, getMemberTableLayoutStyles} from './member-table-layout';
-import type {ActiveColumn} from '@/members/member-query-params';
+import type {MemberActiveColumn} from '@/members/member-query-params';
 import type {RefObject} from 'react';
 
 const SpacerRow = ({height}: { height: number }) => (
@@ -43,7 +43,7 @@ interface MembersListProps {
     fetchNextPage: () => void;
     isLoading?: boolean;
     showEmailOpenRate?: boolean;
-    activeColumns: ActiveColumn[];
+    activeColumns: MemberActiveColumn[];
     timezone: string;
     pageHeaderRef?: RefObject<HTMLElement | null>;
     onRowClick?: (memberId: string) => void;

--- a/apps/admin/src/members/custom-field-filter-renderer.tsx
+++ b/apps/admin/src/members/custom-field-filter-renderer.tsx
@@ -1,18 +1,16 @@
 import React, {useEffect} from 'react';
-import {CUSTOM_FIELD_OPERATORS, CUSTOM_FIELD_SET_OPERATORS} from './member-fields';
+import {CUSTOM_FIELDS_PREFIX, CUSTOM_FIELD_OPERATORS, CUSTOM_FIELD_SET_OPERATORS} from './member-fields';
 import {FilterSegmentInput, FilterSegmentSelect} from '@tryghost/shade/patterns';
 import {createOperatorOptions} from '@/shared/filters';
 import {memberCustomFieldParts, useBrowseMemberCustomFieldsIncludingArchived} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type {CustomRendererProps} from '@tryghost/shade/patterns';
 
 // The dropdown entry has already chosen the field (its key is in `field.key` as
-// `custom_field.<key>`), so this renders only what's left in the pill: for a
+// `custom_fields.<key>`), so this renders only what's left in the pill: for a
 // composite field a part selector (with "Any" for the whole field), then the
 // operator, then the value. The predicate carries [subfield, value]; subfield is ''
 // for a scalar field or the "Any" whole-field set/unset case. The operator lives here
 // because its valid set depends on the part chosen here.
-
-const KEY_PREFIX = 'custom_field.';
 
 const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, values, onChange, operator, onOperatorChange, readOnly}) => {
     // Include-archived so an archived composite field's pill can still resolve its parts
@@ -20,7 +18,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
     const {data} = useBrowseMemberCustomFieldsIncludingArchived();
     const definitions = data?.members_custom_fields ?? [];
 
-    const fieldKey = (field.key ?? '').slice(KEY_PREFIX.length);
+    const fieldKey = (field.key ?? '').slice(CUSTOM_FIELDS_PREFIX.length);
     const definition = definitions.find(candidate => candidate.key === fieldKey);
     // The shared catalog decides which parts a type has and what they are called; a scalar
     // field has none. Its keys are the ones the predicate carries.

--- a/apps/admin/src/members/detail/member-custom-fields-field.tsx
+++ b/apps/admin/src/members/detail/member-custom-fields-field.tsx
@@ -3,9 +3,8 @@ import {Button, Card, CardContent, Dialog, DialogContent, DialogFooter, DialogHe
 import {LucideIcon} from '@tryghost/shade/utils';
 import {dequal} from 'dequal';
 import {ADDRESS_PARTS, buildCustomFieldSavePayload, getCustomFieldValidationErrors, getEditableCustomFieldValues, parseCustomFieldServerErrors} from './member-detail-edit';
-import {formatAddressValue} from './member-detail-format';
 import {toast} from 'sonner';
-import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {formatMemberCustomFieldValue, useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {useEditMember} from '@tryghost/admin-x-framework/api/members';
 import type {EditableAddressValue, EditableCustomFieldValue} from './member-detail-edit';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
@@ -230,17 +229,6 @@ const MemberCustomFieldEditModal: React.FC<{
     );
 };
 
-/** One readable line per value; address collapses to a formatted string. */
-function formatValue(value: EditableCustomFieldValue | undefined): string | null {
-    if (value === undefined) {
-        return null;
-    }
-    if (typeof value === 'string') {
-        return value;
-    }
-    return formatAddressValue(value) || null;
-}
-
 /**
  * The Custom fields section of the member detail screen: a read-only list of
  * the member's values, one row per field defined in Settings. This screen is
@@ -270,7 +258,8 @@ const MemberCustomFieldsField: React.FC<MemberCustomFieldsFieldProps> = ({member
                 <CardContent className='px-6 py-4'>
                     <ul>
                         {fields.map((field) => {
-                            const display = formatValue(values[field.key]);
+                            // Null rather than an empty line, so an unset value shows its placeholder.
+                            const display = formatMemberCustomFieldValue(field.type, values[field.key]) || null;
                             return (
                                 // Dividers fade around the hovered row (its own border-b, and the
                                 // previous row's via :has), so the hover tint floats free of the

--- a/apps/admin/src/members/detail/member-detail-format.test.ts
+++ b/apps/admin/src/members/detail/member-detail-format.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {formatAddressValue, formatMemberLocation, getMemberReferrerSource, parseMemberGeolocation} from './member-detail-format';
+import {formatMemberLocation, getMemberReferrerSource, parseMemberGeolocation} from './member-detail-format';
 
 describe('parseMemberGeolocation', () => {
     it('returns null for missing input', () => {
@@ -79,22 +79,5 @@ describe('getMemberReferrerSource', () => {
     it('hides the "Created manually" placeholder source', () => {
         // Mirrors the Ember gh-member-details referrerSource getter.
         expect(getMemberReferrerSource({referrer_source: 'Created manually'})).toBeNull();
-    });
-});
-
-describe('formatAddressValue', () => {
-    it('formats a full address as one readable line', () => {
-        expect(formatAddressValue({line1: '1 Main St', line2: '12 apt B', city: 'New York', state: 'NY', postal_code: '00001', country: 'US'}))
-            .toBe('1 Main St, 12 apt B, New York, NY 00001, US');
-    });
-
-    it('pairs state and postal code, and drops missing sub-fields cleanly', () => {
-        expect(formatAddressValue({line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}))
-            .toBe('1 Main St, Berlin, 10115, DE');
-        expect(formatAddressValue({city: 'Berlin'})).toBe('Berlin');
-    });
-
-    it('formats an empty address as an empty string', () => {
-        expect(formatAddressValue({})).toBe('');
     });
 });

--- a/apps/admin/src/members/detail/member-detail-format.ts
+++ b/apps/admin/src/members/detail/member-detail-format.ts
@@ -1,5 +1,3 @@
-import type {MemberCustomFieldAddress} from '@tryghost/admin-x-framework/api/member-custom-fields';
-
 export interface MemberGeolocation {
     country_code?: string;
     country?: string;
@@ -49,23 +47,6 @@ export function formatMemberLocation(rawGeolocation: string | null | undefined):
     }
 
     return geo.country || 'Unknown location';
-}
-
-/**
- * An address value as one readable line for the custom fields card:
- * "1 Main St, 12 apt B, New York, NY 00001, US". State and postal code pair
- * up the way people write them; whatever sub-fields are missing simply drop
- * out, so a partial address still reads naturally.
- *
- * The parts are named one by one rather than walked, because where each sits in the
- * sentence is a fact about how an address reads, not one the value schema can supply. A
- * part added upstream will not appear here until someone decides where it belongs.
- */
-export function formatAddressValue(address: Partial<MemberCustomFieldAddress>): string {
-    const statePostal = [address.state, address.postal_code].filter(Boolean).join(' ');
-    return [address.line1, address.line2, address.city, statePostal, address.country]
-        .filter(Boolean)
-        .join(', ');
 }
 
 /**

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -17,6 +17,11 @@ const RAGGED_CSV = 'email,name,note\nada@example.com\ngrace@example.com,Grace Ho
 
 // A Ghost export re-imported somewhere its field no longer exists: archived since, or a
 // different site. The header says what the column is even though nothing matches it.
+// Every browse of the field list, whether or not it carries a status filter: the members
+// screen behind this modal asks for archived fields too, and an exact-path fake would
+// leave that request unhandled.
+const customFieldsBrowsePath = new RegExp('^/members/custom_fields/(\\?|$)');
+
 const EXPORTED_CSV = 'email,custom_fields.nickname\nada@example.com,Countess\n';
 
 /**
@@ -27,7 +32,7 @@ const EXPORTED_CSV = 'email,custom_fields.nickname\nada@example.com,Countess\n';
 function fakeCustomFieldsWorld() {
     const fields: Array<Record<string, unknown>> = [];
     fakeMembers([member({name: 'Ada Lovelace'})]);
-    fakeAdminEndpoint('GET', '/members/custom_fields/', () => ({members_custom_fields: fields}));
+    fakeAdminEndpoint('GET', customFieldsBrowsePath, () => ({members_custom_fields: fields}));
     const uploadApi = fakeAdminEndpoint('POST', '/members/upload/', {
         meta: {stats: {imported: 1, invalid: []}, import_label: {name: 'Import', slug: 'import'}}
     });
@@ -465,7 +470,7 @@ describe('Import members custom fields', () => {
     // A query whose only job is to add targets to a list must not be able to stop the import.
     it('imports with membership fields when custom fields cannot be loaded', async () => {
         fakeMembers([member({name: 'Ada Lovelace'})]);
-        fakeAdminEndpoint('GET', '/members/custom_fields/', {errors: [{message: 'nope'}]}, {status: 500});
+        fakeAdminEndpoint('GET', customFieldsBrowsePath, {errors: [{message: 'nope'}]}, {status: 500});
         const uploadApi = fakeAdminEndpoint('POST', '/members/upload/', {
             meta: {stats: {imported: 1, invalid: []}, import_label: {name: 'Import', slug: 'import'}}
         });

--- a/apps/admin/src/members/import-members-gate.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-gate.acceptance.test.tsx
@@ -17,7 +17,7 @@ const CSV = 'email,name\nada@example.com,Ada Lovelace\n';
  */
 async function openMappingStep(labs: Record<string, boolean>) {
     fakeMembers([member({name: 'Ada Lovelace'})]);
-    fakeAdminEndpoint('GET', '/members/custom_fields/', {members_custom_fields: []});
+    fakeAdminEndpoint('GET', new RegExp('^/members/custom_fields/(\\?|$)'), {members_custom_fields: []});
     await renderAdminApp('/members', {labs});
 
     await membersScreen.openActionsMenu();

--- a/apps/admin/src/members/member-fields.test.ts
+++ b/apps/admin/src/members/member-fields.test.ts
@@ -43,7 +43,7 @@ describe('memberFields', () => {
             'newsletter_feedback',
             'offer_redemptions',
             'count.active_stripe_customers',
-            'custom_field.:key'
+            'custom_fields.:key'
         ]);
     });
 
@@ -91,25 +91,25 @@ describe('memberFields', () => {
         expect(memberFields.label.metadata).toEqual({
             activeColumn: {
                 key: 'labels',
-                label: 'Labels',
-                include: 'labels'
-            }
+                label: 'Labels'
+            },
+            columnInclude: 'labels'
         });
 
         expect(memberFields.tier_id.metadata).toEqual({
             activeColumn: {
                 key: 'tiers',
-                label: 'Tiers',
-                include: 'tiers'
-            }
+                label: 'Tiers'
+            },
+            columnInclude: 'tiers'
         });
 
         expect(memberFields['subscriptions.current_period_end'].metadata).toEqual({
             activeColumn: {
                 key: 'subscriptions.current_period_end',
-                label: 'Next billing date',
-                include: 'subscriptions'
-            }
+                label: 'Next billing date'
+            },
+            columnInclude: 'subscriptions'
         });
     });
 

--- a/apps/admin/src/members/member-fields.ts
+++ b/apps/admin/src/members/member-fields.ts
@@ -149,8 +149,8 @@ export const CUSTOM_FIELD_OPERATORS: readonly string[] = [
 ];
 
 /**
- * The namespace custom fields are addressed under, so one field reads the same wherever
- * it is named.
+ * The namespace custom fields are addressed under, in filter field keys and list column
+ * keys alike, so one field reads the same wherever it is named.
  *
  * Named rather than spelled out at each use because the namespace describes a bag of
  * fields, and there is one bag today. An extension bringing its own bag would bring its
@@ -547,6 +547,20 @@ const baseMemberFields = defineFields({
             label: 'Custom field',
             type: 'custom',
             component: 'custom-field'
+        },
+        metadata: {
+            // One column per field filtered on, named after the field itself. A value a
+            // publisher collected varies member to member, which is what earns a column;
+            // it is shown whatever the operator, the way Label is. No name resolved means
+            // no such field for this site (or the flag is off), so no column either.
+            activeColumn: ({params, label}) => (label
+                ? {key: `${CUSTOM_FIELDS_PREFIX}${params.key}`, label}
+                : null),
+            // Asked for as soon as a custom field is filtered on, without waiting for the
+            // names: the values are what the column will hold, and they travel on the same
+            // request the filter already sends. The API takes this include whether or not
+            // the flag is on, and returns values only when it is.
+            columnInclude: 'custom_fields'
         },
         codec: customFieldsCodec
     }

--- a/apps/admin/src/members/member-fields.ts
+++ b/apps/admin/src/members/member-fields.ts
@@ -148,6 +148,16 @@ export const CUSTOM_FIELD_OPERATORS: readonly string[] = [
     ...CUSTOM_FIELD_SET_OPERATORS
 ];
 
+/**
+ * The namespace custom fields are addressed under, so one field reads the same wherever
+ * it is named.
+ *
+ * Named rather than spelled out at each use because the namespace describes a bag of
+ * fields, and there is one bag today. An extension bringing its own bag would bring its
+ * own namespace, which is a change to what this resolves to rather than to its callers.
+ */
+export const CUSTOM_FIELDS_PREFIX = 'custom_fields.';
+
 // NQL operator symbol for each value operator. The field is named in the value
 // position (`custom_fields.key:'…'`) so its key can carry hyphens; the value is
 // matched on `custom_fields.value` (scalar) or `custom_fields.value.<subfield>`
@@ -168,7 +178,7 @@ const customFieldsCodec: FilterCodec = {
     parse() {
         return null;
     },
-    // The field's stable key comes from the dropdown entry (`custom_field.<key>`,
+    // The field's stable key comes from the dropdown entry (`custom_fields.<key>`,
     // resolved into `ctx.params.key`); the predicate carries only [subfield, value],
     // with subfield '' for a scalar field or the "Any" (whole-field set/unset) case.
     serialize(predicate, ctx) {
@@ -242,9 +252,9 @@ const baseMemberFields = defineFields({
         metadata: {
             activeColumn: {
                 key: 'labels',
-                label: 'Labels',
-                include: 'labels'
-            }
+                label: 'Labels'
+            },
+            columnInclude: 'labels'
         },
         codec: setCodec()
     },
@@ -317,9 +327,9 @@ const baseMemberFields = defineFields({
         metadata: {
             activeColumn: {
                 key: 'tiers',
-                label: 'Tiers',
-                include: 'tiers'
-            }
+                label: 'Tiers'
+            },
+            columnInclude: 'tiers'
         },
         codec: setCodec()
     },
@@ -351,9 +361,9 @@ const baseMemberFields = defineFields({
         metadata: {
             activeColumn: {
                 key: 'subscriptions.plan_interval',
-                label: 'Billing period',
-                include: 'subscriptions'
-            }
+                label: 'Billing period'
+            },
+            columnInclude: 'subscriptions'
         },
         codec: scalarCodec()
     },
@@ -368,9 +378,9 @@ const baseMemberFields = defineFields({
         metadata: {
             activeColumn: {
                 key: 'subscriptions.status',
-                label: 'Subscription status',
-                include: 'subscriptions'
-            }
+                label: 'Subscription status'
+            },
+            columnInclude: 'subscriptions'
         },
         codec: scalarCodec()
     },
@@ -384,9 +394,9 @@ const baseMemberFields = defineFields({
         metadata: {
             activeColumn: {
                 key: 'subscriptions.start_date',
-                label: 'Paid start date',
-                include: 'subscriptions'
-            }
+                label: 'Paid start date'
+            },
+            columnInclude: 'subscriptions'
         },
         codec: dateCodec()
     },
@@ -400,9 +410,9 @@ const baseMemberFields = defineFields({
         metadata: {
             activeColumn: {
                 key: 'subscriptions.current_period_end',
-                label: 'Next billing date',
-                include: 'subscriptions'
-            }
+                label: 'Next billing date'
+            },
+            columnInclude: 'subscriptions'
         },
         codec: dateCodec()
     },
@@ -529,9 +539,9 @@ const baseMemberFields = defineFields({
         codec: multipleActiveSubscriptionsCodec
     },
     // Each defined custom field is its own filter, named directly in the dropdown
-    // (`custom_field.<key>`), so this template supplies the shared operators and codec;
+    // (`custom_fields.<key>`), so this template supplies the shared operators and codec;
     // use-member-filter-fields builds one entry per field from the definitions.
-    'custom_field.:key': {
+    'custom_fields.:key': {
         operators: CUSTOM_FIELD_OPERATORS,
         ui: {
             label: 'Custom field',

--- a/apps/admin/src/members/member-filter-query.test.ts
+++ b/apps/admin/src/members/member-filter-query.test.ts
@@ -337,24 +337,24 @@ describe('isPredicateEnabled', () => {
 describe('member-filter-query - custom fields', () => {
     // Serialize each operator to NQL, then parse it back, and confirm the predicate
     // survives the round trip a saved segment relies on. Each field is its own
-    // predicate keyed `custom_field.<key>`; `values` is [subfield, value].
+    // predicate keyed `custom_fields.<key>`; `values` is [subfield, value].
     const cases: Array<{field: string; operator: string; values: [string, string]; nql: string}> = [
-        {field: 'custom_field.company', operator: 'is', values: ['', 'Ghost'], nql: "(custom_fields.key:'company'+custom_fields.value:'Ghost')"},
-        {field: 'custom_field.company', operator: 'is-not', values: ['', 'Ghost'], nql: "(custom_fields.key:'company'+custom_fields.value:-'Ghost')"},
-        {field: 'custom_field.company', operator: 'contains', values: ['', 'host'], nql: "(custom_fields.key:'company'+custom_fields.value:~'host')"},
-        {field: 'custom_field.company', operator: 'does-not-contain', values: ['', 'host'], nql: "(custom_fields.key:'company'+custom_fields.value:-~'host')"},
-        {field: 'custom_field.company', operator: 'starts-with', values: ['', 'Gh'], nql: "(custom_fields.key:'company'+custom_fields.value:~^'Gh')"},
-        {field: 'custom_field.company', operator: 'ends-with', values: ['', 'st'], nql: "(custom_fields.key:'company'+custom_fields.value:~$'st')"},
+        {field: 'custom_fields.company', operator: 'is', values: ['', 'Ghost'], nql: "(custom_fields.key:'company'+custom_fields.value:'Ghost')"},
+        {field: 'custom_fields.company', operator: 'is-not', values: ['', 'Ghost'], nql: "(custom_fields.key:'company'+custom_fields.value:-'Ghost')"},
+        {field: 'custom_fields.company', operator: 'contains', values: ['', 'host'], nql: "(custom_fields.key:'company'+custom_fields.value:~'host')"},
+        {field: 'custom_fields.company', operator: 'does-not-contain', values: ['', 'host'], nql: "(custom_fields.key:'company'+custom_fields.value:-~'host')"},
+        {field: 'custom_fields.company', operator: 'starts-with', values: ['', 'Gh'], nql: "(custom_fields.key:'company'+custom_fields.value:~^'Gh')"},
+        {field: 'custom_fields.company', operator: 'ends-with', values: ['', 'st'], nql: "(custom_fields.key:'company'+custom_fields.value:~$'st')"},
         // A value that ends with a literal `$` must survive as contains, not be
         // misread as ends-with when the regex source (`5\$`) is parsed back.
-        {field: 'custom_field.company', operator: 'contains', values: ['', '5$'], nql: "(custom_fields.key:'company'+custom_fields.value:~'5$')"},
-        {field: 'custom_field.shipping-address', operator: 'is', values: ['country', 'GB'], nql: "(custom_fields.key:'shipping-address'+custom_fields.value.country:'GB')"},
-        {field: 'custom_field.shipping-address', operator: 'is-not', values: ['country', 'GB'], nql: "(custom_fields.key:'shipping-address'+custom_fields.value.country:-'GB')"},
-        {field: 'custom_field.phone', operator: 'is-set', values: ['', ''], nql: "custom_fields.key:'phone'"},
-        {field: 'custom_field.phone', operator: 'is-not-set', values: ['', ''], nql: "custom_fields.key:-'phone'"},
+        {field: 'custom_fields.company', operator: 'contains', values: ['', '5$'], nql: "(custom_fields.key:'company'+custom_fields.value:~'5$')"},
+        {field: 'custom_fields.shipping-address', operator: 'is', values: ['country', 'GB'], nql: "(custom_fields.key:'shipping-address'+custom_fields.value.country:'GB')"},
+        {field: 'custom_fields.shipping-address', operator: 'is-not', values: ['country', 'GB'], nql: "(custom_fields.key:'shipping-address'+custom_fields.value.country:-'GB')"},
+        {field: 'custom_fields.phone', operator: 'is-set', values: ['', ''], nql: "custom_fields.key:'phone'"},
+        {field: 'custom_fields.phone', operator: 'is-not-set', values: ['', ''], nql: "custom_fields.key:-'phone'"},
         // A part's set / not-set targets its presence via `path`, not the whole field.
-        {field: 'custom_field.shipping-address', operator: 'is-set', values: ['country', ''], nql: "(custom_fields.key:'shipping-address'+custom_fields.path:'country')"},
-        {field: 'custom_field.shipping-address', operator: 'is-not-set', values: ['country', ''], nql: "(custom_fields.key:'shipping-address'+custom_fields.path:-'country')"}
+        {field: 'custom_fields.shipping-address', operator: 'is-set', values: ['country', ''], nql: "(custom_fields.key:'shipping-address'+custom_fields.path:'country')"},
+        {field: 'custom_fields.shipping-address', operator: 'is-not-set', values: ['country', ''], nql: "(custom_fields.key:'shipping-address'+custom_fields.path:-'country')"}
     ];
 
     it.each(cases)('serializes $field $operator to the expected NQL', ({field, operator, values, nql}) => {

--- a/apps/admin/src/members/member-filter-query.ts
+++ b/apps/admin/src/members/member-filter-query.ts
@@ -247,7 +247,7 @@ function interpretCustomFieldValue(raw: unknown): {operator: string; value: stri
 
 // A custom-field filter is `(custom_fields.key:'<key>'+custom_fields.value[.sub]:<v>)`,
 // or the flat `custom_fields.key:'<key>'` / `:-'<key>'` for set / not set. Each field
-// is its own predicate keyed `custom_field.<key>`, so the field's stable key becomes
+// is its own predicate keyed `custom_fields.<key>`, so the field's stable key becomes
 // part of the predicate field and the remaining `values` are [subfield, value]
 // (subfield '' for a scalar field or the whole-field set/unset case). This can't ride
 // the generic parser because the key lives in the value of the key clause, not the key.
@@ -258,11 +258,11 @@ function matchCustomFieldNode(node: AstNode): ParsedPredicate | null {
         const keyValue = node['custom_fields.key'];
 
         if (typeof keyValue === 'string') {
-            return {field: `custom_field.${keyValue}`, operator: 'is-set', values: ['', '']};
+            return {field: `custom_fields.${keyValue}`, operator: 'is-set', values: ['', '']};
         }
 
         if (keyValue && typeof keyValue === 'object' && !Array.isArray(keyValue) && typeof (keyValue as Record<string, unknown>).$ne === 'string') {
-            return {field: `custom_field.${(keyValue as Record<string, string>).$ne}`, operator: 'is-not-set', values: ['', '']};
+            return {field: `custom_fields.${(keyValue as Record<string, string>).$ne}`, operator: 'is-not-set', values: ['', '']};
         }
 
         return null;
@@ -305,7 +305,7 @@ function matchCustomFieldNode(node: AstNode): ParsedPredicate | null {
     // A `path` clause is a part's set / not-set: its presence, carrying no value.
     if (pathEntry) {
         return {
-            field: `custom_field.${fieldKey}`,
+            field: `custom_fields.${fieldKey}`,
             operator: pathEntry.negated ? 'is-not-set' : 'is-set',
             values: [pathEntry.subfield, '']
         };
@@ -322,7 +322,7 @@ function matchCustomFieldNode(node: AstNode): ParsedPredicate | null {
     }
 
     return {
-        field: `custom_field.${fieldKey}`,
+        field: `custom_fields.${fieldKey}`,
         operator: interpreted.operator,
         values: [valueEntry.subfield, interpreted.value]
     };

--- a/apps/admin/src/members/member-query-params.test.ts
+++ b/apps/admin/src/members/member-query-params.test.ts
@@ -1,7 +1,6 @@
 import {
     buildMemberListSearchParams,
     buildMemberOperationParams,
-    getActiveColumnValue,
     getMemberActiveColumns
 } from './member-query-params';
 import {describe, expect, it} from 'vitest';
@@ -29,6 +28,16 @@ const member = (overrides: Partial<Member> = {}): Member => ({
     subscriptions: [],
     ...overrides
 } as Member);
+
+/**
+ * The column a filter on this field earns, read the way the list reads it: a column is only
+ * ever reached through the filter that raised it, so a test that hand-wrote one could pass
+ * against a column the app can no longer produce.
+ */
+const columnFor = (field: string) => {
+    const filters: FilterPredicate[] = [{id: '1', field, operator: 'is', values: ['x']}];
+    return getMemberActiveColumns(filters)[0];
+};
 
 describe('member-query-params', () => {
     it('keeps search separate while deriving includes from active field metadata', () => {
@@ -76,16 +85,14 @@ describe('member-query-params', () => {
             }
         ];
 
-        expect(getMemberActiveColumns(filters)).toEqual([
+        expect(getMemberActiveColumns(filters).map(({key, label}) => ({key, label}))).toEqual([
             {
                 key: 'labels',
-                label: 'Labels',
-                include: 'labels'
+                label: 'Labels'
             },
             {
                 key: 'subscriptions.current_period_end',
-                label: 'Next billing date',
-                include: 'subscriptions'
+                label: 'Next billing date'
             }
         ]);
     });
@@ -115,23 +122,23 @@ describe('member-query-params', () => {
     });
 });
 
-describe('getActiveColumnValue reads the resolved current_subscription', () => {
+describe('a subscription column reads the resolved current_subscription', () => {
     const activeMonthly = sub({id: 'a', status: 'active', plan: {id: 'p', nickname: 'M', interval: 'month', currency: 'usd', amount: 1000}});
     const cancelledYearly = sub({id: 'c', status: 'canceled', plan: {id: 'p', nickname: 'Y', interval: 'year', currency: 'usd', amount: 10000}});
 
     it('reads status and plan from current_subscription', () => {
         const m = member({current_subscription: activeMonthly, subscriptions: [activeMonthly, cancelledYearly]});
-        expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')?.text).toBe('Active');
-        expect(getActiveColumnValue({key: 'subscriptions.plan_interval', label: 'Plan'}, m, 'UTC')?.text).toBe('Monthly');
+        expect(columnFor('subscriptions.status').getValue(m, 'UTC')?.text).toBe('Active');
+        expect(columnFor('subscriptions.plan_interval').getValue(m, 'UTC')?.text).toBe('Monthly');
     });
 
     it('returns null when the member has no current subscription', () => {
         const m = member({current_subscription: null, subscriptions: [cancelledYearly]});
-        expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')).toBeNull();
+        expect(columnFor('subscriptions.status').getValue(m, 'UTC')).toBeNull();
     });
 
     it('returns null when the field is absent', () => {
         const m = member({subscriptions: [cancelledYearly]});
-        expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')).toBeNull();
+        expect(columnFor('subscriptions.status').getValue(m, 'UTC')).toBeNull();
     });
 });

--- a/apps/admin/src/members/member-query-params.test.ts
+++ b/apps/admin/src/members/member-query-params.test.ts
@@ -5,6 +5,7 @@ import {
 } from './member-query-params';
 import {describe, expect, it} from 'vitest';
 import type {FilterPredicate} from '@/shared/filters';
+import type {MemberActiveColumnOptions} from './member-query-params';
 import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
 
 const sub = (overrides: Partial<MemberSubscription> = {}): MemberSubscription => ({
@@ -34,9 +35,9 @@ const member = (overrides: Partial<Member> = {}): Member => ({
  * ever reached through the filter that raised it, so a test that hand-wrote one could pass
  * against a column the app can no longer produce.
  */
-const columnFor = (field: string) => {
+const columnFor = (field: string, options?: MemberActiveColumnOptions) => {
     const filters: FilterPredicate[] = [{id: '1', field, operator: 'is', values: ['x']}];
-    return getMemberActiveColumns(filters)[0];
+    return getMemberActiveColumns(filters, options)[0];
 };
 
 describe('member-query-params', () => {
@@ -140,5 +141,64 @@ describe('a subscription column reads the resolved current_subscription', () => 
     it('returns null when the field is absent', () => {
         const m = member({subscriptions: [cancelledYearly]});
         expect(columnFor('subscriptions.status').getValue(m, 'UTC')).toBeNull();
+    });
+});
+
+describe('custom field columns', () => {
+    const customFields = [
+        {key: 'job_title', name: 'Job title', type: 'short_text' as const},
+        {key: 'shipping_address', name: 'Shipping address', type: 'address' as const}
+    ];
+
+    const filterOn = (key: string): FilterPredicate[] => [
+        {id: '1', field: `custom_fields.${key}`, operator: 'contains', values: ['x']}
+    ];
+
+    it('names one column per field filtered on, from the field itself', () => {
+        expect(getMemberActiveColumns(filterOn('job_title'), {customFields}).map(({key, label}) => ({key, label})))
+            .toEqual([{key: 'custom_fields.job_title', label: 'Job title'}]);
+    });
+
+    // The template resolves to one shared definition for every custom field, so two
+    // filters must still produce two distinct columns rather than collapsing into one.
+    it('gives two filtered fields a column each', () => {
+        const filters = [...filterOn('job_title'), ...filterOn('shipping_address')];
+
+        expect(getMemberActiveColumns(filters, {customFields}).map(column => column.key))
+            .toEqual(['custom_fields.job_title', 'custom_fields.shipping_address']);
+    });
+
+    // No names supplied is what the flag being off looks like from here, and what the
+    // moment before the fetch lands looks like too.
+    it('adds no column when the field cannot be named', () => {
+        expect(getMemberActiveColumns(filterOn('job_title'))).toEqual([]);
+        expect(getMemberActiveColumns(filterOn('nonexistent'), {customFields})).toEqual([]);
+    });
+
+    // Naming the column waits on the fetch; asking for the values must not, or the list
+    // fetches once without them and again once the names land.
+    it('asks for values as soon as a custom field is filtered on, named or not', () => {
+        expect(buildMemberListSearchParams({filters: filterOn('job_title'), nql: 'x', search: ''})?.include)
+            .toBe('labels,tiers,custom_fields');
+    });
+
+    it('reads a scalar value by key', () => {
+        const m = member({custom_fields: {job_title: 'Editor'}});
+
+        expect(columnFor('custom_fields.job_title', {customFields}).getValue(m, 'UTC'))
+            .toEqual({text: 'Editor'});
+    });
+
+    it('reads a composite value as one line', () => {
+        const m = member({custom_fields: {shipping_address: {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}}});
+
+        expect(columnFor('custom_fields.shipping_address', {customFields}).getValue(m, 'UTC'))
+            .toEqual({text: '1 Main St, Berlin, 10115, DE'});
+    });
+
+    it('returns null when the member has no value', () => {
+        const m = member({custom_fields: {}});
+
+        expect(columnFor('custom_fields.job_title', {customFields}).getValue(m, 'UTC')).toBeNull();
     });
 });

--- a/apps/admin/src/members/member-query-params.ts
+++ b/apps/admin/src/members/member-query-params.ts
@@ -1,20 +1,29 @@
 import moment from 'moment-timezone';
-import {type FilterPredicate, resolveField} from '@/shared/filters';
+import {type ActiveColumn, type FilterPredicate, resolveField} from '@/shared/filters';
 import {memberFields} from './member-fields';
 import type {Member} from '@tryghost/admin-x-framework/api/members';
 
 const MAX_ACTIVE_COLUMNS = 2;
 
-export type ActiveColumn = {
-    key: string;
-    label: string;
-    include?: string;
-};
+export type {ActiveColumn};
 
 export type ColumnValue = {
     text: string;
     subtext?: string;
 };
+
+type ColumnValueReader = (member: Member, timezone: string) => ColumnValue | null;
+
+/**
+ * A column the member list appends, carrying how to read one member's value for it.
+ *
+ * The reader is attached where the column is built, which is where everything it needs is
+ * already in hand. A cell asks the column rather than working back from its key to the
+ * field behind it.
+ */
+export interface MemberActiveColumn extends ActiveColumn {
+    getValue: ColumnValueReader;
+}
 
 interface BuildMemberListSearchParamsOptions {
     filters: FilterPredicate[];
@@ -27,26 +36,43 @@ interface BuildMemberOperationParamsOptions {
     search: string;
 }
 
-export function getMemberActiveColumns(filters: FilterPredicate[]): ActiveColumn[] {
-    const columns = new Map<string, ActiveColumn>();
+export function getMemberActiveColumns(filters: FilterPredicate[]): MemberActiveColumn[] {
+    const columns = new Map<string, MemberActiveColumn>();
 
     for (const filter of filters) {
-        const activeColumn = resolveField(memberFields, filter.field, 'UTC')?.definition.metadata?.activeColumn;
+        const resolved = resolveField(memberFields, filter.field, 'UTC');
+        const activeColumn = resolved?.definition.metadata?.activeColumn;
 
-        if (activeColumn) {
-            columns.set(activeColumn.key, activeColumn);
+        if (!activeColumn) {
+            continue;
+        }
+
+        const getValue = fixedColumnValues[activeColumn.key];
+
+        if (getValue) {
+            columns.set(activeColumn.key, {...activeColumn, getValue});
         }
     }
 
     return Array.from(columns.values()).slice(0, MAX_ACTIVE_COLUMNS);
 }
 
+/**
+ * What the list asks the API for, given the filters applied.
+ *
+ * Read off the filtered fields themselves rather than off the columns they resolve to.
+ * Whether a value is needed follows from the filter, so it is known on the first render;
+ * whether a column can be named can wait on data still in flight, and a column can be
+ * dropped by the display budget while its values are still wanted.
+ */
 function getMemberIncludes(filters: FilterPredicate[]): string {
     const includes = new Set(['labels', 'tiers']);
 
-    for (const column of getMemberActiveColumns(filters)) {
-        if (column.include) {
-            includes.add(column.include);
+    for (const filter of filters) {
+        const columnInclude = resolveField(memberFields, filter.field, 'UTC')?.definition.metadata?.columnInclude;
+
+        if (columnInclude) {
+            includes.add(columnInclude);
         }
     }
 
@@ -96,31 +122,29 @@ function formatDateColumn(date: string | undefined, timezone: string): ColumnVal
     };
 }
 
-export function getActiveColumnValue(
-    column: ActiveColumn,
-    member: Member,
-    timezone: string
-): ColumnValue | null {
-    switch (column.key) {
-    case 'labels':
-        return member.labels?.length
-            ? {text: member.labels.map(l => l.name).join(', ')}
-            : null;
+/**
+ * How each fixed column reads a member, filed under the column its field declares. A field
+ * names a column and this names the same column's value, so the two are found the same way
+ * instead of one being declared and the other matched by hand.
+ */
+const fixedColumnValues: Record<string, ColumnValueReader | undefined> = {
+    labels: member => (member.labels?.length
+        ? {text: member.labels.map(l => l.name).join(', ')}
+        : null),
 
-    case 'tiers':
-        return member.tiers?.length
-            ? {text: member.tiers.map(t => t.name).join(', ')}
-            : null;
+    tiers: member => (member.tiers?.length
+        ? {text: member.tiers.map(t => t.name).join(', ')}
+        : null),
 
-    case 'subscriptions.plan_interval': {
+    'subscriptions.plan_interval': (member) => {
         const interval = member.current_subscription?.plan?.interval;
         if (!interval) {
             return null;
         }
         return {text: interval === 'month' ? 'Monthly' : 'Yearly'};
-    }
+    },
 
-    case 'subscriptions.status': {
+    'subscriptions.status': (member) => {
         const status = member.current_subscription?.status;
         if (!status) {
             return null;
@@ -131,21 +155,19 @@ export function getActiveColumnValue(
                 .map(part => part.charAt(0).toUpperCase() + part.slice(1))
                 .join(' ')
         };
-    }
+    },
 
-    case 'subscriptions.start_date':
-        return formatDateColumn(
-            member.current_subscription?.start_date,
-            timezone
-        );
+    'subscriptions.start_date': (member, timezone) => formatDateColumn(
+        member.current_subscription?.start_date,
+        timezone
+    ),
 
-    case 'subscriptions.current_period_end':
-        return formatDateColumn(
-            member.current_subscription?.current_period_end,
-            timezone
-        );
+    'subscriptions.current_period_end': (member, timezone) => formatDateColumn(
+        member.current_subscription?.current_period_end,
+        timezone
+    ),
 
-    case 'offer_redemptions': {
+    offer_redemptions: (member) => {
         const offers = member.subscriptions
             ?.map(s => s.offer?.name)
             .filter(Boolean);
@@ -153,8 +175,4 @@ export function getActiveColumnValue(
             ? {text: offers.join(', ')}
             : null;
     }
-
-    default:
-        return null;
-    }
-}
+};

--- a/apps/admin/src/members/member-query-params.ts
+++ b/apps/admin/src/members/member-query-params.ts
@@ -1,11 +1,25 @@
 import moment from 'moment-timezone';
 import {type ActiveColumn, type FilterPredicate, resolveField} from '@/shared/filters';
 import {memberFields} from './member-fields';
+import {formatMemberCustomFieldValue} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type {Member} from '@tryghost/admin-x-framework/api/members';
+import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 const MAX_ACTIVE_COLUMNS = 2;
 
 export type {ActiveColumn};
+
+/** All a column needs of a custom field: the name to head it with, and the type to read its value as. */
+export type MemberColumnCustomField = Pick<MemberCustomField, 'key' | 'name' | 'type'>;
+
+/**
+ * Runtime data the static field schema cannot hold. Custom fields are defined by the
+ * publisher, so their names arrive from the API; passing none (the default) simply leaves
+ * them out of the columns, which is also what the flag being off looks like.
+ */
+export interface MemberActiveColumnOptions {
+    customFields?: MemberColumnCustomField[];
+}
 
 export type ColumnValue = {
     text: string;
@@ -36,7 +50,10 @@ interface BuildMemberOperationParamsOptions {
     search: string;
 }
 
-export function getMemberActiveColumns(filters: FilterPredicate[]): MemberActiveColumn[] {
+export function getMemberActiveColumns(
+    filters: FilterPredicate[],
+    options: MemberActiveColumnOptions = {}
+): MemberActiveColumn[] {
     const columns = new Map<string, MemberActiveColumn>();
 
     for (const filter of filters) {
@@ -47,10 +64,30 @@ export function getMemberActiveColumns(filters: FilterPredicate[]): MemberActive
             continue;
         }
 
-        const getValue = fixedColumnValues[activeColumn.key];
+        const {context} = resolved;
 
-        if (getValue) {
-            columns.set(activeColumn.key, {...activeColumn, getValue});
+        // A field that declares a fixed column is read by the reader filed under it.
+        if (typeof activeColumn !== 'function') {
+            const getValue = fixedColumnValues[activeColumn.key];
+
+            if (getValue) {
+                columns.set(activeColumn.key, {...activeColumn, getValue});
+            }
+            continue;
+        }
+
+        // A pattern field stands for many columns, so it is hydrated from whatever runtime
+        // record names the key it matched, then resolves its own column from that name.
+        const hydrated = patternColumnHydrators[context.pattern]?.(context.params, options);
+
+        if (!hydrated) {
+            continue;
+        }
+
+        const column = activeColumn({...context, label: hydrated.label});
+
+        if (column) {
+            columns.set(column.key, {...column, getValue: hydrated.getValue});
         }
     }
 
@@ -174,5 +211,37 @@ const fixedColumnValues: Record<string, ColumnValueReader | undefined> = {
         return offers?.length
             ? {text: offers.join(', ')}
             : null;
+    }
+};
+
+/**
+ * How a pattern field's column is filled in, filed under the pattern it matches.
+ *
+ * A pattern field's columns are named by data that only exists at runtime, so each one
+ * says which record names it and how a member's value is read once a record is found.
+ * Returning null is how "nothing here answers to that key" is said, and it costs the
+ * column: unnamed is unshown. A second pattern field earning a column adds an entry here
+ * rather than a branch anywhere.
+ */
+const patternColumnHydrators: Record<
+    string,
+    ((params: Record<string, string>, options: MemberActiveColumnOptions) => {label: string; getValue: ColumnValueReader} | null) | undefined
+> = {
+    'custom_fields.:key': ({key}, {customFields}) => {
+        const field = customFields?.find(candidate => candidate.key === key);
+
+        if (!field) {
+            return null;
+        }
+
+        return {
+            label: field.name,
+            // The catalog turns whatever type the field is into one line, so this reads a
+            // composite the same way the member detail screen does.
+            getValue: (member) => {
+                const text = formatMemberCustomFieldValue(field.type, member.custom_fields?.[field.key]);
+                return text ? {text} : null;
+            }
+        };
     }
 };

--- a/apps/admin/src/members/members.tsx
+++ b/apps/admin/src/members/members.tsx
@@ -12,6 +12,7 @@ import {Box, Container} from '@tryghost/shade/primitives';
 import {ListPage} from '@tryghost/shade/page-templates';
 import {keepPreviousData} from '@tanstack/react-query';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+import {CUSTOM_FIELDS_PREFIX} from './member-fields';
 import {buildMemberListSearchParams, getMemberActiveColumns} from './member-query-params';
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
 import {checkStripeEnabled, getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -19,8 +20,10 @@ import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezo
 import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './hooks/use-members-filter-state';
 import {useActiveMemberView, useMemberViews} from './hooks/use-member-views';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useBrowseMemberCustomFieldsIncludingArchived} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
 import {useDebouncedCallback} from 'use-debounce';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 import {useLocation, useSearchParams} from 'react-router';
 import {useMultipleActiveSubscriptionsCount} from './hooks/use-multiple-active-subscriptions-count';
 
@@ -62,9 +65,26 @@ const MembersPage: React.FC<MembersPageProps> = ({
         hasResolvedCount: hasResolvedMultipleActiveSubscriptionsCount
     } = useMultipleActiveSubscriptionsCount({enabled: hasStripeEnabled});
 
+    // Names the custom field columns. Archived fields are included so a filter on one
+    // still shows its values, matching the read-only pill the filter bar renders for it.
+    //
+    // Only a filter on a custom field earns a column, and naming one is all these are for,
+    // so the fetch waits for a filter rather than riding every visit to the members list.
+    const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+    const hasCustomFieldFilter = useMemo(
+        () => filters.some(filter => filter.field.startsWith(CUSTOM_FIELDS_PREFIX)),
+        [filters]
+    );
+    const {data: customFieldsData} = useBrowseMemberCustomFieldsIncludingArchived({
+        enabled: customFieldsEnabled && hasCustomFieldFilter
+    });
+    // Left undefined until the fetch lands (and while the flag is off) rather than defaulted
+    // to an empty array, so the identity the memos below depend on stays stable.
+    const customFields = customFieldsData?.members_custom_fields;
+
     const activeColumns = useMemo(() => {
-        return getMemberActiveColumns(filters);
-    }, [filters]);
+        return getMemberActiveColumns(filters, {customFields});
+    }, [filters, customFields]);
 
     const canBulkDelete = useMemo(() => {
         return canBulkDeleteMembers(filters, nql);

--- a/apps/admin/src/members/use-member-filter-fields.test.ts
+++ b/apps/admin/src/members/use-member-filter-fields.test.ts
@@ -238,8 +238,8 @@ describe('useMemberFilterFields', () => {
         const customFields = result.current.find(group => group.group === 'Custom fields')?.fields ?? [];
 
         expect(customFields.map(field => ({key: field.key, label: field.label}))).toEqual([
-            {key: 'custom_field.shipping_address', label: 'Shipping address'},
-            {key: 'custom_field.job_title', label: 'Job title'}
+            {key: 'custom_fields.shipping_address', label: 'Shipping address'},
+            {key: 'custom_fields.job_title', label: 'Job title'}
         ]);
     });
 

--- a/apps/admin/src/members/use-member-filter-fields.ts
+++ b/apps/admin/src/members/use-member-filter-fields.ts
@@ -6,7 +6,7 @@ import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
 import {LabelFilterRenderer} from '@/members/label-picker';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD} from './multiple-active-subscriptions';
-import {getMemberFields} from './member-fields';
+import {CUSTOM_FIELDS_PREFIX, getMemberFields} from './member-fields';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type {Offer} from '@tryghost/admin-x-framework/api/offers';
 
@@ -285,8 +285,8 @@ export function useMemberFilterFields({
             let field;
             if (key.startsWith('newsletters.')) {
                 field = fields['newsletters.:slug'];
-            } else if (key.startsWith('custom_field.')) {
-                field = fields['custom_field.:key'];
+            } else if (key.startsWith(CUSTOM_FIELDS_PREFIX)) {
+                field = fields['custom_fields.:key'];
             } else {
                 field = fields[key as MemberFieldKey];
             }
@@ -371,7 +371,7 @@ export function useMemberFilterFields({
         // "Custom field" door. A simple field filters on its value; a composite field's
         // renderer opens its parts (plus "Any") in the pill.
         if (customFieldsEnabled) {
-            const customFieldFields = customFields.map(field => createFieldConfig(`custom_field.${field.key}`, {
+            const customFieldFields = customFields.map(field => createFieldConfig(`custom_fields.${field.key}`, {
                 label: field.name,
                 // The dropdown entry and the added filter show the field type's own icon
                 // rather than a generic custom-field mark.
@@ -389,7 +389,7 @@ export function useMemberFilterFields({
             // removable-only pill with an archive icon. Its key is already in the filter,
             // so the picker's own de-dup keeps it out of the add-list — it only ever
             // renders as an existing pill.
-            const archivedFieldFields = archivedCustomFields.map(field => createFieldConfig(`custom_field.${field.key}`, {
+            const archivedFieldFields = archivedCustomFields.map(field => createFieldConfig(`custom_fields.${field.key}`, {
                 label: field.name,
                 icon: React.createElement(LucideIcon.Archive, {className: 'size-4'}),
                 // Read-only: the operator and value stay visible so the segment reads

--- a/apps/admin/src/shared/filters/filter-types.ts
+++ b/apps/admin/src/shared/filters/filter-types.ts
@@ -19,6 +19,12 @@ export interface FilterCodec {
     serialize: (predicate: FilterPredicate, ctx: CodecContext) => string[] | null;
 }
 
+/** A column the list appends while a filter on this field is active. */
+export interface ActiveColumn {
+    key: string;
+    label: string;
+}
+
 export interface FilterField {
     operators: readonly string[];
     parseKeys?: readonly string[];
@@ -29,11 +35,16 @@ export interface FilterField {
     };
     options?: Array<{value: string; label: string}>;
     metadata?: {
-        activeColumn?: {
-            key: string;
-            label: string;
-            include?: string;
-        };
+        activeColumn?: ActiveColumn;
+        /**
+         * What the list must ask the API to return for this field's column to hold values.
+         *
+         * Declared apart from the column, because the two questions are answerable at
+         * different moments: whether to ask follows from the filter alone, while naming
+         * the column can wait on data that arrives later. Tying them together would make
+         * the list fetch once without the values and again once the names landed.
+         */
+        columnInclude?: string;
     };
     codec: FilterCodec;
 }

--- a/apps/admin/src/shared/filters/filter-types.ts
+++ b/apps/admin/src/shared/filters/filter-types.ts
@@ -25,6 +25,15 @@ export interface ActiveColumn {
     label: string;
 }
 
+export interface ActiveColumnContext extends CodecContext {
+    /**
+     * The display name the domain resolved for this key, where the schema cannot hold one:
+     * a publisher-defined field is named at runtime. Absent when the caller supplied no
+     * names, or has none for this key — a resolver returns null rather than guess.
+     */
+    label?: string;
+}
+
 export interface FilterField {
     operators: readonly string[];
     parseKeys?: readonly string[];
@@ -35,7 +44,12 @@ export interface FilterField {
     };
     options?: Array<{value: string; label: string}>;
     metadata?: {
-        activeColumn?: ActiveColumn;
+        /**
+         * A field whose key is a pattern stands for many columns, one per key it matches,
+         * so it resolves its column per instance from the matched params instead of
+         * declaring a fixed one.
+         */
+        activeColumn?: ActiveColumn | ((context: ActiveColumnContext) => ActiveColumn | null);
         /**
          * What the list must ask the API to return for this field's column to hold values.
          *

--- a/e2e/helpers/pages/admin/members/member-details-page.ts
+++ b/e2e/helpers/pages/admin/members/member-details-page.ts
@@ -141,6 +141,35 @@ export class MemberDetailsPage extends AdminPage {
     }
 
     /**
+     * Fill a composite field's parts, keyed by the label each part carries in the editor.
+     * A composite's inputs are labelled per part rather than by the field's own name, so
+     * they cannot be reached the way a scalar's single input is.
+     */
+    async setCompositeCustomFieldValue(fieldName: string, parts: Record<string, string>): Promise<void> {
+        await this.customFieldEditButton(fieldName).click();
+
+        for (const [partLabel, value] of Object.entries(parts)) {
+            await this.customFieldModal.getByLabel(partLabel, {exact: true}).fill(value);
+        }
+
+        await this.customFieldModal.getByRole('button', {name: 'Save', exact: true}).click();
+        await this.customFieldModal.waitFor({state: 'detached'});
+    }
+
+    /**
+     * The custom fields card's row for one field, named for the value it is showing.
+     * The row carries its rendered value in its accessible name, which is the only place
+     * the detail screen's rendering of a value can be read as one string.
+     */
+    customFieldRow(fieldName: string): Locator {
+        // A publisher names their own fields, so the name can hold regex metacharacters:
+        // "Address (home)" would match something other than itself, and "C++" would not
+        // compile at all.
+        const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return this.page.getByRole('button', {name: new RegExp(`^Edit ${escaped}: `)});
+    }
+
+    /**
      * Removes a complimentary subscription from the first subscription row.
      * Removal always asks for confirmation first.
      */

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -98,6 +98,25 @@ export class MembersListPage extends AdminPage {
         await this.page.keyboard.press('Escape');
     }
 
+    /**
+     * A column the list appends for the filter applied to it, taken from the accessible
+     * table rather than the painted one.
+     *
+     * At desktop widths the header a reader sees is a sticky duplicate marked
+     * `aria-hidden`, and the header carrying the real column semantics is the in-flow one,
+     * collapsed to zero height so the two do not stack. So this locator resolves to a
+     * header that is present and never visible, and asserting on it means asserting the
+     * column exists. What the column is *showing* is asserted on the member's row.
+     */
+    getColumnHeader(label: string): Locator {
+        return this.page.getByRole('columnheader', {name: label, exact: true});
+    }
+
+    /** The cell of one member's row holding the given text, whichever column it sits in. */
+    getMemberCellWithText(name: string, text: string): Locator {
+        return this.getMemberByName(name).getByRole('cell').filter({hasText: text});
+    }
+
     async getVisibleMemberCount(): Promise<number> {
         return await this.memberRows.count();
     }

--- a/e2e/helpers/pages/admin/settings/sections/custom-fields-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/custom-fields-section.ts
@@ -35,4 +35,18 @@ export class CustomFieldsSection extends BasePage {
         await this.modal.getByRole('button', {name: 'Save'}).click();
         await this.listItem(name).waitFor();
     }
+
+    /**
+     * Create a composite field, whose value is several parts rather than one string.
+     * The type can only be chosen at creation — the picker is disabled thereafter.
+     */
+    async createAddressField(name: string): Promise<void> {
+        await this.addButton.waitFor();
+        await this.addButton.click();
+        await this.modal.getByLabel('Name').fill(name);
+        await this.modal.getByLabel('Type').click();
+        await this.page.getByRole('option', {name: 'Address'}).click();
+        await this.modal.getByRole('button', {name: 'Save'}).click();
+        await this.listItem(name).waitFor();
+    }
 }

--- a/e2e/tests/admin/members/custom-field-filter-column.test.ts
+++ b/e2e/tests/admin/members/custom-field-filter-column.test.ts
@@ -1,0 +1,100 @@
+import {MemberDetailsPage, MembersListPage, SettingsPage} from '@/admin-pages';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * Filtering the members list by a custom field earns a column showing what each matched
+ * member holds for it. A filter says who matched; the column is what they said.
+ *
+ * Driven end to end because the column only appears if every layer agrees: the field is
+ * defined in Settings, the filter asks the API to return its values, and the list reads
+ * them back under the name the publisher gave the field. A unit test can pin the column
+ * derivation but cannot prove the values ever arrive.
+ *
+ * React member detail (the value editor is React-only) plus the membersCustomFields flag
+ * that gates the whole feature.
+ */
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Custom field filter columns', () => {
+    test.use({labs: {membersCustomFields: true, memberDetailsReact: true}});
+
+    test('a filtered custom field earns a column showing each member\'s value', async ({page}) => {
+        test.slow();
+
+        const stamp = Date.now();
+        const fieldName = `Company ${stamp}`;
+        const memberFactory = createMemberFactory(page.request);
+
+        const memberName = `Ghost Employee ${stamp}`;
+        // Shares nothing with the member's name or email, so the assertion below can only
+        // be satisfied by the column and not by text the row already had.
+        const value = `Wraith Industries ${stamp}`;
+
+        const member = await memberFactory.create({name: memberName, email: `ghost-${stamp}@example.com`});
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+        const membersPage = new MembersListPage(page);
+
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createShortTextField(fieldName);
+
+        await page.goto(`/ghost/#/members/${member.id}`);
+        await memberDetailsPage.setCustomFieldValue(fieldName, value);
+
+        // Unfiltered, the field has earned nothing: a column is the filter's doing.
+        await page.goto('/ghost/#/members');
+        await expect(membersPage.getMemberByName(memberName)).toBeVisible();
+        await expect(membersPage.getColumnHeader(fieldName)).toHaveCount(0);
+
+        await membersPage.addCustomFieldFilter({field: fieldName, value});
+
+        await expect(membersPage.getColumnHeader(fieldName)).toHaveCount(1);
+        await expect(membersPage.getMemberCellWithText(memberName, value)).toBeVisible();
+    });
+
+    test('a composite field reads as the same one line in the column and on the member', async ({page}) => {
+        test.slow();
+
+        const stamp = Date.now();
+        const fieldName = `Shipping ${stamp}`;
+        const memberName = `Shipped To ${stamp}`;
+        // State and postal code pair up, and the unfilled line 2 drops out rather than
+        // leaving a gap, which is what makes this one line rather than a join of parts.
+        const expectedLine = '1 Main St, Berlin, BE 10115, DE';
+        const memberFactory = createMemberFactory(page.request);
+
+        const member = await memberFactory.create({name: memberName, email: `shipped-${stamp}@example.com`});
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+        const membersPage = new MembersListPage(page);
+
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createAddressField(fieldName);
+
+        await page.goto(`/ghost/#/members/${member.id}`);
+        await memberDetailsPage.setCompositeCustomFieldValue(fieldName, {
+            'Address line 1': '1 Main St',
+            City: 'Berlin',
+            State: 'BE',
+            'Postal code': '10115',
+            Country: 'DE'
+        });
+
+        // The detail screen's rendering, read from the row's accessible name.
+        await expect(memberDetailsPage.customFieldRow(fieldName))
+            .toHaveAccessibleName(`Edit ${fieldName}: ${expectedLine}`);
+
+        await page.goto('/ghost/#/members');
+        // Choosing a part leaves the operator on "is set", which takes no value, so the
+        // operator has to be named before there is anywhere to type one.
+        await membersPage.addCustomFieldFilter({field: fieldName, subfield: 'City', operator: 'is', value: 'Berlin'});
+
+        // The same line, from the same formatter, in the column the filter earned.
+        await expect(membersPage.getColumnHeader(fieldName)).toHaveCount(1);
+        await expect(membersPage.getMemberCellWithText(memberName, expectedLine)).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Describe the problem you are solving

A filter tells a publisher who matched, not what they said. Filtering the members list by a custom field and then opening members one at a time to read the value undoes most of the point of having filtered.

The members list already appends a column for the filter you applied, for labels, tiers and the four subscription filters. Custom fields are the case where it matters most, since a field exists precisely because its value differs member to member, and they were the one filter that produced no column. This PR extends the existing mechanism to cover them.

## Changelog for devs

Two commits: a prefactor of the column layer with no behaviour change, then the feature on top of it.

**Changed member list columns to carry their own value reader** (prefactor)

* Changed a column from a name a cell works back from into a column that knows how to read a member: `getActiveColumnValue`'s switch on `column.key` is now a `fixedColumnValues` record keyed by the same column key the field declares, and a cell asks `column.getValue(member, timezone)`
* Split `columnInclude` out of `activeColumn` in field metadata, so what the list asks the API for is read off the filtered fields rather than off the columns they resolve to. The two questions are answerable at different moments
* Unified the custom fields namespace on `custom_fields.`, named once as `CUSTOM_FIELDS_PREFIX`, replacing the singular `custom_field.` filter keys and the four places that spelled the prefix out for themselves

**Added a members list column for each custom field filtered on** (feature)

* Added a members list column per custom field filtered on, resolved from the filter's own field rather than a hardcoded case
* Changed `metadata.activeColumn` so a field whose key is a pattern (`custom_fields.:key`) can resolve one column per key it matches, hydrated through `patternColumnHydrators` — keyed by pattern, so a second pattern field adds an entry rather than a branch
* Moved `formatAddressValue` out of the member detail screen into the framework's user-type catalog as `formatMemberCustomFieldValue(type, value)`, next to the part labels and CSV column names it already owns; member detail renders through it, so the two cannot drift
* Made that catalog total over the field types, the way `fieldTypePresentation` above it is, so a new composite type fails the build until someone decides how its value reads rather than rendering blank on every surface
* Added `include=custom_fields` whenever a custom field is filtered on, without waiting for the field names to load
* Gated the field-name fetch on a custom field filter actually being applied, so an ordinary visit to the members list does not request it
* Added a native `title` to dynamic column cells so a truncated value can be read in full
* Added e2e coverage: a filtered field earns a column showing its value, and a composite reads as the same one line in the column and on the member detail screen

## Changelog for customers

Nothing yet. Everything here sits behind the `membersCustomFields` flag, which is not on for any site.

When the flag ships, this is part of "filter and segment members by custom fields":

* Added a column to the members list showing the values you filtered on, so you can read your collected data without opening each member

## Notes

* **Rebased.** This previously targeted `feat/ber-3792-...`. That branch merged as #29640, so this is now rebased onto `main` and the diff is just these two commits.

* **Flag-off behaviour is unchanged, with one deliberate exception.** The field-name fetch is gated by `useFeatureFlag('membersCustomFields')` and by a custom field filter being applied, and the column resolver returns `null` when no field name resolves.

  The exception: the native `title` is on `MembersListItemDynamicColumn`, which renders every dynamic column, so a Labels or Tiers column now shows a hover tooltip with the flag off. Additive and agreed deliberately, but calling it out since it is the one thing here that crosses the flag.

* **Why the include does not wait for the names.** Whether a value is needed follows from the filter alone and is known on the first render; whether a column can be named waits on a fetch. Tying them together made the list fetch once without the values and again once the names landed.

* **Why `title` and not a tooltip component.** The list is virtualised over up to 1000 members with up to two dynamic columns. A Radix tooltip per cell would mount and unmount on every scroll. `title` costs nothing per row. It is a fallback for an edge case, not a designed affordance, and can be upgraded if design wants it.

* **Composite values.** An address renders as one line through the shared formatter, joined the way that type reads, with missing parts dropping out. It is written per type rather than walked from the schema, because where a part sits in the sentence (state and postal code pairing up) is not something the value schema can supply.

* **Test configs.** `pnpm exec vitest run src/members` does not run acceptance tests, and neither does the build. They need `-c vitest.acceptance.config.ts`. Verified green on both commits: 1570 unit, 486 acceptance, 505 framework, plus the e2e above.

## Technical debt

* **Only two columns show.** `MAX_ACTIVE_COLUMNS = 2` is pre-existing, from when the feature was built for labels and tiers, and a third column is dropped with no indication in the UI. Custom fields make that limit much easier to reach. Not addressed here.

* **Composite values truncate.** Every dynamic column gets the same fixed width (`member-table-layout.ts`), and a full address rarely fits. `getMemberTableLayout` takes only a column count, not column identities, so giving composite columns more room means changing how the table budgets width across all its columns. Left alone; `title` covers reading the value.

* **A judgement call, not a decision.** A filter on an archived field keeps its column, matching the read-only pill the filter bar already shows for it. Easy to reverse if design disagrees.

* **Two fetches of the field list on one screen.** The page fetches the fields to name its columns and the filter bar fetches them for its dropdown. React Query collapses the identical ones, but the page owning a single fetch and passing it down would be tidier.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [x] Enhances the readability of our code
- [x] Simplifies the maintenance of our software
- [ ] Fixes a bug
- [x] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
