### PR TITLE
Upload content CSVs to new endpoint from universal importer modal

### DIFF
--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -80,6 +80,17 @@ export const useDeletePost = createMutation<unknown, string>({
     path: id => `/posts/${id}/`
 });
 
+export const useImportContentCSV = createMutation<unknown, File>({
+    method: 'POST',
+    retry: false,
+    path: () => '/posts/upload/',
+    body: (file) => {
+        const formData = new FormData();
+        formData.append('postsfile', file);
+        return formData;
+    }
+});
+
 // Search index endpoints for efficient search
 export const useSearchIndexPosts = createQuery<PostsResponseType>({
     dataType,

--- a/apps/admin-x-framework/test/unit/api/db.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/db.test.tsx
@@ -1,0 +1,40 @@
+import {act} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+import {renderHookWithProviders} from '../../../src/test/test-utils';
+import {useImportContent} from '../../../src/api/db';
+import {withMockFetch} from '../../utils/mock-fetch';
+
+describe('db api', () => {
+    it('imports JSON content via the db endpoint', async () => {
+        const file = new File(['{}'], 'export.json', {type: 'application/json'});
+
+        await withMockFetch({}, async (mock) => {
+            const {result} = renderHookWithProviders(() => useImportContent());
+
+            await act(async () => {
+                await result.current.mutateAsync(file);
+            });
+
+            expect(mock.calls[0][0]).toBe('http://localhost:3000/ghost/api/admin/db/');
+            expect(mock.calls[0][1].method).toBe('POST');
+            expect(mock.calls[0][1].body).toBeInstanceOf(FormData);
+            expect(mock.calls[0][1].body.get('importfile')).toBe(file);
+            expect(mock.calls[0][1].headers).not.toHaveProperty('content-type');
+        });
+    });
+
+    it('imports zip content via the db endpoint', async () => {
+        const file = new File(['PK'], 'export.zip', {type: 'application/zip'});
+
+        await withMockFetch({}, async (mock) => {
+            const {result} = renderHookWithProviders(() => useImportContent());
+
+            await act(async () => {
+                await result.current.mutateAsync(file);
+            });
+
+            expect(mock.calls[0][0]).toBe('http://localhost:3000/ghost/api/admin/db/');
+            expect(mock.calls[0][1].body.get('importfile')).toBe(file);
+        });
+    });
+});

--- a/apps/admin-x-framework/test/unit/api/posts.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/posts.test.tsx
@@ -1,0 +1,48 @@
+import {act} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {createTestQueryClient, renderHookWithProviders} from '../../../src/test/test-utils';
+import {useImportContentCSV} from '../../../src/api/posts';
+import {withMockFetch} from '../../utils/mock-fetch';
+
+describe('posts api', () => {
+    it('imports CSV content via the posts upload endpoint', async () => {
+        const file = new File(['title\nHello'], 'posts.csv', {type: 'text/csv'});
+
+        await withMockFetch({}, async (mock) => {
+            const {result} = renderHookWithProviders(() => useImportContentCSV());
+
+            await act(async () => {
+                await result.current.mutateAsync(file);
+            });
+
+            expect(mock.calls[0][0]).toBe('http://localhost:3000/ghost/api/admin/posts/upload/');
+            expect(mock.calls[0][1].method).toBe('POST');
+            expect(mock.calls[0][1].body).toBeInstanceOf(FormData);
+            expect(mock.calls[0][1].body.get('postsfile')).toBe(file);
+            expect(mock.calls[0][1].headers).not.toHaveProperty('content-type');
+        });
+    });
+
+    it('does not retry content CSV import uploads after transient network failures', async () => {
+        const queryClient = createTestQueryClient();
+        const file = new File(['title\nHello'], 'posts.csv', {type: 'text/csv'});
+        const originalFetch = globalThis.fetch;
+        const mockFetch = vi.fn<typeof globalThis.fetch>(() => Promise.reject(new TypeError('Network failed')));
+
+        vi.useFakeTimers();
+        globalThis.fetch = mockFetch as typeof globalThis.fetch;
+
+        try {
+            const {result} = renderHookWithProviders(() => useImportContentCSV(), {queryClient});
+            const importPromise = result.current.mutateAsync(file).catch(error => error);
+
+            await vi.advanceTimersByTimeAsync(600);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            await expect(importPromise).resolves.toBeInstanceOf(Error);
+        } finally {
+            globalThis.fetch = originalFetch;
+            vi.useRealTimers();
+        }
+    });
+});

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.test.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.test.tsx
@@ -1,0 +1,141 @@
+import NiceModal from '@ebay/nice-modal-react';
+import UniversalImportModal from '@/settings/app/components/settings/advanced/migration-tools/universal-import-modal';
+import {ConfirmationProvider} from '@/settings/app/components/providers/confirmation-provider';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+
+const {mockImportContent, mockImportContentCSV, mockUseFeatureFlag, mockHandleError} = vi.hoisted(() => ({
+    mockImportContent: vi.fn(),
+    mockImportContentCSV: vi.fn(),
+    mockUseFeatureFlag: vi.fn(),
+    mockHandleError: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/db', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/db')>('@tryghost/admin-x-framework/api/db');
+    return {...actual, useImportContent: () => ({mutateAsync: mockImportContent})};
+});
+
+vi.mock('@tryghost/admin-x-framework/api/posts', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/posts')>('@tryghost/admin-x-framework/api/posts');
+    return {...actual, useImportContentCSV: () => ({mutateAsync: mockImportContentCSV})};
+});
+
+vi.mock('@tryghost/admin-x-framework/hooks', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/hooks')>('@tryghost/admin-x-framework/hooks');
+    return {...actual, useHandleError: () => mockHandleError};
+});
+
+vi.mock('@/settings/app/hooks/use-feature-flag', () => ({
+    default: (flag: string) => mockUseFeatureFlag(flag)
+}));
+
+describe('UniversalImportModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockImportContent.mockResolvedValue({});
+        mockImportContentCSV.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        void NiceModal.remove(UniversalImportModal);
+    });
+
+    const showModal = () => {
+        render(<ConfirmationProvider><NiceModal.Provider /></ConfirmationProvider>);
+
+        act(() => {
+            void NiceModal.show(UniversalImportModal);
+        });
+    };
+
+    const fileInput = async () => await screen.findByTestId('import-file');
+
+    const description = async () => await screen.findByTestId('import-file-description');
+
+    const dropFile = async (file: File) => {
+        const input = await fileInput();
+
+        // act() flushes react-dropzone's async file processing, so a
+        // "not called" assertion afterwards can't pass vacuously
+        await act(async () => {
+            fireEvent.change(input, {target: {files: [file]}});
+        });
+    };
+
+    it('reads the csvContentImporter flag', async () => {
+        mockUseFeatureFlag.mockReturnValue(false);
+        showModal();
+
+        await fileInput();
+        expect(mockUseFeatureFlag).toHaveBeenCalledWith('csvContentImporter');
+    });
+
+    it('sends JSON files to the db import when csvContentImporter is disabled', async () => {
+        mockUseFeatureFlag.mockReturnValue(false);
+        showModal();
+
+        expect(await description()).toHaveTextContent(/Select any JSON or zip file/);
+
+        const file = new File(['{}'], 'export.json', {type: 'application/json'});
+        await dropFile(file);
+
+        await waitFor(() => expect(mockImportContent).toHaveBeenCalledWith(file));
+        expect(mockImportContentCSV).not.toHaveBeenCalled();
+        expect(await screen.findByTestId('confirmation-modal')).toHaveTextContent('Import in progress');
+    });
+
+    it('rejects CSV files when csvContentImporter is disabled', async () => {
+        mockUseFeatureFlag.mockReturnValue(false);
+        showModal();
+
+        const input = await fileInput();
+        expect(input).toHaveAttribute('accept', expect.not.stringContaining('.csv'));
+
+        await dropFile(new File(['title\nHello'], 'posts.csv', {type: 'text/csv'}));
+
+        expect(mockImportContent).not.toHaveBeenCalled();
+        expect(mockImportContentCSV).not.toHaveBeenCalled();
+        expect(screen.getByTestId('universal-import-modal')).toBeInTheDocument();
+    });
+
+    it('sends CSV files to the posts upload endpoint when csvContentImporter is enabled', async () => {
+        mockUseFeatureFlag.mockReturnValue(true);
+        showModal();
+
+        expect(await description()).toHaveTextContent(/Select any JSON, zip or CSV file/);
+
+        const input = await fileInput();
+        expect(input).toHaveAttribute('accept', expect.stringContaining('.csv'));
+
+        const file = new File(['title\nHello'], 'posts.csv', {type: 'text/csv'});
+        await dropFile(file);
+
+        await waitFor(() => expect(mockImportContentCSV).toHaveBeenCalledWith(file));
+        expect(mockImportContent).not.toHaveBeenCalled();
+        expect(await screen.findByTestId('confirmation-modal')).toHaveTextContent('Import in progress');
+    });
+
+    it('still sends JSON files to the db import when csvContentImporter is enabled', async () => {
+        mockUseFeatureFlag.mockReturnValue(true);
+        showModal();
+
+        const file = new File(['{}'], 'export.json', {type: 'application/json'});
+        await dropFile(file);
+
+        await waitFor(() => expect(mockImportContent).toHaveBeenCalledWith(file));
+        expect(mockImportContentCSV).not.toHaveBeenCalled();
+    });
+
+    it('surfaces an error and keeps the modal open when the import fails', async () => {
+        const error = new Error('Import failed');
+        mockUseFeatureFlag.mockReturnValue(true);
+        mockImportContentCSV.mockRejectedValue(error);
+        showModal();
+
+        await dropFile(new File(['title\nHello'], 'posts.csv', {type: 'text/csv'}));
+
+        await waitFor(() => expect(mockHandleError).toHaveBeenCalledWith(error));
+        expect(screen.getByTestId('universal-import-modal')).toBeInTheDocument();
+        expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+    });
+});

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -19,7 +19,7 @@ const UniversalImportModal: React.FC = () => {
     const handleError = useHandleError();
     const {confirm} = useConfirmation();
 
-    const acceptedTypes = csvContentImporter
+    const acceptedTypes: React.ComponentProps<typeof Dropzone>['accept'] = csvContentImporter
         ? {'application/json': ['.json'], 'application/zip': ['.zip'], 'text/csv': ['.csv']}
         : {'application/json': ['.json'], 'application/zip': ['.zip']};
 

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -1,5 +1,6 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
+import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import {Button, Dropzone} from '@tryghost/shade/components';
 import {ExternalLink} from 'lucide-react';
 import {Inline} from '@tryghost/shade/primitives';
@@ -7,13 +8,20 @@ import {SettingsModal} from '@tryghost/shade/patterns';
 import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useImportContent} from '@tryghost/admin-x-framework/api/db';
+import {useImportContentCSV} from '@tryghost/admin-x-framework/api/posts';
 
 const UniversalImportModal: React.FC = () => {
     const modal = useModal();
     const {mutateAsync: importContent} = useImportContent();
+    const {mutateAsync: importContentCSV} = useImportContentCSV();
+    const csvContentImporter = useFeatureFlag('csvContentImporter');
     const [uploading, setUploading] = useState(false);
     const handleError = useHandleError();
     const {confirm} = useConfirmation();
+
+    const acceptedTypes = csvContentImporter
+        ? {'application/json': ['.json'], 'application/zip': ['.zip'], 'text/csv': ['.csv']}
+        : {'application/json': ['.json'], 'application/zip': ['.zip']};
 
     return (
         <SettingsModal
@@ -34,12 +42,17 @@ const UniversalImportModal: React.FC = () => {
         >
             <div className='py-4'>
                 <Dropzone
-                    accept={{'application/json': ['.json'], 'application/zip': ['.zip']}}
+                    accept={acceptedTypes}
                     inputId="import-file"
+                    inputTestId="import-file"
                     onDropAccepted={async ([file]) => {
                         setUploading(true);
                         try {
-                            await importContent(file);
+                            if (csvContentImporter && file.name.toLowerCase().endsWith('.csv')) {
+                                await importContentCSV(file);
+                            } else {
+                                await importContent(file);
+                            }
                             modal.remove();
                             confirm({
                                 title: 'Import in progress',
@@ -56,9 +69,9 @@ const UniversalImportModal: React.FC = () => {
                         }
                     }}
                 >
-                    <div className="text-center">
+                    <div className="text-center" data-testid="import-file-description">
                         {uploading ? 'Uploading...' : <>
-                        Select any JSON or zip file that contains <br />posts and settings
+                        Select any {csvContentImporter ? 'JSON, zip or CSV' : 'JSON or zip'} file that contains <br />posts and settings
                         </>}
                     </div>
                 </Dropzone>

--- a/ghost/core/test/e2e-api/admin/__snapshots__/db.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/db.test.js.snap
@@ -110,3 +110,34 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`DB API Rejects CSV file uploads 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Unsupported file. Please try any of the following formats: .json,.zip",
+      "property": null,
+      "type": "UnsupportedMediaTypeError",
+    },
+  ],
+}
+`;
+
+exports[`DB API Rejects CSV file uploads 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "267",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/db.test.js
+++ b/ghost/core/test/e2e-api/admin/db.test.js
@@ -131,4 +131,21 @@ describe('DB API', function () {
                 }]
             });
     });
+
+    // CSV content is imported via POST /posts/upload/, not the db backup endpoint
+    it('Rejects CSV file uploads', async function () {
+        await agent
+            .post('db/')
+            .attach('importfile', path.join(__dirname, '../../utils/fixtures/csv/valid-posts-import.csv'))
+            .expectStatus(415)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/MIG-1437/

- adds a testid attribute to the existing file upload dropbox description
- adds test to ensure existing behaviour is not changed when the `csvContentImporter` flag is enabled
- adds tests for when the `csvContentImporter` is enabled
- adds a conditional for the file drop placeholder text