### PR TITLE
Tightened object lookup in data generator sorter

### DIFF
--- a/ghost/core/core/server/data/seeders/utils/topological-sort.ts
+++ b/ghost/core/core/server/data/seeders/utils/topological-sort.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import type {ReadonlyDeep} from 'type-fest';
 
 type TopologicalSortable = ReadonlyDeep<{
@@ -26,9 +27,7 @@ export function topologicalSort<T extends TopologicalSortable>(objects: Readonly
         }
 
         const object = objectsByName.get(name);
-        if (!object) {
-            return;
-        }
+        assert(object, `Expected an object with name ${name}`);
 
         visited.add(name);
 


### PR DESCRIPTION
no ref

This helps fix a hypothetical bug in the topological sorter. If you supply a dependency that doesn't exist, this will now error instead of silently passing.

Noticed this while looking at `topologicalSort`. `reset:data` still works after this change.
