### PR TITLE
🐛 Fixed text filters losing values ending in a dollar sign

### DIFF
--- a/apps/admin/src/shared/filters/filter-codec-roundtrip.test.ts
+++ b/apps/admin/src/shared/filters/filter-codec-roundtrip.test.ts
@@ -1,0 +1,148 @@
+import nql from '@tryghost/nql-lang';
+import {dateCodec, numberCodec, scalarCodec, setCodec, textCodec} from './filter-codecs';
+import {describe, expect, it} from 'vitest';
+import type {CodecContext, FilterCodec, FilterPredicate} from './filter-types';
+
+// What a saved segment actually relies on: a predicate the publisher built in the UI
+// is serialized to NQL, stored, and read back the next time the page loads. Every
+// codec must survive that trip for every operator it advertises, whatever the value
+// holds — the per-codec tests above assert one direction at a time against hand-written
+// NQL, which is how the anchor readers in this engine and in member-filter-query.ts
+// drifted apart without a test noticing.
+
+function context(key: string, timezone = 'UTC'): CodecContext {
+    return {key, pattern: key, params: {}, timezone};
+}
+
+function roundTrip(codec: FilterCodec, predicate: Omit<FilterPredicate, 'id'>, ctx: CodecContext) {
+    const clauses = codec.serialize({id: 'x', ...predicate}, ctx);
+
+    if (!clauses) {
+        throw new Error(`serialize returned null for ${predicate.operator}`);
+    }
+
+    const node = nql.parse(clauses.join('+'), {preserveRelativeDates: true});
+
+    return codec.parse(node, ctx);
+}
+
+// Values chosen for what they do to the regex the text codec builds: `$` and `^` are
+// the anchors the parse side reads operators from, so a value containing one is the
+// case where escaping and anchoring have to be told apart.
+const TEXT_VALUES = [
+    'Ghost',
+    'two words',
+    '5$',
+    '$5',
+    '^caret',
+    'a.b',
+    "it's",
+    'back\\slash',
+    '-leading-hyphen',
+    'trailing$'
+];
+
+const TEXT_OPERATORS = [
+    'is',
+    'contains',
+    'does-not-contain',
+    'starts-with',
+    'does-not-start-with',
+    'ends-with',
+    'does-not-end-with'
+];
+
+describe('codec round trips', () => {
+    describe('textCodec', () => {
+        const ctx = context('email');
+        const codec = textCodec();
+
+        for (const operator of TEXT_OPERATORS) {
+            it.each(TEXT_VALUES)(`round-trips ${operator} %j`, (value) => {
+                expect(roundTrip(codec, {field: 'email', operator, values: [value]}, ctx)).toEqual({
+                    field: 'email',
+                    operator,
+                    values: [value]
+                });
+            });
+        }
+    });
+
+    describe('scalarCodec', () => {
+        const ctx = context('status');
+        const codec = scalarCodec();
+
+        for (const operator of ['is', 'is-not']) {
+            it.each(['paid', 'two words', '-leading', "it's", 'a.b'])(`round-trips ${operator} %j`, (value) => {
+                expect(roundTrip(codec, {field: 'status', operator, values: [value]}, ctx)).toEqual({
+                    field: 'status',
+                    operator,
+                    values: [value]
+                });
+            });
+        }
+    });
+
+    describe('setCodec', () => {
+        const ctx = context('label');
+        const codec = setCodec();
+
+        for (const operator of ['is-any', 'is-not-any']) {
+            it.each([
+                [['vip']],
+                [['vip', 'founder']],
+                [['two words', 'a.b']]
+            ])(`round-trips ${operator} %j`, (values) => {
+                const parsed = roundTrip(codec, {field: 'label', operator, values}, ctx);
+
+                expect(parsed?.operator).toBe(operator);
+                expect(parsed?.values).toEqual([...values].sort((left, right) => left.localeCompare(right)));
+            });
+        }
+    });
+
+    describe('numberCodec', () => {
+        const ctx = context('email_count');
+        const codec = numberCodec();
+
+        for (const operator of ['is', 'is-greater', 'is-or-greater', 'is-less', 'is-or-less']) {
+            it.each([0, 1, 42])(`round-trips ${operator} %j`, (value) => {
+                expect(roundTrip(codec, {field: 'email_count', operator, values: [value]}, ctx)).toEqual({
+                    field: 'email_count',
+                    operator,
+                    values: [value]
+                });
+            });
+        }
+    });
+
+    describe('dateCodec', () => {
+        const codec = dateCodec();
+
+        for (const timezone of ['UTC', 'Europe/Berlin', 'America/Los_Angeles']) {
+            for (const operator of ['is-less', 'is-or-less', 'is-greater', 'is-or-greater']) {
+                it(`round-trips ${operator} in ${timezone}`, () => {
+                    const ctx = context('created_at', timezone);
+
+                    expect(roundTrip(codec, {field: 'created_at', operator, values: ['2026-08-11']}, ctx)).toEqual({
+                        field: 'created_at',
+                        operator,
+                        values: ['2026-08-11']
+                    });
+                });
+            }
+
+            for (const operator of ['in-the-last', 'in-the-next']) {
+                it(`round-trips ${operator} in ${timezone}`, () => {
+                    const ctx = context('created_at', timezone);
+
+                    expect(roundTrip(codec, {field: 'created_at', operator, values: [30]}, ctx)).toEqual({
+                        field: 'created_at',
+                        operator,
+                        values: [30]
+                    });
+                });
+            }
+        }
+    });
+});

--- a/apps/admin/src/shared/filters/filter-codecs.ts
+++ b/apps/admin/src/shared/filters/filter-codecs.ts
@@ -83,38 +83,53 @@ function serializeScalarValue(value: unknown, config?: CodecConfig): string {
     return String(value);
 }
 
-function extractRegexOperator(pattern: RegExp, negated = false): string {
-    const source = pattern.source;
-    const startsWith = source.startsWith('^');
-    const endsWith = source.endsWith('$');
-
-    if (startsWith && endsWith) {
-        return negated ? 'does-not-contain' : 'contains';
+// A trailing `$` anchors the regex only when it isn't itself escaped: a value holding a
+// literal `$` (contains `5$`) reaches here as the source `5\$`, which still ends in `$`.
+// An odd run of backslashes before it means it is escaped, so it is part of the value.
+// A literal `^` is always escaped to `\^`, so a leading `^` needs no such check.
+function hasEndAnchor(source: string): boolean {
+    if (!source.endsWith('$')) {
+        return false;
     }
 
-    if (startsWith) {
+    let backslashes = 0;
+
+    for (let index = source.length - 2; index >= 0 && source[index] === '\\'; index -= 1) {
+        backslashes += 1;
+    }
+
+    return backslashes % 2 === 0;
+}
+
+// Which anchors a regex carries, and the value left once they are removed. Read together
+// rather than one at a time: the operator and the value are two answers to the same
+// question, and deciding the anchors twice is how a value could keep a `$` the operator
+// had already consumed.
+function decomposeRegex(pattern: RegExp): {anchorStart: boolean; anchorEnd: boolean; value: string} {
+    const source = pattern.source;
+    const anchorStart = source.startsWith('^');
+    const anchorEnd = hasEndAnchor(source);
+    const body = source.slice(anchorStart ? 1 : 0, anchorEnd ? -1 : undefined);
+
+    return {
+        anchorStart,
+        anchorEnd,
+        value: body.replace(/\\([\\.^$|?*+()[\]{}/-])/g, '$1')
+    };
+}
+
+// Anchors read back into the operator that would have produced them. Both anchors is not
+// an operator this codec emits, so it falls back to the unanchored reading.
+function anchorsToOperator(anchorStart: boolean, anchorEnd: boolean, negated: boolean): string {
+    if (anchorStart && !anchorEnd) {
         return negated ? 'does-not-start-with' : 'starts-with';
     }
 
-    if (endsWith) {
+    if (anchorEnd && !anchorStart) {
         return negated ? 'does-not-end-with' : 'ends-with';
     }
 
     return negated ? 'does-not-contain' : 'contains';
-}
-
-function normalizeRegexValue(pattern: RegExp): string {
-    let source = pattern.source;
-
-    if (source.startsWith('^')) {
-        source = source.slice(1);
-    }
-
-    if (source.endsWith('$')) {
-        source = source.slice(0, -1);
-    }
-
-    return source.replace(/\\([\\.^$|?*+()[\]{}/-])/g, '$1');
 }
 
 export function scalarCodec(config?: CodecConfig): FilterCodec {
@@ -179,18 +194,22 @@ export function textCodec(config?: CodecConfig): FilterCodec {
             }
 
             if (comparator.operator === '$regex' && comparator.value instanceof RegExp) {
+                const {anchorStart, anchorEnd, value} = decomposeRegex(comparator.value);
+
                 return {
                     field: ctx.key,
-                    operator: extractRegexOperator(comparator.value),
-                    values: [normalizeRegexValue(comparator.value)]
+                    operator: anchorsToOperator(anchorStart, anchorEnd, false),
+                    values: [value]
                 };
             }
 
             if (comparator.operator === '$not' && comparator.value instanceof RegExp) {
+                const {anchorStart, anchorEnd, value} = decomposeRegex(comparator.value);
+
                 return {
                     field: ctx.key,
-                    operator: extractRegexOperator(comparator.value, true),
-                    values: [normalizeRegexValue(comparator.value)]
+                    operator: anchorsToOperator(anchorStart, anchorEnd, true),
+                    values: [value]
                 };
             }
 

--- a/e2e/tests/admin/members/filter-round-trip.test.ts
+++ b/e2e/tests/admin/members/filter-round-trip.test.ts
@@ -1,0 +1,48 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersListPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright/fixture';
+
+// A filter is written into the URL as NQL and read back out of it on every navigation, so
+// what a publisher typed only survives if those two agree. `$` is where they disagreed: it
+// both ends a value and marks the end of a pattern, and the value was escaped to say which
+// was meant. Reading it back ignored the escaping, so a filter for names containing "5$"
+// returned as a filter for names ending in "5", with the value itself mangled.
+//
+// Reloading is the whole test. It is the point where the filter stops being state the page
+// is holding and becomes text that has to be parsed again — and a saved view goes through
+// exactly the same path, which is how the misreading became permanent rather than cosmetic.
+//
+// The assertions are about the filter, not about which members come back. Whether the server
+// answers the right question is a separate concern in the query layer, covered at the API
+// level; what is checked here is that admin still asks the question the publisher typed.
+test.describe('Ghost Admin - Members Filter Round Trip', () => {
+    let memberFactory: MemberFactory;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('keeps a value ending in a dollar sign across a reload', async ({page}) => {
+        test.slow();
+
+        await memberFactory.create({name: 'Ticket 5$', email: 'ticket-dollar@example.com'});
+
+        const membersPage = new MembersListPage(page);
+        await page.goto('/ghost/#/members');
+
+        await membersPage.addFilter('Name', '5$');
+
+        const filterItem = membersPage.getFilterItem('Name');
+        await expect(filterItem.getByRole('textbox')).toHaveValue('5$');
+        await expect(filterItem).toContainText('contains');
+
+        await page.reload();
+
+        // Both halves were corrupted together, so both are asserted. The trailing `$` was
+        // taken for an end-of-pattern marker, which turned "contains" into "ends with" and
+        // left the value itself a character short.
+        const reloaded = membersPage.getFilterItem('Name');
+        await expect(reloaded.getByRole('textbox')).toHaveValue('5$');
+        await expect(reloaded).toContainText('contains');
+    });
+});


### PR DESCRIPTION
## Problem

A member's name or email can contain a dollar sign, and a publisher can reasonably filter on one. But `$` is also how a regex marks the end of a pattern, and the admin filter engine used the same character for both.

Reading a saved filter back, the engine asked twice whether the pattern ended in a `$` — once to work out which operator had been used, and again to strip the anchor off the value. Neither check considered that the character might have been escaped because it was part of the value, and neither knew what the other had concluded.

So a filter for names containing "5$" came back as a filter for names ending in "5", and the value itself was left mangled with a trailing backslash. Starts-with came back as contains. This affected contains, does-not-contain, starts-with and does-not-start-with on member name and email, and on comment filters.

The damage was not limited to display. Opening a segment and saving it wrote the misread filter back, so the corruption became permanent, and the saved segment quietly changed who it was about.

## Solution

Read the anchors once, in a single step that also produces the value, so the operator and the value can no longer disagree about what the pattern contained. That check is now escape-aware: a trailing anchor character counts as an anchor only when it is not escaped, which is what separates a value ending in a dollar from a genuine end-of-pattern marker.

Round-trip coverage was missing entirely, so it is added across every codec and operator: each filter is written to NQL, read back, and required to produce the predicate it started from.

Note this is the client-side half of the problem. The query layer had a related fault, where the same characters were unescaped before the anchors were read, which made the server answer the wrong question even for a correctly written filter. That is fixed separately in TryGhost/NQL#213 and reaches Ghost through a dependency bump. The two are independent: this one corrupts what a publisher sees and can permanently rewrite a saved filter, so it is worth shipping on its own.