### PR TITLE
Added "total run count" stat to automation browse endpoint

### DIFF
--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -68,6 +68,7 @@ export interface AutomationSummary {
 export interface AutomationBrowseResult extends AutomationSummary {
     stats: {
         last_run_created_at: Date | null;
+        total_run_count: number;
     };
 }
 

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -55,6 +55,7 @@ interface AutomationRow {
 
 interface AutomationBrowseRow extends AutomationRow {
     last_run_created_at: DatabaseDate | null;
+    total_run_count: string | number | null;
 }
 
 interface ActionRow {
@@ -1018,11 +1019,12 @@ async function loadAutomationBySlug(trx: Knex.Transaction, slug: string): Promis
 }
 
 async function loadAutomations(trx: Knex.Transaction): Promise<AutomationBrowseRow[]> {
-    const latestRunDates = trx('automation_runs')
+    const runStats = trx('automation_runs')
         .select('automation_id')
         .max({last_run_created_at: 'created_at'})
+        .count({total_run_count: '*'})
         .groupBy('automation_id')
-        .as('latest_run_dates');
+        .as('run_stats');
     return await trx('automations')
         .select(
             'automations.id',
@@ -1031,9 +1033,10 @@ async function loadAutomations(trx: Knex.Transaction): Promise<AutomationBrowseR
             'automations.status',
             'automations.created_at',
             'automations.updated_at',
-            'latest_run_dates.last_run_created_at'
+            'run_stats.last_run_created_at',
+            'run_stats.total_run_count'
         )
-        .leftJoin(latestRunDates, 'automations.id', 'latest_run_dates.automation_id')
+        .leftJoin(runStats, 'automations.id', 'run_stats.automation_id')
         .orderBy('automations.name');
 }
 
@@ -1377,7 +1380,8 @@ function buildAutomationBrowseResult(automation: AutomationBrowseRow): Automatio
     return {
         ...buildAutomationSummary(automation),
         stats: {
-            last_run_created_at: automation.last_run_created_at ? fromDatabaseDate(automation.last_run_created_at) : null
+            last_run_created_at: automation.last_run_created_at ? fromDatabaseDate(automation.last_run_created_at) : null,
+            total_run_count: Number(automation.total_run_count ?? 0)
         }
     };
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
@@ -10,6 +10,7 @@ Object {
       "slug": "member-welcome-email-free",
       "stats": Object {
         "last_run_created_at": null,
+        "total_run_count": 0,
       },
       "status": "active",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -21,6 +22,7 @@ Object {
       "slug": "member-welcome-email-paid",
       "stats": Object {
         "last_run_created_at": null,
+        "total_run_count": 0,
       },
       "status": "active",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -43,7 +45,7 @@ exports[`Automations API browse returns automations sourced from the database 2:
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "584",
+  "content-length": "624",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -24,7 +24,8 @@ const matchAutomationBase = () => ({
 const matchAutomationSummary = () => ({
     ...matchAutomationBase(),
     stats: {
-        last_run_created_at: null
+        last_run_created_at: null,
+        total_run_count: 0
     }
 });
 
@@ -208,6 +209,25 @@ describe('Automations API', function () {
             const automation = body.automations.find(candidate => candidate.id === automationId);
 
             assert.equal(automation.stats.last_run_created_at, latestRunCreatedAt.toISOString());
+        });
+
+        it('returns zero total run counts for automations without runs', async function () {
+            const {body} = await agent.get('automations').expectStatus(200);
+
+            assert.deepEqual(body.automations.map(automation => automation.stats.total_run_count), [0, 0]);
+        });
+
+        it('returns the total automation run count', async function () {
+            const {body: beforeBody} = await agent.get('automations').expectStatus(200);
+            const automationId = beforeBody.automations[0].id;
+
+            await createAutomationRun(automationId, new Date('2026-01-01T00:00:00.000Z'));
+            await createAutomationRun(automationId, new Date('2026-01-02T00:00:00.000Z'));
+
+            const {body} = await agent.get('automations').expectStatus(200);
+            const automation = body.automations.find(candidate => candidate.id === automationId);
+
+            assert.equal(automation.stats.total_run_count, 2);
         });
 
         it('upserts the default free and paid automations', async function () {

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -680,6 +680,31 @@ describe('automations repository', function () {
             assert.deepEqual(automation.stats.last_run_created_at, latestRunCreatedAt);
         });
 
+        it('returns zero for "total run count" if the automation has no runs', async function () {
+            const result = await repo.browse();
+
+            assert(result.data.every(automation => automation.stats.total_run_count === 0));
+        });
+
+        it('returns the number of runs for the automation', async function () {
+            const automationId = (await getAutomationBySlug('member-welcome-email-free')).id;
+            const otherAutomationId = (await getAutomationBySlug('member-welcome-email-paid')).id;
+
+            await insertRun(automationId);
+            await insertRun(automationId);
+            await insertRun(automationId);
+            await insertRun(otherAutomationId);
+
+            const browseResult = await repo.browse();
+            const automation = browseResult.data.find(candidate => candidate.id === automationId);
+            const otherAutomation = browseResult.data.find(candidate => candidate.id === otherAutomationId);
+            assert(automation);
+            assert(otherAutomation);
+
+            assert.equal(automation.stats.total_run_count, 3);
+            assert.equal(otherAutomation.stats.total_run_count, 1);
+        });
+
         it('creates missing default free and paid automations', async function () {
             const automationIds = await knex('automations')
                 .whereIn('slug', ['member-welcome-email-free', 'member-welcome-email-paid'])


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1529
ref ce0841435c44a24bd444277cc587e3a18adc052d

This adds `stats.last_run_created_at` to each automation, which we'll display in the UI soon.

This was built by Claude Opus 5 with the following prompt:

> Commit `ce0841435c44a24bd444277cc587e3a18adc052d` adds a "last run created at" stat to the automation browse endpoint.
>
> I want a new key, `total_run_count`, which is a count of all the runs for that automation.
>
> * Update `AutomationBrowseResult`.
> * Update `AutomationBrowseRow`.
> * Update `loadAutomations`.
> * Update `buildAutomationBrowseResult`.
> * Update `ghost/core/test/e2e-api/admin/automations.test.js`.
> * Update `ghost/core/test/unit/server/services/automations/automations-repository.test.ts`.
> * Re-generate the snapshots with `UPDATE_SNAPSHOTS=1` and running the necessary tests.
>
> Use red/green TDD.
>
> This should be a fairly straightforward change.

In addition to unit and E2E tests, I also verified that the data appeared by checking the Network tab of the Firefox devtools:

![devtools screenshot](https://github.com/user-attachments/assets/de9bb167-ac6d-487c-9196-37d7528ba6bd)