### PR TITLE
🐛 Fixed member events API pagination

### DIFF
--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -504,6 +504,7 @@ const controller = {
         },
         options: [
             'limit',
+            'page',
             'filter'
         ],
         permissions: {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -72,11 +72,24 @@ module.exports = class EventRepository {
             options.limit = 10;
         }
 
+        const requestedLimit = options.limit;
+        const page = options.page === undefined ? null : parseInt(options.page, 10) || 1;
+        const limit = page === null ? Number(requestedLimit) : parseInt(requestedLimit, 10) || 10;
+
         const [typeFilter, otherFilter] = this.getNQLSubset(options.filter);
 
         // Changing this order might need a change in the query functions
         // because of the different underlying models.
         options.order = 'created_at desc, id desc';
+
+        // Every source must contribute all candidates up to the end of the requested
+        // global page. Applying the requested page to each source would skip events
+        // that belong in the merged timeline.
+        const sourceOptions = page === null ? options : {
+            ...options,
+            page: 1,
+            limit: page * limit
+        };
 
         // Create a list of all events that can be queried
         const pageActions = [
@@ -121,49 +134,68 @@ module.exports = class EventRepository {
         if (typeFilter) {
             // Ideally we should be able to create a NQL filter without having a string
             const query = new mingo.Query(typeFilter);
-            filteredPages = filteredPages.filter(page => query.test(page));
+            filteredPages = filteredPages.filter(pageAction => query.test(pageAction));
         }
 
         //Start the promises
-        const pages = filteredPages.map((page) => {
-            return this[page.action](options, otherFilter);
+        const pages = filteredPages.map((pageAction) => {
+            return this[pageAction.action](sourceOptions, otherFilter);
         });
 
         const allEventPages = await Promise.all(pages);
 
-        const allEvents = allEventPages.flatMap(page => page.data);
-        const totalEvents = allEventPages.reduce((accumulator, page) => accumulator + page.meta.pagination.total, 0);
+        const allEvents = allEventPages.flatMap(eventPage => eventPage.data);
+        const totalEvents = allEventPages.reduce((accumulator, eventPage) => accumulator + eventPage.meta.pagination.total, 0);
+
+        const sortedEvents = allEvents.sort((a, b) => {
+            const diff = new Date(b.data.created_at).getTime() - new Date(a.data.created_at).getTime();
+            if (diff !== 0) {
+                return diff;
+            }
+            // Tiebreaker for events sharing the same created_at:
+            // Signup > Newsletter subscription > Subscription / gift redemption event > Login
+            const tieOrder = {
+                login_event: 0,
+                subscription_event: 1,
+                gift_redemption_event: 1,
+                gift_ended_event: 1,
+                newsletter_event: 2,
+                signup_event: 3
+            };
+            const orderA = tieOrder[a.type];
+            const orderB = tieOrder[b.type];
+            if (orderA !== undefined && orderB !== undefined && orderA !== orderB) {
+                return orderA - orderB;
+            }
+            return b.data.id.localeCompare(a.data.id);
+        });
+
+        if (page !== null) {
+            const pagesCount = Math.max(1, Math.ceil(totalEvents / limit));
+            const start = (page - 1) * limit;
+
+            return {
+                events: sortedEvents.slice(start, start + limit),
+                meta: {
+                    pagination: {
+                        page,
+                        limit,
+                        pages: pagesCount,
+                        total: totalEvents,
+                        next: page < pagesCount ? page + 1 : null,
+                        prev: page > 1 ? page - 1 : null
+                    }
+                }
+            };
+        }
 
         return {
-            events: allEvents.sort(
-                (a, b) => {
-                    const diff = new Date(b.data.created_at).getTime() - new Date(a.data.created_at).getTime();
-                    if (diff !== 0) {
-                        return diff;
-                    }
-                    // Tiebreaker for events sharing the same created_at:
-                    // Signup > Newsletter subscription > Subscription / gift redemption event > Login
-                    const tieOrder = {
-                        login_event: 0,
-                        subscription_event: 1,
-                        gift_redemption_event: 1,
-                        gift_ended_event: 1,
-                        newsletter_event: 2,
-                        signup_event: 3
-                    };
-                    const orderA = tieOrder[a.type];
-                    const orderB = tieOrder[b.type];
-                    if (orderA !== undefined && orderB !== undefined && orderA !== orderB) {
-                        return orderA - orderB;
-                    }
-                    return b.data.id.localeCompare(a.data.id);
-                }
-            ).slice(0, options.limit),
+            events: sortedEvents.slice(0, limit),
             meta: {
                 pagination: {
-                    limit: options.limit,
+                    limit: requestedLimit,
                     total: totalEvents,
-                    pages: options.limit > 0 ? Math.ceil(totalEvents / options.limit) : null,
+                    pages: limit > 0 ? Math.ceil(totalEvents / limit) : null,
 
                     // Other values are unavailable (not possible to calculate easily)
                     page: null,

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -5,6 +5,10 @@ const {replaceFilters, expandFilters, splitFilter, getUsedKeys, chainTransformer
 const {default: ObjectID} = require('bson-objectid');
 const db = require('../../../../data/db');
 
+// Explicit global pages query a prefix from every source. Cap each prefix at
+// 100 full-size Admin API pages to bound database reads and in-memory sorting.
+const MAX_EVENT_CANDIDATES = 10_000;
+
 /**
  * This mongo transformer ignores the provided filter option and replaces the filter with a custom filter that was provided to the transformer. Allowing us to set a mongo filter instead of a string based NQL filter.
  */
@@ -73,8 +77,16 @@ module.exports = class EventRepository {
         }
 
         const requestedLimit = options.limit;
-        const page = options.page === undefined ? null : parseInt(options.page, 10) || 1;
-        const limit = page === null ? Number(requestedLimit) : parseInt(requestedLimit, 10) || 10;
+        const parsedPage = Number.parseInt(options.page, 10);
+        const page = options.page === undefined ? null : Math.max(1, parsedPage || 1);
+        const limit = page === null ? Number(requestedLimit) : Number.parseInt(requestedLimit, 10) || 10;
+        const candidateLimit = page === null ? null : page * limit;
+
+        if (candidateLimit > MAX_EVENT_CANDIDATES) {
+            throw new errors.BadRequestError({
+                message: 'Requested page is too large'
+            });
+        }
 
         const [typeFilter, otherFilter] = this.getNQLSubset(options.filter);
 
@@ -88,7 +100,7 @@ module.exports = class EventRepository {
         const sourceOptions = page === null ? options : {
             ...options,
             page: 1,
-            limit: page * limit
+            limit: candidateLimit
         };
 
         // Create a list of all events that can be queried

--- a/ghost/core/test/e2e-api/admin/activity-feed.test.js
+++ b/ghost/core/test/e2e-api/admin/activity-feed.test.js
@@ -230,6 +230,73 @@ describe('Activity Feed API', function () {
         });
     });
 
+    describe('Page-based pagination', function () {
+        it('returns distinct global pages with standard pagination metadata', async function () {
+            const skippedTypes = ['email_opened_event', 'email_failed_event', 'email_delivered_event', 'aggregated_click_event'];
+            const filter = encodeURIComponent(`type:-[${skippedTypes.join(',')}]`);
+
+            const [{body: firstPage}, {body: secondPage}, {body: combinedPage}] = await Promise.all([
+                agent.get(`/members/events?filter=${filter}&limit=5&page=1`).expectStatus(200),
+                agent.get(`/members/events?filter=${filter}&limit=5&page=2`).expectStatus(200),
+                agent.get(`/members/events?filter=${filter}&limit=10&page=1`).expectStatus(200)
+            ]);
+
+            const eventIdentity = event => `${event.type}:${event.data.id}`;
+            const firstPageIds = firstPage.events.map(eventIdentity);
+            const secondPageIds = secondPage.events.map(eventIdentity);
+
+            assert.deepEqual([...firstPageIds, ...secondPageIds], combinedPage.events.map(eventIdentity));
+            assert.equal(firstPageIds.some(id => secondPageIds.includes(id)), false);
+            assert.deepEqual(firstPage.meta.pagination, {
+                page: 1,
+                limit: 5,
+                pages: 8,
+                total: 40,
+                next: 2,
+                prev: null
+            });
+            assert.deepEqual(secondPage.meta.pagination, {
+                page: 2,
+                limit: 5,
+                pages: 8,
+                total: 40,
+                next: 3,
+                prev: 1
+            });
+        });
+
+        it('applies member filters before paginating the global timeline', async function () {
+            const memberId = fixtureManager.get('members', 0).id;
+            const filter = encodeURIComponent(`data.member_id:'${memberId}'`);
+
+            const [{body: firstPage}, {body: secondPage}, {body: combinedPage}] = await Promise.all([
+                agent.get(`/members/events?filter=${filter}&limit=1&page=1`).expectStatus(200),
+                agent.get(`/members/events?filter=${filter}&limit=1&page=2`).expectStatus(200),
+                agent.get(`/members/events?filter=${filter}&limit=2&page=1`).expectStatus(200)
+            ]);
+
+            assert.equal(firstPage.events.length, 1);
+            assert.equal(secondPage.events.length, 1);
+            assert.deepEqual([...firstPage.events, ...secondPage.events], combinedPage.events);
+            assert.equal(firstPage.meta.pagination.total, combinedPage.meta.pagination.total);
+            assert.equal(secondPage.meta.pagination.total, combinedPage.meta.pagination.total);
+
+            for (const event of combinedPage.events) {
+                assert.equal(event.data.member_id, memberId);
+            }
+        });
+
+        it('caps the explicit page size at 100', async function () {
+            const {body} = await agent
+                .get('/members/events?limit=101&page=1')
+                .expectStatus(200);
+
+            assert.equal(body.meta.pagination.page, 1);
+            assert.equal(body.meta.pagination.limit, 100);
+            assert(body.events.length <= 100);
+        });
+    });
+
     // Activity feed
     it('Returns comments in activity feed', async function () {
         // Check activity feed

--- a/ghost/core/test/e2e-api/admin/activity-feed.test.js
+++ b/ghost/core/test/e2e-api/admin/activity-feed.test.js
@@ -295,6 +295,12 @@ describe('Activity Feed API', function () {
             assert.equal(body.meta.pagination.limit, 100);
             assert(body.events.length <= 100);
         });
+
+        it('rejects page windows larger than 10,000 events', async function () {
+            await agent
+                .get('/members/events?limit=100&page=101')
+                .expectStatus(400);
+        });
     });
 
     // Activity feed

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -4,6 +4,114 @@ const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 
 describe('EventRepository', function () {
+    describe('getEventTimeline', function () {
+        function createEventModel(id, createdAt) {
+            return {
+                toJSON() {
+                    return {
+                        id,
+                        created_at: createdAt,
+                        member: null
+                    };
+                }
+            };
+        }
+
+        function createPaginatedModel(events) {
+            return {
+                findPage(options) {
+                    const page = Number(options.page ?? 1);
+                    const limit = Number(options.limit);
+                    const start = (page - 1) * limit;
+                    const orderedEvents = options.order === 'created_at desc, id desc' ? events : [...events].reverse();
+
+                    return {
+                        data: orderedEvents.slice(start, start + limit),
+                        meta: {
+                            pagination: {
+                                total: events.length
+                            }
+                        }
+                    };
+                }
+            };
+        }
+
+        function createRepository() {
+            return new EventRepository({
+                EmailRecipient: null,
+                MemberLoginEvent: createPaginatedModel([
+                    createEventModel('login-4', '2026-08-17T04:00:00.000Z'),
+                    createEventModel('login-2', '2026-08-17T02:00:00.000Z')
+                ]),
+                MemberPaymentEvent: createPaginatedModel([
+                    createEventModel('payment-3', '2026-08-17T03:00:00.000Z'),
+                    createEventModel('payment-1', '2026-08-17T01:00:00.000Z')
+                ])
+            });
+        }
+
+        it('paginates the globally ordered timeline across interleaved event sources', async function () {
+            const eventRepository = createRepository();
+
+            const result = await eventRepository.getEventTimeline({
+                filter: 'type:[login_event,payment_event]',
+                limit: 2,
+                page: 2
+            });
+
+            assert.deepEqual(result.events.map(event => event.data.id), ['login-2', 'payment-1']);
+            assert.deepEqual(result.meta.pagination, {
+                page: 2,
+                limit: 2,
+                pages: 2,
+                total: 4,
+                next: null,
+                prev: 1
+            });
+        });
+
+        it('normalizes page zero to the first page', async function () {
+            const eventRepository = createRepository();
+
+            const result = await eventRepository.getEventTimeline({
+                filter: 'type:[login_event,payment_event]',
+                limit: '2',
+                page: '0'
+            });
+
+            assert.deepEqual(result.events.map(event => event.data.id), ['login-4', 'payment-3']);
+            assert.deepEqual(result.meta.pagination, {
+                page: 1,
+                limit: 2,
+                pages: 2,
+                total: 4,
+                next: 2,
+                prev: null
+            });
+        });
+
+        it('uses integer pagination semantics', async function () {
+            const eventRepository = createRepository();
+
+            const result = await eventRepository.getEventTimeline({
+                filter: 'type:[login_event,payment_event]',
+                limit: '2.5',
+                page: '1.5'
+            });
+
+            assert.deepEqual(result.events.map(event => event.data.id), ['login-4', 'payment-3']);
+            assert.deepEqual(result.meta.pagination, {
+                page: 1,
+                limit: 2,
+                pages: 2,
+                total: 4,
+                next: 2,
+                prev: null
+            });
+        });
+    });
+
     describe('getNQLSubset', function () {
         let eventRepository;
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -91,6 +91,44 @@ describe('EventRepository', function () {
             });
         });
 
+        it('normalizes negative pages to the first page', async function () {
+            const eventRepository = createRepository();
+
+            const result = await eventRepository.getEventTimeline({
+                filter: 'type:[login_event,payment_event]',
+                limit: '2',
+                page: '-1'
+            });
+
+            assert.deepEqual(result.events.map(event => event.data.id), ['login-4', 'payment-3']);
+            assert.deepEqual(result.meta.pagination, {
+                page: 1,
+                limit: 2,
+                pages: 2,
+                total: 4,
+                next: 2,
+                prev: null
+            });
+        });
+
+        it('rejects page windows larger than 10,000 events', async function () {
+            const eventRepository = createRepository();
+            const loginEvents = sinon.spy(eventRepository, 'getLoginEvents');
+            const paymentEvents = sinon.spy(eventRepository, 'getPaymentEvents');
+
+            await assert.rejects(eventRepository.getEventTimeline({
+                filter: 'type:[login_event,payment_event]',
+                limit: '100',
+                page: '101'
+            }), {
+                name: 'BadRequestError',
+                message: 'Requested page is too large'
+            });
+
+            sinon.assert.notCalled(loginEvents);
+            sinon.assert.notCalled(paymentEvents);
+        });
+
         it('uses integer pagination semantics', async function () {
             const eventRepository = createRepository();
 


### PR DESCRIPTION
## What changed

`/members/events/` now honors explicit `page` requests using standard numeric pagination metadata. Each filtered event source contributes enough candidates for the requested global window; the results are merged, globally sorted, and then sliced.

Requests that omit `page` keep the existing cursor behavior, ordering, filters, totals, and metadata shape used by current Admin consumers.

The change also adds unit coverage for interleaved event sources and Admin API coverage for page composition, member filtering, and the 100-event limit cap.

## Why

The endpoint exposed pagination metadata but discarded the incoming `page` option. Applying the page independently to each heterogeneous event source would also skip valid events after the global merge, so pagination has to happen after filtering and sorting the combined timeline.

fixes https://linear.app/ghost/issue/ONC-1948/make-membersevents-honor-admin-api-pagination

## Testing

- `pnpm test:single test/unit/server/services/members/members-api/repositories/event-repository.test.js` — 33 passed
- `pnpm test:single test/e2e-api/admin/activity-feed.test.js` — 23 passed
- `pnpm nx run ghost:lint` — passed
- `pnpm nx run ghost:build:tsc` — passed
- Commit lint, dependency, secret, submodule, and changeset hooks — passed
- Full `pnpm check` reached two unrelated failures: an existing email-renderer date assertion and a Koenig browser timeout; the Koenig test passed on isolated rerun

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
