### PR TITLE
Extracted the members CSV transform into its own module

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members-csv-transform.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members-csv-transform.js
@@ -1,0 +1,51 @@
+//@ts-check
+const {Transform} = require('stream');
+const {serialize: serializeCSV} = require('../../../../../services/members/import-export/csv');
+// The export CSV row shape and its encode live in the domain (typed against the export
+// row) rather than here, so a change to the export row is caught by the compiler.
+const {toExportCsvRow} = require('../../../../../services/members/import-export/export/exporter');
+
+/**
+ * Create a CSV Transform stream
+ *
+ * Pipe a `Readable` of member objects in, pipe CSV string out. Extracted from
+ * the members output serializer so the site export orchestrator can reuse it.
+ *
+ * @returns {Transform} Transform stream that converts objects to CSV
+ */
+function createCSVTransform() {
+    // Locked in from the first row rather than declared up front: custom fields
+    // add a column per site, so the column set isn't known until a row arrives.
+    // Every row carries the same keys, so the first is representative.
+    let fields = null;
+
+    return new Transform({
+        objectMode: true,
+        transform(member, encoding, callback) {
+            try {
+                // Format the member data for CSV
+                const formattedMember = toExportCsvRow(member);
+
+                // For first chunk, include the headers
+                if (fields === null) {
+                    fields = Object.keys(formattedMember);
+                    const csv = serializeCSV([formattedMember], {columns: fields, header: true});
+                    callback(null, csv);
+                } else {
+                    // For subsequent chunks, don't include headers, just the data
+                    const csv = serializeCSV([formattedMember], {columns: fields, header: false});
+
+                    // Make sure each row starts with a newline to ensure separation between rows
+                    // Ensure consistent line endings by using explicit CR+LF sequence
+                    callback(null, '\r\n' + csv.replace(/^\r?\n+/, ''));
+                }
+            } catch (err) {
+                callback(err);
+            }
+        }
+    });
+}
+
+module.exports = {
+    createCSVTransform
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -1,12 +1,8 @@
 //@ts-check
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:output:members');
-const {serialize: serializeCSV} = require('../../../../../services/members/import-export/csv');
-// The export CSV row shape and its encode live in the domain (typed against the export
-// row) rather than here, so a change to the export row is caught by the compiler.
-const {toExportCsvRow} = require('../../../../../services/members/import-export/export/exporter');
 const mappers = require('./mappers');
-const {Transform} = require('stream');
+const {createCSVTransform} = require('./members-csv-transform');
 const {createCSVStreamResponse} = require('./stream-csv-response');
 module.exports = {
     browse: createSerializer('browse', paginatedMembers),
@@ -361,43 +357,6 @@ function serializeNewsletters(newsletters) {
             return a.sort_order - b.sort_order;
         })
         .map(newsletter => serializeNewsletter(newsletter));
-}
-
-/**
- * Create a CSV Transform stream
- * @returns {Transform} Transform stream that converts objects to CSV
- */
-function createCSVTransform() {
-    // Locked in from the first row rather than declared up front: custom fields
-    // add a column per site, so the column set isn't known until a row arrives.
-    // Every row carries the same keys, so the first is representative.
-    let fields = null;
-
-    return new Transform({
-        objectMode: true,
-        transform(member, encoding, callback) {
-            try {
-                // Format the member data for CSV
-                const formattedMember = toExportCsvRow(member);
-
-                // For first chunk, include the headers
-                if (fields === null) {
-                    fields = Object.keys(formattedMember);
-                    const csv = serializeCSV([formattedMember], {columns: fields, header: true});
-                    callback(null, csv);
-                } else {
-                    // For subsequent chunks, don't include headers, just the data
-                    const csv = serializeCSV([formattedMember], {columns: fields, header: false});
-
-                    // Make sure each row starts with a newline to ensure separation between rows
-                    // Ensure consistent line endings by using explicit CR+LF sequence
-                    callback(null, '\r\n' + csv.replace(/^\r?\n+/, ''));
-                }
-            } catch (err) {
-                callback(err);
-            }
-        }
-    });
 }
 
 /**


### PR DESCRIPTION
ref https://linear.app/ghost/issue/GVA-917

**This PR does not change behaviour.** 

## What moves

The transform that turns member rows into CSV chunks moves out of the members output serializer (`serializers/output/members.js`) into its own module, `members-csv-transform.js` — mirroring how the posts CSV transform already lives in `posts-csv-transform.ts`. The function body is moved verbatim; the serializer keeps calling the identical code.

## Why

The upcoming site export orchestrator needs to reuse this transform to produce `members.csv` inside the export zip. Without the extraction it would have to import the whole members serializer (mappers and all) to get at one pure function.
