### PR TITLE
Extracted a shared helper from the CSV stream response

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/stream-csv-response.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/stream-csv-response.ts
@@ -1,6 +1,5 @@
-import {pipeline, Readable, Transform} from 'node:stream';
-import {IncomingMessage, ServerResponse} from 'node:http';
-import {InternalServerError} from '@tryghost/errors';
+import {Readable, Transform} from 'node:stream';
+import {createStreamResponse} from './stream-response';
 
 interface CSVStreamResponseOptions {
     /** Object-mode readable producing the rows to export. */
@@ -12,36 +11,15 @@ interface CSVStreamResponseOptions {
 }
 
 /**
- * Builds the `frame.response` handler for a streaming CSV download, centralising
- * the wiring shared by every CSV export: the Content-Type/Content-Disposition
- * headers, the `no-transform` cache directive (so proxies don't recompress and
- * corrupt the byte stream), and `pipeline()` piping that tears down every stream
- * on error.
+ * Builds the `frame.response` handler for a streaming CSV download — the
+ * shared header/piping wiring lives in `stream-response`.
  */
 export function createCSVStreamResponse({source, transform, filename}: CSVStreamResponseOptions) {
-    return function streamResponse(req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) {
-        if (!filename) {
-            return next(new InternalServerError({
-                message: 'Missing CSV export filename'
-            }));
-        }
-
-        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-        res.setHeader('Content-Disposition', `Attachment; filename="${filename}"`);
-
-        const cacheControl = res.getHeader('Cache-Control');
-        const cacheControlDirectives = cacheControl ? String(cacheControl).split(',').map((value: string) => value.trim().toLowerCase()) : [];
-        if (!cacheControlDirectives.includes('no-transform')) {
-            res.setHeader('Cache-Control', cacheControl ? `${cacheControl}, no-transform` : 'no-transform');
-        }
-
-        pipeline(source, transform, res, (err) => {
-            // On success, pipeline has already ended the response and there's no
-            // downstream middleware waiting. Only forward errors so the framework's
-            // error handler can log them and (if possible) send a status to the client.
-            if (err) {
-                next(err);
-            }
-        });
-    };
+    return createStreamResponse({
+        source,
+        transform,
+        filename,
+        contentType: 'text/csv; charset=utf-8',
+        missingFilenameMessage: 'Missing CSV export filename'
+    });
 }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/stream-response.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/stream-response.ts
@@ -1,0 +1,57 @@
+import {pipeline, Transform} from 'node:stream';
+import {IncomingMessage, ServerResponse} from 'node:http';
+import {InternalServerError} from '@tryghost/errors';
+
+interface StreamResponseOptions {
+    /** Readable producing the response bytes (or rows, when a transform is given). */
+    source: NodeJS.ReadableStream;
+    /** Optional transform between source and response (e.g. rows → CSV chunks). */
+    transform?: Transform;
+    /** Filename to advertise in the `Content-Disposition` header. */
+    filename: string;
+    /** Value for the `Content-Type` header. */
+    contentType: string;
+    /** Error message when `filename` is missing — format-specific for callers that pin it. */
+    missingFilenameMessage?: string;
+}
+
+/**
+ * Builds the `frame.response` handler for a streaming download, centralising
+ * the wiring shared by every streamed export (CSV, zip): the
+ * Content-Type/Content-Disposition headers, the `no-transform` cache directive
+ * (so proxies don't recompress and corrupt the byte stream), and `pipeline()`
+ * piping that tears down every stream on error.
+ */
+export function createStreamResponse({source, transform, filename, contentType, missingFilenameMessage = 'Missing export filename'}: StreamResponseOptions) {
+    return function streamResponse(req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) {
+        if (!filename) {
+            return next(new InternalServerError({
+                message: missingFilenameMessage
+            }));
+        }
+
+        res.setHeader('Content-Type', contentType);
+        res.setHeader('Content-Disposition', `Attachment; filename="${filename}"`);
+
+        const cacheControl = res.getHeader('Cache-Control');
+        const cacheControlDirectives = cacheControl ? String(cacheControl).split(',').map((value: string) => value.trim().toLowerCase()) : [];
+        if (!cacheControlDirectives.includes('no-transform')) {
+            res.setHeader('Cache-Control', cacheControl ? `${cacheControl}, no-transform` : 'no-transform');
+        }
+
+        // On success, pipeline has already ended the response and there's no
+        // downstream middleware waiting. Only forward errors so the framework's
+        // error handler can log them and (if possible) send a status to the client.
+        const done = (err?: NodeJS.ErrnoException | null) => {
+            if (err) {
+                next(err);
+            }
+        };
+
+        if (transform) {
+            pipeline(source, transform, res, done);
+        } else {
+            pipeline(source, res, done);
+        }
+    };
+}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/GVA-917

**This PR does not change behaviour.** 

## What moves

`stream-csv-response.ts` owned three concerns that are not CSV-specific: the `Content-Type`/`Content-Disposition` headers, the `no-transform` cache directive (so proxies don't recompress and corrupt a byte stream), and the `pipeline()` teardown wiring. Those move into a generic `stream-response.ts`; the CSV helper becomes a thin wrapper that pins its content type and its exact `Missing CSV export filename` error message (which a unit test asserts).

## Why

The upcoming site export streams a zip and needs the identical response plumbing. A near-verbatim second copy would let the two silently drift — e.g. a future Content-Disposition escaping fix landing in only one of them.

