### PR TITLE
Extracted theme zipping into a reusable zipToFile

### DIFF
--- a/ghost/core/core/server/services/themes/index.js
+++ b/ghost/core/core/server/services/themes/index.js
@@ -31,6 +31,7 @@ module.exports = {
         activate: activate.activate,
         getThemeErrors: validate.getThemeErrors,
         getZip: storage.getZip,
+        zipToFile: storage.zipToFile,
         setFromZip: storage.setFromZip,
         installFromGithub: installer.installFromGithub,
         destroy: storage.destroy

--- a/ghost/core/core/server/services/themes/storage.js
+++ b/ghost/core/core/server/services/themes/storage.js
@@ -53,6 +53,25 @@ module.exports = {
             name: themeName
         });
     },
+    /**
+     * The same artifact `getZip` serves, for callers that need a file
+     * instead of an express handler.
+     *
+     * @param {string} themeName
+     * @param {string} zipPath - full path the zip is written to
+     * @returns {Promise<{path: string, size: number}>}
+     */
+    zipToFile: async (themeName, zipPath) => {
+        const theme = list.get(themeName);
+
+        if (!theme) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.invalidThemeName)
+            });
+        }
+
+        return await getStorage().zipToFile(themeName, zipPath);
+    },
     setFromZip: async (zip, {copySettingsFrom} = {}) => {
         const themeName = getStorage().getSanitizedFileName(zip.name.split('.zip')[0]);
         const backupName = `${themeName}_${ObjectID()}`;

--- a/ghost/core/core/server/services/themes/theme-storage.js
+++ b/ghost/core/core/server/services/themes/theme-storage.js
@@ -20,12 +20,23 @@ class ThemeStorage extends LocalStorageBase {
         return this.storagePath;
     }
 
+    /**
+     * The single place a theme is turned into a zip — shared by the theme
+     * download endpoint and the site export.
+     *
+     * @param {string} themeName
+     * @param {string} zipPath - full path the zip is written to
+     * @returns {Promise<{path: string, size: number}>}
+     */
+    zipToFile(themeName, zipPath) {
+        return compress(path.join(this.storagePath, themeName), zipPath);
+    }
+
     serve(options) {
         const self = this;
 
         return function downloadTheme(req, res, next) {
             const themeName = options.name;
-            const themePath = path.join(self.storagePath, themeName);
             const zipName = themeName + '.zip';
 
             // store this in a unique temporary folder
@@ -36,7 +47,7 @@ class ThemeStorage extends LocalStorageBase {
 
             fs.ensureDir(zipBasePath)
                 .then(function () {
-                    return compress(themePath, zipPath);
+                    return self.zipToFile(themeName, zipPath);
                 })
                 .then(function (result) {
                     res.set({

--- a/ghost/core/test/unit/server/services/themes/storage.test.js
+++ b/ghost/core/test/unit/server/services/themes/storage.test.js
@@ -1,0 +1,13 @@
+const assert = require('node:assert/strict');
+const storage = require('../../../../../core/server/services/themes/storage');
+
+describe('Themes storage', function () {
+    describe('zipToFile', function () {
+        it('rejects a theme that is not installed', async function () {
+            await assert.rejects(
+                storage.zipToFile('not-installed', '/tmp/not-installed.zip'),
+                {name: 'BadRequestError'}
+            );
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/GVA-917

**This PR does not change behaviour** for the theme download.

## What moves

`ThemeStorage.serve()` built the theme zip inline with `compress(themePath, zipPath)`. That call moves into a new `ThemeStorage.zipToFile(themeName, zipPath)` and `serve()` delegates to it — same arguments, identical zip. The method is also exposed through the themes storage API with the same installed-theme validation gate `getZip` applies, and that validation branch gains a unit test.

## Why

The upcoming site export bundles one zip per installed theme, and those zips must stay byte-compatible with what the theme upload accepts. Keeping zip creation in exactly one place makes drift between the download endpoint and the export impossible.
