### PR TITLE
Generalized the export filename builder beyond CSV

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/csv-export-filename.js
+++ b/ghost/core/core/server/api/endpoints/utils/csv-export-filename.js
@@ -2,24 +2,34 @@ const {slugify} = require('@tryghost/string');
 const settingsCache = require('../../../../shared/settings-cache');
 
 /**
- * Builds a CSV export filename prefixed with the slugified site title, e.g.
- * `my-site.ghost.members.2024-01-01.csv` (falling back to `ghost.<type>.<date>.csv`
+ * Builds an export filename prefixed with the slugified site title, e.g.
+ * `my-site.ghost.members.2024-01-01.csv` (falling back to `ghost.<type>.<date>.<ext>`
  * when the title is empty or slugifies to nothing).
  *
  * Single source of truth: the API sets this on `Content-Disposition` and the
  * admin client reads it back, so the convention only lives here.
  *
- * @param {string} type - The export type, e.g. `members` or `analytics`.
+ * @param {string} type - The export type, e.g. `members`, `analytics` or `export`.
+ * @param {string} extension - The file extension, e.g. `csv` or `zip`.
  * @returns {string}
  */
-function getCSVExportFileName(type) {
+function getExportFileName(type, extension) {
     const datetime = (new Date()).toJSON().substring(0, 10);
     const slug = slugify(settingsCache.get('title') || '');
     const titlePrefix = slug ? `${slug}.` : '';
 
-    return `${titlePrefix}ghost.${type}.${datetime}.csv`;
+    return `${titlePrefix}ghost.${type}.${datetime}.${extension}`;
+}
+
+/**
+ * @param {string} type - The export type, e.g. `members` or `analytics`.
+ * @returns {string}
+ */
+function getCSVExportFileName(type) {
+    return getExportFileName(type, 'csv');
 }
 
 module.exports = {
-    getCSVExportFileName
+    getCSVExportFileName,
+    getExportFileName
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/GVA-917

**This PR does not change behaviour.**

## What changes

`getCSVExportFileName(type)` returns byte-identical filenames, now by delegating to a `getExportFileName(type, extension)` that can also build filenames for other extensions.

## Why

The upcoming site export zip uses the same site-title-prefixed naming convention (`my-site.ghost.export.2026-01-01.zip`), and this file is documented as the single source of truth for that convention — the API sets it on `Content-Disposition` and the admin client reads it back.
