### PR TITLE
Added the sync site export behind the selfServeArchives flag

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -111,6 +111,11 @@ export type Config = {
         managedEmail?: {
             enabled?: boolean
             sendingDomain?: string
+        },
+        export?: {
+            // Host archive webhook — when set, "Export data" delivers the
+            // archive by email instead of a synchronous download
+            generate_archive_url?: string
         }
     }
     security?: {

--- a/apps/admin-x-framework/src/api/exports.ts
+++ b/apps/admin-x-framework/src/api/exports.ts
@@ -1,0 +1,12 @@
+import {blobDownloadFromEndpoint, type BlobDownloadOptions} from '../utils/helpers';
+
+export type SiteExportComponent = 'content' | 'members' | 'analytics' | 'themes' | 'routes';
+
+/**
+ * Downloads the sync site export zip. Fetch-based rather than a plain
+ * navigation so callers can observe completion, errors and cancellation —
+ * a navigation download is invisible to the page.
+ */
+export const downloadSiteExport = (components: SiteExportComponent[], options: BlobDownloadOptions = {}): Promise<void> => {
+    return blobDownloadFromEndpoint(`/exports/download/?components=${components.join(',')}`, 'site-export.zip', options);
+};

--- a/apps/admin-x-framework/src/utils/helpers.ts
+++ b/apps/admin-x-framework/src/utils/helpers.ts
@@ -72,6 +72,11 @@ export function getFilenameFromContentDisposition(header: string | null): string
     return undefined;
 }
 
+export interface BlobDownloadOptions {
+    /** Aborts the in-flight fetch (e.g. the user cancelled the download). */
+    signal?: AbortSignal;
+}
+
 /**
  * Downloads a file by fetching it as a blob and triggering a browser download.
  * Use this instead of downloadFile/downloadFromEndpoint for streaming responses
@@ -80,8 +85,8 @@ export function getFilenameFromContentDisposition(header: string | null): string
  * The filename comes from the response's `Content-Disposition` header;
  * `fallbackFilename` is only used when the server omits it.
  */
-export async function blobDownload(url: string, fallbackFilename?: string): Promise<void> {
-    const response = await fetch(url, {method: 'GET'});
+export async function blobDownload(url: string, fallbackFilename?: string, {signal}: BlobDownloadOptions = {}): Promise<void> {
+    const response = await fetch(url, {method: 'GET', signal});
 
     if (!response.ok) {
         throw new Error(`Download failed: ${response.status} ${response.statusText}`);
@@ -103,7 +108,7 @@ export async function blobDownload(url: string, fallbackFilename?: string): Prom
     window.URL.revokeObjectURL(blobUrl);
 }
 
-export async function blobDownloadFromEndpoint(path: string, fallbackFilename?: string): Promise<void> {
+export async function blobDownloadFromEndpoint(path: string, fallbackFilename?: string, options: BlobDownloadOptions = {}): Promise<void> {
     const url = `${getGhostPaths().apiRoot}${path}`;
-    return blobDownload(url, fallbackFilename);
+    return blobDownload(url, fallbackFilename, options);
 }

--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -1,13 +1,24 @@
 import {describe, expect, it} from "vitest";
 import {page} from "vitest/browser";
 
-import {configResponse, fakeSettingsScreens, renderAdminApp} from "@test-utils/acceptance";
+import {configResponse, fakeAdminEndpoint, fakeSettingsScreens, renderAdminApp} from "@test-utils/acceptance";
 import {settingsScreen} from "@/settings/settings.screen";
 
 async function openExportTab() {
     const section = settingsScreen.section("migrationtools");
     await section.getByRole("tab", {name: "Export"}).click();
     return section;
+}
+
+/** A minimal but valid (empty) zip: just the end-of-central-directory record. */
+function emptyZip(): ArrayBuffer {
+    const bytes = new Uint8Array(22);
+    bytes.set([0x50, 0x4b, 0x05, 0x06]);
+    return bytes.buffer;
+}
+
+function fakeExportDownload() {
+    return fakeAdminEndpoint("GET", /^\/exports\/download\//, emptyZip(), {contentType: "application/zip"});
 }
 
 describe("Migration tools export", () => {
@@ -21,8 +32,9 @@ describe("Migration tools export", () => {
         await expect.element(section.getByRole("button", {name: "Export data"})).not.toBeInTheDocument();
     });
 
-    it("offers the sync export dialog without media when no archive host is configured", async () => {
+    it("offers the sync export dialog without media and downloads the zip", async () => {
         fakeSettingsScreens();
+        const download = fakeExportDownload();
         await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
 
         const section = await openExportTab();
@@ -34,7 +46,43 @@ describe("Migration tools export", () => {
         await expect.element(dialog.getByText("Media files", {exact: true})).not.toBeInTheDocument();
 
         await dialog.getByRole("button", {name: "Export", exact: true}).click();
-        await expect.element(dialog.getByText("Preparing your export", {exact: false})).toBeVisible();
+
+        // The dialog reaches a real done state once the download completes
+        await expect.element(dialog.getByText("Export downloaded", {exact: false})).toBeVisible();
+        expect(download.lastRequest?.url).toContain("/exports/download/?components=content,members,analytics,themes,routes");
+    });
+
+    it("only requests the selected components", async () => {
+        fakeSettingsScreens();
+        const download = fakeExportDownload();
+        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByRole("checkbox", {name: "Members"}).click();
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        await expect.element(dialog.getByText("Export downloaded", {exact: false})).toBeVisible();
+        expect(download.lastRequest?.url).toContain("/exports/download/?components=content,analytics,themes,routes");
+    });
+
+    it("returns to the selection and surfaces the error when the download fails", async () => {
+        fakeSettingsScreens();
+        fakeAdminEndpoint("GET", /^\/exports\/download\//, {errors: [{message: "Boom"}]}, {status: 500});
+        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        // The error is surfaced, and we're back on the selection for a retry
+        await expect.element(page.getByText("Something went wrong, please try again.")).toBeVisible();
+        await expect.element(dialog.getByRole("button", {name: "Export", exact: true})).toBeVisible();
+        await expect.element(dialog.getByText("Export downloaded", {exact: false})).not.toBeInTheDocument();
     });
 
     it("offers media and email delivery when an archive host is configured", async () => {

--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -48,7 +48,7 @@ describe("Migration tools export", () => {
         await dialog.getByRole("button", {name: "Export", exact: true}).click();
 
         // The dialog reaches a real done state once the download completes
-        await expect.element(dialog.getByText("Export downloaded", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Export complete", {exact: false})).toBeVisible();
         expect(download.lastRequest?.url).toContain("/exports/download/?components=content,members,analytics,themes,routes");
     });
 
@@ -64,7 +64,7 @@ describe("Migration tools export", () => {
         await dialog.getByRole("checkbox", {name: "Members"}).click();
         await dialog.getByRole("button", {name: "Export", exact: true}).click();
 
-        await expect.element(dialog.getByText("Export downloaded", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Export complete", {exact: false})).toBeVisible();
         expect(download.lastRequest?.url).toContain("/exports/download/?components=content,analytics,themes,routes");
     });
 
@@ -82,7 +82,7 @@ describe("Migration tools export", () => {
         // The error is surfaced, and we're back on the selection for a retry
         await expect.element(page.getByText("Something went wrong, please try again.")).toBeVisible();
         await expect.element(dialog.getByRole("button", {name: "Export", exact: true})).toBeVisible();
-        await expect.element(dialog.getByText("Export downloaded", {exact: false})).not.toBeInTheDocument();
+        await expect.element(dialog.getByText("Export complete", {exact: false})).not.toBeInTheDocument();
     });
 
     it("offers media and email delivery when an archive host is configured", async () => {

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -193,11 +193,11 @@ const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => 
                     <>
                         <DialogHeader>
                             <DialogTitle className='flex items-center gap-2'>
-                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Export downloaded
+                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Export complete
                             </DialogTitle>
                         </DialogHeader>
                         <DialogDescription>
-                            Your export has been downloaded as a zip file.
+                            The data has been exported as a zip file. You can now close this window.
                         </DialogDescription>
                         <DialogFooter className='sm:justify-end'>
                             <Button onClick={() => handleOpenChange(false)}>Close</Button>

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -149,7 +149,7 @@ const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => 
                         </div>
                         <DialogFooter className='gap-2 sm:justify-end'>
                             <Button variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
-                            <Button disabled={noneSelected} onClick={startExport}>
+                            <Button disabled={noneSelected} onClick={() => void startExport()}>
                                 <LucideIcon.Download /> Export
                             </Button>
                         </DialogFooter>

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -11,7 +11,9 @@ import {
     LoadingIndicator
 } from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {downloadSiteExport, type SiteExportComponent} from '@tryghost/admin-x-framework/api/exports';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 export type ExportMode = 'sync' | 'async';
 
@@ -38,6 +40,7 @@ type ExportPhase = 'select' | 'confirmed' | 'preparing' | 'done';
 
 const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => void; mode: ExportMode}> = ({open, onOpenChange, mode}) => {
     const {data: currentUser} = useCurrentUser();
+    const handleError = useHandleError();
     const [phase, setPhase] = useState<ExportPhase>('select');
     const [selected, setSelected] = useState<Record<ExportComponentKey, boolean>>(() => {
         const initial = {} as Record<ExportComponentKey, boolean>;
@@ -46,8 +49,8 @@ const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => 
         });
         return initial;
     });
-    const mockTimerRef = useRef<ReturnType<typeof setTimeout>>();
     const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
+    const abortRef = useRef<AbortController>();
 
     const email = currentUser?.email;
     const visibleComponents = EXPORT_COMPONENTS.filter(component => mode === 'async' || !component.asyncOnly);
@@ -60,40 +63,44 @@ const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => 
             setPhase('select');
             return;
         }
-        clearTimeout(mockTimerRef.current);
+        abortRef.current?.abort();
         clearTimeout(resetTimerRef.current);
         // Reset for the next open, after the close animation
         resetTimerRef.current = setTimeout(() => setPhase('select'), 200);
     };
 
-    // Static UX/UI mockup, nothing is wired to a backend
-    const startExport = () => {
+    const startExport = async () => {
         if (mode === 'async') {
+            // Host mode is not wired to a backend yet — mocked confirmation only
             setPhase('confirmed');
             return;
         }
-        setPhase('preparing');
-        mockTimerRef.current = setTimeout(() => {
-            triggerMockDownload();
-            setPhase('done');
-        }, 10000);
-    };
 
-    const triggerMockDownload = () => {
-        const emptyZip = new Uint8Array([0x50, 0x4b, 0x05, 0x06, ...new Array<number>(18).fill(0)]);
-        const url = URL.createObjectURL(new Blob([emptyZip], {type: 'application/zip'}));
-        const anchor = document.createElement('a');
-        anchor.href = url;
-        anchor.download = 'ghost-export.zip';
-        document.body.appendChild(anchor);
-        anchor.click();
-        anchor.remove();
-        URL.revokeObjectURL(url);
+        const components = visibleComponents
+            .filter(component => selected[component.key] && component.key !== 'media')
+            .map(component => component.key as SiteExportComponent);
+
+        const controller = new AbortController();
+        abortRef.current = controller;
+        setPhase('preparing');
+
+        try {
+            await downloadSiteExport(components, {signal: controller.signal});
+            // The functional updates guard against a stale transition after
+            // the dialog was closed and reset meanwhile
+            setPhase(current => (current === 'preparing' ? 'done' : current));
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                return;
+            }
+            handleError(error);
+            setPhase(current => (current === 'preparing' ? 'select' : current));
+        }
     };
 
     useEffect(() => {
         return () => {
-            clearTimeout(mockTimerRef.current);
+            abortRef.current?.abort();
             clearTimeout(resetTimerRef.current);
         };
     }, []);

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -197,7 +197,7 @@ const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => 
                             </DialogTitle>
                         </DialogHeader>
                         <DialogDescription>
-                            The data has been exported as a zip file. You can now close this window.
+                            Your export has been downloaded as a zip file.
                         </DialogDescription>
                         <DialogFooter className='sm:justify-end'>
                             <Button onClick={() => handleOpenChange(false)}>Close</Button>

--- a/apps/admin/src/settings/advanced/migration-tools/migration-tools-export.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/migration-tools-export.tsx
@@ -15,8 +15,7 @@ const MigrationToolsExport: React.FC = () => {
 
     const hasSelfServeArchives = useFeatureFlag('selfServeArchives');
     const {data: configData} = useBrowseConfig();
-    const hostSettings = configData?.config?.hostSettings as {export?: {generate_archive_url?: string}} | undefined;
-    const mode: ExportMode = hostSettings?.export?.generate_archive_url ? 'async' : 'sync';
+    const mode: ExportMode = configData?.config.hostSettings?.export?.generate_archive_url ? 'async' : 'sync';
 
     const exportPosts = async () => {
         if (isExportingPosts) {

--- a/ghost/core/core/server/api/endpoints/exports.js
+++ b/ghost/core/core/server/api/endpoints/exports.js
@@ -1,0 +1,139 @@
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const security = require('@tryghost/security');
+const exporter = require('../../data/exporter');
+const membersService = require('../../services/members');
+const getPostServiceInstance = require('../../services/posts/posts-service-instance');
+const routeSettings = require('../../services/route-settings');
+const customRedirects = require('../../services/custom-redirects');
+const {serializeToYaml} = require('../../services/custom-redirects/redirect-config-parser');
+const themeService = require('../../services/themes');
+const themeList = require('../../services/themes/list');
+const {SiteExporter, EXPORT_COMPONENTS} = require('../../services/exports/site-exporter');
+const {getExportFileName} = require('./utils/csv-export-filename');
+const {rejectAdminApiRestrictedFieldsTransformer} = require('./utils/api-filter-utils');
+const {createCSVTransform: createMembersCSVTransform} = require('./utils/serializers/output/members-csv-transform');
+const {createCSVTransform: createPostsCSVTransform} = require('./utils/serializers/output/posts-csv-transform');
+const {pipeline} = require('stream');
+
+const postsService = getPostServiceInstance();
+
+const messages = {
+    noComponentsSelected: 'No export components selected'
+};
+
+/**
+ * Pipes export rows through their CSV transform. `pipeline` (rather than
+ * `.pipe`) so a source error destroys the transform too — the zip stream
+ * then errors instead of hanging.
+ *
+ * @param {string} label - Which export the stream belongs to, for the error log
+ * @param {NodeJS.ReadableStream} rows
+ * @param {import('stream').Transform} transform
+ * @returns {NodeJS.ReadableStream}
+ */
+function toCSVStream(label, rows, transform) {
+    pipeline(rows, transform, (err) => {
+        if (err) {
+            logging.error(new errors.InternalServerError({
+                message: `Site export: the ${label} stream failed mid-export`,
+                err
+            }));
+        }
+    });
+    return transform;
+}
+
+/**
+ * Zips one theme into its own temp directory. The caller (SiteExporter)
+ * streams the file into the archive and runs `cleanup` when the archive
+ * closes.
+ *
+ * @param {string} name - theme name
+ * @returns {Promise<{zipPath: string, cleanup(): Promise<void>}>}
+ */
+async function zipThemeToTempFile(name) {
+    const tmpDir = path.join(os.tmpdir(), `ghost-export-${security.identifier.uid(10)}`);
+    await fs.ensureDir(tmpDir);
+
+    try {
+        const zipPath = path.join(tmpDir, `${name}.zip`);
+        await themeService.api.zipToFile(name, zipPath);
+        return {zipPath, cleanup: () => fs.remove(tmpDir)};
+    } catch (err) {
+        await fs.remove(tmpDir);
+        throw err;
+    }
+}
+
+function createSiteExporter() {
+    return new SiteExporter({
+        // Same shape the `/db/` download produces, so the file stays importable
+        exportContent: async () => ({db: [await exporter.doExport()]}),
+        // `limit: 'all'` keeps both CSV exporters on their unfiltered
+        // streaming path — without it the members exporter materialises every
+        // id into a WHERE IN and the posts exporter caps at its default page
+        exportMembersCSV: async () => toCSVStream(
+            'members',
+            await membersService.export({limit: 'all'}),
+            createMembersCSVTransform()
+        ),
+        // Same restricted-fields guard the `/posts/export/` endpoint applies
+        exportPostAnalyticsCSV: async () => toCSVStream(
+            'post analytics',
+            await postsService.export({limit: 'all', mongoTransformer: rejectAdminApiRestrictedFieldsTransformer}),
+            createPostsCSVTransform()
+        ),
+        listThemes: () => Object.keys(themeList.getAll()),
+        zipTheme: zipThemeToTempFile,
+        exportRoutesYaml: () => routeSettings.api.download(),
+        exportRedirectsYaml: async () => serializeToYaml(await customRedirects.api.getAll())
+    });
+}
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'exports',
+
+    download: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'components'
+        ],
+        validation: {
+            options: {
+                components: {
+                    values: [...EXPORT_COMPONENTS]
+                }
+            }
+        },
+        // A site export contains everything a database export contains, so
+        // the same Owner/Administrator-only gate applies
+        permissions: {
+            docName: 'db',
+            method: 'exportContent'
+        },
+        query(frame) {
+            // Absent means everything; explicitly empty means nothing selected
+            const components = frame.options.components ?? [...EXPORT_COMPONENTS];
+
+            if (components.length === 0) {
+                throw new errors.ValidationError({
+                    message: messages.noComponentsSelected
+                });
+            }
+
+            return {
+                archive: createSiteExporter().createArchive(components),
+                filename: getExportFileName('export', 'zip')
+            };
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -27,6 +27,10 @@ module.exports = {
         return apiFramework.pipeline(require('./db'), localUtils);
     },
 
+    get exports() {
+        return apiFramework.pipeline(require('./exports'), localUtils);
+    },
+
     get identities() {
         return apiFramework.pipeline(require('./identities'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/exports.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/exports.js
@@ -1,0 +1,16 @@
+const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:exports');
+const optionsUtil = require('@tryghost/api-framework').utils.options;
+
+module.exports = {
+    download(apiConfig, frame) {
+        debug('download');
+
+        // `components` arrives as a comma-separated string, or as an array
+        // when the query param is repeated; absent stays absent
+        if (frame.options.components !== undefined) {
+            frame.options.components = optionsUtil
+                .trimAndLowerCase(frame.options.components)
+                .filter(component => component !== '');
+        }
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/index.js
@@ -3,6 +3,10 @@ module.exports = {
         return require('./db');
     },
 
+    get exports() {
+        return require('./exports');
+    },
+
     get emails() {
         return require('./emails');
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/exports.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/exports.js
@@ -1,0 +1,16 @@
+const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:output:exports');
+const {createZipStreamResponse} = require('./stream-zip-response');
+
+module.exports = {
+    /**
+     * @param {{archive: NodeJS.ReadableStream, filename: string}} data
+     */
+    download(data, apiConfig, frame) {
+        debug('download');
+
+        frame.response = createZipStreamResponse({
+            source: data.archive,
+            filename: data.filename
+        });
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -28,6 +28,10 @@ module.exports = {
         return require('./db');
     },
 
+    get exports() {
+        return require('./exports');
+    },
+
     get pages() {
         return require('./pages');
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/stream-zip-response.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/stream-zip-response.ts
@@ -1,0 +1,21 @@
+import {createStreamResponse} from './stream-response';
+
+interface ZipStreamResponseOptions {
+    /** Readable producing the zip bytes (e.g. an archiver instance). */
+    source: NodeJS.ReadableStream;
+    /** Filename to advertise in the `Content-Disposition` header. */
+    filename: string;
+}
+
+/**
+ * Builds the `frame.response` handler for a streaming zip download — the
+ * shared header/piping wiring lives in `stream-response`.
+ */
+export function createZipStreamResponse({source, filename}: ZipStreamResponseOptions) {
+    return createStreamResponse({
+        source,
+        filename,
+        contentType: 'application/zip',
+        missingFilenameMessage: 'Missing zip export filename'
+    });
+}

--- a/ghost/core/core/server/services/exports/site-exporter.ts
+++ b/ghost/core/core/server/services/exports/site-exporter.ts
@@ -1,0 +1,202 @@
+import {ZipArchive, type Archiver} from 'archiver';
+import * as errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
+
+/**
+ * The components a sync site export can contain, in zip-entry order. The
+ * streaming CSVs come first so their DB connections release while the
+ * (buffered) content JSON is still being built. `media` is deliberately
+ * absent: it needs background jobs and email delivery, so it is only
+ * available through a host archive webhook.
+ */
+export const EXPORT_COMPONENTS = ['members', 'analytics', 'content', 'themes', 'routes'] as const;
+
+export type ExportComponent = typeof EXPORT_COMPONENTS[number];
+
+export interface SiteExporterDeps {
+    /** Full site JSON in the same shape the `/db/` download produces. */
+    exportContent(): Promise<unknown>;
+    /** Members CSV as a text stream (rows already serialized). */
+    exportMembersCSV(): Promise<NodeJS.ReadableStream>;
+    /** Post analytics CSV as a text stream (rows already serialized). */
+    exportPostAnalyticsCSV(): Promise<NodeJS.ReadableStream>;
+    /** Names of all installed themes. */
+    listThemes(): string[];
+    /**
+     * A single theme zipped to a temp file — the same artifact the theme
+     * download endpoint serves. The exporter calls `cleanup` once the
+     * archive is closed.
+     */
+    zipTheme(name: string): Promise<{zipPath: string; cleanup(): Promise<void>}>;
+    /** The raw routes.yaml source. */
+    exportRoutesYaml(): Promise<string>;
+    /** The redirects config serialized to yaml. */
+    exportRedirectsYaml(): Promise<string>;
+}
+
+/**
+ * Composes a site export zip from the same services the individual export
+ * endpoints call, streamed while it is being built. A component that fails
+ * to acquire is skipped and logged rather than failing the request: the
+ * response headers are typically already sent, so a mid-flight HTTP error
+ * is impossible and a bundle missing one piece beats a broken download.
+ */
+export class SiteExporter {
+    #deps: SiteExporterDeps;
+
+    constructor(deps: SiteExporterDeps) {
+        this.#deps = deps;
+    }
+
+    /**
+     * Builds a zip stream of the selected components; the caller pipes it to
+     * the response while it fills. Deflate-compressed — the nested theme zips
+     * opt out per-entry since they are already compressed.
+     */
+    createArchive(components: ExportComponent[]): Archiver {
+        const archive = new ZipArchive();
+        const cleanups: Array<() => Promise<void>> = [];
+
+        // 'close' fires on normal end and on destroy (client disconnect),
+        // so temp files are removed on every path
+        archive.once('close', () => {
+            for (const cleanup of cleanups) {
+                cleanup().catch(() => {});
+            }
+        });
+
+        this.#populate(archive, new Set(components), cleanups).catch((err) => {
+            archive.destroy(err instanceof Error ? err : new errors.InternalServerError({message: String(err)}));
+        });
+
+        return archive;
+    }
+
+    async #populate(archive: Archiver, components: Set<ExportComponent>, cleanups: Array<() => Promise<void>>): Promise<void> {
+        for (const component of EXPORT_COMPONENTS) {
+            if (archive.destroyed) {
+                return;
+            }
+
+            if (!components.has(component)) {
+                continue;
+            }
+
+            await this.#appendComponent(archive, component, cleanups);
+        }
+
+        if (archive.destroyed) {
+            return;
+        }
+
+        await archive.finalize();
+    }
+
+    async #appendComponent(archive: Archiver, component: ExportComponent, cleanups: Array<() => Promise<void>>): Promise<void> {
+        try {
+            switch (component) {
+            case 'content': {
+                const data = await this.#deps.exportContent();
+                archive.append(JSON.stringify(data), {name: 'export.json'});
+                break;
+            }
+            case 'members':
+                this.#appendStream(archive, await this.#deps.exportMembersCSV(), 'members.csv');
+                break;
+            case 'analytics':
+                this.#appendStream(archive, await this.#deps.exportPostAnalyticsCSV(), 'post-analytics.csv');
+                break;
+            case 'themes':
+                await this.#appendThemes(archive, cleanups);
+                break;
+            case 'routes':
+                await this.#appendYamlFiles(archive);
+                break;
+            }
+        } catch (err) {
+            logging.error(new errors.InternalServerError({
+                message: `Site export: the ${component} component failed and was skipped`,
+                err: err instanceof Error ? err : undefined
+            }));
+        }
+    }
+
+    /**
+     * Ties a streaming entry's lifecycle to the archive in both directions:
+     * a source error destroys the archive — archiver wraps sources with
+     * `.pipe()`, which never propagates errors, so the response would
+     * otherwise hang forever — and a closed archive destroys the source, so
+     * a paused row stream releases its DB connection.
+     */
+    #appendStream(archive: Archiver, source: NodeJS.ReadableStream, name: string): void {
+        const destroyable = source as NodeJS.ReadableStream & {destroy?: () => void};
+
+        // Closed while the source was being acquired — a 'close' listener
+        // registered now would never fire
+        if (archive.destroyed) {
+            destroyable.destroy?.();
+            return;
+        }
+
+        source.on('error', (err: Error) => {
+            archive.destroy(err);
+        });
+
+        archive.once('close', () => {
+            destroyable.destroy?.();
+        });
+
+        archive.append(source, {name});
+    }
+
+    /**
+     * One nested zip per theme — the exact artifact the theme upload UI
+     * restores from — staged as temp files and streamed off disk rather than
+     * buffered. A theme that fails to zip is skipped so the rest still make
+     * it into the bundle.
+     */
+    async #appendThemes(archive: Archiver, cleanups: Array<() => Promise<void>>): Promise<void> {
+        for (const name of this.#deps.listThemes()) {
+            if (archive.destroyed) {
+                return;
+            }
+
+            try {
+                const {zipPath, cleanup} = await this.#deps.zipTheme(name);
+
+                // Closed while this theme was zipping — the close handler has
+                // already run the cleanups, so remove the temp file directly
+                if (archive.destroyed) {
+                    cleanup().catch(() => {});
+                    return;
+                }
+
+                cleanups.push(cleanup);
+                archive.file(zipPath, {name: `themes/${name}.zip`, store: true});
+            } catch (err) {
+                logging.error(new errors.InternalServerError({
+                    message: `Site export: the ${name} theme failed to zip and was skipped`,
+                    err: err instanceof Error ? err : undefined
+                }));
+            }
+        }
+    }
+
+    async #appendYamlFiles(archive: Archiver): Promise<void> {
+        const files: Array<[string, () => Promise<string>]> = [
+            ['routes.yaml', () => this.#deps.exportRoutesYaml()],
+            ['redirects.yaml', () => this.#deps.exportRedirectsYaml()]
+        ];
+
+        for (const [filename, getContents] of files) {
+            try {
+                archive.append(await getContents(), {name: filename});
+            } catch (err) {
+                logging.error(new errors.InternalServerError({
+                    message: `Site export: ${filename} failed and was skipped`,
+                    err: err instanceof Error ? err : undefined
+                }));
+            }
+        }
+    }
+}

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -289,6 +289,9 @@ module.exports = function apiRoutes() {
         http(api.db.inlineMedia)
     );
 
+    // ## Exports
+    router.get('/exports/download', mw.authAdminApi, labs.enabledMiddleware('selfServeArchives'), http(api.exports.download));
+
     // ## Slack
     router.post('/slack/test', mw.authAdminApi, http(api.slack.sendTest));
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -143,7 +143,7 @@
         "@tryghost/validator": "0.2.22",
         "@tryghost/version": "2.3.2",
         "@tryghost/zip": "3.5.1",
-        "archiver": "catalog:",
+        "archiver": "8.0.0",
         "body-parser": "1.20.6",
         "bookshelf": "1.2.0",
         "bookshelf-relations": "2.8.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -143,6 +143,7 @@
         "@tryghost/validator": "0.2.22",
         "@tryghost/version": "2.3.2",
         "@tryghost/zip": "3.5.1",
+        "archiver": "catalog:",
         "body-parser": "1.20.6",
         "bookshelf": "1.2.0",
         "bookshelf-relations": "2.8.0",

--- a/ghost/core/test/e2e-api/admin/exports-download.test.js
+++ b/ghost/core/test/e2e-api/admin/exports-download.test.js
@@ -1,0 +1,188 @@
+const assert = require('node:assert/strict');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const supertest = require('supertest');
+const {extract} = require('@tryghost/zip');
+const config = require('../../../core/shared/config');
+const models = require('../../../core/server/models');
+const localUtils = require('./utils');
+
+// These tests make real HTTP requests (like the theme download tests) instead
+// of using the in-process test agent: the zip response streams with
+// backpressure, which the test agent's mock socket cannot signal — large
+// bodies deadlock it. The 4xx cases live in exports.test.js.
+
+// More posts than the posts exporter's default page cap, so the test proves
+// the export is not silently truncated to the default limit
+const EXTRA_POST_COUNT = 20;
+
+/**
+ * Collects a binary response body into a Buffer (superagent only buffers
+ * text-like content types by itself).
+ */
+function binaryParser(res, callback) {
+    const chunks = [];
+    res.on('data', chunk => chunks.push(chunk));
+    res.on('end', () => callback(null, Buffer.concat(chunks)));
+}
+
+/**
+ * Writes the zip response body to a temp file, extracts it and returns the
+ * extraction directory. Callers read entries with plain fs.
+ */
+async function extractZipResponse(body) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghost-exports-test-'));
+    const zipPath = path.join(dir, 'export.zip');
+    const outPath = path.join(dir, 'out');
+
+    await fs.writeFile(zipPath, body);
+    await extract(zipPath, outPath);
+
+    return outPath;
+}
+
+async function listFiles(dir) {
+    const entries = await fs.readdir(dir, {recursive: true, withFileTypes: true});
+
+    return entries
+        .filter(entry => entry.isFile())
+        .map(entry => path.relative(dir, path.join(entry.parentPath, entry.name)))
+        .sort();
+}
+
+describe('Exports API — download', function () {
+    let request;
+
+    beforeAll(async function () {
+        await localUtils.startGhost({copyThemes: true});
+        request = supertest.agent(config.get('url'));
+        await localUtils.doAuth(request, 'posts', 'newsletters', 'members:newsletters');
+
+        for (let i = 0; i < EXTRA_POST_COUNT; i++) {
+            await models.Post.add({
+                title: `Analytics post ${i}`,
+                slug: `analytics-post-${i}`,
+                status: 'published',
+                published_at: new Date()
+            }, {context: {internal: true}});
+        }
+    });
+
+    it('Can download a full site export zip', async function () {
+        const res = await request
+            .get(localUtils.API.getApiQuery('exports/download/'))
+            .set('Origin', config.get('url'))
+            .buffer(true)
+            .parse(binaryParser)
+            .expect('Content-Type', /application\/zip/)
+            .expect(200);
+
+        assert.match(res.headers['content-disposition'], /^Attachment; filename="[A-Za-z0-9._-]*ghost\.export\.\d{4}-\d{2}-\d{2}\.zip"$/);
+        assert.match(res.headers['cache-control'], /no-transform/);
+
+        const outPath = await extractZipResponse(res.body);
+        const files = await listFiles(outPath);
+
+        // Every component is present
+        assert.ok(files.includes('export.json'), `export.json missing from ${files}`);
+        assert.ok(files.includes('members.csv'), `members.csv missing from ${files}`);
+        assert.ok(files.includes('post-analytics.csv'), `post-analytics.csv missing from ${files}`);
+        assert.ok(files.includes('routes.yaml'), `routes.yaml missing from ${files}`);
+        assert.ok(files.includes('redirects.yaml'), `redirects.yaml missing from ${files}`);
+        assert.ok(files.includes('themes/casper.zip'), `themes/casper.zip missing from ${files}`);
+        assert.ok(files.includes('themes/source.zip'), `themes/source.zip missing from ${files}`);
+
+        // The content JSON has the same shape as the /db/ download, so it
+        // stays importable
+        const exportJSON = await fs.readJSON(path.join(outPath, 'export.json'));
+        assert.ok(Array.isArray(exportJSON.db), 'export.json should contain a db array');
+        assert.ok(exportJSON.db[0].data.posts.length > 0, 'export.json should contain posts');
+        assert.ok(exportJSON.db[0].meta.version, 'export.json should carry the Ghost version');
+
+        // Settings keys on the blocklist (e.g. Stripe secrets) never leave the site
+        const settingKeys = exportJSON.db[0].data.settings.map(setting => setting.key);
+        assert.ok(!settingKeys.includes('stripe_connect_secret_key'), 'blocklisted settings must not be exported');
+
+        // The CSVs are the same exports the standalone endpoints produce
+        const membersCSV = await fs.readFile(path.join(outPath, 'members.csv'), 'utf8');
+        assert.match(membersCSV, /^id,email,name/, 'members.csv should start with its header row');
+        assert.ok(membersCSV.split('\r\n').length > 1, 'members.csv should contain member rows');
+
+        // Every published post makes it into the analytics CSV — the exporter
+        // must not fall back to its default page cap
+        const analyticsCSV = await fs.readFile(path.join(outPath, 'post-analytics.csv'), 'utf8');
+        const analyticsRows = analyticsCSV.trim().split('\r\n').length - 1;
+        assert.ok(analyticsRows >= EXTRA_POST_COUNT, `expected at least ${EXTRA_POST_COUNT} analytics rows, got ${analyticsRows}`);
+
+        // The nested theme zips are themselves valid archives
+        const themeOut = path.join(outPath, 'themes-check');
+        await extract(path.join(outPath, 'themes/casper.zip'), themeOut);
+        assert.ok(await fs.pathExists(path.join(themeOut, 'package.json')), 'theme zip should contain the theme files');
+    });
+
+    it('Produces artifacts the existing import surfaces accept', async function () {
+        const res = await request
+            .get(localUtils.API.getApiQuery('exports/download/'))
+            .set('Origin', config.get('url'))
+            .buffer(true)
+            .parse(binaryParser)
+            .expect(200);
+
+        const outPath = await extractZipResponse(res.body);
+
+        // export.json → universal importer
+        await request
+            .post(localUtils.API.getApiQuery('db/'))
+            .set('Origin', config.get('url'))
+            .attach('importfile', path.join(outPath, 'export.json'))
+            .expect(200);
+
+        // members.csv → members importer (existing members show up as
+        // per-row duplicates, not a rejected file)
+        await request
+            .post(localUtils.API.getApiQuery('members/upload/'))
+            .set('Origin', config.get('url'))
+            .attach('membersfile', path.join(outPath, 'members.csv'))
+            .expect((response) => {
+                assert.ok([201, 202].includes(response.status), `expected 201/202, got ${response.status}`);
+            });
+
+        // themes/{name}.zip → theme upload (test-theme rather than casper:
+        // overriding default themes is blocked by design)
+        await request
+            .post(localUtils.API.getApiQuery('themes/upload/'))
+            .set('Origin', config.get('url'))
+            .attach('file', path.join(outPath, 'themes/test-theme.zip'))
+            .expect(200);
+
+        // routes.yaml → routes upload
+        await request
+            .post(localUtils.API.getApiQuery('settings/routes/yaml/'))
+            .set('Origin', config.get('url'))
+            .attach('routes', path.join(outPath, 'routes.yaml'))
+            .expect(200);
+
+        // redirects.yaml → redirects upload
+        await request
+            .post(localUtils.API.getApiQuery('redirects/upload/'))
+            .set('Origin', config.get('url'))
+            .attach('redirects', path.join(outPath, 'redirects.yaml'))
+            .expect(200);
+    });
+
+    it('Can download a subset of components', async function () {
+        const res = await request
+            .get(localUtils.API.getApiQuery('exports/download/?components=content,routes'))
+            .set('Origin', config.get('url'))
+            .buffer(true)
+            .parse(binaryParser)
+            .expect('Content-Type', /application\/zip/)
+            .expect(200);
+
+        const outPath = await extractZipResponse(res.body);
+        const files = await listFiles(outPath);
+
+        assert.deepEqual(files, ['export.json', 'redirects.yaml', 'routes.yaml']);
+    });
+});

--- a/ghost/core/test/e2e-api/admin/exports.test.js
+++ b/ghost/core/test/e2e-api/admin/exports.test.js
@@ -1,0 +1,63 @@
+const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+
+// The successful download path streams a large zip over real HTTP and lives in
+// exports-download.test.js — the in-process test agent used here cannot stream
+// large response bodies (its mock socket never signals drain).
+describe('Exports API', function () {
+    let agent;
+
+    beforeAll(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    afterEach(function () {
+        mockManager.restore();
+    });
+
+    it('Accepts a repeated components query param', async function () {
+        // qs parses repeated params into an array — the endpoint must
+        // normalize it rather than 500 (a routes-only zip is small enough
+        // for the in-process agent to buffer)
+        await agent
+            .get('exports/download/?components=routes&components=routes')
+            .expectStatus(200);
+    });
+
+    it('Rejects an export with no components selected', async function () {
+        await agent
+            .get('exports/download/?components=')
+            .expectStatus(422);
+    });
+
+    it('Cannot request the media component', async function () {
+        await agent
+            .get('exports/download/?components=media')
+            .expectStatus(422);
+    });
+
+    it('Cannot request an unknown component', async function () {
+        await agent
+            .get('exports/download/?components=content,everything')
+            .expectStatus(422);
+    });
+
+    it('Cannot download an export without the selfServeArchives flag', async function () {
+        mockManager.mockLabsDisabled('selfServeArchives');
+
+        await agent
+            .get('exports/download/')
+            .expectStatus(404);
+    });
+
+    it('Cannot download an export as an editor', async function () {
+        await agent.loginAsEditor();
+
+        await agent
+            .get('exports/download/')
+            .expectStatus(403);
+
+        await agent.loginAsOwner();
+    });
+});

--- a/ghost/core/test/unit/server/services/exports/site-exporter.test.ts
+++ b/ghost/core/test/unit/server/services/exports/site-exporter.test.ts
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import {once} from 'node:events';
+import {PassThrough, Readable, Writable, pipeline} from 'stream';
+import {SiteExporter, EXPORT_COMPONENTS, type SiteExporterDeps} from '../../../../../core/server/services/exports/site-exporter';
+
+// @tryghost/zip ships no types; only `extract` is used here
+const {extract} = require('@tryghost/zip') as {extract(zipPath: string, destination: string): Promise<unknown>};
+
+/** Consumes the archive into a Buffer, resolving on end and rejecting on error. */
+function collectArchive(archive: NodeJS.ReadableStream): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        const sink = new Writable({
+            write(chunk, _encoding, callback) {
+                chunks.push(chunk);
+                callback();
+            }
+        });
+        pipeline(archive, sink, (err) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(Buffer.concat(chunks));
+            }
+        });
+    });
+}
+
+async function readZip(buffer: Buffer): Promise<{files: string[], read(name: string): Promise<string>}> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'site-exporter-test-'));
+    const zipPath = path.join(dir, 'test.zip');
+    const outPath = path.join(dir, 'out');
+
+    await fs.writeFile(zipPath, buffer);
+    await extract(zipPath, outPath);
+
+    const entries = await fs.readdir(outPath, {recursive: true, withFileTypes: true});
+    const files = entries
+        .filter(entry => entry.isFile())
+        .map(entry => path.relative(outPath, path.join(entry.parentPath, entry.name)))
+        .sort();
+
+    return {
+        files,
+        read: (name: string) => fs.readFile(path.join(outPath, name), 'utf8')
+    };
+}
+
+async function stageThemeZip(contents: string): Promise<{zipPath: string, cleanup(): Promise<void>}> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'site-exporter-theme-'));
+    const zipPath = path.join(dir, 'theme.zip');
+    await fs.writeFile(zipPath, contents);
+    return {zipPath, cleanup: () => fs.remove(dir)};
+}
+
+/** Polls a condition instead of sleeping a fixed time — loaded CI machines
+ * make fixed sleeps flaky. */
+async function waitFor(condition: () => boolean | Promise<boolean>, description: string, timeoutMs = 2000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (await condition()) {
+            return;
+        }
+        await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+        });
+    }
+    throw new Error(`Timed out waiting for: ${description}`);
+}
+
+function buildDeps(overrides: Partial<SiteExporterDeps> = {}): SiteExporterDeps {
+    return {
+        exportContent: async () => ({db: [{meta: {}, data: {}}]}),
+        exportMembersCSV: async () => Readable.from(['id,email\r\n1,member@example.com']),
+        exportPostAnalyticsCSV: async () => Readable.from(['title\r\nA post']),
+        listThemes: () => ['casper'],
+        zipTheme: () => stageThemeZip('fake-zip-bytes'),
+        exportRoutesYaml: async () => 'routes: {}',
+        exportRedirectsYaml: async () => '301: {}',
+        ...overrides
+    };
+}
+
+describe('SiteExporter', function () {
+    it('composes every component into one zip', async function () {
+        const exporter = new SiteExporter(buildDeps());
+        const archive = exporter.createArchive([...EXPORT_COMPONENTS]);
+
+        const zip = await readZip(await collectArchive(archive));
+
+        assert.deepEqual(zip.files, [
+            'export.json',
+            'members.csv',
+            'post-analytics.csv',
+            'redirects.yaml',
+            'routes.yaml',
+            'themes/casper.zip'
+        ]);
+    });
+
+    it('only includes the selected components', async function () {
+        const exporter = new SiteExporter(buildDeps());
+        const archive = exporter.createArchive(['content', 'routes']);
+
+        const zip = await readZip(await collectArchive(archive));
+
+        assert.deepEqual(zip.files, ['export.json', 'redirects.yaml', 'routes.yaml']);
+    });
+
+    it('skips a component that fails to acquire and completes the zip', async function () {
+        const exporter = new SiteExporter(buildDeps({
+            exportPostAnalyticsCSV: async () => {
+                throw new Error('analytics blew up');
+            }
+        }));
+        const archive = exporter.createArchive([...EXPORT_COMPONENTS]);
+
+        const zip = await readZip(await collectArchive(archive));
+
+        assert.ok(!zip.files.includes('post-analytics.csv'));
+        assert.ok(zip.files.includes('members.csv'), 'the other components still make it into the bundle');
+        assert.ok(zip.files.includes('export.json'), 'the other components still make it into the bundle');
+    });
+
+    it('keeps the remaining themes when one fails to zip', async function () {
+        const exporter = new SiteExporter(buildDeps({
+            listThemes: () => ['casper', 'broken-theme'],
+            zipTheme: (name) => {
+                if (name === 'broken-theme') {
+                    throw new Error('cannot zip');
+                }
+                return stageThemeZip('fake-zip-bytes');
+            }
+        }));
+        const archive = exporter.createArchive(['themes']);
+
+        const zip = await readZip(await collectArchive(archive));
+
+        assert.deepEqual(zip.files, ['themes/casper.zip']);
+    });
+
+    it('keeps routes.yaml when the redirects export fails', async function () {
+        const exporter = new SiteExporter(buildDeps({
+            exportRedirectsYaml: async () => {
+                throw new Error('no redirects');
+            }
+        }));
+        const archive = exporter.createArchive(['routes']);
+
+        const zip = await readZip(await collectArchive(archive));
+
+        assert.deepEqual(zip.files, ['routes.yaml']);
+    });
+
+    it('fails the download when a streaming source errors mid-flight', async function () {
+        // archiver wraps sources with .pipe(), which never propagates errors —
+        // without explicit forwarding the archive would hang forever instead
+        // of erroring (a dropped DB connection mid-export must not hang the
+        // response)
+        const source = new PassThrough();
+        const exporter = new SiteExporter(buildDeps({
+            exportMembersCSV: async () => source
+        }));
+        const archive = exporter.createArchive(['members']);
+
+        const collected = collectArchive(archive);
+
+        // The entry's local header bytes flow as soon as the source is wired
+        // to the archive — only then can it blow up "mid-flight"
+        await once(archive, 'data');
+        source.write('id,email\r\n');
+        source.destroy(new Error('db connection lost'));
+
+        await assert.rejects(collected, /db connection lost/);
+    });
+
+    it('destroys streaming sources and cleans up theme files when the client disconnects', async function () {
+        const source = new PassThrough();
+        source.write('id,email\r\n');
+
+        const staged = await stageThemeZip('fake-zip-bytes');
+        const exporter = new SiteExporter(buildDeps({
+            exportMembersCSV: async () => source,
+            listThemes: () => ['casper'],
+            zipTheme: async () => staged
+        }));
+        const archive = exporter.createArchive(['members', 'themes']);
+
+        const collected = collectArchive(archive).catch(() => {});
+
+        // Wait until the first entry's bytes flow (the entries are appended),
+        // then simulate the client hanging up
+        await once(archive, 'data');
+        archive.destroy(new Error('client disconnected'));
+        await collected;
+
+        // The paused row stream must be released (frees its DB connection)…
+        await waitFor(() => source.destroyed, 'the members stream to be destroyed');
+
+        // …and the staged theme zip must be removed
+        await waitFor(async () => !(await fs.pathExists(staged.zipPath)), 'the staged theme zip to be removed');
+    });
+
+    it('removes a theme zip that finishes staging after the client disconnects', async function () {
+        let resolveZip!: (staged: {zipPath: string, cleanup(): Promise<void>}) => void;
+        const pendingZip = new Promise<{zipPath: string, cleanup(): Promise<void>}>((resolve) => {
+            resolveZip = resolve;
+        });
+        let zipRequested!: () => void;
+        const zipRequestedPromise = new Promise<void>((resolve) => {
+            zipRequested = resolve;
+        });
+
+        const exporter = new SiteExporter(buildDeps({
+            listThemes: () => ['casper'],
+            zipTheme: () => {
+                zipRequested();
+                return pendingZip;
+            }
+        }));
+        const archive = exporter.createArchive(['themes']);
+        collectArchive(archive).catch(() => {});
+
+        await zipRequestedPromise;
+
+        // The client hangs up while the theme is still being zipped — the
+        // archive's close handler has already run its cleanups, so the
+        // exporter must remove the late-staged temp file itself
+        archive.destroy(new Error('client disconnected'));
+
+        const staged = await stageThemeZip('fake-zip-bytes');
+        resolveZip(staged);
+
+        await waitFor(async () => !(await fs.pathExists(staged.zipPath)), 'the late-staged theme zip to be removed');
+    });
+});

--- a/ghost/core/types/archiver.d.ts
+++ b/ghost/core/types/archiver.d.ts
@@ -1,0 +1,23 @@
+// archiver v8 ships no types and the DefinitelyTyped package targets the old
+// (v7) factory API, so we declare the surface we actually use. This types
+// every `import 'archiver'` in ghost/core — extend it here when a caller
+// needs more of the real API.
+declare module 'archiver' {
+    import {Transform} from 'stream';
+
+    interface EntryData {
+        name: string;
+        /** Write this entry uncompressed (STORE) — for already-compressed sources. */
+        store?: boolean;
+    }
+
+    export class Archiver extends Transform {
+        append(source: Buffer | string | NodeJS.ReadableStream, data: EntryData): this;
+        file(filepath: string, data: EntryData): this;
+        finalize(): Promise<void>;
+    }
+
+    export class ZipArchive extends Archiver {
+        constructor(options?: {store?: boolean});
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ catalogs:
     ajv-formats:
       specifier: 3.0.1
       version: 3.0.1
+    archiver:
+      specifier: ^8.0.0
+      version: 8.0.0
     better-sqlite3:
       specifier: 12.11.1
       version: 12.11.1
@@ -2377,6 +2380,9 @@ importers:
       '@tryghost/zip':
         specifier: 3.5.1
         version: 3.5.1(supports-color@10.2.2)
+      archiver:
+        specifier: 'catalog:'
+        version: 8.0.0
       body-parser:
         specifier: 1.20.6
         version: 1.20.6(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,9 +255,6 @@ catalogs:
     ajv-formats:
       specifier: 3.0.1
       version: 3.0.1
-    archiver:
-      specifier: 8.0.0
-      version: 8.0.0
     better-sqlite3:
       specifier: 12.11.1
       version: 12.11.1
@@ -2381,7 +2378,7 @@ importers:
         specifier: 3.5.1
         version: 3.5.1(supports-color@10.2.2)
       archiver:
-        specifier: 'catalog:'
+        specifier: 8.0.0
         version: 8.0.0
       body-parser:
         specifier: 1.20.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ catalogs:
       specifier: 3.0.1
       version: 3.0.1
     archiver:
-      specifier: ^8.0.0
+      specifier: 8.0.0
       version: 8.0.0
     better-sqlite3:
       specifier: 12.11.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -203,6 +203,7 @@ catalog:
   '@octokit/plugin-throttling': 11.0.5
   '@secretlint/secretlint-rule-pattern': 13.0.4
   '@secretlint/secretlint-rule-preset-recommend': 13.0.4
+  archiver: ^8.0.0
   knip: 6.32.1
   lint-staged: 17.3.0
   secretlint: 13.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -203,7 +203,7 @@ catalog:
   '@octokit/plugin-throttling': 11.0.5
   '@secretlint/secretlint-rule-pattern': 13.0.4
   '@secretlint/secretlint-rule-preset-recommend': 13.0.4
-  archiver: ^8.0.0
+  archiver: 8.0.0
   knip: 6.32.1
   lint-staged: 17.3.0
   secretlint: 13.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -203,7 +203,6 @@ catalog:
   '@octokit/plugin-throttling': 11.0.5
   '@secretlint/secretlint-rule-pattern': 13.0.4
   '@secretlint/secretlint-rule-preset-recommend': 13.0.4
-  archiver: 8.0.0
   knip: 6.32.1
   lint-staged: 17.3.0
   secretlint: 13.0.4


### PR DESCRIPTION
closes https://linear.app/ghost/issue/GVA-917

Implements the sync delivery mode of the one-click data export, building on the mockup that landed in #29915 and the four behaviour-preserving refactors below this PR in the stack. With the `selfServeArchives` labs flag on, "Export data" now really downloads a full site archive: `GET /ghost/api/admin/exports/download/` streams one zip composed of content JSON, members CSV, post analytics CSV, per-theme zips, and routes/redirects — everything except media, which stays reserved for the host (async) mode that isn't part of this PR (its dialog branch remains mocked).

## How the zip is composed

The orchestrator calls the same services the five standalone export endpoints call — no HTTP self-calls, no background jobs, no duplicated controller logic:

```mermaid
flowchart LR
    UI["Export data dialog"] -- "GET /exports/download/?components=…" --> C["exports controller"]
    C --> SE["SiteExporter (services/exports)"]
    SE -- "membersService.export({limit:'all'})" --> M["members.csv"]
    SE -- "postsService.export({limit:'all'})" --> A["post-analytics.csv"]
    SE -- "doExport()" --> J["export.json"]
    SE -- "themeStorage.zipToFile()" --> T["themes/{name}.zip"]
    SE -- "routeSettings / customRedirects" --> R["routes.yaml + redirects.yaml"]
    M & A & J & T & R --> Z["archiver zip → streamed response"]
```

Decisions worth reviewing:

- **Streamed, not staged.** The zip pipes to the response while it's built, so memory stays flat and the download starts immediately. The price is failure semantics: once headers are sent, a component that fails to acquire can only be skipped (it's logged server-side and simply absent from the bundle). A mid-stream failure of a CSV source deliberately destroys the archive — a visibly broken download beats a silently incomplete one — and stream lifecycles are tied together in both directions so a dropped DB connection can't hang the response and a client disconnect can't pin a DB connection or leak staged temp files.
- **Restorable artifacts.** `export.json` is byte-identical to the `/db/` download and themes are the exact zips the theme upload accepts, so every piece of the bundle restores through existing import surfaces — proven by a round-trip e2e test that re-imports each artifact through the real import endpoints.
- **Permissions reuse `db.exportContent`** (Owner/Administrator only) instead of minting a new permission + migration: a site export contains everything a database export contains, so the same gate applies — and it's a superset of every composed component's own requirement.
- **Flag-only gating.** The feature stays behind the `selfServeArchives` labs flag, and that flag is the whole gate — no config capability signal for deploy skew at this stage. If the flag graduates, feature detection can come back with the GA work.
- **The dialog downloads through the fetch-based blob helper** rather than a plain navigation: a navigation download is unobservable from the page, which would leave the dialog stuck on "Preparing your export…" forever and swallow errors. The blob approach gives a real "Export downloaded" state, error feedback with retry, and a working Cancel (AbortController). Browsers back large blobs with disk, so the zip doesn't have to fit in tab memory.
- **`archiver` becomes a direct dependency** of ghost/core, but adds no new code to the tree: `@tryghost/zip` already pins the same `archiver@8.0.0` internally, and its own file-based `compress`/`extract` API can't stream a zip into an HTTP response.

## Testing it locally

1. `pnpm dev`, then in Ghost Admin enable **Settings → Labs → Private features → Self-serve archives** (developer experiments must be on).
2. Go to **Settings → Import/Export → Export** — the individual export buttons are replaced by one **Export data** button.
3. Pick components and hit Export: the dialog shows "Preparing your export…" with a working Cancel, and flips to "Export downloaded" when the zip lands in your downloads.
4. Restore-compatibility: the zip's `export.json` imports via the universal importer, `members.csv` via the members importer, `themes/*.zip` via theme upload, `routes.yaml`/`redirects.yaml` via their uploads.
5. With the flag off, the Export tab is byte-identical to `main`.

## Automated tests

- `SiteExporter` unit tests cover the failure paths: component skipping, partial themes, mid-stream teardown, client-abort cleanup.
- E2E tests are split across two files by necessity: the 4xx cases (validation, labs gate, permissions) use the in-process agent, while the actual downloads run over real HTTP like the theme download tests — the in-process agent's mock socket never signals `drain`, deadlocking any streamed body larger than the write buffer.
- The download test seeds more posts than the posts exporter's default page cap, guarding against silent truncation (an unlimited export once defaulted to 15 posts).
- A round-trip e2e test re-imports every artifact through the real import endpoints, so format drift fails CI instead of surfacing as a broken restore.
- Admin acceptance tests cover both dialog modes, component selection, and the download-complete and download-failed states.
