### PR TITLE
HKG-1914: Add the class-based jobs backend infrastructure

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -160,6 +160,14 @@ async function initCore({ghostServer, config}) {
             await mentionsJobService.shutdown();
         });
         debug('End: Mentions Job Service');
+
+        debug('Begin: Jobs Service');
+        const jobsService = require('./server/services/jobs-service');
+
+        ghostServer.registerCleanupTask(async () => {
+            await jobsService.shutdown({timeoutMs: config.get('server:shutdownTimeout')});
+        });
+        debug('End: Jobs Service');
     }
 
     debug('End: initCore');
@@ -610,6 +618,13 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
         }
 
         await initServices({ghostServer, config, prometheusClient});
+
+        debug('Begin: Register job handlers');
+        const jobsService = require('./server/services/jobs-service');
+        const service = jobsService.init();
+        require('./server/services/jobs-service/register-job-handlers').default();
+        await service.start();
+        debug('End: Register job handlers');
         debug('End: Load Ghost Services & Apps');
 
         // Step 5 - Mount the full Ghost app onto the minimal root app & disable maintenance mode

--- a/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
+++ b/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
@@ -1,0 +1,136 @@
+import errors from '@tryghost/errors';
+import fastq from 'fastq';
+import type {queueAsPromised} from 'fastq';
+import {JobsBackendBase} from '@tryghost/adapter-base-jobs';
+import type {
+    JobProcessor,
+    JobEnvelope,
+    JobsStartOptions,
+    RecurringSchedule,
+    JobsShutdownOptions
+} from '@tryghost/adapter-base-jobs';
+
+const later = require('@breejs/later');
+const logging = require('@tryghost/logging');
+
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10000;
+const DEFAULT_CONCURRENCY = 3;
+
+function hasSeconds(cron: string): boolean {
+    return cron.trim().split(/\s+/).length >= 6;
+}
+
+function resolveConcurrency(value: unknown): number {
+    if (value === undefined || value === null) {
+        return DEFAULT_CONCURRENCY;
+    }
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+        throw new errors.IncorrectUsageError({
+            message: `Invalid jobs backend concurrency: ${JSON.stringify(value)}. Expected a positive integer.`
+        });
+    }
+    return value;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+interface RecurringTimer {
+    clear(): void;
+}
+
+export default class InMemoryJobsBackend extends JobsBackendBase {
+    private _processor: JobProcessor | null;
+    private _stopped: boolean;
+    private _concurrency: number;
+    private _queue: queueAsPromised<JobEnvelope>;
+    private _recurring: Map<string, RecurringTimer>;
+
+    constructor(config: {concurrency?: unknown} = {}) {
+        super();
+        this._processor = null;
+        this._stopped = false;
+        this._concurrency = resolveConcurrency(config.concurrency);
+        this._queue = this._createQueue();
+        this._recurring = new Map();
+    }
+
+    private _createQueue(): queueAsPromised<JobEnvelope> {
+        const queue = fastq.promise((envelope: JobEnvelope) => this._deliver(envelope), this._concurrency);
+        // Paused until start() attaches a processor; enqueue buffers meanwhile.
+        queue.pause();
+        return queue;
+    }
+
+    start({processor}: JobsStartOptions): void {
+        this._processor = processor;
+        this._stopped = false;
+        this._queue.resume();
+    }
+
+    enqueue(envelope: JobEnvelope): void {
+        if (this._stopped) {
+            return;
+        }
+        this._queue.push(envelope);
+    }
+
+    private async _deliver(envelope: JobEnvelope): Promise<void> {
+        const processor = this._processor;
+        if (!processor) {
+            throw new errors.IncorrectUsageError({
+                message: 'InMemoryJobsBackend attempted a delivery with no processor attached - the backend lifecycle is broken.'
+            });
+        }
+        try {
+            await processor(envelope);
+        } catch (err) {
+            logging.error(`Job "${envelope.type}" delivery failed`, err);
+        }
+    }
+
+    scheduleRecurring(envelope: JobEnvelope, {cron}: RecurringSchedule): void {
+        // First schedule per type wins; a re-registration must not disturb a
+        // schedule that is already running (parity with a durable backend).
+        if (this._stopped || this._recurring.has(envelope.type)) {
+            return;
+        }
+
+        const parsed = later.parse.cron(cron, hasSeconds(cron));
+        const timer = later.setInterval(() => {
+            this.enqueue(envelope);
+        }, parsed);
+        this._recurring.set(envelope.type, timer);
+    }
+
+    private _clearRecurring(type: string): void {
+        const timer = this._recurring.get(type);
+        if (timer) {
+            timer.clear();
+            this._recurring.delete(type);
+        }
+    }
+
+    async shutdown(options: JobsShutdownOptions = {}): Promise<void> {
+        const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+        this._stopped = true;
+
+        for (const type of [...this._recurring.keys()]) {
+            this._clearRecurring(type);
+        }
+
+        const queue = this._queue;
+        queue.kill();
+        if (!queue.idle()) {
+            await Promise.race([queue.drained(), delay(timeoutMs)]);
+        }
+
+        // Fresh (paused) queue so a re-boot never inherits this lifecycle's
+        // abandoned in-flight deliveries against its concurrency limit.
+        this._queue = this._createQueue();
+        this._processor = null;
+    }
+}

--- a/ghost/core/core/server/services/adapter-manager/base-classes.ts
+++ b/ghost/core/core/server/services/adapter-manager/base-classes.ts
@@ -4,6 +4,7 @@ import {SSOBase} from '@tryghost/adapter-base-sso';
 import {CacheBase} from '@tryghost/adapter-base-cache';
 import {RedirectsStoreBase} from '@tryghost/adapter-base-redirects';
 import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
+import {JobsBackendBase} from '@tryghost/adapter-base-jobs';
 
 import type {BaseClassMap} from './adapter-manager';
 
@@ -18,5 +19,6 @@ export const baseClasses = {
     sso: SSOBase,
     cache: CacheBase,
     redirects: RedirectsStoreBase,
-    'route-settings': RouteSettingsStoreBase
+    'route-settings': RouteSettingsStoreBase,
+    jobs: JobsBackendBase
 } satisfies BaseClassMap;

--- a/ghost/core/core/server/services/jobs-service/index.ts
+++ b/ghost/core/core/server/services/jobs-service/index.ts
@@ -1,0 +1,35 @@
+import errors from '@tryghost/errors';
+import {JobsService} from './jobs-service';
+import type {JobsShutdownOptions} from '@tryghost/adapter-base-jobs';
+
+let instance: JobsService | undefined;
+
+export function init(): JobsService {
+    const adapterManager = require('../adapter-manager').default;
+    const logging = require('@tryghost/logging');
+    const sentry = require('../../../shared/sentry');
+
+    instance = new JobsService({
+        backend: adapterManager.getAdapter('jobs'),
+        logging,
+        sentry
+    });
+
+    return instance;
+}
+
+export function getInstance(): JobsService {
+    if (!instance) {
+        throw new errors.IncorrectUsageError({
+            message: 'Jobs service used before init(). Call init() from boot first.'
+        });
+    }
+    return instance;
+}
+
+export function shutdown(options?: JobsShutdownOptions): Promise<void> {
+    if (!instance) {
+        return Promise.resolve();
+    }
+    return instance.shutdown(options);
+}

--- a/ghost/core/core/server/services/jobs-service/job.ts
+++ b/ghost/core/core/server/services/jobs-service/job.ts
@@ -1,0 +1,10 @@
+export abstract class Job {
+}
+
+export interface JobConstructor<T extends Job = Job, D = never> {
+    readonly type: string;
+    readonly name?: string;
+    new (data: D): T;
+}
+
+export type JobHandler<T extends Job = Job> = (job: T) => Promise<void> | void;

--- a/ghost/core/core/server/services/jobs-service/jobs-service.ts
+++ b/ghost/core/core/server/services/jobs-service/jobs-service.ts
@@ -1,0 +1,120 @@
+import errors from '@tryghost/errors';
+import cronValidate from 'cron-validate';
+import type {
+    JobsBackendBase,
+    JobEnvelope,
+    JobsShutdownOptions,
+    RecurringSchedule
+} from '@tryghost/adapter-base-jobs';
+import {Job, JobConstructor, JobHandler} from './job';
+
+export interface JobsLogger {
+    error(...args: unknown[]): void;
+    info(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+}
+
+export interface JobsErrorReporter {
+    captureException(err: unknown, captureContext?: {tags?: Record<string, string>}): void;
+}
+
+export interface JobsServiceOptions {
+    backend: JobsBackendBase;
+    logging: JobsLogger;
+    sentry?: JobsErrorReporter;
+}
+
+type Deliverer = (payload: string) => Promise<void> | void;
+
+export class JobsService {
+    readonly #backend: JobsBackendBase;
+    readonly #logging: JobsLogger;
+    readonly #sentry?: JobsErrorReporter;
+    readonly #registry = new Map<string, Deliverer>();
+
+    constructor({backend, logging, sentry}: JobsServiceOptions) {
+        this.#backend = backend;
+        this.#logging = logging;
+        this.#sentry = sentry;
+    }
+
+    handle<T extends Job, D>(JobClass: JobConstructor<T, D>, handler: JobHandler<T>): void {
+        const type = JobClass.type;
+        if (typeof type !== 'string' || type.length === 0) {
+            throw new errors.IncorrectUsageError({
+                message: `Cannot register a job handler: ${JobClass.name ?? 'job class'} is missing a static "type" string.`
+            });
+        }
+        if (this.#registry.has(type)) {
+            throw new errors.IncorrectUsageError({
+                message: `A handler for job type "${type}" is already registered.`
+            });
+        }
+        this.#registry.set(type, payload => handler(new JobClass(JSON.parse(payload))));
+    }
+
+    async dispatch(job: Job): Promise<void> {
+        await this.#backend.enqueue(this.#buildEnvelope(job));
+    }
+
+    async scheduleRecurring(job: Job, schedule: RecurringSchedule): Promise<void> {
+        this.#assertValidCron(schedule.cron);
+        await this.#backend.scheduleRecurring(this.#buildEnvelope(job), schedule);
+    }
+
+    // later.parse.cron does not strictly validate: it silently coerces a
+    // malformed expression into a bogus schedule (garbage -> every minute,
+    // out-of-range -> clamped, an impossible date -> effectively never), so
+    // validate up front and fail loudly instead.
+    #assertValidCron(cron: string): void {
+        const result = cronValidate(cron, {
+            preset: 'default', // the seconds field is not supported in the default preset
+            override: {useSeconds: true}
+        });
+        if (!result.isValid()) {
+            throw new errors.IncorrectUsageError({
+                message: `Invalid cron expression: ${JSON.stringify(cron)}.`
+            });
+        }
+    }
+
+    async start(): Promise<void> {
+        await this.#backend.start({
+            processor: envelope => this.#process(envelope)
+        });
+    }
+
+    async shutdown(options?: JobsShutdownOptions): Promise<void> {
+        await this.#backend.shutdown(options);
+    }
+
+    #buildEnvelope(job: Job): JobEnvelope {
+        return {type: this.#typeOf(job), payload: JSON.stringify(job)};
+    }
+
+    #typeOf(job: Job): string {
+        const ctor: {type?: unknown; name?: string} = job.constructor;
+        const type = ctor.type;
+        if (typeof type !== 'string' || type.length === 0) {
+            throw new errors.IncorrectUsageError({
+                message: `Cannot dispatch job: ${ctor.name ?? 'job'} is missing a static "type" string.`
+            });
+        }
+        return type;
+    }
+
+    async #process(envelope: JobEnvelope): Promise<void> {
+        const deliver = this.#registry.get(envelope.type);
+        if (!deliver) {
+            this.#logging.error(`No handler registered for job type "${envelope.type}"; dropping delivery.`);
+            return;
+        }
+
+        try {
+            await deliver(envelope.payload);
+        } catch (err) {
+            this.#sentry?.captureException(err, {tags: {job_type: envelope.type}});
+            throw err;
+        }
+    }
+}

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,0 +1,3 @@
+export default function registerJobHandlers(): void {
+    // Job handlers are registered here as jobs migrate onto the class-based service.
+}

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -56,6 +56,12 @@
             "active": "FileStore",
             "FileStore": {},
             "S3RouteSettingsStore": {}
+        },
+        "jobs": {
+            "active": "InMemoryJobsBackend",
+            "InMemoryJobsBackend": {
+                "concurrency": 3
+            }
         }
     },
     "storage": {

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -81,12 +81,14 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "3.1079.0",
+        "@breejs/later": "catalog:",
         "@extractus/oembed-extractor": "3.2.1",
         "@faker-js/faker": "catalog:",
         "@isaacs/ttlcache": "1.4.1",
         "@sentry/node": "7.120.4",
         "@slack/webhook": "7.1.0",
         "@tryghost/adapter-base-cache": "workspace:*",
+        "@tryghost/adapter-base-jobs": "workspace:*",
         "@tryghost/adapter-base-redirects": "workspace:*",
         "@tryghost/adapter-base-route-settings": "workspace:*",
         "@tryghost/adapter-base-scheduling": "workspace:*",
@@ -158,6 +160,7 @@
         "cookies": "0.9.1",
         "cors": "2.8.6",
         "countries-and-timezones": "3.9.0",
+        "cron-validate": "catalog:",
         "csso": "5.0.5",
         "dequal": "catalog:",
         "dompurify": "catalog:",
@@ -171,6 +174,7 @@
         "express-query-boolean": "2.0.0",
         "express-queue": "0.0.13",
         "express-session": "1.19.0",
+        "fastq": "catalog:",
         "file-type": "21.3.4",
         "form-data": "catalog:",
         "fs-extra": "catalog:",
@@ -239,6 +243,9 @@
         "unidecode": "catalog:",
         "xml": "1.0.1",
         "zod": "catalog:"
+    },
+    "overrides": {
+        "cron-validate": "1.4.5"
     },
     "optionalDependencies": {
         "better-sqlite3": "catalog:"

--- a/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
+++ b/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
@@ -1,0 +1,304 @@
+import assert from 'node:assert/strict';
+import type {JobEnvelope} from '@tryghost/adapter-base-jobs';
+import {runJobsBackendContractTests} from '@tryghost/adapter-base-jobs/contract-test-suite';
+import InMemoryJobsBackend from '../../../../../core/server/adapters/jobs/InMemoryJobsBackend';
+
+const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+
+runJobsBackendContractTests(() => new InMemoryJobsBackend(), {describe, it});
+
+describe('InMemoryJobsBackend', function () {
+    it('has the required contract methods', function () {
+        const backend = new InMemoryJobsBackend();
+        assert.deepEqual(backend.requiredFns, ['start', 'enqueue', 'scheduleRecurring', 'shutdown']);
+    });
+
+    it('buffers envelopes enqueued before start, then delivers on start', async function () {
+        const received: JobEnvelope[] = [];
+        const backend = new InMemoryJobsBackend();
+
+        backend.enqueue({type: 'buffered', payload: '{"n":1}'});
+
+        backend.start({processor: async (env) => {
+            received.push(env);
+        }});
+        await backend.shutdown({timeoutMs: 1000});
+
+        assert.deepEqual(received, [{type: 'buffered', payload: '{"n":1}'}]);
+    });
+
+    it('caps concurrent deliveries at the default concurrency', async function () {
+        let running = 0;
+        let maxConcurrent = 0;
+        const release: Array<() => void> = [];
+        const backend = new InMemoryJobsBackend();
+
+        backend.start({processor: async () => {
+            running = running + 1;
+            maxConcurrent = Math.max(maxConcurrent, running);
+            await new Promise<void>((resolve) => {
+                release.push(resolve);
+            });
+            running = running - 1;
+        }});
+
+        for (let i = 0; i < 8; i = i + 1) {
+            backend.enqueue({type: 'work', payload: `{"i":${i}}`});
+        }
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+        assert.equal(maxConcurrent, 3, 'at most 3 deliveries run concurrently');
+
+        release.forEach(resolve => resolve());
+        const drainRelease = setInterval(() => release.forEach(resolve => resolve()), 5);
+        await backend.shutdown({timeoutMs: 2000});
+        clearInterval(drainRelease);
+
+        assert.ok(maxConcurrent <= 3);
+    });
+
+    it('caps concurrent deliveries at the configured concurrency', async function () {
+        let running = 0;
+        let maxConcurrent = 0;
+        const release: Array<() => void> = [];
+        const backend = new InMemoryJobsBackend({concurrency: 2});
+
+        backend.start({processor: async () => {
+            running = running + 1;
+            maxConcurrent = Math.max(maxConcurrent, running);
+            await new Promise<void>((resolve) => {
+                release.push(resolve);
+            });
+            running = running - 1;
+        }});
+
+        for (let i = 0; i < 8; i = i + 1) {
+            backend.enqueue({type: 'work', payload: `{"i":${i}}`});
+        }
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+        assert.equal(maxConcurrent, 2, 'at most the configured 2 deliveries run concurrently');
+
+        release.forEach(resolve => resolve());
+        const drainRelease = setInterval(() => release.forEach(resolve => resolve()), 5);
+        await backend.shutdown({timeoutMs: 2000});
+        clearInterval(drainRelease);
+    });
+
+    it('rejects an invalid concurrency config instead of silently stalling the pump', function () {
+        assert.throws(() => new InMemoryJobsBackend({concurrency: 0}), /concurrency/i);
+        assert.throws(() => new InMemoryJobsBackend({concurrency: -1}), /concurrency/i);
+        assert.throws(() => new InMemoryJobsBackend({concurrency: 1.5}), /concurrency/i);
+        assert.throws(() => new InMemoryJobsBackend({concurrency: NaN}), /concurrency/i);
+        assert.throws(() => new InMemoryJobsBackend({concurrency: '3'}), /concurrency/i);
+    });
+
+    it('falls back to the default when no concurrency is configured', function () {
+        assert.doesNotThrow(() => new InMemoryJobsBackend());
+        assert.doesNotThrow(() => new InMemoryJobsBackend({}));
+    });
+
+    it('logs a rejected delivery with its job type and keeps delivering subsequent work', async function () {
+        const errorStub = sinon.stub(logging, 'error');
+        try {
+            const delivered: string[] = [];
+            const backend = new InMemoryJobsBackend({concurrency: 1});
+
+            backend.start({processor: async (env) => {
+                delivered.push(env.type);
+                if (env.type === 'boom') {
+                    throw new Error('delivery failed');
+                }
+            }});
+
+            backend.enqueue({type: 'boom', payload: '{}'});
+            backend.enqueue({type: 'next', payload: '{}'});
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 20);
+            });
+            await backend.shutdown({timeoutMs: 1000});
+
+            assert.deepEqual(delivered, ['boom', 'next'], 'a rejected delivery does not stall the queue');
+            assert.ok(errorStub.calledOnce, 'the rejected delivery is logged');
+            assert.match(String(errorStub.firstCall.args[0]), /boom/);
+        } finally {
+            errorStub.restore();
+        }
+    });
+
+    it('drops queued-but-unstarted deliveries on shutdown', async function () {
+        const received: string[] = [];
+        const backend = new InMemoryJobsBackend();
+        const gate: Array<() => void> = [];
+
+        backend.start({processor: async (env) => {
+            received.push(env.type);
+            await new Promise<void>((resolve) => {
+                gate.push(resolve);
+            });
+        }});
+
+        for (let i = 0; i < 6; i = i + 1) {
+            backend.enqueue({type: `job-${i}`, payload: '{}'});
+        }
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+
+        gate.forEach(resolve => resolve());
+        const releaser = setInterval(() => gate.forEach(resolve => resolve()), 5);
+        await backend.shutdown({timeoutMs: 2000});
+        clearInterval(releaser);
+
+        assert.equal(received.length, 3, `only in-flight deliveries ran, got ${received.join(',')}`);
+    });
+
+    it('drops work enqueued after shutdown (no replay on the next start)', async function () {
+        const received: string[] = [];
+        const backend = new InMemoryJobsBackend();
+
+        backend.start({processor: async (env) => {
+            received.push(env.type);
+        }});
+        await backend.shutdown({timeoutMs: 1000});
+
+        backend.enqueue({type: 'late', payload: '{}'});
+
+        backend.start({processor: async (env) => {
+            received.push(env.type);
+        }});
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+        await backend.shutdown({timeoutMs: 1000});
+
+        assert.deepEqual(received, [], 'the post-shutdown enqueue was neither delivered nor replayed');
+    });
+
+    it('releases abandoned in-flight slots after a timed-out drain so a re-boot can start work', async function () {
+        const backend = new InMemoryJobsBackend();
+
+        backend.start({processor: () => new Promise<void>(() => {})});
+        for (let i = 0; i < 3; i = i + 1) {
+            backend.enqueue({type: `hung-${i}`, payload: '{}'});
+        }
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+
+        await backend.shutdown({timeoutMs: 30});
+
+        const received: string[] = [];
+        backend.start({processor: async (env) => {
+            received.push(env.type);
+        }});
+        backend.enqueue({type: 'fresh', payload: '{}'});
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+        await backend.shutdown({timeoutMs: 1000});
+
+        assert.deepEqual(received, ['fresh'], 'a re-boot starts new work despite prior hung handlers');
+    });
+
+    describe('recurring schedules', function () {
+        let clock: {tickAsync(ms: number): Promise<void>; restore(): void} | undefined;
+
+        afterEach(function () {
+            if (clock) {
+                clock.restore();
+                clock = undefined;
+            }
+        });
+
+        it('fires the processor on each cron tick', async function () {
+            clock = sinon.useFakeTimers({now: Date.UTC(2020, 0, 1)});
+            const received: JobEnvelope[] = [];
+            const backend = new InMemoryJobsBackend();
+            backend.start({processor: async (env) => {
+                received.push(env);
+            }});
+
+            backend.scheduleRecurring({type: 'tick', payload: '{}'}, {cron: '*/1 * * * * *'});
+            await clock!.tickAsync(3000);
+
+            assert.ok(received.length >= 2, `expected at least 2 ticks, got ${received.length}`);
+            assert.equal(received[0].type, 'tick');
+        });
+
+        it('keeps the first schedule for a type and ignores re-registration', async function () {
+            clock = sinon.useFakeTimers({now: Date.UTC(2020, 0, 1)});
+            const received: string[] = [];
+            const backend = new InMemoryJobsBackend();
+            backend.start({processor: async (env) => {
+                received.push(env.payload);
+            }});
+
+            backend.scheduleRecurring({type: 'tick', payload: '"first"'}, {cron: '*/1 * * * * *'});
+            backend.scheduleRecurring({type: 'tick', payload: '"second"'}, {cron: '*/1 * * * * *'});
+
+            await clock!.tickAsync(2000);
+
+            assert.ok(received.length >= 1);
+            assert.ok(received.every(p => p === '"first"'), `a re-registration must not replace the running schedule, got ${received.join(',')}`);
+        });
+
+        it('schedules a day-of-week cron on the correct day (0 = Sunday)', async function () {
+            clock = sinon.useFakeTimers({now: Date.UTC(2026, 7, 17)});
+            const fireDays: number[] = [];
+            const backend = new InMemoryJobsBackend();
+            backend.start({processor: async () => {
+                fireDays.push(new Date().getUTCDay());
+            }});
+
+            backend.scheduleRecurring({type: 'weekly', payload: '{}'}, {cron: '0 0 * * 0'});
+            await clock!.tickAsync(14 * 24 * 60 * 60 * 1000);
+            await backend.shutdown({timeoutMs: 100});
+
+            assert.ok(fireDays.length >= 1, `expected at least one fire, got ${fireDays.length}`);
+            assert.ok(fireDays.every(day => day === 0), `weekly Sunday cron must only fire on Sundays, got ${fireDays.join(',')}`);
+        });
+
+        it('stops firing after shutdown', async function () {
+            clock = sinon.useFakeTimers({now: Date.UTC(2020, 0, 1)});
+            const received: JobEnvelope[] = [];
+            const backend = new InMemoryJobsBackend();
+            backend.start({processor: async (env) => {
+                received.push(env);
+            }});
+
+            backend.scheduleRecurring({type: 'tick', payload: '{}'}, {cron: '*/1 * * * * *'});
+            await clock!.tickAsync(1500);
+            await backend.shutdown({timeoutMs: 100});
+            const countAtShutdown = received.length;
+
+            await clock!.tickAsync(3000);
+            assert.equal(received.length, countAtShutdown, 'no ticks should fire after shutdown');
+        });
+
+        it('does not install a recurring schedule after shutdown (no reactivation on re-boot)', async function () {
+            clock = sinon.useFakeTimers({now: Date.UTC(2020, 0, 1)});
+            const received: JobEnvelope[] = [];
+            const backend = new InMemoryJobsBackend();
+            backend.start({processor: async (env) => {
+                received.push(env);
+            }});
+            await backend.shutdown({timeoutMs: 100});
+
+            backend.scheduleRecurring({type: 'tick', payload: '{}'}, {cron: '*/1 * * * * *'});
+
+            backend.start({processor: async (env) => {
+                received.push(env);
+            }});
+            await clock!.tickAsync(3000);
+
+            assert.deepEqual(received, [], 'a schedule installed after shutdown must never fire, even after re-start');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/index.test.js
+++ b/ghost/core/test/unit/server/services/jobs-service/index.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const jobsService = require('../../../../../core/server/services/jobs-service');
+const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
+
+describe('jobs-service wrapper', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    // These two run before any init() in this file, so the module singleton is
+    // still undefined.
+    it('shutdown before init resolves without constructing a service', async function () {
+        await assert.doesNotReject(() => jobsService.shutdown());
+    });
+
+    it('getInstance throws before init', function () {
+        assert.throws(() => jobsService.getInstance(), /used before init/);
+    });
+
+    it('init builds the service from the jobs adapter and getInstance returns it', function () {
+        const fakeBackend = {
+            requiredFns: ['start', 'enqueue', 'scheduleRecurring', 'shutdown'],
+            start() {},
+            enqueue() {},
+            scheduleRecurring() {},
+            async shutdown() {}
+        };
+        sinon.stub(adapterManager, 'getAdapter').withArgs('jobs').returns(fakeBackend);
+
+        const service = jobsService.init();
+
+        assert.equal(jobsService.getInstance(), service, 'getInstance returns the instance built by init');
+    });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import {describe, it, beforeEach} from 'vitest';
+import type {
+    JobsBackendBase,
+    JobEnvelope,
+    JobsStartOptions,
+    JobProcessor,
+    RecurringSchedule,
+    JobsShutdownOptions
+} from '@tryghost/adapter-base-jobs';
+import {JobsService, JobsLogger, JobsErrorReporter} from '../../../../../core/server/services/jobs-service/jobs-service';
+import {Job} from '../../../../../core/server/services/jobs-service/job';
+
+class FakeBackend implements JobsBackendBase {
+    readonly requiredFns = ['start', 'enqueue', 'scheduleRecurring', 'shutdown'] as const;
+    processor: JobProcessor | null = null;
+    enqueued: JobEnvelope[] = [];
+    recurring: {envelope: JobEnvelope; schedule: RecurringSchedule}[] = [];
+    shutdownCalls: (JobsShutdownOptions | undefined)[] = [];
+
+    start(options: JobsStartOptions): void {
+        this.processor = options.processor;
+    }
+
+    enqueue(envelope: JobEnvelope): void {
+        this.enqueued.push(envelope);
+    }
+
+    scheduleRecurring(envelope: JobEnvelope, schedule: RecurringSchedule): void {
+        this.recurring.push({envelope, schedule});
+    }
+
+    shutdown(options?: JobsShutdownOptions): void {
+        this.shutdownCalls.push(options);
+    }
+
+    async deliver(index = 0): Promise<void> {
+        assert.ok(this.processor, 'processor must be wired via start()');
+        await this.processor!(this.enqueued[index]!);
+    }
+}
+
+function makeLogger() {
+    const calls = {error: [] as unknown[][], info: [] as unknown[][], warn: [] as unknown[][]};
+    const logging: JobsLogger = {
+        error: (...args) => {
+            calls.error.push(args);
+        },
+        info: (...args) => {
+            calls.info.push(args);
+        },
+        warn: (...args) => {
+            calls.warn.push(args);
+        }
+    };
+    return {logging, calls};
+}
+
+function makeSentry() {
+    const captured: {err: unknown; context?: unknown}[] = [];
+    const sentry: JobsErrorReporter = {
+        captureException: (err, context) => captured.push({err, context})
+    };
+    return {sentry, captured};
+}
+
+class GreetJob extends Job {
+    static type = 'greet';
+    name: string;
+    constructor(data: {name: string}) {
+        super();
+        this.name = data.name;
+    }
+}
+
+describe('JobsService', function () {
+    let backend: FakeBackend;
+    let logger: ReturnType<typeof makeLogger>;
+
+    beforeEach(function () {
+        backend = new FakeBackend();
+        logger = makeLogger();
+    });
+
+    function makeService(overrides: {sentry?: JobsErrorReporter} = {}) {
+        return new JobsService({
+            backend,
+            logging: logger.logging,
+            sentry: overrides.sentry
+        });
+    }
+
+    describe('handle', function () {
+        it('throws when the job class has no static type', function () {
+            const service = makeService();
+            class Untyped extends Job {}
+            assert.throws(() => service.handle(Untyped as never, async () => {}), /missing a static "type"/);
+        });
+
+        it('throws on a duplicate type registration', function () {
+            const service = makeService();
+            service.handle(GreetJob, async () => {});
+            assert.throws(() => service.handle(GreetJob, async () => {}), /already registered/);
+        });
+    });
+
+    describe('dispatch', function () {
+        it('enqueues a {type, payload} envelope, not the live instance', async function () {
+            const service = makeService();
+            await service.dispatch(new GreetJob({name: 'Ada'}));
+
+            assert.equal(backend.enqueued.length, 1);
+            const envelope = backend.enqueued[0]!;
+            assert.equal(envelope.type, 'greet');
+            assert.equal(typeof envelope.payload, 'string');
+            assert.deepEqual(JSON.parse(envelope.payload), {name: 'Ada'});
+        });
+
+        it('delivers a rehydrated instance to the handler, never the dispatched object', async function () {
+            const service = makeService();
+            const dispatched = new GreetJob({name: 'Ada'});
+            let received: unknown = null;
+            service.handle(GreetJob, async (job) => {
+                received = job;
+            });
+            await service.start();
+
+            await service.dispatch(dispatched);
+            await backend.deliver();
+
+            assert.ok(received instanceof GreetJob, 'handler receives a real GreetJob instance');
+            assert.notEqual(received, dispatched, 'handler must not receive the dispatched object');
+            assert.equal(received.name, 'Ada');
+        });
+
+        it('throws when dispatching a job with no static type', async function () {
+            const service = makeService();
+            class Untyped extends Job {}
+            await assert.rejects(() => service.dispatch(new Untyped()), /missing a static "type"/);
+        });
+    });
+
+    describe('delivery error handling', function () {
+        it('captures handler errors with job context and rethrows so the backend sees a failed delivery', async function () {
+            const {sentry, captured} = makeSentry();
+            const service = makeService({sentry});
+            const boom = new Error('handler exploded');
+            service.handle(GreetJob, async () => {
+                throw boom;
+            });
+            await service.start();
+
+            await service.dispatch(new GreetJob({name: 'Ada'}));
+            await assert.rejects(() => backend.deliver(), /handler exploded/);
+
+            assert.equal(captured.length, 1);
+            assert.equal(captured[0]!.err, boom);
+            assert.deepEqual(captured[0]!.context, {tags: {job_type: 'greet'}});
+            assert.equal(logger.calls.error.length, 0, 'delivery failures are logged by the backend, not the service');
+        });
+
+        it('logs and drops delivery for an unknown job type', async function () {
+            const service = makeService();
+            await service.start();
+            await service.dispatch(new GreetJob({name: 'Ada'}));
+            await backend.deliver();
+
+            assert.equal(logger.calls.error.length, 1);
+            assert.match(String(logger.calls.error[0]![0]), /No handler registered for job type "greet"/);
+        });
+    });
+
+    describe('scheduleRecurring', function () {
+        it('hands the backend an envelope and schedule', async function () {
+            const service = makeService();
+            await service.scheduleRecurring(new GreetJob({name: 'cron'}), {cron: '0 0 3 * * *'});
+
+            assert.equal(backend.recurring.length, 1);
+            assert.equal(backend.recurring[0]!.envelope.type, 'greet');
+            assert.equal(backend.recurring[0]!.schedule.cron, '0 0 3 * * *');
+        });
+
+        it('rejects an invalid cron before touching the backend', async function () {
+            const service = makeService();
+            await assert.rejects(
+                () => service.scheduleRecurring(new GreetJob({name: 'cron'}), {cron: 'not-a-cron'}),
+                /Invalid cron expression/
+            );
+            assert.equal(backend.recurring.length, 0);
+        });
+    });
+
+    describe('shutdown', function () {
+        it('delegates to the backend with the given options', async function () {
+            const service = makeService();
+            await service.shutdown({timeoutMs: 42});
+            assert.deepEqual(backend.shutdownCalls, [{timeoutMs: 42}]);
+        });
+    });
+});

--- a/packages/adapters/jobs-base/README.md
+++ b/packages/adapters/jobs-base/README.md
@@ -1,0 +1,45 @@
+# @tryghost/adapter-base-jobs
+
+Base class and contract for Ghost jobs backends.
+
+A jobs backend is the swappable transport behind Ghost's class-based jobs
+interface. It only ever sees serialised `{type, payload}` envelopes and a single
+delivery `processor` callback - it never touches a live job instance. That is
+what keeps jobs serialisable end to end and lets a durable backend replace the
+in-memory one with no call-site change.
+
+## Contract
+
+A backend extends `JobsBackendBase` and implements four methods:
+
+- `start({processor})` - wire the single delivery callback and begin accepting work.
+- `enqueue(envelope)` - accept an envelope for delivery. Resolves on **acceptance**, not completion.
+- `scheduleRecurring(envelope, {cron})` - register the recurring schedule for the envelope's type. The first registration per type wins; a later call for an already-scheduled type is ignored.
+- `shutdown({timeoutMs})` - stop accepting work and drain in-flight work within a bounded time.
+
+### Delivery outcome
+
+The backend delivers an envelope by calling `processor(envelope)` and awaiting the
+returned promise. **The processor may reject: a rejected promise means a failed
+delivery.** The backend decides what happens next - the in-memory reference
+backend logs and drops it (parity with the legacy in-process queue, no
+redelivery); a durable backend can redeliver. The processor never throws
+synchronously, so a backend only needs to handle the rejected-promise case.
+
+`scheduleRecurring` is idempotent per type - the first schedule wins and
+re-registration is a no-op, so a durable backend must not disturb an
+already-running schedule. `cron` is a 5-field expression or 6 fields with a
+leading seconds field. Delivery is at-most-once in memory but at-least-once on a
+durable backend, so handlers must tolerate redelivery.
+
+## Shared contract test suite
+
+The package exports a backend-agnostic test suite so every backend runs the same
+acceptance / delivery / drain / bounded-shutdown assertions:
+
+```ts
+import {runJobsBackendContractTests} from '@tryghost/adapter-base-jobs/contract-test-suite';
+
+// `describe`/`it` are injected so the suite depends on no specific test runner
+runJobsBackendContractTests(() => new MyJobsBackend(), {describe, it});
+```

--- a/packages/adapters/jobs-base/eslint.config.mjs
+++ b/packages/adapters/jobs-base/eslint.config.mjs
@@ -1,0 +1,9 @@
+import {nodeLibConfig} from '@internal/cfg-eslint';
+
+export default nodeLibConfig({
+    // The shared contract test suite is authored in src/ (it is a package export)
+    // but it uses vitest globals; treat it like test code for lint purposes.
+    extraTestRules: {
+        'ghost/ghost-custom/no-native-error': 'off'
+    }
+});

--- a/packages/adapters/jobs-base/package.json
+++ b/packages/adapters/jobs-base/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@tryghost/adapter-base-jobs",
+  "version": "0.0.0",
+  "description": "Base class and contract for Ghost jobs backends.",
+  "private": true,
+  "ghostPackage": {
+    "goldenPath": "compliant"
+  },
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "packages/adapters/jobs-base"
+  },
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "keywords": [
+    "ghost",
+    "jobs",
+    "adapter"
+  ],
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./contract-test-suite": {
+      "source": "./src/contract-test-suite.ts",
+      "types": "./build/contract-test-suite.d.ts",
+      "default": "./build/contract-test-suite.js"
+    }
+  },
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test:unit": "NODE_ENV=testing vitest run --coverage",
+    "test": "pnpm run '/^test:/'",
+    "test:types": "tsc --noEmit -p test/tsconfig.json",
+    "lint:code": "eslint src/ --cache",
+    "lint:test": "eslint test/ --cache",
+    "lint": "pnpm run '/^lint:/'"
+  },
+  "files": [
+    "build"
+  ],
+  "devDependencies": {
+    "@internal/cfg-eslint": "workspace:*",
+    "@internal/cfg-typescript": "workspace:*",
+    "@internal/cfg-vitest": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/build"
+        ]
+      }
+    }
+  }
+}

--- a/packages/adapters/jobs-base/src/base.ts
+++ b/packages/adapters/jobs-base/src/base.ts
@@ -1,0 +1,37 @@
+export interface JobEnvelope {
+    type: string;
+    payload: string;
+}
+
+export type JobProcessor = (envelope: JobEnvelope) => Promise<void>;
+
+export interface JobsStartOptions {
+    processor: JobProcessor;
+}
+
+export interface RecurringSchedule {
+    cron: string;
+}
+
+export interface JobsShutdownOptions {
+    timeoutMs?: number;
+}
+
+export abstract class JobsBackendBase {
+    declare readonly requiredFns: readonly ['start', 'enqueue', 'scheduleRecurring', 'shutdown'];
+
+    constructor() {
+        Object.defineProperty(this, 'requiredFns', {
+            value: Object.freeze(['start', 'enqueue', 'scheduleRecurring', 'shutdown']),
+            writable: false
+        });
+    }
+
+    abstract start(options: JobsStartOptions): void | Promise<void>;
+
+    abstract enqueue(envelope: JobEnvelope): void | Promise<void>;
+
+    abstract scheduleRecurring(envelope: JobEnvelope, schedule: RecurringSchedule): void | Promise<void>;
+
+    abstract shutdown(options?: JobsShutdownOptions): void | Promise<void>;
+}

--- a/packages/adapters/jobs-base/src/contract-test-suite.ts
+++ b/packages/adapters/jobs-base/src/contract-test-suite.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import {JobsBackendBase, JobEnvelope} from './base.ts';
+
+export type BackendFactory = () => JobsBackendBase;
+
+export interface JobsContractTestFramework {
+    describe(name: string, fn: () => void): void;
+    it(name: string, fn: () => void | Promise<void>): void;
+}
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return {promise, resolve};
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+export function runJobsBackendContractTests(
+    makeBackend: BackendFactory,
+    {describe, it}: JobsContractTestFramework
+): void {
+    const envelope: JobEnvelope = {type: 'test-job', payload: '{"value":1}'};
+
+    describe('jobs backend contract', function () {
+        it('delivers an enqueued envelope to the processor', async function () {
+            const received: JobEnvelope[] = [];
+            const backend = makeBackend();
+            await backend.start({processor: async (env) => {
+                received.push(env);
+            }});
+
+            await backend.enqueue(envelope);
+            await backend.shutdown({timeoutMs: 1000});
+
+            assert.deepEqual(received, [envelope]);
+        });
+
+        it('resolves enqueue on acceptance, not on completion', async function () {
+            let completed = false;
+            const release = deferred();
+            const started = deferred();
+
+            const backend = makeBackend();
+            await backend.start({processor: async () => {
+                started.resolve();
+                await release.promise;
+                completed = true;
+            }});
+
+            await backend.enqueue(envelope);
+
+            await started.promise;
+            assert.equal(completed, false);
+
+            release.resolve();
+            await backend.shutdown({timeoutMs: 1000});
+            assert.equal(completed, true);
+        });
+
+        it('drains in-flight work on shutdown', async function () {
+            let completed = false;
+            const backend = makeBackend();
+            await backend.start({processor: async () => {
+                await delay(30);
+                completed = true;
+            }});
+
+            await backend.enqueue(envelope);
+            await backend.shutdown({timeoutMs: 1000});
+
+            assert.equal(completed, true);
+        });
+
+        it('bounds shutdown when a handler hangs', async function () {
+            const backend = makeBackend();
+            const started = deferred();
+            await backend.start({processor: () => new Promise<void>(() => {
+                started.resolve();
+            })});
+
+            await backend.enqueue(envelope);
+            await started.promise;
+
+            const raced = await Promise.race([
+                Promise.resolve(backend.shutdown({timeoutMs: 30})).then(() => 'shutdown'),
+                delay(2000).then(() => 'hung')
+            ]);
+
+            assert.equal(raced, 'shutdown');
+        });
+
+        it('tolerates start after a prior shutdown', async function () {
+            const received: JobEnvelope[] = [];
+            const backend = makeBackend();
+
+            await backend.start({processor: async () => {}});
+            await backend.shutdown({timeoutMs: 1000});
+
+            await backend.start({processor: async (env) => {
+                received.push(env);
+            }});
+            await backend.enqueue(envelope);
+            await backend.shutdown({timeoutMs: 1000});
+
+            assert.deepEqual(received, [envelope]);
+        });
+    });
+}

--- a/packages/adapters/jobs-base/src/index.ts
+++ b/packages/adapters/jobs-base/src/index.ts
@@ -1,0 +1,1 @@
+export * from './base.ts';

--- a/packages/adapters/jobs-base/test/base.test.ts
+++ b/packages/adapters/jobs-base/test/base.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+
+import {JobsBackendBase, JobEnvelope, RecurringSchedule, JobsStartOptions} from '../src/base.ts';
+
+class TestBackend extends JobsBackendBase {
+    start(_options: JobsStartOptions) {}
+    enqueue(_envelope: JobEnvelope) {}
+    scheduleRecurring(_envelope: JobEnvelope, _schedule: RecurringSchedule) {}
+    shutdown() {}
+}
+
+describe('adapter-base-jobs', function () {
+    it('exposes the frozen requiredFns contract', function () {
+        const backend = new TestBackend();
+        assert.deepEqual(backend.requiredFns, ['start', 'enqueue', 'scheduleRecurring', 'shutdown']);
+        assert.ok(Object.isFrozen(backend.requiredFns), 'requiredFns should be frozen');
+    });
+});

--- a/packages/adapters/jobs-base/test/tsconfig.json
+++ b/packages/adapters/jobs-base/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "..",
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "**/*"
+    ]
+}

--- a/packages/adapters/jobs-base/tsconfig.json
+++ b/packages/adapters/jobs-base/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@internal/cfg-typescript/esm.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "build"
+    },
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/packages/adapters/jobs-base/vitest.config.ts
+++ b/packages/adapters/jobs-base/vitest.config.ts
@@ -1,0 +1,12 @@
+import {createVitestConfig} from '@internal/cfg-vitest';
+
+// The shared contract test suite (contract-test-suite.ts) is a package export
+// exercised by each *backend's* tests (e.g. the in-memory backend in ghost/core),
+// not by this package's own unit tests - exclude it from this package's coverage.
+export default createVitestConfig({
+    test: {
+        coverage: {
+            exclude: ['src/contract-test-suite.ts']
+        }
+    }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@breejs/later':
+      specifier: 4.2.0
+      version: 4.2.0
     '@codemirror/autocomplete':
       specifier: 6.20.3
       version: 6.20.3
@@ -318,6 +321,9 @@ catalogs:
     execa:
       specifier: 10.0.1
       version: 10.0.1
+    fastq:
+      specifier: ^1.20.1
+      version: 1.20.1
     form-data:
       specifier: 4.0.6
       version: 4.0.6
@@ -496,6 +502,7 @@ catalogs:
       version: 3.4.19
 
 overrides:
+  cron-validate: 1.4.5
   knex-migrator>knex: 2.4.2
   '@tryghost/errors': 3.3.8
   '@tryghost/logging': 5.3.4
@@ -2190,6 +2197,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: 3.1079.0
         version: 3.1079.0
+      '@breejs/later':
+        specifier: 'catalog:'
+        version: 4.2.0
       '@extractus/oembed-extractor':
         specifier: 3.2.1
         version: 3.2.1(encoding@0.1.13)
@@ -2208,6 +2218,9 @@ importers:
       '@tryghost/adapter-base-cache':
         specifier: workspace:*
         version: link:../../packages/adapters/cache-base
+      '@tryghost/adapter-base-jobs':
+        specifier: workspace:*
+        version: link:../../packages/adapters/jobs-base
       '@tryghost/adapter-base-redirects':
         specifier: workspace:*
         version: link:../../packages/adapters/redirects-base
@@ -2421,6 +2434,9 @@ importers:
       countries-and-timezones:
         specifier: 3.9.0
         version: 3.9.0
+      cron-validate:
+        specifier: 1.4.5
+        version: 1.4.5
       csso:
         specifier: 5.0.5
         version: 5.0.5
@@ -2460,6 +2476,9 @@ importers:
       express-session:
         specifier: 1.19.0
         version: 1.19.0(supports-color@10.2.2)
+      fastq:
+        specifier: 'catalog:'
+        version: 1.20.1
       file-type:
         specifier: 21.3.4
         version: 21.3.4(supports-color@10.2.2)
@@ -3699,6 +3718,36 @@ importers:
         version: 13.6.31
 
   packages/adapters/cache-base:
+    devDependencies:
+      '@internal/cfg-eslint':
+        specifier: workspace:*
+        version: link:../../../configs/eslint
+      '@internal/cfg-typescript':
+        specifier: workspace:*
+        version: link:../../../configs/typescript
+      '@internal/cfg-vitest':
+        specifier: workspace:*
+        version: link:../../../configs/vitest
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.1)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.12)(yaml@2.9.0))
+
+  packages/adapters/jobs-base:
     devDependencies:
       '@internal/cfg-eslint':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -213,6 +213,9 @@ catalog:
   remark-validate-links: 13.1.0
   markdownlint-cli2: 0.23.2
   parse-email-address: 0.0.4
+  '@breejs/later': 4.2.0
+  fastq: ^1.20.1
+  cron-validate: 1.4.5
 
 catalogs:
   react17:
@@ -230,6 +233,7 @@ overrides:
   # Ghost's migrations build queries with the 2.4.2 query builder and knex-migrator
   # executes them, so its knex must match Ghost's major or the 3.x runner throws on
   # the 2.x builder. Pin it back to 2.4.2 until ghost/core itself moves to knex 3.x.
+  cron-validate: 1.4.5
   'knex-migrator>knex': 2.4.2
   '@tryghost/errors': 'catalog:'
   '@tryghost/logging': 'catalog:'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1914

This is the infrastructure for Ghost's class-based jobs interface, split out from the wider spike so the seam can land on its own and existing jobs can be migrated onto it incrementally. No existing jobs are migrated here — those follow in stacked PRs.

Two commits:

- **`@tryghost/adapter-base-jobs`** — the contract every jobs backend implements: `JobsBackendBase` (frozen `start`/`enqueue`/`scheduleRecurring`/`shutdown`), the serialised `{type, payload}` envelope, and the single delivery-processor callback. A backend only ever sees serialised envelopes, never a live job instance, which keeps jobs serialisable end to end and lets a durable backend drop in for the in-memory one without touching a call site. Ships a backend-agnostic contract test suite so every backend is held to the same behaviour.

- **The in-memory jobs service and backend** — the class-based service owns the handler registry, the JSON envelope boundary, rehydration, cron validation and error reporting; `InMemoryJobsBackend` is the reference implementation, with bounded `fastq` delivery, config-driven concurrency, bounded shutdown that drains in-flight work, and first-write-wins recurring scheduling. Boot constructs the service, runs an initially-empty central registration step so there is one place to wire handlers, then starts delivery.

The seam is wired and inert — ready to start migrating jobs onto it.
