### PR TITLE
HKG-1971: Migrate media-inliner to the class-based jobs service

### DIFF
--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,12 +1,14 @@
 import { getInstance } from './index';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
+import MediaInlinerJob from '../media-inliner/media-inliner-job';
 
 const jobLogging = require('../jobs/job-logging');
 
 export default function registerJobHandlers(): void {
   const jobsService = getInstance();
   const db = require('../../data/db');
+  const mediaInlinerService = require('../media-inliner');
 
   jobsService.handle(CleanTokensJob, async () => {
     const startedAt = Date.now();
@@ -31,6 +33,24 @@ export default function registerJobHandlers(): void {
         `[Background Job] clean-tokens failed after ${Date.now() - startedAt}ms`,
       );
       throw error;
+    }
+  });
+
+  jobsService.handle(MediaInlinerJob, async (job: MediaInlinerJob) => {
+    const startedAt = Date.now();
+    jobLogging.info('[Background Job] external-media-inliner started');
+
+    try {
+      await mediaInlinerService.inline(job.domains);
+      jobLogging.info(
+        `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
+      );
+    } catch (err) {
+      jobLogging.error(
+        err,
+        `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
+      );
+      throw err;
     }
   });
 }

--- a/ghost/core/core/server/services/media-inliner/media-inliner-job.ts
+++ b/ghost/core/core/server/services/media-inliner/media-inliner-job.ts
@@ -1,0 +1,16 @@
+import {Job} from '../jobs-service/job';
+
+interface MediaInlinerJobData {
+    domains: string[];
+}
+
+export default class MediaInlinerJob extends Job {
+    static type = 'media-inliner';
+
+    domains: string[];
+
+    constructor(data: MediaInlinerJobData) {
+        super();
+        this.domains = data.domains;
+    }
+}

--- a/ghost/core/core/server/services/media-inliner/media-inliner-job.ts
+++ b/ghost/core/core/server/services/media-inliner/media-inliner-job.ts
@@ -1,16 +1,16 @@
-import {Job} from '../jobs-service/job';
+import { Job } from '../jobs-service/job';
 
 interface MediaInlinerJobData {
-    domains: string[];
+  domains: string[];
 }
 
 export default class MediaInlinerJob extends Job {
-    static type = 'media-inliner';
+  static type = 'media-inliner';
 
-    domains: string[];
+  domains: string[];
 
-    constructor(data: MediaInlinerJobData) {
-        super();
-        this.domains = data.domains;
-    }
+  constructor(data: MediaInlinerJobData) {
+    super();
+    this.domains = data.domains;
+  }
 }

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,10 +1,13 @@
+const MediaInlinerJob = require('./media-inliner-job').default;
+
+const DEFAULT_DOMAINS = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+
+let mediaInliner;
+
 module.exports = {
   async init() {
-    const debug = require('@tryghost/debug')('mediaInliner');
     const MediaInliner = require('./external-media-inliner');
-    const jobLogging = require('../jobs/job-logging');
     const models = require('../../models');
-    const jobsService = require('../jobs');
     const adapterManager = require('../../services/adapter-manager').default;
 
     const mediaStorage = adapterManager.getAdapter('storage:media');
@@ -13,7 +16,7 @@ module.exports = {
 
     const config = require('../../../shared/config');
 
-    const mediaInliner = new MediaInliner({
+    mediaInliner = new MediaInliner({
       PostModel: models.Post,
       TagModel: models.Tag,
       UserModel: models.User,
@@ -33,43 +36,27 @@ module.exports = {
 
     this.api = {
       startMediaInliner: async (domains) => {
+        const debug = require('@tryghost/debug')('mediaInliner');
+        const jobLogging = require('../jobs/job-logging');
+        const jobsService = require('../jobs-service').getInstance();
+
         if (!domains || !domains.length) {
-          // default domains to inline from if none are provided
-          domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+          domains = DEFAULT_DOMAINS;
         }
 
         debug('[Inliner] Starting media inlining job for domains: ', domains);
 
-        // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
-        //        limited to migrational, so there is no expectations for site's availability etc.
         jobLogging.info('[Background Job] external-media-inliner queued');
-        await jobsService.addJob({
-          name: 'external-media-inliner',
-          job: async (data) => {
-            const startedAt = Date.now();
-            jobLogging.info('[Background Job] external-media-inliner started');
-            try {
-              const result = await mediaInliner.inline(data.domains);
-              jobLogging.info(
-                `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
-              );
-              return result;
-            } catch (err) {
-              jobLogging.error(
-                err,
-                `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
-              );
-              throw err;
-            }
-          },
-          data: { domains },
-          offloaded: false,
-        });
+        await jobsService.dispatch(new MediaInlinerJob({ domains }));
 
         return {
           status: 'success',
         };
       },
     };
+  },
+
+  inline(domains) {
+    return mediaInliner.inline(domains);
   },
 };

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.js
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const jobsService = require('../../../../../core/server/services/jobs-service');
+const registerJobHandlers = require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
+const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
+const MediaInlinerJob = require('../../../../../core/server/services/media-inliner/media-inliner-job').default;
+
+function flush() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 20);
+    });
+}
+
+describe('register-job-handlers', function () {
+    let inlineStub;
+    let service;
+
+    beforeEach(async function () {
+        inlineStub = sinon.stub(mediaInlinerService, 'inline').resolves();
+
+        service = jobsService.init();
+        registerJobHandlers();
+        await service.start();
+    });
+
+    afterEach(async function () {
+        await jobsService.shutdown({timeoutMs: 1000});
+        sinon.restore();
+    });
+
+    it('wires the media-inliner handler: dispatching MediaInlinerJob runs the inliner with round-tripped domains', async function () {
+        const domains = ['https://a.example', 'https://b.example'];
+
+        await service.dispatch(new MediaInlinerJob({domains}));
+        await flush();
+
+        assert.ok(inlineStub.calledOnceWithExactly(domains));
+    });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.js
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.js
@@ -2,39 +2,41 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 
 const jobsService = require('../../../../../core/server/services/jobs-service');
-const registerJobHandlers = require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
+const registerJobHandlers =
+  require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
 const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
-const MediaInlinerJob = require('../../../../../core/server/services/media-inliner/media-inliner-job').default;
+const MediaInlinerJob =
+  require('../../../../../core/server/services/media-inliner/media-inliner-job').default;
 
 function flush() {
-    return new Promise((resolve) => {
-        setTimeout(resolve, 20);
-    });
+  return new Promise((resolve) => {
+    setTimeout(resolve, 20);
+  });
 }
 
 describe('register-job-handlers', function () {
-    let inlineStub;
-    let service;
+  let inlineStub;
+  let service;
 
-    beforeEach(async function () {
-        inlineStub = sinon.stub(mediaInlinerService, 'inline').resolves();
+  beforeEach(async function () {
+    inlineStub = sinon.stub(mediaInlinerService, 'inline').resolves();
 
-        service = jobsService.init();
-        registerJobHandlers();
-        await service.start();
-    });
+    service = jobsService.init();
+    registerJobHandlers();
+    await service.start();
+  });
 
-    afterEach(async function () {
-        await jobsService.shutdown({timeoutMs: 1000});
-        sinon.restore();
-    });
+  afterEach(async function () {
+    await jobsService.shutdown({ timeoutMs: 1000 });
+    sinon.restore();
+  });
 
-    it('wires the media-inliner handler: dispatching MediaInlinerJob runs the inliner with round-tripped domains', async function () {
-        const domains = ['https://a.example', 'https://b.example'];
+  it('wires the media-inliner handler: dispatching MediaInlinerJob runs the inliner with round-tripped domains', async function () {
+    const domains = ['https://a.example', 'https://b.example'];
 
-        await service.dispatch(new MediaInlinerJob({domains}));
-        await flush();
+    await service.dispatch(new MediaInlinerJob({ domains }));
+    await flush();
 
-        assert.ok(inlineStub.calledOnceWithExactly(domains));
-    });
+    assert.ok(inlineStub.calledOnceWithExactly(domains));
+  });
 });

--- a/ghost/core/test/unit/server/services/media-inliner/dispatch.test.js
+++ b/ghost/core/test/unit/server/services/media-inliner/dispatch.test.js
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
+const ExternalMediaInliner = require('../../../../../core/server/services/media-inliner/external-media-inliner');
+const jobsService = require('../../../../../core/server/services/jobs-service');
+const registerJobHandlers = require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
+const db = require('../../../../../core/server/data/db');
+
+function flush() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 20);
+    });
+}
+
+describe('media-inliner dispatch', function () {
+    let inlineStub;
+
+    beforeAll(async function () {
+        inlineStub = sinon.stub(ExternalMediaInliner.prototype, 'inline').resolves();
+
+        await mediaInlinerService.init();
+
+        sinon.stub(db, 'knex').get(() => sinon.stub().returns({where: () => ({delete: sinon.stub().resolves(0)})}));
+
+        const service = jobsService.init();
+        registerJobHandlers();
+        await service.start();
+    });
+
+    afterAll(async function () {
+        await jobsService.shutdown({timeoutMs: 1000});
+        sinon.restore();
+    });
+
+    afterEach(function () {
+        inlineStub.resetHistory();
+    });
+
+    it('runs the inliner with the provided domains', async function () {
+        const domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+
+        const result = await mediaInlinerService.api.startMediaInliner(domains);
+        assert.equal(result.status, 'success');
+
+        await flush();
+
+        assert.ok(inlineStub.calledOnceWithExactly(domains));
+    });
+
+    it('defaults the domains when none are provided', async function () {
+        await mediaInlinerService.api.startMediaInliner();
+
+        await flush();
+
+        const [calledDomains] = inlineStub.firstCall.args;
+        assert.deepEqual(calledDomains, [
+            'https://s3.amazonaws.com/revue',
+            'https://substackcdn.com'
+        ]);
+    });
+});

--- a/ghost/core/test/unit/server/services/media-inliner/dispatch.test.js
+++ b/ghost/core/test/unit/server/services/media-inliner/dispatch.test.js
@@ -4,59 +4,59 @@ const sinon = require('sinon');
 const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
 const ExternalMediaInliner = require('../../../../../core/server/services/media-inliner/external-media-inliner');
 const jobsService = require('../../../../../core/server/services/jobs-service');
-const registerJobHandlers = require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
+const registerJobHandlers =
+  require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
 const db = require('../../../../../core/server/data/db');
 
 function flush() {
-    return new Promise((resolve) => {
-        setTimeout(resolve, 20);
-    });
+  return new Promise((resolve) => {
+    setTimeout(resolve, 20);
+  });
 }
 
 describe('media-inliner dispatch', function () {
-    let inlineStub;
+  let inlineStub;
 
-    beforeAll(async function () {
-        inlineStub = sinon.stub(ExternalMediaInliner.prototype, 'inline').resolves();
+  beforeAll(async function () {
+    inlineStub = sinon.stub(ExternalMediaInliner.prototype, 'inline').resolves();
 
-        await mediaInlinerService.init();
+    await mediaInlinerService.init();
 
-        sinon.stub(db, 'knex').get(() => sinon.stub().returns({where: () => ({delete: sinon.stub().resolves(0)})}));
+    sinon
+      .stub(db, 'knex')
+      .get(() => sinon.stub().returns({ where: () => ({ delete: sinon.stub().resolves(0) }) }));
 
-        const service = jobsService.init();
-        registerJobHandlers();
-        await service.start();
-    });
+    const service = jobsService.init();
+    registerJobHandlers();
+    await service.start();
+  });
 
-    afterAll(async function () {
-        await jobsService.shutdown({timeoutMs: 1000});
-        sinon.restore();
-    });
+  afterAll(async function () {
+    await jobsService.shutdown({ timeoutMs: 1000 });
+    sinon.restore();
+  });
 
-    afterEach(function () {
-        inlineStub.resetHistory();
-    });
+  afterEach(function () {
+    inlineStub.resetHistory();
+  });
 
-    it('runs the inliner with the provided domains', async function () {
-        const domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+  it('runs the inliner with the provided domains', async function () {
+    const domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
 
-        const result = await mediaInlinerService.api.startMediaInliner(domains);
-        assert.equal(result.status, 'success');
+    const result = await mediaInlinerService.api.startMediaInliner(domains);
+    assert.equal(result.status, 'success');
 
-        await flush();
+    await flush();
 
-        assert.ok(inlineStub.calledOnceWithExactly(domains));
-    });
+    assert.ok(inlineStub.calledOnceWithExactly(domains));
+  });
 
-    it('defaults the domains when none are provided', async function () {
-        await mediaInlinerService.api.startMediaInliner();
+  it('defaults the domains when none are provided', async function () {
+    await mediaInlinerService.api.startMediaInliner();
 
-        await flush();
+    await flush();
 
-        const [calledDomains] = inlineStub.firstCall.args;
-        assert.deepEqual(calledDomains, [
-            'https://s3.amazonaws.com/revue',
-            'https://substackcdn.com'
-        ]);
-    });
+    const [calledDomains] = inlineStub.firstCall.args;
+    assert.deepEqual(calledDomains, ['https://s3.amazonaws.com/revue', 'https://substackcdn.com']);
+  });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1971

Migrates media-inlining off the legacy job manager and onto the class-based jobs service. The infrastructure it builds on landed in #30058.

Media-inlining is dispatched as a `MediaInlinerJob`; the domains to inline travel as a plain serialisable payload and survive the JSON round-trip into the rehydrated job the handler receives, wired centrally in `register-job-handlers`.
