### PR TITLE
Improved the field picker in the members import mapping

### DIFF
--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
@@ -1,14 +1,22 @@
 import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
-import {Button, Command, CommandCheck, CommandGroup, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger, inputSurfaceClasses} from '@tryghost/shade/components';
+import {Badge, Button, Command, CommandCheck, CommandGroup, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger, commandDefaultFilter, inputSurfaceClasses} from '@tryghost/shade/components';
 import {LucideIcon, cn} from '@tryghost/shade/utils';
 import {useRef} from 'react';
 import {type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 // One list, two sections, so what a column can be imported as is answered by reading rather
 // than by trying each kind in turn. The section a field sits in is what tells a native "Name"
-// apart from a custom field someone called "Name", so the trigger repeats it once chosen.
+// apart from a custom field someone called "Name", and the trigger has to carry that once the
+// list is closed.
+//
+// Marked only where that is in doubt: a custom field whose name a native field already has.
+// Naming every row's kind put "Membership field" under nearly the whole table to settle a
+// question almost none of those rows raise, and a mark that appears where two things read the
+// same is the same answer without the noise. Its own word rather than CUSTOM_GROUP: the
+// headings pluralise with a bare `s`, and a badge has less room than a line of its own had.
 const NATIVE_GROUP = 'Membership field';
 const CUSTOM_GROUP = 'Custom field';
+const CUSTOM_BADGE = 'Custom';
 
 // Icons for the native targets. Written here rather than taken from somewhere shared because
 // nothing shared exists: the members filter picker hand-writes its own switch, and analytics
@@ -28,6 +36,32 @@ const NATIVE_ICONS: Record<string, typeof LucideIcon.Type> = {
     gift_id: LucideIcon.Gift,
     import_tier: LucideIcon.Star
 };
+
+// "Shipping Address (Address line 1)" -> ["Shipping Address", "(Address line 1)"]. The parts of
+// a composite are labelled `${name} (${part})` in memberCustomFieldCsvColumns, so every row of
+// one address reads the same until its last few words. Split here, the name is what gives way to
+// a narrow column and the part stays whole; truncating the label as one string takes away the
+// only thing telling those rows apart. Anything without a bracketed tail has nothing to protect.
+function splitPartLabel(label: string): [string, string] {
+    const parted = /^(.*) (\([^()]*\))$/.exec(label);
+    return parted ? [parted[1], parted[2]] : [label, ''];
+}
+
+// Case and surrounding space are no help in telling two of these apart on sight, so a name that
+// differs only by them counts as the same name.
+function sameLabel(a: string, b: string): boolean {
+    return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+// Scored over the label alone, which the list's items carry as their one keyword. Identity is the
+// target instead, and cmdk scores an item's value and its keywords as one joined string — so with
+// the target in there, "custom" reached every namespaced column, and a match was free to run from
+// one into the other: `subscribed_to_emails` and its own label together hold a c-u-s-t-o-m that
+// neither holds by itself. Naming what to search leaves the target doing nothing but telling two
+// fields of the same name apart.
+function scoreByLabel(_target: string, query: string, keywords?: string[]): number {
+    return commandDefaultFilter((keywords ?? []).join(' '), query);
+}
 
 function NativeIcon({value, className}: {value: string; className?: string}) {
     const Icon = NATIVE_ICONS[value] ?? LucideIcon.Type;
@@ -80,6 +114,12 @@ export function FieldPicker({
     const selectedCustom = customFieldMappings.find(field => field.value === value);
     const selectedNative = fieldMappings.find(field => field.value === value);
     const selected = selectedCustom ?? selectedNative;
+    const [labelHead, labelTail] = splitPartLabel(selected?.label ?? '');
+    // Against what this picker is offering rather than the whole native set, since Tier is only
+    // among them on a site with tiers to import onto — where it is not offered, a custom field
+    // called "Tier" is the only "Tier" in the list and has nothing to be told apart from.
+    const ambiguous = selectedCustom !== undefined
+        && fieldMappings.some(native => sameLabel(native.label, selectedCustom.label));
 
     const choose = (target: string) => {
         onOpenChange(false);
@@ -117,10 +157,18 @@ export function FieldPicker({
                     aria-invalid={invalid || undefined}
                     // Names the column and what it is mapped to. A bare "Field for <column>"
                     // would replace the trigger's own text in the accessible name, so the
-                    // selection — the whole point of the two lines below — would never be read.
-                    aria-label={selected ? `Field for ${columnKey}, ${selected.label}` : `Field for ${columnKey}, not chosen`}
+                    // selection — the whole point of the label below — would never be read.
+                    // Every custom field names its kind here, not only the ones the badge marks.
+                    // The badge is spent narrowly because it costs room in a column that has none
+                    // to spare; a name read aloud costs nothing, so there is no reason to hold it
+                    // back from the rest. Spelled out in full, since "Custom" alone names nothing.
+                    aria-label={selected ? `Field for ${columnKey}, ${selected.label}${selectedCustom ? `, ${CUSTOM_GROUP}` : ''}` : `Field for ${columnKey}, not chosen`}
                     className={cn(
-                        'h-auto w-full scroll-my-8 justify-start gap-2 px-2.5 py-1.5 font-normal',
+                        // px-2 rather than the combobox recipe's px-3: at the 32px control height a
+                        // 16px icon sits 8px off the top and bottom, and the same 8px at the start
+                        // squares that off. It is what the list's own items are set to, so the
+                        // icon does not move sideways as the popover opens under it.
+                        'h-(--control-height) w-full scroll-my-8 justify-start gap-2 px-2 font-normal',
                         className,
                         // Button's outline hover (bg-button-hover) is what the Select trigger this
                         // replaced used too, so hovering weighs what it always did. Only the text
@@ -142,39 +190,50 @@ export function FieldPicker({
                     role="combobox"
                     variant="outline"
                 >
-                    {/* Blocked rather than bare, the way the font pickers show a chosen face: next
-                        to two lines of text a loose glyph reads as debris, and the tile gives it
-                        somewhere to sit. Only here — inside the list the icons sit against a
-                        single line and stay flat, as the filter picker has them.
+                    {/* Flat and inline, the way these same icons sit inside the list below. The
+                        tile they used to sit in was answering to the second line of text: two
+                        lines give a loose glyph nothing to be centred against, and the tile both
+                        gave it somewhere to sit and held the row's height open. With one line
+                        left, neither job remains, and the control comes back to the height every
+                        other one in Shade stands at.
 
-                        The tile is what sets the control's height, so an empty row is exactly as
-                        tall as a chosen one without a blank line held open to do it. Empty is an
-                        outline: a slot still to fill, not a thing with no icon. */}
-                    <span className={cn(
-                        'flex size-8 shrink-0 items-center justify-center rounded-md',
-                        // Filled is the font picker's tile exactly (global-settings.tsx:53), at the
-                        // size a table row can carry rather than its 48px: same border token, same
-                        // elevated surface, same shadow.
-                        selected && 'border border-border-default bg-surface-elevated shadow-xs',
-                        disabled && 'opacity-60'
-                    )}>
+                        Empty still carries a mark of its own, so the names down the column all
+                        start in the same place whether a row is filled or not. An outline reads
+                        as a slot still to fill rather than as a thing with no icon. */}
+                    <span className={cn('flex shrink-0 items-center', disabled && 'opacity-60')}>
                         {selectedCustom && <CustomFieldIcon className="size-4 text-foreground" type={selectedCustom.type} />}
                         {selectedNative && <NativeIcon className="size-4 text-foreground" value={selectedNative.value} />}
-                        {/* Inside the slot rather than filling it: an empty dashed outline reads
-                            larger than a filled tile of the same size, since the border is the
-                            whole shape and there is nothing inside to give it a middle. Drawn
-                            smaller, the two look the same size — and the slot around it keeps its
-                            32px, so a row does not change height as columns go in and out. */}
-                        {!selected && <span className="size-7 rounded-md border border-dashed border-border-strong" />}
+                        {!selected && <span className="size-4 rounded-sm border border-dashed border-border-strong" />}
                     </span>
                     {selected ? (
-                        // The field first, then which list it came from — without that second line
-                        // a custom field named like a native one is indistinguishable once the
-                        // list is closed.
-                        <span className={cn('flex min-w-0 flex-col items-start text-left leading-tight', disabled && 'opacity-60')}>
-                            <span className="w-full truncate text-sm font-medium">{selected.label}</span>
-                            <span className="text-2xs text-muted-foreground">{selectedCustom ? CUSTOM_GROUP : NATIVE_GROUP}</span>
-                        </span>
+                        // The badge sits against the end of the control rather than trailing the
+                        // name, so it holds the same place on every row it appears on instead of
+                        // one that moves with the length of the label. flex-1 on the label is what
+                        // puts it there.
+                        <>
+                            <span className={cn('flex min-w-0 flex-1 items-baseline text-left text-sm font-medium', disabled && 'opacity-60')}>
+                                {/* Both give way, the name far sooner: shrink is a ratio, so a name
+                                    set to shrink hundreds of times faster is spent down to nothing
+                                    before the part it belongs to loses a character. What it cannot
+                                    be is unshrinkable — a part with nowhere to give runs out of the
+                                    control instead of truncating, which is what a narrow screen
+                                    does to an address. Nothing is lost with the name gone: the
+                                    column it maps from is named in full one cell to the left. */}
+                                <span className="min-w-0 shrink-[999] truncate">{labelHead}</span>
+                                {/* The space belongs to the text rather than to a gap between the
+                                    two boxes: read out, copied, or asserted on, this is one label
+                                    and it reads as one. Held by whitespace-pre, which is what stops
+                                    a space at the start of a box being dropped. */}
+                                {labelTail && <span className="min-w-0 truncate whitespace-pre">{` ${labelTail}`}</span>}
+                            </span>
+                            {/* Dropped on a narrow screen, where it is taking width from a label
+                                that has none to give. Worth being plain about the trade: it only
+                                appears where it is the one thing telling two same-named fields
+                                apart, so this gives that up exactly where it was earning its keep,
+                                and the name it makes room for is the more useful half of the row.
+                                The kind survives in the accessible name and in the open list. */}
+                            {ambiguous && <Badge className={cn('ms-2 shrink-0 max-md:hidden', disabled && 'opacity-60')} variant="secondary">{CUSTOM_BADGE}</Badge>}
+                        </>
                     ) : (
                         <span className={cn('min-w-0 truncate text-sm text-muted-foreground', disabled && 'opacity-60')}>Select field</span>
                     )}
@@ -204,16 +263,25 @@ export function FieldPicker({
                     onCreateField();
                 }}
             >
-                <Command className="min-h-0">
+                <Command className="min-h-0" filter={scoreByLabel}>
                     <CommandInput className="h-(--control-height) shrink-0" placeholder="Search fields..." value={search} onValueChange={onSearchChange} />
                     {/* Shade's own max-height stands; only the shrinking is added. flex-1 with
                         min-h-0 lets the list give up height to the available-height cap on the
                         content above, which is what keeps a row near the bottom of the dialog
                         from opening a list that runs off the screen. */}
                     <CommandList className="min-h-0 flex-1">
+                        {/* Keyed by the target rather than by the label, because a site can call a
+                            custom field "Name" and then two items carry the same label. cmdk holds
+                            the highlighted item as a value and marks every item equal to it, so a
+                            shared label is one item to it: both rows light up, and the one Enter
+                            takes is whichever the DOM has first — always the native one, whichever
+                            was arrowed to. The targets are already distinct, namespaced apart as
+                            `name` and `custom_fields.name`, so they are what identity is taken
+                            from, and the label moves to keywords, which is what scoreByLabel reads
+                            so that search still answers to the name on the row. */}
                         <CommandGroup heading={`${NATIVE_GROUP}s`}>
                             {fieldMappings.map(field => (
-                                <CommandItem key={field.value} value={field.label} onSelect={() => choose(field.value)}>
+                                <CommandItem key={field.value} keywords={[field.label]} value={field.value} onSelect={() => choose(field.value)}>
                                     <NativeIcon value={field.value} />
                                     <span className="truncate">{field.label}</span>
                                     {value === field.value && <CommandCheck />}
@@ -222,7 +290,7 @@ export function FieldPicker({
                         </CommandGroup>
                         <CommandGroup heading={`${CUSTOM_GROUP}s`}>
                             {customFieldMappings.map(field => (
-                                <CommandItem key={field.value} value={field.label} onSelect={() => choose(field.value)}>
+                                <CommandItem key={field.value} keywords={[field.label]} value={field.value} onSelect={() => choose(field.value)}>
                                     <CustomFieldIcon type={field.type} />
                                     <span className="truncate">{field.label}</span>
                                     {value === field.value && <CommandCheck />}

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -109,10 +109,38 @@ describe('Import members custom fields', () => {
 
         // The row carries the new field immediately, from the create response: the browse query
         // is invalidated but not awaited, so waiting for the refetch would leave the picker
-        // blank in between. And the trigger names the list it came from, so a custom field
-        // called "Name" could not be read as the member's own name once the list is closed.
+        // blank in between.
         await expect.element(fieldSelect('nickname')).toHaveTextContent('Nickname');
-        await expect.element(fieldSelect('nickname')).toHaveTextContent('Custom field');
+    });
+
+    it('marks a custom field a membership field already has the name of', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await userEvent.fill(createForm().getByLabelText('Name'), 'Name');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        // Two rows read "Name" now, and the mark on the custom one is the whole of what tells
+        // them apart once the list is closed. The membership field carries nothing: it is the
+        // rule rather than the exception, and marking both is what this replaced.
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Name');
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Custom');
+        await expect.element(fieldSelect('name')).toHaveTextContent('Name');
+        await expect.element(fieldSelect('name')).not.toHaveTextContent('Custom');
+    });
+
+    it('leaves a custom field no membership field is named like unmarked', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Nickname');
+        await expect.element(fieldSelect('nickname')).not.toHaveTextContent('Custom');
     });
 
     it('puts the create form away when another picker is opened', async () => {

--- a/apps/shade/src/components/ui/command.tsx
+++ b/apps/shade/src/components/ui/command.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 import {cn} from '@/lib/utils';
 import {Dialog, DialogContent, DialogTitle} from '@/components/ui/dialog';
 import {type DialogProps} from '@radix-ui/react-dialog';
-import {Command as CommandPrimitive} from 'cmdk';
+// The scorer cmdk filters with by default, passed on because a list whose items are identified
+// by something other than their label has to say what to search instead, and the answer should
+// be "the same way as everywhere else, over this string" rather than a second kind of matching.
+import {Command as CommandPrimitive, defaultFilter as commandDefaultFilter} from 'cmdk';
 import {Check, LucideIcon, Search} from 'lucide-react';
 
 function Command({className, ...props}: React.ComponentProps<typeof CommandPrimitive>) {
@@ -135,5 +138,6 @@ export {
     CommandItem,
     CommandList,
     CommandSeparator,
-    CommandShortcut
+    CommandShortcut,
+    commandDefaultFilter
 };


### PR DESCRIPTION
## Describe the problem you are solving

This PR refines the field picker in the members CSV import mapping, and fixes a selection defect it surfaced.

The closed trigger named the kind of every field it was showing, which put "Membership field" under nearly every row of the mapping table to answer a question almost none of those rows raise. Design feedback was to mark only the exception. The kind is now named only where a custom field's name is one a membership field already has, and with the second line gone the icon comes out of its tile so the control returns to the height every other one stands at.

Underneath that was a real bug. The list identified its items by their label, so a custom field named "Name" and the membership "Name" were a single item to cmdk: both drew as selected together, and because the active item is resolved by querying the first match in the DOM, Enter always took the membership one whichever had been arrowed to. A publisher with a custom field named like a built-in one could not reliably map a column to the one they meant.

ref https://linear.app/ghost/issue/BER-3876/refine-the-field-picker-in-the-members-import-mapping

## Changelog for devs

* Changed the closed field picker trigger to a single line: no kind subtitle, a flat inline icon instead of a bordered tile, and Shade's shared `--control-height`
* Added a `Custom` badge to the trigger, shown only when the selected custom field's name matches a membership field's, and hidden below the `md` breakpoint
* Fixed cmdk item identity in the picker: items are keyed by their namespaced target (`name` vs `custom_fields.name`) instead of their display label, so two fields sharing a name highlight and select independently, including by keyboard
* Added a `filter` to the picker's `Command` that scores the label alone, closing cmdk's value/keywords seam — the default filter joins the two before scoring, which matched "custom" against `subscribed_to_emails`
* Added a `commandDefaultFilter` re-export of cmdk's `defaultFilter` from Shade's `Command`, so the picker's own filter ranks the same way cmdk does everywhere else
* Fixed composite field labels being truncated at the part name, which made two rows of one address read identically
* Changed the trigger's `aria-label` to name the field kind for every custom selection
* Added acceptance coverage for the marked and unmarked cases

## Changelog for customers

Behind the `membersCustomFields` flag, so nothing here reaches a site without it. For publishers who do have it on, mapping a members CSV:

* Improved the mapping list: a column now shows just the field it maps to. Every row used to spell out which kind of field that was, which meant reading "Membership field" under nearly all of them to settle a question only a couple of rows ever raise
* Added a "Custom" marker, shown only where a custom field shares its name with a built-in one. That is the only case where the name on its own is ambiguous, so the answer now appears where it is needed instead of on every row
* Fixed choosing between two fields that share a name: they highlighted as though they were one field, and the keyboard always selected the built-in one whichever had been picked
* Fixed the parts of an address field being cut off at the point that told them apart, so several rows of one address read identically
* Improved the mapping table's density, fitting more of the file on screen before scrolling

## Notes

* Flag-gated throughout; there is no flag-off behaviour change.
* The Shade change is two lines that re-export an upstream cmdk utility Shade already depends on. No existing Shade consumer changes behaviour. It is needed because `cmdk` is Shade's dependency, not Admin's, so Admin cannot import `defaultFilter` directly without declaring a dependency it does not have.
* `text-left` on the label span looks like a leftover from the old two-line layout but is load-bearing: `<button>` carries a UA `text-align: center`, which shifts truncated overflowing text.
* `h-(--control-height)` on the trigger is redundant against `buttonVariants`' default size. It is kept as an explicit statement of the height the neighbouring comment argues for.

## Technical debt

* cmdk shows any item scoring above zero, so weak fuzzy matches surface as noise — searching "city" offers "Complimentary plan". A measured floor around `0.05` separates real matches (>= 0.15) from noise (<= 0.005) cleanly. This affects every cmdk picker in Admin, so it belongs in Shade's `Command` rather than in this one picker, and was deliberately left out of this PR.
* The same duplicate-value collision fixed here likely exists in the post and page pickers, where the option label is a bare title with no disambiguating detail and titles are not unique. Different files, needs its own verification.
* If those are fixed the same way, moving identity to an id and the label into `keywords` recreates the value/keywords seam. That argues for lifting this PR's filter into Shade's `Command` as its default rather than repeating it per picker.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [x] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
