### PR TITLE
Removed all `@ts-ignore` usages

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/snippets.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/snippets.js
@@ -10,7 +10,6 @@ module.exports = (snippet, frame) => {
     return {
         id: json.id,
         name: json.name,
-        // @ts-ignore
         mobiledoc: json.mobiledoc,
         lexical: json.lexical,
         created_at: json.created_at,

--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -182,7 +182,6 @@ class SettingsHelpers {
         unsubscribeUrl.pathname = `${unsubscribeUrl.pathname}/unsubscribe/`.replace('//', '/');
         if (uuid) {
             // hash key with member uuid for verification (and to not leak uuid) - it's possible to update member email prefs without logging in
-            // @ts-ignore
             const hmac = crypto.createHmac('sha256', key).update(`${uuid}`).digest('hex');
             unsubscribeUrl.searchParams.set('uuid', uuid);
             unsubscribeUrl.searchParams.set('key', hmac);

--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -971,9 +971,7 @@ class PostsStatsService {
             const dailyChanges = [];
             for (const row of rawDeltas) {
                 if (row) {
-                    // @ts-ignore
                     const dateValue = row.date || '';
-                    // @ts-ignore
                     const changeValue = row.value || 0;
                     dailyChanges.push({
                         date: String(dateValue),

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -1,6 +1,4 @@
-// @ts-ignore
 const {VersionMismatchError} = require('@tryghost/errors');
-// @ts-ignore
 const debug = require('@tryghost/debug')('stripe');
 const ghostConfig = require('../../../shared/config');
 const stripe = require('stripe');
@@ -67,6 +65,7 @@ module.exports = class StripeAPI {
      * StripeAPI
      * @param {object} deps
      * @param {object} deps.labs
+     * @param {(key: string) => boolean} deps.labs.isSet
      */
     constructor(deps) {
         /** @type {Stripe} */
@@ -223,8 +222,7 @@ module.exports = class StripeAPI {
             unit_amount: options.amount,
             active: options.active,
             nickname: options.nickname,
-            // @ts-ignore
-            custom_unit_amount: options.custom_unit_amount, // missing in .d.ts definitions in the Stripe node version we use, but should be supported in Stripe API at this version (:
+            custom_unit_amount: options.custom_unit_amount,
             recurring: options.type === 'recurring' && options.interval ? {
                 interval: options.interval
             } : undefined
@@ -593,7 +591,6 @@ module.exports = class StripeAPI {
             managed_payments: MANAGED_PAYMENTS_DISABLED,
             success_url: options.successUrl || this._config.checkoutSessionSuccessUrl,
             cancel_url: options.cancelUrl || this._config.checkoutSessionCancelUrl,
-            // @ts-ignore - we need to update to latest stripe library to correctly use newer features
             allow_promotion_codes: discounts ? undefined : this._config.enablePromoCodes,
             automatic_tax: {
                 enabled: this._config.enableAutomaticTax
@@ -622,7 +619,6 @@ module.exports = class StripeAPI {
 
         this._applyAutomaticTaxSessionOptions(stripeSessionOptions, {hasCustomer: Boolean(customerId)});
 
-        // @ts-ignore
         const session = await this._stripe.checkout.sessions.create(stripeSessionOptions);
 
         return session;
@@ -692,7 +688,6 @@ module.exports = class StripeAPI {
 
         this._applyAutomaticTaxSessionOptions(stripeSessionOptions, {hasCustomer: Boolean(customer)});
 
-        // @ts-ignore
         const session = await this._stripe.checkout.sessions.create(stripeSessionOptions);
         return session;
     }
@@ -750,7 +745,6 @@ module.exports = class StripeAPI {
 
         this._applyAutomaticTaxSessionOptions(stripeSessionOptions, {hasCustomer: Boolean(customer)});
 
-        // @ts-ignore
         const session = await this._stripe.checkout.sessions.create(stripeSessionOptions);
 
         return session;
@@ -783,7 +777,6 @@ module.exports = class StripeAPI {
 
             // Note: this is required for dynamic payment methods
             // https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-currency
-            // @ts-ignore
             currency: this.labs.isSet('additionalPaymentMethods') ? options.currency : undefined
         });
 

--- a/ghost/core/eslint.config.mjs
+++ b/ghost/core/eslint.config.mjs
@@ -41,7 +41,7 @@ const tsLegacyRelaxations = {
     '@typescript-eslint/no-unused-expressions': 'off',
     // LEGACY: tseslint v8 default. `Function` used as a type for callbacks.
     '@typescript-eslint/no-unsafe-function-type': 'off',
-    // LEGACY: tseslint v8 default. `// @ts-ignore` comments still exist.
+    // LEGACY: tseslint v8 default.
     '@typescript-eslint/ban-ts-comment': 'off',
     // LEGACY: previous posture from plugin:ghost/ts allowed inferrable types.
     '@typescript-eslint/no-inferrable-types': 'off',

--- a/ghost/core/test/e2e-api/admin/pages.test.js
+++ b/ghost/core/test/e2e-api/admin/pages.test.js
@@ -119,7 +119,6 @@ describe('Pages API', function () {
                         status: 'draft'
                     };
 
-                    // @ts-ignore
                     const products = await models.Product.findAll();
 
                     const freeTier = products.models[0];

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -699,7 +699,6 @@ describe('Posts API', function () {
                         status: 'draft'
                     };
 
-                    // @ts-ignore
                     const products = await models.Product.findAll();
 
                     const freeTier = products.models[0];

--- a/ghost/core/test/integration/services/email-service/cards.test.js
+++ b/ghost/core/test/integration/services/email-service/cards.test.js
@@ -32,16 +32,19 @@ const excludedNodes = [
  * Remove the preheader span from the email html and put it in a separate field called preheader
  * @template {{html: string}} T
  * @param {T} data
- * @returns {asserts data is T & {preheader: string}}
+ * @returns {T & {html: string, preheader: string}}
  */
 function splitPreheader(data) {
     // Remove the preheader span from the email using cheerio
     const $ = cheerio.load(data.html);
     const preheader = $('.preheader');
-    // @ts-ignore
-    data.preheader = preheader.html();
+    const preheaderHtml = preheader.html();
     preheader.remove();
-    data.html = $.html();
+    return {
+        ...data,
+        html: $.html(),
+        preheader: preheaderHtml
+    };
 }
 
 function createParagraphCard(text = 'Hello world.') {
@@ -129,12 +132,12 @@ describe('Can send cards via email', function () {
         });
 
         // Remove the preheader span from the email using cheerio
-        splitPreheader(data);
+        const email = splitPreheader(data);
 
         // Check only contains once in every part
-        assert.equal(data.html.match(/This is a paragraph test\./g).length, 1);
-        assert.equal(data.plaintext.match(/This is a paragraph test\./g).length, 1);
-        assert.equal(data.preheader.match(/This is a paragraph test\./g).length, 1);
+        assert.equal(email.html.match(/This is a paragraph test\./g).length, 1);
+        assert.equal(email.plaintext.match(/This is a paragraph test\./g).length, 1);
+        assert.equal(email.preheader.match(/This is a paragraph test\./g).length, 1);
 
         await matchEmailSnapshot();
     });
@@ -165,16 +168,16 @@ describe('Can send cards via email', function () {
             ])
         });
 
-        splitPreheader(data);
+        const email = splitPreheader(data);
 
         // Check the plaintext does contain the paragraph, but doesn't contain the signup card
-        assert.ok(!data.html.includes('Sign up for Koenig Lexical'));
-        assert.ok(!data.plaintext.includes('Sign up for Koenig Lexical'));
-        assert.ok(!data.preheader.includes('Sign up for Koenig Lexical'));
+        assert.ok(!email.html.includes('Sign up for Koenig Lexical'));
+        assert.ok(!email.plaintext.includes('Sign up for Koenig Lexical'));
+        assert.ok(!email.preheader.includes('Sign up for Koenig Lexical'));
 
-        assert.ok(data.html.includes('This is a paragraph'));
-        assert.ok(data.plaintext.includes('This is a paragraph'));
-        assert.ok(data.preheader.includes('This is a paragraph'));
+        assert.ok(email.html.includes('This is a paragraph'));
+        assert.ok(email.plaintext.includes('This is a paragraph'));
+        assert.ok(email.preheader.includes('This is a paragraph'));
 
         await matchEmailSnapshot();
     });

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -19,6 +19,8 @@ function trimSpaces(string) {
 
 describe('{{#recommendations}} helper', function () {
     let logging;
+    /** @type {sinon.SinonStub} */
+    let settingsCacheGetStub;
 
     beforeAll(async function () {
         hbs.express4({
@@ -33,9 +35,8 @@ describe('{{#recommendations}} helper', function () {
         hbs.registerHelper('readable_url', readable_url);
 
         // Stub settings cache
-        sinon.stub(settingsCache, 'get');
-        // @ts-ignore
-        settingsCache.get.withArgs('recommendations_enabled').returns(true);
+        settingsCacheGetStub = sinon.stub(settingsCache, 'get');
+        settingsCacheGetStub.withArgs('recommendations_enabled').returns(true);
 
         // Stub Recommendation Content API
         const meta = {pagination: {}};
@@ -129,8 +130,7 @@ describe('{{#recommendations}} helper', function () {
 
     describe('when recommendations_enabled is false', function () {
         beforeAll(function () {
-            // @ts-ignore
-            settingsCache.get.withArgs('recommendations_enabled').returns(true);
+            settingsCacheGetStub.withArgs('recommendations_enabled').returns(true);
         });
 
         it('renders nothing', async function () {

--- a/ghost/core/test/unit/server/services/email-address/email-address-parser.test.ts
+++ b/ghost/core/test/unit/server/services/email-address/email-address-parser.test.ts
@@ -55,13 +55,13 @@ describe('EmailAddressParser', function () {
         });
 
         it('should return null for null input', function () {
-            // @ts-ignore - Testing null input
+            // @ts-expect-error - Testing null input
             const email = EmailAddressParser.parse(null);
             assert.equal(email, null);
         });
 
         it('should return null for undefined input', function () {
-            // @ts-ignore - Testing undefined input
+            // @ts-expect-error - Testing undefined input
             const email = EmailAddressParser.parse(undefined);
             assert.equal(email, null);
         });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -2,7 +2,6 @@ const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 
-// @ts-ignore - Intentionally ignoring TypeScript errors for tests
 const RouterController = require('../../../../../../../core/server/services/members/members-api/controllers/router-controller');
 
 describe('RouterController', function () {

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -247,7 +247,6 @@ const mockMailgun = (customStubbedSend) => {
 
     // We need to stub the Mailgun client before starting Ghost
     sinon.stub(MailgunClient.prototype, 'getInstance').returns({
-        // @ts-ignore
         messages: {
             create: async function () {
                 return await mailgunCreateMessageStub.call(this, ...arguments);


### PR DESCRIPTION
no ref

This change should have no user impact.

[`@ts-ignore` should never be used.][0] This removes all usages. Most of the time, we could simply delete it. Sometimes, we needed to replace it with something.

All of the functionality changes were (1) only in tests (2) minor.

[0]: https://evanhahn.com/ts-ignore-is-almost-always-the-worst-option/
