### PR TITLE
Used `const` for variables that are never reassigned

### DIFF
--- a/ghost/core/core/server/adapters/scheduling/scheduling-default.ts
+++ b/ghost/core/core/server/adapters/scheduling/scheduling-default.ts
@@ -40,10 +40,10 @@ export default class SchedulingDefault extends SchedulingBase {
     request = request;
 
     _addJob(job: SchedulerJob) {
-        let timestamp = moment(job.time).valueOf();
+        const timestamp = moment(job.time).valueOf();
         let keys: string[] = [];
-        let sortedJobs: Record<string, SchedulerJob[]> = {};
-        let instantJob: Record<string, SchedulerJob[]> = {};
+        const sortedJobs: Record<string, SchedulerJob[]> = {};
+        const instantJob: Record<string, SchedulerJob[]> = {};
         let i = 0;
 
         // CASE: should have been already pinged or should be pinged soon
@@ -95,15 +95,14 @@ export default class SchedulingDefault extends SchedulingBase {
         const self = this; // eslint-disable-line @typescript-eslint/no-this-alias
 
         keys.forEach(function (timestamp) {
-            let timeout: NodeJS.Timeout | undefined;
-            let diff = moment(Number(timestamp)).diff(moment());
+            const diff = moment(Number(timestamp)).diff(moment());
 
             // NOTE: awake a little before...
-            timeout = setTimeout(function () {
+            const timeout = setTimeout(function () {
                 clearTimeout(timeout);
 
                 (function retry() {
-                    let immediate = setImmediate(function () {
+                    const immediate = setImmediate(function () {
                         clearImmediate(immediate);
 
                         // CASE: It's not the time yet...

--- a/ghost/core/core/server/adapters/storage/LocalStorageBase.ts
+++ b/ghost/core/core/server/adapters/storage/LocalStorageBase.ts
@@ -132,15 +132,11 @@ class LocalStorageBase extends StorageBase {
      * - returns a promise which ultimately returns the full url to the uploaded file
      */
     async save(file: StorageFile, targetDir?: string): Promise<string> {
-        let targetFilename;
-
         targetDir = targetDir
             ? this._resolveAndValidateStoragePath(targetDir)
             : this.getTargetDir(this.storagePath);
 
-        const filename = await this.getUniqueFileName(file, targetDir);
-
-        targetFilename = filename;
+        const targetFilename = await this.getUniqueFileName(file, targetDir);
 
         // Verify that we are saving directly under `targetDir` and not outside of it.
         const expectedPrefix = path.join(path.resolve(targetDir), '/');

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -371,7 +371,7 @@ export class EmailAnalyticsService {
         const eventProcessor = this.#createEventProcessor();
 
         // We keep the processing result here, so we also have a result in case of failures
-        let processingResult = new EventProcessingResult();
+        const processingResult = new EventProcessingResult();
         // Track cumulative event counts separately since processingResult gets reset during intermediate aggregations
         const cumulativeResult = new EventProcessingResult();
         let error: unknown = null;

--- a/ghost/core/eslint.config.mjs
+++ b/ghost/core/eslint.config.mjs
@@ -44,9 +44,7 @@ const tsLegacyRelaxations = {
     // LEGACY: tseslint v8 default. `// @ts-ignore` comments still exist.
     '@typescript-eslint/ban-ts-comment': 'off',
     // LEGACY: previous posture from plugin:ghost/ts allowed inferrable types.
-    '@typescript-eslint/no-inferrable-types': 'off',
-    // LEGACY: `let` declarations across the codebase could be `const`.
-    'prefer-const': 'off'
+    '@typescript-eslint/no-inferrable-types': 'off'
 };
 
 const migrationLoopRules = ['error',

--- a/ghost/core/test/unit/server/adapters/storage/index.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/index.test.ts
@@ -61,12 +61,10 @@ describe('storage: index_spec', function () {
             '}' +
             'module.exports = AnotherAdapter';
 
-        let chosenStorage;
-
         fs.writeFileSync(scope.adapter, jsFile);
 
         assert.equal(configUtils.config.get('storage:active'), 'custom-adapter');
-        chosenStorage = adapterManager.getAdapter('storage:images');
+        const chosenStorage = adapterManager.getAdapter('storage:images');
         assert.equal((chosenStorage instanceof LocalStorageBase), false);
         assert.equal((chosenStorage instanceof StorageBase), true);
     });

--- a/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.ts
@@ -41,7 +41,7 @@ describe('Local Storage Base', function () {
 
     describe('urlToPath', function () {
         it('returns relative path from full url', function () {
-            let localStorageBase = new LocalStorageBase({
+            const localStorageBase = new LocalStorageBase({
                 storagePath: '/media-storage/path/',
                 staticFileURLPrefix: 'content/media',
                 siteUrl: 'http://example.com/blog/'
@@ -54,7 +54,7 @@ describe('Local Storage Base', function () {
         });
 
         it('returns relative path from prefix url', function () {
-            let localStorageBase = new LocalStorageBase({
+            const localStorageBase = new LocalStorageBase({
                 storagePath: '/media-storage/path/',
                 staticFileURLPrefix: 'content/media',
                 siteUrl: 'http://example.com/'
@@ -67,7 +67,7 @@ describe('Local Storage Base', function () {
         });
 
         it('throws if the url resolves outside the storage root', function () {
-            let localStorageBase = new LocalStorageBase({
+            const localStorageBase = new LocalStorageBase({
                 storagePath: '/media-storage/path/',
                 staticFileURLPrefix: 'content/media',
                 siteUrl: 'http://example.com/blog/'
@@ -79,7 +79,7 @@ describe('Local Storage Base', function () {
         });
 
         it('throws if the prefix url resolves outside the storage root', function () {
-            let localStorageBase = new LocalStorageBase({
+            const localStorageBase = new LocalStorageBase({
                 storagePath: '/media-storage/path/',
                 staticFileURLPrefix: 'content/media',
                 siteUrl: 'http://example.com/'
@@ -91,7 +91,7 @@ describe('Local Storage Base', function () {
         });
 
         it('throws if the url does not match current site', function () {
-            let localStorageBase = new LocalStorageBase({
+            const localStorageBase = new LocalStorageBase({
                 storagePath: '/media-storage/path/',
                 staticFileURLPrefix: 'content/media',
                 siteUrl: 'http://example.com/blog/'

--- a/ghost/core/test/unit/server/adapters/storage/utils.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/utils.test.ts
@@ -31,70 +31,65 @@ describe('storage utils', function () {
     describe('fn: getLocalImagesStoragePath', function () {
         it('should return local file storage path for absolute URL', function () {
             const url = 'http://myblog.com/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
-            result = storageUtils.getLocalImagesStoragePath(url);
+            const result = storageUtils.getLocalImagesStoragePath(url);
             assertExists(result);
             assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should return local file storage path for absolute URL with subdirectory', function () {
             const url = 'http://myblog.com/blog/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
-            result = storageUtils.getLocalImagesStoragePath(url);
+            const result = storageUtils.getLocalImagesStoragePath(url);
             assertExists(result);
             assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should return local file storage path for relative URL', function () {
             const filePath = '/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
-            result = storageUtils.getLocalImagesStoragePath(filePath);
+            const result = storageUtils.getLocalImagesStoragePath(filePath);
             assertExists(result);
             assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should return local file storage path for relative URL with subdirectory', function () {
             const filePath = '/blog/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
-            result = storageUtils.getLocalImagesStoragePath(filePath);
+            const result = storageUtils.getLocalImagesStoragePath(filePath);
             assertExists(result);
             assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should not sanitize URL if not local file storage', function () {
             const url = 'http://example-blog.com/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
-            result = storageUtils.getLocalImagesStoragePath(url);
+            const result = storageUtils.getLocalImagesStoragePath(url);
             assertExists(result);
             assert.equal(result, 'http://example-blog.com/ghost-logo.png');
         });
@@ -103,70 +98,65 @@ describe('storage utils', function () {
     describe('fn: isLocalImage', function () {
         it('should return true when absolute URL and local file', function () {
             const url = 'http://myblog.com/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
-            result = storageUtils.isLocalImage(url);
+            const result = storageUtils.isLocalImage(url);
             assertExists(result);
             assert.equal(result, true);
         });
 
         it('should return true when absolute URL with subdirectory and local file', function () {
             const url = 'http://myblog.com/blog/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
-            result = storageUtils.isLocalImage(url);
+            const result = storageUtils.isLocalImage(url);
             assertExists(result);
             assert.equal(result, true);
         });
 
         it('should return true when relative URL and local file', function () {
             const url = '/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
-            result = storageUtils.isLocalImage(url);
+            const result = storageUtils.isLocalImage(url);
             assertExists(result);
             assert.equal(result, true);
         });
 
         it('should return true when relative URL and local file (blog subdir)', function () {
             const url = '/blog/content/images/2017/07/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
-            result = storageUtils.isLocalImage(url);
+            const result = storageUtils.isLocalImage(url);
             assertExists(result);
             assert.equal(result, true);
         });
 
         it('should return false when no local file', function () {
             const url = 'http://somewebsite.com/ghost-logo.png';
-            let result;
 
             urlForStub = sinon.stub(urlUtils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
             urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
-            result = storageUtils.isLocalImage(url);
+            const result = storageUtils.isLocalImage(url);
             assertExists(result);
             assert.equal(result, false);
         });

--- a/ghost/core/test/unit/server/models/set-is-roles.test.ts
+++ b/ghost/core/test/unit/server/models/set-is-roles.test.ts
@@ -59,12 +59,12 @@ describe('setIsRoles function behavior', function () {
     };
 
     it('returns an object', function () {
-        let result = setIsRoles(loadedPermissionsEditor);
+        const result = setIsRoles(loadedPermissionsEditor);
         assert(_.isPlainObject(result));
     });
 
     it('returns the correct object for Editor', function () {
-        let result = setIsRoles(loadedPermissionsEditor);
+        const result = setIsRoles(loadedPermissionsEditor);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
@@ -76,7 +76,7 @@ describe('setIsRoles function behavior', function () {
     });
 
     it('returns the correct object for Administrator', function () {
-        let result = setIsRoles(loadedPermissionsAdmin);
+        const result = setIsRoles(loadedPermissionsAdmin);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, true);
@@ -88,7 +88,7 @@ describe('setIsRoles function behavior', function () {
     });
 
     it('returns the correct object for Author', function () {
-        let result = setIsRoles(loadedPermissionsAuthor);
+        const result = setIsRoles(loadedPermissionsAuthor);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
@@ -100,7 +100,7 @@ describe('setIsRoles function behavior', function () {
     });
 
     it('returns the correct object for Super Editor', function () {
-        let result = setIsRoles(loadedPermissionsSuperEditor);
+        const result = setIsRoles(loadedPermissionsSuperEditor);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
@@ -112,7 +112,7 @@ describe('setIsRoles function behavior', function () {
     });
 
     it('returns the correct object for multiple roles', function () {
-        let result = setIsRoles(loadedPermissionsWithMultipleRoles);
+        const result = setIsRoles(loadedPermissionsWithMultipleRoles);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
@@ -123,7 +123,7 @@ describe('setIsRoles function behavior', function () {
         assert.equal(result.isEitherEditor, true);
     });
     it('returns the correct object for no roles', function () {
-        let result = setIsRoles(loadedPermissionsWithNoRoles);
+        const result = setIsRoles(loadedPermissionsWithNoRoles);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
@@ -134,7 +134,7 @@ describe('setIsRoles function behavior', function () {
         assert.equal(result.isEitherEditor, false);
     });
     it('returns the correct object for no user', function () {
-        let result = setIsRoles(loadedPermissionsWithNoUser);
+        const result = setIsRoles(loadedPermissionsWithNoUser);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
@@ -145,7 +145,7 @@ describe('setIsRoles function behavior', function () {
         assert.equal(result.isEitherEditor, false);
     });
     it('returns the correct object for permissions without role', function () {
-        let result = setIsRoles(loadedPermissionswithPermissions);
+        const result = setIsRoles(loadedPermissionswithPermissions);
         assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-controller.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-controller.test.ts
@@ -590,7 +590,7 @@ describe('RecommendationController', function () {
 
         describe('include', function () {
             let listSpy: SinonSpy;
-            let rec = {
+            const rec = {
                 id: '1',
                 title: 'Test',
                 description: null,


### PR DESCRIPTION
To quote [ESLint's docs][0]:

> If a variable is never reassigned, using the `const` declaration is better.

This enables the `prefer-const` ESLint rule and fixes all violations.

[0]: https://eslint.org/docs/latest/rules/prefer-const
