### PR TITLE
Improved gift presentation

### DIFF
--- a/apps/portal/src/components/pages/beta-gift-redemption-page.jsx
+++ b/apps/portal/src/components/pages/beta-gift-redemption-page.jsx
@@ -79,7 +79,7 @@ const BetaGiftRedemptionPage = () => {
             status: 'error',
             autoHide: false,
             closeable: true,
-            message: getGiftRedemptionErrorMessage()
+            message: getGiftRedemptionErrorMessage({code: 'GIFT_NOT_FOUND'})
         });
         doAction('closePopup');
     }, [doAction, gift]);

--- a/apps/portal/src/components/pages/gift-redemption-page.jsx
+++ b/apps/portal/src/components/pages/gift-redemption-page.jsx
@@ -47,7 +47,7 @@ const GiftRedemptionPage = () => {
             status: 'error',
             autoHide: false,
             closeable: true,
-            message: getGiftRedemptionErrorMessage()
+            message: getGiftRedemptionErrorMessage({code: 'GIFT_NOT_FOUND'})
         });
         doAction('closePopup');
     }, [doAction, gift]);

--- a/apps/portal/src/utils/gift-redemption-notification.js
+++ b/apps/portal/src/utils/gift-redemption-notification.js
@@ -66,6 +66,9 @@ export function getGiftRedemptionErrorMessage(error) {
 
     if (error?.code) {
         switch (error.code) {
+        case 'GIFT_NOT_FOUND':
+            subtitle = t('This gift link is invalid.');
+            break;
         case 'GIFT_REDEEMED':
             subtitle = t('This gift has already been redeemed.');
             break;

--- a/apps/portal/test/portal-links.test.jsx
+++ b/apps/portal/test/portal-links.test.jsx
@@ -543,7 +543,7 @@ describe('Portal Data links:', () => {
             let {
                 ghostApi, triggerButtonFrame, ...utils
             } = await setupGiftRedemption({
-                giftError: new Error('Gift not found')
+                giftError: Object.assign(new Error('Gift not found'), {code: 'GIFT_NOT_FOUND'})
             });
 
             expect(triggerButtonFrame).toBeInTheDocument();
@@ -551,7 +551,7 @@ describe('Portal Data links:', () => {
 
             await expectGiftRedemptionErrorToast({
                 utils,
-                subtitle: /Something went wrong, please try again later\./i
+                subtitle: /This gift link is invalid\./i
             });
         });
 

--- a/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
@@ -113,7 +113,7 @@ describe.each([
                 closeable: true,
                 message: {
                     title: 'Gift could not be redeemed',
-                    subtitle: 'Something went wrong, please try again later.'
+                    subtitle: 'This gift link is invalid.'
                 }
             });
         });

--- a/ghost/core/core/server/services/gifts/email-templates/gift-delivery.hbs
+++ b/ghost/core/core/server/services/gifts/email-templates/gift-delivery.hbs
@@ -1,20 +1,108 @@
 <!doctype html>
 <html>
-  <head><meta name="viewport" content="width=device-width"><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>{{t 'A gift, just for you'}}</title></head>
-  <body style="background:#fff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;margin:0;padding:0;color:#3A464C;">
-    <span class="preheader" style="color:transparent;display:none;height:0;max-height:0;max-width:0;opacity:0;overflow:hidden;visibility:hidden;width:0;">{{t 'You\'ve been gifted a membership to {siteTitle}' siteTitle=siteTitle}}</span>
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center">
-      <table role="presentation" width="540" cellpadding="0" cellspacing="0" border="0" style="max-width:540px;width:100%;"><tr><td style="padding:40px 20px;">
-        {{#if siteIconUrl}}<a href="{{siteUrl}}"><img src="{{siteIconUrl}}" alt="{{siteTitle}}" width="48" height="48" style="border-radius:4px;"></a>{{else}}<a href="{{siteUrl}}" style="color:{{accentColor}};font-size:17px;font-weight:700;text-decoration:none;">{{siteTitle}}</a>{{/if}}
-        <h1 style="color:#15212A;font-size:26px;line-height:31px;margin:22px 0 14px;">{{t 'A gift, just for you'}}</h1>
-        {{#if recipientName}}<p style="font-size:16px;line-height:24px;margin:0 0 16px;">{{t 'Hi {recipientName},' recipientName=(strong recipientName)}}</p>{{/if}}
-        <p style="font-size:16px;line-height:24px;margin:0 0 24px;">{{#if gift.isMonthly}}{{t '{buyerName} has gifted you a {duration}-month {tierName} membership to {siteTitle}' buyerName=(strong buyerName) duration=(strong gift.duration) count=gift.duration tierName=(strong gift.tierName) siteTitle=siteTitle}}{{else}}{{t '{buyerName} has gifted you a {duration}-year {tierName} membership to {siteTitle}' buyerName=(strong buyerName) duration=(strong gift.duration) count=gift.duration tierName=(strong gift.tierName) siteTitle=siteTitle}}{{/if}}</p>
-        {{#if personalMessage}}<div style="background:{{accentTint}};border-radius:8px;margin-bottom:24px;padding:16px 18px;"><p style="color:#15212A;font-size:16px;font-style:italic;line-height:24px;margin:0;white-space:pre-line;word-break:break-word;">{{personalMessage}}</p><p style="color:{{accentShade}};font-size:14px;margin:10px 0 0;">{{buyerName}}</p></div>{{/if}}
-        {{#if gift.benefits.length}}<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:32px;"><tr><td><p style="font-size:16px;line-height:24px;margin:0 0 6px;">{{t 'What\'s included'}}</p></td></tr>{{#each gift.benefits}}<tr><td style="font-size:16px;line-height:24px;padding:4px 0;"><span style="color:{{../accentColor}};font-weight:bold;">&#10003;</span>&nbsp;&nbsp;{{this}}</td></tr>{{/each}}</table>{{/if}}
-        <a href="{{gift.link}}" style="background:{{accentColor}};border-radius:5px;color:#fff;display:block;font-size:16px;padding:10px 22px;text-align:center;text-decoration:none;">{{t 'Redeem your gift:'}}</a>
-        <p style="color:#738A94;font-size:13px;line-height:20px;margin:16px 0 0;">{{t 'This gift can only be redeemed once and expires on {expiresAt}.' expiresAt=(strong gift.expiresAt)}}</p>
-        <p style="color:#738A94;font-size:11px;line-height:16px;margin:40px 0 0;">{{t 'This message was sent from {siteDomain} to {email} on behalf of {buyerName} ({buyerEmail}).' siteDomain=(linkTag siteUrl siteDomain style="color:#738A94;") email=(linkTag (mailto toEmail) toEmail style="color:#738A94;") buyerName=buyerName buyerEmail=(linkTag (mailto buyerEmail) buyerEmail style="color:#738A94;")}}</p>
-      </td></tr></table>
-    </td></tr></table>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>{{t 'A gift, just for you'}}</title>
+    <style>
+      @media only screen and (max-width: 620px) {
+        table.body h1 { font-size: 22px !important; padding-bottom: 16px !important; }
+        table.body p, table.body td, table.body a { font-size: 16px !important; }
+        table.body .wrapper { padding: 10px !important; }
+        table.body .content { padding: 0 !important; }
+        table.body .container { padding: 0 !important; width: 100% !important; }
+        table.body .main { border-radius: 0 !important; }
+        table.body .btn a { width: 100% !important; }
+        table.body p.small, table.body a.small { font-size: 11px !important; }
+      }
+    </style>
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">{{t 'You\'ve been gifted a membership to {siteTitle}' siteTitle=siteTitle}}</span>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+      <tr>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+          <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+            <table role="presentation" class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
+              <tr>
+                <td class="wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                    <tr>
+                      <td align="left" style="padding-bottom: 22px; text-align: left;">
+                        {{#if siteIconUrl}}
+                          <a href="{{siteUrl}}"><img src="{{siteIconUrl}}" alt="{{siteTitle}}" border="0" width="48" height="48" style="border-radius: 4px;"></a>
+                        {{else}}
+                          <a href="{{siteUrl}}" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 17px; font-weight: 700; color: {{accentColor}}; text-decoration: none;">{{siteTitle}}</a>
+                        {{/if}}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
+                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 31px; letter-spacing: -0.26px; margin: 0; padding-bottom: 14px;">{{t 'A gift, just for you'}}</h1>
+                        {{#if recipientName}}<p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 24px; margin: 0; padding-bottom: 16px;">{{t 'Hi {recipientName},' recipientName=(strong recipientName)}}</p>{{/if}}
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 24px; margin: 0; padding-bottom: 24px;">{{#if gift.isMonthly}}{{t '{buyerName} has gifted you a {duration}-month {tierName} membership to {siteTitle}' buyerName=(strong buyerName) duration=(strong gift.duration) count=gift.duration tierName=(strong gift.tierName) siteTitle=siteTitle}}{{else}}{{t '{buyerName} has gifted you a {duration}-year {tierName} membership to {siteTitle}' buyerName=(strong buyerName) duration=(strong gift.duration) count=gift.duration tierName=(strong gift.tierName) siteTitle=siteTitle}}{{/if}}</p>
+                        {{#if personalMessage}}
+                          <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background:{{accentTint}}; border-radius: 8px; margin-bottom: 24px;">
+                            <tbody>
+                              <tr>
+                                <td align="left" style="padding: 16px 18px;">
+                                  <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; font-style: italic; line-height: 24px; color: #15212A; margin: 0; word-break: break-word; white-space: pre-line;">{{personalMessage}}</p>
+                                  <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; line-height: 20px; color:{{accentShade}}; margin: 10px 0 0;">{{buyerName}}</p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        {{/if}}
+                        {{#if gift.benefits.length}}
+                          <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box; margin-bottom: 32px;">
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: 400; line-height: 24px; margin: 0 0 6px;">{{t 'What\'s included'}}</p>
+                                </td>
+                              </tr>
+                              {{#each gift.benefits}}
+                                <tr>
+                                  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; line-height: 24px; padding: 4px 0;"><span style="color: {{../accentColor}}; font-weight: bold;">&#10003;</span>&nbsp;&nbsp;{{this}}</td>
+                                </tr>
+                              {{/each}}
+                            </tbody>
+                          </table>
+                        {{/if}}
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="center" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;">
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;">
+                                        <a href="{{gift.link}}" target="_blank" style="display: block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">{{t 'Redeem your gift:'}}</a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 13px; color: #738A94; font-weight: normal; line-height: 20px; margin: 0; padding-top: 16px;">{{t 'This gift can only be redeemed once and expires on {expiresAt}.' expiresAt=(strong gift.expiresAt)}}</p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 40px;">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 16px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0;">{{t 'This message was sent from {siteDomain} to {email} on behalf of {buyerName} ({buyerEmail}).' siteDomain=(linkTag siteUrl siteDomain class="small" style="text-decoration: underline; color: #738A94; font-size: 11px;") email=(linkTag (mailto toEmail) toEmail class="small" style="text-decoration: underline; color: #738A94; font-size: 11px;") buyerName=buyerName buyerEmail=(linkTag (mailto buyerEmail) buyerEmail class="small" style="text-decoration: underline; color: #738A94; font-size: 11px;")}}</p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </td>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/ghost/core/core/server/services/gifts/email-templates/gift-reminder.hbs
+++ b/ghost/core/core/server/services/gifts/email-templates/gift-reminder.hbs
@@ -49,8 +49,8 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 6px; text-align: center;">
-                                        <a href="{{gift.manageSubscriptionUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 6px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: 600; margin: 0; padding: 12px 22px; border-color: {{accentColor}};">{{t 'Continue subscription'}}</a>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;">
+                                        <a href="{{gift.manageSubscriptionUrl}}" target="_blank" style="display: block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">{{t 'Continue subscription'}}</a>
                                       </td>
                                     </tr>
                                   </tbody>

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -708,7 +708,10 @@ export class GiftService {
         if (!redeemableCheck.redeemable) {
             switch (redeemableCheck.reason) {
             case 'payment-pending':
-                throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
+                throw new errors.NotFoundError({
+                    message: tpl(errorMessages.giftNotFound),
+                    code: 'GIFT_NOT_FOUND'
+                });
             case 'redeemed':
                 throw new errors.BadRequestError({
                     message: tpl(errorMessages.giftAlreadyRedeemed),
@@ -751,7 +754,10 @@ export class GiftService {
         const gift = await this.deps.giftRepository.getByToken(input.token);
 
         if (!gift) {
-            throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
+            throw new errors.NotFoundError({
+                message: tpl(errorMessages.giftNotFound),
+                code: 'GIFT_NOT_FOUND'
+            });
         }
 
         this.assertRedeemable(gift, input.memberStatus);
@@ -822,7 +828,10 @@ export class GiftService {
 
         const gift = await this.deps.giftRepository.getByToken(token, {transacting, forUpdate: true});
         if (!gift) {
-            throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
+            throw new errors.NotFoundError({
+                message: tpl(errorMessages.giftNotFound),
+                code: 'GIFT_NOT_FOUND'
+            });
         }
 
         if (options.newMember) {

--- a/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
+++ b/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
@@ -265,7 +265,39 @@ describe('GiftEmailService', function () {
             sinon.assert.match(message.plaintext, sinon.match('This message was sent from example.com to recipient@example.com on behalf of Buyer (buyer@example.com).'));
             sinon.assert.match(message.html, sinon.match('Redeem your gift:'));
             sinon.assert.match(message.html, sinon.match('<strong>Buyer</strong> has gifted you a <strong>1</strong>-year <strong>Gold</strong> membership to Test Site'));
-            sinon.assert.match(message.html, sinon.match('on behalf of Buyer (<a href="mailto:buyer@example.com"'));
+            sinon.assert.match(message.html, sinon.match(/on behalf of Buyer \(<a[^>]+href="mailto:buyer@example\.com"/));
+            sinon.assert.match(message.html, sinon.match('background:#fff3ed'));
+            sinon.assert.match(message.html, sinon.match('color:#bd460c'));
+        });
+
+        it('shows the publication title when the publication has no icon', async function () {
+            const iconlessService = new GiftEmailService({
+                transactionalMailer,
+                bulkMailer,
+                settingsCache,
+                urlUtils,
+                getFromAddress,
+                blogIcon: {getIconUrl: () => null},
+                t: translate()
+            });
+
+            await iconlessService.sendGiftDelivery({
+                recipientEmail: 'recipient@example.com',
+                recipientName: null,
+                buyerEmail: 'buyer@example.com',
+                buyerName: 'Buyer',
+                personalMessage: null,
+                token: 'abc-123',
+                tierName: 'Gold',
+                benefits: [],
+                cadence: 'year',
+                duration: 1,
+                expiresAt: new Date('2027-04-07')
+            });
+
+            const html = bulkMailer.send.firstCall.firstArg.html;
+            assert.match(html, /<a href="https:\/\/example\.com\/"[^>]*>Test Site<\/a>/);
+            assert.doesNotMatch(html, /<img /);
         });
 
         it('formats the claim deadline in the publication locale and timezone', async function () {
@@ -338,6 +370,31 @@ describe('GiftEmailService', function () {
             const message = bulkMailer.send.firstCall.firstArg;
             sinon.assert.match(message.html, sinon.match('6 Apr 2027'));
             sinon.assert.match(message.plaintext, sinon.match('6 Apr 2027'));
+        });
+
+        it('falls back to neutral delivery colors when the accent color is invalid', async function () {
+            const invalidColorSettingsCache = {
+                get: key => key === 'accent_color' ? 'invalid' : settingsCache.get(key)
+            };
+            const invalidColorService = new GiftEmailService({transactionalMailer, bulkMailer, settingsCache: invalidColorSettingsCache, urlUtils, getFromAddress, blogIcon, t: translate()});
+
+            await invalidColorService.sendGiftDelivery({
+                recipientEmail: 'recipient@example.com',
+                recipientName: 'Recipient',
+                buyerEmail: 'buyer@example.com',
+                buyerName: 'Buyer',
+                personalMessage: 'Enjoy this gift',
+                token: 'abc-123',
+                tierName: 'Gold',
+                benefits: [],
+                cadence: 'year',
+                duration: 1,
+                expiresAt: new Date('2027-04-07')
+            });
+
+            const html = bulkMailer.send.firstCall.firstArg.html;
+            sinon.assert.match(html, sinon.match('background:#F4F5F6'));
+            sinon.assert.match(html, sinon.match('color:#738A94'));
         });
 
         it('falls back to transactional email when bulk Mailgun is not configured', async function () {

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -618,6 +618,7 @@ describe('GiftService', function () {
                 (err: any) => {
                     assert.equal(err.errorType, 'NotFoundError');
                     assert.equal(err.message, 'This gift does not exist.');
+                    assert.equal(err.code, 'GIFT_NOT_FOUND');
                     return true;
                 }
             );

--- a/packages/i18n/locales/af/portal.json
+++ b/packages/i18n/locales/af/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Hierdie webwerf is slegs op uitnodiging, kontak die eienaar vir toegang.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/ar/portal.json
+++ b/packages/i18n/locales/ar/portal.json
@@ -264,6 +264,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "هذا الموقع للمشتركين فقط، تواصل مع ادارة الموقع للحصول على اشتراك.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "هذا الموقع لا يقبل المدفوعات في الوقت الحالي",

--- a/packages/i18n/locales/bg/portal.json
+++ b/packages/i18n/locales/bg/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "Този подарък вече е активиран.",
     "This gift has been refunded.": "Този подарък е възстановен.",
     "This gift has expired.": "Валидността на подаръка е изтекла.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Сайтът е само с покани. Свържете се със собственика, за да получите достъп.",
     "This site is not accepting donations at the moment.": "В момента сайтът не приема дарения.",
     "This site is not accepting payments at the moment.": "В момента сайтът не приема плащания.",

--- a/packages/i18n/locales/bn/portal.json
+++ b/packages/i18n/locales/bn/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "এই সাইটটি কেবল আমন্ত্রণের মাধ্যমে, প্রবেশাধিকার পেতে মালিকের সাথে যোগাযোগ করুন।",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/bs/portal.json
+++ b/packages/i18n/locales/bs/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ova je stranica samo na poziv, kontaktiraj vlasnika za pristup.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/ca/portal.json
+++ b/packages/i18n/locales/ca/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Aquest lloc web és accessible només per invitació, contacta amb el propietari per obtenir-hi accés.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Aquest lloc web no està acceptant pagaments en aquests moments.",

--- a/packages/i18n/locales/context.json
+++ b/packages/i18n/locales/context.json
@@ -367,6 +367,7 @@
     "This gift has already been redeemed.": "Error message when redeeming a gift subscription",
     "This gift has been refunded.": "Error message when redeeming a gift subscription",
     "This gift has expired.": "Error message when redeeming a gift subscription",
+    "This gift link is invalid.": "Error message shown when a gift redemption link does not identify an available gift subscription",
     "This message was sent from {siteDomain} to {email} on behalf of {buyerName} ({buyerEmail}).": "Footer text in the gift delivery email. {siteDomain} identifies the publication, {email} is the recipient address, and {buyerName} and {buyerEmail} identify the gift buyer.",
     "This message was sent from {siteDomain} to {email}.": "Text in the footer of emails, e.g. reply to comments notifications",
     "This site is invite-only, contact the owner for access.": "A message on the member login screen indicating that a site is not-open to public signups",

--- a/packages/i18n/locales/cs/portal.json
+++ b/packages/i18n/locales/cs/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Tento web je pouze pro pozvané, kontaktujte provozovatele pro přístup.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Tento web momentálně nepřijímá platby.",

--- a/packages/i18n/locales/da/portal.json
+++ b/packages/i18n/locales/da/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Denne sider kræver at du skal være inviteret. Kontakt ejeres for at få adgang.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Denne side accepterer ikke betalinger i øjeblikket.",

--- a/packages/i18n/locales/de-CH/portal.json
+++ b/packages/i18n/locales/de-CH/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "Dieses Geschenk wurde bereits eingelöst.",
     "This gift has been refunded.": "Dieses Geschenk wurde zurückerstattet.",
     "This gift has expired.": "Dieses Geschenk ist abgelaufen.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Der Zugang zu diesem Inhalt ist eingeschränkt. Bitte kontaktieren Sie uns, wenn Sie Zugang wünschen.",
     "This site is not accepting donations at the moment.": "Diese Website nimmt derzeit keine Spenden entgegen.",
     "This site is not accepting payments at the moment.": "Diese Seite nimmt momentan keine Zahlungen entgegen.",

--- a/packages/i18n/locales/de/portal.json
+++ b/packages/i18n/locales/de/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Für diese Seite benötigst du eine Einladung. Bitte kontaktiere den Inhaber.",
     "This site is not accepting donations at the moment.": "Diese Website nimmt derzeit keine Spenden entgegen.",
     "This site is not accepting payments at the moment.": "Diese Website nimmt zur Zeit keine Zahlungen entgegen.",

--- a/packages/i18n/locales/el/portal.json
+++ b/packages/i18n/locales/el/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "Αυτό το δώρο έχει ήδη εξαργυρωθεί.",
     "This gift has been refunded.": "Έχει γίνει επιστροφή χρημάτων για αυτό το δώρο.",
     "This gift has expired.": "Αυτό το δώρο έχει λήξει.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Αυτός ο ιστότοπος είναι μόνο με πρόσκληση, επικοινωνήστε με τον ιδιοκτήτη για πρόσβαση.",
     "This site is not accepting donations at the moment.": "Αυτός ο ιστότοπος δεν δέχεται δωρεές αυτή τη στιγμή.",
     "This site is not accepting payments at the moment.": "Αυτός ο ιστότοπος δεν δέχεται πληρωμές αυτή τη στιγμή.",

--- a/packages/i18n/locales/en/portal.json
+++ b/packages/i18n/locales/en/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/eo/portal.json
+++ b/packages/i18n/locales/eo/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ĉi tiu retejo estas nur por invitiĝuloj, kontaktu la proprietulo por alireblo.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/es/portal.json
+++ b/packages/i18n/locales/es/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "Este regalo ya ha sido canjeado.",
     "This gift has been refunded.": "Este regalo ha sido devuelto.",
     "This gift has expired.": "Este regalo ha expirado.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "A este sitio solo se puede acceder por invitación, contacta con el propietario para obtener acceso.",
     "This site is not accepting donations at the moment.": "Este sitio no acepta donaciones en este momento.",
     "This site is not accepting payments at the moment.": "Este sitio no acepta pagos en este momento.",

--- a/packages/i18n/locales/et/portal.json
+++ b/packages/i18n/locales/et/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "See sait on ainult kutsetega, juurdepääsu saamiseks võtke ühendust omanikuga.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/eu/portal.json
+++ b/packages/i18n/locales/eu/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Gune hau gonbidatuentzat bakarrik da, jarri harremanetan jabearekin sarbidea eskuratzeko.",
     "This site is not accepting donations at the moment.": "Gune honek ez du une honetan dohaintzarik onartzen.",
     "This site is not accepting payments at the moment.": "Gune honek ez du une honetan ordainketarik onartzen.",

--- a/packages/i18n/locales/fa/portal.json
+++ b/packages/i18n/locales/fa/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "این هدیه قبلاً فعال شده است.",
     "This gift has been refunded.": "این هدیه بازپرداخت شده است.",
     "This gift has expired.": "این هدیه منقضی شده است.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "این سایت فقط با دعوت\u200cنامه قابل دسترسی است، برای دریافت دسترسی با مالک تماس بگیرید.",
     "This site is not accepting donations at the moment.": "این سایت در حال حاضر کمک\u200cهای مالی را نمی\u200cپذیرد.",
     "This site is not accepting payments at the moment.": "این سایت در حال حاضر پرداخت\u200cها را نمی\u200cپذیرد.",

--- a/packages/i18n/locales/fi/portal.json
+++ b/packages/i18n/locales/fi/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Tämä sivu on vain kutsutuille, ota yhteyttä omistajaan saadaksesi pääsyoikeuden.",
     "This site is not accepting donations at the moment.": "Tämä sivu ei vastaanota lahjoituksia juuri nyt.",
     "This site is not accepting payments at the moment.": "Tämä sivu ei vastaanota maksuja juuri nyt.",

--- a/packages/i18n/locales/fr/portal.json
+++ b/packages/i18n/locales/fr/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "Cette offre a déjà été activée.",
     "This gift has been refunded.": "Cette offre a été remboursée.",
     "This gift has expired.": "Cette offre a expiré.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ce site est réservé aux invités. Veuillez écrire au propriétaire pour en demander l'accès.",
     "This site is not accepting donations at the moment.": "Ce site n'accepte pas les dons pour le moment.",
     "This site is not accepting payments at the moment.": "Ce site n'accepte pas les paiements pour le moment.",

--- a/packages/i18n/locales/gd/portal.json
+++ b/packages/i18n/locales/gd/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Feumar cuireadh airson an làrach-lìn seo, leig fios dhan rianaire ma tha thu ag iarraidh cothrom-inntrigidh.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Chan eil an làrach seo a' gabhail ri phàighidhean an-dràsta.",

--- a/packages/i18n/locales/he/portal.json
+++ b/packages/i18n/locales/he/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "אתר זה פתוח למוזמנים בלבד, פנו לבעל האתר לגישה.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "אתר זה לא מקבל תשלומים כרגע.",

--- a/packages/i18n/locales/hi/portal.json
+++ b/packages/i18n/locales/hi/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "यह साइट केवल निमंत्रण द्वारा है, पहुँच के लिए मालिक से संपर्क करें।",
     "This site is not accepting donations at the moment.": "यह साइट इस समय दान स्वीकार नहीं कर रही है।",
     "This site is not accepting payments at the moment.": "यह साइट इस समय भुगतान स्वीकार नहीं कर रही है।",

--- a/packages/i18n/locales/hr/portal.json
+++ b/packages/i18n/locales/hr/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ove stranice su samo za članove, kontaktirajte vlasnika kako biste dobili pristup.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ova stranica trenutno ne prihvaća uplate.",

--- a/packages/i18n/locales/hu/portal.json
+++ b/packages/i18n/locales/hu/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "A weboldal csak meghívóval látogatható. Meghívóért lépj kapcsolatba a weboldal tulajdonosával.",
     "This site is not accepting donations at the moment.": "Ez az oldal jelenleg nem fogad adományokat.",
     "This site is not accepting payments at the moment.": "A weboldal jelenleg nem fogad el fizetést.",

--- a/packages/i18n/locales/id/portal.json
+++ b/packages/i18n/locales/id/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Situs ini hanya untuk yang diundang, hubungi pemiliknya untuk mendapatkan akses.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Situs ini tidak menerima pembayaran saat ini.",

--- a/packages/i18n/locales/is/portal.json
+++ b/packages/i18n/locales/is/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Aðgangur krefst boðsmiða, hafið samband við eiganda síðunnar til að fá aðgang.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/it/portal.json
+++ b/packages/i18n/locales/it/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "Questo regalo è già stato riscattato.",
     "This gift has been refunded.": "Questo regalo è stato rimborsato.",
     "This gift has expired.": "Questo regalo è scaduto.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Questo sito è accessibile solo su invito, contatta il proprietario per poter accedere.",
     "This site is not accepting donations at the moment.": "Questo sito non accetta donazioni al momento.",
     "This site is not accepting payments at the moment.": "Questo sito non accetta pagamenti al momento.",

--- a/packages/i18n/locales/ja/portal.json
+++ b/packages/i18n/locales/ja/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "このサイトは招待制です。アクセスするにはオーナーに連絡してください。",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/ko/portal.json
+++ b/packages/i18n/locales/ko/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "이 선물은 이미 사용되었어요.",
     "This gift has been refunded.": "이 선물은 환불되었어요.",
     "This gift has expired.": "이 선물은 만료되었어요.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "위 사이트는 초대된 사용자만 사용이 가능해요. 접근을 위해서는 관리자에게 연락해 주세요.",
     "This site is not accepting donations at the moment.": "현재 이 사이트는 후원을 받지 않고 있어요.",
     "This site is not accepting payments at the moment.": "현재 이 사이트는 결제를 받지 않고 있어요.",

--- a/packages/i18n/locales/kz/portal.json
+++ b/packages/i18n/locales/kz/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Бұл сайтқа тек шақырту бойынша кіруге болады, рұқсат алу үшін иесіне хабарласыңыз.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/lt/portal.json
+++ b/packages/i18n/locales/lt/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ši svetainė pasiekiama tik su pakvietimu, susisiekite su savininku dėl prieigos. ",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/lv/portal.json
+++ b/packages/i18n/locales/lv/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Šī vietne ir paredzēta tikai ielūgumam. Lai iegūtu piekļuvi, sazinieties ar īpašnieku.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Šī vietne pašlaik nepieņem maksājumus.",

--- a/packages/i18n/locales/mk/portal.json
+++ b/packages/i18n/locales/mk/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Оваа страница е достапна само со покана. За пристап контактирајте го сопственикот.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/mn/portal.json
+++ b/packages/i18n/locales/mn/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Энэхүү сайт руу зөвхөн урилгаар нэвтрэх боломжтой тул та админд нь хандана уу.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Энэхүү сайт одоогоор төлбөр хүлээн авахгүй байна.",

--- a/packages/i18n/locales/ms/portal.json
+++ b/packages/i18n/locales/ms/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Laman web ini hanya untuk jemputan, hubungi pemilik untuk akses.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/nb/portal.json
+++ b/packages/i18n/locales/nb/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Denne nettsiden er kun for inviterte. Kontakt eieren for invitasjon.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Denne nettsiden godtar ikke betalinger for øyeblikket.",

--- a/packages/i18n/locales/ne/portal.json
+++ b/packages/i18n/locales/ne/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/nl/portal.json
+++ b/packages/i18n/locales/nl/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Deze site is alleen toegankelijk op uitnodiging, neem contact op met de eigenaar.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Deze site accepteert momenteel geen betalingen.",

--- a/packages/i18n/locales/nn/portal.json
+++ b/packages/i18n/locales/nn/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Denne sida er kun for inviterte, ta kontakt med eigaren for tilgang.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/pa/portal.json
+++ b/packages/i18n/locales/pa/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "ਇਹ ਸਾਈਟ ਸਿਰਫ਼ ਸੱਦਾ-ਪੱਤਰ 'ਤੇ ਹੈ, ਪਹੁੰਚ ਲਈ ਮਾਲਕ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।",
     "This site is not accepting donations at the moment.": "ਇਹ ਸਾਈਟ ਇਸ ਵੇਲੇ ਦਾਨ ਨਹੀਂ ਲੈ ਰਹੀ ਹੈ।",
     "This site is not accepting payments at the moment.": "ਇਹ ਸਾਈਟ ਇਸ ਸਮੇਂ ਭੁਗਤਾਨ ਸਵੀਕਾਰ ਨਹੀਂ ਕਰ ਰਹੀ ਹੈ।",

--- a/packages/i18n/locales/pl/portal.json
+++ b/packages/i18n/locales/pl/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ta strona posiada zamknięty dostęp. Skontaktuj się z właścicielem, aby uzyskać dostęp.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ta strona nie przyjmuje obecnie płatności.",

--- a/packages/i18n/locales/pt-BR/portal.json
+++ b/packages/i18n/locales/pt-BR/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "Este presente já foi resgatado.",
     "This gift has been refunded.": "Este presente foi reembolsado.",
     "This gift has expired.": "Este presente expirou.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Este site é apenas para convidados. Entre em contato com o proprietário para obter acesso.",
     "This site is not accepting donations at the moment.": "Este site não está aceitando doações no momento.",
     "This site is not accepting payments at the moment.": "Este site não está aceitando pagamentos no momento.",

--- a/packages/i18n/locales/pt/portal.json
+++ b/packages/i18n/locales/pt/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "O acesso a este site é feito apenas por convite. Entre em contacto com o proprietário para obter acesso.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Este site não está a aceitar pagamentos de momento",

--- a/packages/i18n/locales/ro/portal.json
+++ b/packages/i18n/locales/ro/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Acest site este disponibil doar pe bază de invitație, contactează proprietarul pentru acces.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/ru/portal.json
+++ b/packages/i18n/locales/ru/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Доступ к материалам этого сайта возможен только по приглашению. Для получения доступа свяжитесь с владельцем сайта.",
     "This site is not accepting donations at the moment.": "В данный момент сайт не принимает пожертвования.",
     "This site is not accepting payments at the moment.": "В данный момент сайт не принимает платежи.",

--- a/packages/i18n/locales/si/portal.json
+++ b/packages/i18n/locales/si/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "මෙම වෙබ් අඩවිය ආරාධිතයන් සඳහා පමණි, ප්\u200dරවේශ වීම සඳහා හිමිකරු අමතන්න.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/sk/portal.json
+++ b/packages/i18n/locales/sk/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Táto stránka je iba pre pozvaných úžívateľov, kontaktujte vlastníka stránky.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Táto stránka momentálne neprijíma platby.",

--- a/packages/i18n/locales/sl/portal.json
+++ b/packages/i18n/locales/sl/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "To spletno mesto je dostopno samo s povabilom, obrnite se na lastnika.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "To spletno mesto trenutno ne sprejema plačil.",

--- a/packages/i18n/locales/sq/portal.json
+++ b/packages/i18n/locales/sq/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Kjo faqe eshte vetem me ftesa, kontaktoni zoteruesin per akses.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/sr-Cyrl/portal.json
+++ b/packages/i18n/locales/sr-Cyrl/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Овај сајт је само на позив, контактирајте власника ради приступа.",
     "This site is not accepting donations at the moment.": "Овај сајт тренутно не прима донације.",
     "This site is not accepting payments at the moment.": "Овај сајт тренутно не прихвата уплате.",

--- a/packages/i18n/locales/sr/portal.json
+++ b/packages/i18n/locales/sr/portal.json
@@ -261,6 +261,7 @@
     "This gift has already been redeemed.": "Ovaj poklon je već preuzet.",
     "This gift has been refunded.": "Za ovaj poklon je izvršen povrat novca.",
     "This gift has expired.": "Ovaj poklon je istekao.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Ovaj sajt je samo na poziv, kontaktirajte vlasnika radi pristupa.",
     "This site is not accepting donations at the moment.": "Ovaj sajt trenutno ne prima donacije.",
     "This site is not accepting payments at the moment.": "Ovaj sajt trenutno ne prihvata uplate.",

--- a/packages/i18n/locales/sv/portal.json
+++ b/packages/i18n/locales/sv/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "Denna gåvoprenumeration är redan förbrukad.",
     "This gift has been refunded.": "Denna gåva är återbetalad.",
     "This gift has expired.": "Denna gåva har löpt ut.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Den här sidan är endast för inbjudna, kontakta ägaren för åtkomst.",
     "This site is not accepting donations at the moment.": "Den här webbsidan tar för närvarande inte emot donationer.",
     "This site is not accepting payments at the moment.": "Den här webbsidan accepterar inte betalningar för tillfället.",

--- a/packages/i18n/locales/sw/portal.json
+++ b/packages/i18n/locales/sw/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Tovuti hii ni ya mialiko pekee, wasiliana na mmiliki kupata ufikiaji.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/ta/portal.json
+++ b/packages/i18n/locales/ta/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "இந்த தளம் அழைப்பு மட்டுமே, அணுகலுக்கு உரிமையாளரைத் தொடர்பு கொள்ளவும்.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "இந்த தளம் தற்போது கட்டணங்களை ஏற்கவில்லை.",

--- a/packages/i18n/locales/th/portal.json
+++ b/packages/i18n/locales/th/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "เว็บไซต์นี้สำหรับผู้ได้รับเชิญเท่านั้น โปรดติดต่อเจ้าของเพื่อเข้าถึง",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/tr/portal.json
+++ b/packages/i18n/locales/tr/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "Bu hediye zaten kullanılmış.",
     "This gift has been refunded.": "Bu hediye iade edilmiştir.",
     "This gift has expired.": "Bu hediyenin suresi doldu.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Bu site sadece davetiyesi olanlar içindir, erişim için site sahibiyle iletişime geç.",
     "This site is not accepting donations at the moment.": "Bu site şu anda bağış kabul etmemektedir.",
     "This site is not accepting payments at the moment.": "Bu site şu anda ödeme kabul etmemektedir.",

--- a/packages/i18n/locales/uk/portal.json
+++ b/packages/i18n/locales/uk/portal.json
@@ -262,6 +262,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Цей сайт доступний тільки за запрошенням, звернись до власника сайта для доступу.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Цей сайт на даний момент не приймає платежі.",

--- a/packages/i18n/locales/ur/portal.json
+++ b/packages/i18n/locales/ur/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "یہ سائٹ صرف دعوتی ہے، دستیابی کے لئے مالک سے رابطہ کریں۔",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/uz/portal.json
+++ b/packages/i18n/locales/uz/portal.json
@@ -260,6 +260,7 @@
     "This gift has already been redeemed.": "",
     "This gift has been refunded.": "",
     "This gift has expired.": "",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Bu saytda faqat taklif qilinadi, kirish uchun egasiga murojaat qiling.",
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",

--- a/packages/i18n/locales/vi/portal.json
+++ b/packages/i18n/locales/vi/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "Món quà này đã được đổi.",
     "This gift has been refunded.": "Món quà này đã được hoàn tiền.",
     "This gift has expired.": "Món quà này đã hết hạn.",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "Trang web này chỉ dành cho những người được mời, hãy liên hệ với chủ sở hữu để cấp quyền truy cập.",
     "This site is not accepting donations at the moment.": "Trang web này hiện chưa nhận quyên góp.",
     "This site is not accepting payments at the moment.": "Trang web này hiện chưa chấp nhận thanh toán.",

--- a/packages/i18n/locales/zh-Hant/portal.json
+++ b/packages/i18n/locales/zh-Hant/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "此禮物已被兌換。",
     "This gift has been refunded.": "此禮物已退款。",
     "This gift has expired.": "此禮物已過期。",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "此網站僅限邀請，請聯絡網站擁有者以取得存取權限。",
     "This site is not accepting donations at the moment.": "本網站目前不接受捐贈。",
     "This site is not accepting payments at the moment.": "本網站目前暫不接受付款。",

--- a/packages/i18n/locales/zh/portal.json
+++ b/packages/i18n/locales/zh/portal.json
@@ -259,6 +259,7 @@
     "This gift has already been redeemed.": "该礼物已被兑换。",
     "This gift has been refunded.": "该礼物已退款。",
     "This gift has expired.": "该礼物已过期。",
+    "This gift link is invalid.": "",
     "This site is invite-only, contact the owner for access.": "此网站仅限受邀访问，请联系网站所有者以获取权限。",
     "This site is not accepting donations at the moment.": "本网站目前不接受捐赠。",
     "This site is not accepting payments at the moment.": "本网站目前暂不接受付款。",


### PR DESCRIPTION
Linear: https://linear.app/ghost/issue/BER-3856/

## Context

This PR contains the remaining recipient-facing presentation work on top of the focused claim-deadline handling in #30136. Keeping the presentation layer separate makes its email and Portal behavior independently reviewable.

## What changed

- updates the responsive recipient email with live publication and tier presentation, an iconless publication-name fallback, personal-message treatment, benefits, CTA, and privacy-preserving footer
- aligns the existing ending-reminder CTA with the delivery email presentation
- gives invalid or missing gift links a privacy-safe translated notification while preserving the existing terminal-state messages
- adds focused rendering and invalid-link coverage

## Stack

- #29967 immediate gift delivery
- #29968 Portal purchase and redemption
- #29969 delivery outcomes
- #30136 claim deadline handling
- this PR: gift presentation