### PR TITLE
Added targeted session replay recording for Automations

### DIFF
--- a/apps/admin/src/automations/automations.tsx
+++ b/apps/admin/src/automations/automations.tsx
@@ -17,7 +17,7 @@ const Automations: React.FC = () => {
     }
 
     return (
-        <Box className='size-full'>
+        <Box className='size-full' data-sentry-mask='true'>
             <Container className='relative flex h-full flex-col' size='page'>
             <ListPage data-testid="automations-page">
                 <ListPage.Header>

--- a/apps/admin/src/automations/components/email-modal/email-content-modal.tsx
+++ b/apps/admin/src/automations/components/email-modal/email-content-modal.tsx
@@ -278,6 +278,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
                     ref={setDialogContentNode}
                     aria-describedby={undefined}
                     className='top-0 left-0 h-[100dvh] w-full max-w-full translate-0 grid-rows-[1fr] gap-0 rounded-none border-0 p-0 shadow-none outline-hidden sm:rounded-none dark:bg-[#151719]'
+                    data-sentry-mask='true'
                     onEscapeKeyDown={(event) => {
                         if (isKoenigPortalFocused()) {
                             // prevent Radix dismissing the dialog but let the

--- a/apps/admin/src/automations/components/email-modal/preview-frame.tsx
+++ b/apps/admin/src/automations/components/email-modal/preview-frame.tsx
@@ -135,6 +135,7 @@ const EmailPreviewFrame: React.FC<EmailPreviewFrameProps> = ({previewState}) => 
                     <iframe
                         ref={previewIframeRef}
                         className='w-full rounded bg-white'
+                        data-sentry-block='true'
                         data-testid='email-preview-iframe'
                         sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                         srcDoc={previewState.html}

--- a/apps/admin/src/automations/components/email-modal/test-email-dropdown.tsx
+++ b/apps/admin/src/automations/components/email-modal/test-email-dropdown.tsx
@@ -81,7 +81,7 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     };
 
     return (
-        <PopoverContent align='end' className='w-[260px] p-4' data-testid='test-email-dropdown' sideOffset={8}>
+        <PopoverContent align='end' className='w-[260px] p-4' data-sentry-mask='true' data-testid='test-email-dropdown' sideOffset={8}>
             <div className='mb-3'>
                 <label className='mb-2 block text-sm font-semibold' htmlFor='test-email-input'>Send test email</label>
                 <Input

--- a/apps/admin/src/automations/components/email-modal/use-email-preview.ts
+++ b/apps/admin/src/automations/components/email-modal/use-email-preview.ts
@@ -33,6 +33,8 @@ const preparePreviewHtml = (html: string) => {
     const parser = new DOMParser();
     const parsed = parser.parseFromString(html, 'text/html');
 
+    parsed.body.setAttribute('data-sentry-mask', 'true');
+
     parsed.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((link) => {
         link.target = '_blank';
         link.rel = 'noopener noreferrer';

--- a/apps/admin/src/automations/editor.tsx
+++ b/apps/admin/src/automations/editor.tsx
@@ -402,7 +402,7 @@ const AutomationEditorContent: React.FC<{automationId: string}> = ({automationId
     }, []);
 
     return (
-        <div className='fixed inset-0 z-50 flex flex-col bg-background' data-testid='automation-editor'>
+        <div className='fixed inset-0 z-50 flex flex-col bg-background' data-sentry-mask='true' data-testid='automation-editor'>
             <AutomationHeader
                 automation={draft}
                 isLoadingAutomation={isEditorLoading}

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -27,6 +27,76 @@ function K() {
     return this;
 }
 
+const AUTOMATIONS_REPLAY_SAMPLE_RATE = 1;
+const AUTOMATIONS_REPLAY_MASK_ATTRIBUTE = 'data-sentry-automations-mask';
+
+function isAutomationsUrl(url) {
+    const path = new URL(url).hash.replace(/^#/, '').split('?')[0].replace(/\/+$/, '');
+    return path === '/automations' || path.startsWith('/automations/');
+}
+
+function setupAutomationsSessionReplay(replay, shouldStartRecording) {
+    let initialRouteCheck;
+    let removeNavigationListener;
+    let recordingStarted = false;
+
+    const teardown = () => {
+        clearTimeout(initialRouteCheck);
+        removeNavigationListener?.();
+        document.body.removeAttribute(AUTOMATIONS_REPLAY_MASK_ATTRIBUTE);
+    };
+
+    const updateAutomationsMask = (url) => {
+        const isAutomations = isAutomationsUrl(url);
+
+        if (isAutomations) {
+            document.body.setAttribute(AUTOMATIONS_REPLAY_MASK_ATTRIBUTE, 'true');
+        } else {
+            document.body.removeAttribute(AUTOMATIONS_REPLAY_MASK_ATTRIBUTE);
+        }
+
+        return isAutomations;
+    };
+
+    const maybeStartRecording = (url) => {
+        const isAutomations = updateAutomationsMask(url);
+
+        if (!shouldStartRecording || !isAutomations || recordingStarted) {
+            return;
+        }
+
+        recordingStarted = true;
+        clearTimeout(initialRouteCheck);
+
+        replay.stop().then(() => replay.start()).catch((error) => {
+            try {
+                replay.startBuffering();
+            } catch (e) {
+                // Replay is still running, nothing to restore
+            }
+            console.error('Error starting Sentry Replay recording:', error); // eslint-disable-line no-console
+        });
+    };
+
+    // Keep listening after recording starts so portalled Automations content is
+    // masked only while an Automations route is active. React-owned admin
+    // routes navigate via pushState, which doesn't fire `hashchange`.
+    if (window.navigation) {
+        const onNavigate = event => maybeStartRecording(event.destination.url);
+        window.navigation.addEventListener('navigate', onNavigate);
+        removeNavigationListener = () => window.navigation.removeEventListener('navigate', onNavigate);
+    }
+
+    // Mask direct Automations loads before Replay creates its initial buffer.
+    updateAutomationsMask(window.location.href);
+
+    // Replay defers its sampling initialization during Sentry.init(). Queue the
+    // initial route check behind it to avoid starting a second rrweb recorder.
+    initialRouteCheck = setTimeout(() => maybeStartRecording(window.location.href));
+
+    return teardown;
+}
+
 let shortcuts = {};
 
 shortcuts.esc = {action: 'closeMenus', scope: 'default'};
@@ -192,6 +262,7 @@ export default Route.extend(ShortcutsRoute, {
     },
 
     willDestroy() {
+        this._cleanupAutomationsSessionReplay?.();
         this.ui.cleanupBodyDragHandlers();
     },
 
@@ -203,6 +274,15 @@ export default Route.extend(ShortcutsRoute, {
         if (this.config.sentry_dsn) {
             const sentryConfig = getSentryConfig(this.config.sentry_dsn, this.config.sentry_env, this.config.version);
             Sentry.init(sentryConfig);
+
+            // Keep error-triggered replay buffering everywhere and mask all
+            // Automations portals. Once a sampled app load enters Automations,
+            // record a full session replay for the rest of that load.
+            const replay = Sentry.getClient()?.getIntegrationByName('Replay');
+            if (replay) {
+                const shouldStartRecording = Math.random() < AUTOMATIONS_REPLAY_SAMPLE_RATE;
+                this._cleanupAutomationsSessionReplay = setupAutomationsSessionReplay(replay, shouldStartRecording);
+            }
         }
 
         if (this.session.isAuthenticated) {

--- a/apps/ember-admin/app/utils/sentry.js
+++ b/apps/ember-admin/app/utils/sentry.js
@@ -68,8 +68,12 @@ export function getSentryConfig(dsn, environment, appVersion, transport) {
                 // Replace with `Sentry.replayIntegration()` once we've migrated to @sentry/ember 8.x
                 // Docs: https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/#removal-of-sentryreplay-package
                 new Replay({
-                    mask: ['.koenig-lexical', '.gh-dashboard'],
-                    unmask: ['[role="menu"]', '[data-testid="settings-panel"]', '.gh-nav'],
+                    mask: ['.koenig-lexical', '.gh-dashboard', '[data-sentry-automations-mask]'],
+                    unmask: [
+                        'body:not([data-sentry-automations-mask]) [role="menu"]',
+                        'body:not([data-sentry-automations-mask]) [data-testid="settings-panel"]',
+                        'body:not([data-sentry-automations-mask]) .gh-nav'
+                    ],
                     maskAllText: false,
                     maskAllInputs: true,
                     blockAllMedia: true


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1504

Automations investigations need session context even when no error occurs. Once a sampled app load enters an Automations route, record a full session replay for the rest of that load while preserving error-triggered replay buffering everywhere else. 

This follows Sentry's documented approach for recording replays on specific URLs: https://docs.sentry.io/platforms/javascript/session-replay/understanding-sessions/#record-session-replays-on-specific-urls

Currently i have sampling set to 1.0 for automations, meaning that anyone who enters an automations route will start a session replay. i think this makes sense 1) to make sure it works and 2) while the feature's in beta, because we won't get too many hits to these routes. we can always lower the rate if it's recording too many.

I also set it to mask _any_ text on these routes. That's certainly more than we need to mask but i wanted the setup to be as simple as possible. if we find we need to read non-sensitive data like certain labels and such, we can tweak later.

It'll look like this in the sentry dashboard:
<img width="1399" height="1054" alt="Screenshot 2026-08-20 at 10 39 28 AM" src="https://github.com/user-attachments/assets/640e06dd-c5ab-437e-ae3b-7c71d2abfabf" />
