### PR TITLE
Fixed stale automation stats after route changes

### DIFF
--- a/apps/admin/src/automations/automations.test.tsx
+++ b/apps/admin/src/automations/automations.test.tsx
@@ -94,6 +94,11 @@ describe('Automations', () => {
     it('shows free and paid sequences when Stripe is connected', () => {
         renderPage();
 
+        expect(mockUseBrowseAutomations).toHaveBeenCalledWith({
+            defaultErrorHandler: false,
+            refetchOnMount: 'always',
+            staleTime: 0
+        });
         expect(screen.getByText('Free member welcome flow')).toBeInTheDocument();
         expect(screen.getByText('Paid member welcome flow')).toBeInTheDocument();
     });

--- a/apps/admin/src/automations/hooks/use-visible-automations.ts
+++ b/apps/admin/src/automations/hooks/use-visible-automations.ts
@@ -6,7 +6,9 @@ import type {Config} from '@tryghost/admin-x-framework/api/config';
 
 export const useVisibleAutomations = () => {
     const {data, error, isError, isLoading} = useBrowseAutomations({
-        defaultErrorHandler: false
+        defaultErrorHandler: false,
+        refetchOnMount: 'always',
+        staleTime: 0
     });
     const {data: settingsData, isLoading: isSettingsLoading} = useBrowseSettings();
     const {data: configData, isLoading: isConfigLoading} = useBrowseConfig();


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1525/check-how-the-caching-works-for-the-automations-endpoint-and-make-sure

Automation run counts change independently of Admin mutations. Refetching the browse query whenever the list mounts prevents the five-minute client freshness window from leaving summary stats behind the detail view while retaining cached data for rendering.