### PR TITLE
Added "in progress run count" stat to automation browse endpoint

### DIFF
--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -69,6 +69,7 @@ export interface AutomationBrowseResult extends AutomationSummary {
     stats: {
         last_run_created_at: Date | null;
         total_run_count: number;
+        in_progress_run_count: number;
     };
 }
 

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -56,6 +56,7 @@ interface AutomationRow {
 interface AutomationBrowseRow extends AutomationRow {
     last_run_created_at: DatabaseDate | null;
     total_run_count: string | number | null;
+    in_progress_run_count: string | number | null;
 }
 
 interface ActionRow {
@@ -1019,11 +1020,17 @@ async function loadAutomationBySlug(trx: Knex.Transaction, slug: string): Promis
 }
 
 async function loadAutomations(trx: Knex.Transaction): Promise<AutomationBrowseRow[]> {
+    const inProgressRuns = trx('automation_run_steps')
+        .distinct('automation_run_id')
+        .where('status', 'pending')
+        .as('in_progress_runs');
     const runStats = trx('automation_runs')
-        .select('automation_id')
-        .max({last_run_created_at: 'created_at'})
+        .select('automation_runs.automation_id')
+        .max({last_run_created_at: 'automation_runs.created_at'})
         .count({total_run_count: '*'})
-        .groupBy('automation_id')
+        .count({in_progress_run_count: 'in_progress_runs.automation_run_id'})
+        .leftJoin(inProgressRuns, 'automation_runs.id', 'in_progress_runs.automation_run_id')
+        .groupBy('automation_runs.automation_id')
         .as('run_stats');
     return await trx('automations')
         .select(
@@ -1034,7 +1041,8 @@ async function loadAutomations(trx: Knex.Transaction): Promise<AutomationBrowseR
             'automations.created_at',
             'automations.updated_at',
             'run_stats.last_run_created_at',
-            'run_stats.total_run_count'
+            'run_stats.total_run_count',
+            'run_stats.in_progress_run_count'
         )
         .leftJoin(runStats, 'automations.id', 'run_stats.automation_id')
         .orderBy('automations.name');
@@ -1381,7 +1389,8 @@ function buildAutomationBrowseResult(automation: AutomationBrowseRow): Automatio
         ...buildAutomationSummary(automation),
         stats: {
             last_run_created_at: automation.last_run_created_at ? fromDatabaseDate(automation.last_run_created_at) : null,
-            total_run_count: Number(automation.total_run_count ?? 0)
+            total_run_count: Number(automation.total_run_count ?? 0),
+            in_progress_run_count: Number(automation.in_progress_run_count ?? 0)
         }
     };
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
@@ -9,6 +9,7 @@ Object {
       "name": "Free member welcome flow",
       "slug": "member-welcome-email-free",
       "stats": Object {
+        "in_progress_run_count": 0,
         "last_run_created_at": null,
         "total_run_count": 0,
       },
@@ -21,6 +22,7 @@ Object {
       "name": "Paid member welcome flow",
       "slug": "member-welcome-email-paid",
       "stats": Object {
+        "in_progress_run_count": 0,
         "last_run_created_at": null,
         "total_run_count": 0,
       },
@@ -45,7 +47,7 @@ exports[`Automations API browse returns automations sourced from the database 2:
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "624",
+  "content-length": "676",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -25,7 +25,8 @@ const matchAutomationSummary = () => ({
     ...matchAutomationBase(),
     stats: {
         last_run_created_at: null,
-        total_run_count: 0
+        total_run_count: 0,
+        in_progress_run_count: 0
     }
 });
 
@@ -115,13 +116,38 @@ describe('Automations API', function () {
 
     describe('browse', function () {
         async function createAutomationRun(automationId, createdAt) {
+            const runId = ObjectId().toHexString();
             await models.Base.knex('automation_runs').insert({
-                id: ObjectId().toHexString(),
+                id: runId,
                 automation_id: automationId,
                 member_id: null,
                 member_email: 'member@example.com',
                 created_at: createdAt,
                 updated_at: createdAt
+            });
+            return runId;
+        }
+
+        async function createAutomationRunStep(automationId, runId, status) {
+            const revisionId = await models.Base.knex('automation_action_revisions')
+                .innerJoin('automation_actions', 'automation_actions.id', 'automation_action_revisions.action_id')
+                .where('automation_actions.automation_id', automationId)
+                .first('automation_action_revisions.id')
+                .then(revision => revision.id);
+            const now = new Date();
+            await models.Base.knex('automation_run_steps').insert({
+                id: ObjectId().toHexString(),
+                automation_run_id: runId,
+                automation_action_revision_id: revisionId,
+                ready_at: now,
+                step_attempts: 0,
+                started_at: null,
+                finished_at: null,
+                status,
+                locked_by: null,
+                locked_at: null,
+                created_at: now,
+                updated_at: now
             });
         }
 
@@ -228,6 +254,31 @@ describe('Automations API', function () {
             const automation = body.automations.find(candidate => candidate.id === automationId);
 
             assert.equal(automation.stats.total_run_count, 2);
+        });
+
+        it('returns zero in progress run counts for automations without runs', async function () {
+            const {body} = await agent.get('automations').expectStatus(200);
+
+            assert.deepEqual(body.automations.map(automation => automation.stats.in_progress_run_count), [0, 0]);
+        });
+
+        it('returns the number of runs with pending steps', async function () {
+            const {body: beforeBody} = await agent.get('automations').expectStatus(200);
+            const automationId = beforeBody.automations[0].id;
+
+            const pendingRunId = await createAutomationRun(automationId, new Date('2026-01-01T00:00:00.000Z'));
+            await createAutomationRunStep(automationId, pendingRunId, 'finished');
+            await createAutomationRunStep(automationId, pendingRunId, 'pending');
+
+            const finishedRunId = await createAutomationRun(automationId, new Date('2026-01-02T00:00:00.000Z'));
+            await createAutomationRunStep(automationId, finishedRunId, 'finished');
+
+            await createAutomationRun(automationId, new Date('2026-01-03T00:00:00.000Z'));
+
+            const {body} = await agent.get('automations').expectStatus(200);
+            const automation = body.automations.find(candidate => candidate.id === automationId);
+
+            assert.equal(automation.stats.in_progress_run_count, 1);
         });
 
         it('upserts the default free and paid automations', async function () {

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -705,6 +705,57 @@ describe('automations repository', function () {
             assert.equal(otherAutomation.stats.total_run_count, 1);
         });
 
+        it('returns zero for "in progress run count" if the automation has no runs', async function () {
+            const result = await repo.browse();
+
+            assert(result.data.every(automation => automation.stats.in_progress_run_count === 0));
+        });
+
+        it('returns zero for "in progress run count" if none of the runs have pending steps', async function () {
+            const automationId = (await getAutomationBySlug('member-welcome-email-free')).id;
+            const {revision_id: revisionId} = await getActionByIndex(automationId, 0);
+            const run = await insertRun(automationId);
+            await insertStep(run.id, revisionId, {status: 'finished'});
+
+            const browseResult = await repo.browse();
+            const automation = browseResult.data.find(candidate => candidate.id === automationId);
+            assert(automation);
+
+            assert.equal(automation.stats.in_progress_run_count, 0);
+        });
+
+        it('returns the number of runs with pending steps for the automation', async function () {
+            const automationId = (await getAutomationBySlug('member-welcome-email-free')).id;
+            const otherAutomationId = (await getAutomationBySlug('member-welcome-email-paid')).id;
+            const {revision_id: revisionId} = await getActionByIndex(automationId, 0);
+            const {revision_id: otherRevisionId} = await getActionByIndex(otherAutomationId, 0);
+
+            const pendingRun = await insertRun(automationId);
+            await insertStep(pendingRun.id, revisionId, {status: 'finished'});
+            await insertStep(pendingRun.id, revisionId, {status: 'pending'});
+
+            const multiStepPendingRun = await insertRun(automationId);
+            await insertStep(multiStepPendingRun.id, revisionId, {status: 'pending'});
+            await insertStep(multiStepPendingRun.id, revisionId, {status: 'pending'});
+
+            const finishedRun = await insertRun(automationId);
+            await insertStep(finishedRun.id, revisionId, {status: 'finished'});
+
+            await insertRun(automationId);
+
+            const otherPendingRun = await insertRun(otherAutomationId);
+            await insertStep(otherPendingRun.id, otherRevisionId, {status: 'pending'});
+
+            const browseResult = await repo.browse();
+            const automation = browseResult.data.find(candidate => candidate.id === automationId);
+            const otherAutomation = browseResult.data.find(candidate => candidate.id === otherAutomationId);
+            assert(automation);
+            assert(otherAutomation);
+
+            assert.equal(automation.stats.in_progress_run_count, 2);
+            assert.equal(otherAutomation.stats.in_progress_run_count, 1);
+        });
+
         it('creates missing default free and paid automations', async function () {
             const automationIds = await knex('automations')
                 .whereIn('slug', ['member-welcome-email-free', 'member-welcome-email-paid'])


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1530
ref ce0841435c44a24bd444277cc587e3a18adc052d
ref 1773748282248ee9af3cdca8670023e531ea67e6

This was written by Claude Opus 5 with the following prompt:

> Commit `ce0841435c44a24bd444277cc587e3a18adc052d` adds a "last run created at" stat to the automation browse endpoint. Commit `1773748282248ee9af3cdca8670023e531ea67e6` built on top of that and added `total_run_count`.
>
> I want a new key, `in_progress_run_count`, which is a count of all the runs for that automation that have any `pending` steps.
>
> Use red/green TDD. Re-generate the snapshots with `UPDATE_SNAPSHOTS=1` and running the necessary tests.
>
> This should be a fairly straightforward change, except maybe the database query.

A tiny amount of additional prompting (removing some comments and unnecessary test assertions) followed.