### PR TITLE
Changed import mapping targets to describe themselves to the field picker

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -103,12 +103,22 @@ export const userTypeForFieldType = (type: FieldType): MemberCustomFieldUserType
 // As above, for a field loaded from the API.
 export const userTypeForField = (field: MemberCustomField): MemberCustomFieldUserType => userTypeForFieldType(field.type);
 
-// A custom field CSV column offered as an import mapping target: the column name the
-// backend reads (`value`) and a human label for the picker.
-// The field's type rides along so a picker can show what kind of thing the column holds
-// without being handed the fields as well. Every column of a composite carries the
-// composite's own type, which is what its icon is drawn from.
-export type MemberCustomFieldCsvColumn = {label: string; value: string; type: FieldType};
+/**
+ * A custom field CSV column offered as an import mapping target.
+ *
+ * Name and part are given apart as well as joined: a name a publisher chose can hold brackets
+ * of its own, so the joined form cannot be split back into them. Every column of a composite
+ * carries the composite's own type, which is what its icon is drawn from.
+ */
+export type MemberCustomFieldCsvColumn = {
+    /** The CSV column the exporter writes and the importer reads. */
+    value: string;
+    fieldName: string;
+    partLabel?: string;
+    /** `fieldName`, or `fieldName (partLabel)`. */
+    label: string;
+    type: FieldType;
+};
 
 /**
  * The CSV import mapping targets for a set of custom fields: one per column the export
@@ -119,11 +129,16 @@ export type MemberCustomFieldCsvColumn = {label: string; value: string; type: Fi
 export const memberCustomFieldCsvColumns = (fields: MemberCustomField[]): MemberCustomFieldCsvColumn[] => {
     return fields.flatMap((field) => {
         const labels = partLabelsFor(field.type);
-        return csvColumnsForField({key: field.key, type: field.type}).map(({column, subField}) => ({
-            label: subField === null ? field.name : `${field.name} (${labels[subField]})`,
-            value: column,
-            type: field.type
-        }));
+        return csvColumnsForField({key: field.key, type: field.type}).map(({column, subField}) => {
+            const partLabel = subField === null ? undefined : labels[subField];
+            return {
+                value: column,
+                fieldName: field.name,
+                ...(partLabel === undefined ? {} : {partLabel}),
+                label: partLabel === undefined ? field.name : `${field.name} (${partLabel})`,
+                type: field.type
+            };
+        });
     });
 };
 

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -35,7 +35,7 @@ describe('member custom fields api helpers', () => {
     describe('memberCustomFieldCsvColumns', () => {
         it('gives a scalar field one target labelled by its name', () => {
             expect(memberCustomFieldCsvColumns([field({key: 'nickname', name: 'Nickname'})])).toEqual([
-                {label: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'}
+                {label: 'Nickname', fieldName: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'}
             ]);
         });
 
@@ -43,13 +43,25 @@ describe('member custom fields api helpers', () => {
             const columns = memberCustomFieldCsvColumns([field({key: 'shipping_address', name: 'Shipping Address', type: 'address'})]);
 
             expect(columns).toEqual([
-                {label: 'Shipping Address (Address line 1)', value: 'custom_fields.shipping_address.line1', type: 'address'},
-                {label: 'Shipping Address (Address line 2)', value: 'custom_fields.shipping_address.line2', type: 'address'},
-                {label: 'Shipping Address (City)', value: 'custom_fields.shipping_address.city', type: 'address'},
-                {label: 'Shipping Address (State)', value: 'custom_fields.shipping_address.state', type: 'address'},
-                {label: 'Shipping Address (Postal code)', value: 'custom_fields.shipping_address.postal_code', type: 'address'},
-                {label: 'Shipping Address (Country)', value: 'custom_fields.shipping_address.country', type: 'address'}
+                {label: 'Shipping Address (Address line 1)', fieldName: 'Shipping Address', partLabel: 'Address line 1', value: 'custom_fields.shipping_address.line1', type: 'address'},
+                {label: 'Shipping Address (Address line 2)', fieldName: 'Shipping Address', partLabel: 'Address line 2', value: 'custom_fields.shipping_address.line2', type: 'address'},
+                {label: 'Shipping Address (City)', fieldName: 'Shipping Address', partLabel: 'City', value: 'custom_fields.shipping_address.city', type: 'address'},
+                {label: 'Shipping Address (State)', fieldName: 'Shipping Address', partLabel: 'State', value: 'custom_fields.shipping_address.state', type: 'address'},
+                {label: 'Shipping Address (Postal code)', fieldName: 'Shipping Address', partLabel: 'Postal code', value: 'custom_fields.shipping_address.postal_code', type: 'address'},
+                {label: 'Shipping Address (Country)', fieldName: 'Shipping Address', partLabel: 'Country', value: 'custom_fields.shipping_address.country', type: 'address'}
             ]);
+        });
+
+        it('keeps a bracketed name whole alongside its part', () => {
+            const columns = memberCustomFieldCsvColumns([field({key: 'address_home', name: 'Address (Home)', type: 'address'})]);
+
+            expect(columns[2]).toEqual({
+                label: 'Address (Home) (City)',
+                fieldName: 'Address (Home)',
+                partLabel: 'City',
+                value: 'custom_fields.address_home.city',
+                type: 'address'
+            });
         });
 
         it('returns no targets for an empty field set', () => {
@@ -62,7 +74,7 @@ describe('member custom fields api helpers', () => {
             const future = field({key: 'mystery', name: 'Mystery', type: 'a_type_from_the_future' as MemberCustomField['type']});
 
             expect(memberCustomFieldCsvColumns([future])).toEqual([
-                {label: 'Mystery', value: 'custom_fields.mystery', type: 'a_type_from_the_future'}
+                {label: 'Mystery', fieldName: 'Mystery', value: 'custom_fields.mystery', type: 'a_type_from_the_future'}
             ]);
         });
     });

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
@@ -1,35 +1,16 @@
 import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
 import {Badge, Button, Command, CommandCheck, CommandGroup, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger, commandDefaultFilter, inputSurfaceClasses} from '@tryghost/shade/components';
+import {FIELD_SOURCES, FIELD_SOURCE_ORDER, type FieldTarget} from '@/members/components/bulk-action-modals/import-members/custom-fields/field-targets';
 import {LucideIcon, cn} from '@tryghost/shade/utils';
 import {useRef} from 'react';
-import {type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
-// One list, two sections, so what a column can be imported as is answered by reading rather
-// than by trying each kind in turn. The section a field sits in is what tells a native "Name"
-// apart from a custom field someone called "Name", and the trigger has to carry that once the
-// list is closed.
-//
-// Marked only where that is in doubt: a custom field whose name a native field already has.
-// Naming every row's kind put "Membership field" under nearly the whole table to settle a
-// question almost none of those rows raise, and a mark that appears where two things read the
-// same is the same answer without the noise. Its own word rather than CUSTOM_GROUP: the
-// headings pluralise with a bare `s`, and a badge has less room than a line of its own had.
-const NATIVE_GROUP = 'Membership field';
-const CUSTOM_GROUP = 'Custom field';
-const CUSTOM_BADGE = 'Custom';
-
-// Icons for the native targets. Written here rather than taken from somewhere shared because
-// nothing shared exists: the members filter picker hand-writes its own switch, and analytics
-// its own inline. Custom fields do have a registry, which is why they use CustomFieldIcon
-// below instead of appearing here — a new field type gets its icon from that one place.
-const NATIVE_ICONS: Record<string, typeof LucideIcon.Type> = {
+const MEMBERSHIP_ICONS: Record<string, typeof LucideIcon.Type> = {
     email: LucideIcon.Mail,
     name: LucideIcon.User,
     note: LucideIcon.StickyNote,
     subscribed_to_emails: LucideIcon.Send,
     stripe_customer_id: LucideIcon.CreditCard,
-    // A comp, in the sense a venue means it: paid access granted rather than bought. Gift is
-    // taken, and would be the wrong reading anyway — gift_id is an actual gift someone sent.
+    // A comp, as a venue means it: gift_id is an actual gift someone sent.
     complimentary_plan: LucideIcon.Ticket,
     labels: LucideIcon.Tag,
     created_at: LucideIcon.Calendar,
@@ -37,35 +18,28 @@ const NATIVE_ICONS: Record<string, typeof LucideIcon.Type> = {
     import_tier: LucideIcon.Star
 };
 
-// "Shipping Address (Address line 1)" -> ["Shipping Address", "(Address line 1)"]. The parts of
-// a composite are labelled `${name} (${part})` in memberCustomFieldCsvColumns, so every row of
-// one address reads the same until its last few words. Split here, the name is what gives way to
-// a narrow column and the part stays whole; truncating the label as one string takes away the
-// only thing telling those rows apart. Anything without a bracketed tail has nothing to protect.
-function splitPartLabel(label: string): [string, string] {
-    const parted = /^(.*) (\([^()]*\))$/.exec(label);
-    return parted ? [parted[1], parted[2]] : [label, ''];
+function unknownSourceIcon(_source: never, className?: string) {
+    return <LucideIcon.Type className={className} />;
 }
 
-// Case and surrounding space are no help in telling two of these apart on sight, so a name that
-// differs only by them counts as the same name.
-function sameLabel(a: string, b: string): boolean {
-    return a.trim().toLowerCase() === b.trim().toLowerCase();
+function TargetIcon({target, className}: {target: FieldTarget; className?: string}) {
+    switch (target.source) {
+    case 'membership': {
+        const Icon = MEMBERSHIP_ICONS[target.value] ?? LucideIcon.Type;
+        return <Icon className={className} />;
+    }
+    case 'custom':
+        return <CustomFieldIcon className={className} type={target.type} />;
+    default:
+        return unknownSourceIcon(target, className);
+    }
 }
 
-// Scored over the label alone, which the list's items carry as their one keyword. Identity is the
-// target instead, and cmdk scores an item's value and its keywords as one joined string — so with
-// the target in there, "custom" reached every namespaced column, and a match was free to run from
-// one into the other: `subscribed_to_emails` and its own label together hold a c-u-s-t-o-m that
-// neither holds by itself. Naming what to search leaves the target doing nothing but telling two
-// fields of the same name apart.
+// cmdk scores an item's value and keywords as one joined string, and a match may run from one
+// into the other: with the target as identity, `subscribed_to_emails` and its label together
+// hold a c-u-s-t-o-m that neither holds alone. Scored over the keyword — the label — only.
 function scoreByLabel(_target: string, query: string, keywords?: string[]): number {
     return commandDefaultFilter((keywords ?? []).join(' '), query);
-}
-
-function NativeIcon({value, className}: {value: string; className?: string}) {
-    const Icon = NATIVE_ICONS[value] ?? LucideIcon.Type;
-    return <Icon className={className} />;
 }
 
 interface FieldPickerProps {
@@ -74,8 +48,7 @@ interface FieldPickerProps {
     value: string | null;
     disabled?: boolean;
     invalid?: boolean;
-    fieldMappings: {label: string; value: string}[];
-    customFieldMappings: MemberCustomFieldCsvColumn[];
+    targets: FieldTarget[];
     // Open and search are the caller's, not this component's: creating a composite has to
     // reopen this row's picker filtered to the field it just made, so which picker is open and
     // what it is filtered by have to be sayable from outside.
@@ -94,8 +67,7 @@ export function FieldPicker({
     value,
     disabled,
     invalid,
-    fieldMappings,
-    customFieldMappings,
+    targets,
     open,
     search,
     onOpenChange,
@@ -111,15 +83,9 @@ export function FieldPicker({
     // its autoFocus pulled straight back inside. Both are dealt with at teardown, below.
     const openingCreateForm = useRef(false);
 
-    const selectedCustom = customFieldMappings.find(field => field.value === value);
-    const selectedNative = fieldMappings.find(field => field.value === value);
-    const selected = selectedCustom ?? selectedNative;
-    const [labelHead, labelTail] = splitPartLabel(selected?.label ?? '');
-    // Against what this picker is offering rather than the whole native set, since Tier is only
-    // among them on a site with tiers to import onto — where it is not offered, a custom field
-    // called "Tier" is the only "Tier" in the list and has nothing to be told apart from.
-    const ambiguous = selectedCustom !== undefined
-        && fieldMappings.some(native => sameLabel(native.label, selectedCustom.label));
+    const selected = targets.find(target => target.value === value);
+    const badge = selected?.contested ? FIELD_SOURCES[selected.source].badge : null;
+    const ariaKind = selected ? FIELD_SOURCES[selected.source].ariaKind : null;
 
     const choose = (target: string) => {
         onOpenChange(false);
@@ -158,11 +124,7 @@ export function FieldPicker({
                     // Names the column and what it is mapped to. A bare "Field for <column>"
                     // would replace the trigger's own text in the accessible name, so the
                     // selection — the whole point of the label below — would never be read.
-                    // Every custom field names its kind here, not only the ones the badge marks.
-                    // The badge is spent narrowly because it costs room in a column that has none
-                    // to spare; a name read aloud costs nothing, so there is no reason to hold it
-                    // back from the rest. Spelled out in full, since "Custom" alone names nothing.
-                    aria-label={selected ? `Field for ${columnKey}, ${selected.label}${selectedCustom ? `, ${CUSTOM_GROUP}` : ''}` : `Field for ${columnKey}, not chosen`}
+                    aria-label={selected ? `Field for ${columnKey}, ${selected.label}${ariaKind ? `, ${ariaKind}` : ''}` : `Field for ${columnKey}, not chosen`}
                     className={cn(
                         // px-2 rather than the combobox recipe's px-3: at the 32px control height a
                         // 16px icon sits 8px off the top and bottom, and the same 8px at the start
@@ -190,49 +152,28 @@ export function FieldPicker({
                     role="combobox"
                     variant="outline"
                 >
-                    {/* Flat and inline, the way these same icons sit inside the list below. The
-                        tile they used to sit in was answering to the second line of text: two
-                        lines give a loose glyph nothing to be centred against, and the tile both
-                        gave it somewhere to sit and held the row's height open. With one line
-                        left, neither job remains, and the control comes back to the height every
-                        other one in Shade stands at.
-
-                        Empty still carries a mark of its own, so the names down the column all
-                        start in the same place whether a row is filled or not. An outline reads
-                        as a slot still to fill rather than as a thing with no icon. */}
                     <span className={cn('flex shrink-0 items-center', disabled && 'opacity-60')}>
-                        {selectedCustom && <CustomFieldIcon className="size-4 text-foreground" type={selectedCustom.type} />}
-                        {selectedNative && <NativeIcon className="size-4 text-foreground" value={selectedNative.value} />}
+                        {selected && <TargetIcon className="size-4 text-foreground" target={selected} />}
                         {!selected && <span className="size-4 rounded-sm border border-dashed border-border-strong" />}
                     </span>
                     {selected ? (
-                        // The badge sits against the end of the control rather than trailing the
-                        // name, so it holds the same place on every row it appears on instead of
-                        // one that moves with the length of the label. flex-1 on the label is what
-                        // puts it there.
+                        // flex-1 on the label is what holds the badge against the end of the
+                        // control, so it sits in the same place on every row it appears on.
                         <>
                             <span className={cn('flex min-w-0 flex-1 items-baseline text-left text-sm font-medium', disabled && 'opacity-60')}>
-                                {/* Both give way, the name far sooner: shrink is a ratio, so a name
-                                    set to shrink hundreds of times faster is spent down to nothing
-                                    before the part it belongs to loses a character. What it cannot
-                                    be is unshrinkable — a part with nowhere to give runs out of the
-                                    control instead of truncating, which is what a narrow screen
-                                    does to an address. Nothing is lost with the name gone: the
-                                    column it maps from is named in full one cell to the left. */}
-                                <span className="min-w-0 shrink-[999] truncate">{labelHead}</span>
-                                {/* The space belongs to the text rather than to a gap between the
-                                    two boxes: read out, copied, or asserted on, this is one label
-                                    and it reads as one. Held by whitespace-pre, which is what stops
-                                    a space at the start of a box being dropped. */}
-                                {labelTail && <span className="min-w-0 truncate whitespace-pre">{` ${labelTail}`}</span>}
+                                {/* Every row of one address reads the same until the part, so the
+                                    part is what has to survive a narrow column. Shrink is a ratio:
+                                    at 999 the name is spent to nothing before the part loses a
+                                    character. Not unshrinkable, or the part runs out of the
+                                    control rather than truncating. */}
+                                <span className="min-w-0 shrink-[999] truncate">{selected.fieldName}</span>
+                                {/* whitespace-pre, or the leading space is dropped and the label
+                                    reads as two. */}
+                                {selected.partLabel && <span className="min-w-0 truncate whitespace-pre">{` (${selected.partLabel})`}</span>}
                             </span>
-                            {/* Dropped on a narrow screen, where it is taking width from a label
-                                that has none to give. Worth being plain about the trade: it only
-                                appears where it is the one thing telling two same-named fields
-                                apart, so this gives that up exactly where it was earning its keep,
-                                and the name it makes room for is the more useful half of the row.
-                                The kind survives in the accessible name and in the open list. */}
-                            {ambiguous && <Badge className={cn('ms-2 shrink-0 max-md:hidden', disabled && 'opacity-60')} variant="secondary">{CUSTOM_BADGE}</Badge>}
+                            {/* Dropped where the label has no width to give; the kind survives in
+                                the accessible name and in the open list. */}
+                            {badge && <Badge className={cn('ms-2 shrink-0 max-md:hidden', disabled && 'opacity-60')} variant="secondary">{badge}</Badge>}
                         </>
                     ) : (
                         <span className={cn('min-w-0 truncate text-sm text-muted-foreground', disabled && 'opacity-60')}>Select field</span>
@@ -270,43 +211,29 @@ export function FieldPicker({
                         content above, which is what keeps a row near the bottom of the dialog
                         from opening a list that runs off the screen. */}
                     <CommandList className="min-h-0 flex-1">
-                        {/* Keyed by the target rather than by the label, because a site can call a
-                            custom field "Name" and then two items carry the same label. cmdk holds
-                            the highlighted item as a value and marks every item equal to it, so a
-                            shared label is one item to it: both rows light up, and the one Enter
-                            takes is whichever the DOM has first — always the native one, whichever
-                            was arrowed to. The targets are already distinct, namespaced apart as
-                            `name` and `custom_fields.name`, so they are what identity is taken
-                            from, and the label moves to keywords, which is what scoreByLabel reads
-                            so that search still answers to the name on the row. */}
-                        <CommandGroup heading={`${NATIVE_GROUP}s`}>
-                            {fieldMappings.map(field => (
-                                <CommandItem key={field.value} keywords={[field.label]} value={field.value} onSelect={() => choose(field.value)}>
-                                    <NativeIcon value={field.value} />
-                                    <span className="truncate">{field.label}</span>
-                                    {value === field.value && <CommandCheck />}
-                                </CommandItem>
-                            ))}
-                        </CommandGroup>
-                        <CommandGroup heading={`${CUSTOM_GROUP}s`}>
-                            {customFieldMappings.map(field => (
-                                <CommandItem key={field.value} keywords={[field.label]} value={field.value} onSelect={() => choose(field.value)}>
-                                    <CustomFieldIcon type={field.type} />
-                                    <span className="truncate">{field.label}</span>
-                                    {value === field.value && <CommandCheck />}
-                                </CommandItem>
-                            ))}
-                        </CommandGroup>
-                        {/* Its own group so it is the one thing search cannot take away: cmdk
-                            hands a group's forceMount down to every item in it, so leaving this
-                            among the fields would have pinned all of them too. A search matching
-                            no field is the strongest signal there is that the field wanted does
-                            not exist yet, and the answer to that is the way to make one — which
-                            is why there is no empty state behind it. */}
+                        {/* A site can name a custom field "Name", and cmdk treats every item
+                            equal to the highlighted value as the same item: both would light up,
+                            and Enter would take whichever the DOM had first. Identity is the
+                            target, which is namespaced and so already distinct; the label moves
+                            to keywords for scoreByLabel. */}
+                        {FIELD_SOURCE_ORDER.map(source => (
+                            <CommandGroup key={source} heading={FIELD_SOURCES[source].heading}>
+                                {targets.filter(target => target.source === source).map(target => (
+                                    <CommandItem key={target.value} keywords={[target.label]} value={target.value} onSelect={() => choose(target.value)}>
+                                        <TargetIcon target={target} />
+                                        <span className="truncate">{target.label}</span>
+                                        {value === target.value && <CommandCheck />}
+                                    </CommandItem>
+                                ))}
+                            </CommandGroup>
+                        ))}
+                        {/* Its own group because cmdk hands forceMount down to every item in a
+                            group, so among the fields it would have pinned all of them. Search
+                            finding nothing is the strongest signal the field does not exist yet,
+                            which is why nothing else stands in for an empty state. */}
                         <CommandGroup forceMount>
-                            {/* With a plus, mirroring the label picker below this table. A
-                                publisher can name a field something like "New field", so the
-                                colour is what sets this apart from one. */}
+                            {/* A publisher can name a field "New field", so the colour is what
+                                sets this apart from one. */}
                             <CommandItem
                                 className="font-semibold text-green"
                                 value="Add custom field"

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.test.ts
@@ -1,0 +1,121 @@
+import {FIELD_SOURCES, FIELD_SOURCE_ORDER, fieldTargets} from './field-targets';
+import {type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+const membershipFields = [
+    {label: 'Email', value: 'email'},
+    {label: 'Name', value: 'name'},
+    {label: 'Subscribed to emails', value: 'subscribed_to_emails'}
+];
+
+const customColumn = (overrides: Partial<MemberCustomFieldCsvColumn> = {}): MemberCustomFieldCsvColumn => ({
+    value: 'custom_fields.nickname',
+    fieldName: 'Nickname',
+    label: 'Nickname',
+    type: 'short_text',
+    ...overrides
+});
+
+describe('field targets', () => {
+    describe('fieldTargets', () => {
+        it('gives a membership field the same two halves every target carries', () => {
+            const [target] = fieldTargets({membershipFields: [{label: 'Name', value: 'name'}], customFieldColumns: []});
+
+            expect(target).toEqual({value: 'name', source: 'membership', fieldName: 'Name', label: 'Name', contested: false});
+        });
+
+        it('carries a custom field\'s type, name and part through', () => {
+            const targets = fieldTargets({
+                membershipFields: [],
+                customFieldColumns: [customColumn({
+                    value: 'custom_fields.shipping_address.city',
+                    fieldName: 'Shipping Address',
+                    partLabel: 'City',
+                    label: 'Shipping Address (City)',
+                    type: 'address'
+                })]
+            });
+
+            expect(targets).toEqual([{
+                value: 'custom_fields.shipping_address.city',
+                source: 'custom',
+                fieldName: 'Shipping Address',
+                partLabel: 'City',
+                label: 'Shipping Address (City)',
+                type: 'address',
+                contested: false
+            }]);
+        });
+
+        it('leaves a one-column field with no part at all', () => {
+            const [target] = fieldTargets({membershipFields: [], customFieldColumns: [customColumn()]});
+
+            expect(target).not.toHaveProperty('partLabel');
+        });
+
+        it('offers the sources in the order they are declared in', () => {
+            const targets = fieldTargets({membershipFields, customFieldColumns: [customColumn()]});
+
+            expect([...new Set(targets.map(target => target.source))]).toEqual([...FIELD_SOURCE_ORDER]);
+        });
+    });
+
+    describe('contested', () => {
+        const contestedLabels = (targets: ReturnType<typeof fieldTargets>) =>
+            targets.filter(target => target.contested).map(target => target.label);
+
+        it('finds a custom field a membership field has the name of', () => {
+            const targets = fieldTargets({membershipFields, customFieldColumns: [customColumn({fieldName: 'Name', label: 'Name'})]});
+
+            expect(contestedLabels(targets)).toEqual(['Name', 'Name']);
+        });
+
+        it('leaves a name no other source offers alone', () => {
+            const targets = fieldTargets({membershipFields, customFieldColumns: [customColumn()]});
+
+            expect(contestedLabels(targets)).toEqual([]);
+        });
+
+        it('counts a name differing only in case or space as the same name', () => {
+            const targets = fieldTargets({membershipFields, customFieldColumns: [customColumn({fieldName: ' name ', label: ' name '})]});
+
+            expect(contestedLabels(targets)).toEqual(['Name', ' name ']);
+        });
+
+        it('does not contest a composite part that shares only its field name', () => {
+            const targets = fieldTargets({
+                membershipFields,
+                customFieldColumns: [customColumn({
+                    value: 'custom_fields.name.city',
+                    fieldName: 'Name',
+                    partLabel: 'City',
+                    label: 'Name (City)',
+                    type: 'address'
+                })]
+            });
+
+            expect(contestedLabels(targets)).toEqual([]);
+        });
+
+        it('contests only against the targets in the list it is given', () => {
+            const custom = [customColumn({value: 'custom_fields.tier', fieldName: 'Tier', label: 'Tier'})];
+
+            expect(contestedLabels(fieldTargets({membershipFields, customFieldColumns: custom}))).toEqual([]);
+            expect(contestedLabels(fieldTargets({
+                membershipFields: [...membershipFields, {label: 'Tier', value: 'import_tier'}],
+                customFieldColumns: custom
+            }))).toEqual(['Tier', 'Tier']);
+        });
+    });
+
+    describe('FIELD_SOURCES', () => {
+        it('leaves exactly one source unmarked', () => {
+            const unmarked = FIELD_SOURCE_ORDER.filter(source => FIELD_SOURCES[source].badge === null);
+
+            expect(unmarked).toEqual(['membership']);
+        });
+
+        it('names a marked source in full for the accessible name', () => {
+            expect(FIELD_SOURCES.custom).toEqual({heading: 'Custom fields', badge: 'Custom', ariaKind: 'Custom field'});
+        });
+    });
+});

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.ts
@@ -1,0 +1,86 @@
+import {type MemberCustomField, type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+export type FieldSource = FieldOffer['source'];
+
+interface FieldFacts {
+    /** The CSV column. Namespaced per source, so it identifies a target across all of them. */
+    value: string;
+    fieldName: string;
+    partLabel?: string;
+    /** `fieldName`, plus the part in brackets where there is one. Shown, and searched. */
+    label: string;
+}
+
+type FieldOffer =
+    | (FieldFacts & {source: 'membership'})
+    | (FieldFacts & {source: 'custom'; type: MemberCustomField['type']});
+
+/**
+ * One thing a CSV column can be imported as.
+ *
+ * `contested` belongs to the list rather than to the field: whether "Tier" needs telling apart
+ * depends on whether tiers are on offer at all.
+ */
+export type FieldTarget = FieldOffer & {contested: boolean};
+
+interface FieldSourcePresentation {
+    heading: string;
+    /** Null for the source a reader assumes. Exactly one source may be null. */
+    badge: string | null;
+    /** Named in full, for the accessible name; null to say nothing. */
+    ariaKind: string | null;
+}
+
+export const FIELD_SOURCES: Record<FieldSource, FieldSourcePresentation> = {
+    membership: {heading: 'Membership fields', badge: null, ariaKind: null},
+    custom: {heading: 'Custom fields', badge: 'Custom', ariaKind: 'Custom field'}
+};
+
+export const FIELD_SOURCE_ORDER = Object.keys(FIELD_SOURCES) as FieldSource[];
+
+/** Everything a column can be imported as, in the order the sections offer it. */
+export function fieldTargets({membershipFields, customFieldColumns}: {
+    membershipFields: {label: string; value: string}[];
+    customFieldColumns: MemberCustomFieldCsvColumn[];
+}): FieldTarget[] {
+    const offers: FieldOffer[] = [
+        ...membershipFields.map((field): FieldOffer => ({
+            value: field.value,
+            source: 'membership',
+            fieldName: field.label,
+            label: field.label
+        })),
+        ...customFieldColumns.map((column): FieldOffer => ({
+            value: column.value,
+            source: 'custom',
+            fieldName: column.fieldName,
+            ...(column.partLabel === undefined ? {} : {partLabel: column.partLabel}),
+            label: column.label,
+            type: column.type
+        }))
+    ];
+
+    const contested = labelsSharedAcrossSources(offers);
+    return offers.map(offer => ({...offer, contested: contested.has(readsAs(offer))}));
+}
+
+function readsAs(offer: {label: string}): string {
+    return offer.label.trim().toLowerCase();
+}
+
+/**
+ * Compared on the whole label, not on `fieldName`: an address field called "Name" reads
+ * "Name (City)" beside the membership "Name", which already tells them apart.
+ */
+function labelsSharedAcrossSources(offers: FieldOffer[]): ReadonlySet<string> {
+    const sourcesByLabel = new Map<string, Set<FieldSource>>();
+    for (const offer of offers) {
+        const sources = sourcesByLabel.get(readsAs(offer)) ?? new Set<FieldSource>();
+        sources.add(offer.source);
+        sourcesByLabel.set(readsAs(offer), sources);
+    }
+
+    return new Set(
+        [...sourcesByLabel].filter(([, sources]) => sources.size > 1).map(([label]) => label)
+    );
+}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -8,6 +8,7 @@ import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} fro
 import {HostLimitError, JSONError, RequestEntityTooLargeError, ValidationError, getErrorMessage} from '@tryghost/admin-x-framework/errors';
 import {type ImportResponse} from '@/members/components/bulk-action-modals/import-members/state';
 import {MembersFieldMapping, detectFieldTypes, getFieldMappings} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
+import {fieldTargets} from '@/members/components/bulk-action-modals/import-members/custom-fields/field-targets';
 import {buildImportResponse} from '@/members/components/bulk-action-modals/import-members/upload';
 import {cn} from '@tryghost/shade/utils';
 import {createInitialImportState, importReducer} from '@/members/components/bulk-action-modals/import-members/reducer';
@@ -65,12 +66,14 @@ export function ImportMembersModal({
     useLayoutEffect(() => {
         detectOptionsRef.current = {importMemberTier, customFieldColumns};
     }, [importMemberTier, customFieldColumns]);
-    // Native targets only. Each row's kind decides which list its picker shows, and custom
-    // targets reach it through customFieldColumns. Auto-detection still sees both, via
-    // detectOptionsRef above.
-    const fieldMappings = useMemo(
-        () => getFieldMappings({importMemberTier}),
-        [importMemberTier]
+    // Auto-detection takes customFieldColumns separately, through detectOptionsRef above: it
+    // matches on column names rather than on what is offered.
+    const targets = useMemo(
+        () => fieldTargets({
+            membershipFields: getFieldMappings({importMemberTier}),
+            customFieldColumns
+        }),
+        [importMemberTier, customFieldColumns]
     );
 
     // Whether email is mapped is the mapping step's to answer, because it is the only thing
@@ -400,15 +403,14 @@ export function ImportMembersModal({
 
             {(state.status === 'MAPPING' || state.status === 'UPLOADING') && state.fileData !== null && (
                 <MappingStep
-                    customFieldMappings={customFieldColumns}
                     dataPreviewIndex={state.dataPreviewIndex}
-                    fieldMappings={fieldMappings}
                     fileData={state.fileData}
                     labelPicker={labelPicker}
                     mapping={state.mapping}
                     mappingError={state.mappingError}
                     showMappingErrors={state.showMappingErrors}
                     status={state.status}
+                    targets={targets}
                     onColumnsChanged={() => setHasEdits(true)}
                     onDataPreviewIndexChange={(nextIndex) => {
                         dispatch({

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
@@ -8,7 +8,8 @@ import {LabelPicker} from '@/members/label-picker';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import {MembersFieldMapping, columnsOf} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
 import {Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
-import {type MemberCustomField, type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {type FieldTarget} from '@/members/components/bulk-action-modals/import-members/custom-fields/field-targets';
+import {type MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {type UseLabelPickerResult} from '@/members/hooks/use-label-picker';
 
 interface MappingPreviewRow {
@@ -31,8 +32,7 @@ interface MappingStepProps {
     mappingError: string | null;
     showMappingErrors: boolean;
     dataPreviewIndex: number;
-    fieldMappings: {label: string; value: string}[];
-    customFieldMappings: MemberCustomFieldCsvColumn[];
+    targets: FieldTarget[];
     labelPicker: UseLabelPickerResult;
     onUpdateMapping: (from: string, to: string | null) => void;
     onFieldCreated: (columnKey: string, column: string | null) => void;
@@ -82,8 +82,7 @@ export function MappingStep({
     mappingError,
     showMappingErrors,
     dataPreviewIndex,
-    fieldMappings,
-    customFieldMappings,
+    targets,
     labelPicker,
     onUpdateMapping,
     onFieldCreated,
@@ -470,12 +469,11 @@ export function MappingStep({
                                                         <FieldPicker
                                                             className={cn(!isImported(row) && 'invisible')}
                                                             columnKey={row.key}
-                                                            customFieldMappings={customFieldMappings}
                                                             disabled={isRowLocked(row)}
-                                                            fieldMappings={fieldMappings}
                                                             invalid={incomplete?.columns.has(row.key)}
                                                             open={openPicker?.columnKey === row.key}
                                                             search={openPicker?.columnKey === row.key ? openPicker.search : ''}
+                                                            targets={targets}
                                                             triggerRef={(node) => {
                                                                 if (node) {
                                                                     fieldTriggers.current.set(row.key, node);

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.test.ts
@@ -14,9 +14,9 @@ describe('custom fields mapping helpers', () => {
     });
 
     const customFieldColumns: MemberCustomFieldCsvColumn[] = [
-        {label: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'},
-        {label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1', type: 'address'},
-        {label: 'Shipping Address (First name)', value: 'custom_fields.shipping_address.first_name', type: 'address'}
+        {label: 'Nickname', fieldName: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'},
+        {label: 'Shipping Address (Line 1)', fieldName: 'Shipping Address', partLabel: 'Line 1', value: 'custom_fields.shipping_address.line1', type: 'address'},
+        {label: 'Shipping Address (First name)', fieldName: 'Shipping Address', partLabel: 'First name', value: 'custom_fields.shipping_address.first_name', type: 'address'}
     ];
 
     it('auto-detects a custom field column by its namespaced header', () => {
@@ -52,7 +52,7 @@ describe('custom fields mapping helpers', () => {
     it('does not bind an email-valued custom field column to the member email', () => {
         const mapping = detectFieldTypes([
             {'custom_fields.contact_email': 'contact@example.com', email: 'member@example.com'}
-        ], {customFieldColumns: [{label: 'Contact email', value: 'custom_fields.contact_email', type: 'short_text'}]});
+        ], {customFieldColumns: [{label: 'Contact email', fieldName: 'Contact email', value: 'custom_fields.contact_email', type: 'short_text'}]});
 
         expect(mapping.email).toBe('email');
         expect(mapping['custom_fields.contact_email']).toBe('custom_fields.contact_email');

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
@@ -113,9 +113,9 @@ describe('mapping helpers', () => {
     });
 
     const customFieldColumns: MemberCustomFieldCsvColumn[] = [
-        {label: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'},
-        {label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1', type: 'address'},
-        {label: 'Shipping Address (First name)', value: 'custom_fields.shipping_address.first_name', type: 'address'}
+        {label: 'Nickname', fieldName: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'},
+        {label: 'Shipping Address (Line 1)', fieldName: 'Shipping Address', partLabel: 'Line 1', value: 'custom_fields.shipping_address.line1', type: 'address'},
+        {label: 'Shipping Address (First name)', fieldName: 'Shipping Address', partLabel: 'First name', value: 'custom_fields.shipping_address.first_name', type: 'address'}
     ];
 
     it('offers the custom field columns as mapping targets', () => {
@@ -158,7 +158,7 @@ describe('mapping helpers', () => {
     it('does not bind an email-valued custom field column to the member email', () => {
         const mapping = detectFieldTypes([
             {'custom_fields.contact_email': 'contact@example.com', email: 'member@example.com'}
-        ], {customFieldColumns: [{label: 'Contact email', value: 'custom_fields.contact_email', type: 'short_text'}]});
+        ], {customFieldColumns: [{label: 'Contact email', fieldName: 'Contact email', value: 'custom_fields.contact_email', type: 'short_text'}]});
 
         expect(mapping.email).toBe('email');
         expect(mapping['custom_fields.contact_email']).toBe('custom_fields.contact_email');

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -143,10 +143,6 @@ describe('Import members custom fields', () => {
         await expect.element(fieldSelect('nickname')).not.toHaveTextContent('Custom');
     });
 
-    // The two "Name" rows are one item to a list that identifies its items by what they read
-    // as, and the whole of what this picker offers a publisher is the choice between them. So
-    // the choice is made the way it is most easily lost — from the keyboard, on the second of
-    // two identical labels — and read back off the request rather than off the control.
     it('selects the second of two fields sharing a name from the keyboard', async () => {
         const {uploadApi} = fakeCustomFieldsWorld();
         await renderAdminApp('/members', FLAGS);
@@ -159,20 +155,14 @@ describe('Import members custom fields', () => {
 
         await importToggle('city').click();
         await fieldSelect('city').click();
-        // Both are named "Name" and nothing else in either list is, so the list is down to the
-        // membership one, the custom one, and the row that makes a new field.
         await userEvent.fill(page.getByPlaceholder('Search fields...'), 'Name');
         await expect(page.getByRole('option', {name: 'Name', exact: true})).toHaveCount(2);
 
-        // Off the first match onto the second, and taken with the key that takes whatever is
-        // highlighted. Highlighting and selecting have to agree about which of the two this is.
+        // Highlighting and selecting have to agree about which of the two this is.
         await userEvent.keyboard('{ArrowDown}{Enter}');
 
-        // The custom one, which is the one the arrow was on. Reading the badge is not enough on
-        // its own: it says a custom field was chosen, not which column the import will write.
         await expect.element(fieldSelect('city')).toHaveTextContent('Custom');
-        // And `nickname` gives it up, because a target belongs to one column at a time. Nothing
-        // else would move it, so this is the custom field changing hands.
+        // A target belongs to one column at a time, so this is the custom field changing hands.
         await expect.element(fieldSelect('nickname')).toHaveTextContent('Select field');
 
         await importToggle('nickname').click();
@@ -186,10 +176,6 @@ describe('Import members custom fields', () => {
         });
     });
 
-    // Searching reads the names on the rows and nothing else. The columns behind them are
-    // namespaced, so a list that searched those too would answer "custom" with every custom
-    // field's column plus whatever a fuzzy match could reach by running out of one and into
-    // the other -- `subscribed_to_emails` and its own label hold a c-u-s-t-o-m between them.
     it('searches the names on the rows rather than the columns behind them', async () => {
         fakeCustomFieldsWorld();
         await renderAdminApp('/members', FLAGS);
@@ -201,13 +187,11 @@ describe('Import members custom fields', () => {
         await fieldSelect('nickname').click();
         await userEvent.fill(page.getByPlaceholder('Search fields...'), 'custom');
 
-        // The one row that offers to make a field is force-mounted, so it is there whatever the
-        // search says. Nothing else is: no field is named "custom".
+        // Force-mounted, so it survives any search. Nothing else should: no field is "custom".
         await expect.element(page.getByRole('option', {name: 'Add custom field'})).toBeVisible();
         await expect.element(page.getByRole('option', {name: 'Subscribed to emails'})).not.toBeInTheDocument();
         await expect.element(page.getByRole('option', {name: 'Nickname'})).not.toBeInTheDocument();
 
-        // And the name on the row still finds it.
         await userEvent.fill(page.getByPlaceholder('Search fields...'), 'nick');
         await expect.element(page.getByRole('option', {name: 'Nickname'})).toBeVisible();
     });

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -143,6 +143,75 @@ describe('Import members custom fields', () => {
         await expect.element(fieldSelect('nickname')).not.toHaveTextContent('Custom');
     });
 
+    // The two "Name" rows are one item to a list that identifies its items by what they read
+    // as, and the whole of what this picker offers a publisher is the choice between them. So
+    // the choice is made the way it is most easily lost — from the keyboard, on the second of
+    // two identical labels — and read back off the request rather than off the control.
+    it('selects the second of two fields sharing a name from the keyboard', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await userEvent.fill(createForm().getByLabelText('Name'), 'Name');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Name');
+
+        await importToggle('city').click();
+        await fieldSelect('city').click();
+        // Both are named "Name" and nothing else in either list is, so the list is down to the
+        // membership one, the custom one, and the row that makes a new field.
+        await userEvent.fill(page.getByPlaceholder('Search fields...'), 'Name');
+        await expect(page.getByRole('option', {name: 'Name', exact: true})).toHaveCount(2);
+
+        // Off the first match onto the second, and taken with the key that takes whatever is
+        // highlighted. Highlighting and selecting have to agree about which of the two this is.
+        await userEvent.keyboard('{ArrowDown}{Enter}');
+
+        // The custom one, which is the one the arrow was on. Reading the badge is not enough on
+        // its own: it says a custom field was chosen, not which column the import will write.
+        await expect.element(fieldSelect('city')).toHaveTextContent('Custom');
+        // And `nickname` gives it up, because a target belongs to one column at a time. Nothing
+        // else would move it, so this is the custom field changing hands.
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Select field');
+
+        await importToggle('nickname').click();
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+        await expect.poll(() => uploadApi.lastRequest && sentMapping(uploadApi.lastRequest.body)).toEqual({
+            email: 'email',
+            name: 'name',
+            nickname: '',
+            city: 'custom_fields.name',
+            postcode: ''
+        });
+    });
+
+    // Searching reads the names on the rows and nothing else. The columns behind them are
+    // namespaced, so a list that searched those too would answer "custom" with every custom
+    // field's column plus whatever a fuzzy match could reach by running out of one and into
+    // the other -- `subscribed_to_emails` and its own label hold a c-u-s-t-o-m between them.
+    it('searches the names on the rows rather than the columns behind them', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        await fieldSelect('nickname').click();
+        await userEvent.fill(page.getByPlaceholder('Search fields...'), 'custom');
+
+        // The one row that offers to make a field is force-mounted, so it is there whatever the
+        // search says. Nothing else is: no field is named "custom".
+        await expect.element(page.getByRole('option', {name: 'Add custom field'})).toBeVisible();
+        await expect.element(page.getByRole('option', {name: 'Subscribed to emails'})).not.toBeInTheDocument();
+        await expect.element(page.getByRole('option', {name: 'Nickname'})).not.toBeInTheDocument();
+
+        // And the name on the row still finds it.
+        await userEvent.fill(page.getByPlaceholder('Search fields...'), 'nick');
+        await expect.element(page.getByRole('option', {name: 'Nickname'})).toBeVisible();
+    });
+
     it('puts the create form away when another picker is opened', async () => {
         fakeCustomFieldsWorld();
         await renderAdminApp('/members', FLAGS);


### PR DESCRIPTION
## Problem

The field picker in the members CSV import mapping answered "what kind of field is this?" by working out which of two lists it had found the selection in, and it did that separately for the icon, the label, the badge and the accessible name. It also recovered a composite field's name and its part by running a regex back over a label that had already been joined from those two halves, which a field name containing brackets defeats.

Both are fine while there are exactly two kinds of field. Adding a third — Stripe-backed fields being the obvious candidate — would have meant a third list, a third lookup, a third icon branch and a third section, and would have turned the single same-name check into a pairwise scan. The "Custom" badge in particular was a boolean against one hard-coded word, with nowhere to put a second marked source and an unstated assumption that anything unmarked is built in.

## Solution

Targets now describe themselves. A CSV column carries its field name and part label alongside the joined form, so nothing downstream takes a label apart again. The picker takes one list of targets, each carrying which source it came from and whether another source offers a field reading the same, and reads those instead of deriving them. Whether a name is ambiguous is settled once where the list is built rather than per row.

How each source is presented — its section heading, whether it is marked, what it is called when read aloud — lives in one record keyed by the set of sources. Adding a source to that set is a build failure until it has all of those and an icon, and the section order is read off the same record so a new source cannot silently end up with no section.

No behaviour change. Two acceptance tests were added first, covering keyboard selection between two same-named fields and search matching the names on the rows, both verified to fail without the code that makes them pass.
