### PR TITLE
Improved automation canvas recentering after deletion

### DIFF
--- a/apps/admin/src/automations/components/canvas/use-canvas-viewport.ts
+++ b/apps/admin/src/automations/components/canvas/use-canvas-viewport.ts
@@ -80,7 +80,7 @@ export const useCanvasViewport = <NodeType extends Node = Node, EdgeType extends
     }, []);
 
     const onMove = useCallback<OnMove>((_, viewport) => {
-        setZoom(viewport.zoom);
+        setZoom(currentZoom => Math.abs(currentZoom - viewport.zoom) < 1e-6 ? currentZoom : viewport.zoom);
     }, []);
 
     const contentBottom = contentBounds?.bottom;
@@ -103,7 +103,10 @@ export const useCanvasViewport = <NodeType extends Node = Node, EdgeType extends
         const nextViewport = constrainViewport(currentViewport, canvasSize, nextExtent);
 
         if (nextViewport.x !== currentViewport.x || nextViewport.y !== currentViewport.y) {
-            void reactFlowInstance.setViewport(nextViewport);
+            void reactFlowInstance.setViewport(nextViewport, {
+                duration: 250,
+                interpolate: 'linear'
+            });
         }
     }, [canvasSize.height, canvasSize.width, contentBottom, contentLeft, contentRight, initialViewport.y, reactFlowInstance, zoom]);
 

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -177,15 +177,19 @@ type StubReactFlowProps = {
 };
 type NodeRenderProps = {id: string; data: Record<string, unknown>; type: string};
 type EdgeRenderProps = {id: string; data: Record<string, unknown>; sourceX: number; sourceY: number; targetX: number; targetY: number; sourcePosition: string; targetPosition: string};
+let mockOnMove: StubReactFlowProps['onMove'];
 
 vi.mock('@xyflow/react', async () => {
     const actual = await vi.importActual<typeof import('@xyflow/react')>('@xyflow/react');
     return {
         ...actual,
-        ReactFlow: ({nodes, edges, children, className, nodeTypes, edgeTypes, onInit, onNodeClick, onNodeDoubleClick, onPaneClick, zoomOnDoubleClick}: StubReactFlowProps) => {
+        ReactFlow: ({nodes, edges, children, className, nodeTypes, edgeTypes, onInit, onMove, onNodeClick, onNodeDoubleClick, onPaneClick, zoomOnDoubleClick}: StubReactFlowProps) => {
             React.useEffect(() => {
                 onInit?.(mockReactFlow);
             }, [onInit]);
+            React.useEffect(() => {
+                mockOnMove = onMove;
+            }, [onMove]);
 
             return (
                 <div className={className} data-testid='react-flow-mock' data-zoom-on-double-click={String(zoomOnDoubleClick)} onClick={onPaneClick}>
@@ -941,7 +945,14 @@ describe('AutomationEditor', () => {
             fireEvent.click(screen.getByRole('button', {name: 'Wait: 1 day'}));
             fireEvent.click(within(screen.getByRole('complementary', {name: 'Step details'})).getByRole('button', {name: 'Delete step'}));
 
-            await waitFor(() => expect(mockReactFlow.setViewport).toHaveBeenCalledWith({x: 372, y: -8, zoom: 1}));
+            await waitFor(() => expect(mockReactFlow.setViewport).toHaveBeenCalledWith(
+                {x: 372, y: -8, zoom: 1},
+                {duration: 250, interpolate: 'linear'}
+            ));
+
+            mockReactFlow.setViewport.mockClear();
+            act(() => mockOnMove?.(null, {x: 372, y: -187, zoom: 1 + Number.EPSILON}));
+            expect(mockReactFlow.setViewport).not.toHaveBeenCalled();
         } finally {
             clientWidthSpy.mockRestore();
             clientHeightSpy.mockRestore();


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1532/animate-automation-canvas-recentering-when-deleting-the-final-step

A corrective viewport clamp after deleting the final step should make the workflow movement clear instead of snapping. Ignore floating-point zoom noise from the programmatic pan so it cannot restart its own transition.

Video shows the nodes from the end of the list getting deleted and the canvas recentering smoothly. note it also shows that deleting a node from the middle of the workflow will _not_ animate smoothly, it just immediately goes away like it did before. The code for implementing that will be a little more involved and handled in a separate PR.

https://github.com/user-attachments/assets/5bc13334-ec5d-42e6-a939-b308edf42956

