### PR TITLE
Changed settings save callbacks to accept async handlers

### DIFF
--- a/apps/admin/src/settings/app/components/top-level-group.tsx
+++ b/apps/admin/src/settings/app/components/top-level-group.tsx
@@ -31,7 +31,8 @@ interface TopLevelGroupProps {
     highlightOnModalClose?: boolean;
     enableCMDS?: boolean;
     onEditingChange?: (isEditing: boolean) => void;
-    onSave?: () => void;
+    /** May be async; the group fires it without awaiting, so the handler owns its own error handling. */
+    onSave?: () => void | Promise<unknown>;
     onCancel?: () => void;
 }
 
@@ -81,7 +82,7 @@ const TopLevelGroup: React.FC<TopLevelGroupProps> = ({
         const handleSaveShortcut = (event: KeyboardEvent) => {
             if ((event.metaKey || event.ctrlKey) && event.key === 's') {
                 event.preventDefault();
-                onSave?.();
+                void onSave?.();
             }
         };
 
@@ -100,7 +101,7 @@ const TopLevelGroup: React.FC<TopLevelGroupProps> = ({
         <Inline className='-mt-1.25' gap='sm'>
             <Button size='sm' type='button' variant='ghost' onClick={handleCancel}>Cancel</Button>
             {(saveState === 'unsaved' || alwaysShowSaveButton) && (
-                <Button disabled={saveState !== 'unsaved'} size='sm' type='button' onClick={onSave}>
+                <Button disabled={saveState !== 'unsaved'} size='sm' type='button' onClick={() => void onSave?.()}>
                     {saveState === 'saving' ? 'Saving...' : 'Save'}
                 </Button>
             )}

--- a/apps/admin/src/settings/app/hooks/use-pintura-editor.ts
+++ b/apps/admin/src/settings/app/hooks/use-pintura-editor.ts
@@ -4,10 +4,11 @@ import {type Setting, getSettingValues} from '@tryghost/admin-x-framework/api/se
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 interface OpenEditorParams {
     image: string;
-    handleSave: (dest: File) => void;
+    handleSave: (dest: File) => void | Promise<void>;
 }
 
 type FrameOptionType = 'solidSharp' | 'solidRound' | 'lineSingle' | 'hook' | 'polaroid' | undefined;
@@ -47,6 +48,7 @@ declare global {
 
 export default function usePinturaEditor() {
     const {config: globalConfig, settings} = useGlobalData() as { config: Config, settings: Setting[] };
+    const handleError = useHandleError();
     const [pintura] = getSettingValues<boolean>(settings, ['pintura']);
     const [scriptLoaded, setScriptLoaded] = useState<boolean>(false);
     const [cssLoaded, setCssLoaded] = useState<boolean>(false);
@@ -219,13 +221,13 @@ export default function usePinturaEditor() {
                 });
 
                 editor.on('process', (result) => {
-                    handleSave(result.dest);
+                    Promise.resolve(handleSave(result.dest)).catch(handleError);
                 });
 
                 setIsOpen(true);
             }
         },
-        [isEnabled]
+        [handleError, isEnabled]
     );
 
     // Only allow closing the modal if the close button was clicked

--- a/apps/shade/src/components/patterns/settings-modal.tsx
+++ b/apps/shade/src/components/patterns/settings-modal.tsx
@@ -39,7 +39,8 @@ export interface SettingsModalProps {
     footerClassName?: string;
     header?: boolean;
     padding?: boolean;
-    onOk?: () => void;
+    /** May be async; the modal fires it without awaiting, so the handler owns its own error handling. */
+    onOk?: () => void | Promise<void>;
     onCancel?: () => void;
     topRightContent?: 'close' | React.ReactNode;
     hideXOnMobile?: boolean;
@@ -222,7 +223,7 @@ const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
         const handleCMDS = (event: KeyboardEvent) => {
             if ((event.metaKey || event.ctrlKey) && event.key === 's') {
                 event.preventDefault();
-                onOk();
+                void onOk();
             }
         };
 
@@ -291,7 +292,7 @@ const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
                         </Button>
                     )}
                     {okLabel && (
-                        <Button data-testid='ok-modal' disabled={buttonsDisabled || okDisabled || okLoading} type='button' variant={okVariant} onClick={onOk}>
+                        <Button data-testid='ok-modal' disabled={buttonsDisabled || okDisabled || okLoading} type='button' variant={okVariant} onClick={() => void onOk?.()}>
                             {okLoading && <LoadingIndicator size='sm' />}
                             {okLabel}
                         </Button>


### PR DESCRIPTION
no ref

`SettingsModal.onOk` (Shade), `TopLevelGroup.onSave` and the Pintura editor's `handleSave` are all passed async handlers throughout settings, but were typed as returning `void`. Under the type-checked lint rules that apply outside the settings quarantine, every one of those call sites is a `no-misused-promises` error — 30-odd sites across the areas about to move out of `settings/app/`.

The callers fire the handler and do not await it, so the honest type is `void | Promise<…>`, with the callers discarding the result explicitly (`void onOk()`). This lets the settings code move out of the quarantine without wrapping dozens of handlers in `() => void handle()` arrows.

## Verification

- `tsc --noEmit` + eslint clean on `apps/admin` and `apps/shade`
- Shade `SettingsModal` / overlay-escape unit tests 20/20