### PR TITLE
Changed ESLint config and inline directives to survive the Oxfmt cutover

### DIFF
--- a/.changeset/easy-wasps-appear.md
+++ b/.changeset/easy-wasps-appear.md
@@ -1,0 +1,13 @@
+---
+"@tryghost/kg-utils": none
+"@tryghost/kg-unsplash-selector": none
+"@tryghost/kg-markdown-html-renderer": none
+"@tryghost/kg-html-to-lexical": none
+"@tryghost/kg-default-transforms": none
+"@tryghost/kg-default-cards": none
+"@tryghost/kg-converters": none
+"@tryghost/kg-clean-basic-html": none
+"@tryghost/kg-card-factory": none
+---
+
+Switched lint config to formatter-neutral rules; no runtime change

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -154,7 +154,7 @@ export const useFetchApi = () => {
     const {ghostVersion, sentryDSN} = useFramework();
 
     // Memoized so hooks that depend on fetchApi can cache
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     return useCallback(async <ResponseData = any>(
         endpoint: string | URL,
         {
@@ -167,6 +167,7 @@ export const useFetchApi = () => {
             onUploadProgress
         }: RequestOptions = {}
     ): Promise<ResponseData> => {
+        /* eslint-enable @typescript-eslint/no-explicit-any */
         const controller = new AbortController();
 
         const requestInit: InternalRequestInit = {

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -695,8 +695,7 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
         initialState: newsletter,
         savingDelay: 500,
         onSave: async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            const {meta: {sent_email_verification: [emailToVerify] = []} = {}} = await editNewsletter(formState); ``;
+            const {meta: {sent_email_verification: [emailToVerify] = []} = {}} = await editNewsletter(formState);
             let toastMessage;
 
             if (emailToVerify && emailToVerify === 'sender_email') {

--- a/apps/admin/src/settings/app/utils/iframe-buffering.tsx
+++ b/apps/admin/src/settings/app/utils/iframe-buffering.tsx
@@ -13,10 +13,12 @@ type IframeBufferingProps = {
   addDelay?: boolean;
 };
 
-function debounce(func: any, wait: number) { // eslint-disable-line
+// eslint-disable-next-line
+function debounce(func: any, wait: number) {
     let timeout: NodeJS.Timeout;
 
-    return function executedFunction(...args: any) { // eslint-disable-line
+    // eslint-disable-next-line
+    return function executedFunction(...args: any) {
         const later = () => {
             clearTimeout(timeout);
             func(...args);

--- a/apps/signup-form/test/e2e/attribution.test.ts
+++ b/apps/signup-form/test/e2e/attribution.test.ts
@@ -2,7 +2,7 @@ import {expect} from '@playwright/test';
 import {initialize} from '../utils/e2e';
 import {test} from '@playwright/test';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/* eslint-disable @typescript-eslint/no-explicit-any */
 async function testHistory({page, embeddedOnUrl, path, urlHistory, sessionStorageHistory}: {page: any, embeddedOnUrl?: string, path: string, urlHistory: any[], sessionStorageHistory?: any[]}) {
     const {frame, lastApiRequest} = await initialize({page, title: 'Sign up', embeddedOnUrl, path});
 
@@ -30,6 +30,7 @@ async function testHistory({page, embeddedOnUrl, path, urlHistory, sessionStorag
     expect(lastApiRequest.body).toHaveProperty('email', 'jamie@example.com');
     expect(lastApiRequest.body).toHaveProperty('urlHistory', urlHistory);
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 test.describe('Attribution', async () => {
     test('Sends the current path', async ({page}) => {

--- a/e2e/eslint.config.js
+++ b/e2e/eslint.config.js
@@ -148,6 +148,11 @@ export default tseslint.config([
             // Manually include rules from plugin:ghost/ts and plugin:ghost/ts-test
             // These would normally come from the extends, but flat config requires explicit inclusion
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
 
             // Sort multiple import lines into alphabetical groups
             'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {

--- a/ghost/core/core/frontend/apps/private-blogging/lib/helpers/input_password.js
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/helpers/input_password.js
@@ -7,7 +7,8 @@
 const {SafeString, templates} = require('../../../../services/handlebars');
 
 // We use the name input_password to match the helper for consistency:
-module.exports = function input_password(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function input_password(options) {
     options = options || {};
     options.hash = options.hash || {};
 

--- a/ghost/core/core/frontend/helpers/body_class.js
+++ b/ghost/core/core/frontend/helpers/body_class.js
@@ -11,7 +11,8 @@ const {SafeString} = require('../services/handlebars');
  */
 
 // We use the name body_class to match the helper for consistency
-module.exports = function body_class(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function body_class(options) {
     let classes = [];
     const context = options.data.root.context || [];
     const obj = this.post || this.page;

--- a/ghost/core/core/frontend/helpers/cancel_link.js
+++ b/ghost/core/core/frontend/helpers/cancel_link.js
@@ -15,7 +15,8 @@ const messages = {
     invalidData: 'The {{cancel_link}} helper was used outside of a subscription context. See https://ghost.org/docs/themes/members/#cancel-links.'
 };
 
-function cancel_link(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+function cancel_link(options) {
     let truncateOptions = (options || {}).hash || {};
 
     if (this.id === undefined || this.cancel_at_period_end === undefined) {

--- a/ghost/core/core/frontend/helpers/color_to_rgba.js
+++ b/ghost/core/core/frontend/helpers/color_to_rgba.js
@@ -1,6 +1,7 @@
 const {Color} = require('@tryghost/color-utils');
 
-module.exports = function color_to_rgba(color, alpha) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function color_to_rgba(color, alpha) {
     const backgroundColor = (typeof color === 'string' && color.trim()) ? color.trim() : '#15171A';
     const opacity = Number.isFinite(alpha) ? alpha : Number.parseFloat(alpha);
     const normalizedOpacity = Number.isFinite(opacity) ? Math.max(0, Math.min(1, opacity)) : 0.25;

--- a/ghost/core/core/frontend/helpers/content_api_key.js
+++ b/ghost/core/core/frontend/helpers/content_api_key.js
@@ -2,7 +2,8 @@ const {SafeString} = require('../services/handlebars');
 const logging = require('@tryghost/logging');
 const {getFrontendKey} = require('../services/proxy');
 
-module.exports = async function content_api_key() { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = async function content_api_key() {
     try {
         const frontendKey = await getFrontendKey();
 

--- a/ghost/core/core/frontend/helpers/content_api_url.js
+++ b/ghost/core/core/frontend/helpers/content_api_url.js
@@ -2,7 +2,8 @@ const {SafeString} = require('../services/handlebars');
 const logging = require('@tryghost/logging');
 const {urlUtils} = require('../services/proxy');
 
-module.exports = function content_api_url(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function content_api_url(options) {
     let result;
     const absoluteUrlRequested = getAbsoluteOption(options);
 

--- a/ghost/core/core/frontend/helpers/contrast_text_color.js
+++ b/ghost/core/core/frontend/helpers/contrast_text_color.js
@@ -1,6 +1,7 @@
 const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 
-module.exports = function contrast_text_color(color) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function contrast_text_color(color) {
     const backgroundColor = (typeof color === 'string' && color.trim()) ? color.trim() : '#15171A';
 
     try {

--- a/ghost/core/core/frontend/helpers/facebook_url.js
+++ b/ghost/core/core/frontend/helpers/facebook_url.js
@@ -9,7 +9,8 @@ const {localUtils} = require('../services/handlebars');
 /**
  * @deprecated Use {{social_url type="facebook"}} instead.
  */
-module.exports = function facebook_url(username, options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function facebook_url(username, options) {
     if (!options) {
         options = username;
         username = localUtils.findKey('facebook', this, options.data.site);

--- a/ghost/core/core/frontend/helpers/ghost_foot.js
+++ b/ghost/core/core/frontend/helpers/ghost_foot.js
@@ -9,7 +9,8 @@ const _ = require('lodash');
 const createFrame = hbs.handlebars.createFrame;
 
 // We use the name ghost_foot to match the helper for consistency:
-module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function ghost_foot(options) {
     const foot = [];
 
     const globalCodeinjection = settingsCache.get('codeinjection_foot');

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -320,7 +320,8 @@ function getTinybirdTrackerScript(dataRoot) {
  *  Also see how the root object gets created, https://github.com/wycats/handlebars.js/blob/v4.0.6/lib/handlebars/runtime.js#L259
  */
 // We use the name ghost_head to match the helper for consistency:
-module.exports = async function ghost_head(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = async function ghost_head(options) {
     debug('begin');
     // if server error page do nothing
     if (options.data.root.statusCode >= 500) {

--- a/ghost/core/core/frontend/helpers/has.js
+++ b/ghost/core/core/frontend/helpers/has.js
@@ -107,9 +107,11 @@ function evaluateStringMatch(expr, str, ci) {
  * @param {Object} data - global params
  */
 function evaluateList(type, expr, obj, data) {
-    return expr.split(',').map(function (prop) {
+    const props = expr.split(',').map(function (prop) {
         return prop.trim().toLocaleLowerCase();
-    })[type](function (prop) {
+    });
+
+    return props[type](function (prop) {
         if (prop.match(/^@/)) {
             return _.has(data, prop.replace(/@/, '')) && !_.isEmpty(_.get(data, prop.replace(/@/, '')));
         } else {

--- a/ghost/core/core/frontend/helpers/link_class.js
+++ b/ghost/core/core/frontend/helpers/link_class.js
@@ -12,7 +12,8 @@ const messages = {
     forIsRequired: 'The {{link_class}} helper requires a for="" attribute.'
 };
 
-module.exports = function link_class(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function link_class(options) {
     options = options || {};
     options.hash = options.hash || {};
     options.data = options.data || {};

--- a/ghost/core/core/frontend/helpers/meta_description.js
+++ b/ghost/core/core/frontend/helpers/meta_description.js
@@ -6,7 +6,8 @@ const metaData = require('../meta');
 const {getMetaDataDescription} = metaData;
 
 // We use the name meta_description to match the helper for consistency:
-module.exports = function meta_description(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function meta_description(options) {
     options = options || {};
 
     return getMetaDataDescription(this, options.data.root) || '';

--- a/ghost/core/core/frontend/helpers/meta_title.js
+++ b/ghost/core/core/frontend/helpers/meta_title.js
@@ -6,6 +6,7 @@ const metaData = require('../meta');
 const {getMetaDataTitle} = metaData;
 
 // We use the name meta_title to match the helper for consistency:
-module.exports = function meta_title(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function meta_title(options) {
     return getMetaDataTitle(this, options.data.root, options);
 };

--- a/ghost/core/core/frontend/helpers/page_url.js
+++ b/ghost/core/core/frontend/helpers/page_url.js
@@ -8,7 +8,8 @@ const metaData = require('../meta');
 const getPaginatedUrl = metaData.getPaginatedUrl;
 
 // We use the name page_url to match the helper for consistency:
-module.exports = function page_url(page, options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function page_url(page, options) {
     if (!options) {
         options = page;
         page = 1;

--- a/ghost/core/core/frontend/helpers/post_class.js
+++ b/ghost/core/core/frontend/helpers/post_class.js
@@ -5,7 +5,8 @@
 const {SafeString} = require('../services/handlebars');
 
 // We use the name post_class to match the helper for consistency:
-module.exports = function post_class() { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function post_class() {
     let classes = ['post'];
 
     const tags = this.post && this.post.tags ? this.post.tags : this.tags || [];

--- a/ghost/core/core/frontend/helpers/reading_time.js
+++ b/ghost/core/core/frontend/helpers/reading_time.js
@@ -15,7 +15,8 @@ const {SafeString} = require('../services/handlebars');
 
 const {readingTime: calculateAndFormatReadingTime} = require('@tryghost/helpers');
 
-module.exports = function reading_time(options) {// eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function reading_time(options) {
     options = options || {};
     options.hash = options.hash || {};
     const possiblyPost = this;

--- a/ghost/core/core/frontend/helpers/social_accounts.js
+++ b/ghost/core/core/frontend/helpers/social_accounts.js
@@ -45,7 +45,8 @@ const SOCIAL_PLATFORMS = [
     {type: 'instagram', name: 'Instagram'}
 ];
 
-module.exports = function social_accounts(source, options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function social_accounts(source, options) {
     // {{#social_accounts}} with no positional arg: handlebars passes only options.
     if (arguments.length < 2) {
         throw new errors.IncorrectUsageError({

--- a/ghost/core/core/frontend/helpers/social_url.js
+++ b/ghost/core/core/frontend/helpers/social_url.js
@@ -6,7 +6,8 @@ const {socialUrls} = require('../services/proxy');
 const {localUtils} = require('../services/handlebars');
 
 // We use the name social_url to match the helper for consistency:
-module.exports = function social_url(options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function social_url(options) {
     // Check for required hash option 'type'
     if (!options || !options.hash || !options.hash.type) {
         return null;

--- a/ghost/core/core/frontend/helpers/total_members.js
+++ b/ghost/core/core/frontend/helpers/total_members.js
@@ -4,7 +4,8 @@
 const {SafeString} = require('../services/handlebars');
 const {memberCountRounding, getMemberStats} = require('../utils/member-count');
 
-module.exports = async function total_members () { //eslint-disable-line
+// eslint-disable-next-line
+module.exports = async function total_members () {
     if (this.total) {
         return new SafeString(memberCountRounding(this.total));
     } else {

--- a/ghost/core/core/frontend/helpers/total_paid_members.js
+++ b/ghost/core/core/frontend/helpers/total_paid_members.js
@@ -3,7 +3,8 @@
 const {SafeString} = require('../services/handlebars');
 const {memberCountRounding, getMemberStats} = require('../utils/member-count');
 
-module.exports = async function total_paid_members () { //eslint-disable-line
+// eslint-disable-next-line
+module.exports = async function total_paid_members () {
     if (this.paid) {
         return new SafeString(memberCountRounding(this.paid));
     } else {

--- a/ghost/core/core/frontend/helpers/twitter_url.js
+++ b/ghost/core/core/frontend/helpers/twitter_url.js
@@ -9,7 +9,8 @@ const {localUtils} = require('../services/handlebars');
 /**
  * @deprecated Use {{social_url type="twitter"}} instead.
  */
-module.exports = function twitter_url(username, options) { // eslint-disable-line camelcase
+// eslint-disable-next-line camelcase
+module.exports = function twitter_url(username, options) {
     if (!options) {
         options = username;
         username = localUtils.findKey('twitter', this, options.data.site);

--- a/ghost/core/core/server/api/endpoints/utils/permissions.js
+++ b/ghost/core/core/server/api/endpoints/utils/permissions.js
@@ -41,7 +41,8 @@ const nonePublicAuth = async (apiConfig, frame) => {
     }
 
     try {
-        const result = await permissions.canThis(frame.options.context)[apiConfig.method][singular](permissionIdentifier, unsafeAttrObject);
+        const permissionCheck = permissions.canThis(frame.options.context)[apiConfig.method][singular];
+        const result = await permissionCheck(permissionIdentifier, unsafeAttrObject);
 
         /*
          * Allow the permissions function to return a list of excluded attributes.

--- a/ghost/core/core/server/data/importer/handlers/json.js
+++ b/ghost/core/core/server/data/importer/handlers/json.js
@@ -17,7 +17,8 @@ JSONHandler = {
     contentTypes: ['application/octet-stream', 'application/json'],
     directories: [],
 
-    loadFile: async function (files, startDir) { // eslint-disable-line no-unused-vars
+    // eslint-disable-next-line no-unused-vars
+    loadFile: async function (files, startDir) {
         debug('loadFile', files);
         // @TODO: Handle multiple JSON files
         const filePath = files[0].path;

--- a/ghost/core/core/server/data/migrations/versions/5.19/2022-09-02-20-52-backfill-new-product-columns.js
+++ b/ghost/core/core/server/data/migrations/versions/5.19/2022-09-02-20-52-backfill-new-product-columns.js
@@ -22,7 +22,8 @@ module.exports = createTransactionalMigration(
             logging.info(`Updating ${rows.length} Tiers with price and currency information`);
         }
 
-        for (const row of rows) { // eslint-disable-line no-restricted-syntax
+        // eslint-disable-next-line no-restricted-syntax
+        for (const row of rows) {
             await knex('products').update(row).where('id', row.id);
         }
     },

--- a/ghost/core/core/server/data/migrations/versions/5.21/2022-10-26-04-50-member-subscription-created-batch-id.js
+++ b/ghost/core/core/server/data/migrations/versions/5.21/2022-10-26-04-50-member-subscription-created-batch-id.js
@@ -26,14 +26,16 @@ module.exports = createTransactionalMigration(
         }
 
         // Attach a unique id to each row
-        for (const row of rows) { // eslint-disable-line no-restricted-syntax
+        // eslint-disable-next-line no-restricted-syntax
+        for (const row of rows) {
             row.batch_id = ObjectId().toHexString();
         }
 
         // Create batches (insertBatch doesn't support the onConflict option)
         const batches = _.chunk(rows, 1000);
     
-        for (const batch of batches) { // eslint-disable-line no-restricted-syntax
+        // eslint-disable-next-line no-restricted-syntax
+        for (const batch of batches) {
             // Update the members_created_events table using INSERT ON DUPLICATE KEY UPDATE trick
             const response1 = await knex('members_created_events').insert(batch.map((r) => {
                 return {

--- a/ghost/core/core/server/data/migrations/versions/5.22/2022-10-31-12-03-backfill-new-product-columns.js
+++ b/ghost/core/core/server/data/migrations/versions/5.22/2022-10-31-12-03-backfill-new-product-columns.js
@@ -25,7 +25,8 @@ module.exports = createTransactionalMigration(
             logging.info(`Updating ${rows.length} Tiers with price and currency information`);
         }
 
-        for (const row of rows) { // eslint-disable-line no-restricted-syntax
+        // eslint-disable-next-line no-restricted-syntax
+        for (const row of rows) {
             await knex('products').update(row).where('id', row.id);
         }
     },

--- a/ghost/core/core/server/data/seeders/importers/members-created-events-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-created-events-importer.js
@@ -20,15 +20,16 @@ class MembersCreatedEventsImporter extends TableImporter {
     }
 
     generateSource() {
-        let source = 'member';
         if (luck(10)) {
-            source = 'admin';
-        } else if (luck(5)) {
-            source = 'api';
-        } else if (luck(5)) { // eslint-disable-line no-dupe-else-if
-            source = 'import';
+            return 'admin';
         }
-        return source;
+        if (luck(5)) {
+            return 'api';
+        }
+        if (luck(5)) {
+            return 'import';
+        }
+        return 'member';
     }
 
     generate() {

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -6,7 +6,9 @@ import type {GhostMetrics} from '@tryghost/metrics';
 import type SettingsCache from '../../../shared/settings-cache';
 import {EmailAnalyticsServiceWrapper} from './email-analytics-service-wrapper';
 // @ts-expect-error This module lacks type definitions.
-import {AGGREGATE_MEMBER_STATS_METRIC_NAME, NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analytics-batch-processor';
+import {AGGREGATE_MEMBER_STATS_METRIC_NAME} from './newsletter-email-analytics-batch-processor';
+// @ts-expect-error This module lacks type definitions.
+import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analytics-batch-processor';
 // @ts-expect-error This module lacks type definitions.
 import NewsletterEmailEventStorage from '../email-service/newsletter-email-event-storage';
 // @ts-expect-error This module lacks type definitions.

--- a/ghost/core/core/server/services/email-suppression-list/email-suppression-list.js
+++ b/ghost/core/core/server/services/email-suppression-list/email-suppression-list.js
@@ -63,7 +63,8 @@ class AbstractEmailSuppressionList {
      * @param {string} email
      * @returns {Promise<boolean>}
      */
-    async removeEmail(email) { // eslint-disable-line
+    // eslint-disable-next-line
+    async removeEmail(email) {
         return Promise.reject();
     }
 
@@ -71,7 +72,8 @@ class AbstractEmailSuppressionList {
      * @param {string} email
      * @returns {Promise<EmailSuppressionData>}
      */
-    async getSuppressionData(email) { // eslint-disable-line
+    // eslint-disable-next-line
+    async getSuppressionData(email) {
         return Promise.reject();
     }
 

--- a/koenig/kg-card-factory/eslint.config.mjs
+++ b/koenig/kg-card-factory/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
         plugins: {ghost: ghostPlugin},
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
             '@typescript-eslint/no-explicit-any': 'error'
         }
     },

--- a/koenig/kg-clean-basic-html/eslint.config.mjs
+++ b/koenig/kg-clean-basic-html/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
     plugins: { ghost: ghostPlugin },
     rules: {
       ...ghostPlugin.configs.ts.rules,
+      // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+      ...ghostPlugin.configs['ts-no-style'].rules,
+      camelcase: ghostPlugin.configs.ts.rules.camelcase,
+      curly: ghostPlugin.configs.ts.rules.curly,
+      'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
       '@typescript-eslint/no-explicit-any': 'error',
     },
   },

--- a/koenig/kg-converters/eslint.config.mjs
+++ b/koenig/kg-converters/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
     plugins: { ghost: ghostPlugin },
     rules: {
       ...ghostPlugin.configs.ts.rules,
+      // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+      ...ghostPlugin.configs['ts-no-style'].rules,
+      camelcase: ghostPlugin.configs.ts.rules.camelcase,
+      curly: ghostPlugin.configs.ts.rules.curly,
+      'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
       '@typescript-eslint/no-explicit-any': 'error',
     },
   },

--- a/koenig/kg-default-cards/eslint.config.mjs
+++ b/koenig/kg-default-cards/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
         plugins: {ghost: ghostPlugin},
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
             '@typescript-eslint/no-explicit-any': 'error'
         }
     },

--- a/koenig/kg-default-transforms/eslint.config.mjs
+++ b/koenig/kg-default-transforms/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
         plugins: {ghost: ghostPlugin},
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
             '@typescript-eslint/no-explicit-any': 'error'
         }
     },

--- a/koenig/kg-html-to-lexical/eslint.config.mjs
+++ b/koenig/kg-html-to-lexical/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
         plugins: {ghost: ghostPlugin},
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
             '@typescript-eslint/no-explicit-any': 'error'
         }
     },

--- a/koenig/kg-markdown-html-renderer/eslint.config.mjs
+++ b/koenig/kg-markdown-html-renderer/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
         plugins: {ghost: ghostPlugin},
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
             '@typescript-eslint/no-explicit-any': 'error'
         }
     },

--- a/koenig/kg-unsplash-selector/eslint.config.js
+++ b/koenig/kg-unsplash-selector/eslint.config.js
@@ -38,6 +38,11 @@ export default defineConfig([
         },
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
 
             // sort multiple import lines into alphabetical groups
             'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {

--- a/koenig/kg-utils/eslint.config.mjs
+++ b/koenig/kg-utils/eslint.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig([
         plugins: {ghost: ghostPlugin},
         rules: {
             ...ghostPlugin.configs.ts.rules,
+            // Formatting is owned by Oxfmt; keep the non-formatting rules ts-no-style also switches off
+            ...ghostPlugin.configs['ts-no-style'].rules,
+            camelcase: ghostPlugin.configs.ts.rules.camelcase,
+            curly: ghostPlugin.configs.ts.rules.curly,
+            'dot-notation': ghostPlugin.configs.ts.rules['dot-notation'],
             '@typescript-eslint/no-explicit-any': 'error'
         }
     },

--- a/packages/i18n/test/i18n.lint.js
+++ b/packages/i18n/test/i18n.lint.js
@@ -272,7 +272,8 @@ class LinterContext {
             resultsToFilter.add(resultIndex);
         }
 
-        console.log(`Applied ${this._fixes.length} fixes`); // eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.log(`Applied ${this._fixes.length} fixes`);
 
         for (const resultIndex of resultsToFilter) {
             this.summary.results[resultIndex].messages = this.summary.results[resultIndex].messages.filter(Boolean);
@@ -310,17 +311,20 @@ async function exitWithSummary(summary) {
     const formattedResults = await formatter.format(summary.results, {cwd: '', rulesMeta: {}});
 
     if (formattedResults) {
-        console.log(formattedResults); // eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.log(formattedResults);
     }
 
     if (summary.ignoreAllFlagProvidedWithoutFixFlag) {
-        console.warn( // eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.warn(
             '--unsafe-ignore-all was provided without --fix; errors were not ignored'
         );
     }
 
     if (summary.errorCount > 0) {
-        console.log( // eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.log(
             `\nNote: Since JSON doesn't support comments, use test/i18n-ignore.json to waive messages.\n\n`
         );
         process.exit(1);
@@ -479,7 +483,8 @@ async function analyze() {
 
 if (require.main === module) {
     analyze().then(results => exitWithSummary(results)).catch((error) => {
-        console.error(error); // eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.error(error);
         process.exit(1);
     });
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-137

Groundwork so the upcoming full-repo Oxfmt run can be a pure formatting commit. Formatting everything and then linting surfaced two classes of breakage; both are fixed here without any formatting churn.

**ESLint configs still on the styled `ghostPlugin.configs.ts` (e2e + nine `koenig/kg-*` packages)**
Those enforce `indent`, `quotes`, `arrow-parens` and `implicit-arrow-linebreak`, which fight the formatter (160 errors after a dry run). They now also spread `ts-no-style`, re-enabling only `camelcase`, `curly` and `dot-notation` from the rules it switches off. Every other workspace already uses the formatter-neutral shared factory. Changeset with `none` bumps included for the koenig packages.

**Inline directives that stop covering their line once Oxfmt reflows the code**
- 36 trailing `// eslint-disable-line …` on block openers / open calls → `// eslint-disable-next-line …`
- `@ts-expect-error` above an over-long import that Oxfmt wraps → import split so each directive covers one line
- Two `-next-line` directives above statements Oxfmt splits (`fetch-api.ts`, signup-form `attribution.test.ts`) → scoped `/* eslint-disable … */ … /* eslint-enable … */`
- Two `.map(...)[type](...)` chains that Oxfmt breaks into a `no-unexpected-multiline` violation (`helpers/has.js`, `api/endpoints/utils/permissions.js`) → split into two statements
- `members-created-events-importer.js` seeder rewritten as early returns instead of a `no-dupe-else-if` suppression
- Removed the stray `` ``; `` in `newsletter-detail-modal.tsx` (accidental leftover from #19148) instead of keeping its suppression

**Verification**
- `nx run-many -t lint` on this branch as-is: 39/39 projects clean
- `oxfmt .` on top of this branch, then `nx run-many -t lint`: 39/39 projects clean (formatting not committed)
- Unit tests for frontend helpers, permissions service, email-analytics; e2e-api posts/tags suites: passing