### PR TITLE
Added Oxfmt format scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "lint:boundaries": "depcruise ghost/core/core apps --config .dependency-cruiser.cjs",
     "lint:packages": "node scripts/check-internal-packages.js",
     "lint:docs": "pnpm lint:agent-skills && pnpm lint:agent-guidance && pnpm lint:markdown && pnpm lint:doc-links",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
     "check": "pnpm lint && pnpm test",
     "test": "pnpm nx run-many -t test --exclude @tryghost/e2e --exclude ghost-admin",
     "test:unit": "pnpm nx run-many -t test:unit",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-137

Groundwork for the full-repo Oxfmt cutover: `pnpm format` / `pnpm format:check` root scripts, so there is one spelling for running the formatter. No enforcement yet — the CI check and lint-staged wiring land with the cutover so there is no half-state where CI reports thousands of unformatted files.

Also verified (no change needed): formatting every Markdown file in the repo and running `pnpm lint:docs` (markdownlint, remark link validation, agent skill/guidance checks) passes, so Markdown needs no overrides or ignores.