### PR TITLE
Added automation entry stats to the list view

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -12,6 +12,16 @@ export type Automation = {
     status: AutomationStatus;
 }
 
+export type AutomationStats = {
+    last_run_created_at: string | null;
+    total_run_count: number;
+    in_progress_run_count: number;
+}
+
+export type AutomationBrowseItem = Automation & {
+    stats: AutomationStats;
+}
+
 export type AutomationWaitAction = {
     id: string;
     type: 'wait';
@@ -62,7 +72,7 @@ export type EditAutomationPayload = {
 
 export interface AutomationsResponseType {
     meta?: Meta;
-    automations: Automation[];
+    automations: AutomationBrowseItem[];
 }
 
 export interface AutomationDetailResponseType {

--- a/apps/admin/src/automations/automations.acceptance.test.tsx
+++ b/apps/admin/src/automations/automations.acceptance.test.tsx
@@ -5,6 +5,7 @@ import { automationsScreen } from "./automations.screen";
 
 // Automations ships behind the `automations` beta labs flag.
 const AUTOMATIONS_ENABLED = { labs: { automations: true } };
+const RUN_ANALYTICS_ENABLED = { labs: { automations: true, automationRunAnalytics: true } };
 
 describe("Automations list", () => {
     it("renders the automations page", async () => {
@@ -12,18 +13,42 @@ describe("Automations list", () => {
         await renderAdminApp("/automations", AUTOMATIONS_ENABLED);
 
         await expect.element(automationsScreen.heading()).toBeVisible();
+        await expect.element(automationsScreen.columnHeader("Last entry")).not.toBeInTheDocument();
     });
 
     it("lists the welcome automations", async () => {
         fakeAutomations([
-            automation({ name: "Free member welcome flow", slug: "member-welcome-email-free", status: "active" }),
-            automation({ name: "Paid member welcome flow", slug: "member-welcome-email-paid", status: "inactive" }),
+            automation({
+                name: "Free member welcome flow",
+                slug: "member-welcome-email-free",
+                status: "active",
+                stats: {
+                    last_run_created_at: "2026-07-21T07:12:00.000Z",
+                    total_run_count: 1432,
+                    in_progress_run_count: 118,
+                },
+            }),
+            automation({
+                name: "Paid member welcome flow",
+                slug: "member-welcome-email-paid",
+                status: "inactive",
+                stats: {
+                    last_run_created_at: null,
+                    total_run_count: 0,
+                    in_progress_run_count: 0,
+                },
+            }),
         ]);
-        await renderAdminApp("/automations", AUTOMATIONS_ENABLED);
+        await renderAdminApp("/automations", RUN_ANALYTICS_ENABLED);
 
         await expect.element(automationsScreen.link("Free member welcome flow")).toBeVisible();
+        await expect.element(automationsScreen.columnHeader("Last entry")).toBeVisible();
+        await expect.element(automationsScreen.columnHeader("Total entries")).toBeVisible();
+        await expect.element(automationsScreen.columnHeader("In progress")).toBeVisible();
         const row = automationsScreen.rows();
         await expect.element(row).toHaveTextContent("Welcome new free members after they sign up.");
+        await expect.element(row).toHaveTextContent("1,432");
+        await expect.element(row).toHaveTextContent("118");
         await expect.element(row).toHaveTextContent("Live");
         // Stripe is disconnected in the default boot, which hides the paid welcome flow.
         await expect(automationsScreen.rows()).toHaveCount(1);

--- a/apps/admin/src/automations/automations.screen.ts
+++ b/apps/admin/src/automations/automations.screen.ts
@@ -5,6 +5,7 @@ import { automationListRow, automationsList, automationsPage } from "@tryghost/t
 export const automationsScreen = {
     heading: () => page.getByTestId(automationsPage).getByRole("heading", { name: "Automations" }),
     list: () => page.getByTestId(automationsList),
+    columnHeader: (name: string) => page.getByTestId(automationsList).getByRole("columnheader", { name }),
     rows: () => page.getByTestId(automationListRow),
     link: (name: string) => page.getByRole("link", { name, exact: true }),
 };

--- a/apps/admin/src/automations/automations.test.tsx
+++ b/apps/admin/src/automations/automations.test.tsx
@@ -3,6 +3,16 @@ import {MemoryRouter} from 'react-router';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 
+const mockRunAnalyticsFlag = vi.hoisted(() => ({enabled: true}));
+
+vi.mock('@tryghost/admin-x-framework/hooks', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/hooks')>('@tryghost/admin-x-framework/hooks');
+    return {
+        ...actual,
+        useFeatureFlag: () => mockRunAnalyticsFlag.enabled
+    };
+});
+
 const {mockUseBrowseAutomations, mockUseBrowseSettings, mockUseBrowseConfig, mockUseCurrentUser} = vi.hoisted(() => ({
     mockUseBrowseAutomations: vi.fn(),
     mockUseBrowseSettings: vi.fn(),
@@ -65,12 +75,22 @@ const automations = [{
     id: 'automation-id-1',
     name: 'Free member welcome flow',
     slug: 'member-welcome-email-free',
-    status: 'active' as const
+    status: 'active' as const,
+    stats: {
+        last_run_created_at: '2026-07-21T07:12:00.000Z',
+        total_run_count: 1432,
+        in_progress_run_count: 118
+    }
 }, {
     id: 'automation-id-2',
     name: 'Paid member welcome flow',
     slug: 'member-welcome-email-paid',
-    status: 'inactive' as const
+    status: 'inactive' as const,
+    stats: {
+        last_run_created_at: null,
+        total_run_count: 0,
+        in_progress_run_count: 0
+    }
 }];
 
 const stripeConnectedSettings = {
@@ -85,10 +105,22 @@ const renderPage = () => render(<MemoryRouter><Automations /></MemoryRouter>);
 describe('Automations', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockRunAnalyticsFlag.enabled = true;
         mockUseBrowseAutomations.mockReturnValue({data: {automations}, isError: false, isLoading: false});
         mockUseBrowseSettings.mockReturnValue({data: stripeConnectedSettings, isLoading: false});
         mockUseBrowseConfig.mockReturnValue({data: {config: {}}, isLoading: false});
         mockUseCurrentUser.mockReturnValue({data: {id: 'user-1', roles: [{name: 'Owner'}]}});
+    });
+
+    it('hides run analytics when the private feature is disabled', () => {
+        mockRunAnalyticsFlag.enabled = false;
+
+        renderPage();
+
+        expect(screen.queryByRole('columnheader', {name: 'Last entry'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', {name: 'Total entries'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', {name: 'In progress'})).not.toBeInTheDocument();
+        expect(screen.queryByText('1,432')).not.toBeInTheDocument();
     });
 
     it('shows free and paid sequences when Stripe is connected', () => {

--- a/apps/admin/src/automations/automations.tsx
+++ b/apps/admin/src/automations/automations.tsx
@@ -6,9 +6,11 @@ import {Box, Container} from '@tryghost/shade/primitives';
 import {ListPage} from '@tryghost/shade/page-templates';
 import {PageHeader} from '@tryghost/shade/patterns';
 import {useVisibleAutomations} from './hooks/use-visible-automations';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 
 const Automations: React.FC = () => {
     const {automations, error, isError, isLoading} = useVisibleAutomations();
+    const showRunAnalytics = useFeatureFlag('automationRunAnalytics');
 
     if (isError) {
         throw error instanceof Error ? error : new Error('Failed to load automations');
@@ -31,7 +33,7 @@ const Automations: React.FC = () => {
                     </PageHeader>
                 </ListPage.Header>
                 <ListPage.Body>
-                    <AutomationsList automations={automations} isLoading={isLoading} />
+                    <AutomationsList automations={automations} isLoading={isLoading} showRunAnalytics={showRunAnalytics} />
                     <AutomationsHelpCards />
                 </ListPage.Body>
             </ListPage>

--- a/apps/admin/src/automations/components/automations-list.test.tsx
+++ b/apps/admin/src/automations/components/automations-list.test.tsx
@@ -1,26 +1,45 @@
 import AutomationsList from './automations-list';
 import React from 'react';
 import {MemoryRouter} from 'react-router';
-import {describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 
 const automations = [{
     id: 'automation-id-1',
     name: 'Free member welcome flow',
     slug: 'member-welcome-email-free',
-    status: 'active' as const
+    status: 'active' as const,
+    stats: {
+        last_run_created_at: '2026-07-21T07:12:00.000Z',
+        total_run_count: 1432,
+        in_progress_run_count: 118
+    }
 }, {
     id: 'automation-id-2',
     name: 'Paid member welcome flow',
     slug: 'member-welcome-email-paid',
-    status: 'inactive' as const
+    status: 'inactive' as const,
+    stats: {
+        last_run_created_at: null,
+        total_run_count: 0,
+        in_progress_run_count: 0
+    }
 }];
 
 const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
 
 describe('AutomationsList', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-04T07:12:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('renders fetched automations with private beta copy and status labels', () => {
-        renderWithRouter(<AutomationsList automations={automations} />);
+        renderWithRouter(<AutomationsList automations={automations} showRunAnalytics={true} />);
 
         expect(screen.getAllByTestId('automation-list-row')).toHaveLength(2);
         expect(screen.getByText('Free member welcome flow')).toBeInTheDocument();
@@ -29,17 +48,40 @@ describe('AutomationsList', () => {
         expect(screen.getByText('Welcome new paid members after they start their subscription.')).toBeInTheDocument();
         expect(screen.getByText('Live')).toBeInTheDocument();
         expect(screen.getByText('Off')).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: 'Last entry'})).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: 'Total entries'})).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: 'In progress'})).toBeInTheDocument();
+        expect(screen.getByText('1,432')).toBeInTheDocument();
+        expect(screen.getByText('118')).toBeInTheDocument();
+        expect(screen.getByText('14 days ago')).toHaveAttribute('datetime', '2026-07-21T07:12:00.000Z');
+    });
+
+    it('renders Never when an automation has no last entry', () => {
+        renderWithRouter(<AutomationsList automations={[automations[1]]} showRunAnalytics={true} />);
+
+        expect(screen.getByText('Never')).toBeInTheDocument();
+    });
+
+    it('hides run analytics when the feature is disabled', () => {
+        renderWithRouter(<AutomationsList automations={automations} showRunAnalytics={false} />);
+
+        expect(screen.queryByRole('columnheader', {name: 'Last entry'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', {name: 'Total entries'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', {name: 'In progress'})).not.toBeInTheDocument();
+        expect(screen.queryByText('1,432')).not.toBeInTheDocument();
     });
 
     it('links each row to the automation sequence by id', () => {
         renderWithRouter(<AutomationsList automations={automations} />);
 
+        expect(screen.getByRole('table', {name: 'Automations'})).toBeInTheDocument();
+        expect(screen.getAllByRole('rowheader')).toHaveLength(2);
         expect(screen.getByRole('link', {name: 'Free member welcome flow'})).toHaveAttribute('href', '/automations/automation-id-1');
         expect(screen.getByRole('link', {name: 'Paid member welcome flow'})).toHaveAttribute('href', '/automations/automation-id-2');
     });
 
     it('renders a table skeleton while loading', () => {
-        renderWithRouter(<AutomationsList isLoading={true} />);
+        renderWithRouter(<AutomationsList isLoading={true} showRunAnalytics={true} />);
 
         expect(screen.getByTestId('automations-list-loading')).toBeInTheDocument();
     });

--- a/apps/admin/src/automations/components/automations-list.tsx
+++ b/apps/admin/src/automations/components/automations-list.tsx
@@ -1,35 +1,49 @@
 import AutomationStatusBadge from './automation-status-badge';
 import React from 'react';
-import type {Automation} from '@tryghost/admin-x-framework/api/automations';
+import type {AutomationBrowseItem} from '@tryghost/admin-x-framework/api/automations';
 import {Link} from '@tryghost/admin-x-framework';
-import {Skeleton, Table, TableBody, TableCell, TableRow} from '@tryghost/shade/components';
+import {Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
+import {cn, formatNumber} from '@tryghost/shade/utils';
+import moment from 'moment';
 
 const AUTOMATION_DESCRIPTIONS: Record<string, string> = {
     'member-welcome-email-free': 'Welcome new free members after they sign up.',
     'member-welcome-email-paid': 'Welcome new paid members after they start their subscription.'
 };
 
+const AUTOMATION_STAT_COLUMNS = [
+    {key: 'lastEntry', label: 'Last entry', widthClassName: 'w-40', skeletonWidthClassName: 'w-20'},
+    {key: 'totalEntries', label: 'Total entries', widthClassName: 'w-32', skeletonWidthClassName: 'w-10'},
+    {key: 'inProgressEntries', label: 'In progress', widthClassName: 'w-32', skeletonWidthClassName: 'w-10'}
+] as const;
+
 interface AutomationsListProps {
-    automations?: Automation[];
+    automations?: AutomationBrowseItem[];
     isLoading?: boolean;
+    showRunAnalytics?: boolean;
 }
 
-const AutomationsListSkeleton: React.FC = () => {
+const AutomationsListSkeleton: React.FC<{showRunAnalytics: boolean}> = ({showRunAnalytics}) => {
     return (
-        <Table className="flex flex-col border-t" data-testid="automations-list-loading">
-            <TableBody className="flex flex-col">
+        <Table aria-busy="true" aria-label="Automations" className={cn('flex table-fixed flex-col lg:table', !showRunAnalytics && 'border-t')} data-testid="automations-list-loading">
+            <TableBody className="flex flex-col lg:table-row-group">
                 {Array.from({length: 2}, (_, index) => (
                     <TableRow
                         key={index}
                         aria-hidden="true"
-                        className="grid w-full grid-cols-[1fr_auto] items-center gap-x-4 p-2 lg:p-0"
+                        className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 p-2 lg:table-row lg:p-0"
                     >
-                        <TableCell className="min-w-0 lg:p-4">
+                        <TableCell className="min-w-0 p-0 lg:table-cell lg:p-4">
                             <Skeleton className="mb-1 h-3 w-48 max-w-full " />
                             <Skeleton className="h-3 w-80 max-w-full" />
                         </TableCell>
-                        <TableCell className="text-right lg:w-32 lg:p-4">
-                            <Skeleton className="ml-auto h-3 w-16" />
+                        {showRunAnalytics && AUTOMATION_STAT_COLUMNS.map(column => (
+                            <TableCell key={column.key} className={cn('hidden lg:table-cell lg:p-4', column.widthClassName)}>
+                                <Skeleton className={cn('h-3', column.skeletonWidthClassName)} />
+                            </TableCell>
+                        ))}
+                        <TableCell className={cn('w-auto p-0 text-right lg:table-cell lg:p-4', showRunAnalytics ? 'lg:w-28 lg:text-left' : 'lg:w-32')}>
+                            <Skeleton className={cn('ml-auto h-3 w-16', showRunAnalytics && 'lg:ml-0')} />
                         </TableCell>
                     </TableRow>
                 ))}
@@ -38,24 +52,52 @@ const AutomationsListSkeleton: React.FC = () => {
     );
 };
 
-const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLoading = false}) => {
+const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLoading = false, showRunAnalytics = false}) => {
     if (isLoading) {
-        return <AutomationsListSkeleton />;
+        return <AutomationsListSkeleton showRunAnalytics={showRunAnalytics} />;
     }
 
     return (
-        <Table className="flex flex-col border-t" data-testid="automations-list">
-            <TableBody className="flex flex-col">
+        <Table aria-label="Automations" className={cn('flex table-fixed flex-col lg:table', !showRunAnalytics && 'border-t')} data-testid="automations-list">
+            {showRunAnalytics && (
+                <TableHeader className="hidden lg:table-header-group">
+                    <TableRow className="hover:bg-transparent">
+                        <TableHead className="lg:px-4" scope="col">Name</TableHead>
+                        {AUTOMATION_STAT_COLUMNS.map(column => (
+                            <TableHead key={column.key} className={cn('lg:px-4', column.widthClassName)} scope="col">{column.label}</TableHead>
+                        ))}
+                        <TableHead className="w-28 lg:px-4" scope="col">Status</TableHead>
+                    </TableRow>
+                </TableHeader>
+            )}
+            <TableBody className="flex flex-col lg:table-row-group">
                 {automations.map((automation) => {
                     const description = AUTOMATION_DESCRIPTIONS[automation.slug];
+                    const lastEntry = automation.stats.last_run_created_at;
+                    const totalEntries = automation.stats.total_run_count;
+                    const inProgressEntries = automation.stats.in_progress_run_count;
+                    const statCells = {
+                        lastEntry: {
+                            content: lastEntry ? <time dateTime={lastEntry}>{moment(lastEntry).fromNow()}</time> : 'Never',
+                            isEmpty: !lastEntry
+                        },
+                        totalEntries: {
+                            content: formatNumber(totalEntries),
+                            isEmpty: totalEntries === 0
+                        },
+                        inProgressEntries: {
+                            content: formatNumber(inProgressEntries),
+                            isEmpty: inProgressEntries === 0
+                        }
+                    };
 
                     return (
                         <TableRow
                             key={automation.slug}
-                            className="grid w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-x-4 p-2 hover:bg-table-row-hover lg:p-0"
+                            className="grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 p-2 hover:bg-table-row-hover lg:table-row lg:p-0"
                             data-testid="automation-list-row"
                         >
-                            <TableCell className="static min-w-0 lg:p-4">
+                            <TableHead className="static h-auto min-w-0 p-0 text-left text-base font-normal tracking-normal text-foreground lg:table-cell lg:p-4" scope="row">
                                 <Link
                                     className="before:absolute before:inset-0 before:z-10 before:rounded-sm focus-visible:outline-hidden focus-visible:before:ring-2 focus-visible:before:ring-focus-ring"
                                     to={`/automations/${automation.id}`}
@@ -69,8 +111,17 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
                                         {description}
                                     </span>
                                 )}
-                            </TableCell>
-                            <TableCell className="text-right lg:w-32 lg:p-4">
+                            </TableHead>
+                            {showRunAnalytics && AUTOMATION_STAT_COLUMNS.map((column) => {
+                                const cell = statCells[column.key];
+
+                                return (
+                                    <TableCell key={column.key} className={cn('hidden lg:table-cell lg:p-4', column.widthClassName, cell.isEmpty && 'text-muted-foreground')}>
+                                        {cell.content}
+                                    </TableCell>
+                                );
+                            })}
+                            <TableCell className={cn('w-auto p-0 text-right lg:table-cell lg:p-4', showRunAnalytics ? 'lg:w-28 lg:text-left' : 'lg:w-32')}>
                                 <AutomationStatusBadge status={automation.status} />
                             </TableCell>
                         </TableRow>

--- a/packages/testing/test-data/src/builders/automation.ts
+++ b/packages/testing/test-data/src/builders/automation.ts
@@ -8,6 +8,11 @@ export interface Automation {
     name: string;
     slug: string;
     status: "active" | "inactive";
+    stats: {
+        last_run_created_at: string | null;
+        total_run_count: number;
+        in_progress_run_count: number;
+    };
 }
 
 export const automation = createBuilder<Automation>(() => {
@@ -17,6 +22,11 @@ export const automation = createBuilder<Automation>(() => {
         id: generateId(),
         name,
         slug: `${generateSlug(name)}-${faker.string.alphanumeric(6).toLowerCase()}`,
-        status: "inactive"
+        status: "inactive",
+        stats: {
+            last_run_created_at: null,
+            total_run_count: 0,
+            in_progress_run_count: 0
+        }
     };
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1526

Added Last entry, Total entries, and In progress columns using stats from the automation browse API. Kept the mobile list focused on name and status, and gated the new stats behind automationRunAnalytics while run analytics remains experimental.

<img width="1560" height="1043" alt="image" src="https://github.com/user-attachments/assets/c60cfc64-480e-4e6f-a0c9-490391d1099e" />
