### PR TITLE
Changed Renovate automerge to rebase instead of squash

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,6 +45,13 @@
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,
+    // Merge automerged PRs by rebasing the branch's own commits onto the base
+    // instead of squashing. Renovate branches are a single, concise commit
+    // (e.g. "chore(deps): update X to Y"), so a squash merge would replace that
+    // clean message with the PR title *and* the full PR body — release-note
+    // tables, changelogs, dependency dashboards — producing a giant commit
+    // message on main. Rebase preserves the branch commit message verbatim.
+    "automergeStrategy": "rebase",
     // Branch protection does not require up-to-date branches (the required
     // status checks ruleset has strict: false), so a green-but-behind branch
     // is still mergeable. Rebasing on every `main` commit therefore buys


### PR DESCRIPTION
no ref

Renovate had no automergeStrategy set, so automerges used the platform default (squash). Squash merges compose the commit message from the PR title and full PR body, and Renovate PR bodies are huge (release-note tables, changelogs), producing giant commit messages on main. Renovate branches are a single concise commit, so rebasing preserves that clean message verbatim.