### PR TITLE
Fixed Mailgun tags for automation emails

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -420,10 +420,15 @@ class MemberWelcomeEmailService {
             tags = [MEMBER_WELCOME_EMAIL_TAG];
             sendEmail = this.#sendTransactionalEmail.bind(this);
             break;
-        case 'automation':
+        case 'automation': {
             tags = [AUTOMATION_EMAIL_TAG];
+            const mailgunTagFromConfig = config.get('bulkEmail:mailgun:tag');
+            if (typeof mailgunTagFromConfig === 'string' && mailgunTagFromConfig.length > 0) {
+                tags.push(mailgunTagFromConfig);
+            }
             sendEmail = this.#sendBulkEmail.bind(this);
             break;
+        }
         default: {
             /** @type {never} */ const _exhaustive = emailType;
             throw new errors.InternalServerError({

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -5,6 +5,7 @@ const testUtils = require('../../utils');
 const {mockManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const db = require('../../../core/server/data/db');
+const config = require('../../../core/shared/config');
 const MailgunClient = require('../../../core/server/services/lib/mailgun-client');
 const mailService = require('../../../core/server/services/mail');
 const settingsHelpers = require('../../../core/server/services/settings-helpers');
@@ -484,6 +485,17 @@ describe('Member Welcome Emails Integration', function () {
             sinon.assert.calledOnce(MailgunClient.prototype.send);
             const sendCall = MailgunClient.prototype.send.firstCall;
             assert.deepEqual(sendCall.args[0].tags, ['automation-email']);
+        });
+
+        it('adds the configured bulk email Mailgun tag to automation emails', async function () {
+            sinon.stub(config, 'get').callThrough()
+                .withArgs('bulkEmail:mailgun:tag').returns('blog-123');
+
+            await sendAutomationEmail();
+
+            sinon.assert.calledOnce(MailgunClient.prototype.send);
+            const sendCall = MailgunClient.prototype.send.firstCall;
+            assert.deepEqual(sendCall.args[0].tags, ['automation-email', 'blog-123']);
         });
 
         it('passes the open tracking value through for automation emails', async function () {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1535/re-add-the-blog-siteid-mailgun-tag-to-automation-emails
closes https://linear.app/ghost/issue/NY-1536/add-bulkemailmailguntag-to-each-automation-emails-tags-when-submitting

## Summary

- Apply the configured `bulkEmail:mailgun:tag` to real automation email sends.
- Preserve the existing `automation-email` classification and untagged fallback.
- Leave automation analytics filtering unchanged so production can transition safely before requiring the configured tag.

Automation sends call the lower-level Mailgun client directly and therefore bypass the provider that adds the configured site tag to newsletters. Adding the tag at the automation send boundary fixes that gap without prematurely excluding events from automation emails sent before this rollout.