### PR TITLE
Fixed flaky comments thread navigation acceptance test

### DIFF
--- a/apps/admin/src/comments/comments.acceptance.test.tsx
+++ b/apps/admin/src/comments/comments.acceptance.test.tsx
@@ -62,7 +62,9 @@ describe("Comments thread sidebar", () => {
         // Direct children carry no replied-to context in their parent's thread.
         await expect.element(commentsScreen.threadRow(firstReply.id).repliedToLink()).not.toBeInTheDocument();
 
-        await commentsScreen.threadRow(firstReply.id).repliesMetric().click();
+        const repliesLink = commentsScreen.threadRow(firstReply.id).repliesMetric();
+        await expect.element(repliesLink).toHaveAttribute("href", `#/comments?thread=is%3A${firstReply.id}`);
+        await repliesLink.click();
 
         await expect.poll(currentRoute).toContain(`thread=is%3A${firstReply.id}`);
         await expect.element(commentsScreen.threadRow(firstReply.id)).toBeVisible();


### PR DESCRIPTION
## What changed

- waits for the nested thread's exact `href` before clicking the replies metric
- keeps the existing route and rendered-thread assertions unchanged

## Why

The Admin acceptance test sometimes clicked the replies metric before it was ready as the expected link. Under CI load, the click completed without navigation and the route stayed on the original thread, causing the poll at line 67 to time out.

Failed run: https://github.com/TryGhost/Ghost/actions/runs/32174553586/job/95833865879

## Validation

- focused acceptance file passed 10 consecutive runs (40 tests)
- `pnpm check`
