### PR TITLE
Changed the Koenig font install to Liberation Sans from msttcorefonts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1035,34 +1035,19 @@ jobs:
       # of the runner image (setup-playwright deliberately avoids apt-get, see
       # its README note about hangs — scoping this to one matrix leg contains
       # that risk):
-      #  - MS core fonts: caret-position assertions depend on where text wraps,
-      #    which depends on Arial's font metrics
+      #  - Liberation Sans: caret-position assertions depend on where text wraps,
+      #    which depends on Arial's metrics. Liberation Sans is metric-compatible
+      #    with Arial and fontconfig aliases Arial to it, so wraps land the same.
+      #    Shipped in the Ubuntu repos, so no msttcorefonts SourceForge download
+      #    (that fetch hung CI indefinitely).
       #  - playwright firefox deps: system media codecs so firefox can decode
       #    the H.264 fixtures in the video card tests
-      # msttcorefonts downloads the font files from SourceForge at install time;
-      # mirror-redirect roulette there can hang indefinitely. timeout-minutes is
-      # the backstop, and each network op is bounded + retried so a stuck fetch
-      # fails fast and re-rolls onto a different mirror instead of sitting.
       - name: Install Koenig editor test dependencies (fonts + media codecs)
         if: matrix.app == '@tryghost/koenig-lexical'
-        timeout-minutes: 10
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          DEBCONF_NONINTERACTIVE_SEEN: "true"
+        timeout-minutes: 5
         run: |
-          sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
-          sudo apt-get update -yq -o Acquire::Retries=3 -o Acquire::http::Timeout=30
-          installed=
-          for i in 1 2 3; do
-            if sudo timeout -k 5 120 apt-get install -yq \
-                 -o Acquire::Retries=3 -o Acquire::http::Timeout=30 msttcorefonts; then
-              installed=1; break
-            fi
-            echo "msttcorefonts attempt $i failed/stuck, retrying..."; sleep 5
-          done
-          if [ -z "$installed" ]; then
-            echo "msttcorefonts failed after 3 attempts"; exit 1
-          fi
+          sudo apt-get update -yq
+          sudo apt-get install -yq fonts-liberation
           pnpm exec playwright install-deps firefox
 
       - name: Run Playwright tests


### PR DESCRIPTION
## Summary

Follow-up to #30087 (Option B from that discussion). #30087 bounded the `msttcorefonts` install so a stuck SourceForge fetch fails fast. This removes the SourceForge dependency entirely.

`msttcorefonts` downloads the actual font files from SourceForge **at install time** — the source of the CI hang. `fonts-liberation` ships **Liberation Sans** from the Ubuntu repos: no network fetch, no EULA prompt. Liberation Sans is **metric-compatible with Arial** (identical advance widths) and fontconfig aliases `Arial` → Liberation Sans, so text wraps at the same place and the caret-position assertions should hold.

## Changes

- Install `fonts-liberation` instead of `msttcorefonts`.
- Drop the debconf EULA plumbing, the apt `Acquire` retry/timeout options, and the timeout-guarded retry loop — none needed without a network download.
- `timeout-minutes: 5` retained as a cheap backstop.

## Risk / validation

This is a **behavioral change to what the tests render against** — the font is now Liberation Sans (Arial-aliased) rather than genuine Arial. Advance widths match, so wrap points and caret positions should be identical, but this needs the koenig-lexical acceptance leg to go green to confirm. Watching CI on this PR.

Supersedes the retry/timeout approach in #30087 if it passes; otherwise #30087 already keeps CI unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)