### PR TITLE
🐛 Fixed donation checkout failing when the note label translation is too long

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1261,20 +1261,24 @@ module.exports = class RouterController {
     }
 };
 
+// Stripe's limit on `custom_fields[].label.custom` — longer labels make session creation fail
+const STRIPE_CUSTOM_FIELD_LABEL_MAX_LENGTH = 50;
+
 function parsePersonalNote(rawText) {
     if (rawText && typeof rawText !== 'string') {
         logging.warn('Donation personal note is not a string, ignoring');
         return '';
     }
-    if (rawText && rawText.length > 255) {
-        logging.warn('Donation personal note is too long, ignoring:', rawText);
-        return '';
-    }
 
-    const safeInput = sanitizeHtml(rawText, {
+    // Bounded twice, for two different reasons. Before sanitising because this is a
+    // public endpoint and nothing past the limit can survive anyway, so there is no
+    // reason to sanitise more than that. After, because sanitising can lengthen the
+    // string (`&` becomes `&amp;`), and the second bound is the one Stripe measures.
+    const bounded = (rawText ?? '').slice(0, STRIPE_CUSTOM_FIELD_LABEL_MAX_LENGTH);
+    const safeInput = sanitizeHtml(bounded, {
         allowedTags: [],
         allowedAttributes: {}
     });
 
-    return safeInput;
+    return safeInput.slice(0, STRIPE_CUSTOM_FIELD_LABEL_MAX_LENGTH);
 }

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -584,7 +584,7 @@ describe('RouterController', function () {
                     }
                 }));
             });
-            it('silently discards too-long personal notes', async function () {
+            it('truncates too-long personal notes', async function () {
                 const routerController = new RouterController({
                     tiersService,
                     paymentsService,
@@ -604,7 +604,7 @@ describe('RouterController', function () {
                         type: 'donation',
                         successUrl: 'https://example.com/?type=success',
                         cancelUrl: 'https://example.com/?type=cancel',
-                        personalNote: 'a'.repeat(1000),
+                        personalNote: 'a'.repeat(51),
                         metadata: {
                             test: 'hello',
                             urlHistory: [
@@ -626,7 +626,103 @@ describe('RouterController', function () {
                 sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
-                    personalNote: '',
+                    personalNote: 'a'.repeat(50),
+                    metadata: {
+                        test: 'hello'
+                    }
+                }));
+            });
+            it('bounds a personal note far past the limit', async function () {
+                const routerController = new RouterController({
+                    tiersService,
+                    paymentsService,
+                    offersAPI,
+                    stripeAPIService,
+                    labsService,
+                    settingsCache,
+                    settingsHelpers,
+                    urlUtils,
+                    memberAttributionService: {
+                        getAttribution: sinon.stub().resolves({})
+                    }
+                });
+
+                await routerController.createCheckoutSession({
+                    body: {
+                        type: 'donation',
+                        successUrl: 'https://example.com/?type=success',
+                        cancelUrl: 'https://example.com/?type=cancel',
+                        personalNote: 'a'.repeat(10000),
+                        metadata: {
+                            test: 'hello',
+                            urlHistory: [
+                                {
+                                    path: 'https://example.com/',
+                                    time: Date.now(),
+                                    referrerMedium: null,
+                                    referrerSource: 'ghost-explore',
+                                    referrerUrl: 'https://example.com/blog/'
+                                }
+                            ]
+                        }
+                    }
+                }, {
+                    writeHead: () => {},
+                    end: () => {}
+                });
+                sinon.assert.calledOnce(getDonationLinkSpy);
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
+                    successUrl: 'https://example.com/?type=success',
+                    cancelUrl: 'https://example.com/?type=cancel',
+                    personalNote: 'a'.repeat(50),
+                    metadata: {
+                        test: 'hello'
+                    }
+                }));
+            });
+            it('truncates personal notes that grow past the limit when sanitised', async function () {
+                const routerController = new RouterController({
+                    tiersService,
+                    paymentsService,
+                    offersAPI,
+                    stripeAPIService,
+                    labsService,
+                    settingsCache,
+                    settingsHelpers,
+                    urlUtils,
+                    memberAttributionService: {
+                        getAttribution: sinon.stub().resolves({})
+                    }
+                });
+
+                await routerController.createCheckoutSession({
+                    body: {
+                        type: 'donation',
+                        successUrl: 'https://example.com/?type=success',
+                        cancelUrl: 'https://example.com/?type=cancel',
+                        personalNote: 'a'.repeat(30) + '&'.repeat(10),
+                        metadata: {
+                            test: 'hello',
+                            urlHistory: [
+                                {
+                                    path: 'https://example.com/',
+                                    time: Date.now(),
+                                    referrerMedium: null,
+                                    referrerSource: 'ghost-explore',
+                                    referrerUrl: 'https://example.com/blog/'
+                                }
+                            ]
+                        }
+                    }
+                }, {
+                    writeHead: () => {},
+                    end: () => {}
+                });
+                sinon.assert.calledOnce(getDonationLinkSpy);
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
+                    successUrl: 'https://example.com/?type=success',
+                    cancelUrl: 'https://example.com/?type=cancel',
+                    personalNote: 'a'.repeat(30) + '&amp;'.repeat(4),
                     metadata: {
                         test: 'hello'
                     }

--- a/packages/i18n/locales/context.json
+++ b/packages/i18n/locales/context.json
@@ -10,7 +10,7 @@
     "Account": "A label in Portal for your account area",
     "Account details updated successfully": "Popover message in Portal",
     "Account settings": "A label in Portal for your account settings",
-    "Add a personal note": "Becomes the field label for donations in Stripe",
+    "Add a personal note": "Becomes the field label for donations in Stripe, which limits it to 50 characters",
     "Add comment": "Button text to post a comment",
     "Add context to your comment, share your name and expertise to foster a healthy discussion.": "Invitation to include additional info when commenting",
     "Add reply": "Button text to post your reply",


### PR DESCRIPTION
## Problem
Ghost's donation checkout labels the optional message field in Stripe Checkout with a translated string ("Add a personal note"). Stripe rejects the entire checkout session if that label is longer than 50 characters, but Ghost only rejected labels over 255 characters. A translation between 51 and 255 characters would therefore stop the donation checkout from opening for every site in that locale, with visitors seeing only a generic error.

## Solution
The label is now truncated to Stripe's 50-character limit, applied after HTML sanitisation since sanitising can lengthen the string. Truncating rather than rejecting keeps the label in the site's language instead of falling back to the English default. The translator-facing description of the string now also mentions the 50-character limit so longer translations are caught before they ship.