### PR TITLE
🐛 Fixed negated newsletter filters being read as their opposite

### DIFF
--- a/apps/admin/src/members/member-filter-query.test.ts
+++ b/apps/admin/src/members/member-filter-query.test.ts
@@ -36,6 +36,28 @@ describe('member-filter-query', () => {
         ]);
     });
 
+    it('reads newsletter subscription state from the slug clause polarity', () => {
+        expect(stripIds(parseMemberFilter('(newsletters.slug:-weekly,email_disabled:1)', 'UTC'))).toEqual([
+            {field: 'newsletters.weekly', operator: 'is', values: ['unsubscribed']}
+        ]);
+
+        // Hand-written shapes pairing the slug with the "wrong" join and
+        // email_disabled value still follow the slug's polarity.
+        expect(stripIds(parseMemberFilter('(newsletters.slug:-weekly+email_disabled:0)', 'UTC'))).toEqual([
+            {field: 'newsletters.weekly', operator: 'is', values: ['unsubscribed']}
+        ]);
+
+        expect(stripIds(parseMemberFilter('(newsletters.slug:weekly,email_disabled:1)', 'UTC'))).toEqual([
+            {field: 'newsletters.weekly', operator: 'is', values: ['subscribed']}
+        ]);
+    });
+
+    it('round-trips a mismatched unsubscribed compound to the canonical shape', () => {
+        const parsed = parseMemberFilter('(newsletters.slug:-weekly+email_disabled:0)', 'UTC');
+
+        expect(serializeMemberFilters(parsed, 'UTC')).toBe('(newsletters.slug:-weekly,email_disabled:1)');
+    });
+
     it('parses legacy scalar set filters and preserves singleton offer ids', () => {
         const parsed = parseMemberFilter('offer_redemptions:\'offer_123\'', 'UTC');
 

--- a/apps/admin/src/members/member-filter-query.ts
+++ b/apps/admin/src/members/member-filter-query.ts
@@ -103,13 +103,15 @@ function matchNewsletterGroupedNode(node: AstNode): ParsedPredicate | null {
     }
 
     let slug: string | undefined;
-    let emailDisabledValue: number | undefined;
+    let slugNegated = false;
+    let hasEmailDisabled = false;
 
     for (const child of compound.children) {
         const newsletterSlug = child['newsletters.slug'];
 
         if (typeof newsletterSlug === 'string') {
             slug = newsletterSlug;
+            slugNegated = false;
         }
 
         if (
@@ -119,34 +121,27 @@ function matchNewsletterGroupedNode(node: AstNode): ParsedPredicate | null {
             typeof (newsletterSlug as Record<string, unknown>).$ne === 'string'
         ) {
             slug = (newsletterSlug as Record<string, string>).$ne;
+            slugNegated = true;
         }
 
         if (typeof child.email_disabled === 'number') {
-            emailDisabledValue = child.email_disabled;
+            hasEmailDisabled = true;
         }
     }
 
-    if (!slug) {
+    if (!slug || !hasEmailDisabled) {
         return null;
     }
 
-    if (compound.operator === '$and' && emailDisabledValue === 0) {
-        return {
-            field: `newsletters.${slug}`,
-            operator: 'is',
-            values: ['subscribed']
-        };
-    }
-
-    if (compound.operator === '$or' && emailDisabledValue === 1) {
-        return {
-            field: `newsletters.${slug}`,
-            operator: 'is',
-            values: ['unsubscribed']
-        };
-    }
-
-    return null;
+    // The slug clause's polarity is the subscription state. Serialize pairs it
+    // with a fixed join + email_disabled shape, but hand-written filters may
+    // pair them differently; the email_disabled clause only marks the compound
+    // as a newsletter subscription filter and never flips its meaning.
+    return {
+        field: `newsletters.${slug}`,
+        operator: 'is',
+        values: [slugNegated ? 'unsubscribed' : 'subscribed']
+    };
 }
 
 function matchFeedbackGroupedNode(node: AstNode): ParsedPredicate | null {


### PR DESCRIPTION
## Problem

A member segment filtering on a newsletter subscription with a negated slug (saying "not subscribed") was read by Admin as its opposite ("subscribed"). Because Admin writes the parsed filter back when a segment is saved, opening and saving such a filter silently inverted who it matched.

## Solution

The subscription state is now taken from the slug clause itself: a negated slug always reads as unsubscribed and a plain slug as subscribed, regardless of how the accompanying email-disabled clause is joined, which is the reading the legacy Ember admin used. Saved filters carrying these hand-written mismatched shapes will now be read by their slug's meaning rather than inverted, and re-saving normalizes them to the canonical shape. Ghost itself only ever writes the canonical shapes, which are unaffected.
