### PR TITLE
Added async export request endpoint for one-click data export

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -117,7 +117,7 @@ export type Config = {
     export?: {
       // Host archive webhook — when set, "Export data" delivers the
       // archive by email instead of a synchronous download
-      generate_archive_url?: string;
+      webhookUrl?: string;
     };
   };
   security?: {

--- a/apps/admin-x-framework/src/api/exports.ts
+++ b/apps/admin-x-framework/src/api/exports.ts
@@ -1,5 +1,5 @@
-import {blobDownloadFromEndpoint, type BlobDownloadOptions} from '../utils/helpers';
-import {createMutation} from '../utils/api/hooks';
+import { blobDownloadFromEndpoint, type BlobDownloadOptions } from '../utils/helpers';
+import { createMutation } from '../utils/api/hooks';
 
 export type SiteExportComponent = 'content' | 'members' | 'analytics' | 'themes' | 'routes';
 
@@ -8,28 +8,35 @@ export type SiteExportComponent = 'content' | 'members' | 'analytics' | 'themes'
  * navigation so callers can observe completion, errors and cancellation —
  * a navigation download is invisible to the page.
  */
-export const downloadSiteExport = (components: SiteExportComponent[], options: BlobDownloadOptions = {}): Promise<void> => {
-    return blobDownloadFromEndpoint(`/exports/download/?components=${components.join(',')}`, 'site-export.zip', options);
+export const downloadSiteExport = (
+  components: SiteExportComponent[],
+  options: BlobDownloadOptions = {},
+): Promise<void> => {
+  return blobDownloadFromEndpoint(
+    `/exports/download/?components=${components.join(',')}`,
+    'site-export.zip',
+    options,
+  );
 };
 
 export type ExportComponents = {
-    content?: boolean;
-    members?: boolean;
-    analytics?: boolean;
-    themes?: boolean;
-    routes?: boolean;
-    media?: boolean;
+  content?: boolean;
+  members?: boolean;
+  analytics?: boolean;
+  themes?: boolean;
+  routes?: boolean;
+  media?: boolean;
 };
 
 export type ExportRequestPayload = {
-    components: ExportComponents;
+  components: ExportComponents;
 };
 
 export const useRequestExport = createMutation<unknown, ExportRequestPayload>({
-    method: 'POST',
-    path: () => '/exports/',
-    body: ({components}) => ({components}),
-    // Not idempotent: each delivered request can schedule an archive and an
-    // email, so a lost response must not trigger an automatic re-send.
-    retry: false
+  method: 'POST',
+  path: () => '/exports/',
+  body: ({ components }) => ({ components }),
+  // Not idempotent: each delivered request can schedule an archive and an
+  // email, so a lost response must not trigger an automatic re-send.
+  retry: false,
 });

--- a/apps/admin-x-framework/src/api/exports.ts
+++ b/apps/admin-x-framework/src/api/exports.ts
@@ -1,4 +1,5 @@
-import { blobDownloadFromEndpoint, type BlobDownloadOptions } from '../utils/helpers';
+import {blobDownloadFromEndpoint, type BlobDownloadOptions} from '../utils/helpers';
+import {createMutation} from '../utils/api/hooks';
 
 export type SiteExportComponent = 'content' | 'members' | 'analytics' | 'themes' | 'routes';
 
@@ -7,13 +8,28 @@ export type SiteExportComponent = 'content' | 'members' | 'analytics' | 'themes'
  * navigation so callers can observe completion, errors and cancellation —
  * a navigation download is invisible to the page.
  */
-export const downloadSiteExport = (
-  components: SiteExportComponent[],
-  options: BlobDownloadOptions = {},
-): Promise<void> => {
-  return blobDownloadFromEndpoint(
-    `/exports/download/?components=${components.join(',')}`,
-    'site-export.zip',
-    options,
-  );
+export const downloadSiteExport = (components: SiteExportComponent[], options: BlobDownloadOptions = {}): Promise<void> => {
+    return blobDownloadFromEndpoint(`/exports/download/?components=${components.join(',')}`, 'site-export.zip', options);
 };
+
+export type ExportComponents = {
+    content?: boolean;
+    members?: boolean;
+    analytics?: boolean;
+    themes?: boolean;
+    routes?: boolean;
+    media?: boolean;
+};
+
+export type ExportRequestPayload = {
+    components: ExportComponents;
+};
+
+export const useRequestExport = createMutation<unknown, ExportRequestPayload>({
+    method: 'POST',
+    path: () => '/exports/',
+    body: ({components}) => ({components}),
+    // Not idempotent: each delivered request can schedule an archive and an
+    // email, so a lost response must not trigger an automatic re-send.
+    retry: false
+});

--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -1,132 +1,198 @@
-import { describe, expect, it } from 'vitest';
-import { page } from 'vitest/browser';
+import {describe, expect, it} from "vitest";
+import {page, userEvent} from "vitest/browser";
 
-import {
-  configResponse,
-  fakeAdminEndpoint,
-  fakeSettingsScreens,
-  renderAdminApp,
-} from '@test-utils/acceptance';
-import { settingsScreen } from '@/settings/settings.screen';
+import {configResponse, fakeAdminEndpoint, fakeSettingsScreens, renderAdminApp} from "@test-utils/acceptance";
+import {settingsScreen} from "@/settings/settings.screen";
 
 async function openExportTab() {
-  const section = settingsScreen.section('migrationtools');
-  await section.getByRole('tab', { name: 'Export' }).click();
-  return section;
+    const section = settingsScreen.section("migrationtools");
+    await section.getByRole("tab", {name: "Export"}).click();
+    return section;
 }
 
 /** A minimal but valid (empty) zip: just the end-of-central-directory record. */
 function emptyZip(): ArrayBuffer {
-  const bytes = new Uint8Array(22);
-  bytes.set([0x50, 0x4b, 0x05, 0x06]);
-  return bytes.buffer;
+    const bytes = new Uint8Array(22);
+    bytes.set([0x50, 0x4b, 0x05, 0x06]);
+    return bytes.buffer;
 }
 
 function fakeExportDownload() {
-  return fakeAdminEndpoint('GET', /^\/exports\/download\//, emptyZip(), {
-    contentType: 'application/zip',
-  });
+    return fakeAdminEndpoint("GET", /^\/exports\/download\//, emptyZip(), {contentType: "application/zip"});
 }
 
-describe('Migration tools export', () => {
-  it('keeps the individual export buttons without the selfServeArchives flag', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings/advanced');
-
-    const section = await openExportTab();
-    await expect.element(section.getByRole('button', { name: 'Content & settings' })).toBeVisible();
-    await expect.element(section.getByRole('button', { name: 'Post analytics' })).toBeVisible();
-    await expect
-      .element(section.getByRole('button', { name: 'Export data' }))
-      .not.toBeInTheDocument();
-  });
-
-  it('offers the sync export dialog without media and downloads the zip', async () => {
-    fakeSettingsScreens();
-    const download = fakeExportDownload();
-    await renderAdminApp('/settings/advanced', { labs: { selfServeArchives: true } });
-
-    const section = await openExportTab();
-    await section.getByRole('button', { name: 'Export data' }).click();
-
-    const dialog = page.getByRole('dialog');
-    await expect
-      .element(dialog.getByText('downloaded as a single zip', { exact: false }))
-      .toBeVisible();
-    await expect.element(dialog.getByText('Members', { exact: true })).toBeVisible();
-    await expect.element(dialog.getByText('Media files', { exact: true })).not.toBeInTheDocument();
-
-    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
-
-    // The dialog reaches a real done state once the download completes
-    await expect.element(dialog.getByText('Export complete', { exact: false })).toBeVisible();
-    expect(download.lastRequest?.url).toContain(
-      '/exports/download/?components=content,members,analytics,themes,routes',
-    );
-  });
-
-  it('only requests the selected components', async () => {
-    fakeSettingsScreens();
-    const download = fakeExportDownload();
-    await renderAdminApp('/settings/advanced', { labs: { selfServeArchives: true } });
-
-    const section = await openExportTab();
-    await section.getByRole('button', { name: 'Export data' }).click();
-
-    const dialog = page.getByRole('dialog');
-    await dialog.getByRole('checkbox', { name: 'Members' }).click();
-    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
-
-    await expect.element(dialog.getByText('Export complete', { exact: false })).toBeVisible();
-    expect(download.lastRequest?.url).toContain(
-      '/exports/download/?components=content,analytics,themes,routes',
-    );
-  });
-
-  it('returns to the selection and surfaces the error when the download fails', async () => {
-    fakeSettingsScreens();
-    fakeAdminEndpoint(
-      'GET',
-      /^\/exports\/download\//,
-      { errors: [{ message: 'Boom' }] },
-      { status: 500 },
-    );
-    await renderAdminApp('/settings/advanced', { labs: { selfServeArchives: true } });
-
-    const section = await openExportTab();
-    await section.getByRole('button', { name: 'Export data' }).click();
-
-    const dialog = page.getByRole('dialog');
-    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
-
-    // The error is surfaced, and we're back on the selection for a retry
-    await expect.element(page.getByText('Something went wrong, please try again.')).toBeVisible();
-    await expect.element(dialog.getByRole('button', { name: 'Export', exact: true })).toBeVisible();
-    await expect
-      .element(dialog.getByText('Export complete', { exact: false }))
-      .not.toBeInTheDocument();
-  });
-
-  it('offers media and email delivery when an archive host is configured', async () => {
-    fakeSettingsScreens();
-    const config = configResponse({ labs: { selfServeArchives: true } });
-    (config.config as { hostSettings?: object }).hostSettings = {
-      ...(config.config as { hostSettings?: object }).hostSettings,
-      export: { generate_archive_url: 'https://archives.example.com/generate' },
+async function renderWithArchiveHost() {
+    const config = configResponse({labs: {selfServeArchives: true}});
+    (config.config as {hostSettings?: object}).hostSettings = {
+        ...(config.config as {hostSettings?: object}).hostSettings,
+        export: {webhookUrl: "https://archives.example.com/generate"},
     };
-    await renderAdminApp('/settings/advanced', {
-      labs: { selfServeArchives: true },
-      boot: { browseConfig: { response: config } },
+    await renderAdminApp("/settings/advanced", {
+        labs: {selfServeArchives: true},
+        boot: {browseConfig: {response: config}},
+    });
+}
+
+describe("Migration tools export", () => {
+    it("keeps the individual export buttons without the selfServeArchives flag", async () => {
+        fakeSettingsScreens();
+        await renderAdminApp("/settings/advanced");
+
+        const section = await openExportTab();
+        await expect.element(section.getByRole("button", {name: "Content & settings"})).toBeVisible();
+        await expect.element(section.getByRole("button", {name: "Post analytics"})).toBeVisible();
+        await expect.element(section.getByRole("button", {name: "Export data"})).not.toBeInTheDocument();
     });
 
-    const section = await openExportTab();
-    await section.getByRole('button', { name: 'Export data' }).click();
+    it("offers the sync export dialog without media and downloads the zip", async () => {
+        fakeSettingsScreens();
+        const download = fakeExportDownload();
+        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
 
-    const dialog = page.getByRole('dialog');
-    await expect.element(dialog.getByText('sent to you by email', { exact: false })).toBeVisible();
-    await expect.element(dialog.getByText('Media files', { exact: true })).toBeVisible();
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
 
-    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
-    await expect.element(dialog.getByText('Exporting data', { exact: false })).toBeVisible();
-  });
+        const dialog = page.getByRole("dialog");
+        await expect.element(dialog.getByText("downloaded as a single zip", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Members", {exact: true})).toBeVisible();
+        await expect.element(dialog.getByText("Media files", {exact: true})).not.toBeInTheDocument();
+
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        // The dialog reaches a real done state once the download completes
+        await expect.element(dialog.getByText("Export complete", {exact: false})).toBeVisible();
+        expect(download.lastRequest?.url).toContain("/exports/download/?components=content,members,analytics,themes,routes");
+    });
+
+    it("only requests the selected components", async () => {
+        fakeSettingsScreens();
+        const download = fakeExportDownload();
+        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByRole("checkbox", {name: "Members"}).click();
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        await expect.element(dialog.getByText("Export complete", {exact: false})).toBeVisible();
+        expect(download.lastRequest?.url).toContain("/exports/download/?components=content,analytics,themes,routes");
+    });
+
+    it("returns to the selection and surfaces the error when the download fails", async () => {
+        fakeSettingsScreens();
+        fakeAdminEndpoint("GET", /^\/exports\/download\//, {errors: [{message: "Boom"}]}, {status: 500});
+        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        // The error is surfaced, and we're back on the selection for a retry
+        await expect.element(page.getByText("Something went wrong, please try again.")).toBeVisible();
+        await expect.element(dialog.getByRole("button", {name: "Export", exact: true})).toBeVisible();
+        await expect.element(dialog.getByText("Export complete", {exact: false})).not.toBeInTheDocument();
+    });
+
+    it("offers media and email delivery when an archive host is configured", async () => {
+        fakeSettingsScreens();
+        const exportsApi = fakeAdminEndpoint("POST", "/exports/", {}, {status: 202});
+        await renderWithArchiveHost();
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await expect.element(dialog.getByText("sent to you by email", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Media files", {exact: true})).toBeVisible();
+
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
+
+        // The default selection: everything except media
+        await expect.poll(() => exportsApi.lastRequest?.body).toEqual({
+            components: {
+                content: true,
+                members: true,
+                analytics: true,
+                themes: true,
+                routes: true,
+                media: false,
+            },
+        });
+    });
+
+    it("keeps the dialog open while the export request is in flight", async () => {
+        fakeSettingsScreens();
+        let releaseRequest!: () => void;
+        const gate = new Promise<void>((resolve) => {
+            releaseRequest = resolve;
+        });
+        fakeAdminEndpoint("POST", "/exports/", async () => {
+            await gate;
+            return {};
+        }, {status: 202});
+        await renderWithArchiveHost();
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        // Non-idempotent request: the dialog must not be dismissible while pending
+        await expect.element(dialog.getByRole("button", {name: "Cancel"})).toBeDisabled();
+        await userEvent.keyboard("{Escape}");
+        await expect.element(dialog.getByText("sent to you by email", {exact: false})).toBeVisible();
+
+        releaseRequest();
+        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
+    });
+
+    it("sends the selected components to the exports endpoint", async () => {
+        fakeSettingsScreens();
+        const exportsApi = fakeAdminEndpoint("POST", "/exports/", {}, {status: 202});
+        await renderWithArchiveHost();
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByText("Post analytics", {exact: true}).click();
+        await dialog.getByText("Media files", {exact: true}).click();
+
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
+
+        await expect.poll(() => exportsApi.lastRequest?.body).toEqual({
+            components: {
+                content: true,
+                members: true,
+                analytics: false,
+                themes: true,
+                routes: true,
+                media: true,
+            },
+        });
+    });
+
+    it("stays on the selection and surfaces an error when the export request fails", async () => {
+        fakeSettingsScreens();
+        // An older backend without the endpoint 404s — must not crash the dialog
+        fakeAdminEndpoint("POST", "/exports/", {}, {status: 404});
+        await renderWithArchiveHost();
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+
+        await expect.element(page.getByText("Something went wrong while loading exports", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Media files", {exact: true})).toBeVisible();
+        await expect.element(dialog.getByText("Exporting data", {exact: false})).not.toBeInTheDocument();
+    });
 });

--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -128,7 +128,9 @@ describe('Migration tools export', () => {
     await section.getByRole('button', { name: 'Export data' }).click();
 
     const dialog = page.getByRole('dialog');
-    await expect.element(dialog.getByText('sent to you by email', { exact: false })).toBeVisible();
+    await expect
+      .element(dialog.getByText('emailed to the site owner', { exact: false }))
+      .toBeVisible();
     await expect.element(dialog.getByText('Media files', { exact: true })).toBeVisible();
 
     await dialog.getByRole('button', { name: 'Export', exact: true }).click();
@@ -175,7 +177,9 @@ describe('Migration tools export', () => {
     // Non-idempotent request: the dialog must not be dismissible while pending
     await expect.element(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
     await userEvent.keyboard('{Escape}');
-    await expect.element(dialog.getByText('sent to you by email', { exact: false })).toBeVisible();
+    await expect
+      .element(dialog.getByText('emailed to the site owner', { exact: false }))
+      .toBeVisible();
 
     releaseRequest();
     await expect.element(dialog.getByText('Exporting data', { exact: false })).toBeVisible();

--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -1,198 +1,233 @@
-import {describe, expect, it} from "vitest";
-import {page, userEvent} from "vitest/browser";
+import { describe, expect, it } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 
-import {configResponse, fakeAdminEndpoint, fakeSettingsScreens, renderAdminApp} from "@test-utils/acceptance";
-import {settingsScreen} from "@/settings/settings.screen";
+import {
+  configResponse,
+  fakeAdminEndpoint,
+  fakeSettingsScreens,
+  renderAdminApp,
+} from '@test-utils/acceptance';
+import { settingsScreen } from '@/settings/settings.screen';
 
 async function openExportTab() {
-    const section = settingsScreen.section("migrationtools");
-    await section.getByRole("tab", {name: "Export"}).click();
-    return section;
+  const section = settingsScreen.section('migrationtools');
+  await section.getByRole('tab', { name: 'Export' }).click();
+  return section;
 }
 
 /** A minimal but valid (empty) zip: just the end-of-central-directory record. */
 function emptyZip(): ArrayBuffer {
-    const bytes = new Uint8Array(22);
-    bytes.set([0x50, 0x4b, 0x05, 0x06]);
-    return bytes.buffer;
+  const bytes = new Uint8Array(22);
+  bytes.set([0x50, 0x4b, 0x05, 0x06]);
+  return bytes.buffer;
 }
 
 function fakeExportDownload() {
-    return fakeAdminEndpoint("GET", /^\/exports\/download\//, emptyZip(), {contentType: "application/zip"});
+  return fakeAdminEndpoint('GET', /^\/exports\/download\//, emptyZip(), {
+    contentType: 'application/zip',
+  });
 }
 
 async function renderWithArchiveHost() {
-    const config = configResponse({labs: {selfServeArchives: true}});
-    (config.config as {hostSettings?: object}).hostSettings = {
-        ...(config.config as {hostSettings?: object}).hostSettings,
-        export: {webhookUrl: "https://archives.example.com/generate"},
-    };
-    await renderAdminApp("/settings/advanced", {
-        labs: {selfServeArchives: true},
-        boot: {browseConfig: {response: config}},
-    });
+  const config = configResponse({ labs: { selfServeArchives: true } });
+  (config.config as { hostSettings?: object }).hostSettings = {
+    ...(config.config as { hostSettings?: object }).hostSettings,
+    export: { webhookUrl: 'https://archives.example.com/generate' },
+  };
+  await renderAdminApp('/settings/advanced', {
+    labs: { selfServeArchives: true },
+    boot: { browseConfig: { response: config } },
+  });
 }
 
-describe("Migration tools export", () => {
-    it("keeps the individual export buttons without the selfServeArchives flag", async () => {
-        fakeSettingsScreens();
-        await renderAdminApp("/settings/advanced");
+describe('Migration tools export', () => {
+  it('keeps the individual export buttons without the selfServeArchives flag', async () => {
+    fakeSettingsScreens();
+    await renderAdminApp('/settings/advanced');
 
-        const section = await openExportTab();
-        await expect.element(section.getByRole("button", {name: "Content & settings"})).toBeVisible();
-        await expect.element(section.getByRole("button", {name: "Post analytics"})).toBeVisible();
-        await expect.element(section.getByRole("button", {name: "Export data"})).not.toBeInTheDocument();
+    const section = await openExportTab();
+    await expect.element(section.getByRole('button', { name: 'Content & settings' })).toBeVisible();
+    await expect.element(section.getByRole('button', { name: 'Post analytics' })).toBeVisible();
+    await expect
+      .element(section.getByRole('button', { name: 'Export data' }))
+      .not.toBeInTheDocument();
+  });
+
+  it('offers the sync export dialog without media and downloads the zip', async () => {
+    fakeSettingsScreens();
+    const download = fakeExportDownload();
+    await renderAdminApp('/settings/advanced', { labs: { selfServeArchives: true } });
+
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect
+      .element(dialog.getByText('downloaded as a single zip', { exact: false }))
+      .toBeVisible();
+    await expect.element(dialog.getByText('Members', { exact: true })).toBeVisible();
+    await expect.element(dialog.getByText('Media files', { exact: true })).not.toBeInTheDocument();
+
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+
+    // The dialog reaches a real done state once the download completes
+    await expect.element(dialog.getByText('Export complete', { exact: false })).toBeVisible();
+    expect(download.lastRequest?.url).toContain(
+      '/exports/download/?components=content,members,analytics,themes,routes',
+    );
+  });
+
+  it('only requests the selected components', async () => {
+    fakeSettingsScreens();
+    const download = fakeExportDownload();
+    await renderAdminApp('/settings/advanced', { labs: { selfServeArchives: true } });
+
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('checkbox', { name: 'Members' }).click();
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+
+    await expect.element(dialog.getByText('Export complete', { exact: false })).toBeVisible();
+    expect(download.lastRequest?.url).toContain(
+      '/exports/download/?components=content,analytics,themes,routes',
+    );
+  });
+
+  it('returns to the selection and surfaces the error when the download fails', async () => {
+    fakeSettingsScreens();
+    fakeAdminEndpoint(
+      'GET',
+      /^\/exports\/download\//,
+      { errors: [{ message: 'Boom' }] },
+      { status: 500 },
+    );
+    await renderAdminApp('/settings/advanced', { labs: { selfServeArchives: true } });
+
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+
+    // The error is surfaced, and we're back on the selection for a retry
+    await expect.element(page.getByText('Something went wrong, please try again.')).toBeVisible();
+    await expect.element(dialog.getByRole('button', { name: 'Export', exact: true })).toBeVisible();
+    await expect
+      .element(dialog.getByText('Export complete', { exact: false }))
+      .not.toBeInTheDocument();
+  });
+
+  it('offers media and email delivery when an archive host is configured', async () => {
+    fakeSettingsScreens();
+    const exportsApi = fakeAdminEndpoint('POST', '/exports/', {}, { status: 202 });
+    await renderWithArchiveHost();
+
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect.element(dialog.getByText('sent to you by email', { exact: false })).toBeVisible();
+    await expect.element(dialog.getByText('Media files', { exact: true })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+    await expect.element(dialog.getByText('Exporting data', { exact: false })).toBeVisible();
+
+    // The default selection: everything except media
+    await expect
+      .poll(() => exportsApi.lastRequest?.body)
+      .toEqual({
+        components: {
+          content: true,
+          members: true,
+          analytics: true,
+          themes: true,
+          routes: true,
+          media: false,
+        },
+      });
+  });
+
+  it('keeps the dialog open while the export request is in flight', async () => {
+    fakeSettingsScreens();
+    let releaseRequest!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
     });
+    fakeAdminEndpoint(
+      'POST',
+      '/exports/',
+      async () => {
+        await gate;
+        return {};
+      },
+      { status: 202 },
+    );
+    await renderWithArchiveHost();
 
-    it("offers the sync export dialog without media and downloads the zip", async () => {
-        fakeSettingsScreens();
-        const download = fakeExportDownload();
-        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
 
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
 
-        const dialog = page.getByRole("dialog");
-        await expect.element(dialog.getByText("downloaded as a single zip", {exact: false})).toBeVisible();
-        await expect.element(dialog.getByText("Members", {exact: true})).toBeVisible();
-        await expect.element(dialog.getByText("Media files", {exact: true})).not.toBeInTheDocument();
+    // Non-idempotent request: the dialog must not be dismissible while pending
+    await expect.element(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    await userEvent.keyboard('{Escape}');
+    await expect.element(dialog.getByText('sent to you by email', { exact: false })).toBeVisible();
 
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+    releaseRequest();
+    await expect.element(dialog.getByText('Exporting data', { exact: false })).toBeVisible();
+  });
 
-        // The dialog reaches a real done state once the download completes
-        await expect.element(dialog.getByText("Export complete", {exact: false})).toBeVisible();
-        expect(download.lastRequest?.url).toContain("/exports/download/?components=content,members,analytics,themes,routes");
-    });
+  it('sends the selected components to the exports endpoint', async () => {
+    fakeSettingsScreens();
+    const exportsApi = fakeAdminEndpoint('POST', '/exports/', {}, { status: 202 });
+    await renderWithArchiveHost();
 
-    it("only requests the selected components", async () => {
-        fakeSettingsScreens();
-        const download = fakeExportDownload();
-        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
 
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByText('Post analytics', { exact: true }).click();
+    await dialog.getByText('Media files', { exact: true }).click();
 
-        const dialog = page.getByRole("dialog");
-        await dialog.getByRole("checkbox", {name: "Members"}).click();
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+    await expect.element(dialog.getByText('Exporting data', { exact: false })).toBeVisible();
 
-        await expect.element(dialog.getByText("Export complete", {exact: false})).toBeVisible();
-        expect(download.lastRequest?.url).toContain("/exports/download/?components=content,analytics,themes,routes");
-    });
+    await expect
+      .poll(() => exportsApi.lastRequest?.body)
+      .toEqual({
+        components: {
+          content: true,
+          members: true,
+          analytics: false,
+          themes: true,
+          routes: true,
+          media: true,
+        },
+      });
+  });
 
-    it("returns to the selection and surfaces the error when the download fails", async () => {
-        fakeSettingsScreens();
-        fakeAdminEndpoint("GET", /^\/exports\/download\//, {errors: [{message: "Boom"}]}, {status: 500});
-        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+  it('stays on the selection and surfaces an error when the export request fails', async () => {
+    fakeSettingsScreens();
+    // An older backend without the endpoint 404s — must not crash the dialog
+    fakeAdminEndpoint('POST', '/exports/', {}, { status: 404 });
+    await renderWithArchiveHost();
 
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
+    const section = await openExportTab();
+    await section.getByRole('button', { name: 'Export data' }).click();
 
-        const dialog = page.getByRole("dialog");
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
 
-        // The error is surfaced, and we're back on the selection for a retry
-        await expect.element(page.getByText("Something went wrong, please try again.")).toBeVisible();
-        await expect.element(dialog.getByRole("button", {name: "Export", exact: true})).toBeVisible();
-        await expect.element(dialog.getByText("Export complete", {exact: false})).not.toBeInTheDocument();
-    });
-
-    it("offers media and email delivery when an archive host is configured", async () => {
-        fakeSettingsScreens();
-        const exportsApi = fakeAdminEndpoint("POST", "/exports/", {}, {status: 202});
-        await renderWithArchiveHost();
-
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
-
-        const dialog = page.getByRole("dialog");
-        await expect.element(dialog.getByText("sent to you by email", {exact: false})).toBeVisible();
-        await expect.element(dialog.getByText("Media files", {exact: true})).toBeVisible();
-
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
-        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
-
-        // The default selection: everything except media
-        await expect.poll(() => exportsApi.lastRequest?.body).toEqual({
-            components: {
-                content: true,
-                members: true,
-                analytics: true,
-                themes: true,
-                routes: true,
-                media: false,
-            },
-        });
-    });
-
-    it("keeps the dialog open while the export request is in flight", async () => {
-        fakeSettingsScreens();
-        let releaseRequest!: () => void;
-        const gate = new Promise<void>((resolve) => {
-            releaseRequest = resolve;
-        });
-        fakeAdminEndpoint("POST", "/exports/", async () => {
-            await gate;
-            return {};
-        }, {status: 202});
-        await renderWithArchiveHost();
-
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
-
-        const dialog = page.getByRole("dialog");
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
-
-        // Non-idempotent request: the dialog must not be dismissible while pending
-        await expect.element(dialog.getByRole("button", {name: "Cancel"})).toBeDisabled();
-        await userEvent.keyboard("{Escape}");
-        await expect.element(dialog.getByText("sent to you by email", {exact: false})).toBeVisible();
-
-        releaseRequest();
-        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
-    });
-
-    it("sends the selected components to the exports endpoint", async () => {
-        fakeSettingsScreens();
-        const exportsApi = fakeAdminEndpoint("POST", "/exports/", {}, {status: 202});
-        await renderWithArchiveHost();
-
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
-
-        const dialog = page.getByRole("dialog");
-        await dialog.getByText("Post analytics", {exact: true}).click();
-        await dialog.getByText("Media files", {exact: true}).click();
-
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
-        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
-
-        await expect.poll(() => exportsApi.lastRequest?.body).toEqual({
-            components: {
-                content: true,
-                members: true,
-                analytics: false,
-                themes: true,
-                routes: true,
-                media: true,
-            },
-        });
-    });
-
-    it("stays on the selection and surfaces an error when the export request fails", async () => {
-        fakeSettingsScreens();
-        // An older backend without the endpoint 404s — must not crash the dialog
-        fakeAdminEndpoint("POST", "/exports/", {}, {status: 404});
-        await renderWithArchiveHost();
-
-        const section = await openExportTab();
-        await section.getByRole("button", {name: "Export data"}).click();
-
-        const dialog = page.getByRole("dialog");
-        await dialog.getByRole("button", {name: "Export", exact: true}).click();
-
-        await expect.element(page.getByText("Something went wrong while loading exports", {exact: false})).toBeVisible();
-        await expect.element(dialog.getByText("Media files", {exact: true})).toBeVisible();
-        await expect.element(dialog.getByText("Exporting data", {exact: false})).not.toBeInTheDocument();
-    });
+    await expect
+      .element(page.getByText('Something went wrong while loading exports', { exact: false }))
+      .toBeVisible();
+    await expect.element(dialog.getByText('Media files', { exact: true })).toBeVisible();
+    await expect
+      .element(dialog.getByText('Exporting data', { exact: false }))
+      .not.toBeInTheDocument();
+  });
 });

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -16,7 +16,6 @@ import {
   useRequestExport,
   type SiteExportComponent,
 } from '@tryghost/admin-x-framework/api/exports';
-import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
 import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 
 export type ExportMode = 'sync' | 'async';
@@ -79,7 +78,6 @@ const ExportAllModal: React.FC<{
   onOpenChange: (open: boolean) => void;
   mode: ExportMode;
 }> = ({ open, onOpenChange, mode }) => {
-  const { data: currentUser } = useCurrentUser();
   const { mutateAsync: requestExport, isPending: isRequestingExport } = useRequestExport();
   const handleError = useHandleError();
   const [phase, setPhase] = useState<ExportPhase>('select');
@@ -93,7 +91,6 @@ const ExportAllModal: React.FC<{
   const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const abortRef = useRef<AbortController>();
 
-  const email = currentUser?.email;
   const visibleComponents = EXPORT_COMPONENTS.filter(
     (component) => mode === 'async' || !component.asyncOnly,
   );
@@ -170,7 +167,7 @@ const ExportAllModal: React.FC<{
               <DialogTitle>Export data</DialogTitle>
               <DialogDescription>
                 {mode === 'async' ? (
-                  'Choose what to include. Your export will be prepared in the background and a download link sent to you by email.'
+                  'Choose what to include. Your export will be prepared in the background and a download link emailed to the site owner.'
                 ) : (
                   <>
                     Your export will be downloaded as a single zip file. Images, videos and files
@@ -235,8 +232,7 @@ const ExportAllModal: React.FC<{
               </DialogTitle>
             </DialogHeader>
             <DialogDescription>
-              A link to download your data will be sent to your email{' '}
-              <span className="font-medium text-foreground">{email}</span> once the export is
+              A link to download your data will be emailed to the site owner once the export is
               complete. The link will be valid for 7 days. You can now close this window.
             </DialogDescription>
             <DialogFooter className="sm:justify-end">

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -1,224 +1,284 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
-    Button,
-    Checkbox,
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    LoadingIndicator
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  LoadingIndicator,
 } from '@tryghost/shade/components';
-import {LucideIcon} from '@tryghost/shade/utils';
-import {downloadSiteExport, useRequestExport, type SiteExportComponent} from '@tryghost/admin-x-framework/api/exports';
-import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import { LucideIcon } from '@tryghost/shade/utils';
+import {
+  downloadSiteExport,
+  useRequestExport,
+  type SiteExportComponent,
+} from '@tryghost/admin-x-framework/api/exports';
+import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 
 export type ExportMode = 'sync' | 'async';
 
 type ExportComponentKey = 'content' | 'members' | 'analytics' | 'themes' | 'routes' | 'media';
 
 type ExportComponent = {
-    key: ExportComponentKey;
-    label: string;
-    description: string;
-    defaultChecked: boolean;
-    asyncOnly?: boolean;
+  key: ExportComponentKey;
+  label: string;
+  description: string;
+  defaultChecked: boolean;
+  asyncOnly?: boolean;
 };
 
 const EXPORT_COMPONENTS: ExportComponent[] = [
-    {key: 'content', label: 'Content & settings', description: 'Posts, pages, tags, tiers and settings (JSON)', defaultChecked: true},
-    {key: 'members', label: 'Members', description: 'All members with labels and subscription status (CSV)', defaultChecked: true},
-    {key: 'analytics', label: 'Post analytics', description: 'Sends, opens, clicks and conversions per post (CSV)', defaultChecked: true},
-    {key: 'themes', label: 'Themes', description: 'All installed themes, including custom code', defaultChecked: true},
-    {key: 'routes', label: 'Redirects & routes', description: 'routes.yaml and redirects configuration', defaultChecked: true},
-    {key: 'media', label: 'Media files', description: 'All images, video and audio files. May significantly increase export size and duration', defaultChecked: false, asyncOnly: true}
+  {
+    key: 'content',
+    label: 'Content & settings',
+    description: 'Posts, pages, tags, tiers and settings (JSON)',
+    defaultChecked: true,
+  },
+  {
+    key: 'members',
+    label: 'Members',
+    description: 'All members with labels and subscription status (CSV)',
+    defaultChecked: true,
+  },
+  {
+    key: 'analytics',
+    label: 'Post analytics',
+    description: 'Sends, opens, clicks and conversions per post (CSV)',
+    defaultChecked: true,
+  },
+  {
+    key: 'themes',
+    label: 'Themes',
+    description: 'All installed themes, including custom code',
+    defaultChecked: true,
+  },
+  {
+    key: 'routes',
+    label: 'Redirects & routes',
+    description: 'routes.yaml and redirects configuration',
+    defaultChecked: true,
+  },
+  {
+    key: 'media',
+    label: 'Media files',
+    description:
+      'All images, video and audio files. May significantly increase export size and duration',
+    defaultChecked: false,
+    asyncOnly: true,
+  },
 ];
 
 type ExportPhase = 'select' | 'confirmed' | 'preparing' | 'done';
 
-const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => void; mode: ExportMode}> = ({open, onOpenChange, mode}) => {
-    const {data: currentUser} = useCurrentUser();
-    const {mutateAsync: requestExport, isPending: isRequestingExport} = useRequestExport();
-    const handleError = useHandleError();
-    const [phase, setPhase] = useState<ExportPhase>('select');
-    const [selected, setSelected] = useState<Record<ExportComponentKey, boolean>>(() => {
-        const initial = {} as Record<ExportComponentKey, boolean>;
-        EXPORT_COMPONENTS.forEach((component) => {
-            initial[component.key] = component.defaultChecked;
-        });
-        return initial;
+const ExportAllModal: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: ExportMode;
+}> = ({ open, onOpenChange, mode }) => {
+  const { data: currentUser } = useCurrentUser();
+  const { mutateAsync: requestExport, isPending: isRequestingExport } = useRequestExport();
+  const handleError = useHandleError();
+  const [phase, setPhase] = useState<ExportPhase>('select');
+  const [selected, setSelected] = useState<Record<ExportComponentKey, boolean>>(() => {
+    const initial = {} as Record<ExportComponentKey, boolean>;
+    EXPORT_COMPONENTS.forEach((component) => {
+      initial[component.key] = component.defaultChecked;
     });
-    const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
-    const abortRef = useRef<AbortController>();
+    return initial;
+  });
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const abortRef = useRef<AbortController>();
 
-    const email = currentUser?.email;
-    const visibleComponents = EXPORT_COMPONENTS.filter(component => mode === 'async' || !component.asyncOnly);
-    const noneSelected = visibleComponents.every(component => !selected[component.key]);
+  const email = currentUser?.email;
+  const visibleComponents = EXPORT_COMPONENTS.filter(
+    (component) => mode === 'async' || !component.asyncOnly,
+  );
+  const noneSelected = visibleComponents.every((component) => !selected[component.key]);
 
-    const handleOpenChange = (next: boolean) => {
-        // The export request is not idempotent: closing mid-flight would
-        // detach the pending promise and let it flip a later session's phase.
-        if (!next && isRequestingExport) {
-            return;
-        }
-        onOpenChange(next);
-        if (next) {
-            clearTimeout(resetTimerRef.current);
-            setPhase('select');
-            return;
-        }
-        abortRef.current?.abort();
-        clearTimeout(resetTimerRef.current);
-        // Reset for the next open, after the close animation
-        resetTimerRef.current = setTimeout(() => setPhase('select'), 200);
+  const handleOpenChange = (next: boolean) => {
+    // The export request is not idempotent: closing mid-flight would
+    // detach the pending promise and let it flip a later session's phase.
+    if (!next && isRequestingExport) {
+      return;
+    }
+    onOpenChange(next);
+    if (next) {
+      clearTimeout(resetTimerRef.current);
+      setPhase('select');
+      return;
+    }
+    abortRef.current?.abort();
+    clearTimeout(resetTimerRef.current);
+    // Reset for the next open, after the close animation
+    resetTimerRef.current = setTimeout(() => setPhase('select'), 200);
+  };
+
+  const startExport = async () => {
+    if (mode === 'async') {
+      try {
+        const components = Object.fromEntries(
+          visibleComponents.map((component) => [component.key, selected[component.key]]),
+        );
+        await requestExport({ components });
+        setPhase('confirmed');
+      } catch (e) {
+        // An older backend without the endpoint 404s into the same path
+        handleError(e);
+      }
+      return;
+    }
+
+    const components = visibleComponents
+      .filter((component) => selected[component.key] && component.key !== 'media')
+      .map((component) => component.key as SiteExportComponent);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setPhase('preparing');
+
+    try {
+      await downloadSiteExport(components, { signal: controller.signal });
+      // The functional updates guard against a stale transition after
+      // the dialog was closed and reset meanwhile
+      setPhase((current) => (current === 'preparing' ? 'done' : current));
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+      handleError(error);
+      setPhase((current) => (current === 'preparing' ? 'select' : current));
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      clearTimeout(resetTimerRef.current);
     };
+  }, []);
 
-    const startExport = async () => {
-        if (mode === 'async') {
-            try {
-                const components = Object.fromEntries(visibleComponents.map(component => [component.key, selected[component.key]]));
-                await requestExport({components});
-                setPhase('confirmed');
-            } catch (e) {
-                // An older backend without the endpoint 404s into the same path
-                handleError(e);
-            }
-            return;
-        }
-
-        const components = visibleComponents
-            .filter(component => selected[component.key] && component.key !== 'media')
-            .map(component => component.key as SiteExportComponent);
-
-        const controller = new AbortController();
-        abortRef.current = controller;
-        setPhase('preparing');
-
-        try {
-            await downloadSiteExport(components, {signal: controller.signal});
-            // The functional updates guard against a stale transition after
-            // the dialog was closed and reset meanwhile
-            setPhase(current => (current === 'preparing' ? 'done' : current));
-        } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return;
-            }
-            handleError(error);
-            setPhase(current => (current === 'preparing' ? 'select' : current));
-        }
-    };
-
-    useEffect(() => {
-        return () => {
-            abortRef.current?.abort();
-            clearTimeout(resetTimerRef.current);
-        };
-    }, []);
-
-    return (
-        <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogContent className='max-h-[85vh] max-w-md overflow-y-auto'>
-                {phase === 'select' && (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle>Export data</DialogTitle>
-                            <DialogDescription>
-                                {mode === 'async'
-                                    ? 'Choose what to include. Your export will be prepared in the background and a download link sent to you by email.'
-                                    : <>
-                                        Your export will be downloaded as a single zip file.{' '}
-                                        Images, videos and files are not included.{' '}
-                                        <a
-                                            className='font-medium whitespace-nowrap text-foreground hover:underline'
-                                            href='https://docs.ghost.org/migration/ghost#images'
-                                            rel='noopener noreferrer'
-                                            target='_blank'
-                                        >Learn more &rarr;</a>
-                                    </>}
-                            </DialogDescription>
-                        </DialogHeader>
-                        <div className='flex flex-col gap-1 py-1'>
-                            {visibleComponents.map(component => (
-                                <label
-                                    key={component.key}
-                                    className='flex cursor-pointer items-start gap-3 rounded-md px-2 py-1.5 hover:bg-muted/60'
-                                    htmlFor={`export-${component.key}`}
-                                >
-                                    <Checkbox
-                                        checked={selected[component.key]}
-                                        className='mt-0.5'
-                                        id={`export-${component.key}`}
-                                        onCheckedChange={checked => setSelected(current => ({...current, [component.key]: checked === true}))}
-                                    />
-                                    <span className='flex flex-col'>
-                                        <span className='text-sm font-medium text-foreground'>{component.label}</span>
-                                        <span className='text-xs text-muted-foreground'>{component.description}</span>
-                                    </span>
-                                </label>
-                            ))}
-                        </div>
-                        <DialogFooter className='gap-2 sm:justify-end'>
-                            <Button disabled={isRequestingExport} variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
-                            <Button disabled={noneSelected || isRequestingExport} onClick={() => void startExport()}>
-                                <LucideIcon.Download /> Export
-                            </Button>
-                        </DialogFooter>
-                    </>
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[85vh] max-w-md overflow-y-auto">
+        {phase === 'select' && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Export data</DialogTitle>
+              <DialogDescription>
+                {mode === 'async' ? (
+                  'Choose what to include. Your export will be prepared in the background and a download link sent to you by email.'
+                ) : (
+                  <>
+                    Your export will be downloaded as a single zip file. Images, videos and files
+                    are not included.{' '}
+                    <a
+                      className="font-medium whitespace-nowrap text-foreground hover:underline"
+                      href="https://docs.ghost.org/migration/ghost#images"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more &rarr;
+                    </a>
+                  </>
                 )}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-1 py-1">
+              {visibleComponents.map((component) => (
+                <label
+                  key={component.key}
+                  className="flex cursor-pointer items-start gap-3 rounded-md px-2 py-1.5 hover:bg-muted/60"
+                  htmlFor={`export-${component.key}`}
+                >
+                  <Checkbox
+                    checked={selected[component.key]}
+                    className="mt-0.5"
+                    id={`export-${component.key}`}
+                    onCheckedChange={(checked) =>
+                      setSelected((current) => ({ ...current, [component.key]: checked === true }))
+                    }
+                  />
+                  <span className="flex flex-col">
+                    <span className="text-sm font-medium text-foreground">{component.label}</span>
+                    <span className="text-xs text-muted-foreground">{component.description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            <DialogFooter className="gap-2 sm:justify-end">
+              <Button
+                disabled={isRequestingExport}
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={noneSelected || isRequestingExport}
+                onClick={() => void startExport()}
+              >
+                <LucideIcon.Download /> Export
+              </Button>
+            </DialogFooter>
+          </>
+        )}
 
-                {phase === 'confirmed' && (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle className='flex items-center gap-2'>
-                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Exporting data&hellip;
-                            </DialogTitle>
-                        </DialogHeader>
-                        <DialogDescription>
-                            A link to download your data will be sent to your email <span className='font-medium text-foreground'>{email}</span> once
-                            the export is complete. The link will be valid for 7 days. You can now close this window.
-                        </DialogDescription>
-                        <DialogFooter className='sm:justify-end'>
-                            <Button onClick={() => handleOpenChange(false)}>Close</Button>
-                        </DialogFooter>
-                    </>
-                )}
+        {phase === 'confirmed' && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <LucideIcon.CircleCheck className="size-5 text-green-600" /> Exporting data&hellip;
+              </DialogTitle>
+            </DialogHeader>
+            <DialogDescription>
+              A link to download your data will be sent to your email{' '}
+              <span className="font-medium text-foreground">{email}</span> once the export is
+              complete. The link will be valid for 7 days. You can now close this window.
+            </DialogDescription>
+            <DialogFooter className="sm:justify-end">
+              <Button onClick={() => handleOpenChange(false)}>Close</Button>
+            </DialogFooter>
+          </>
+        )}
 
-                {phase === 'preparing' && (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle className='flex items-center gap-2'>
-                                <LoadingIndicator size='sm' /> Preparing your export&hellip;
-                            </DialogTitle>
-                        </DialogHeader>
-                        <DialogDescription>
-                            Your download will start automatically when it&rsquo;s ready. Keep this window open.
-                        </DialogDescription>
-                        <DialogFooter className='sm:justify-end'>
-                            <Button variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
-                        </DialogFooter>
-                    </>
-                )}
+        {phase === 'preparing' && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <LoadingIndicator size="sm" /> Preparing your export&hellip;
+              </DialogTitle>
+            </DialogHeader>
+            <DialogDescription>
+              Your download will start automatically when it&rsquo;s ready. Keep this window open.
+            </DialogDescription>
+            <DialogFooter className="sm:justify-end">
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </>
+        )}
 
-                {phase === 'done' && (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle className='flex items-center gap-2'>
-                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Export complete
-                            </DialogTitle>
-                        </DialogHeader>
-                        <DialogDescription>
-                            Your export has been downloaded as a zip file.
-                        </DialogDescription>
-                        <DialogFooter className='sm:justify-end'>
-                            <Button onClick={() => handleOpenChange(false)}>Close</Button>
-                        </DialogFooter>
-                    </>
-                )}
-            </DialogContent>
-        </Dialog>
-    );
+        {phase === 'done' && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <LucideIcon.CircleCheck className="size-5 text-green-600" /> Export complete
+              </DialogTitle>
+            </DialogHeader>
+            <DialogDescription>Your export has been downloaded as a zip file.</DialogDescription>
+            <DialogFooter className="sm:justify-end">
+              <Button onClick={() => handleOpenChange(false)}>Close</Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
 };
 
 export default ExportAllModal;

--- a/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/export-all-modal.tsx
@@ -1,262 +1,224 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {
-  Button,
-  Checkbox,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  LoadingIndicator,
+    Button,
+    Checkbox,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    LoadingIndicator
 } from '@tryghost/shade/components';
-import { LucideIcon } from '@tryghost/shade/utils';
-import {
-  downloadSiteExport,
-  type SiteExportComponent,
-} from '@tryghost/admin-x-framework/api/exports';
-import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
-import { useHandleError } from '@tryghost/admin-x-framework/hooks';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {downloadSiteExport, useRequestExport, type SiteExportComponent} from '@tryghost/admin-x-framework/api/exports';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 export type ExportMode = 'sync' | 'async';
 
 type ExportComponentKey = 'content' | 'members' | 'analytics' | 'themes' | 'routes' | 'media';
 
 type ExportComponent = {
-  key: ExportComponentKey;
-  label: string;
-  description: string;
-  defaultChecked: boolean;
-  asyncOnly?: boolean;
+    key: ExportComponentKey;
+    label: string;
+    description: string;
+    defaultChecked: boolean;
+    asyncOnly?: boolean;
 };
 
 const EXPORT_COMPONENTS: ExportComponent[] = [
-  {
-    key: 'content',
-    label: 'Content & settings',
-    description: 'Posts, pages, tags, tiers and settings (JSON)',
-    defaultChecked: true,
-  },
-  {
-    key: 'members',
-    label: 'Members',
-    description: 'All members with labels and subscription status (CSV)',
-    defaultChecked: true,
-  },
-  {
-    key: 'analytics',
-    label: 'Post analytics',
-    description: 'Sends, opens, clicks and conversions per post (CSV)',
-    defaultChecked: true,
-  },
-  {
-    key: 'themes',
-    label: 'Themes',
-    description: 'All installed themes, including custom code',
-    defaultChecked: true,
-  },
-  {
-    key: 'routes',
-    label: 'Redirects & routes',
-    description: 'routes.yaml and redirects configuration',
-    defaultChecked: true,
-  },
-  {
-    key: 'media',
-    label: 'Media files',
-    description:
-      'All images, video and audio files. May significantly increase export size and duration',
-    defaultChecked: false,
-    asyncOnly: true,
-  },
+    {key: 'content', label: 'Content & settings', description: 'Posts, pages, tags, tiers and settings (JSON)', defaultChecked: true},
+    {key: 'members', label: 'Members', description: 'All members with labels and subscription status (CSV)', defaultChecked: true},
+    {key: 'analytics', label: 'Post analytics', description: 'Sends, opens, clicks and conversions per post (CSV)', defaultChecked: true},
+    {key: 'themes', label: 'Themes', description: 'All installed themes, including custom code', defaultChecked: true},
+    {key: 'routes', label: 'Redirects & routes', description: 'routes.yaml and redirects configuration', defaultChecked: true},
+    {key: 'media', label: 'Media files', description: 'All images, video and audio files. May significantly increase export size and duration', defaultChecked: false, asyncOnly: true}
 ];
 
 type ExportPhase = 'select' | 'confirmed' | 'preparing' | 'done';
 
-const ExportAllModal: React.FC<{
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  mode: ExportMode;
-}> = ({ open, onOpenChange, mode }) => {
-  const { data: currentUser } = useCurrentUser();
-  const handleError = useHandleError();
-  const [phase, setPhase] = useState<ExportPhase>('select');
-  const [selected, setSelected] = useState<Record<ExportComponentKey, boolean>>(() => {
-    const initial = {} as Record<ExportComponentKey, boolean>;
-    EXPORT_COMPONENTS.forEach((component) => {
-      initial[component.key] = component.defaultChecked;
+const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => void; mode: ExportMode}> = ({open, onOpenChange, mode}) => {
+    const {data: currentUser} = useCurrentUser();
+    const {mutateAsync: requestExport, isPending: isRequestingExport} = useRequestExport();
+    const handleError = useHandleError();
+    const [phase, setPhase] = useState<ExportPhase>('select');
+    const [selected, setSelected] = useState<Record<ExportComponentKey, boolean>>(() => {
+        const initial = {} as Record<ExportComponentKey, boolean>;
+        EXPORT_COMPONENTS.forEach((component) => {
+            initial[component.key] = component.defaultChecked;
+        });
+        return initial;
     });
-    return initial;
-  });
-  const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const abortRef = useRef<AbortController>();
+    const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
+    const abortRef = useRef<AbortController>();
 
-  const email = currentUser?.email;
-  const visibleComponents = EXPORT_COMPONENTS.filter(
-    (component) => mode === 'async' || !component.asyncOnly,
-  );
-  const noneSelected = visibleComponents.every((component) => !selected[component.key]);
+    const email = currentUser?.email;
+    const visibleComponents = EXPORT_COMPONENTS.filter(component => mode === 'async' || !component.asyncOnly);
+    const noneSelected = visibleComponents.every(component => !selected[component.key]);
 
-  const handleOpenChange = (next: boolean) => {
-    onOpenChange(next);
-    if (next) {
-      clearTimeout(resetTimerRef.current);
-      setPhase('select');
-      return;
-    }
-    abortRef.current?.abort();
-    clearTimeout(resetTimerRef.current);
-    // Reset for the next open, after the close animation
-    resetTimerRef.current = setTimeout(() => setPhase('select'), 200);
-  };
-
-  const startExport = async () => {
-    if (mode === 'async') {
-      // Host mode is not wired to a backend yet — mocked confirmation only
-      setPhase('confirmed');
-      return;
-    }
-
-    const components = visibleComponents
-      .filter((component) => selected[component.key] && component.key !== 'media')
-      .map((component) => component.key as SiteExportComponent);
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setPhase('preparing');
-
-    try {
-      await downloadSiteExport(components, { signal: controller.signal });
-      // The functional updates guard against a stale transition after
-      // the dialog was closed and reset meanwhile
-      setPhase((current) => (current === 'preparing' ? 'done' : current));
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') {
-        return;
-      }
-      handleError(error);
-      setPhase((current) => (current === 'preparing' ? 'select' : current));
-    }
-  };
-
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort();
-      clearTimeout(resetTimerRef.current);
+    const handleOpenChange = (next: boolean) => {
+        // The export request is not idempotent: closing mid-flight would
+        // detach the pending promise and let it flip a later session's phase.
+        if (!next && isRequestingExport) {
+            return;
+        }
+        onOpenChange(next);
+        if (next) {
+            clearTimeout(resetTimerRef.current);
+            setPhase('select');
+            return;
+        }
+        abortRef.current?.abort();
+        clearTimeout(resetTimerRef.current);
+        // Reset for the next open, after the close animation
+        resetTimerRef.current = setTimeout(() => setPhase('select'), 200);
     };
-  }, []);
 
-  return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[85vh] max-w-md overflow-y-auto">
-        {phase === 'select' && (
-          <>
-            <DialogHeader>
-              <DialogTitle>Export data</DialogTitle>
-              <DialogDescription>
-                {mode === 'async' ? (
-                  'Choose what to include. Your export will be prepared in the background and a download link sent to you by email.'
-                ) : (
-                  <>
-                    Your export will be downloaded as a single zip file. Images, videos and files
-                    are not included.{' '}
-                    <a
-                      className="font-medium whitespace-nowrap text-foreground hover:underline"
-                      href="https://docs.ghost.org/migration/ghost#images"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Learn more &rarr;
-                    </a>
-                  </>
+    const startExport = async () => {
+        if (mode === 'async') {
+            try {
+                const components = Object.fromEntries(visibleComponents.map(component => [component.key, selected[component.key]]));
+                await requestExport({components});
+                setPhase('confirmed');
+            } catch (e) {
+                // An older backend without the endpoint 404s into the same path
+                handleError(e);
+            }
+            return;
+        }
+
+        const components = visibleComponents
+            .filter(component => selected[component.key] && component.key !== 'media')
+            .map(component => component.key as SiteExportComponent);
+
+        const controller = new AbortController();
+        abortRef.current = controller;
+        setPhase('preparing');
+
+        try {
+            await downloadSiteExport(components, {signal: controller.signal});
+            // The functional updates guard against a stale transition after
+            // the dialog was closed and reset meanwhile
+            setPhase(current => (current === 'preparing' ? 'done' : current));
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                return;
+            }
+            handleError(error);
+            setPhase(current => (current === 'preparing' ? 'select' : current));
+        }
+    };
+
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+            clearTimeout(resetTimerRef.current);
+        };
+    }, []);
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className='max-h-[85vh] max-w-md overflow-y-auto'>
+                {phase === 'select' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle>Export data</DialogTitle>
+                            <DialogDescription>
+                                {mode === 'async'
+                                    ? 'Choose what to include. Your export will be prepared in the background and a download link sent to you by email.'
+                                    : <>
+                                        Your export will be downloaded as a single zip file.{' '}
+                                        Images, videos and files are not included.{' '}
+                                        <a
+                                            className='font-medium whitespace-nowrap text-foreground hover:underline'
+                                            href='https://docs.ghost.org/migration/ghost#images'
+                                            rel='noopener noreferrer'
+                                            target='_blank'
+                                        >Learn more &rarr;</a>
+                                    </>}
+                            </DialogDescription>
+                        </DialogHeader>
+                        <div className='flex flex-col gap-1 py-1'>
+                            {visibleComponents.map(component => (
+                                <label
+                                    key={component.key}
+                                    className='flex cursor-pointer items-start gap-3 rounded-md px-2 py-1.5 hover:bg-muted/60'
+                                    htmlFor={`export-${component.key}`}
+                                >
+                                    <Checkbox
+                                        checked={selected[component.key]}
+                                        className='mt-0.5'
+                                        id={`export-${component.key}`}
+                                        onCheckedChange={checked => setSelected(current => ({...current, [component.key]: checked === true}))}
+                                    />
+                                    <span className='flex flex-col'>
+                                        <span className='text-sm font-medium text-foreground'>{component.label}</span>
+                                        <span className='text-xs text-muted-foreground'>{component.description}</span>
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                        <DialogFooter className='gap-2 sm:justify-end'>
+                            <Button disabled={isRequestingExport} variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
+                            <Button disabled={noneSelected || isRequestingExport} onClick={() => void startExport()}>
+                                <LucideIcon.Download /> Export
+                            </Button>
+                        </DialogFooter>
+                    </>
                 )}
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex flex-col gap-1 py-1">
-              {visibleComponents.map((component) => (
-                <label
-                  key={component.key}
-                  className="flex cursor-pointer items-start gap-3 rounded-md px-2 py-1.5 hover:bg-muted/60"
-                  htmlFor={`export-${component.key}`}
-                >
-                  <Checkbox
-                    checked={selected[component.key]}
-                    className="mt-0.5"
-                    id={`export-${component.key}`}
-                    onCheckedChange={(checked) =>
-                      setSelected((current) => ({ ...current, [component.key]: checked === true }))
-                    }
-                  />
-                  <span className="flex flex-col">
-                    <span className="text-sm font-medium text-foreground">{component.label}</span>
-                    <span className="text-xs text-muted-foreground">{component.description}</span>
-                  </span>
-                </label>
-              ))}
-            </div>
-            <DialogFooter className="gap-2 sm:justify-end">
-              <Button variant="outline" onClick={() => handleOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button disabled={noneSelected} onClick={() => void startExport()}>
-                <LucideIcon.Download /> Export
-              </Button>
-            </DialogFooter>
-          </>
-        )}
 
-        {phase === 'confirmed' && (
-          <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <LucideIcon.CircleCheck className="size-5 text-green-600" /> Exporting data&hellip;
-              </DialogTitle>
-            </DialogHeader>
-            <DialogDescription>
-              A link to download your data will be sent to your email{' '}
-              <span className="font-medium text-foreground">{email}</span> once the export is
-              complete. The link will be valid for 7 days. You can now close this window.
-            </DialogDescription>
-            <DialogFooter className="sm:justify-end">
-              <Button onClick={() => handleOpenChange(false)}>Close</Button>
-            </DialogFooter>
-          </>
-        )}
+                {phase === 'confirmed' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle className='flex items-center gap-2'>
+                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Exporting data&hellip;
+                            </DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription>
+                            A link to download your data will be sent to your email <span className='font-medium text-foreground'>{email}</span> once
+                            the export is complete. The link will be valid for 7 days. You can now close this window.
+                        </DialogDescription>
+                        <DialogFooter className='sm:justify-end'>
+                            <Button onClick={() => handleOpenChange(false)}>Close</Button>
+                        </DialogFooter>
+                    </>
+                )}
 
-        {phase === 'preparing' && (
-          <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <LoadingIndicator size="sm" /> Preparing your export&hellip;
-              </DialogTitle>
-            </DialogHeader>
-            <DialogDescription>
-              Your download will start automatically when it&rsquo;s ready. Keep this window open.
-            </DialogDescription>
-            <DialogFooter className="sm:justify-end">
-              <Button variant="outline" onClick={() => handleOpenChange(false)}>
-                Cancel
-              </Button>
-            </DialogFooter>
-          </>
-        )}
+                {phase === 'preparing' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle className='flex items-center gap-2'>
+                                <LoadingIndicator size='sm' /> Preparing your export&hellip;
+                            </DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription>
+                            Your download will start automatically when it&rsquo;s ready. Keep this window open.
+                        </DialogDescription>
+                        <DialogFooter className='sm:justify-end'>
+                            <Button variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
+                        </DialogFooter>
+                    </>
+                )}
 
-        {phase === 'done' && (
-          <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <LucideIcon.CircleCheck className="size-5 text-green-600" /> Export complete
-              </DialogTitle>
-            </DialogHeader>
-            <DialogDescription>Your export has been downloaded as a zip file.</DialogDescription>
-            <DialogFooter className="sm:justify-end">
-              <Button onClick={() => handleOpenChange(false)}>Close</Button>
-            </DialogFooter>
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
-  );
+                {phase === 'done' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle className='flex items-center gap-2'>
+                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Export complete
+                            </DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription>
+                            Your export has been downloaded as a zip file.
+                        </DialogDescription>
+                        <DialogFooter className='sm:justify-end'>
+                            <Button onClick={() => handleOpenChange(false)}>Close</Button>
+                        </DialogFooter>
+                    </>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
 };
 
 export default ExportAllModal;

--- a/apps/admin/src/settings/advanced/migration-tools/migration-tools-export.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/migration-tools-export.tsx
@@ -15,7 +15,8 @@ const MigrationToolsExport: React.FC = () => {
   const hasSelfServeArchives = useFeatureFlag('selfServeArchives');
   const { data: configData } = useBrowseConfig();
   const webhookUrl = configData?.config.hostSettings?.export?.webhookUrl;
-  const mode: ExportMode = typeof webhookUrl === 'string' && webhookUrl.length > 0 ? 'async' : 'sync';
+  const mode: ExportMode =
+    typeof webhookUrl === 'string' && webhookUrl.length > 0 ? 'async' : 'sync';
 
   const exportPosts = async () => {
     if (isExportingPosts) {

--- a/apps/admin/src/settings/advanced/migration-tools/migration-tools-export.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/migration-tools-export.tsx
@@ -14,9 +14,8 @@ const MigrationToolsExport: React.FC = () => {
 
   const hasSelfServeArchives = useFeatureFlag('selfServeArchives');
   const { data: configData } = useBrowseConfig();
-  const mode: ExportMode = configData?.config.hostSettings?.export?.generate_archive_url
-    ? 'async'
-    : 'sync';
+  const webhookUrl = configData?.config.hostSettings?.export?.webhookUrl;
+  const mode: ExportMode = typeof webhookUrl === 'string' && webhookUrl.length > 0 ? 'async' : 'sync';
 
   const exportPosts = async () => {
     if (isExportingPosts) {

--- a/ghost/core/core/server/api/endpoints/exports.js
+++ b/ghost/core/core/server/api/endpoints/exports.js
@@ -12,7 +12,11 @@ const customRedirects = require('../../services/custom-redirects');
 const { serializeToYaml } = require('../../services/custom-redirects/redirect-config-parser');
 const themeService = require('../../services/themes');
 const themeList = require('../../services/themes/list');
-const { SiteExporter, EXPORT_COMPONENTS } = require('../../services/exports/site-exporter');
+const { SiteExporter } = require('../../services/exports/site-exporter');
+const {
+  SYNC_EXPORT_COMPONENTS,
+  ASYNC_EXPORT_COMPONENTS,
+} = require('../../services/exports/export-components');
 const { getExportFileName } = require('./utils/csv-export-filename');
 const { rejectAdminApiRestrictedFieldsTransformer } = require('./utils/api-filter-utils');
 const {
@@ -30,8 +34,6 @@ const postsService = getPostServiceInstance();
 const messages = {
   noComponentsSelected: 'No export components selected',
 };
-
-const ALLOWED_REQUEST_COMPONENTS = ['content', 'members', 'analytics', 'themes', 'routes', 'media'];
 
 /**
  * Pipes export rows through their CSV transform. `pipeline` (rather than
@@ -138,7 +140,7 @@ const controller = {
     validation: {
       options: {
         components: {
-          values: [...EXPORT_COMPONENTS],
+          values: [...SYNC_EXPORT_COMPONENTS],
         },
       },
     },
@@ -148,7 +150,7 @@ const controller = {
     },
     query(frame) {
       // Absent means everything; explicitly empty means nothing selected
-      const components = frame.options.components ?? [...EXPORT_COMPONENTS];
+      const components = frame.options.components ?? [...SYNC_EXPORT_COMPONENTS];
 
       if (components.length === 0) {
         throw new errors.ValidationError({
@@ -178,7 +180,7 @@ const controller = {
       }
 
       const keys = Object.keys(components);
-      const unknownKeys = keys.filter((key) => !ALLOWED_REQUEST_COMPONENTS.includes(key));
+      const unknownKeys = keys.filter((key) => !ASYNC_EXPORT_COMPONENTS.includes(key));
 
       if (unknownKeys.length > 0) {
         throw new errors.BadRequestError({
@@ -204,7 +206,7 @@ const controller = {
     },
     async query(frame) {
       const components = {};
-      for (const key of ALLOWED_REQUEST_COMPONENTS) {
+      for (const key of ASYNC_EXPORT_COMPONENTS) {
         components[key] = frame.data.components[key] === true;
       }
 

--- a/ghost/core/core/server/api/endpoints/exports.js
+++ b/ghost/core/core/server/api/endpoints/exports.js
@@ -9,22 +9,26 @@ const membersService = require('../../services/members');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const routeSettings = require('../../services/route-settings');
 const customRedirects = require('../../services/custom-redirects');
-const {serializeToYaml} = require('../../services/custom-redirects/redirect-config-parser');
+const { serializeToYaml } = require('../../services/custom-redirects/redirect-config-parser');
 const themeService = require('../../services/themes');
 const themeList = require('../../services/themes/list');
-const {SiteExporter, EXPORT_COMPONENTS} = require('../../services/exports/site-exporter');
-const {getExportFileName} = require('./utils/csv-export-filename');
-const {rejectAdminApiRestrictedFieldsTransformer} = require('./utils/api-filter-utils');
-const {createCSVTransform: createMembersCSVTransform} = require('./utils/serializers/output/members-csv-transform');
-const {createCSVTransform: createPostsCSVTransform} = require('./utils/serializers/output/posts-csv-transform');
-const {pipeline} = require('stream');
+const { SiteExporter, EXPORT_COMPONENTS } = require('../../services/exports/site-exporter');
+const { getExportFileName } = require('./utils/csv-export-filename');
+const { rejectAdminApiRestrictedFieldsTransformer } = require('./utils/api-filter-utils');
+const {
+  createCSVTransform: createMembersCSVTransform,
+} = require('./utils/serializers/output/members-csv-transform');
+const {
+  createCSVTransform: createPostsCSVTransform,
+} = require('./utils/serializers/output/posts-csv-transform');
+const { pipeline } = require('stream');
 const models = require('../../models');
-const {exportRequestsService} = require('../../services/export-requests/export-requests-service');
+const { exportRequestsService } = require('../../services/export-requests/export-requests-service');
 
 const postsService = getPostServiceInstance();
 
 const messages = {
-    noComponentsSelected: 'No export components selected'
+  noComponentsSelected: 'No export components selected',
 };
 
 const ALLOWED_REQUEST_COMPONENTS = ['content', 'members', 'analytics', 'themes', 'routes', 'media'];
@@ -40,15 +44,17 @@ const ALLOWED_REQUEST_COMPONENTS = ['content', 'members', 'analytics', 'themes',
  * @returns {NodeJS.ReadableStream}
  */
 function toCSVStream(label, rows, transform) {
-    pipeline(rows, transform, (err) => {
-        if (err) {
-            logging.error(new errors.InternalServerError({
-                message: `Site export: the ${label} stream failed mid-export`,
-                err
-            }));
-        }
-    });
-    return transform;
+  pipeline(rows, transform, (err) => {
+    if (err) {
+      logging.error(
+        new errors.InternalServerError({
+          message: `Site export: the ${label} stream failed mid-export`,
+          err,
+        }),
+      );
+    }
+  });
+  return transform;
 }
 
 /**
@@ -60,42 +66,47 @@ function toCSVStream(label, rows, transform) {
  * @returns {Promise<{zipPath: string, cleanup(): Promise<void>}>}
  */
 async function zipThemeToTempFile(name) {
-    const tmpDir = path.join(os.tmpdir(), `ghost-export-${security.identifier.uid(10)}`);
-    await fs.ensureDir(tmpDir);
+  const tmpDir = path.join(os.tmpdir(), `ghost-export-${security.identifier.uid(10)}`);
+  await fs.ensureDir(tmpDir);
 
-    try {
-        const zipPath = path.join(tmpDir, `${name}.zip`);
-        await themeService.api.zipToFile(name, zipPath);
-        return {zipPath, cleanup: () => fs.remove(tmpDir)};
-    } catch (err) {
-        await fs.remove(tmpDir);
-        throw err;
-    }
+  try {
+    const zipPath = path.join(tmpDir, `${name}.zip`);
+    await themeService.api.zipToFile(name, zipPath);
+    return { zipPath, cleanup: () => fs.remove(tmpDir) };
+  } catch (err) {
+    await fs.remove(tmpDir);
+    throw err;
+  }
 }
 
 function createSiteExporter() {
-    return new SiteExporter({
-        // Same shape the `/db/` download produces, so the file stays importable
-        exportContent: async () => ({db: [await exporter.doExport()]}),
-        // `limit: 'all'` keeps both CSV exporters on their unfiltered
-        // streaming path — without it the members exporter materialises every
-        // id into a WHERE IN and the posts exporter caps at its default page
-        exportMembersCSV: async () => toCSVStream(
-            'members',
-            await membersService.export({limit: 'all'}),
-            createMembersCSVTransform()
-        ),
-        // Same restricted-fields guard the `/posts/export/` endpoint applies
-        exportPostAnalyticsCSV: async () => toCSVStream(
-            'post analytics',
-            await postsService.export({limit: 'all', mongoTransformer: rejectAdminApiRestrictedFieldsTransformer}),
-            createPostsCSVTransform()
-        ),
-        listThemes: () => Object.keys(themeList.getAll()),
-        zipTheme: zipThemeToTempFile,
-        exportRoutesYaml: () => routeSettings.api.download(),
-        exportRedirectsYaml: async () => serializeToYaml(await customRedirects.api.getAll())
-    });
+  return new SiteExporter({
+    // Same shape the `/db/` download produces, so the file stays importable
+    exportContent: async () => ({ db: [await exporter.doExport()] }),
+    // `limit: 'all'` keeps both CSV exporters on their unfiltered
+    // streaming path — without it the members exporter materialises every
+    // id into a WHERE IN and the posts exporter caps at its default page
+    exportMembersCSV: async () =>
+      toCSVStream(
+        'members',
+        await membersService.export({ limit: 'all' }),
+        createMembersCSVTransform(),
+      ),
+    // Same restricted-fields guard the `/posts/export/` endpoint applies
+    exportPostAnalyticsCSV: async () =>
+      toCSVStream(
+        'post analytics',
+        await postsService.export({
+          limit: 'all',
+          mongoTransformer: rejectAdminApiRestrictedFieldsTransformer,
+        }),
+        createPostsCSVTransform(),
+      ),
+    listThemes: () => Object.keys(themeList.getAll()),
+    zipTheme: zipThemeToTempFile,
+    exportRoutesYaml: () => routeSettings.api.download(),
+    exportRedirectsYaml: async () => serializeToYaml(await customRedirects.api.getAll()),
+  });
 }
 
 /**
@@ -103,113 +114,111 @@ function createSiteExporter() {
  * never trust an email supplied in the request body.
  */
 async function resolveRequestedBy(frame) {
-    if (frame.user && frame.user.get) {
-        return frame.user.get('email');
-    }
+  if (frame.user && frame.user.get) {
+    return frame.user.get('email');
+  }
 
-    if (frame.options.context.user) {
-        const user = await models.User.findOne({id: frame.options.context.user});
-        return user && user.get('email');
-    }
+  if (frame.options.context.user) {
+    const user = await models.User.findOne({ id: frame.options.context.user });
+    return user && user.get('email');
+  }
 
-    return null;
+  return null;
 }
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
-    docName: 'exports',
+  docName: 'exports',
 
-    download: {
-        headers: {
-            cacheInvalidate: false
-        },
-        options: [
-            'components'
-        ],
-        validation: {
-            options: {
-                components: {
-                    values: [...EXPORT_COMPONENTS]
-                }
-            }
-        },
-        permissions: {
-            docName: 'db',
-            method: 'exportContent'
-        },
-        query(frame) {
-            // Absent means everything; explicitly empty means nothing selected
-            const components = frame.options.components ?? [...EXPORT_COMPONENTS];
-
-            if (components.length === 0) {
-                throw new errors.ValidationError({
-                    message: messages.noComponentsSelected
-                });
-            }
-
-            return {
-                archive: createSiteExporter().createArchive(components),
-                filename: getExportFileName('export', 'zip')
-            };
-        }
+  download: {
+    headers: {
+      cacheInvalidate: false,
     },
-
-    add: {
-        statusCode: 202,
-        headers: {
-            cacheInvalidate: false
+    options: ['components'],
+    validation: {
+      options: {
+        components: {
+          values: [...EXPORT_COMPONENTS],
         },
-        validation(frame) {
-            const components = frame.data && frame.data.components;
+      },
+    },
+    permissions: {
+      docName: 'db',
+      method: 'exportContent',
+    },
+    query(frame) {
+      // Absent means everything; explicitly empty means nothing selected
+      const components = frame.options.components ?? [...EXPORT_COMPONENTS];
 
-            if (!components || typeof components !== 'object' || Array.isArray(components)) {
-                throw new errors.BadRequestError({
-                    message: 'components must be an object'
-                });
-            }
+      if (components.length === 0) {
+        throw new errors.ValidationError({
+          message: messages.noComponentsSelected,
+        });
+      }
 
-            const keys = Object.keys(components);
-            const unknownKeys = keys.filter(key => !ALLOWED_REQUEST_COMPONENTS.includes(key));
+      return {
+        archive: createSiteExporter().createArchive(components),
+        filename: getExportFileName('export', 'zip'),
+      };
+    },
+  },
 
-            if (unknownKeys.length > 0) {
-                throw new errors.BadRequestError({
-                    message: `Unknown export components: ${unknownKeys.join(', ')}`
-                });
-            }
+  add: {
+    statusCode: 202,
+    headers: {
+      cacheInvalidate: false,
+    },
+    validation(frame) {
+      const components = frame.data && frame.data.components;
 
-            if (keys.some(key => typeof components[key] !== 'boolean')) {
-                throw new errors.BadRequestError({
-                    message: 'Export component values must be booleans'
-                });
-            }
+      if (!components || typeof components !== 'object' || Array.isArray(components)) {
+        throw new errors.BadRequestError({
+          message: 'components must be an object',
+        });
+      }
 
-            if (!keys.some(key => components[key] === true)) {
-                throw new errors.BadRequestError({
-                    message: 'At least one export component must be selected'
-                });
-            }
-        },
-        permissions: {
-            docName: 'db',
-            method: 'exportContent'
-        },
-        async query(frame) {
-            const components = {};
-            for (const key of ALLOWED_REQUEST_COMPONENTS) {
-                components[key] = frame.data.components[key] === true;
-            }
+      const keys = Object.keys(components);
+      const unknownKeys = keys.filter((key) => !ALLOWED_REQUEST_COMPONENTS.includes(key));
 
-            const requestedBy = await resolveRequestedBy(frame);
+      if (unknownKeys.length > 0) {
+        throw new errors.BadRequestError({
+          message: `Unknown export components: ${unknownKeys.join(', ')}`,
+        });
+      }
 
-            if (!requestedBy) {
-                throw new errors.NoPermissionError({
-                    message: 'Export requests require an authenticated staff user'
-                });
-            }
+      if (keys.some((key) => typeof components[key] !== 'boolean')) {
+        throw new errors.BadRequestError({
+          message: 'Export component values must be booleans',
+        });
+      }
 
-            await exportRequestsService.requestArchive({components, requestedBy});
-        }
-    }
+      if (!keys.some((key) => components[key] === true)) {
+        throw new errors.BadRequestError({
+          message: 'At least one export component must be selected',
+        });
+      }
+    },
+    permissions: {
+      docName: 'db',
+      method: 'exportContent',
+    },
+    async query(frame) {
+      const components = {};
+      for (const key of ALLOWED_REQUEST_COMPONENTS) {
+        components[key] = frame.data.components[key] === true;
+      }
+
+      const requestedBy = await resolveRequestedBy(frame);
+
+      if (!requestedBy) {
+        throw new errors.NoPermissionError({
+          message: 'Export requests require an authenticated staff user',
+        });
+      }
+
+      await exportRequestsService.requestArchive({ components, requestedBy });
+    },
+  },
 };
 
 module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/exports.js
+++ b/ghost/core/core/server/api/endpoints/exports.js
@@ -26,7 +26,6 @@ const {
   createCSVTransform: createPostsCSVTransform,
 } = require('./utils/serializers/output/posts-csv-transform');
 const { pipeline } = require('stream');
-const models = require('../../models');
 const { exportRequestsService } = require('../../services/export-requests/export-requests-service');
 
 const postsService = getPostServiceInstance();
@@ -111,23 +110,6 @@ function createSiteExporter() {
   });
 }
 
-/**
- * Resolves the delivery email server-side from the authenticated user —
- * never trust an email supplied in the request body.
- */
-async function resolveRequestedBy(frame) {
-  if (frame.user && frame.user.get) {
-    return frame.user.get('email');
-  }
-
-  if (frame.options.context.user) {
-    const user = await models.User.findOne({ id: frame.options.context.user });
-    return user && user.get('email');
-  }
-
-  return null;
-}
-
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
   docName: 'exports',
@@ -210,15 +192,7 @@ const controller = {
         components[key] = frame.data.components[key] === true;
       }
 
-      const requestedBy = await resolveRequestedBy(frame);
-
-      if (!requestedBy) {
-        throw new errors.NoPermissionError({
-          message: 'Export requests require an authenticated staff user',
-        });
-      }
-
-      await exportRequestsService.requestArchive({ components, requestedBy });
+      await exportRequestsService.requestArchive({ components });
     },
   },
 };

--- a/ghost/core/core/server/api/endpoints/exports.js
+++ b/ghost/core/core/server/api/endpoints/exports.js
@@ -9,25 +9,25 @@ const membersService = require('../../services/members');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const routeSettings = require('../../services/route-settings');
 const customRedirects = require('../../services/custom-redirects');
-const { serializeToYaml } = require('../../services/custom-redirects/redirect-config-parser');
+const {serializeToYaml} = require('../../services/custom-redirects/redirect-config-parser');
 const themeService = require('../../services/themes');
 const themeList = require('../../services/themes/list');
-const { SiteExporter, EXPORT_COMPONENTS } = require('../../services/exports/site-exporter');
-const { getExportFileName } = require('./utils/csv-export-filename');
-const { rejectAdminApiRestrictedFieldsTransformer } = require('./utils/api-filter-utils');
-const {
-  createCSVTransform: createMembersCSVTransform,
-} = require('./utils/serializers/output/members-csv-transform');
-const {
-  createCSVTransform: createPostsCSVTransform,
-} = require('./utils/serializers/output/posts-csv-transform');
-const { pipeline } = require('stream');
+const {SiteExporter, EXPORT_COMPONENTS} = require('../../services/exports/site-exporter');
+const {getExportFileName} = require('./utils/csv-export-filename');
+const {rejectAdminApiRestrictedFieldsTransformer} = require('./utils/api-filter-utils');
+const {createCSVTransform: createMembersCSVTransform} = require('./utils/serializers/output/members-csv-transform');
+const {createCSVTransform: createPostsCSVTransform} = require('./utils/serializers/output/posts-csv-transform');
+const {pipeline} = require('stream');
+const models = require('../../models');
+const {exportRequestsService} = require('../../services/export-requests/export-requests-service');
 
 const postsService = getPostServiceInstance();
 
 const messages = {
-  noComponentsSelected: 'No export components selected',
+    noComponentsSelected: 'No export components selected'
 };
+
+const ALLOWED_REQUEST_COMPONENTS = ['content', 'members', 'analytics', 'themes', 'routes', 'media'];
 
 /**
  * Pipes export rows through their CSV transform. `pipeline` (rather than
@@ -40,17 +40,15 @@ const messages = {
  * @returns {NodeJS.ReadableStream}
  */
 function toCSVStream(label, rows, transform) {
-  pipeline(rows, transform, (err) => {
-    if (err) {
-      logging.error(
-        new errors.InternalServerError({
-          message: `Site export: the ${label} stream failed mid-export`,
-          err,
-        }),
-      );
-    }
-  });
-  return transform;
+    pipeline(rows, transform, (err) => {
+        if (err) {
+            logging.error(new errors.InternalServerError({
+                message: `Site export: the ${label} stream failed mid-export`,
+                err
+            }));
+        }
+    });
+    return transform;
 }
 
 /**
@@ -62,87 +60,156 @@ function toCSVStream(label, rows, transform) {
  * @returns {Promise<{zipPath: string, cleanup(): Promise<void>}>}
  */
 async function zipThemeToTempFile(name) {
-  const tmpDir = path.join(os.tmpdir(), `ghost-export-${security.identifier.uid(10)}`);
-  await fs.ensureDir(tmpDir);
+    const tmpDir = path.join(os.tmpdir(), `ghost-export-${security.identifier.uid(10)}`);
+    await fs.ensureDir(tmpDir);
 
-  try {
-    const zipPath = path.join(tmpDir, `${name}.zip`);
-    await themeService.api.zipToFile(name, zipPath);
-    return { zipPath, cleanup: () => fs.remove(tmpDir) };
-  } catch (err) {
-    await fs.remove(tmpDir);
-    throw err;
-  }
+    try {
+        const zipPath = path.join(tmpDir, `${name}.zip`);
+        await themeService.api.zipToFile(name, zipPath);
+        return {zipPath, cleanup: () => fs.remove(tmpDir)};
+    } catch (err) {
+        await fs.remove(tmpDir);
+        throw err;
+    }
 }
 
 function createSiteExporter() {
-  return new SiteExporter({
-    // Same shape the `/db/` download produces, so the file stays importable
-    exportContent: async () => ({ db: [await exporter.doExport()] }),
-    // `limit: 'all'` keeps both CSV exporters on their unfiltered
-    // streaming path — without it the members exporter materialises every
-    // id into a WHERE IN and the posts exporter caps at its default page
-    exportMembersCSV: async () =>
-      toCSVStream(
-        'members',
-        await membersService.export({ limit: 'all' }),
-        createMembersCSVTransform(),
-      ),
-    // Same restricted-fields guard the `/posts/export/` endpoint applies
-    exportPostAnalyticsCSV: async () =>
-      toCSVStream(
-        'post analytics',
-        await postsService.export({
-          limit: 'all',
-          mongoTransformer: rejectAdminApiRestrictedFieldsTransformer,
-        }),
-        createPostsCSVTransform(),
-      ),
-    listThemes: () => Object.keys(themeList.getAll()),
-    zipTheme: zipThemeToTempFile,
-    exportRoutesYaml: () => routeSettings.api.download(),
-    exportRedirectsYaml: async () => serializeToYaml(await customRedirects.api.getAll()),
-  });
+    return new SiteExporter({
+        // Same shape the `/db/` download produces, so the file stays importable
+        exportContent: async () => ({db: [await exporter.doExport()]}),
+        // `limit: 'all'` keeps both CSV exporters on their unfiltered
+        // streaming path — without it the members exporter materialises every
+        // id into a WHERE IN and the posts exporter caps at its default page
+        exportMembersCSV: async () => toCSVStream(
+            'members',
+            await membersService.export({limit: 'all'}),
+            createMembersCSVTransform()
+        ),
+        // Same restricted-fields guard the `/posts/export/` endpoint applies
+        exportPostAnalyticsCSV: async () => toCSVStream(
+            'post analytics',
+            await postsService.export({limit: 'all', mongoTransformer: rejectAdminApiRestrictedFieldsTransformer}),
+            createPostsCSVTransform()
+        ),
+        listThemes: () => Object.keys(themeList.getAll()),
+        zipTheme: zipThemeToTempFile,
+        exportRoutesYaml: () => routeSettings.api.download(),
+        exportRedirectsYaml: async () => serializeToYaml(await customRedirects.api.getAll())
+    });
+}
+
+/**
+ * Resolves the delivery email server-side from the authenticated user —
+ * never trust an email supplied in the request body.
+ */
+async function resolveRequestedBy(frame) {
+    if (frame.user && frame.user.get) {
+        return frame.user.get('email');
+    }
+
+    if (frame.options.context.user) {
+        const user = await models.User.findOne({id: frame.options.context.user});
+        return user && user.get('email');
+    }
+
+    return null;
 }
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
-  docName: 'exports',
+    docName: 'exports',
 
-  download: {
-    headers: {
-      cacheInvalidate: false,
-    },
-    options: ['components'],
-    validation: {
-      options: {
-        components: {
-          values: [...EXPORT_COMPONENTS],
+    download: {
+        headers: {
+            cacheInvalidate: false
         },
-      },
-    },
-    // A site export contains everything a database export contains, so
-    // the same Owner/Administrator-only gate applies
-    permissions: {
-      docName: 'db',
-      method: 'exportContent',
-    },
-    query(frame) {
-      // Absent means everything; explicitly empty means nothing selected
-      const components = frame.options.components ?? [...EXPORT_COMPONENTS];
+        options: [
+            'components'
+        ],
+        validation: {
+            options: {
+                components: {
+                    values: [...EXPORT_COMPONENTS]
+                }
+            }
+        },
+        permissions: {
+            docName: 'db',
+            method: 'exportContent'
+        },
+        query(frame) {
+            // Absent means everything; explicitly empty means nothing selected
+            const components = frame.options.components ?? [...EXPORT_COMPONENTS];
 
-      if (components.length === 0) {
-        throw new errors.ValidationError({
-          message: messages.noComponentsSelected,
-        });
-      }
+            if (components.length === 0) {
+                throw new errors.ValidationError({
+                    message: messages.noComponentsSelected
+                });
+            }
 
-      return {
-        archive: createSiteExporter().createArchive(components),
-        filename: getExportFileName('export', 'zip'),
-      };
+            return {
+                archive: createSiteExporter().createArchive(components),
+                filename: getExportFileName('export', 'zip')
+            };
+        }
     },
-  },
+
+    add: {
+        statusCode: 202,
+        headers: {
+            cacheInvalidate: false
+        },
+        validation(frame) {
+            const components = frame.data && frame.data.components;
+
+            if (!components || typeof components !== 'object' || Array.isArray(components)) {
+                throw new errors.BadRequestError({
+                    message: 'components must be an object'
+                });
+            }
+
+            const keys = Object.keys(components);
+            const unknownKeys = keys.filter(key => !ALLOWED_REQUEST_COMPONENTS.includes(key));
+
+            if (unknownKeys.length > 0) {
+                throw new errors.BadRequestError({
+                    message: `Unknown export components: ${unknownKeys.join(', ')}`
+                });
+            }
+
+            if (keys.some(key => typeof components[key] !== 'boolean')) {
+                throw new errors.BadRequestError({
+                    message: 'Export component values must be booleans'
+                });
+            }
+
+            if (!keys.some(key => components[key] === true)) {
+                throw new errors.BadRequestError({
+                    message: 'At least one export component must be selected'
+                });
+            }
+        },
+        permissions: {
+            docName: 'db',
+            method: 'exportContent'
+        },
+        async query(frame) {
+            const components = {};
+            for (const key of ALLOWED_REQUEST_COMPONENTS) {
+                components[key] = frame.data.components[key] === true;
+            }
+
+            const requestedBy = await resolveRequestedBy(frame);
+
+            if (!requestedBy) {
+                throw new errors.NoPermissionError({
+                    message: 'Export requests require an authenticated staff user'
+                });
+            }
+
+            await exportRequestsService.requestArchive({components, requestedBy});
+        }
+    }
 };
 
 module.exports = controller;

--- a/ghost/core/core/server/lib/signed-webhook.ts
+++ b/ghost/core/core/server/lib/signed-webhook.ts
@@ -1,0 +1,75 @@
+import crypto from 'crypto';
+const ghostVersion = require('@tryghost/version');
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+type SignedWebhookRequestOptions = {
+  method: 'POST';
+  body: string;
+  headers: Record<string, string | number>;
+  timeout: { request: number };
+  retry: { limit: number };
+};
+
+/**
+ * Wire format for webhooks Ghost posts to the host (e.g. email verification,
+ * export archive requests). The receiver verifies
+ * `X-Ghost-Signature: base64(HMAC-SHA256(secret, "{timestamp}:{rawBody}"))`
+ * against the raw request body, so the body must be sent exactly as signed.
+ */
+export function computeWebhookSignature(timestamp: string, body: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(`${timestamp}:${body}`).digest('base64');
+}
+
+/**
+ * Reduces a webhook URL to its origin so logs never leak credentials or
+ * tokens embedded in the path or query string.
+ */
+export function sanitizeWebhookUrl(webhookUrl: string): string {
+  try {
+    return new URL(webhookUrl).origin;
+  } catch {
+    return '[invalid webhook url]';
+  }
+}
+
+/**
+ * Builds the request options for a signed host webhook delivery. When no
+ * secret is configured the payload is sent unsigned (the receiver decides
+ * whether to accept that).
+ */
+export function buildSignedWebhookRequest({
+  payload,
+  secret,
+  retryLimit,
+}: {
+  payload: unknown;
+  secret?: string;
+  retryLimit: number;
+}): SignedWebhookRequestOptions {
+  const body = JSON.stringify(payload);
+  const timestamp = Date.now().toString();
+
+  const headers: Record<string, string | number> = {
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'application/json',
+    'Content-Version': `v${ghostVersion.safe}`,
+    'X-Ghost-Request-Timestamp': timestamp,
+  };
+
+  if (secret) {
+    headers['X-Ghost-Signature'] = computeWebhookSignature(timestamp, body, secret);
+  }
+
+  return {
+    method: 'POST',
+    body,
+    headers,
+    timeout: {
+      request: REQUEST_TIMEOUT_MS,
+    },
+    retry: {
+      limit: retryLimit,
+    },
+  };
+}

--- a/ghost/core/core/server/services/export-requests/export-requests-service.ts
+++ b/ghost/core/core/server/services/export-requests/export-requests-service.ts
@@ -6,153 +6,160 @@ const errors = require('@tryghost/errors');
 const config = require('../../../shared/config');
 
 export type ExportComponents = {
-    content: boolean;
-    members: boolean;
-    analytics: boolean;
-    themes: boolean;
-    routes: boolean;
-    media: boolean;
+  content: boolean;
+  members: boolean;
+  analytics: boolean;
+  themes: boolean;
+  routes: boolean;
+  media: boolean;
 };
 
 type ExportRequestBody = {
-    type: 'export';
-    siteId: string;
-    requestedBy: string;
-    components: ExportComponents;
+  type: 'export';
+  siteId: string;
+  requestedBy: string;
+  components: ExportComponents;
 };
 
 type ExportRequestsServiceDependencies = {
-    config: {
-        get: (key: string) => unknown;
-    };
-    logging: {
-        info: (message: string) => void;
-        warn: (message: string) => void;
-        error: (message: string) => void;
-    };
-    request: (url: string, options: unknown) => Promise<unknown>;
+  config: {
+    get: (key: string) => unknown;
+  };
+  logging: {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
+  request: (url: string, options: unknown) => Promise<unknown>;
 };
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
 export class ExportRequestsService {
-    #config: ExportRequestsServiceDependencies['config'];
-    #logging: ExportRequestsServiceDependencies['logging'];
-    #request: ExportRequestsServiceDependencies['request'];
+  #config: ExportRequestsServiceDependencies['config'];
+  #logging: ExportRequestsServiceDependencies['logging'];
+  #request: ExportRequestsServiceDependencies['request'];
 
-    constructor(dependencies: ExportRequestsServiceDependencies = {config, logging, request}) {
-        this.#config = dependencies.config;
-        this.#logging = dependencies.logging;
-        this.#request = dependencies.request;
+  constructor(dependencies: ExportRequestsServiceDependencies = { config, logging, request }) {
+    this.#config = dependencies.config;
+    this.#logging = dependencies.logging;
+    this.#request = dependencies.request;
+  }
+
+  #readExportRequestConfig() {
+    return {
+      webhookUrl: this.#config.get('hostSettings:export:webhookUrl'),
+      webhookSecret: this.#config.get('hostSettings:export:webhookSecret'),
+      siteId: this.#config.get('hostSettings:siteId'),
+    };
+  }
+
+  #computeSignature(timestamp: string, body: string, secret: string): string {
+    const baseString = `${timestamp}:${body}`;
+    return crypto.createHmac('sha256', secret).update(baseString).digest('base64');
+  }
+
+  #sanitizeUrl(url: string): string {
+    try {
+      return new URL(url).origin;
+    } catch {
+      return '[invalid archive url]';
+    }
+  }
+
+  /**
+   * Requests an async export archive from the configured host service.
+   * The host service generates the archive in the background and emails a
+   * download link to `requestedBy`.
+   *
+   * The webhook is a shared channel that dispatches on the `type` field of
+   * the event envelope, and the receiver is fire-and-forget (it always
+   * responds 200) — a 2xx means "delivered", not "validated".
+   */
+  async requestArchive({
+    components,
+    requestedBy,
+  }: {
+    components: ExportComponents;
+    requestedBy: string;
+  }): Promise<void> {
+    const { webhookUrl, webhookSecret, siteId } = this.#readExportRequestConfig();
+
+    if (typeof webhookUrl !== 'string' || webhookUrl.length === 0) {
+      throw new errors.NotFoundError({
+        message: 'Export archive generation is not enabled on this site',
+      });
     }
 
-    #readExportRequestConfig() {
-        return {
-            webhookUrl: this.#config.get('hostSettings:export:webhookUrl'),
-            webhookSecret: this.#config.get('hostSettings:export:webhookSecret'),
-            siteId: this.#config.get('hostSettings:siteId')
-        };
+    if (typeof webhookSecret !== 'string' || webhookSecret.length === 0) {
+      this.#logging.error(
+        'Export archive request is misconfigured: hostSettings:export:webhookSecret is missing while hostSettings:export:webhookUrl is set.',
+      );
+      throw new errors.IncorrectUsageError({
+        message: 'Export requests are not configured correctly on this site',
+      });
     }
 
-    #computeSignature(timestamp: string, body: string, secret: string): string {
-        const baseString = `${timestamp}:${body}`;
-        return crypto.createHmac('sha256', secret).update(baseString).digest('base64');
+    const normalizedSiteId =
+      typeof siteId === 'string' ? siteId : typeof siteId === 'number' ? String(siteId) : '';
+
+    if (normalizedSiteId.length === 0) {
+      this.#logging.error(
+        'Export archive request is misconfigured: hostSettings:siteId is missing while hostSettings:export:webhookUrl is set.',
+      );
+      throw new errors.IncorrectUsageError({
+        message: 'Export requests are not configured correctly on this site',
+      });
     }
 
-    #sanitizeUrl(url: string): string {
-        try {
-            return new URL(url).origin;
-        } catch {
-            return '[invalid archive url]';
-        }
+    const payload: ExportRequestBody = {
+      type: 'export',
+      siteId: normalizedSiteId,
+      requestedBy,
+      components,
+    };
+
+    const requestBody = JSON.stringify(payload);
+    const timestamp = Date.now().toString();
+
+    const headers: Record<string, string | number> = {
+      'Content-Length': Buffer.byteLength(requestBody),
+      'Content-Type': 'application/json',
+      'Content-Version': `v${ghostVersion.safe}`,
+      'X-Ghost-Request-Timestamp': timestamp,
+      'X-Ghost-Signature': this.#computeSignature(timestamp, requestBody, webhookSecret),
+    };
+
+    const requestOptions = {
+      method: 'POST',
+      body: requestBody,
+      headers,
+      timeout: {
+        request: REQUEST_TIMEOUT_MS,
+      },
+      // No retries: the request is not idempotent (each delivery can
+      // schedule an archive)
+      retry: {
+        limit: 0,
+      },
+    };
+
+    const sanitizedUrl = this.#sanitizeUrl(webhookUrl);
+    this.#logging.info(`Requesting export archive generation from "${sanitizedUrl}"`);
+
+    try {
+      await this.#request(webhookUrl, requestOptions);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.#logging.error(
+        `Failed to request export archive generation from "${sanitizedUrl}": ${message}`,
+      );
+      throw new errors.InternalServerError({
+        statusCode: 502,
+        message: 'Failed to start the export. Please try again later.',
+      });
     }
-
-    /**
-     * Requests an async export archive from the configured host service.
-     * The host service generates the archive in the background and emails a
-     * download link to `requestedBy`.
-     *
-     * The webhook is a shared channel that dispatches on the `type` field of
-     * the event envelope, and the receiver is fire-and-forget (it always
-     * responds 200) — a 2xx means "delivered", not "validated".
-     */
-    async requestArchive({
-        components,
-        requestedBy
-    }: {
-        components: ExportComponents;
-        requestedBy: string;
-    }): Promise<void> {
-        const {webhookUrl, webhookSecret, siteId} = this.#readExportRequestConfig();
-
-        if (typeof webhookUrl !== 'string' || webhookUrl.length === 0) {
-            throw new errors.NotFoundError({
-                message: 'Export archive generation is not enabled on this site'
-            });
-        }
-
-        if (typeof webhookSecret !== 'string' || webhookSecret.length === 0) {
-            this.#logging.error('Export archive request is misconfigured: hostSettings:export:webhookSecret is missing while hostSettings:export:webhookUrl is set.');
-            throw new errors.IncorrectUsageError({
-                message: 'Export requests are not configured correctly on this site'
-            });
-        }
-
-        const normalizedSiteId = typeof siteId === 'string' ? siteId : (typeof siteId === 'number' ? String(siteId) : '');
-
-        if (normalizedSiteId.length === 0) {
-            this.#logging.error('Export archive request is misconfigured: hostSettings:siteId is missing while hostSettings:export:webhookUrl is set.');
-            throw new errors.IncorrectUsageError({
-                message: 'Export requests are not configured correctly on this site'
-            });
-        }
-
-        const payload: ExportRequestBody = {
-            type: 'export',
-            siteId: normalizedSiteId,
-            requestedBy,
-            components
-        };
-
-        const requestBody = JSON.stringify(payload);
-        const timestamp = Date.now().toString();
-
-        const headers: Record<string, string | number> = {
-            'Content-Length': Buffer.byteLength(requestBody),
-            'Content-Type': 'application/json',
-            'Content-Version': `v${ghostVersion.safe}`,
-            'X-Ghost-Request-Timestamp': timestamp,
-            'X-Ghost-Signature': this.#computeSignature(timestamp, requestBody, webhookSecret)
-        };
-
-        const requestOptions = {
-            method: 'POST',
-            body: requestBody,
-            headers,
-            timeout: {
-                request: REQUEST_TIMEOUT_MS
-            },
-            // No retries: the request is not idempotent (each delivery can
-            // schedule an archive)
-            retry: {
-                limit: 0
-            }
-        };
-
-        const sanitizedUrl = this.#sanitizeUrl(webhookUrl);
-        this.#logging.info(`Requesting export archive generation from "${sanitizedUrl}"`);
-
-        try {
-            await this.#request(webhookUrl, requestOptions);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            this.#logging.error(`Failed to request export archive generation from "${sanitizedUrl}": ${message}`);
-            throw new errors.InternalServerError({
-                statusCode: 502,
-                message: 'Failed to start the export. Please try again later.'
-            });
-        }
-    }
+  }
 }
 
 export const exportRequestsService = new ExportRequestsService();

--- a/ghost/core/core/server/services/export-requests/export-requests-service.ts
+++ b/ghost/core/core/server/services/export-requests/export-requests-service.ts
@@ -10,7 +10,6 @@ const config = require('../../../shared/config');
 type ExportRequestBody = {
   type: 'export';
   siteId: string;
-  requestedBy: string;
   components: AsyncExportComponents;
 };
 
@@ -48,19 +47,13 @@ export class ExportRequestsService {
   /**
    * Requests an async export archive from the configured host service.
    * The host service generates the archive in the background and emails a
-   * download link to `requestedBy`.
+   * download link to the site owner.
    *
    * The webhook is a shared channel that dispatches on the `type` field of
    * the event envelope, and the receiver is fire-and-forget (it always
    * responds 200) — a 2xx means "delivered", not "validated".
    */
-  async requestArchive({
-    components,
-    requestedBy,
-  }: {
-    components: AsyncExportComponents;
-    requestedBy: string;
-  }): Promise<void> {
+  async requestArchive({ components }: { components: AsyncExportComponents }): Promise<void> {
     const { webhookUrl, webhookSecret, siteId } = this.#readExportRequestConfig();
 
     if (typeof webhookUrl !== 'string' || webhookUrl.length === 0) {
@@ -93,7 +86,6 @@ export class ExportRequestsService {
     const payload: ExportRequestBody = {
       type: 'export',
       siteId: normalizedSiteId,
-      requestedBy,
       components,
     };
 

--- a/ghost/core/core/server/services/export-requests/export-requests-service.ts
+++ b/ghost/core/core/server/services/export-requests/export-requests-service.ts
@@ -1,0 +1,158 @@
+import crypto from 'crypto';
+const logging = require('@tryghost/logging');
+const request = require('@tryghost/request');
+const ghostVersion = require('@tryghost/version');
+const errors = require('@tryghost/errors');
+const config = require('../../../shared/config');
+
+export type ExportComponents = {
+    content: boolean;
+    members: boolean;
+    analytics: boolean;
+    themes: boolean;
+    routes: boolean;
+    media: boolean;
+};
+
+type ExportRequestBody = {
+    type: 'export';
+    siteId: string;
+    requestedBy: string;
+    components: ExportComponents;
+};
+
+type ExportRequestsServiceDependencies = {
+    config: {
+        get: (key: string) => unknown;
+    };
+    logging: {
+        info: (message: string) => void;
+        warn: (message: string) => void;
+        error: (message: string) => void;
+    };
+    request: (url: string, options: unknown) => Promise<unknown>;
+};
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export class ExportRequestsService {
+    #config: ExportRequestsServiceDependencies['config'];
+    #logging: ExportRequestsServiceDependencies['logging'];
+    #request: ExportRequestsServiceDependencies['request'];
+
+    constructor(dependencies: ExportRequestsServiceDependencies = {config, logging, request}) {
+        this.#config = dependencies.config;
+        this.#logging = dependencies.logging;
+        this.#request = dependencies.request;
+    }
+
+    #readExportRequestConfig() {
+        return {
+            webhookUrl: this.#config.get('hostSettings:export:webhookUrl'),
+            webhookSecret: this.#config.get('hostSettings:export:webhookSecret'),
+            siteId: this.#config.get('hostSettings:siteId')
+        };
+    }
+
+    #computeSignature(timestamp: string, body: string, secret: string): string {
+        const baseString = `${timestamp}:${body}`;
+        return crypto.createHmac('sha256', secret).update(baseString).digest('base64');
+    }
+
+    #sanitizeUrl(url: string): string {
+        try {
+            return new URL(url).origin;
+        } catch {
+            return '[invalid archive url]';
+        }
+    }
+
+    /**
+     * Requests an async export archive from the configured host service.
+     * The host service generates the archive in the background and emails a
+     * download link to `requestedBy`.
+     *
+     * The webhook is a shared channel that dispatches on the `type` field of
+     * the event envelope, and the receiver is fire-and-forget (it always
+     * responds 200) — a 2xx means "delivered", not "validated".
+     */
+    async requestArchive({
+        components,
+        requestedBy
+    }: {
+        components: ExportComponents;
+        requestedBy: string;
+    }): Promise<void> {
+        const {webhookUrl, webhookSecret, siteId} = this.#readExportRequestConfig();
+
+        if (typeof webhookUrl !== 'string' || webhookUrl.length === 0) {
+            throw new errors.NotFoundError({
+                message: 'Export archive generation is not enabled on this site'
+            });
+        }
+
+        if (typeof webhookSecret !== 'string' || webhookSecret.length === 0) {
+            this.#logging.error('Export archive request is misconfigured: hostSettings:export:webhookSecret is missing while hostSettings:export:webhookUrl is set.');
+            throw new errors.IncorrectUsageError({
+                message: 'Export requests are not configured correctly on this site'
+            });
+        }
+
+        const normalizedSiteId = typeof siteId === 'string' ? siteId : (typeof siteId === 'number' ? String(siteId) : '');
+
+        if (normalizedSiteId.length === 0) {
+            this.#logging.error('Export archive request is misconfigured: hostSettings:siteId is missing while hostSettings:export:webhookUrl is set.');
+            throw new errors.IncorrectUsageError({
+                message: 'Export requests are not configured correctly on this site'
+            });
+        }
+
+        const payload: ExportRequestBody = {
+            type: 'export',
+            siteId: normalizedSiteId,
+            requestedBy,
+            components
+        };
+
+        const requestBody = JSON.stringify(payload);
+        const timestamp = Date.now().toString();
+
+        const headers: Record<string, string | number> = {
+            'Content-Length': Buffer.byteLength(requestBody),
+            'Content-Type': 'application/json',
+            'Content-Version': `v${ghostVersion.safe}`,
+            'X-Ghost-Request-Timestamp': timestamp,
+            'X-Ghost-Signature': this.#computeSignature(timestamp, requestBody, webhookSecret)
+        };
+
+        const requestOptions = {
+            method: 'POST',
+            body: requestBody,
+            headers,
+            timeout: {
+                request: REQUEST_TIMEOUT_MS
+            },
+            // No retries: the request is not idempotent (each delivery can
+            // schedule an archive)
+            retry: {
+                limit: 0
+            }
+        };
+
+        const sanitizedUrl = this.#sanitizeUrl(webhookUrl);
+        this.#logging.info(`Requesting export archive generation from "${sanitizedUrl}"`);
+
+        try {
+            await this.#request(webhookUrl, requestOptions);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.#logging.error(`Failed to request export archive generation from "${sanitizedUrl}": ${message}`);
+            throw new errors.InternalServerError({
+                statusCode: 502,
+                message: 'Failed to start the export. Please try again later.'
+            });
+        }
+    }
+}
+
+export const exportRequestsService = new ExportRequestsService();

--- a/ghost/core/core/server/services/export-requests/export-requests-service.ts
+++ b/ghost/core/core/server/services/export-requests/export-requests-service.ts
@@ -1,24 +1,17 @@
-import crypto from 'crypto';
+import { buildSignedWebhookRequest, sanitizeWebhookUrl } from '../../lib/signed-webhook';
+import { ASYNC_EXPORT_COMPONENTS } from '../exports/export-components';
+
+type AsyncExportComponents = Record<(typeof ASYNC_EXPORT_COMPONENTS)[number], boolean>;
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
-const ghostVersion = require('@tryghost/version');
 const errors = require('@tryghost/errors');
 const config = require('../../../shared/config');
-
-export type ExportComponents = {
-  content: boolean;
-  members: boolean;
-  analytics: boolean;
-  themes: boolean;
-  routes: boolean;
-  media: boolean;
-};
 
 type ExportRequestBody = {
   type: 'export';
   siteId: string;
   requestedBy: string;
-  components: ExportComponents;
+  components: AsyncExportComponents;
 };
 
 type ExportRequestsServiceDependencies = {
@@ -32,8 +25,6 @@ type ExportRequestsServiceDependencies = {
   };
   request: (url: string, options: unknown) => Promise<unknown>;
 };
-
-const REQUEST_TIMEOUT_MS = 30_000;
 
 export class ExportRequestsService {
   #config: ExportRequestsServiceDependencies['config'];
@@ -54,19 +45,6 @@ export class ExportRequestsService {
     };
   }
 
-  #computeSignature(timestamp: string, body: string, secret: string): string {
-    const baseString = `${timestamp}:${body}`;
-    return crypto.createHmac('sha256', secret).update(baseString).digest('base64');
-  }
-
-  #sanitizeUrl(url: string): string {
-    try {
-      return new URL(url).origin;
-    } catch {
-      return '[invalid archive url]';
-    }
-  }
-
   /**
    * Requests an async export archive from the configured host service.
    * The host service generates the archive in the background and emails a
@@ -80,7 +58,7 @@ export class ExportRequestsService {
     components,
     requestedBy,
   }: {
-    components: ExportComponents;
+    components: AsyncExportComponents;
     requestedBy: string;
   }): Promise<void> {
     const { webhookUrl, webhookSecret, siteId } = this.#readExportRequestConfig();
@@ -119,32 +97,15 @@ export class ExportRequestsService {
       components,
     };
 
-    const requestBody = JSON.stringify(payload);
-    const timestamp = Date.now().toString();
-
-    const headers: Record<string, string | number> = {
-      'Content-Length': Buffer.byteLength(requestBody),
-      'Content-Type': 'application/json',
-      'Content-Version': `v${ghostVersion.safe}`,
-      'X-Ghost-Request-Timestamp': timestamp,
-      'X-Ghost-Signature': this.#computeSignature(timestamp, requestBody, webhookSecret),
-    };
-
-    const requestOptions = {
-      method: 'POST',
-      body: requestBody,
-      headers,
-      timeout: {
-        request: REQUEST_TIMEOUT_MS,
-      },
+    const requestOptions = buildSignedWebhookRequest({
+      payload,
+      secret: webhookSecret,
       // No retries: the request is not idempotent (each delivery can
       // schedule an archive)
-      retry: {
-        limit: 0,
-      },
-    };
+      retryLimit: 0,
+    });
 
-    const sanitizedUrl = this.#sanitizeUrl(webhookUrl);
+    const sanitizedUrl = sanitizeWebhookUrl(webhookUrl);
     this.#logging.info(`Requesting export archive generation from "${sanitizedUrl}"`);
 
     try {

--- a/ghost/core/core/server/services/exports/export-components.ts
+++ b/ghost/core/core/server/services/exports/export-components.ts
@@ -1,0 +1,10 @@
+export const SYNC_EXPORT_COMPONENTS = [
+  'members',
+  'analytics',
+  'content',
+  'themes',
+  'routes',
+] as const;
+
+// Media assets are only available in the async export as they can be quite large
+export const ASYNC_EXPORT_COMPONENTS = [...SYNC_EXPORT_COMPONENTS, 'media'] as const;

--- a/ghost/core/core/server/services/exports/site-exporter.ts
+++ b/ghost/core/core/server/services/exports/site-exporter.ts
@@ -1,17 +1,9 @@
 import { ZipArchive, type Archiver } from 'archiver';
 import * as errors from '@tryghost/errors';
 import logging from '@tryghost/logging';
+import { SYNC_EXPORT_COMPONENTS } from './export-components';
 
-/**
- * The components a sync site export can contain, in zip-entry order. The
- * streaming CSVs come first so their DB connections release while the
- * (buffered) content JSON is still being built. `media` is deliberately
- * absent: it needs background jobs and email delivery, so it is only
- * available through a host archive webhook.
- */
-export const EXPORT_COMPONENTS = ['members', 'analytics', 'content', 'themes', 'routes'] as const;
-
-export type ExportComponent = (typeof EXPORT_COMPONENTS)[number];
+type SyncExportComponent = (typeof SYNC_EXPORT_COMPONENTS)[number];
 
 export interface SiteExporterDeps {
   /** Full site JSON in the same shape the `/db/` download produces. */
@@ -53,7 +45,7 @@ export class SiteExporter {
    * the response while it fills. Deflate-compressed — the nested theme zips
    * opt out per-entry since they are already compressed.
    */
-  createArchive(components: ExportComponent[]): Archiver {
+  createArchive(components: SyncExportComponent[]): Archiver {
     const archive = new ZipArchive();
     const cleanups: Array<() => Promise<void>> = [];
 
@@ -76,10 +68,10 @@ export class SiteExporter {
 
   async #populate(
     archive: Archiver,
-    components: Set<ExportComponent>,
+    components: Set<SyncExportComponent>,
     cleanups: Array<() => Promise<void>>,
   ): Promise<void> {
-    for (const component of EXPORT_COMPONENTS) {
+    for (const component of SYNC_EXPORT_COMPONENTS) {
       if (archive.destroyed) {
         return;
       }
@@ -100,7 +92,7 @@ export class SiteExporter {
 
   async #appendComponent(
     archive: Archiver,
-    component: ExportComponent,
+    component: SyncExportComponent,
     cleanups: Array<() => Promise<void>>,
   ): Promise<void> {
     try {

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -1,82 +1,95 @@
-const { isPlainObject } = require('lodash');
+const {isPlainObject, omit} = require('lodash');
 const config = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
 const labs = require('../../../shared/labs');
 const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
 
-const tinybirdStatsPayloadProperties = ['endpoint', 'endpointBrowser', 'version', 'datasource'];
+const tinybirdStatsPayloadProperties = [
+    'endpoint',
+    'endpointBrowser',
+    'version',
+    'datasource'
+];
 
-const tinybirdLocalStatsPayloadProperties = ['enabled', 'endpoint', 'datasource'];
+const tinybirdLocalStatsPayloadProperties = [
+    'enabled',
+    'endpoint',
+    'datasource'
+];
+
+const sanitizeHostSettings = (hostSettings) => {
+    if (!isPlainObject(hostSettings) || !isPlainObject(hostSettings.export)) {
+        return hostSettings;
+    }
+
+    return {...hostSettings, export: omit(hostSettings.export, 'webhookSecret')};
+};
 
 const copyPayloadProperties = (target, source, properties) => {
-  for (const property of properties) {
-    if (Object.prototype.hasOwnProperty.call(source, property)) {
-      target[property] = source[property];
+    for (const property of properties) {
+        if (Object.prototype.hasOwnProperty.call(source, property)) {
+            target[property] = source[property];
+        }
     }
-  }
 };
 
 const getTinybirdStatsPayload = (statsConfig, siteUuid) => {
-  const statsPayload = {};
+    const statsPayload = {};
 
-  copyPayloadProperties(statsPayload, statsConfig, tinybirdStatsPayloadProperties);
+    copyPayloadProperties(statsPayload, statsConfig, tinybirdStatsPayloadProperties);
 
-  statsPayload.id = siteUuid;
+    statsPayload.id = siteUuid;
 
-  if (isPlainObject(statsConfig.local)) {
-    const localStatsPayload = {};
-    copyPayloadProperties(
-      localStatsPayload,
-      statsConfig.local,
-      tinybirdLocalStatsPayloadProperties,
-    );
+    if (isPlainObject(statsConfig.local)) {
+        const localStatsPayload = {};
+        copyPayloadProperties(localStatsPayload, statsConfig.local, tinybirdLocalStatsPayloadProperties);
 
-    if (Object.keys(localStatsPayload).length > 0) {
-      statsPayload.local = localStatsPayload;
+        if (Object.keys(localStatsPayload).length > 0) {
+            statsPayload.local = localStatsPayload;
+        }
     }
-  }
 
-  return statsPayload;
+    return statsPayload;
 };
 
 module.exports = function getConfigProperties() {
-  const configProperties = {
-    version: process.env.GHOST_BUILD_VERSION || ghostVersion.original,
-    environment: config.get('env'),
-    database: databaseInfo.getEngine(),
-    mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
-    useGravatar: !config.isPrivacyDisabled('useGravatar'),
-    labs: labs.getAll(),
-    clientExtensions: config.get('clientExtensions') || {},
-    enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
-    stripeDirect: config.get('stripeDirect'),
-    mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
-    emailAnalytics: config.get('emailAnalytics:enabled'),
-    hostSettings: config.get('hostSettings'),
-    klipy: config.get('klipy'),
-    pintura: config.get('pintura'),
-    signupForm: config.get('signupForm'),
-    security: config.get('security'),
-  };
-
-  if (config.get('explore') && config.get('explore:testimonials_url')) {
-    configProperties.exploreTestimonialsUrl = config.get('explore:testimonials_url');
-  }
-
-  if (config.get('tinybird') && config.get('tinybird:stats')) {
-    const statsConfig = config.get('tinybird:stats');
-    const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
-    configProperties.stats = getTinybirdStatsPayload(statsConfig, siteUuid);
-  }
-
-  if (config.get('featurebase')) {
-    // Expose only the public featurebase config properties
-    configProperties.featurebase = {
-      enabled: config.get('featurebase:enabled'),
-      organization: config.get('featurebase:organization'),
+    const configProperties = {
+        version: process.env.GHOST_BUILD_VERSION || ghostVersion.original,
+        environment: config.get('env'),
+        database: databaseInfo.getEngine(),
+        mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
+        useGravatar: !config.isPrivacyDisabled('useGravatar'),
+        labs: labs.getAll(),
+        clientExtensions: config.get('clientExtensions') || {},
+        enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
+        stripeDirect: config.get('stripeDirect'),
+        mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
+        emailAnalytics: config.get('emailAnalytics:enabled'),
+        hostSettings: sanitizeHostSettings(config.get('hostSettings')),
+        klipy: config.get('klipy'),
+        pintura: config.get('pintura'),
+        signupForm: config.get('signupForm'),
+        security: config.get('security')
     };
-  }
 
-  return configProperties;
+    if (config.get('explore') && config.get('explore:testimonials_url')) {
+        configProperties.exploreTestimonialsUrl = config.get('explore:testimonials_url');
+    }
+
+    if (config.get('tinybird') && config.get('tinybird:stats')) {
+        const statsConfig = config.get('tinybird:stats');
+        const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
+        configProperties.stats = getTinybirdStatsPayload(statsConfig, siteUuid);
+    }
+
+    if (config.get('featurebase')) {
+        // Expose only the public featurebase config properties
+        configProperties.featurebase = {
+            enabled: config.get('featurebase:enabled'),
+            organization: config.get('featurebase:organization')
+        };
+    }
+
+    return configProperties;
 };

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -10,11 +10,11 @@ const tinybirdStatsPayloadProperties = ['endpoint', 'endpointBrowser', 'version'
 const tinybirdLocalStatsPayloadProperties = ['enabled', 'endpoint', 'datasource'];
 
 const sanitizeHostSettings = (hostSettings) => {
-  if (!isPlainObject(hostSettings) || !isPlainObject(hostSettings.export)) {
+  if (!isPlainObject(hostSettings)) {
     return hostSettings;
   }
 
-  return { ...hostSettings, export: omit(hostSettings.export, 'webhookSecret') };
+  return omit(hostSettings, ['export.webhookSecret', 'emailVerification.webhookSecret']);
 };
 
 const copyPayloadProperties = (target, source, properties) => {

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -1,95 +1,90 @@
-const {isPlainObject, omit} = require('lodash');
+const { isPlainObject, omit } = require('lodash');
 const config = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
 const labs = require('../../../shared/labs');
 const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
 
-const tinybirdStatsPayloadProperties = [
-    'endpoint',
-    'endpointBrowser',
-    'version',
-    'datasource'
-];
+const tinybirdStatsPayloadProperties = ['endpoint', 'endpointBrowser', 'version', 'datasource'];
 
-const tinybirdLocalStatsPayloadProperties = [
-    'enabled',
-    'endpoint',
-    'datasource'
-];
+const tinybirdLocalStatsPayloadProperties = ['enabled', 'endpoint', 'datasource'];
 
 const sanitizeHostSettings = (hostSettings) => {
-    if (!isPlainObject(hostSettings) || !isPlainObject(hostSettings.export)) {
-        return hostSettings;
-    }
+  if (!isPlainObject(hostSettings) || !isPlainObject(hostSettings.export)) {
+    return hostSettings;
+  }
 
-    return {...hostSettings, export: omit(hostSettings.export, 'webhookSecret')};
+  return { ...hostSettings, export: omit(hostSettings.export, 'webhookSecret') };
 };
 
 const copyPayloadProperties = (target, source, properties) => {
-    for (const property of properties) {
-        if (Object.prototype.hasOwnProperty.call(source, property)) {
-            target[property] = source[property];
-        }
+  for (const property of properties) {
+    if (Object.prototype.hasOwnProperty.call(source, property)) {
+      target[property] = source[property];
     }
+  }
 };
 
 const getTinybirdStatsPayload = (statsConfig, siteUuid) => {
-    const statsPayload = {};
+  const statsPayload = {};
 
-    copyPayloadProperties(statsPayload, statsConfig, tinybirdStatsPayloadProperties);
+  copyPayloadProperties(statsPayload, statsConfig, tinybirdStatsPayloadProperties);
 
-    statsPayload.id = siteUuid;
+  statsPayload.id = siteUuid;
 
-    if (isPlainObject(statsConfig.local)) {
-        const localStatsPayload = {};
-        copyPayloadProperties(localStatsPayload, statsConfig.local, tinybirdLocalStatsPayloadProperties);
+  if (isPlainObject(statsConfig.local)) {
+    const localStatsPayload = {};
+    copyPayloadProperties(
+      localStatsPayload,
+      statsConfig.local,
+      tinybirdLocalStatsPayloadProperties,
+    );
 
-        if (Object.keys(localStatsPayload).length > 0) {
-            statsPayload.local = localStatsPayload;
-        }
+    if (Object.keys(localStatsPayload).length > 0) {
+      statsPayload.local = localStatsPayload;
     }
+  }
 
-    return statsPayload;
+  return statsPayload;
 };
 
 module.exports = function getConfigProperties() {
-    const configProperties = {
-        version: process.env.GHOST_BUILD_VERSION || ghostVersion.original,
-        environment: config.get('env'),
-        database: databaseInfo.getEngine(),
-        mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
-        useGravatar: !config.isPrivacyDisabled('useGravatar'),
-        labs: labs.getAll(),
-        clientExtensions: config.get('clientExtensions') || {},
-        enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
-        stripeDirect: config.get('stripeDirect'),
-        mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
-        emailAnalytics: config.get('emailAnalytics:enabled'),
-        hostSettings: sanitizeHostSettings(config.get('hostSettings')),
-        klipy: config.get('klipy'),
-        pintura: config.get('pintura'),
-        signupForm: config.get('signupForm'),
-        security: config.get('security')
+  const configProperties = {
+    version: process.env.GHOST_BUILD_VERSION || ghostVersion.original,
+    environment: config.get('env'),
+    database: databaseInfo.getEngine(),
+    mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
+    useGravatar: !config.isPrivacyDisabled('useGravatar'),
+    labs: labs.getAll(),
+    clientExtensions: config.get('clientExtensions') || {},
+    enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
+    stripeDirect: config.get('stripeDirect'),
+    mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
+    emailAnalytics: config.get('emailAnalytics:enabled'),
+    hostSettings: sanitizeHostSettings(config.get('hostSettings')),
+    klipy: config.get('klipy'),
+    pintura: config.get('pintura'),
+    signupForm: config.get('signupForm'),
+    security: config.get('security'),
+  };
+
+  if (config.get('explore') && config.get('explore:testimonials_url')) {
+    configProperties.exploreTestimonialsUrl = config.get('explore:testimonials_url');
+  }
+
+  if (config.get('tinybird') && config.get('tinybird:stats')) {
+    const statsConfig = config.get('tinybird:stats');
+    const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
+    configProperties.stats = getTinybirdStatsPayload(statsConfig, siteUuid);
+  }
+
+  if (config.get('featurebase')) {
+    // Expose only the public featurebase config properties
+    configProperties.featurebase = {
+      enabled: config.get('featurebase:enabled'),
+      organization: config.get('featurebase:organization'),
     };
+  }
 
-    if (config.get('explore') && config.get('explore:testimonials_url')) {
-        configProperties.exploreTestimonialsUrl = config.get('explore:testimonials_url');
-    }
-
-    if (config.get('tinybird') && config.get('tinybird:stats')) {
-        const statsConfig = config.get('tinybird:stats');
-        const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
-        configProperties.stats = getTinybirdStatsPayload(statsConfig, siteUuid);
-    }
-
-    if (config.get('featurebase')) {
-        // Expose only the public featurebase config properties
-        configProperties.featurebase = {
-            enabled: config.get('featurebase:enabled'),
-            organization: config.get('featurebase:organization')
-        };
-    }
-
-    return configProperties;
+  return configProperties;
 };

--- a/ghost/core/core/server/services/verification/verification-webhook-service.ts
+++ b/ghost/core/core/server/services/verification/verification-webhook-service.ts
@@ -1,7 +1,6 @@
-import crypto from 'crypto';
+import { buildSignedWebhookRequest, sanitizeWebhookUrl } from '../../lib/signed-webhook';
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
-const ghostVersion = require('@tryghost/version');
 const config = require('../../../shared/config');
 
 type VerificationTriggerMethod = 'admin' | 'api' | 'import';
@@ -26,7 +25,6 @@ type VerificationWebhookServiceDependencies = {
   request: (url: string, options: unknown) => Promise<unknown>;
 };
 
-const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_RETRY_LIMIT = 5;
 
 export class VerificationWebhookService {
@@ -47,19 +45,6 @@ export class VerificationWebhookService {
       webhookSecret: this.#config.get('hostSettings:emailVerification:webhookSecret') || '',
       siteId: this.#config.get('hostSettings:siteId') || null,
     };
-  }
-
-  #computeSignature(timestamp: string, body: string, secret: string): string {
-    const baseString = `${timestamp}:${body}`;
-    return crypto.createHmac('sha256', secret).update(baseString).digest('base64');
-  }
-
-  #sanitizeWebhookUrl(webhookUrl: string): string {
-    try {
-      return new URL(webhookUrl).origin;
-    } catch {
-      return '[invalid webhook url]';
-    }
   }
 
   /**
@@ -94,33 +79,13 @@ export class VerificationWebhookService {
       method,
     };
 
-    const requestBody = JSON.stringify(payload);
-    const timestamp = Date.now().toString();
+    const requestOptions = buildSignedWebhookRequest({
+      payload,
+      secret: typeof webhookSecret === 'string' && webhookSecret !== '' ? webhookSecret : undefined,
+      retryLimit: process.env.NODE_ENV?.startsWith('test') ? 0 : MAX_RETRY_LIMIT,
+    });
 
-    const headers: Record<string, string | number> = {
-      'Content-Length': Buffer.byteLength(requestBody),
-      'Content-Type': 'application/json',
-      'Content-Version': `v${ghostVersion.safe}`,
-      'X-Ghost-Request-Timestamp': timestamp,
-    };
-
-    if (typeof webhookSecret === 'string' && webhookSecret !== '') {
-      headers['X-Ghost-Signature'] = this.#computeSignature(timestamp, requestBody, webhookSecret);
-    }
-
-    const requestOptions = {
-      method: 'POST',
-      body: requestBody,
-      headers,
-      timeout: {
-        request: REQUEST_TIMEOUT_MS,
-      },
-      retry: {
-        limit: process.env.NODE_ENV?.startsWith('test') ? 0 : MAX_RETRY_LIMIT,
-      },
-    };
-
-    const sanitizedWebhookUrl = this.#sanitizeWebhookUrl(webhookUrl);
+    const sanitizedWebhookUrl = sanitizeWebhookUrl(webhookUrl);
     this.#logging.info(`Triggering verification webhook to "${sanitizedWebhookUrl}"`);
 
     try {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -1,6 +1,6 @@
 const express = require('../../../../../shared/express');
 const api = require('../../../../api').endpoints;
-const { http } = require('@tryghost/api-framework');
+const {http} = require('@tryghost/api-framework');
 const auth = require('../../../../services/auth');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
@@ -12,548 +12,438 @@ const shared = require('../../../shared');
  * @returns {import('express').Router}
  */
 module.exports = function apiRoutes() {
-  const router = express.Router('admin api');
-
-  router.use(apiMw.cors);
-
-  // ## Public
-  router.get('/site', mw.publicAdminApi, http(api.site.read));
-
-  // ## Configuration
-  router.get('/config', mw.authAdminApi, http(api.config.read));
-  router.get('/config/featurebase', mw.authAdminApi, http(api.config.featurebase));
-
-  // ## Posts
-  router.get('/posts', mw.authAdminApi, http(api.posts.browse));
-  router.get('/posts/export', mw.authAdminApi, http(api.posts.exportCSV));
-
-  router.post('/posts', mw.authAdminApi, http(api.posts.add));
-  router.delete('/posts', mw.authAdminApi, http(api.posts.bulkDestroy));
-  router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
-  router.post(
-    '/posts/upload',
-    mw.authAdminApi,
-    labs.enabledMiddleware('csvContentImporter'),
-    apiMw.upload.single('postsfile'),
-    apiMw.upload.validation({ type: 'posts' }),
-    http(api.posts.importCSV),
-  );
-  router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
-  router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));
-  router.put('/posts/:id', mw.authAdminApi, http(api.posts.edit));
-  router.delete('/posts/:id', mw.authAdminApi, http(api.posts.destroy));
-  router.post('/posts/:id/copy', mw.authAdminApi, http(api.posts.copy));
-
-  router.get('/mentions', mw.authAdminApi, http(api.mentions.browse));
-
-  // Comments - browseAll must come before :id routes
-  router.get('/comments', mw.authAdminApi, http(api.comments.browseAll));
-  router.get('/comments/:id', mw.authAdminApi, http(api.commentReplies.read));
-  router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
-  router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
-  router.get('/comments/:id/likes', mw.authAdminApi, http(api.commentLikes.browse));
-  router.get('/comments/:id/dislikes', mw.authAdminApi, http(api.commentDislikes.browse));
-  router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
-  router.post('/comments', mw.authAdminApi, http(api.comments.add));
-  router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));
-
-  // ## Pages
-  router.get('/pages', mw.authAdminApi, http(api.pages.browse));
-  router.delete('/pages', mw.authAdminApi, http(api.pages.bulkDestroy));
-  router.put('/pages/bulk', mw.authAdminApi, http(api.pages.bulkEdit));
-  router.post('/pages', mw.authAdminApi, http(api.pages.add));
-  router.get('/pages/:id', mw.authAdminApi, http(api.pages.read));
-  router.get('/pages/slug/:slug', mw.authAdminApi, http(api.pages.read));
-  router.put('/pages/:id', mw.authAdminApi, http(api.pages.edit));
-  router.delete('/pages/:id', mw.authAdminApi, http(api.pages.destroy));
-  router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));
-
-  // Gift links
-  router.get('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
-  router.put('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
-  router.post('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
-  router.get('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
-  router.put('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
-  router.post('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
-  router.put('/gift_links/remove_all', mw.authAdminApi, http(api.giftLinks.removeAll));
-
-  // # Integrations
-
-  router.get('/integrations', mw.authAdminApi, http(api.integrations.browse));
-  router.get('/integrations/:id', mw.authAdminApi, http(api.integrations.read));
-  router.post('/integrations', mw.authAdminApi, http(api.integrations.add));
-  router.post(
-    '/integrations/:id/api_key/:keyid/refresh',
-    mw.authAdminApi,
-    http(api.integrations.edit),
-  );
-  router.put('/integrations/:id', mw.authAdminApi, http(api.integrations.edit));
-  router.delete('/integrations/:id', mw.authAdminApi, http(api.integrations.destroy));
-
-  // ## Schedules
-  router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(api.schedules.publish));
-
-  // ## Gifts
-  router.put('/gifts/flush_reminders', mw.authAdminApiWithUrl, http(api.gifts.flushReminders));
-
-  // ## Settings
-  router.get('/settings/routes/yaml', mw.authAdminApi, http(api.settings.download));
-  router.post(
-    '/settings/routes/yaml',
-    mw.authAdminApi,
-    apiMw.upload.single('routes'),
-    apiMw.upload.validation({ type: 'routes' }),
-    http(api.settings.upload),
-  );
-
-  router.get('/settings', mw.authAdminApi, http(api.settings.browse));
-  router.put('/settings', mw.authAdminApi, http(api.settings.edit));
-  router.post(
-    '/settings/access_code/regenerate',
-    mw.authAdminApi,
-    http(api.settings.regenerateAccessCode),
-  );
-  router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
-  router.delete(
-    '/settings/stripe/connect',
-    mw.authAdminApi,
-    http(api.settings.disconnectStripeConnectIntegration),
-  );
-
-  // ## Users
-  router.get('/users', mw.authAdminApi, http(api.users.browse));
-  router.get('/users/:id', mw.authAdminApi, http(api.users.read));
-  router.get('/users/slug/:slug', mw.authAdminApi, http(api.users.read));
-  // NOTE: We don't expose any email addresses via the public api.
-  router.get('/users/email/:email', mw.authAdminApi, http(api.users.read));
-  router.get('/users/:id/token', mw.authAdminApi, http(api.users.readStaffToken));
-
-  router.put('/users/password', mw.authAdminApi, http(api.users.changePassword));
-  router.put('/users/owner', mw.authAdminApi, http(api.users.transferOwnership));
-  router.put('/users/:id', mw.authAdminApi, http(api.users.edit));
-  router.put('/users/:id/token', mw.authAdminApi, http(api.users.regenerateStaffToken));
-  router.delete('/users/:id', mw.authAdminApi, http(api.users.destroy));
-
-  // ## Tags
-  router.get('/tags', mw.authAdminApi, http(api.tags.browse));
-  router.get('/tags/:id', mw.authAdminApi, http(api.tags.read));
-  router.get('/tags/slug/:slug', mw.authAdminApi, http(api.tags.read));
-  router.post('/tags', mw.authAdminApi, http(api.tags.add));
-  router.put('/tags/:id', mw.authAdminApi, http(api.tags.edit));
-  router.delete('/tags/:id', mw.authAdminApi, http(api.tags.destroy));
-
-  // Tiers
-  router.get('/tiers', mw.authAdminApi, http(api.tiers.browse));
-  router.post('/tiers', mw.authAdminApi, http(api.tiers.add));
-  router.get('/tiers/:id', mw.authAdminApi, http(api.tiers.read));
-  router.put('/tiers/:id', mw.authAdminApi, http(api.tiers.edit));
-
-  // ## Members
-  router.get('/members', mw.authAdminApi, http(api.members.browse));
-  router.post('/members', mw.authAdminApi, http(api.members.add));
-  router.delete('/members', mw.authAdminApi, http(api.members.bulkDestroy));
-  router.put('/members/bulk', mw.authAdminApi, http(api.members.bulkEdit));
-
-  router.get('/offers', mw.authAdminApi, http(api.offers.browse));
-  router.post('/offers', mw.authAdminApi, http(api.offers.add));
-  router.get('/offers/:id', mw.authAdminApi, http(api.offers.read));
-  router.put('/offers/:id', mw.authAdminApi, http(api.offers.edit));
-
-  router.get('/members/stats/count', mw.authAdminApi, http(api.members.memberStats));
-  router.get('/members/stats/mrr', mw.authAdminApi, http(api.members.mrrStats));
-
-  router.get('/members/events', mw.authAdminApi, http(api.members.activityFeed));
-
-  router.get('/members/upload', mw.authAdminApi, http(api.members.exportCSV));
-  router.post(
-    '/members/upload',
-    mw.authAdminApi,
-    apiMw.upload.single('membersfile'),
-    apiMw.upload.validation({ type: 'members' }),
-    http(api.members.importCSV),
-  );
-
-  router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
-
-  // Member custom field definitions — gated by the members_custom_fields flag.
-  // Registered before /members/:id so the literal path isn't captured by :id.
-  router.get(
-    '/members/custom_fields',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersCustomFields.browse),
-  );
-  router.post(
-    '/members/custom_fields',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersCustomFields.add),
-  );
-  // A PUT on the collection sets the publisher's order for the whole list.
-  router.put(
-    '/members/custom_fields',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersCustomFields.reorder),
-  );
-  router.get(
-    '/members/custom_fields/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersCustomFields.read),
-  );
-  router.put(
-    '/members/custom_fields/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersCustomFields.edit),
-  );
-  router.delete(
-    '/members/custom_fields/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersCustomFields.destroy),
-  );
-
-  router.get('/members/:id', mw.authAdminApi, http(api.members.read));
-  router.put('/members/:id', mw.authAdminApi, http(api.members.edit));
-  router.delete('/members/:id', mw.authAdminApi, http(api.members.destroy));
-  router.delete('/members/:id/sessions', mw.authAdminApi, http(api.members.logout));
-  router.delete(
-    '/members/:id/suppression',
-    mw.authAdminApi,
-    http(api.members.deleteEmailSuppression),
-  );
-
-  router.post('/members/:id/subscriptions/', mw.authAdminApi, http(api.members.createSubscription));
-  router.put(
-    '/members/:id/subscriptions/:subscription_id',
-    mw.authAdminApi,
-    http(api.members.editSubscription),
-  );
-
-  router.get('/members/:id/signin_urls', mw.authAdminApi, http(api.memberSigninUrls.read));
-
-  router.post(
-    '/members/:id/commenting/disable',
-    mw.authAdminApi,
-    http(api.memberCommenting.disable),
-  );
-  router.post('/members/:id/commenting/enable', mw.authAdminApi, http(api.memberCommenting.enable));
-
-  // ## Stats
-  router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
-  router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
-  router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
-  router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
-  router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
-  router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
-  router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
-  router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
-  router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
-  router.get(
-    '/stats/newsletter-basic-stats',
-    mw.authAdminApi,
-    http(api.stats.newsletterBasicStats),
-  );
-  router.get(
-    '/stats/newsletter-click-stats',
-    mw.authAdminApi,
-    http(api.stats.newsletterClickStats),
-  );
-  router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
-  router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrers));
-  router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
-  router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
-  router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
-  router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
-
-  // ## Labels
-  router.get('/labels', mw.authAdminApi, http(api.labels.browse));
-  router.get('/labels/:id', mw.authAdminApi, http(api.labels.read));
-  router.get('/labels/slug/:slug', mw.authAdminApi, http(api.labels.read));
-  router.post('/labels', mw.authAdminApi, http(api.labels.add));
-  router.put('/labels/:id', mw.authAdminApi, http(api.labels.edit));
-  router.delete('/labels/:id', mw.authAdminApi, http(api.labels.destroy));
-
-  // ## Automations
-  router.get('/automations', mw.authAdminApi, http(api.automations.browse));
-  router.get(
-    '/automations/:automation_id/actions/:action_id/links',
-    mw.authAdminApi,
-    http(api.automationActionLinks.browse),
-  );
-  router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
-  router.post(
-    '/automations/:id/email_preview',
-    mw.authAdminApi,
-    http(api.automationEmailPreviews.preview),
-  );
-  router.post(
-    '/automations/:id/email_test',
-    shared.middleware.brute.previewEmailLimiter,
-    mw.authAdminApi,
-    http(api.automationEmailPreviews.sendTestEmail),
-  );
-  router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
-  router.put('/automations/:id', mw.authAdminApi, http(api.automations.edit));
-
-  // ## Automated Emails
-  router.get('/automated_emails', mw.authAdminApi, http(api.automatedEmails.browse));
-  router.get('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.read));
-  router.put('/automated_emails/senders', mw.authAdminApi, http(api.automatedEmails.editSenders));
-  router.put(
-    '/automated_emails/verifications',
-    mw.authAdminApi,
-    http(api.automatedEmails.verifySenderUpdate),
-  );
-  router.get('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.read));
-  router.post('/automated_emails', mw.authAdminApi, http(api.automatedEmails.add));
-  router.put('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.edit));
-  router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
-  router.post('/automated_emails/:id/preview', mw.authAdminApi, http(api.automatedEmails.preview));
-  router.post(
-    '/automated_emails/:id/test',
-    shared.middleware.brute.previewEmailLimiter,
-    mw.authAdminApi,
-    http(api.automatedEmails.sendTestEmail),
-  );
-
-  // ## Roles
-  router.get('/roles/', mw.authAdminApi, http(api.roles.browse));
-
-  // ## Slugs
-  router.get('/slugs/:type/:name', mw.authAdminApi, http(api.slugs.generate));
-  router.get('/slugs/:type/:name/:id', mw.authAdminApi, http(api.slugs.generate));
-
-  // ## Themes
-  router.get('/themes/', mw.authAdminApi, http(api.themes.browse));
-
-  router.get('/themes/:name/download', mw.authAdminApi, http(api.themes.download));
-
-  router.get('/themes/active', mw.authAdminApi, http(api.themes.readActive));
-
-  router.post(
-    '/themes/upload',
-    mw.authAdminApi,
-    apiMw.upload.themeZip('file'),
-    apiMw.upload.validation({ type: 'themes' }),
-    http(api.themes.upload),
-  );
-
-  router.post('/themes/install', mw.authAdminApi, http(api.themes.install));
-
-  router.put('/themes/:name/activate', mw.authAdminApi, http(api.themes.activate));
-
-  router.delete('/themes/:name', mw.authAdminApi, http(api.themes.destroy));
-
-  // ## Notifications
-  router.get('/notifications', mw.authAdminApi, http(api.notifications.browse));
-  router.post('/notifications', mw.authAdminApi, http(api.notifications.add));
-  router.delete(
-    '/notifications/:notification_id',
-    mw.authAdminApi,
-    http(api.notifications.destroy),
-  );
-
-  // ## DB
-  router.get('/db', mw.authAdminApi, http(api.db.exportContent));
-  router.post(
-    '/db',
-    mw.authAdminApi,
-    apiMw.upload.single('importfile'),
-    apiMw.upload.validation({ type: 'db' }),
-    http(api.db.importContent),
-  );
-  router.delete('/db', mw.authAdminApi, http(api.db.deleteAllContent));
-  router.post('/db/backup', mw.authAdminApi, http(api.db.backupContent));
-
-  router.post('/db/media/inline', mw.authAdminApi, http(api.db.inlineMedia));
-
-  // ## Exports
-  router.get(
-    '/exports/download',
-    mw.authAdminApi,
-    labs.enabledMiddleware('selfServeArchives'),
-    http(api.exports.download),
-  );
-
-  // ## Slack
-  router.post('/slack/test', mw.authAdminApi, http(api.slack.sendTest));
-
-  // ## Tinybird
-  router.get('/tinybird/token', mw.authAdminApi, http(api.tinybird.token));
-
-  // ## Featurebase
-  router.get('/featurebase/token', mw.authAdminApi, http(api.featurebase.token));
-
-  // ## Sessions
-  // We don't need auth when creating a new session (logging in)
-  router.post(
-    '/session',
-    shared.middleware.brute.globalBlock,
-    shared.middleware.brute.userLogin,
-    http(api.session.add),
-  );
-  router.delete('/session', mw.authAdminApi, http(api.session.delete));
-  router.post(
-    '/session/verify',
-    shared.middleware.brute.sendVerificationCode,
-    http(api.session.sendVerification),
-  );
-  router.put('/session/verify', shared.middleware.brute.userVerification, http(api.session.verify));
-
-  // ## Identity
-  router.get('/identities', mw.authAdminApi, http(api.identities.read));
-
-  // ## Authentication
-  router.post(
-    '/authentication/password_reset',
-    shared.middleware.brute.globalReset,
-    shared.middleware.brute.userReset,
-    http(api.authentication.generateResetToken),
-  );
-  router.put(
-    '/authentication/password_reset',
-    shared.middleware.brute.globalBlock,
-    auth.session.initSession,
-    http(api.authentication.resetPassword),
-  );
-  router.post('/authentication/invitation', http(api.authentication.acceptInvitation));
-  router.get('/authentication/invitation', http(api.authentication.isInvitation));
-  router.post('/authentication/setup', http(api.authentication.setup));
-  router.put('/authentication/setup', mw.authAdminApi, http(api.authentication.updateSetup));
-  router.get('/authentication/setup', http(api.authentication.isSetup));
-  router.post('/authentication/reset', mw.authAdminApi, http(api.authentication.reset));
-
-  // ## Images
-  router.post(
-    '/images/upload',
-    mw.authAdminApi,
-    apiMw.upload.single('file'),
-    apiMw.upload.validation({ type: 'images' }),
-    http(api.images.upload),
-  );
-
-  // ## media
-  router.post(
-    '/media/upload',
-    mw.authAdminApi,
-    apiMw.upload.media('file', 'thumbnail'),
-    apiMw.upload.mediaValidation({ type: 'media' }),
-    http(api.media.upload),
-  );
-  router.put(
-    '/media/thumbnail/upload',
-    mw.authAdminApi,
-    apiMw.upload.single('file'),
-    apiMw.upload.validation({ type: 'images' }),
-    http(api.media.uploadThumbnail),
-  );
-
-  // ## files
-  router.post(
-    '/files/upload',
-    mw.authAdminApi,
-    apiMw.upload.single('file'),
-    apiMw.upload.fileValidation({ type: 'files' }),
-    http(api.files.upload),
-  );
-
-  // ## Invites
-  router.get('/invites', mw.authAdminApi, http(api.invites.browse));
-  router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));
-  router.post('/invites', mw.authAdminApi, http(api.invites.add));
-  router.delete('/invites/:id', mw.authAdminApi, http(api.invites.destroy));
-
-  // ## Redirects
-  router.get('/redirects/download', mw.authAdminApi, http(api.redirects.download));
-  router.post(
-    '/redirects/upload',
-    mw.authAdminApi,
-    apiMw.upload.single('redirects'),
-    apiMw.upload.validation({ type: 'redirects' }),
-    http(api.redirects.upload),
-  );
-
-  // ## Webhooks (RESTHooks)
-  router.post('/webhooks', mw.authAdminApi, http(api.webhooks.add));
-  router.put('/webhooks/:id', mw.authAdminApi, http(api.webhooks.edit));
-  router.delete('/webhooks/:id', mw.authAdminApi, http(api.webhooks.destroy));
-
-  // ## Oembed (fetch response from oembed provider)
-  router.get('/oembed', mw.authAdminApi, http(api.oembed.read));
-
-  // ## Actions
-  router.get('/actions', mw.authAdminApi, http(api.actions.browse));
-
-  // ## Email Preview
-  router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.read));
-  // preview sending have an additional rate limiter to prevent abuse
-  router.post(
-    '/email_previews/posts/:id',
-    shared.middleware.brute.previewEmailLimiter,
-    mw.authAdminApi,
-    http(api.email_previews.sendTestEmail),
-  );
-
-  // ## Emails
-  router.get('/emails', mw.authAdminApi, http(api.emails.browse));
-  router.get('/emails/:id', mw.authAdminApi, http(api.emails.read));
-  router.put('/emails/:id/retry', mw.authAdminApi, http(api.emails.retry));
-  router.get('/emails/:id/batches', mw.authAdminApi, http(api.emails.browseBatches));
-  router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));
-  router.get('/emails/:id/analytics', mw.authAdminApi, http(api.emails.analyticsStatus));
-  router.put('/emails/:id/analytics', mw.authAdminApi, http(api.emails.scheduleAnalytics));
-  router.delete('/emails/analytics', mw.authAdminApi, http(api.emails.cancelScheduledAnalytics));
-
-  // ## Snippets
-  router.get('/snippets', mw.authAdminApi, http(api.snippets.browse));
-  router.get('/snippets/:id', mw.authAdminApi, http(api.snippets.read));
-  router.post('/snippets', mw.authAdminApi, http(api.snippets.add));
-  router.put('/snippets/:id', mw.authAdminApi, http(api.snippets.edit));
-  router.delete('/snippets/:id', mw.authAdminApi, http(api.snippets.destroy));
-
-  // ## Custom theme settings
-  router.get('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.browse));
-  router.put('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.edit));
-
-  router.get('/newsletters', mw.authAdminApi, http(api.newsletters.browse));
-  router.get('/newsletters/:id', mw.authAdminApi, http(api.newsletters.read));
-  router.post('/newsletters', mw.authAdminApi, http(api.newsletters.add));
-  router.put(
-    '/newsletters/verifications/',
-    mw.authAdminApi,
-    http(api.newsletters.verifyPropertyUpdate),
-  );
-  router.put('/newsletters/:id', mw.authAdminApi, http(api.newsletters.edit));
-
-  router.get('/links', mw.authAdminApi, http(api.links.browse));
-  router.put('/links/bulk', mw.authAdminApi, http(api.links.bulkEdit));
-
-  // Recommendations
-  router.get('/recommendations', mw.authAdminApi, http(api.recommendations.browse));
-  router.get('/recommendations/:id', mw.authAdminApi, http(api.recommendations.read));
-  router.post('/recommendations', mw.authAdminApi, http(api.recommendations.add));
-  router.post('/recommendations/check', mw.authAdminApi, http(api.recommendations.check));
-  router.put('/recommendations/:id', mw.authAdminApi, http(api.recommendations.edit));
-  router.delete('/recommendations/:id', mw.authAdminApi, http(api.recommendations.destroy));
-
-  // Incoming recommendations
-  router.get(
-    '/incoming_recommendations',
-    mw.authAdminApi,
-    http(api.incomingRecommendations.browse),
-  );
-
-  // Feedback
-  router.get('/feedback/:id', mw.authAdminApi, http(api.feedbackMembers.browse));
-
-  // Search index
-  router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
-  router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
-  router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
-  router.get('/search-index/users', mw.authAdminApi, http(api.searchIndex.fetchUsers));
-
-  return router;
+    const router = express.Router('admin api');
+
+    router.use(apiMw.cors);
+
+    // ## Public
+    router.get('/site', mw.publicAdminApi, http(api.site.read));
+
+    // ## Configuration
+    router.get('/config', mw.authAdminApi, http(api.config.read));
+    router.get('/config/featurebase', mw.authAdminApi, http(api.config.featurebase));
+
+    // ## Posts
+    router.get('/posts', mw.authAdminApi, http(api.posts.browse));
+    router.get('/posts/export', mw.authAdminApi, http(api.posts.exportCSV));
+
+    router.post('/posts', mw.authAdminApi, http(api.posts.add));
+    router.delete('/posts', mw.authAdminApi, http(api.posts.bulkDestroy));
+    router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
+    router.post('/posts/upload', mw.authAdminApi, labs.enabledMiddleware('csvContentImporter'), apiMw.upload.single('postsfile'), apiMw.upload.validation({type: 'posts'}), http(api.posts.importCSV));
+    router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
+    router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));
+    router.put('/posts/:id', mw.authAdminApi, http(api.posts.edit));
+    router.delete('/posts/:id', mw.authAdminApi, http(api.posts.destroy));
+    router.post('/posts/:id/copy', mw.authAdminApi, http(api.posts.copy));
+
+    router.get('/mentions', mw.authAdminApi, http(api.mentions.browse));
+
+    // Comments - browseAll must come before :id routes
+    router.get('/comments', mw.authAdminApi, http(api.comments.browseAll));
+    router.get('/comments/:id', mw.authAdminApi, http(api.commentReplies.read));
+    router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
+    router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
+    router.get('/comments/:id/likes', mw.authAdminApi, http(api.commentLikes.browse));
+    router.get('/comments/:id/dislikes', mw.authAdminApi, http(api.commentDislikes.browse));
+    router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
+    router.post('/comments', mw.authAdminApi, http(api.comments.add));
+    router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));
+
+    // ## Pages
+    router.get('/pages', mw.authAdminApi, http(api.pages.browse));
+    router.delete('/pages', mw.authAdminApi, http(api.pages.bulkDestroy));
+    router.put('/pages/bulk', mw.authAdminApi, http(api.pages.bulkEdit));
+    router.post('/pages', mw.authAdminApi, http(api.pages.add));
+    router.get('/pages/:id', mw.authAdminApi, http(api.pages.read));
+    router.get('/pages/slug/:slug', mw.authAdminApi, http(api.pages.read));
+    router.put('/pages/:id', mw.authAdminApi, http(api.pages.edit));
+    router.delete('/pages/:id', mw.authAdminApi, http(api.pages.destroy));
+    router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));
+
+    // Gift links
+    router.get('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
+    router.put('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
+    router.post('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
+    router.get('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
+    router.put('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
+    router.post('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
+    router.put('/gift_links/remove_all', mw.authAdminApi, http(api.giftLinks.removeAll));
+
+    // # Integrations
+
+    router.get('/integrations', mw.authAdminApi, http(api.integrations.browse));
+    router.get('/integrations/:id', mw.authAdminApi, http(api.integrations.read));
+    router.post('/integrations', mw.authAdminApi, http(api.integrations.add));
+    router.post('/integrations/:id/api_key/:keyid/refresh', mw.authAdminApi, http(api.integrations.edit));
+    router.put('/integrations/:id', mw.authAdminApi, http(api.integrations.edit));
+    router.delete('/integrations/:id', mw.authAdminApi, http(api.integrations.destroy));
+
+    // ## Schedules
+    router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(api.schedules.publish));
+
+    // ## Gifts
+    router.put('/gifts/flush_reminders', mw.authAdminApiWithUrl, http(api.gifts.flushReminders));
+
+    // ## Settings
+    router.get('/settings/routes/yaml', mw.authAdminApi, http(api.settings.download));
+    router.post('/settings/routes/yaml',
+        mw.authAdminApi,
+        apiMw.upload.single('routes'),
+        apiMw.upload.validation({type: 'routes'}),
+        http(api.settings.upload)
+    );
+
+    router.get('/settings', mw.authAdminApi, http(api.settings.browse));
+    router.put('/settings', mw.authAdminApi, http(api.settings.edit));
+    router.post('/settings/access_code/regenerate', mw.authAdminApi, http(api.settings.regenerateAccessCode));
+    router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
+    router.delete('/settings/stripe/connect', mw.authAdminApi, http(api.settings.disconnectStripeConnectIntegration));
+
+    // ## Users
+    router.get('/users', mw.authAdminApi, http(api.users.browse));
+    router.get('/users/:id', mw.authAdminApi, http(api.users.read));
+    router.get('/users/slug/:slug', mw.authAdminApi, http(api.users.read));
+    // NOTE: We don't expose any email addresses via the public api.
+    router.get('/users/email/:email', mw.authAdminApi, http(api.users.read));
+    router.get('/users/:id/token', mw.authAdminApi, http(api.users.readStaffToken));
+
+    router.put('/users/password', mw.authAdminApi, http(api.users.changePassword));
+    router.put('/users/owner', mw.authAdminApi, http(api.users.transferOwnership));
+    router.put('/users/:id', mw.authAdminApi, http(api.users.edit));
+    router.put('/users/:id/token', mw.authAdminApi, http(api.users.regenerateStaffToken));
+    router.delete('/users/:id', mw.authAdminApi, http(api.users.destroy));
+
+    // ## Tags
+    router.get('/tags', mw.authAdminApi, http(api.tags.browse));
+    router.get('/tags/:id', mw.authAdminApi, http(api.tags.read));
+    router.get('/tags/slug/:slug', mw.authAdminApi, http(api.tags.read));
+    router.post('/tags', mw.authAdminApi, http(api.tags.add));
+    router.put('/tags/:id', mw.authAdminApi, http(api.tags.edit));
+    router.delete('/tags/:id', mw.authAdminApi, http(api.tags.destroy));
+
+    // Tiers
+    router.get('/tiers', mw.authAdminApi, http(api.tiers.browse));
+    router.post('/tiers', mw.authAdminApi, http(api.tiers.add));
+    router.get('/tiers/:id', mw.authAdminApi, http(api.tiers.read));
+    router.put('/tiers/:id', mw.authAdminApi, http(api.tiers.edit));
+
+    // ## Members
+    router.get('/members', mw.authAdminApi, http(api.members.browse));
+    router.post('/members', mw.authAdminApi, http(api.members.add));
+    router.delete('/members', mw.authAdminApi, http(api.members.bulkDestroy));
+    router.put('/members/bulk', mw.authAdminApi, http(api.members.bulkEdit));
+
+    router.get('/offers', mw.authAdminApi, http(api.offers.browse));
+    router.post('/offers', mw.authAdminApi, http(api.offers.add));
+    router.get('/offers/:id', mw.authAdminApi, http(api.offers.read));
+    router.put('/offers/:id', mw.authAdminApi, http(api.offers.edit));
+
+    router.get('/members/stats/count', mw.authAdminApi, http(api.members.memberStats));
+    router.get('/members/stats/mrr', mw.authAdminApi, http(api.members.mrrStats));
+
+    router.get('/members/events', mw.authAdminApi, http(api.members.activityFeed));
+
+    router.get('/members/upload', mw.authAdminApi, http(api.members.exportCSV));
+    router.post('/members/upload',
+        mw.authAdminApi,
+        apiMw.upload.single('membersfile'),
+        apiMw.upload.validation({type: 'members'}),
+        http(api.members.importCSV)
+    );
+
+    router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
+
+    // Member custom field definitions — gated by the members_custom_fields flag.
+    // Registered before /members/:id so the literal path isn't captured by :id.
+    router.get('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.browse));
+    router.post('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.add));
+    // A PUT on the collection sets the publisher's order for the whole list.
+    router.put('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.reorder));
+    router.get('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.read));
+    router.put('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.edit));
+    router.delete('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.destroy));
+
+    router.get('/members/:id', mw.authAdminApi, http(api.members.read));
+    router.put('/members/:id', mw.authAdminApi, http(api.members.edit));
+    router.delete('/members/:id', mw.authAdminApi, http(api.members.destroy));
+    router.delete('/members/:id/sessions', mw.authAdminApi, http(api.members.logout));
+    router.delete('/members/:id/suppression', mw.authAdminApi, http(api.members.deleteEmailSuppression));
+
+    router.post('/members/:id/subscriptions/', mw.authAdminApi, http(api.members.createSubscription));
+    router.put('/members/:id/subscriptions/:subscription_id', mw.authAdminApi, http(api.members.editSubscription));
+
+    router.get('/members/:id/signin_urls', mw.authAdminApi, http(api.memberSigninUrls.read));
+
+    router.post('/members/:id/commenting/disable', mw.authAdminApi, http(api.memberCommenting.disable));
+    router.post('/members/:id/commenting/enable', mw.authAdminApi, http(api.memberCommenting.enable));
+
+    // ## Stats
+    router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
+    router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
+    router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
+    router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
+    router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
+    router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
+    router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
+    router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
+    router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
+    router.get('/stats/newsletter-basic-stats', mw.authAdminApi, http(api.stats.newsletterBasicStats));
+    router.get('/stats/newsletter-click-stats', mw.authAdminApi, http(api.stats.newsletterClickStats));
+    router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
+    router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrers));
+    router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
+    router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
+    router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
+    router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
+
+    // ## Labels
+    router.get('/labels', mw.authAdminApi, http(api.labels.browse));
+    router.get('/labels/:id', mw.authAdminApi, http(api.labels.read));
+    router.get('/labels/slug/:slug', mw.authAdminApi, http(api.labels.read));
+    router.post('/labels', mw.authAdminApi, http(api.labels.add));
+    router.put('/labels/:id', mw.authAdminApi, http(api.labels.edit));
+    router.delete('/labels/:id', mw.authAdminApi, http(api.labels.destroy));
+
+    // ## Automations
+    router.get('/automations', mw.authAdminApi, http(api.automations.browse));
+    router.get('/automations/:automation_id/actions/:action_id/links', mw.authAdminApi, http(api.automationActionLinks.browse));
+    router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
+    router.post('/automations/:id/email_preview', mw.authAdminApi, http(api.automationEmailPreviews.preview));
+    router.post('/automations/:id/email_test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automationEmailPreviews.sendTestEmail));
+    router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
+    router.put('/automations/:id', mw.authAdminApi, http(api.automations.edit));
+
+    // ## Automated Emails
+    router.get('/automated_emails', mw.authAdminApi, http(api.automatedEmails.browse));
+    router.get('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.read));
+    router.put('/automated_emails/senders', mw.authAdminApi, http(api.automatedEmails.editSenders));
+    router.put('/automated_emails/verifications', mw.authAdminApi, http(api.automatedEmails.verifySenderUpdate));
+    router.get('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.read));
+    router.post('/automated_emails', mw.authAdminApi, http(api.automatedEmails.add));
+    router.put('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.edit));
+    router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
+    router.post('/automated_emails/:id/preview', mw.authAdminApi, http(api.automatedEmails.preview));
+    router.post('/automated_emails/:id/test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automatedEmails.sendTestEmail));
+
+    // ## Roles
+    router.get('/roles/', mw.authAdminApi, http(api.roles.browse));
+
+    // ## Slugs
+    router.get('/slugs/:type/:name', mw.authAdminApi, http(api.slugs.generate));
+    router.get('/slugs/:type/:name/:id', mw.authAdminApi, http(api.slugs.generate));
+
+    // ## Themes
+    router.get('/themes/', mw.authAdminApi, http(api.themes.browse));
+
+    router.get('/themes/:name/download',
+        mw.authAdminApi,
+        http(api.themes.download)
+    );
+
+    router.get('/themes/active',
+        mw.authAdminApi,
+        http(api.themes.readActive)
+    );
+
+    router.post('/themes/upload',
+        mw.authAdminApi,
+        apiMw.upload.themeZip('file'),
+        apiMw.upload.validation({type: 'themes'}),
+        http(api.themes.upload)
+    );
+
+    router.post('/themes/install', mw.authAdminApi, http(api.themes.install));
+
+    router.put('/themes/:name/activate',
+        mw.authAdminApi,
+        http(api.themes.activate)
+    );
+
+    router.delete('/themes/:name',
+        mw.authAdminApi,
+        http(api.themes.destroy)
+    );
+
+    // ## Notifications
+    router.get('/notifications', mw.authAdminApi, http(api.notifications.browse));
+    router.post('/notifications', mw.authAdminApi, http(api.notifications.add));
+    router.delete('/notifications/:notification_id', mw.authAdminApi, http(api.notifications.destroy));
+
+    // ## DB
+    router.get('/db', mw.authAdminApi, http(api.db.exportContent));
+    router.post('/db',
+        mw.authAdminApi,
+        apiMw.upload.single('importfile'),
+        apiMw.upload.validation({type: 'db'}),
+        http(api.db.importContent)
+    );
+    router.delete('/db', mw.authAdminApi, http(api.db.deleteAllContent));
+    router.post('/db/backup',
+        mw.authAdminApi,
+        http(api.db.backupContent)
+    );
+
+    router.post('/db/media/inline',
+        mw.authAdminApi,
+        http(api.db.inlineMedia)
+    );
+
+    // ## Exports
+    router.get('/exports/download', mw.authAdminApi, labs.enabledMiddleware('selfServeArchives'), http(api.exports.download));
+    router.post('/exports', mw.authAdminApi, labs.enabledMiddleware('selfServeArchives'), http(api.exports.add));
+
+    // ## Slack
+    router.post('/slack/test', mw.authAdminApi, http(api.slack.sendTest));
+
+    // ## Tinybird
+    router.get('/tinybird/token', mw.authAdminApi, http(api.tinybird.token));
+
+    // ## Featurebase
+    router.get('/featurebase/token', mw.authAdminApi, http(api.featurebase.token));
+
+    // ## Sessions
+    // We don't need auth when creating a new session (logging in)
+    router.post('/session',
+        shared.middleware.brute.globalBlock,
+        shared.middleware.brute.userLogin,
+        http(api.session.add)
+    );
+    router.delete('/session', mw.authAdminApi, http(api.session.delete));
+    router.post('/session/verify', shared.middleware.brute.sendVerificationCode, http(api.session.sendVerification));
+    router.put('/session/verify', shared.middleware.brute.userVerification, http(api.session.verify));
+
+    // ## Identity
+    router.get('/identities', mw.authAdminApi, http(api.identities.read));
+
+    // ## Authentication
+    router.post('/authentication/password_reset',
+        shared.middleware.brute.globalReset,
+        shared.middleware.brute.userReset,
+        http(api.authentication.generateResetToken)
+    );
+    router.put('/authentication/password_reset',
+        shared.middleware.brute.globalBlock,
+        auth.session.initSession,
+        http(api.authentication.resetPassword)
+    );
+    router.post('/authentication/invitation', http(api.authentication.acceptInvitation));
+    router.get('/authentication/invitation', http(api.authentication.isInvitation));
+    router.post('/authentication/setup', http(api.authentication.setup));
+    router.put('/authentication/setup', mw.authAdminApi, http(api.authentication.updateSetup));
+    router.get('/authentication/setup', http(api.authentication.isSetup));
+    router.post('/authentication/reset', mw.authAdminApi, http(api.authentication.reset));
+
+    // ## Images
+    router.post('/images/upload',
+        mw.authAdminApi,
+        apiMw.upload.single('file'),
+        apiMw.upload.validation({type: 'images'}),
+        http(api.images.upload)
+    );
+
+    // ## media
+    router.post('/media/upload',
+        mw.authAdminApi,
+        apiMw.upload.media('file', 'thumbnail'),
+        apiMw.upload.mediaValidation({type: 'media'}),
+        http(api.media.upload)
+    );
+    router.put('/media/thumbnail/upload',
+        mw.authAdminApi,
+        apiMw.upload.single('file'),
+        apiMw.upload.validation({type: 'images'}),
+        http(api.media.uploadThumbnail)
+    );
+
+    // ## files
+    router.post('/files/upload',
+        mw.authAdminApi,
+        apiMw.upload.single('file'),
+        apiMw.upload.fileValidation({type: 'files'}),
+        http(api.files.upload)
+    );
+
+    // ## Invites
+    router.get('/invites', mw.authAdminApi, http(api.invites.browse));
+    router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));
+    router.post('/invites', mw.authAdminApi, http(api.invites.add));
+    router.delete('/invites/:id', mw.authAdminApi, http(api.invites.destroy));
+
+    // ## Redirects
+    router.get('/redirects/download', mw.authAdminApi, http(api.redirects.download));
+    router.post('/redirects/upload',
+        mw.authAdminApi,
+        apiMw.upload.single('redirects'),
+        apiMw.upload.validation({type: 'redirects'}),
+        http(api.redirects.upload)
+    );
+
+    // ## Webhooks (RESTHooks)
+    router.post('/webhooks', mw.authAdminApi, http(api.webhooks.add));
+    router.put('/webhooks/:id', mw.authAdminApi, http(api.webhooks.edit));
+    router.delete('/webhooks/:id', mw.authAdminApi, http(api.webhooks.destroy));
+
+    // ## Oembed (fetch response from oembed provider)
+    router.get('/oembed', mw.authAdminApi, http(api.oembed.read));
+
+    // ## Actions
+    router.get('/actions', mw.authAdminApi, http(api.actions.browse));
+
+    // ## Email Preview
+    router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.read));
+    // preview sending have an additional rate limiter to prevent abuse
+    router.post('/email_previews/posts/:id', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.email_previews.sendTestEmail));
+
+    // ## Emails
+    router.get('/emails', mw.authAdminApi, http(api.emails.browse));
+    router.get('/emails/:id', mw.authAdminApi, http(api.emails.read));
+    router.put('/emails/:id/retry', mw.authAdminApi, http(api.emails.retry));
+    router.get('/emails/:id/batches', mw.authAdminApi, http(api.emails.browseBatches));
+    router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));
+    router.get('/emails/:id/analytics', mw.authAdminApi, http(api.emails.analyticsStatus));
+    router.put('/emails/:id/analytics', mw.authAdminApi, http(api.emails.scheduleAnalytics));
+    router.delete('/emails/analytics', mw.authAdminApi, http(api.emails.cancelScheduledAnalytics));
+
+    // ## Snippets
+    router.get('/snippets', mw.authAdminApi, http(api.snippets.browse));
+    router.get('/snippets/:id', mw.authAdminApi, http(api.snippets.read));
+    router.post('/snippets', mw.authAdminApi, http(api.snippets.add));
+    router.put('/snippets/:id', mw.authAdminApi, http(api.snippets.edit));
+    router.delete('/snippets/:id', mw.authAdminApi, http(api.snippets.destroy));
+
+    // ## Custom theme settings
+    router.get('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.browse));
+    router.put('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.edit));
+
+    router.get('/newsletters', mw.authAdminApi, http(api.newsletters.browse));
+    router.get('/newsletters/:id', mw.authAdminApi, http(api.newsletters.read));
+    router.post('/newsletters', mw.authAdminApi, http(api.newsletters.add));
+    router.put('/newsletters/verifications/', mw.authAdminApi, http(api.newsletters.verifyPropertyUpdate));
+    router.put('/newsletters/:id', mw.authAdminApi, http(api.newsletters.edit));
+
+    router.get('/links', mw.authAdminApi, http(api.links.browse));
+    router.put('/links/bulk', mw.authAdminApi, http(api.links.bulkEdit));
+
+    // Recommendations
+    router.get('/recommendations', mw.authAdminApi, http(api.recommendations.browse));
+    router.get('/recommendations/:id', mw.authAdminApi, http(api.recommendations.read));
+    router.post('/recommendations', mw.authAdminApi, http(api.recommendations.add));
+    router.post('/recommendations/check', mw.authAdminApi, http(api.recommendations.check));
+    router.put('/recommendations/:id', mw.authAdminApi, http(api.recommendations.edit));
+    router.delete('/recommendations/:id', mw.authAdminApi, http(api.recommendations.destroy));
+
+    // Incoming recommendations
+    router.get('/incoming_recommendations', mw.authAdminApi, http(api.incomingRecommendations.browse));
+
+    // Feedback
+    router.get('/feedback/:id', mw.authAdminApi, http(api.feedbackMembers.browse));
+
+    // Search index
+    router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
+    router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
+    router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
+    router.get('/search-index/users', mw.authAdminApi, http(api.searchIndex.fetchUsers));
+
+    return router;
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -1,6 +1,6 @@
 const express = require('../../../../../shared/express');
 const api = require('../../../../api').endpoints;
-const {http} = require('@tryghost/api-framework');
+const { http } = require('@tryghost/api-framework');
 const auth = require('../../../../services/auth');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
@@ -12,438 +12,554 @@ const shared = require('../../../shared');
  * @returns {import('express').Router}
  */
 module.exports = function apiRoutes() {
-    const router = express.Router('admin api');
-
-    router.use(apiMw.cors);
-
-    // ## Public
-    router.get('/site', mw.publicAdminApi, http(api.site.read));
-
-    // ## Configuration
-    router.get('/config', mw.authAdminApi, http(api.config.read));
-    router.get('/config/featurebase', mw.authAdminApi, http(api.config.featurebase));
-
-    // ## Posts
-    router.get('/posts', mw.authAdminApi, http(api.posts.browse));
-    router.get('/posts/export', mw.authAdminApi, http(api.posts.exportCSV));
-
-    router.post('/posts', mw.authAdminApi, http(api.posts.add));
-    router.delete('/posts', mw.authAdminApi, http(api.posts.bulkDestroy));
-    router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
-    router.post('/posts/upload', mw.authAdminApi, labs.enabledMiddleware('csvContentImporter'), apiMw.upload.single('postsfile'), apiMw.upload.validation({type: 'posts'}), http(api.posts.importCSV));
-    router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
-    router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));
-    router.put('/posts/:id', mw.authAdminApi, http(api.posts.edit));
-    router.delete('/posts/:id', mw.authAdminApi, http(api.posts.destroy));
-    router.post('/posts/:id/copy', mw.authAdminApi, http(api.posts.copy));
-
-    router.get('/mentions', mw.authAdminApi, http(api.mentions.browse));
-
-    // Comments - browseAll must come before :id routes
-    router.get('/comments', mw.authAdminApi, http(api.comments.browseAll));
-    router.get('/comments/:id', mw.authAdminApi, http(api.commentReplies.read));
-    router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
-    router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
-    router.get('/comments/:id/likes', mw.authAdminApi, http(api.commentLikes.browse));
-    router.get('/comments/:id/dislikes', mw.authAdminApi, http(api.commentDislikes.browse));
-    router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
-    router.post('/comments', mw.authAdminApi, http(api.comments.add));
-    router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));
-
-    // ## Pages
-    router.get('/pages', mw.authAdminApi, http(api.pages.browse));
-    router.delete('/pages', mw.authAdminApi, http(api.pages.bulkDestroy));
-    router.put('/pages/bulk', mw.authAdminApi, http(api.pages.bulkEdit));
-    router.post('/pages', mw.authAdminApi, http(api.pages.add));
-    router.get('/pages/:id', mw.authAdminApi, http(api.pages.read));
-    router.get('/pages/slug/:slug', mw.authAdminApi, http(api.pages.read));
-    router.put('/pages/:id', mw.authAdminApi, http(api.pages.edit));
-    router.delete('/pages/:id', mw.authAdminApi, http(api.pages.destroy));
-    router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));
-
-    // Gift links
-    router.get('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
-    router.put('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
-    router.post('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
-    router.get('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
-    router.put('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
-    router.post('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
-    router.put('/gift_links/remove_all', mw.authAdminApi, http(api.giftLinks.removeAll));
-
-    // # Integrations
-
-    router.get('/integrations', mw.authAdminApi, http(api.integrations.browse));
-    router.get('/integrations/:id', mw.authAdminApi, http(api.integrations.read));
-    router.post('/integrations', mw.authAdminApi, http(api.integrations.add));
-    router.post('/integrations/:id/api_key/:keyid/refresh', mw.authAdminApi, http(api.integrations.edit));
-    router.put('/integrations/:id', mw.authAdminApi, http(api.integrations.edit));
-    router.delete('/integrations/:id', mw.authAdminApi, http(api.integrations.destroy));
-
-    // ## Schedules
-    router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(api.schedules.publish));
-
-    // ## Gifts
-    router.put('/gifts/flush_reminders', mw.authAdminApiWithUrl, http(api.gifts.flushReminders));
-
-    // ## Settings
-    router.get('/settings/routes/yaml', mw.authAdminApi, http(api.settings.download));
-    router.post('/settings/routes/yaml',
-        mw.authAdminApi,
-        apiMw.upload.single('routes'),
-        apiMw.upload.validation({type: 'routes'}),
-        http(api.settings.upload)
-    );
-
-    router.get('/settings', mw.authAdminApi, http(api.settings.browse));
-    router.put('/settings', mw.authAdminApi, http(api.settings.edit));
-    router.post('/settings/access_code/regenerate', mw.authAdminApi, http(api.settings.regenerateAccessCode));
-    router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
-    router.delete('/settings/stripe/connect', mw.authAdminApi, http(api.settings.disconnectStripeConnectIntegration));
-
-    // ## Users
-    router.get('/users', mw.authAdminApi, http(api.users.browse));
-    router.get('/users/:id', mw.authAdminApi, http(api.users.read));
-    router.get('/users/slug/:slug', mw.authAdminApi, http(api.users.read));
-    // NOTE: We don't expose any email addresses via the public api.
-    router.get('/users/email/:email', mw.authAdminApi, http(api.users.read));
-    router.get('/users/:id/token', mw.authAdminApi, http(api.users.readStaffToken));
-
-    router.put('/users/password', mw.authAdminApi, http(api.users.changePassword));
-    router.put('/users/owner', mw.authAdminApi, http(api.users.transferOwnership));
-    router.put('/users/:id', mw.authAdminApi, http(api.users.edit));
-    router.put('/users/:id/token', mw.authAdminApi, http(api.users.regenerateStaffToken));
-    router.delete('/users/:id', mw.authAdminApi, http(api.users.destroy));
-
-    // ## Tags
-    router.get('/tags', mw.authAdminApi, http(api.tags.browse));
-    router.get('/tags/:id', mw.authAdminApi, http(api.tags.read));
-    router.get('/tags/slug/:slug', mw.authAdminApi, http(api.tags.read));
-    router.post('/tags', mw.authAdminApi, http(api.tags.add));
-    router.put('/tags/:id', mw.authAdminApi, http(api.tags.edit));
-    router.delete('/tags/:id', mw.authAdminApi, http(api.tags.destroy));
-
-    // Tiers
-    router.get('/tiers', mw.authAdminApi, http(api.tiers.browse));
-    router.post('/tiers', mw.authAdminApi, http(api.tiers.add));
-    router.get('/tiers/:id', mw.authAdminApi, http(api.tiers.read));
-    router.put('/tiers/:id', mw.authAdminApi, http(api.tiers.edit));
-
-    // ## Members
-    router.get('/members', mw.authAdminApi, http(api.members.browse));
-    router.post('/members', mw.authAdminApi, http(api.members.add));
-    router.delete('/members', mw.authAdminApi, http(api.members.bulkDestroy));
-    router.put('/members/bulk', mw.authAdminApi, http(api.members.bulkEdit));
-
-    router.get('/offers', mw.authAdminApi, http(api.offers.browse));
-    router.post('/offers', mw.authAdminApi, http(api.offers.add));
-    router.get('/offers/:id', mw.authAdminApi, http(api.offers.read));
-    router.put('/offers/:id', mw.authAdminApi, http(api.offers.edit));
-
-    router.get('/members/stats/count', mw.authAdminApi, http(api.members.memberStats));
-    router.get('/members/stats/mrr', mw.authAdminApi, http(api.members.mrrStats));
-
-    router.get('/members/events', mw.authAdminApi, http(api.members.activityFeed));
-
-    router.get('/members/upload', mw.authAdminApi, http(api.members.exportCSV));
-    router.post('/members/upload',
-        mw.authAdminApi,
-        apiMw.upload.single('membersfile'),
-        apiMw.upload.validation({type: 'members'}),
-        http(api.members.importCSV)
-    );
-
-    router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
-
-    // Member custom field definitions — gated by the members_custom_fields flag.
-    // Registered before /members/:id so the literal path isn't captured by :id.
-    router.get('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.browse));
-    router.post('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.add));
-    // A PUT on the collection sets the publisher's order for the whole list.
-    router.put('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.reorder));
-    router.get('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.read));
-    router.put('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.edit));
-    router.delete('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.destroy));
-
-    router.get('/members/:id', mw.authAdminApi, http(api.members.read));
-    router.put('/members/:id', mw.authAdminApi, http(api.members.edit));
-    router.delete('/members/:id', mw.authAdminApi, http(api.members.destroy));
-    router.delete('/members/:id/sessions', mw.authAdminApi, http(api.members.logout));
-    router.delete('/members/:id/suppression', mw.authAdminApi, http(api.members.deleteEmailSuppression));
-
-    router.post('/members/:id/subscriptions/', mw.authAdminApi, http(api.members.createSubscription));
-    router.put('/members/:id/subscriptions/:subscription_id', mw.authAdminApi, http(api.members.editSubscription));
-
-    router.get('/members/:id/signin_urls', mw.authAdminApi, http(api.memberSigninUrls.read));
-
-    router.post('/members/:id/commenting/disable', mw.authAdminApi, http(api.memberCommenting.disable));
-    router.post('/members/:id/commenting/enable', mw.authAdminApi, http(api.memberCommenting.enable));
-
-    // ## Stats
-    router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
-    router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
-    router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
-    router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
-    router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
-    router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
-    router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
-    router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
-    router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
-    router.get('/stats/newsletter-basic-stats', mw.authAdminApi, http(api.stats.newsletterBasicStats));
-    router.get('/stats/newsletter-click-stats', mw.authAdminApi, http(api.stats.newsletterClickStats));
-    router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
-    router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrers));
-    router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
-    router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
-    router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
-    router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
-
-    // ## Labels
-    router.get('/labels', mw.authAdminApi, http(api.labels.browse));
-    router.get('/labels/:id', mw.authAdminApi, http(api.labels.read));
-    router.get('/labels/slug/:slug', mw.authAdminApi, http(api.labels.read));
-    router.post('/labels', mw.authAdminApi, http(api.labels.add));
-    router.put('/labels/:id', mw.authAdminApi, http(api.labels.edit));
-    router.delete('/labels/:id', mw.authAdminApi, http(api.labels.destroy));
-
-    // ## Automations
-    router.get('/automations', mw.authAdminApi, http(api.automations.browse));
-    router.get('/automations/:automation_id/actions/:action_id/links', mw.authAdminApi, http(api.automationActionLinks.browse));
-    router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
-    router.post('/automations/:id/email_preview', mw.authAdminApi, http(api.automationEmailPreviews.preview));
-    router.post('/automations/:id/email_test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automationEmailPreviews.sendTestEmail));
-    router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
-    router.put('/automations/:id', mw.authAdminApi, http(api.automations.edit));
-
-    // ## Automated Emails
-    router.get('/automated_emails', mw.authAdminApi, http(api.automatedEmails.browse));
-    router.get('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.read));
-    router.put('/automated_emails/senders', mw.authAdminApi, http(api.automatedEmails.editSenders));
-    router.put('/automated_emails/verifications', mw.authAdminApi, http(api.automatedEmails.verifySenderUpdate));
-    router.get('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.read));
-    router.post('/automated_emails', mw.authAdminApi, http(api.automatedEmails.add));
-    router.put('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.edit));
-    router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
-    router.post('/automated_emails/:id/preview', mw.authAdminApi, http(api.automatedEmails.preview));
-    router.post('/automated_emails/:id/test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automatedEmails.sendTestEmail));
-
-    // ## Roles
-    router.get('/roles/', mw.authAdminApi, http(api.roles.browse));
-
-    // ## Slugs
-    router.get('/slugs/:type/:name', mw.authAdminApi, http(api.slugs.generate));
-    router.get('/slugs/:type/:name/:id', mw.authAdminApi, http(api.slugs.generate));
-
-    // ## Themes
-    router.get('/themes/', mw.authAdminApi, http(api.themes.browse));
-
-    router.get('/themes/:name/download',
-        mw.authAdminApi,
-        http(api.themes.download)
-    );
-
-    router.get('/themes/active',
-        mw.authAdminApi,
-        http(api.themes.readActive)
-    );
-
-    router.post('/themes/upload',
-        mw.authAdminApi,
-        apiMw.upload.themeZip('file'),
-        apiMw.upload.validation({type: 'themes'}),
-        http(api.themes.upload)
-    );
-
-    router.post('/themes/install', mw.authAdminApi, http(api.themes.install));
-
-    router.put('/themes/:name/activate',
-        mw.authAdminApi,
-        http(api.themes.activate)
-    );
-
-    router.delete('/themes/:name',
-        mw.authAdminApi,
-        http(api.themes.destroy)
-    );
-
-    // ## Notifications
-    router.get('/notifications', mw.authAdminApi, http(api.notifications.browse));
-    router.post('/notifications', mw.authAdminApi, http(api.notifications.add));
-    router.delete('/notifications/:notification_id', mw.authAdminApi, http(api.notifications.destroy));
-
-    // ## DB
-    router.get('/db', mw.authAdminApi, http(api.db.exportContent));
-    router.post('/db',
-        mw.authAdminApi,
-        apiMw.upload.single('importfile'),
-        apiMw.upload.validation({type: 'db'}),
-        http(api.db.importContent)
-    );
-    router.delete('/db', mw.authAdminApi, http(api.db.deleteAllContent));
-    router.post('/db/backup',
-        mw.authAdminApi,
-        http(api.db.backupContent)
-    );
-
-    router.post('/db/media/inline',
-        mw.authAdminApi,
-        http(api.db.inlineMedia)
-    );
-
-    // ## Exports
-    router.get('/exports/download', mw.authAdminApi, labs.enabledMiddleware('selfServeArchives'), http(api.exports.download));
-    router.post('/exports', mw.authAdminApi, labs.enabledMiddleware('selfServeArchives'), http(api.exports.add));
-
-    // ## Slack
-    router.post('/slack/test', mw.authAdminApi, http(api.slack.sendTest));
-
-    // ## Tinybird
-    router.get('/tinybird/token', mw.authAdminApi, http(api.tinybird.token));
-
-    // ## Featurebase
-    router.get('/featurebase/token', mw.authAdminApi, http(api.featurebase.token));
-
-    // ## Sessions
-    // We don't need auth when creating a new session (logging in)
-    router.post('/session',
-        shared.middleware.brute.globalBlock,
-        shared.middleware.brute.userLogin,
-        http(api.session.add)
-    );
-    router.delete('/session', mw.authAdminApi, http(api.session.delete));
-    router.post('/session/verify', shared.middleware.brute.sendVerificationCode, http(api.session.sendVerification));
-    router.put('/session/verify', shared.middleware.brute.userVerification, http(api.session.verify));
-
-    // ## Identity
-    router.get('/identities', mw.authAdminApi, http(api.identities.read));
-
-    // ## Authentication
-    router.post('/authentication/password_reset',
-        shared.middleware.brute.globalReset,
-        shared.middleware.brute.userReset,
-        http(api.authentication.generateResetToken)
-    );
-    router.put('/authentication/password_reset',
-        shared.middleware.brute.globalBlock,
-        auth.session.initSession,
-        http(api.authentication.resetPassword)
-    );
-    router.post('/authentication/invitation', http(api.authentication.acceptInvitation));
-    router.get('/authentication/invitation', http(api.authentication.isInvitation));
-    router.post('/authentication/setup', http(api.authentication.setup));
-    router.put('/authentication/setup', mw.authAdminApi, http(api.authentication.updateSetup));
-    router.get('/authentication/setup', http(api.authentication.isSetup));
-    router.post('/authentication/reset', mw.authAdminApi, http(api.authentication.reset));
-
-    // ## Images
-    router.post('/images/upload',
-        mw.authAdminApi,
-        apiMw.upload.single('file'),
-        apiMw.upload.validation({type: 'images'}),
-        http(api.images.upload)
-    );
-
-    // ## media
-    router.post('/media/upload',
-        mw.authAdminApi,
-        apiMw.upload.media('file', 'thumbnail'),
-        apiMw.upload.mediaValidation({type: 'media'}),
-        http(api.media.upload)
-    );
-    router.put('/media/thumbnail/upload',
-        mw.authAdminApi,
-        apiMw.upload.single('file'),
-        apiMw.upload.validation({type: 'images'}),
-        http(api.media.uploadThumbnail)
-    );
-
-    // ## files
-    router.post('/files/upload',
-        mw.authAdminApi,
-        apiMw.upload.single('file'),
-        apiMw.upload.fileValidation({type: 'files'}),
-        http(api.files.upload)
-    );
-
-    // ## Invites
-    router.get('/invites', mw.authAdminApi, http(api.invites.browse));
-    router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));
-    router.post('/invites', mw.authAdminApi, http(api.invites.add));
-    router.delete('/invites/:id', mw.authAdminApi, http(api.invites.destroy));
-
-    // ## Redirects
-    router.get('/redirects/download', mw.authAdminApi, http(api.redirects.download));
-    router.post('/redirects/upload',
-        mw.authAdminApi,
-        apiMw.upload.single('redirects'),
-        apiMw.upload.validation({type: 'redirects'}),
-        http(api.redirects.upload)
-    );
-
-    // ## Webhooks (RESTHooks)
-    router.post('/webhooks', mw.authAdminApi, http(api.webhooks.add));
-    router.put('/webhooks/:id', mw.authAdminApi, http(api.webhooks.edit));
-    router.delete('/webhooks/:id', mw.authAdminApi, http(api.webhooks.destroy));
-
-    // ## Oembed (fetch response from oembed provider)
-    router.get('/oembed', mw.authAdminApi, http(api.oembed.read));
-
-    // ## Actions
-    router.get('/actions', mw.authAdminApi, http(api.actions.browse));
-
-    // ## Email Preview
-    router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.read));
-    // preview sending have an additional rate limiter to prevent abuse
-    router.post('/email_previews/posts/:id', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.email_previews.sendTestEmail));
-
-    // ## Emails
-    router.get('/emails', mw.authAdminApi, http(api.emails.browse));
-    router.get('/emails/:id', mw.authAdminApi, http(api.emails.read));
-    router.put('/emails/:id/retry', mw.authAdminApi, http(api.emails.retry));
-    router.get('/emails/:id/batches', mw.authAdminApi, http(api.emails.browseBatches));
-    router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));
-    router.get('/emails/:id/analytics', mw.authAdminApi, http(api.emails.analyticsStatus));
-    router.put('/emails/:id/analytics', mw.authAdminApi, http(api.emails.scheduleAnalytics));
-    router.delete('/emails/analytics', mw.authAdminApi, http(api.emails.cancelScheduledAnalytics));
-
-    // ## Snippets
-    router.get('/snippets', mw.authAdminApi, http(api.snippets.browse));
-    router.get('/snippets/:id', mw.authAdminApi, http(api.snippets.read));
-    router.post('/snippets', mw.authAdminApi, http(api.snippets.add));
-    router.put('/snippets/:id', mw.authAdminApi, http(api.snippets.edit));
-    router.delete('/snippets/:id', mw.authAdminApi, http(api.snippets.destroy));
-
-    // ## Custom theme settings
-    router.get('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.browse));
-    router.put('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.edit));
-
-    router.get('/newsletters', mw.authAdminApi, http(api.newsletters.browse));
-    router.get('/newsletters/:id', mw.authAdminApi, http(api.newsletters.read));
-    router.post('/newsletters', mw.authAdminApi, http(api.newsletters.add));
-    router.put('/newsletters/verifications/', mw.authAdminApi, http(api.newsletters.verifyPropertyUpdate));
-    router.put('/newsletters/:id', mw.authAdminApi, http(api.newsletters.edit));
-
-    router.get('/links', mw.authAdminApi, http(api.links.browse));
-    router.put('/links/bulk', mw.authAdminApi, http(api.links.bulkEdit));
-
-    // Recommendations
-    router.get('/recommendations', mw.authAdminApi, http(api.recommendations.browse));
-    router.get('/recommendations/:id', mw.authAdminApi, http(api.recommendations.read));
-    router.post('/recommendations', mw.authAdminApi, http(api.recommendations.add));
-    router.post('/recommendations/check', mw.authAdminApi, http(api.recommendations.check));
-    router.put('/recommendations/:id', mw.authAdminApi, http(api.recommendations.edit));
-    router.delete('/recommendations/:id', mw.authAdminApi, http(api.recommendations.destroy));
-
-    // Incoming recommendations
-    router.get('/incoming_recommendations', mw.authAdminApi, http(api.incomingRecommendations.browse));
-
-    // Feedback
-    router.get('/feedback/:id', mw.authAdminApi, http(api.feedbackMembers.browse));
-
-    // Search index
-    router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
-    router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
-    router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
-    router.get('/search-index/users', mw.authAdminApi, http(api.searchIndex.fetchUsers));
-
-    return router;
+  const router = express.Router('admin api');
+
+  router.use(apiMw.cors);
+
+  // ## Public
+  router.get('/site', mw.publicAdminApi, http(api.site.read));
+
+  // ## Configuration
+  router.get('/config', mw.authAdminApi, http(api.config.read));
+  router.get('/config/featurebase', mw.authAdminApi, http(api.config.featurebase));
+
+  // ## Posts
+  router.get('/posts', mw.authAdminApi, http(api.posts.browse));
+  router.get('/posts/export', mw.authAdminApi, http(api.posts.exportCSV));
+
+  router.post('/posts', mw.authAdminApi, http(api.posts.add));
+  router.delete('/posts', mw.authAdminApi, http(api.posts.bulkDestroy));
+  router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
+  router.post(
+    '/posts/upload',
+    mw.authAdminApi,
+    labs.enabledMiddleware('csvContentImporter'),
+    apiMw.upload.single('postsfile'),
+    apiMw.upload.validation({ type: 'posts' }),
+    http(api.posts.importCSV),
+  );
+  router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
+  router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));
+  router.put('/posts/:id', mw.authAdminApi, http(api.posts.edit));
+  router.delete('/posts/:id', mw.authAdminApi, http(api.posts.destroy));
+  router.post('/posts/:id/copy', mw.authAdminApi, http(api.posts.copy));
+
+  router.get('/mentions', mw.authAdminApi, http(api.mentions.browse));
+
+  // Comments - browseAll must come before :id routes
+  router.get('/comments', mw.authAdminApi, http(api.comments.browseAll));
+  router.get('/comments/:id', mw.authAdminApi, http(api.commentReplies.read));
+  router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
+  router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
+  router.get('/comments/:id/likes', mw.authAdminApi, http(api.commentLikes.browse));
+  router.get('/comments/:id/dislikes', mw.authAdminApi, http(api.commentDislikes.browse));
+  router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
+  router.post('/comments', mw.authAdminApi, http(api.comments.add));
+  router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));
+
+  // ## Pages
+  router.get('/pages', mw.authAdminApi, http(api.pages.browse));
+  router.delete('/pages', mw.authAdminApi, http(api.pages.bulkDestroy));
+  router.put('/pages/bulk', mw.authAdminApi, http(api.pages.bulkEdit));
+  router.post('/pages', mw.authAdminApi, http(api.pages.add));
+  router.get('/pages/:id', mw.authAdminApi, http(api.pages.read));
+  router.get('/pages/slug/:slug', mw.authAdminApi, http(api.pages.read));
+  router.put('/pages/:id', mw.authAdminApi, http(api.pages.edit));
+  router.delete('/pages/:id', mw.authAdminApi, http(api.pages.destroy));
+  router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));
+
+  // Gift links
+  router.get('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
+  router.put('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
+  router.post('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
+  router.get('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
+  router.put('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
+  router.post('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
+  router.put('/gift_links/remove_all', mw.authAdminApi, http(api.giftLinks.removeAll));
+
+  // # Integrations
+
+  router.get('/integrations', mw.authAdminApi, http(api.integrations.browse));
+  router.get('/integrations/:id', mw.authAdminApi, http(api.integrations.read));
+  router.post('/integrations', mw.authAdminApi, http(api.integrations.add));
+  router.post(
+    '/integrations/:id/api_key/:keyid/refresh',
+    mw.authAdminApi,
+    http(api.integrations.edit),
+  );
+  router.put('/integrations/:id', mw.authAdminApi, http(api.integrations.edit));
+  router.delete('/integrations/:id', mw.authAdminApi, http(api.integrations.destroy));
+
+  // ## Schedules
+  router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(api.schedules.publish));
+
+  // ## Gifts
+  router.put('/gifts/flush_reminders', mw.authAdminApiWithUrl, http(api.gifts.flushReminders));
+
+  // ## Settings
+  router.get('/settings/routes/yaml', mw.authAdminApi, http(api.settings.download));
+  router.post(
+    '/settings/routes/yaml',
+    mw.authAdminApi,
+    apiMw.upload.single('routes'),
+    apiMw.upload.validation({ type: 'routes' }),
+    http(api.settings.upload),
+  );
+
+  router.get('/settings', mw.authAdminApi, http(api.settings.browse));
+  router.put('/settings', mw.authAdminApi, http(api.settings.edit));
+  router.post(
+    '/settings/access_code/regenerate',
+    mw.authAdminApi,
+    http(api.settings.regenerateAccessCode),
+  );
+  router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
+  router.delete(
+    '/settings/stripe/connect',
+    mw.authAdminApi,
+    http(api.settings.disconnectStripeConnectIntegration),
+  );
+
+  // ## Users
+  router.get('/users', mw.authAdminApi, http(api.users.browse));
+  router.get('/users/:id', mw.authAdminApi, http(api.users.read));
+  router.get('/users/slug/:slug', mw.authAdminApi, http(api.users.read));
+  // NOTE: We don't expose any email addresses via the public api.
+  router.get('/users/email/:email', mw.authAdminApi, http(api.users.read));
+  router.get('/users/:id/token', mw.authAdminApi, http(api.users.readStaffToken));
+
+  router.put('/users/password', mw.authAdminApi, http(api.users.changePassword));
+  router.put('/users/owner', mw.authAdminApi, http(api.users.transferOwnership));
+  router.put('/users/:id', mw.authAdminApi, http(api.users.edit));
+  router.put('/users/:id/token', mw.authAdminApi, http(api.users.regenerateStaffToken));
+  router.delete('/users/:id', mw.authAdminApi, http(api.users.destroy));
+
+  // ## Tags
+  router.get('/tags', mw.authAdminApi, http(api.tags.browse));
+  router.get('/tags/:id', mw.authAdminApi, http(api.tags.read));
+  router.get('/tags/slug/:slug', mw.authAdminApi, http(api.tags.read));
+  router.post('/tags', mw.authAdminApi, http(api.tags.add));
+  router.put('/tags/:id', mw.authAdminApi, http(api.tags.edit));
+  router.delete('/tags/:id', mw.authAdminApi, http(api.tags.destroy));
+
+  // Tiers
+  router.get('/tiers', mw.authAdminApi, http(api.tiers.browse));
+  router.post('/tiers', mw.authAdminApi, http(api.tiers.add));
+  router.get('/tiers/:id', mw.authAdminApi, http(api.tiers.read));
+  router.put('/tiers/:id', mw.authAdminApi, http(api.tiers.edit));
+
+  // ## Members
+  router.get('/members', mw.authAdminApi, http(api.members.browse));
+  router.post('/members', mw.authAdminApi, http(api.members.add));
+  router.delete('/members', mw.authAdminApi, http(api.members.bulkDestroy));
+  router.put('/members/bulk', mw.authAdminApi, http(api.members.bulkEdit));
+
+  router.get('/offers', mw.authAdminApi, http(api.offers.browse));
+  router.post('/offers', mw.authAdminApi, http(api.offers.add));
+  router.get('/offers/:id', mw.authAdminApi, http(api.offers.read));
+  router.put('/offers/:id', mw.authAdminApi, http(api.offers.edit));
+
+  router.get('/members/stats/count', mw.authAdminApi, http(api.members.memberStats));
+  router.get('/members/stats/mrr', mw.authAdminApi, http(api.members.mrrStats));
+
+  router.get('/members/events', mw.authAdminApi, http(api.members.activityFeed));
+
+  router.get('/members/upload', mw.authAdminApi, http(api.members.exportCSV));
+  router.post(
+    '/members/upload',
+    mw.authAdminApi,
+    apiMw.upload.single('membersfile'),
+    apiMw.upload.validation({ type: 'members' }),
+    http(api.members.importCSV),
+  );
+
+  router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
+
+  // Member custom field definitions — gated by the members_custom_fields flag.
+  // Registered before /members/:id so the literal path isn't captured by :id.
+  router.get(
+    '/members/custom_fields',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersCustomFields.browse),
+  );
+  router.post(
+    '/members/custom_fields',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersCustomFields.add),
+  );
+  // A PUT on the collection sets the publisher's order for the whole list.
+  router.put(
+    '/members/custom_fields',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersCustomFields.reorder),
+  );
+  router.get(
+    '/members/custom_fields/:key',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersCustomFields.read),
+  );
+  router.put(
+    '/members/custom_fields/:key',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersCustomFields.edit),
+  );
+  router.delete(
+    '/members/custom_fields/:key',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersCustomFields.destroy),
+  );
+
+  router.get('/members/:id', mw.authAdminApi, http(api.members.read));
+  router.put('/members/:id', mw.authAdminApi, http(api.members.edit));
+  router.delete('/members/:id', mw.authAdminApi, http(api.members.destroy));
+  router.delete('/members/:id/sessions', mw.authAdminApi, http(api.members.logout));
+  router.delete(
+    '/members/:id/suppression',
+    mw.authAdminApi,
+    http(api.members.deleteEmailSuppression),
+  );
+
+  router.post('/members/:id/subscriptions/', mw.authAdminApi, http(api.members.createSubscription));
+  router.put(
+    '/members/:id/subscriptions/:subscription_id',
+    mw.authAdminApi,
+    http(api.members.editSubscription),
+  );
+
+  router.get('/members/:id/signin_urls', mw.authAdminApi, http(api.memberSigninUrls.read));
+
+  router.post(
+    '/members/:id/commenting/disable',
+    mw.authAdminApi,
+    http(api.memberCommenting.disable),
+  );
+  router.post('/members/:id/commenting/enable', mw.authAdminApi, http(api.memberCommenting.enable));
+
+  // ## Stats
+  router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
+  router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
+  router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
+  router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
+  router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
+  router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
+  router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
+  router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
+  router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
+  router.get(
+    '/stats/newsletter-basic-stats',
+    mw.authAdminApi,
+    http(api.stats.newsletterBasicStats),
+  );
+  router.get(
+    '/stats/newsletter-click-stats',
+    mw.authAdminApi,
+    http(api.stats.newsletterClickStats),
+  );
+  router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
+  router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrers));
+  router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
+  router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
+  router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
+  router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
+
+  // ## Labels
+  router.get('/labels', mw.authAdminApi, http(api.labels.browse));
+  router.get('/labels/:id', mw.authAdminApi, http(api.labels.read));
+  router.get('/labels/slug/:slug', mw.authAdminApi, http(api.labels.read));
+  router.post('/labels', mw.authAdminApi, http(api.labels.add));
+  router.put('/labels/:id', mw.authAdminApi, http(api.labels.edit));
+  router.delete('/labels/:id', mw.authAdminApi, http(api.labels.destroy));
+
+  // ## Automations
+  router.get('/automations', mw.authAdminApi, http(api.automations.browse));
+  router.get(
+    '/automations/:automation_id/actions/:action_id/links',
+    mw.authAdminApi,
+    http(api.automationActionLinks.browse),
+  );
+  router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
+  router.post(
+    '/automations/:id/email_preview',
+    mw.authAdminApi,
+    http(api.automationEmailPreviews.preview),
+  );
+  router.post(
+    '/automations/:id/email_test',
+    shared.middleware.brute.previewEmailLimiter,
+    mw.authAdminApi,
+    http(api.automationEmailPreviews.sendTestEmail),
+  );
+  router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
+  router.put('/automations/:id', mw.authAdminApi, http(api.automations.edit));
+
+  // ## Automated Emails
+  router.get('/automated_emails', mw.authAdminApi, http(api.automatedEmails.browse));
+  router.get('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.read));
+  router.put('/automated_emails/senders', mw.authAdminApi, http(api.automatedEmails.editSenders));
+  router.put(
+    '/automated_emails/verifications',
+    mw.authAdminApi,
+    http(api.automatedEmails.verifySenderUpdate),
+  );
+  router.get('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.read));
+  router.post('/automated_emails', mw.authAdminApi, http(api.automatedEmails.add));
+  router.put('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.edit));
+  router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
+  router.post('/automated_emails/:id/preview', mw.authAdminApi, http(api.automatedEmails.preview));
+  router.post(
+    '/automated_emails/:id/test',
+    shared.middleware.brute.previewEmailLimiter,
+    mw.authAdminApi,
+    http(api.automatedEmails.sendTestEmail),
+  );
+
+  // ## Roles
+  router.get('/roles/', mw.authAdminApi, http(api.roles.browse));
+
+  // ## Slugs
+  router.get('/slugs/:type/:name', mw.authAdminApi, http(api.slugs.generate));
+  router.get('/slugs/:type/:name/:id', mw.authAdminApi, http(api.slugs.generate));
+
+  // ## Themes
+  router.get('/themes/', mw.authAdminApi, http(api.themes.browse));
+
+  router.get('/themes/:name/download', mw.authAdminApi, http(api.themes.download));
+
+  router.get('/themes/active', mw.authAdminApi, http(api.themes.readActive));
+
+  router.post(
+    '/themes/upload',
+    mw.authAdminApi,
+    apiMw.upload.themeZip('file'),
+    apiMw.upload.validation({ type: 'themes' }),
+    http(api.themes.upload),
+  );
+
+  router.post('/themes/install', mw.authAdminApi, http(api.themes.install));
+
+  router.put('/themes/:name/activate', mw.authAdminApi, http(api.themes.activate));
+
+  router.delete('/themes/:name', mw.authAdminApi, http(api.themes.destroy));
+
+  // ## Notifications
+  router.get('/notifications', mw.authAdminApi, http(api.notifications.browse));
+  router.post('/notifications', mw.authAdminApi, http(api.notifications.add));
+  router.delete(
+    '/notifications/:notification_id',
+    mw.authAdminApi,
+    http(api.notifications.destroy),
+  );
+
+  // ## DB
+  router.get('/db', mw.authAdminApi, http(api.db.exportContent));
+  router.post(
+    '/db',
+    mw.authAdminApi,
+    apiMw.upload.single('importfile'),
+    apiMw.upload.validation({ type: 'db' }),
+    http(api.db.importContent),
+  );
+  router.delete('/db', mw.authAdminApi, http(api.db.deleteAllContent));
+  router.post('/db/backup', mw.authAdminApi, http(api.db.backupContent));
+
+  router.post('/db/media/inline', mw.authAdminApi, http(api.db.inlineMedia));
+
+  // ## Exports
+  router.get(
+    '/exports/download',
+    mw.authAdminApi,
+    labs.enabledMiddleware('selfServeArchives'),
+    http(api.exports.download),
+  );
+  router.post(
+    '/exports',
+    mw.authAdminApi,
+    labs.enabledMiddleware('selfServeArchives'),
+    http(api.exports.add),
+  );
+
+  // ## Slack
+  router.post('/slack/test', mw.authAdminApi, http(api.slack.sendTest));
+
+  // ## Tinybird
+  router.get('/tinybird/token', mw.authAdminApi, http(api.tinybird.token));
+
+  // ## Featurebase
+  router.get('/featurebase/token', mw.authAdminApi, http(api.featurebase.token));
+
+  // ## Sessions
+  // We don't need auth when creating a new session (logging in)
+  router.post(
+    '/session',
+    shared.middleware.brute.globalBlock,
+    shared.middleware.brute.userLogin,
+    http(api.session.add),
+  );
+  router.delete('/session', mw.authAdminApi, http(api.session.delete));
+  router.post(
+    '/session/verify',
+    shared.middleware.brute.sendVerificationCode,
+    http(api.session.sendVerification),
+  );
+  router.put('/session/verify', shared.middleware.brute.userVerification, http(api.session.verify));
+
+  // ## Identity
+  router.get('/identities', mw.authAdminApi, http(api.identities.read));
+
+  // ## Authentication
+  router.post(
+    '/authentication/password_reset',
+    shared.middleware.brute.globalReset,
+    shared.middleware.brute.userReset,
+    http(api.authentication.generateResetToken),
+  );
+  router.put(
+    '/authentication/password_reset',
+    shared.middleware.brute.globalBlock,
+    auth.session.initSession,
+    http(api.authentication.resetPassword),
+  );
+  router.post('/authentication/invitation', http(api.authentication.acceptInvitation));
+  router.get('/authentication/invitation', http(api.authentication.isInvitation));
+  router.post('/authentication/setup', http(api.authentication.setup));
+  router.put('/authentication/setup', mw.authAdminApi, http(api.authentication.updateSetup));
+  router.get('/authentication/setup', http(api.authentication.isSetup));
+  router.post('/authentication/reset', mw.authAdminApi, http(api.authentication.reset));
+
+  // ## Images
+  router.post(
+    '/images/upload',
+    mw.authAdminApi,
+    apiMw.upload.single('file'),
+    apiMw.upload.validation({ type: 'images' }),
+    http(api.images.upload),
+  );
+
+  // ## media
+  router.post(
+    '/media/upload',
+    mw.authAdminApi,
+    apiMw.upload.media('file', 'thumbnail'),
+    apiMw.upload.mediaValidation({ type: 'media' }),
+    http(api.media.upload),
+  );
+  router.put(
+    '/media/thumbnail/upload',
+    mw.authAdminApi,
+    apiMw.upload.single('file'),
+    apiMw.upload.validation({ type: 'images' }),
+    http(api.media.uploadThumbnail),
+  );
+
+  // ## files
+  router.post(
+    '/files/upload',
+    mw.authAdminApi,
+    apiMw.upload.single('file'),
+    apiMw.upload.fileValidation({ type: 'files' }),
+    http(api.files.upload),
+  );
+
+  // ## Invites
+  router.get('/invites', mw.authAdminApi, http(api.invites.browse));
+  router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));
+  router.post('/invites', mw.authAdminApi, http(api.invites.add));
+  router.delete('/invites/:id', mw.authAdminApi, http(api.invites.destroy));
+
+  // ## Redirects
+  router.get('/redirects/download', mw.authAdminApi, http(api.redirects.download));
+  router.post(
+    '/redirects/upload',
+    mw.authAdminApi,
+    apiMw.upload.single('redirects'),
+    apiMw.upload.validation({ type: 'redirects' }),
+    http(api.redirects.upload),
+  );
+
+  // ## Webhooks (RESTHooks)
+  router.post('/webhooks', mw.authAdminApi, http(api.webhooks.add));
+  router.put('/webhooks/:id', mw.authAdminApi, http(api.webhooks.edit));
+  router.delete('/webhooks/:id', mw.authAdminApi, http(api.webhooks.destroy));
+
+  // ## Oembed (fetch response from oembed provider)
+  router.get('/oembed', mw.authAdminApi, http(api.oembed.read));
+
+  // ## Actions
+  router.get('/actions', mw.authAdminApi, http(api.actions.browse));
+
+  // ## Email Preview
+  router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.read));
+  // preview sending have an additional rate limiter to prevent abuse
+  router.post(
+    '/email_previews/posts/:id',
+    shared.middleware.brute.previewEmailLimiter,
+    mw.authAdminApi,
+    http(api.email_previews.sendTestEmail),
+  );
+
+  // ## Emails
+  router.get('/emails', mw.authAdminApi, http(api.emails.browse));
+  router.get('/emails/:id', mw.authAdminApi, http(api.emails.read));
+  router.put('/emails/:id/retry', mw.authAdminApi, http(api.emails.retry));
+  router.get('/emails/:id/batches', mw.authAdminApi, http(api.emails.browseBatches));
+  router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));
+  router.get('/emails/:id/analytics', mw.authAdminApi, http(api.emails.analyticsStatus));
+  router.put('/emails/:id/analytics', mw.authAdminApi, http(api.emails.scheduleAnalytics));
+  router.delete('/emails/analytics', mw.authAdminApi, http(api.emails.cancelScheduledAnalytics));
+
+  // ## Snippets
+  router.get('/snippets', mw.authAdminApi, http(api.snippets.browse));
+  router.get('/snippets/:id', mw.authAdminApi, http(api.snippets.read));
+  router.post('/snippets', mw.authAdminApi, http(api.snippets.add));
+  router.put('/snippets/:id', mw.authAdminApi, http(api.snippets.edit));
+  router.delete('/snippets/:id', mw.authAdminApi, http(api.snippets.destroy));
+
+  // ## Custom theme settings
+  router.get('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.browse));
+  router.put('/custom_theme_settings', mw.authAdminApi, http(api.customThemeSettings.edit));
+
+  router.get('/newsletters', mw.authAdminApi, http(api.newsletters.browse));
+  router.get('/newsletters/:id', mw.authAdminApi, http(api.newsletters.read));
+  router.post('/newsletters', mw.authAdminApi, http(api.newsletters.add));
+  router.put(
+    '/newsletters/verifications/',
+    mw.authAdminApi,
+    http(api.newsletters.verifyPropertyUpdate),
+  );
+  router.put('/newsletters/:id', mw.authAdminApi, http(api.newsletters.edit));
+
+  router.get('/links', mw.authAdminApi, http(api.links.browse));
+  router.put('/links/bulk', mw.authAdminApi, http(api.links.bulkEdit));
+
+  // Recommendations
+  router.get('/recommendations', mw.authAdminApi, http(api.recommendations.browse));
+  router.get('/recommendations/:id', mw.authAdminApi, http(api.recommendations.read));
+  router.post('/recommendations', mw.authAdminApi, http(api.recommendations.add));
+  router.post('/recommendations/check', mw.authAdminApi, http(api.recommendations.check));
+  router.put('/recommendations/:id', mw.authAdminApi, http(api.recommendations.edit));
+  router.delete('/recommendations/:id', mw.authAdminApi, http(api.recommendations.destroy));
+
+  // Incoming recommendations
+  router.get(
+    '/incoming_recommendations',
+    mw.authAdminApi,
+    http(api.incomingRecommendations.browse),
+  );
+
+  // Feedback
+  router.get('/feedback/:id', mw.authAdminApi, http(api.feedbackMembers.browse));
+
+  // Search index
+  router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
+  router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
+  router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
+  router.get('/search-index/users', mw.authAdminApi, http(api.searchIndex.fetchUsers));
+
+  return router;
 };

--- a/ghost/core/test/e2e-api/admin/exports-request.test.ts
+++ b/ghost/core/test/e2e-api/admin/exports-request.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
 
 const nock = require('nock');
-const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+const { agentProvider, fixtureManager } = require('../../utils/e2e-framework');
 const configUtils = require('../../utils/config-utils');
 
 const ARCHIVE_ORIGIN = 'https://archive-generator.example.com';
@@ -11,270 +11,257 @@ const WEBHOOK_SECRET = 'test-export-webhook-secret';
 const SITE_ID = 'test-site-id';
 
 const ALL_COMPONENTS = {
-    content: true,
-    members: true,
-    analytics: true,
-    themes: true,
-    routes: true,
-    media: false
+  content: true,
+  members: true,
+  analytics: true,
+  themes: true,
+  routes: true,
+  media: false,
 };
 
 function configureArchiveHost() {
-    configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
-    configUtils.set('hostSettings:siteId', SITE_ID);
-    configUtils.set('hostSettings:export:webhookSecret', WEBHOOK_SECRET);
+  configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+  configUtils.set('hostSettings:siteId', SITE_ID);
+  configUtils.set('hostSettings:export:webhookSecret', WEBHOOK_SECRET);
 }
 
 type CapturedRequest = {
-    headers?: Record<string, string>;
-    body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
 };
 
-function mockArchiveHost({status = 202} = {}) {
-    const captured: CapturedRequest = {};
+function mockArchiveHost({ status = 202 } = {}) {
+  const captured: CapturedRequest = {};
 
-    nock(ARCHIVE_ORIGIN)
-        .post(ARCHIVE_PATH)
-        .reply(function (this: {req: {headers: Record<string, string>}}, uri: string, requestBody: Record<string, unknown>) {
-            captured.headers = this.req.headers;
-            captured.body = requestBody;
-            return [status, {}];
-        });
+  nock(ARCHIVE_ORIGIN)
+    .post(ARCHIVE_PATH)
+    .reply(function (
+      this: { req: { headers: Record<string, string> } },
+      uri: string,
+      requestBody: Record<string, unknown>,
+    ) {
+      captured.headers = this.req.headers;
+      captured.body = requestBody;
+      return [status, {}];
+    });
 
-    return captured;
+  return captured;
 }
 
 describe('Exports API: archive requests', function () {
-    let agent: {
-        get: (_url: string) => any;
-        post: (_url: string) => any;
-        loginAsOwner: () => Promise<void>;
-        loginAsEditor: () => Promise<void>;
-        loginAsAuthor: () => Promise<void>;
-        useZapierAdminAPIKey: () => Promise<void>;
-    };
+  let agent: {
+    get: (_url: string) => any;
+    post: (_url: string) => any;
+    loginAsOwner: () => Promise<void>;
+    loginAsEditor: () => Promise<void>;
+    loginAsAuthor: () => Promise<void>;
+    useZapierAdminAPIKey: () => Promise<void>;
+  };
 
+  beforeAll(async function () {
+    agent = await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('users');
+  });
+
+  afterEach(async function () {
+    nock.cleanAll();
+    await configUtils.restore();
+  });
+
+  describe('As Unauthorized User', function () {
+    it('Cannot request an export', async function () {
+      configureArchiveHost();
+
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(403);
+    });
+  });
+
+  describe('As Owner', function () {
     beforeAll(async function () {
-        agent = await agentProvider.getAdminAPIAgent();
-        await fixtureManager.init('users');
+      await agent.loginAsOwner();
     });
 
-    afterEach(async function () {
-        nock.cleanAll();
-        await configUtils.restore();
+    it('Can request an export and sends a signed request to the archive host', async function () {
+      configureArchiveHost();
+      const captured = mockArchiveHost();
+
+      await agent
+        .post('/exports/')
+        .body({ components: { content: true, members: true, media: true } })
+        .expectStatus(202);
+
+      assert.ok(captured.body, 'Expected an outbound request to the archive host');
+
+      assert.deepEqual(captured.body, {
+        type: 'export',
+        siteId: SITE_ID,
+        requestedBy: fixtureManager.get('users', 0).email,
+        components: {
+          content: true,
+          members: true,
+          analytics: false,
+          themes: false,
+          routes: false,
+          media: true,
+        },
+      });
+
+      assert.ok(captured.headers, 'Expected the outbound request headers to be captured');
+      assert.equal(captured.headers['content-type'], 'application/json');
+      assert.match(captured.headers['content-version'], /^v\d+\.\d+$/);
+
+      const timestamp = captured.headers['x-ghost-request-timestamp'];
+      assert.match(timestamp, /^\d+$/);
+
+      // nock hands us the parsed body; the service signs the raw
+      // JSON.stringify output, which re-stringifying reproduces exactly
+      const rawBody = JSON.stringify(captured.body);
+      assert.equal(captured.headers['content-length'], `${Buffer.byteLength(rawBody)}`);
+
+      const expectedSignature = crypto
+        .createHmac('sha256', WEBHOOK_SECRET)
+        .update(`${timestamp}:${rawBody}`)
+        .digest('base64');
+
+      assert.equal(captured.headers['x-ghost-signature'], expectedSignature);
     });
 
-    describe('As Unauthorized User', function () {
-        it('Cannot request an export', async function () {
-            configureArchiveHost();
+    it('Ignores an email supplied in the request body', async function () {
+      configureArchiveHost();
+      const captured = mockArchiveHost();
 
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(403);
-        });
+      await agent
+        .post('/exports/')
+        .body({ components: { content: true }, requestedBy: 'attacker@example.com' })
+        .expectStatus(202);
+
+      assert.ok(captured.body, 'Expected an outbound request to the archive host');
+      assert.equal(captured.body.requestedBy, fixtureManager.get('users', 0).email);
     });
 
-    describe('As Owner', function () {
-        beforeAll(async function () {
-            await agent.loginAsOwner();
-        });
-
-        it('Can request an export and sends a signed request to the archive host', async function () {
-            configureArchiveHost();
-            const captured = mockArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: {content: true, members: true, media: true}})
-                .expectStatus(202);
-
-            assert.ok(captured.body, 'Expected an outbound request to the archive host');
-
-            assert.deepEqual(captured.body, {
-                type: 'export',
-                siteId: SITE_ID,
-                requestedBy: fixtureManager.get('users', 0).email,
-                components: {
-                    content: true,
-                    members: true,
-                    analytics: false,
-                    themes: false,
-                    routes: false,
-                    media: true
-                }
-            });
-
-            assert.ok(captured.headers, 'Expected the outbound request headers to be captured');
-            assert.equal(captured.headers['content-type'], 'application/json');
-            assert.match(captured.headers['content-version'], /^v\d+\.\d+$/);
-
-            const timestamp = captured.headers['x-ghost-request-timestamp'];
-            assert.match(timestamp, /^\d+$/);
-
-            // nock hands us the parsed body; the service signs the raw
-            // JSON.stringify output, which re-stringifying reproduces exactly
-            const rawBody = JSON.stringify(captured.body);
-            assert.equal(captured.headers['content-length'], `${Buffer.byteLength(rawBody)}`);
-
-            const expectedSignature = crypto
-                .createHmac('sha256', WEBHOOK_SECRET)
-                .update(`${timestamp}:${rawBody}`)
-                .digest('base64');
-
-            assert.equal(captured.headers['x-ghost-signature'], expectedSignature);
-        });
-
-        it('Ignores an email supplied in the request body', async function () {
-            configureArchiveHost();
-            const captured = mockArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: {content: true}, requestedBy: 'attacker@example.com'})
-                .expectStatus(202);
-
-            assert.ok(captured.body, 'Expected an outbound request to the archive host');
-            assert.equal(captured.body.requestedBy, fixtureManager.get('users', 0).email);
-        });
-
-        it('Returns 404 when no archive host is configured', async function () {
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(404);
-        });
-
-        it('Refuses to send an unsigned request when the secret is missing while the archive host is configured', async function () {
-            configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
-            configUtils.set('hostSettings:siteId', SITE_ID);
-
-            // No archive host is mocked here: an outbound attempt would fail the test
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(400);
-        });
-
-        it('Never exposes the webhook secret through the config endpoint', async function () {
-            configureArchiveHost();
-
-            await agent
-                .get('/config/')
-                .expectStatus(200)
-                .expect(({body}: {body: {config: {hostSettings: {export: Record<string, unknown>}}}}) => {
-                    const exportSettings = body.config.hostSettings.export;
-                    assert.equal(exportSettings.webhookUrl, `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
-                    assert.equal('webhookSecret' in exportSettings, false, 'The signing secret must never be serialized to clients');
-                });
-        });
-
-        it('Refuses to send when the site id is missing while the archive host is configured', async function () {
-            configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
-            configUtils.set('hostSettings:export:webhookSecret', WEBHOOK_SECRET);
-            configUtils.set('hostSettings:siteId', undefined);
-            const captured = mockArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(400);
-
-            assert.equal(captured.body, undefined, 'Expected no outbound request without a site id');
-        });
-
-        it('Returns 502 when the archive host rejects the request', async function () {
-            configureArchiveHost();
-            mockArchiveHost({status: 500});
-
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(502);
-        });
-
-        it('Returns 400 when components is missing', async function () {
-            configureArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({})
-                .expectStatus(400);
-        });
-
-        it('Returns 400 when components contains unknown keys', async function () {
-            configureArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: {content: true, database: true}})
-                .expectStatus(400);
-        });
-
-        it('Returns 400 when component values are not booleans', async function () {
-            configureArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: {content: 'yes'}})
-                .expectStatus(400);
-        });
-
-        it('Returns 400 when no component is selected', async function () {
-            configureArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: {content: false, members: false}})
-                .expectStatus(400);
-        });
+    it('Returns 404 when no archive host is configured', async function () {
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(404);
     });
 
-    describe('As Editor', function () {
-        beforeAll(async function () {
-            await agent.loginAsEditor();
-        });
+    it('Refuses to send an unsigned request when the secret is missing while the archive host is configured', async function () {
+      configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+      configUtils.set('hostSettings:siteId', SITE_ID);
 
-        it('Cannot request an export', async function () {
-            configureArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(403);
-        });
+      // No archive host is mocked here: an outbound attempt would fail the test
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(400);
     });
 
-    describe('As Author', function () {
-        beforeAll(async function () {
-            await agent.loginAsAuthor();
-        });
+    it('Never exposes the webhook secret through the config endpoint', async function () {
+      configureArchiveHost();
 
-        it('Cannot request an export', async function () {
-            configureArchiveHost();
-
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(403);
-        });
+      await agent
+        .get('/config/')
+        .expectStatus(200)
+        .expect(
+          ({
+            body,
+          }: {
+            body: { config: { hostSettings: { export: Record<string, unknown> } } };
+          }) => {
+            const exportSettings = body.config.hostSettings.export;
+            assert.equal(exportSettings.webhookUrl, `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+            assert.equal(
+              'webhookSecret' in exportSettings,
+              false,
+              'The signing secret must never be serialized to clients',
+            );
+          },
+        );
     });
 
-    describe('With an integration token', function () {
-        beforeAll(async function () {
-            await agent.useZapierAdminAPIKey();
-        });
+    it('Refuses to send when the site id is missing while the archive host is configured', async function () {
+      configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+      configUtils.set('hostSettings:export:webhookSecret', WEBHOOK_SECRET);
+      configUtils.set('hostSettings:siteId', undefined);
+      const captured = mockArchiveHost();
 
-        // The exports segment is deliberately absent from the integration
-        // token allowlist in admin/middleware.js - this is a staff-session
-        // only action, and a later allowlist edit must not expose it.
-        it('Cannot request an export', async function () {
-            configureArchiveHost();
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(400);
 
-            await agent
-                .post('/exports/')
-                .body({components: ALL_COMPONENTS})
-                .expectStatus(403);
-        });
+      assert.equal(captured.body, undefined, 'Expected no outbound request without a site id');
     });
+
+    it('Returns 502 when the archive host rejects the request', async function () {
+      configureArchiveHost();
+      mockArchiveHost({ status: 500 });
+
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(502);
+    });
+
+    it('Returns 400 when components is missing', async function () {
+      configureArchiveHost();
+
+      await agent.post('/exports/').body({}).expectStatus(400);
+    });
+
+    it('Returns 400 when components contains unknown keys', async function () {
+      configureArchiveHost();
+
+      await agent
+        .post('/exports/')
+        .body({ components: { content: true, database: true } })
+        .expectStatus(400);
+    });
+
+    it('Returns 400 when component values are not booleans', async function () {
+      configureArchiveHost();
+
+      await agent
+        .post('/exports/')
+        .body({ components: { content: 'yes' } })
+        .expectStatus(400);
+    });
+
+    it('Returns 400 when no component is selected', async function () {
+      configureArchiveHost();
+
+      await agent
+        .post('/exports/')
+        .body({ components: { content: false, members: false } })
+        .expectStatus(400);
+    });
+  });
+
+  describe('As Editor', function () {
+    beforeAll(async function () {
+      await agent.loginAsEditor();
+    });
+
+    it('Cannot request an export', async function () {
+      configureArchiveHost();
+
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(403);
+    });
+  });
+
+  describe('As Author', function () {
+    beforeAll(async function () {
+      await agent.loginAsAuthor();
+    });
+
+    it('Cannot request an export', async function () {
+      configureArchiveHost();
+
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(403);
+    });
+  });
+
+  describe('With an integration token', function () {
+    beforeAll(async function () {
+      await agent.useZapierAdminAPIKey();
+    });
+
+    // The exports segment is deliberately absent from the integration
+    // token allowlist in admin/middleware.js - this is a staff-session
+    // only action, and a later allowlist edit must not expose it.
+    it('Cannot request an export', async function () {
+      configureArchiveHost();
+
+      await agent.post('/exports/').body({ components: ALL_COMPONENTS }).expectStatus(403);
+    });
+  });
 });

--- a/ghost/core/test/e2e-api/admin/exports-request.test.ts
+++ b/ghost/core/test/e2e-api/admin/exports-request.test.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+
+const nock = require('nock');
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+const configUtils = require('../../utils/config-utils');
+
+const ARCHIVE_ORIGIN = 'https://archive-generator.example.com';
+const ARCHIVE_PATH = '/api/generate/';
+const WEBHOOK_SECRET = 'test-export-webhook-secret';
+const SITE_ID = 'test-site-id';
+
+const ALL_COMPONENTS = {
+    content: true,
+    members: true,
+    analytics: true,
+    themes: true,
+    routes: true,
+    media: false
+};
+
+function configureArchiveHost() {
+    configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+    configUtils.set('hostSettings:siteId', SITE_ID);
+    configUtils.set('hostSettings:export:webhookSecret', WEBHOOK_SECRET);
+}
+
+type CapturedRequest = {
+    headers?: Record<string, string>;
+    body?: Record<string, unknown>;
+};
+
+function mockArchiveHost({status = 202} = {}) {
+    const captured: CapturedRequest = {};
+
+    nock(ARCHIVE_ORIGIN)
+        .post(ARCHIVE_PATH)
+        .reply(function (this: {req: {headers: Record<string, string>}}, uri: string, requestBody: Record<string, unknown>) {
+            captured.headers = this.req.headers;
+            captured.body = requestBody;
+            return [status, {}];
+        });
+
+    return captured;
+}
+
+describe('Exports API: archive requests', function () {
+    let agent: {
+        get: (_url: string) => any;
+        post: (_url: string) => any;
+        loginAsOwner: () => Promise<void>;
+        loginAsEditor: () => Promise<void>;
+        loginAsAuthor: () => Promise<void>;
+        useZapierAdminAPIKey: () => Promise<void>;
+    };
+
+    beforeAll(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+    });
+
+    afterEach(async function () {
+        nock.cleanAll();
+        await configUtils.restore();
+    });
+
+    describe('As Unauthorized User', function () {
+        it('Cannot request an export', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(403);
+        });
+    });
+
+    describe('As Owner', function () {
+        beforeAll(async function () {
+            await agent.loginAsOwner();
+        });
+
+        it('Can request an export and sends a signed request to the archive host', async function () {
+            configureArchiveHost();
+            const captured = mockArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: {content: true, members: true, media: true}})
+                .expectStatus(202);
+
+            assert.ok(captured.body, 'Expected an outbound request to the archive host');
+
+            assert.deepEqual(captured.body, {
+                type: 'export',
+                siteId: SITE_ID,
+                requestedBy: fixtureManager.get('users', 0).email,
+                components: {
+                    content: true,
+                    members: true,
+                    analytics: false,
+                    themes: false,
+                    routes: false,
+                    media: true
+                }
+            });
+
+            assert.ok(captured.headers, 'Expected the outbound request headers to be captured');
+            assert.equal(captured.headers['content-type'], 'application/json');
+            assert.match(captured.headers['content-version'], /^v\d+\.\d+$/);
+
+            const timestamp = captured.headers['x-ghost-request-timestamp'];
+            assert.match(timestamp, /^\d+$/);
+
+            // nock hands us the parsed body; the service signs the raw
+            // JSON.stringify output, which re-stringifying reproduces exactly
+            const rawBody = JSON.stringify(captured.body);
+            assert.equal(captured.headers['content-length'], `${Buffer.byteLength(rawBody)}`);
+
+            const expectedSignature = crypto
+                .createHmac('sha256', WEBHOOK_SECRET)
+                .update(`${timestamp}:${rawBody}`)
+                .digest('base64');
+
+            assert.equal(captured.headers['x-ghost-signature'], expectedSignature);
+        });
+
+        it('Ignores an email supplied in the request body', async function () {
+            configureArchiveHost();
+            const captured = mockArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: {content: true}, requestedBy: 'attacker@example.com'})
+                .expectStatus(202);
+
+            assert.ok(captured.body, 'Expected an outbound request to the archive host');
+            assert.equal(captured.body.requestedBy, fixtureManager.get('users', 0).email);
+        });
+
+        it('Returns 404 when no archive host is configured', async function () {
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(404);
+        });
+
+        it('Refuses to send an unsigned request when the secret is missing while the archive host is configured', async function () {
+            configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+            configUtils.set('hostSettings:siteId', SITE_ID);
+
+            // No archive host is mocked here: an outbound attempt would fail the test
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(400);
+        });
+
+        it('Never exposes the webhook secret through the config endpoint', async function () {
+            configureArchiveHost();
+
+            await agent
+                .get('/config/')
+                .expectStatus(200)
+                .expect(({body}: {body: {config: {hostSettings: {export: Record<string, unknown>}}}}) => {
+                    const exportSettings = body.config.hostSettings.export;
+                    assert.equal(exportSettings.webhookUrl, `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+                    assert.equal('webhookSecret' in exportSettings, false, 'The signing secret must never be serialized to clients');
+                });
+        });
+
+        it('Refuses to send when the site id is missing while the archive host is configured', async function () {
+            configUtils.set('hostSettings:export:webhookUrl', `${ARCHIVE_ORIGIN}${ARCHIVE_PATH}`);
+            configUtils.set('hostSettings:export:webhookSecret', WEBHOOK_SECRET);
+            configUtils.set('hostSettings:siteId', undefined);
+            const captured = mockArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(400);
+
+            assert.equal(captured.body, undefined, 'Expected no outbound request without a site id');
+        });
+
+        it('Returns 502 when the archive host rejects the request', async function () {
+            configureArchiveHost();
+            mockArchiveHost({status: 500});
+
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(502);
+        });
+
+        it('Returns 400 when components is missing', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({})
+                .expectStatus(400);
+        });
+
+        it('Returns 400 when components contains unknown keys', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: {content: true, database: true}})
+                .expectStatus(400);
+        });
+
+        it('Returns 400 when component values are not booleans', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: {content: 'yes'}})
+                .expectStatus(400);
+        });
+
+        it('Returns 400 when no component is selected', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: {content: false, members: false}})
+                .expectStatus(400);
+        });
+    });
+
+    describe('As Editor', function () {
+        beforeAll(async function () {
+            await agent.loginAsEditor();
+        });
+
+        it('Cannot request an export', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(403);
+        });
+    });
+
+    describe('As Author', function () {
+        beforeAll(async function () {
+            await agent.loginAsAuthor();
+        });
+
+        it('Cannot request an export', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(403);
+        });
+    });
+
+    describe('With an integration token', function () {
+        beforeAll(async function () {
+            await agent.useZapierAdminAPIKey();
+        });
+
+        // The exports segment is deliberately absent from the integration
+        // token allowlist in admin/middleware.js - this is a staff-session
+        // only action, and a later allowlist edit must not expose it.
+        it('Cannot request an export', async function () {
+            configureArchiveHost();
+
+            await agent
+                .post('/exports/')
+                .body({components: ALL_COMPONENTS})
+                .expectStatus(403);
+        });
+    });
+});

--- a/ghost/core/test/e2e-api/admin/exports-request.test.ts
+++ b/ghost/core/test/e2e-api/admin/exports-request.test.ts
@@ -95,7 +95,6 @@ describe('Exports API: archive requests', function () {
       assert.deepEqual(captured.body, {
         type: 'export',
         siteId: SITE_ID,
-        requestedBy: fixtureManager.get('users', 0).email,
         components: {
           content: true,
           members: true,
@@ -126,7 +125,7 @@ describe('Exports API: archive requests', function () {
       assert.equal(captured.headers['x-ghost-signature'], expectedSignature);
     });
 
-    it('Ignores an email supplied in the request body', async function () {
+    it('Does not forward an email supplied in the request body', async function () {
       configureArchiveHost();
       const captured = mockArchiveHost();
 
@@ -136,7 +135,7 @@ describe('Exports API: archive requests', function () {
         .expectStatus(202);
 
       assert.ok(captured.body, 'Expected an outbound request to the archive host');
-      assert.equal(captured.body.requestedBy, fixtureManager.get('users', 0).email);
+      assert.equal(captured.body.requestedBy, undefined);
     });
 
     it('Returns 404 when no archive host is configured', async function () {

--- a/ghost/core/test/unit/server/services/export-requests/export-requests-service.test.ts
+++ b/ghost/core/test/unit/server/services/export-requests/export-requests-service.test.ts
@@ -1,251 +1,296 @@
 import assert from 'assert/strict';
 import crypto from 'crypto';
-import {ExportRequestsService} from '../../../../../core/server/services/export-requests/export-requests-service';
+import { ExportRequestsService } from '../../../../../core/server/services/export-requests/export-requests-service';
 
 describe('ExportRequestsService', function () {
-    const webhookUrl = 'https://archive-generator.example.com/api/generate/';
-    const webhookSecret = 'not-a-live-secret';
+  const webhookUrl = 'https://archive-generator.example.com/api/generate/';
+  const webhookSecret = 'not-a-live-secret';
 
-    const allComponents = {
+  const allComponents = {
+    content: true,
+    members: true,
+    analytics: true,
+    themes: true,
+    routes: true,
+    media: false,
+  };
+
+  const createService = (
+    overrides: Record<string, unknown> = {},
+    configValues: Record<string, unknown> | null = null,
+  ) => {
+    const request = async () => null;
+    const values: Record<string, unknown> = configValues ?? {
+      'hostSettings:export:webhookUrl': webhookUrl,
+      'hostSettings:export:webhookSecret': webhookSecret,
+      'hostSettings:siteId': '12345',
+    };
+    const dependencies = {
+      config: {
+        get: (key: string) => values[key],
+      },
+      logging: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      request,
+      ...overrides,
+    };
+
+    return new ExportRequestsService(dependencies as any);
+  };
+
+  it('throws a NotFoundError when the webhook URL is not configured', async function () {
+    const service = createService(
+      {},
+      {
+        'hostSettings:export:webhookSecret': webhookSecret,
+        'hostSettings:siteId': '12345',
+      },
+    );
+
+    await assert.rejects(
+      service.requestArchive({
+        components: allComponents,
+        requestedBy: 'owner@example.com',
+      }),
+      (error: any) => {
+        assert.equal(error.errorType, 'NotFoundError');
+        return true;
+      },
+    );
+  });
+
+  it('throws an IncorrectUsageError when the secret is missing while the URL is configured', async function () {
+    let errorMessage: string | undefined;
+    const service = createService(
+      {
+        logging: {
+          info: () => {},
+          warn: () => {},
+          error: (message: string) => {
+            errorMessage = message;
+          },
+        },
+      },
+      {
+        'hostSettings:export:webhookUrl': webhookUrl,
+        'hostSettings:siteId': '12345',
+      },
+    );
+
+    await assert.rejects(
+      service.requestArchive({
+        components: allComponents,
+        requestedBy: 'owner@example.com',
+      }),
+      (error: any) => {
+        assert.equal(error.errorType, 'IncorrectUsageError');
+        return true;
+      },
+    );
+
+    assert.equal(
+      errorMessage,
+      'Export archive request is misconfigured: hostSettings:export:webhookSecret is missing while hostSettings:export:webhookUrl is set.',
+    );
+  });
+
+  it('throws an IncorrectUsageError when the site id is missing while the URL is configured', async function () {
+    let errorMessage: string | undefined;
+    const service = createService(
+      {
+        logging: {
+          info: () => {},
+          warn: () => {},
+          error: (message: string) => {
+            errorMessage = message;
+          },
+        },
+      },
+      {
+        'hostSettings:export:webhookUrl': webhookUrl,
+        'hostSettings:export:webhookSecret': webhookSecret,
+      },
+    );
+
+    await assert.rejects(
+      service.requestArchive({
+        components: allComponents,
+        requestedBy: 'owner@example.com',
+      }),
+      (error: any) => {
+        assert.equal(error.errorType, 'IncorrectUsageError');
+        return true;
+      },
+    );
+
+    assert.equal(
+      errorMessage,
+      'Export archive request is misconfigured: hostSettings:siteId is missing while hostSettings:export:webhookUrl is set.',
+    );
+  });
+
+  it('accepts a numeric site id from env-var config parsing', async function () {
+    let requestOptions: any;
+    const service = createService(
+      {
+        request: async (url: string, options: unknown) => {
+          requestOptions = options;
+          return null;
+        },
+      },
+      {
+        'hostSettings:export:webhookUrl': webhookUrl,
+        'hostSettings:export:webhookSecret': webhookSecret,
+        'hostSettings:siteId': 12345,
+      },
+    );
+
+    await service.requestArchive({
+      components: allComponents,
+      requestedBy: 'owner@example.com',
+    });
+
+    assert.equal(JSON.parse(requestOptions.body).siteId, '12345');
+  });
+
+  it('sends a POST request with the signed payload', async function () {
+    let requestUrl: string | undefined;
+    let requestOptions: any;
+    let infoMessage: string | undefined;
+    const service = createService({
+      logging: {
+        info: (message: string) => {
+          infoMessage = message;
+        },
+        warn: () => {},
+        error: () => {},
+      },
+      request: async (url: string, options: unknown) => {
+        requestUrl = url;
+        requestOptions = options;
+        return null;
+      },
+    });
+
+    await service.requestArchive({
+      components: allComponents,
+      requestedBy: 'owner@example.com',
+    });
+
+    assert.equal(requestUrl, webhookUrl);
+    assert.equal(requestOptions.method, 'POST');
+    assert.equal(
+      infoMessage,
+      'Requesting export archive generation from "https://archive-generator.example.com"',
+    );
+
+    const parsedBody = JSON.parse(requestOptions.body);
+    assert.deepEqual(parsedBody, {
+      type: 'export',
+      siteId: '12345',
+      requestedBy: 'owner@example.com',
+      components: {
         content: true,
         members: true,
         analytics: true,
         themes: true,
         routes: true,
-        media: false
-    };
-
-    const createService = (overrides: Record<string, unknown> = {}, configValues: Record<string, unknown> | null = null) => {
-        const request = async () => null;
-        const values: Record<string, unknown> = configValues ?? {
-            'hostSettings:export:webhookUrl': webhookUrl,
-            'hostSettings:export:webhookSecret': webhookSecret,
-            'hostSettings:siteId': '12345'
-        };
-        const dependencies = {
-            config: {
-                get: (key: string) => values[key]
-            },
-            logging: {
-                info: () => {},
-                warn: () => {},
-                error: () => {}
-            },
-            request,
-            ...overrides
-        };
-
-        return new ExportRequestsService(dependencies as any);
-    };
-
-    it('throws a NotFoundError when the webhook URL is not configured', async function () {
-        const service = createService({}, {
-            'hostSettings:export:webhookSecret': webhookSecret,
-            'hostSettings:siteId': '12345'
-        });
-
-        await assert.rejects(service.requestArchive({
-            components: allComponents,
-            requestedBy: 'owner@example.com'
-        }), (error: any) => {
-            assert.equal(error.errorType, 'NotFoundError');
-            return true;
-        });
+        media: false,
+      },
     });
 
-    it('throws an IncorrectUsageError when the secret is missing while the URL is configured', async function () {
-        let errorMessage: string | undefined;
-        const service = createService({
-            logging: {
-                info: () => {},
-                warn: () => {},
-                error: (message: string) => {
-                    errorMessage = message;
-                }
-            }
-        }, {
-            'hostSettings:export:webhookUrl': webhookUrl,
-            'hostSettings:siteId': '12345'
-        });
+    assert.equal(requestOptions.headers['Content-Type'], 'application/json');
+    assert.equal(requestOptions.headers['Content-Length'], Buffer.byteLength(requestOptions.body));
+    assert.match(requestOptions.headers['Content-Version'], /^v\d+\.\d+$/);
 
-        await assert.rejects(service.requestArchive({
-            components: allComponents,
-            requestedBy: 'owner@example.com'
-        }), (error: any) => {
-            assert.equal(error.errorType, 'IncorrectUsageError');
-            return true;
-        });
+    const timestamp = requestOptions.headers['X-Ghost-Request-Timestamp'];
+    assert.match(timestamp, /^\d+$/);
 
-        assert.equal(errorMessage, 'Export archive request is misconfigured: hostSettings:export:webhookSecret is missing while hostSettings:export:webhookUrl is set.');
+    const expectedSignature = crypto
+      .createHmac('sha256', webhookSecret)
+      .update(`${timestamp}:${requestOptions.body}`)
+      .digest('base64');
+
+    assert.equal(requestOptions.headers['X-Ghost-Signature'], expectedSignature);
+
+    // The request must never retry: each delivery can schedule an archive.
+    assert.deepEqual(requestOptions.retry, { limit: 0 });
+  });
+
+  it('computes the documented HMAC for a known secret, timestamp and body', async function () {
+    // Pins the exact wire contract the receiving host verifies:
+    // base64(HMAC-SHA256(secret, `${timestamp}:${rawBody}`))
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    try {
+      let capturedSignature: string | undefined;
+      let capturedBody: string | undefined;
+      let capturedTimestamp: string | undefined;
+      const service = createService(
+        {
+          request: async (url: string, options: any) => {
+            capturedSignature = options.headers['X-Ghost-Signature'];
+            capturedBody = options.body;
+            capturedTimestamp = options.headers['X-Ghost-Request-Timestamp'];
+            return null;
+          },
+        },
+        {
+          'hostSettings:export:webhookUrl': webhookUrl,
+          'hostSettings:export:webhookSecret': 'known-secret',
+          'hostSettings:siteId': '12345',
+        },
+      );
+
+      await service.requestArchive({
+        components: allComponents,
+        requestedBy: 'owner@example.com',
+      });
+
+      assert.equal(capturedTimestamp, '1700000000000');
+      assert.equal(
+        capturedBody,
+        '{"type":"export","siteId":"12345","requestedBy":"owner@example.com","components":{"content":true,"members":true,"analytics":true,"themes":true,"routes":true,"media":false}}',
+      );
+      assert.equal(capturedSignature, '657rQR/oodu1YtgfAvcaNsK05BbKGFPtTalagMFxqpc=');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('logs a sanitized URL and throws a generic 502 when the request fails', async function () {
+    let errorMessage: string | undefined;
+    const service = createService({
+      logging: {
+        info: () => {},
+        warn: () => {},
+        error: (message: string) => {
+          errorMessage = message;
+        },
+      },
+      request: async () => {
+        throw new Error('Response code 500 (Internal Server Error)');
+      },
     });
 
-    it('throws an IncorrectUsageError when the site id is missing while the URL is configured', async function () {
-        let errorMessage: string | undefined;
-        const service = createService({
-            logging: {
-                info: () => {},
-                warn: () => {},
-                error: (message: string) => {
-                    errorMessage = message;
-                }
-            }
-        }, {
-            'hostSettings:export:webhookUrl': webhookUrl,
-            'hostSettings:export:webhookSecret': webhookSecret
-        });
+    await assert.rejects(
+      service.requestArchive({
+        components: allComponents,
+        requestedBy: 'owner@example.com',
+      }),
+      (error: any) => {
+        assert.equal(error.statusCode, 502);
+        assert.equal(error.message, 'Failed to start the export. Please try again later.');
+        return true;
+      },
+    );
 
-        await assert.rejects(service.requestArchive({
-            components: allComponents,
-            requestedBy: 'owner@example.com'
-        }), (error: any) => {
-            assert.equal(error.errorType, 'IncorrectUsageError');
-            return true;
-        });
-
-        assert.equal(errorMessage, 'Export archive request is misconfigured: hostSettings:siteId is missing while hostSettings:export:webhookUrl is set.');
-    });
-
-    it('accepts a numeric site id from env-var config parsing', async function () {
-        let requestOptions: any;
-        const service = createService({
-            request: async (url: string, options: unknown) => {
-                requestOptions = options;
-                return null;
-            }
-        }, {
-            'hostSettings:export:webhookUrl': webhookUrl,
-            'hostSettings:export:webhookSecret': webhookSecret,
-            'hostSettings:siteId': 12345
-        });
-
-        await service.requestArchive({
-            components: allComponents,
-            requestedBy: 'owner@example.com'
-        });
-
-        assert.equal(JSON.parse(requestOptions.body).siteId, '12345');
-    });
-
-    it('sends a POST request with the signed payload', async function () {
-        let requestUrl: string | undefined;
-        let requestOptions: any;
-        let infoMessage: string | undefined;
-        const service = createService({
-            logging: {
-                info: (message: string) => {
-                    infoMessage = message;
-                },
-                warn: () => {},
-                error: () => {}
-            },
-            request: async (url: string, options: unknown) => {
-                requestUrl = url;
-                requestOptions = options;
-                return null;
-            }
-        });
-
-        await service.requestArchive({
-            components: allComponents,
-            requestedBy: 'owner@example.com'
-        });
-
-        assert.equal(requestUrl, webhookUrl);
-        assert.equal(requestOptions.method, 'POST');
-        assert.equal(infoMessage, 'Requesting export archive generation from "https://archive-generator.example.com"');
-
-        const parsedBody = JSON.parse(requestOptions.body);
-        assert.deepEqual(parsedBody, {
-            type: 'export',
-            siteId: '12345',
-            requestedBy: 'owner@example.com',
-            components: {
-                content: true,
-                members: true,
-                analytics: true,
-                themes: true,
-                routes: true,
-                media: false
-            }
-        });
-
-        assert.equal(requestOptions.headers['Content-Type'], 'application/json');
-        assert.equal(requestOptions.headers['Content-Length'], Buffer.byteLength(requestOptions.body));
-        assert.match(requestOptions.headers['Content-Version'], /^v\d+\.\d+$/);
-
-        const timestamp = requestOptions.headers['X-Ghost-Request-Timestamp'];
-        assert.match(timestamp, /^\d+$/);
-
-        const expectedSignature = crypto
-            .createHmac('sha256', webhookSecret)
-            .update(`${timestamp}:${requestOptions.body}`)
-            .digest('base64');
-
-        assert.equal(requestOptions.headers['X-Ghost-Signature'], expectedSignature);
-
-        // The request must never retry: each delivery can schedule an archive.
-        assert.deepEqual(requestOptions.retry, {limit: 0});
-    });
-
-    it('computes the documented HMAC for a known secret, timestamp and body', async function () {
-        // Pins the exact wire contract the receiving host verifies:
-        // base64(HMAC-SHA256(secret, `${timestamp}:${rawBody}`))
-        const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
-
-        try {
-            let capturedSignature: string | undefined;
-            let capturedBody: string | undefined;
-            let capturedTimestamp: string | undefined;
-            const service = createService({
-                request: async (url: string, options: any) => {
-                    capturedSignature = options.headers['X-Ghost-Signature'];
-                    capturedBody = options.body;
-                    capturedTimestamp = options.headers['X-Ghost-Request-Timestamp'];
-                    return null;
-                }
-            }, {
-                'hostSettings:export:webhookUrl': webhookUrl,
-                'hostSettings:export:webhookSecret': 'known-secret',
-                'hostSettings:siteId': '12345'
-            });
-
-            await service.requestArchive({
-                components: allComponents,
-                requestedBy: 'owner@example.com'
-            });
-
-            assert.equal(capturedTimestamp, '1700000000000');
-            assert.equal(capturedBody, '{"type":"export","siteId":"12345","requestedBy":"owner@example.com","components":{"content":true,"members":true,"analytics":true,"themes":true,"routes":true,"media":false}}');
-            assert.equal(capturedSignature, '657rQR/oodu1YtgfAvcaNsK05BbKGFPtTalagMFxqpc=');
-        } finally {
-            nowSpy.mockRestore();
-        }
-    });
-
-    it('logs a sanitized URL and throws a generic 502 when the request fails', async function () {
-        let errorMessage: string | undefined;
-        const service = createService({
-            logging: {
-                info: () => {},
-                warn: () => {},
-                error: (message: string) => {
-                    errorMessage = message;
-                }
-            },
-            request: async () => {
-                throw new Error('Response code 500 (Internal Server Error)');
-            }
-        });
-
-        await assert.rejects(service.requestArchive({
-            components: allComponents,
-            requestedBy: 'owner@example.com'
-        }), (error: any) => {
-            assert.equal(error.statusCode, 502);
-            assert.equal(error.message, 'Failed to start the export. Please try again later.');
-            return true;
-        });
-
-        assert.equal(errorMessage, 'Failed to request export archive generation from "https://archive-generator.example.com": Response code 500 (Internal Server Error)');
-    });
+    assert.equal(
+      errorMessage,
+      'Failed to request export archive generation from "https://archive-generator.example.com": Response code 500 (Internal Server Error)',
+    );
+  });
 });

--- a/ghost/core/test/unit/server/services/export-requests/export-requests-service.test.ts
+++ b/ghost/core/test/unit/server/services/export-requests/export-requests-service.test.ts
@@ -1,0 +1,251 @@
+import assert from 'assert/strict';
+import crypto from 'crypto';
+import {ExportRequestsService} from '../../../../../core/server/services/export-requests/export-requests-service';
+
+describe('ExportRequestsService', function () {
+    const webhookUrl = 'https://archive-generator.example.com/api/generate/';
+    const webhookSecret = 'not-a-live-secret';
+
+    const allComponents = {
+        content: true,
+        members: true,
+        analytics: true,
+        themes: true,
+        routes: true,
+        media: false
+    };
+
+    const createService = (overrides: Record<string, unknown> = {}, configValues: Record<string, unknown> | null = null) => {
+        const request = async () => null;
+        const values: Record<string, unknown> = configValues ?? {
+            'hostSettings:export:webhookUrl': webhookUrl,
+            'hostSettings:export:webhookSecret': webhookSecret,
+            'hostSettings:siteId': '12345'
+        };
+        const dependencies = {
+            config: {
+                get: (key: string) => values[key]
+            },
+            logging: {
+                info: () => {},
+                warn: () => {},
+                error: () => {}
+            },
+            request,
+            ...overrides
+        };
+
+        return new ExportRequestsService(dependencies as any);
+    };
+
+    it('throws a NotFoundError when the webhook URL is not configured', async function () {
+        const service = createService({}, {
+            'hostSettings:export:webhookSecret': webhookSecret,
+            'hostSettings:siteId': '12345'
+        });
+
+        await assert.rejects(service.requestArchive({
+            components: allComponents,
+            requestedBy: 'owner@example.com'
+        }), (error: any) => {
+            assert.equal(error.errorType, 'NotFoundError');
+            return true;
+        });
+    });
+
+    it('throws an IncorrectUsageError when the secret is missing while the URL is configured', async function () {
+        let errorMessage: string | undefined;
+        const service = createService({
+            logging: {
+                info: () => {},
+                warn: () => {},
+                error: (message: string) => {
+                    errorMessage = message;
+                }
+            }
+        }, {
+            'hostSettings:export:webhookUrl': webhookUrl,
+            'hostSettings:siteId': '12345'
+        });
+
+        await assert.rejects(service.requestArchive({
+            components: allComponents,
+            requestedBy: 'owner@example.com'
+        }), (error: any) => {
+            assert.equal(error.errorType, 'IncorrectUsageError');
+            return true;
+        });
+
+        assert.equal(errorMessage, 'Export archive request is misconfigured: hostSettings:export:webhookSecret is missing while hostSettings:export:webhookUrl is set.');
+    });
+
+    it('throws an IncorrectUsageError when the site id is missing while the URL is configured', async function () {
+        let errorMessage: string | undefined;
+        const service = createService({
+            logging: {
+                info: () => {},
+                warn: () => {},
+                error: (message: string) => {
+                    errorMessage = message;
+                }
+            }
+        }, {
+            'hostSettings:export:webhookUrl': webhookUrl,
+            'hostSettings:export:webhookSecret': webhookSecret
+        });
+
+        await assert.rejects(service.requestArchive({
+            components: allComponents,
+            requestedBy: 'owner@example.com'
+        }), (error: any) => {
+            assert.equal(error.errorType, 'IncorrectUsageError');
+            return true;
+        });
+
+        assert.equal(errorMessage, 'Export archive request is misconfigured: hostSettings:siteId is missing while hostSettings:export:webhookUrl is set.');
+    });
+
+    it('accepts a numeric site id from env-var config parsing', async function () {
+        let requestOptions: any;
+        const service = createService({
+            request: async (url: string, options: unknown) => {
+                requestOptions = options;
+                return null;
+            }
+        }, {
+            'hostSettings:export:webhookUrl': webhookUrl,
+            'hostSettings:export:webhookSecret': webhookSecret,
+            'hostSettings:siteId': 12345
+        });
+
+        await service.requestArchive({
+            components: allComponents,
+            requestedBy: 'owner@example.com'
+        });
+
+        assert.equal(JSON.parse(requestOptions.body).siteId, '12345');
+    });
+
+    it('sends a POST request with the signed payload', async function () {
+        let requestUrl: string | undefined;
+        let requestOptions: any;
+        let infoMessage: string | undefined;
+        const service = createService({
+            logging: {
+                info: (message: string) => {
+                    infoMessage = message;
+                },
+                warn: () => {},
+                error: () => {}
+            },
+            request: async (url: string, options: unknown) => {
+                requestUrl = url;
+                requestOptions = options;
+                return null;
+            }
+        });
+
+        await service.requestArchive({
+            components: allComponents,
+            requestedBy: 'owner@example.com'
+        });
+
+        assert.equal(requestUrl, webhookUrl);
+        assert.equal(requestOptions.method, 'POST');
+        assert.equal(infoMessage, 'Requesting export archive generation from "https://archive-generator.example.com"');
+
+        const parsedBody = JSON.parse(requestOptions.body);
+        assert.deepEqual(parsedBody, {
+            type: 'export',
+            siteId: '12345',
+            requestedBy: 'owner@example.com',
+            components: {
+                content: true,
+                members: true,
+                analytics: true,
+                themes: true,
+                routes: true,
+                media: false
+            }
+        });
+
+        assert.equal(requestOptions.headers['Content-Type'], 'application/json');
+        assert.equal(requestOptions.headers['Content-Length'], Buffer.byteLength(requestOptions.body));
+        assert.match(requestOptions.headers['Content-Version'], /^v\d+\.\d+$/);
+
+        const timestamp = requestOptions.headers['X-Ghost-Request-Timestamp'];
+        assert.match(timestamp, /^\d+$/);
+
+        const expectedSignature = crypto
+            .createHmac('sha256', webhookSecret)
+            .update(`${timestamp}:${requestOptions.body}`)
+            .digest('base64');
+
+        assert.equal(requestOptions.headers['X-Ghost-Signature'], expectedSignature);
+
+        // The request must never retry: each delivery can schedule an archive.
+        assert.deepEqual(requestOptions.retry, {limit: 0});
+    });
+
+    it('computes the documented HMAC for a known secret, timestamp and body', async function () {
+        // Pins the exact wire contract the receiving host verifies:
+        // base64(HMAC-SHA256(secret, `${timestamp}:${rawBody}`))
+        const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+        try {
+            let capturedSignature: string | undefined;
+            let capturedBody: string | undefined;
+            let capturedTimestamp: string | undefined;
+            const service = createService({
+                request: async (url: string, options: any) => {
+                    capturedSignature = options.headers['X-Ghost-Signature'];
+                    capturedBody = options.body;
+                    capturedTimestamp = options.headers['X-Ghost-Request-Timestamp'];
+                    return null;
+                }
+            }, {
+                'hostSettings:export:webhookUrl': webhookUrl,
+                'hostSettings:export:webhookSecret': 'known-secret',
+                'hostSettings:siteId': '12345'
+            });
+
+            await service.requestArchive({
+                components: allComponents,
+                requestedBy: 'owner@example.com'
+            });
+
+            assert.equal(capturedTimestamp, '1700000000000');
+            assert.equal(capturedBody, '{"type":"export","siteId":"12345","requestedBy":"owner@example.com","components":{"content":true,"members":true,"analytics":true,"themes":true,"routes":true,"media":false}}');
+            assert.equal(capturedSignature, '657rQR/oodu1YtgfAvcaNsK05BbKGFPtTalagMFxqpc=');
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it('logs a sanitized URL and throws a generic 502 when the request fails', async function () {
+        let errorMessage: string | undefined;
+        const service = createService({
+            logging: {
+                info: () => {},
+                warn: () => {},
+                error: (message: string) => {
+                    errorMessage = message;
+                }
+            },
+            request: async () => {
+                throw new Error('Response code 500 (Internal Server Error)');
+            }
+        });
+
+        await assert.rejects(service.requestArchive({
+            components: allComponents,
+            requestedBy: 'owner@example.com'
+        }), (error: any) => {
+            assert.equal(error.statusCode, 502);
+            assert.equal(error.message, 'Failed to start the export. Please try again later.');
+            return true;
+        });
+
+        assert.equal(errorMessage, 'Failed to request export archive generation from "https://archive-generator.example.com": Response code 500 (Internal Server Error)');
+    });
+});

--- a/ghost/core/test/unit/server/services/export-requests/export-requests-service.test.ts
+++ b/ghost/core/test/unit/server/services/export-requests/export-requests-service.test.ts
@@ -53,7 +53,6 @@ describe('ExportRequestsService', function () {
     await assert.rejects(
       service.requestArchive({
         components: allComponents,
-        requestedBy: 'owner@example.com',
       }),
       (error: any) => {
         assert.equal(error.errorType, 'NotFoundError');
@@ -83,7 +82,6 @@ describe('ExportRequestsService', function () {
     await assert.rejects(
       service.requestArchive({
         components: allComponents,
-        requestedBy: 'owner@example.com',
       }),
       (error: any) => {
         assert.equal(error.errorType, 'IncorrectUsageError');
@@ -118,7 +116,6 @@ describe('ExportRequestsService', function () {
     await assert.rejects(
       service.requestArchive({
         components: allComponents,
-        requestedBy: 'owner@example.com',
       }),
       (error: any) => {
         assert.equal(error.errorType, 'IncorrectUsageError');
@@ -150,7 +147,6 @@ describe('ExportRequestsService', function () {
 
     await service.requestArchive({
       components: allComponents,
-      requestedBy: 'owner@example.com',
     });
 
     assert.equal(JSON.parse(requestOptions.body).siteId, '12345');
@@ -177,7 +173,6 @@ describe('ExportRequestsService', function () {
 
     await service.requestArchive({
       components: allComponents,
-      requestedBy: 'owner@example.com',
     });
 
     assert.equal(requestUrl, webhookUrl);
@@ -191,7 +186,6 @@ describe('ExportRequestsService', function () {
     assert.deepEqual(parsedBody, {
       type: 'export',
       siteId: '12345',
-      requestedBy: 'owner@example.com',
       components: {
         content: true,
         members: true,
@@ -247,15 +241,14 @@ describe('ExportRequestsService', function () {
 
       await service.requestArchive({
         components: allComponents,
-        requestedBy: 'owner@example.com',
       });
 
       assert.equal(capturedTimestamp, '1700000000000');
       assert.equal(
         capturedBody,
-        '{"type":"export","siteId":"12345","requestedBy":"owner@example.com","components":{"content":true,"members":true,"analytics":true,"themes":true,"routes":true,"media":false}}',
+        '{"type":"export","siteId":"12345","components":{"content":true,"members":true,"analytics":true,"themes":true,"routes":true,"media":false}}',
       );
-      assert.equal(capturedSignature, '657rQR/oodu1YtgfAvcaNsK05BbKGFPtTalagMFxqpc=');
+      assert.equal(capturedSignature, 'wVSf9NNJV/v5vnjx1zclb7HhiE7O4T7iE/EWT1BWr3g=');
     } finally {
       nowSpy.mockRestore();
     }
@@ -279,7 +272,6 @@ describe('ExportRequestsService', function () {
     await assert.rejects(
       service.requestArchive({
         components: allComponents,
-        requestedBy: 'owner@example.com',
       }),
       (error: any) => {
         assert.equal(error.statusCode, 502);

--- a/ghost/core/test/unit/server/services/exports/site-exporter.test.ts
+++ b/ghost/core/test/unit/server/services/exports/site-exporter.test.ts
@@ -6,9 +6,9 @@ import { once } from 'node:events';
 import { PassThrough, Readable, Writable, pipeline } from 'stream';
 import {
   SiteExporter,
-  EXPORT_COMPONENTS,
   type SiteExporterDeps,
 } from '../../../../../core/server/services/exports/site-exporter';
+import { SYNC_EXPORT_COMPONENTS } from '../../../../../core/server/services/exports/export-components';
 
 // @tryghost/zip ships no types; only `extract` is used here
 const { extract } = require('@tryghost/zip') as {
@@ -101,7 +101,7 @@ function buildDeps(overrides: Partial<SiteExporterDeps> = {}): SiteExporterDeps 
 describe('SiteExporter', function () {
   it('composes every component into one zip', async function () {
     const exporter = new SiteExporter(buildDeps());
-    const archive = exporter.createArchive([...EXPORT_COMPONENTS]);
+    const archive = exporter.createArchive([...SYNC_EXPORT_COMPONENTS]);
 
     const zip = await readZip(await collectArchive(archive));
 
@@ -132,7 +132,7 @@ describe('SiteExporter', function () {
         },
       }),
     );
-    const archive = exporter.createArchive([...EXPORT_COMPONENTS]);
+    const archive = exporter.createArchive([...SYNC_EXPORT_COMPONENTS]);
 
     const zip = await readZip(await collectArchive(archive));
 

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -239,5 +239,35 @@ describe('Public-config Service', function () {
       assert.equal(configProperties.featurebase.jwtSecret, undefined);
       assert.equal(configProperties.featurebase.apiKey, undefined);
     });
+
+    it('should strip webhook secrets from hostSettings', function () {
+      configUtils.set('hostSettings', {
+        siteId: '123',
+        export: {
+          webhookUrl: 'https://example.com/export',
+          webhookSecret: 'export-secret',
+        },
+        emailVerification: {
+          verified: true,
+          webhookType: 'email_verification',
+          webhookUrl: 'https://example.com/verify',
+          webhookSecret: 'verification-secret',
+        },
+      });
+
+      const configProperties = getConfigProperties();
+
+      assert.deepEqual(configProperties.hostSettings, {
+        siteId: '123',
+        export: {
+          webhookUrl: 'https://example.com/export',
+        },
+        emailVerification: {
+          verified: true,
+          webhookType: 'email_verification',
+          webhookUrl: 'https://example.com/verify',
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/GVA-911/

This PR wires up the async 1-click export to a configurable webhook url.

When `hostSettings.export.webhookUrl` is configured, `POST /ghost/api/admin/exports/` posts a signed export event to the host's webhook and returns 202; the host builds a full archive and emails the site owner a download link.


```mermaid
sequenceDiagram
    participant Admin as Admin UI
    participant Core as Ghost core
    participant Host as Host webhook
    Admin->>Core: POST /exports/ {components}
    Core->>Host: signed POST {type: "export", siteId, components}
    Host-->>Core: 200 (fire-and-forget)
    Core-->>Admin: 202 → "link will be emailed to the site owner"
```

## API contract

**Endpoint**: `POST /ghost/api/admin/exports/` 

Available to Owner + Administrator staff users.

### Request

#### Body

```json
{
    "type": "export",
    "siteId": "<hostSettings:siteId>",
    "components": {"content": true, "members": true, "analytics": true, "themes": true, "routes": true, "media": false}
}
```
- `{"components": {...}}`: keys a subset of `content | members | analytics | themes | routes | media`, boolean values, at least one true
- the host emails the download link to the site owner; the payload carries no recipient

#### Auth headers

| Header | Value |
|---|---|
| `X-Ghost-Request-Timestamp` | `Date.now().toString()` (ms) |
| `X-Ghost-Signature` | `base64( HMAC-SHA256( secret, "{timestamp}:{rawBody}" ) )` |

The signing key lives at `hostSettings:export:webhookSecret`. 

### Responses

- 202 Accepted (empty body) on success
- 404 when the webhook URL isn't configured
- 400 when the URL is set but the secret is missing
- 502 when the forward fails
