### PR TITLE
Fixed flaky onboarding E2E test

### DIFF
--- a/e2e/tests/admin/onboarding.test.ts
+++ b/e2e/tests/admin/onboarding.test.ts
@@ -4,6 +4,12 @@ import type {Page} from '@playwright/test';
 
 type ChecklistState = 'pending' | 'started' | 'completed' | 'dismissed';
 
+interface OnboardingPreferences {
+    completedSteps: string[];
+    checklistState: ChecklistState;
+    startedAt?: string;
+}
+
 const allSteps = ['customize-design', 'first-post', 'build-audience', 'share-publication'];
 const activeStartedAt = '2026-05-01T00:00:00.000Z';
 const legacyNavigationSteps: Array<[string, RegExp]> = [
@@ -21,18 +27,18 @@ async function getCurrentUser(page: Page) {
     return body.users[0];
 }
 
-async function setOnboardingState(page: Page, checklistState: ChecklistState, completedSteps: string[] = [], startedAt: string | null | undefined = checklistState === 'started' ? activeStartedAt : undefined) {
+async function getOnboardingPreferences(page: Page) {
     const user = await getCurrentUser(page);
     const preferences = user.accessibility ? JSON.parse(user.accessibility) : {};
 
-    preferences.onboarding = {
-        completedSteps,
-        checklistState
-    };
+    return preferences.onboarding;
+}
 
-    if (startedAt) {
-        preferences.onboarding.startedAt = startedAt;
-    }
+async function putOnboardingPreferences(page: Page, onboarding: OnboardingPreferences) {
+    const user = await getCurrentUser(page);
+    const preferences = user.accessibility ? JSON.parse(user.accessibility) : {};
+
+    preferences.onboarding = onboarding;
 
     const response = await page.request.put(`/ghost/api/admin/users/${user.id}/?include=roles`, {
         data: {
@@ -43,15 +49,31 @@ async function setOnboardingState(page: Page, checklistState: ChecklistState, co
         }
     });
     expect(response.ok()).toBe(true);
-
-    await page.reload({waitUntil: 'load'});
 }
 
-async function getOnboardingPreferences(page: Page) {
-    const user = await getCurrentUser(page);
-    const preferences = user.accessibility ? JSON.parse(user.accessibility) : {};
+/**
+ * Sets the onboarding preferences through the API and leaves the page detached
+ * from Admin, so the caller navigates to load Admin against them.
+ *
+ * Admin fills in a missing user preference by writing the whole accessibility
+ * blob, merged over the user it read when the page loaded, and it queues one
+ * such write per mounted consumer. A write from here lands between those queued
+ * writes and the next one reverts it, so detach first to discard the queue and
+ * write until the server agrees to cover a write already on the wire.
+ */
+async function setOnboardingState(page: Page, checklistState: ChecklistState, completedSteps: string[] = [], startedAt: string | null | undefined = checklistState === 'started' ? activeStartedAt : undefined) {
+    const onboarding: OnboardingPreferences = {completedSteps, checklistState};
 
-    return preferences.onboarding;
+    if (startedAt) {
+        onboarding.startedAt = startedAt;
+    }
+
+    await page.goto('about:blank');
+
+    await expect(async () => {
+        await putOnboardingPreferences(page, onboarding);
+        expect(await getOnboardingPreferences(page)).toEqual(onboarding);
+    }).toPass({timeout: 15000});
 }
 
 async function expectOnboardingRoute(page: Page, {returnTo = '/analytics'}: {returnTo?: string} = {}) {


### PR DESCRIPTION
## Problem

The onboarding E2E suite fails intermittently on main. The test that pins a pending user reaching Analytics without being started by the React route read back empty onboarding state instead of the state it had just set, and it failed all three attempts of the same run.

## Solution

Admin fills in a missing user preference by writing the whole preferences blob, merged over the user it read when the page loaded, and it queues one such write per mounted consumer. Those writes trail the page load, so one of them lands after the state the test sets through the API and reverts it.

Setting the onboarding state now detaches the page from Admin first, which discards that queue, and retries the write until the server reports the state back. Admin loads against the written state when the test navigates.

Admin sending that same initialising write once per mounted consumer is a separate problem, worth fixing on its own.
