### PR TITLE
Added explicit Mailgun tracking opt-out

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-email-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-email-service.ts
@@ -11,6 +11,7 @@ interface Mailer {
         text: string;
         from: string;
         forceTextContent: boolean;
+        disableTracking?: boolean;
     }): Promise<void>;
 }
 
@@ -119,7 +120,8 @@ export class GiftEmailService {
             html,
             text,
             from: this.getFromAddress(),
-            forceTextContent: true
+            forceTextContent: true,
+            disableTracking: true
         });
     }
 

--- a/ghost/core/core/server/services/lib/mailgun-client.js
+++ b/ghost/core/core/server/services/lib/mailgun-client.js
@@ -95,8 +95,11 @@ module.exports = class MailgunClient {
                 messageData['o:testmode'] = true;
             }
 
-            // enable tracking if turned on for this email
-            if (message.track_opens) {
+            if (message.disable_tracking) {
+                messageData['o:tracking'] = 'no';
+                messageData['o:tracking-clicks'] = 'no';
+                messageData['o:tracking-opens'] = 'no';
+            } else if (message.track_opens) {
                 messageData['o:tracking-opens'] = true;
             }
 

--- a/ghost/core/core/server/services/mail/ghost-mailer.js
+++ b/ghost/core/core/server/services/mail/ghost-mailer.js
@@ -68,6 +68,7 @@ function createMessage(message) {
     delete cleanMessage.tags;
     delete cleanMessage.forceTextContent;
     delete cleanMessage.trackOpens;
+    delete cleanMessage.disableTracking;
 
     const addresses = getFromAddress(message.from, message.replyTo);
 
@@ -132,6 +133,7 @@ module.exports = class GhostMailer {
      * @param {string} [message.text] - text version of this message
      * @param {string[]} [message.tags] - optional additional Mailgun tags
      * @param {boolean} [message.trackOpens] - per-message override for Mailgun open tracking
+     * @param {boolean} [message.disableTracking] - explicitly disable Mailgun open and click tracking
      * @param {Record<string, string>} [message.headers] - optional additional email headers (merged with defaults)
      * @param {boolean} [message.forceTextContent] - maps to generateTextFromHTML nodemailer option
      * which is: "if set to true uses HTML to generate plain text body part from the HTML if the text is not defined"
@@ -155,7 +157,13 @@ module.exports = class GhostMailer {
             const trackOpens = typeof message.trackOpens === 'boolean' ?
                 message.trackOpens :
                 settingsCache.get('email_track_opens');
-            if (trackOpens) {
+            // nodemailer-mailgun-transport drops falsy option values, so an explicit
+            // opt-out must be Mailgun's string form rather than boolean false
+            if (message.disableTracking === true) {
+                messageToSend['o:tracking'] = 'no';
+                messageToSend['o:tracking-opens'] = 'no';
+                messageToSend['o:tracking-clicks'] = 'no';
+            } else if (trackOpens) {
                 messageToSend['o:tracking-opens'] = true;
             }
             if (messageToSend.headers) {

--- a/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
+++ b/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
@@ -66,7 +66,8 @@ describe('GiftEmailService', function () {
         sinon.assert.calledWith(mailer.send, sinon.match({
             to: 'buyer@example.com',
             subject: 'Your gift is ready',
-            from: 'Test Site <noreply@example.com>'
+            from: 'Test Site <noreply@example.com>',
+            disableTracking: true
         }));
     });
 

--- a/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
+++ b/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
@@ -259,7 +259,8 @@ describe('MailgunClient', function () {
                 replyTo: 'replyTo@example.com',
                 html: '<p>Test Content</p>',
                 plaintext: 'Test Content',
-                tags: ['another-tag']
+                tags: ['another-tag'],
+                disable_tracking: true
             };
             const recipientData = {
                 'test@example.com': {
@@ -279,8 +280,11 @@ describe('MailgunClient', function () {
                         /form-data; name="text"[^]*Test Content/m,
                         /form-data; name="to"[^]*test@example.com/m,
                         /form-data; name="recipient-variables"[^]*\{"test@example.com":\{"name":"Test User"\}\}/m,
-                        /form-data; name="o:tag"[^]*ghost-email/m,
-                        /form-data; name="o:tag"[^]*another-tag/m
+                        /form-data; name="o:tag"\r?\n\r?\nghost-email\r?\n--/m,
+                        /form-data; name="o:tag"\r?\n\r?\nanother-tag\r?\n--/m,
+                        /form-data; name="o:tracking"\r?\n\r?\nno\r?\n--/m,
+                        /form-data; name="o:tracking-clicks"\r?\n\r?\nno\r?\n--/m,
+                        /form-data; name="o:tracking-opens"\r?\n\r?\nno\r?\n--/m
                     ];
                     return regexList.every(regex => regex.test(body));
                 })

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -1,4 +1,5 @@
 const sinon = require('sinon');
+const nock = require('nock');
 const {deferred} = require('../../../../utils/deferred')
 const mail = require('../../../../../core/server/services/mail');
 const settingsCache = require('../../../../../core/shared/settings-cache');
@@ -422,6 +423,41 @@ describe('Mail: Ghostmailer', function () {
             const sentMessage = sendMailSpy.firstCall.args[0];
             assert.equal(sentMessage['o:tracking-opens'], undefined);
             assert.equal(sentMessage.trackOpens, undefined);
+        });
+
+        it('should explicitly disable Mailgun open and click tracking for transactional messages that require it', async function () {
+            configUtils.set({
+                mail: {
+                    transport: 'mailgun',
+                    from: 'from@default.com',
+                    options: {auth: {api_key: 'key', domain: 'domain.com'}}
+                }
+            });
+            sandbox.stub(settingsCache, 'get').withArgs('email_track_opens').returns(true);
+
+            // The transport whitelists and serialises the message before it reaches Mailgun,
+            // so assert on the request body rather than the object handed to sendMail
+            const sendMock = nock('https://api.mailgun.net')
+                .post('/v3/domain.com/messages', function (body) {
+                    const regexList = [
+                        /form-data; name="o:tracking"\r?\n\r?\nno\r?\n--/m,
+                        /form-data; name="o:tracking-opens"\r?\n\r?\nno\r?\n--/m,
+                        /form-data; name="o:tracking-clicks"\r?\n\r?\nno\r?\n--/m
+                    ];
+                    return regexList.every(regex => regex.test(body)) && !/name="disableTracking"/.test(body);
+                })
+                .reply(200, {id: '<message-id@domain.com>', message: 'Queued. Thank you.'});
+
+            mailer = new mail.GhostMailer();
+
+            await mailer.send({
+                to: 'recipient@example.com',
+                subject: 'Gift delivery',
+                html: 'content',
+                disableTracking: true
+            });
+
+            assert(sendMock.isDone());
         });
 
         it('should not add site ID tag when site ID is missing', async function () {


### PR DESCRIPTION
Adds an explicit tracking opt-out to both Mailgun-backed mail paths. The adapters serialize the override using Mailgun's `no` string because the transactional transport drops boolean `false` values.

Transactional messages carrying private redemption links must be able to override publication tracking settings. Keeping that behavior in the mail adapters prevents callers from needing to understand transport-specific fields.

ref https://linear.app/ghost/issue/BER-3851