### PR TITLE
Fixed async gift checkout payment routing

### DIFF
--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -345,6 +345,7 @@ export function buildGiftCheckoutCompletedEvent(opts: {
                 id: opts.sessionId,
                 object: 'checkout.session',
                 mode: 'payment',
+                payment_status: 'paid',
                 amount_total: opts.amount,
                 currency: opts.currency,
                 customer: opts.customerId ?? null,

--- a/e2e/tests/public/portal-gifts.test.ts
+++ b/e2e/tests/public/portal-gifts.test.ts
@@ -1,6 +1,12 @@
 import {FakeStripeCheckoutPage, PortalGiftPage} from '@/helpers/pages';
 import {createPaidPortalTier, expect, test} from '@/helpers/playwright';
 
+interface GiftRedemptionResponse {
+    gifts: Array<{
+        token: string;
+    }>;
+}
+
 test.describe('Ghost Public - Portal Gifts', () => {
     test.use({
         labs: {giftSubCustomization: true},
@@ -42,6 +48,15 @@ test.describe('Ghost Public - Portal Gifts', () => {
 
         const checkoutSession = stripe!.getCheckoutSessions().at(-1);
         expect(checkoutSession).toBeDefined();
+
+        const giftToken = checkoutSession!.response.metadata.gift_token;
+        expect(giftToken).toBeDefined();
+
+        const giftResponse = await page.request.get(`/members/api/gifts/${encodeURIComponent(giftToken!)}/redeem/`);
+        expect(giftResponse.ok()).toBe(true);
+
+        const giftData = await giftResponse.json() as GiftRedemptionResponse;
+        expect(giftData.gifts[0]?.token).toBe(giftToken);
 
         await page.goto(checkoutSession!.response.success_url);
         await portalGiftPage.waitForPortalToOpen();

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -18,6 +18,12 @@ function isGiftCheckoutSession(session) {
     return isStripeMetadataTrue(session.metadata?.ghost_gift);
 }
 
+function isDonationCheckoutSession(session) {
+    return isStripeMetadataTrue(session.metadata?.ghost_donation);
+}
+
+// Matches the donation marker on key presence, not truthiness, so an ill-formed
+// donation marker alongside a true gift marker still counts as a conflict.
 function hasConflictingCheckoutFlowMetadata(session) {
     return hasStripeMetadataKey(session.metadata, 'ghost_donation') && isGiftCheckoutSession(session);
 }
@@ -77,8 +83,8 @@ module.exports = class CheckoutSessionEventService {
         }
 
         if (eventType === 'checkout.session.async_payment_succeeded') {
-            if (session.mode === 'payment') {
-                await this.handlePaymentEvent(session, {giftOnly: true});
+            if (session.mode === 'payment' && isGiftCheckoutSession(session)) {
+                await this.handlePaymentEvent(session);
             }
             return;
         }
@@ -92,7 +98,7 @@ module.exports = class CheckoutSessionEventService {
         }
 
         if (session.mode === 'payment') {
-            await this.handlePaymentEvent(session, {giftOnly: false});
+            await this.handlePaymentEvent(session);
         }
     }
 
@@ -102,9 +108,8 @@ module.exports = class CheckoutSessionEventService {
      * session as paid, whichever event carried it.
      *
      * @param {import('stripe').Stripe.Checkout.Session} session
-     * @param {{giftOnly: boolean}} options
      */
-    async handlePaymentEvent(session, {giftOnly}) {
+    async handlePaymentEvent(session) {
         if (hasConflictingCheckoutFlowMetadata(session)) {
             logging.warn('Ignoring checkout session with conflicting payment flow metadata');
             return;
@@ -118,7 +123,7 @@ module.exports = class CheckoutSessionEventService {
             return;
         }
 
-        if (!giftOnly && isStripeMetadataTrue(session.metadata?.ghost_donation)) {
+        if (isDonationCheckoutSession(session)) {
             await this.handleDonationEvent(session);
         }
     }

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -14,8 +14,12 @@ function hasStripeMetadataKey(metadata, key) {
     return Object.prototype.hasOwnProperty.call(metadata || {}, key);
 }
 
-function hasConflictingCheckoutFlowMetadata(metadata) {
-    return hasStripeMetadataKey(metadata, 'ghost_donation') && hasStripeMetadataKey(metadata, 'ghost_gift');
+function isGiftCheckoutSession(session) {
+    return isStripeMetadataTrue(session.metadata?.ghost_gift);
+}
+
+function hasConflictingCheckoutFlowMetadata(session) {
+    return hasStripeMetadataKey(session.metadata, 'ghost_donation') && isGiftCheckoutSession(session);
 }
 
 function getStripeResourceId(resource) {
@@ -65,8 +69,20 @@ module.exports = class CheckoutSessionEventService {
      * Handles a `checkout.session.completed` event
      * Delegates to the appropriate handler based on the session mode and metadata
      * @param {import('stripe').Stripe.Checkout.Session} session
+     * @param {import('stripe').Stripe.Event.Type} [eventType]
      */
-    async handleEvent(session) {
+    async handleEvent(session, eventType = 'checkout.session.completed') {
+        if (eventType === 'checkout.session.async_payment_failed') {
+            return;
+        }
+
+        if (eventType === 'checkout.session.async_payment_succeeded') {
+            if (session.mode === 'payment') {
+                await this.handlePaymentEvent(session, {giftOnly: true});
+            }
+            return;
+        }
+
         if (session.mode === 'setup') {
             await this.handleSetupEvent(session);
         }
@@ -76,16 +92,34 @@ module.exports = class CheckoutSessionEventService {
         }
 
         if (session.mode === 'payment') {
-            if (hasConflictingCheckoutFlowMetadata(session.metadata)) {
-                logging.warn('Ignoring checkout session with conflicting payment flow metadata');
+            await this.handlePaymentEvent(session, {giftOnly: false});
+        }
+    }
+
+    /**
+     * Routes a `payment` mode session to the donation or gift handler. Gift purchases
+     * may complete asynchronously, so their handler only runs once Stripe reports the
+     * session as paid, whichever event carried it.
+     *
+     * @param {import('stripe').Stripe.Checkout.Session} session
+     * @param {{giftOnly: boolean}} options
+     */
+    async handlePaymentEvent(session, {giftOnly}) {
+        if (hasConflictingCheckoutFlowMetadata(session)) {
+            logging.warn('Ignoring checkout session with conflicting payment flow metadata');
+            return;
+        }
+
+        if (isGiftCheckoutSession(session)) {
+            if (session.payment_status !== 'paid') {
                 return;
             }
+            await this.handleGiftEvent(session);
+            return;
+        }
 
-            if (isStripeMetadataTrue(session.metadata?.ghost_donation)) {
-                await this.handleDonationEvent(session);
-            } else if (isStripeMetadataTrue(session.metadata?.ghost_gift)) {
-                await this.handleGiftEvent(session);
-            }
+        if (!giftOnly && isStripeMetadataTrue(session.metadata?.ghost_donation)) {
+            await this.handleDonationEvent(session);
         }
     }
 

--- a/ghost/core/core/server/services/stripe/webhook-controller.js
+++ b/ghost/core/core/server/services/stripe/webhook-controller.js
@@ -21,6 +21,8 @@ module.exports = class WebhookController {
             'customer.subscription.created': this.subscriptionEvent,
             'invoice.payment_succeeded': this.invoiceEvent,
             'checkout.session.completed': this.checkoutSessionEvent,
+            'checkout.session.async_payment_succeeded': this.checkoutSessionEvent,
+            'checkout.session.async_payment_failed': this.checkoutSessionEvent,
             'charge.refunded': this.chargeRefundedEvent
         };
     }
@@ -119,7 +121,7 @@ module.exports = class WebhookController {
             return;
         }
 
-        await this.handlers[event.type].call(this, event.data.object);
+        await this.handlers[event.type].call(this, event.data.object, event.type);
     }
 
     /**
@@ -143,10 +145,11 @@ module.exports = class WebhookController {
     /**
      * Delegates any `checkout.session.*` events to the `checkoutSessionEventService`
      * @param {import('stripe').Stripe.Checkout.Session} session
+     * @param {import('stripe').Stripe.Event.Type} eventType
      * @private
      */
-    async checkoutSessionEvent(session) {
-        await this.checkoutSessionEventService.handleEvent(session);
+    async checkoutSessionEvent(session, eventType) {
+        await this.checkoutSessionEventService.handleEvent(session, eventType);
     }
 
     /**

--- a/ghost/core/core/server/services/stripe/webhook-manager.js
+++ b/ghost/core/core/server/services/stripe/webhook-manager.js
@@ -43,6 +43,8 @@ module.exports = class WebhookManager {
     /** @type {WebhookEvent[]} */
     static events = [
         'checkout.session.completed',
+        'checkout.session.async_payment_succeeded',
+        'checkout.session.async_payment_failed',
         'customer.subscription.deleted',
         'customer.subscription.updated',
         'customer.subscription.created',

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -179,6 +179,7 @@ describe('Gift Subscriptions', function () {
                     object: {
                         id: checkoutSession.id,
                         mode: 'payment',
+                        payment_status: 'paid',
                         amount_total: paidTier.monthly_price,
                         currency: paidTier.currency.toLowerCase(),
                         customer: checkoutSession.customer,
@@ -253,6 +254,7 @@ describe('Gift Subscriptions', function () {
                     object: {
                         id: checkoutSession.id,
                         mode: 'payment',
+                        payment_status: 'paid',
                         amount_total: paidTier.yearly_price,
                         currency: paidTier.currency.toLowerCase(),
                         customer: checkoutSession.customer,
@@ -275,6 +277,102 @@ describe('Gift Subscriptions', function () {
             assert.equal(gift.get('cadence'), 'year');
             assert.equal(gift.get('amount'), paidTier.yearly_price);
             assert.equal(gift.get('status'), 'purchased');
+        });
+
+        it('Waits for async payment success before creating a gift', async function () {
+            const paidTier = await getPaidTier();
+
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'gift',
+                    tierId: paidTier.id,
+                    cadence: 'month',
+                    metadata: {}
+                })
+                .expectStatus(200);
+
+            const checkoutSession = getLatestCheckoutSession();
+            const session = {
+                id: checkoutSession.id,
+                mode: 'payment',
+                payment_status: 'unpaid',
+                amount_total: paidTier.monthly_price,
+                currency: paidTier.currency.toLowerCase(),
+                customer: checkoutSession.customer,
+                customer_details: {email: 'async-gift-buyer@example.com'},
+                metadata: toWebhookMetadata(checkoutSession.metadata),
+                payment_intent: 'pi_async_gift_test'
+            };
+
+            await stripeMocker.sendWebhook({
+                type: 'checkout.session.completed',
+                data: {object: session}
+            });
+            await DomainEvents.allSettled();
+
+            let gifts = await models.Gift.findAll({
+                filter: `token:'${checkoutSession.metadata.gift_token}'`
+            });
+            assert.equal(gifts.length, 0, 'Should not create a gift before payment succeeds');
+
+            await stripeMocker.sendWebhook({
+                type: 'checkout.session.async_payment_succeeded',
+                data: {
+                    object: {
+                        ...session,
+                        payment_status: 'paid'
+                    }
+                }
+            });
+            await DomainEvents.allSettled();
+
+            gifts = await models.Gift.findAll({
+                filter: `token:'${checkoutSession.metadata.gift_token}'`
+            });
+            assert.equal(gifts.length, 1, 'Should create exactly one gift after payment succeeds');
+        });
+
+        it('Does not create a gift when async payment fails', async function () {
+            const paidTier = await getPaidTier();
+
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'gift',
+                    tierId: paidTier.id,
+                    cadence: 'month',
+                    metadata: {}
+                })
+                .expectStatus(200);
+
+            const checkoutSession = getLatestCheckoutSession();
+            const session = {
+                id: checkoutSession.id,
+                mode: 'payment',
+                payment_status: 'unpaid',
+                amount_total: paidTier.monthly_price,
+                currency: paidTier.currency.toLowerCase(),
+                customer: checkoutSession.customer,
+                customer_details: {email: 'failed-async-gift-buyer@example.com'},
+                metadata: toWebhookMetadata(checkoutSession.metadata),
+                payment_intent: 'pi_failed_async_gift_test'
+            };
+
+            await stripeMocker.sendWebhook({
+                type: 'checkout.session.completed',
+                data: {object: session}
+            });
+            await DomainEvents.allSettled();
+
+            await stripeMocker.sendWebhook({
+                type: 'checkout.session.async_payment_failed',
+                data: {object: session}
+            });
+            await DomainEvents.allSettled();
+
+            const gifts = await models.Gift.findAll({
+                filter: `token:'${checkoutSession.metadata.gift_token}'`
+            });
+            assert.equal(gifts.length, 0, 'Should not create a gift when payment fails');
         });
 
         it('traces a customized 3-month gift from checkout through redemption and member access', async function () {
@@ -307,6 +405,7 @@ describe('Gift Subscriptions', function () {
                     object: {
                         id: checkoutSession.id,
                         mode: 'payment',
+                        payment_status: 'paid',
                         amount_total: expectedAmount,
                         currency: paidTier.currency.toLowerCase(),
                         customer: checkoutSession.customer,
@@ -450,6 +549,7 @@ describe('Gift Subscriptions', function () {
                     object: {
                         id: checkoutSession.id,
                         mode: 'payment',
+                        payment_status: 'paid',
                         amount_total: paidTier.monthly_price,
                         currency: paidTier.currency.toLowerCase(),
                         customer: checkoutSession.customer,
@@ -506,6 +606,7 @@ describe('Gift Subscriptions', function () {
                     object: {
                         id: checkoutSession.id,
                         mode: 'payment',
+                        payment_status: 'paid',
                         amount_total: expectedAmount,
                         currency: paidTier.currency.toLowerCase(),
                         customer: checkoutSession.customer,

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -109,12 +109,65 @@ describe('CheckoutSessionEventService', function () {
 
         it('should call handleGiftEvent if session mode is payment and session metadata ghost_gift is present', async function () {
             const service = createService();
-            const session = {mode: 'payment', metadata: {ghost_gift: 'true'}};
+            const session = {mode: 'payment', payment_status: 'paid', metadata: {ghost_gift: 'true'}};
             const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
 
             await service.handleEvent(session);
 
             sinon.assert.calledWith(handleGiftEventStub, session);
+        });
+
+        it('waits for async payment success when a gift checkout is still unpaid', async function () {
+            const service = createService();
+            const session = {mode: 'payment', payment_status: 'unpaid', metadata: {ghost_gift: 'true'}};
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent(session);
+            sinon.assert.notCalled(handleGiftEventStub);
+
+            await service.handleEvent({...session, payment_status: 'paid'}, 'checkout.session.async_payment_succeeded');
+            sinon.assert.calledOnce(handleGiftEventStub);
+        });
+
+        it('ignores async payment success for a gift that Stripe still reports as unpaid', async function () {
+            const service = createService();
+            const session = {mode: 'payment', payment_status: 'unpaid', metadata: {ghost_gift: 'true'}};
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent(session, 'checkout.session.async_payment_succeeded');
+
+            sinon.assert.notCalled(handleGiftEventStub);
+        });
+
+        it('ignores async payment success with conflicting donation and gift markers', async function () {
+            const service = createService();
+            const session = {mode: 'payment', payment_status: 'paid', metadata: {ghost_donation: 'true', ghost_gift: 'true'}};
+            const handleDonationEventStub = sinon.stub(service, 'handleDonationEvent');
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent(session, 'checkout.session.async_payment_succeeded');
+
+            sinon.assert.notCalled(handleDonationEventStub);
+            sinon.assert.notCalled(handleGiftEventStub);
+        });
+
+        it('does not handle donations on async payment success', async function () {
+            const service = createService();
+            const session = {mode: 'payment', payment_status: 'paid', metadata: {ghost_donation: 'true'}};
+            const handleDonationEventStub = sinon.stub(service, 'handleDonationEvent');
+
+            await service.handleEvent(session, 'checkout.session.async_payment_succeeded');
+
+            sinon.assert.notCalled(handleDonationEventStub);
+        });
+
+        it('ignores failed async gift payments', async function () {
+            const service = createService();
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent({mode: 'payment', metadata: {ghost_gift: 'true'}}, 'checkout.session.async_payment_failed');
+
+            sinon.assert.notCalled(handleGiftEventStub);
         });
 
         it('should ignore false gift metadata flags', async function () {

--- a/ghost/core/test/unit/server/services/stripe/webhook-controller.test.js
+++ b/ghost/core/test/unit/server/services/stripe/webhook-controller.test.js
@@ -98,6 +98,21 @@ describe('WebhookController', function () {
         // expect(res.end.called).to.be.true;
     });
 
+    for (const eventType of ['checkout.session.async_payment_succeeded', 'checkout.session.async_payment_failed']) {
+        it(`should handle ${eventType} event`, async function () {
+            const session = {customer: 'cust_123'};
+            deps.webhookManager.parseWebhook.returns({
+                type: eventType,
+                data: {object: session}
+            });
+
+            await controller.handle(req, res);
+
+            sinon.assert.calledOnceWithExactly(deps.checkoutSessionEventService.handleEvent, session, eventType);
+            sinon.assert.calledWith(res.writeHead, 200);
+        });
+    }
+
     it('should handle customer subscription updated event', async function () {
         const event = {
             type: 'customer.subscription.updated',


### PR DESCRIPTION
Routes completed and asynchronous payment Checkout Session events through one guarded payment path. Legacy gift checkouts now wait until Stripe reports `payment_status: paid`, while asynchronous donation events remain outside this handler.

Delayed payment methods can complete a Checkout Session before the payment succeeds. Finalizing the gift from that first event could grant a gift before payment, and the later success event previously had no registered route.

This PR intentionally supports the existing `ghost_gift` marker only. The immediate-delivery feature can add its new gift identifier and completion payload separately.

ref https://linear.app/ghost/issue/BER-3851