### PR TITLE
Fixed Admin preference writes reverting other writers

### DIFF
--- a/apps/admin-x-framework/src/api/current-user.ts
+++ b/apps/admin-x-framework/src/api/current-user.ts
@@ -1,31 +1,45 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {useCallback, useEffect} from 'react';
 import useHandleError from '../hooks/use-handle-error';
-import { apiUrl, useFetchApi } from '../utils/api/fetch-api';
-import { UsersResponseType } from './users';
+import {apiUrl, useFetchApi} from '../utils/api/fetch-api';
+import {UsersResponseType} from './users';
 
 export const usersDataType = 'UsersResponseType';
 
-const currentUserUrl = apiUrl('/users/me/', { include: 'roles' });
+const currentUserUrl = apiUrl('/users/me/', {include: 'roles'});
 export const currentUserQueryKey = [usersDataType, currentUserUrl] as const;
+
+/**
+ * Reads the current user straight from the API, leaving the query cache alone.
+ *
+ * Backs the query below, and serves a caller that needs the server's state as
+ * the base of a read-modify-write (the user's preferences blob, for one)
+ * without the displayed user flipping to a pre-write value while that write is
+ * in flight.
+ */
+export const useFetchCurrentUser = () => {
+    const fetchApi = useFetchApi();
+
+    return useCallback(() => fetchApi<UsersResponseType>(currentUserUrl), [fetchApi]);
+};
 
 // Special case where we can't use createQuery because this is used by
 // usePermissions, which is then used by createQuery
 export const useCurrentUser = () => {
-  const fetchApi = useFetchApi();
-  const handleError = useHandleError();
+    const fetchCurrentUser = useFetchCurrentUser();
+    const handleError = useHandleError();
 
-  const result = useQuery({
-    queryKey: currentUserQueryKey,
-    queryFn: () => fetchApi<UsersResponseType>(currentUserUrl),
-    select: (data) => data.users[0],
-  });
+    const result = useQuery({
+        queryKey: currentUserQueryKey,
+        queryFn: fetchCurrentUser,
+        select: data => data.users[0]
+    });
 
-  useEffect(() => {
-    if (result.error) {
-      handleError(result.error);
-    }
-  }, [handleError, result.error]);
+    useEffect(() => {
+        if (result.error) {
+            handleError(result.error);
+        }
+    }, [handleError, result.error]);
 
-  return result;
+    return result;
 };

--- a/apps/admin-x-framework/src/api/current-user.ts
+++ b/apps/admin-x-framework/src/api/current-user.ts
@@ -1,12 +1,12 @@
-import {useQuery} from '@tanstack/react-query';
-import {useCallback, useEffect} from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
 import useHandleError from '../hooks/use-handle-error';
-import {apiUrl, useFetchApi} from '../utils/api/fetch-api';
-import {UsersResponseType} from './users';
+import { apiUrl, useFetchApi } from '../utils/api/fetch-api';
+import { UsersResponseType } from './users';
 
 export const usersDataType = 'UsersResponseType';
 
-const currentUserUrl = apiUrl('/users/me/', {include: 'roles'});
+const currentUserUrl = apiUrl('/users/me/', { include: 'roles' });
 export const currentUserQueryKey = [usersDataType, currentUserUrl] as const;
 
 /**
@@ -18,28 +18,28 @@ export const currentUserQueryKey = [usersDataType, currentUserUrl] as const;
  * in flight.
  */
 export const useFetchCurrentUser = () => {
-    const fetchApi = useFetchApi();
+  const fetchApi = useFetchApi();
 
-    return useCallback(() => fetchApi<UsersResponseType>(currentUserUrl), [fetchApi]);
+  return useCallback(() => fetchApi<UsersResponseType>(currentUserUrl), [fetchApi]);
 };
 
 // Special case where we can't use createQuery because this is used by
 // usePermissions, which is then used by createQuery
 export const useCurrentUser = () => {
-    const fetchCurrentUser = useFetchCurrentUser();
-    const handleError = useHandleError();
+  const fetchCurrentUser = useFetchCurrentUser();
+  const handleError = useHandleError();
 
-    const result = useQuery({
-        queryKey: currentUserQueryKey,
-        queryFn: fetchCurrentUser,
-        select: data => data.users[0]
-    });
+  const result = useQuery({
+    queryKey: currentUserQueryKey,
+    queryFn: fetchCurrentUser,
+    select: (data) => data.users[0],
+  });
 
-    useEffect(() => {
-        if (result.error) {
-            handleError(result.error);
-        }
-    }, [handleError, result.error]);
+  useEffect(() => {
+    if (result.error) {
+      handleError(result.error);
+    }
+  }, [handleError, result.error]);
 
-    return result;
+  return result;
 };

--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -1,227 +1,234 @@
-import type {ReadonlyDeep} from 'type-fest';
-import {InfiniteData} from '@tanstack/react-query';
-import {Meta, createInfiniteQuery, createMutation, createQueryWithId} from '../utils/api/hooks';
-import {deleteFromQueryCache, updateQueryCache} from '../utils/api/update-queries';
-import {usersDataType} from './current-user';
-import {UserRole} from './roles';
+import type { ReadonlyDeep } from 'type-fest';
+import { InfiniteData } from '@tanstack/react-query';
+import { Meta, createInfiniteQuery, createMutation, createQueryWithId } from '../utils/api/hooks';
+import { deleteFromQueryCache, updateQueryCache } from '../utils/api/update-queries';
+import { usersDataType } from './current-user';
+import { UserRole } from './roles';
 
 // Types
 
 export type User = {
-    id: string;
-    name: string;
-    slug: string;
-    email: string;
-    profile_image: string|null;
-    cover_image: string|null;
-    bio: string|null;
-    website: string|null;
-    location: string|null;
-    facebook: string|null;
-    twitter: string|null;
-    threads: string|null;
-    bluesky: string|null;
-    mastodon: string|null;
-    tiktok: string|null;
-    youtube: string|null;
-    instagram: string|null;
-    linkedin: string|null;
-    accessibility: string|null;
-    status: string;
-    meta_title: string|null;
-    meta_description: string|null;
-    tour: string|null;
-    last_seen: string|null;
-    created_at: string;
-    updated_at: string;
-    comment_notifications: boolean;
-    free_member_signup_notification: boolean;
-    paid_subscription_canceled_notification: boolean;
-    paid_subscription_started_notification: boolean;
-    mention_notifications: boolean;
-    recommendation_notifications: boolean;
-    milestone_notifications: boolean;
-    donation_notifications: boolean;
-    gift_subscription_notifications: boolean;
-    roles: UserRole[];
-    url: string;
-}
+  id: string;
+  name: string;
+  slug: string;
+  email: string;
+  profile_image: string | null;
+  cover_image: string | null;
+  bio: string | null;
+  website: string | null;
+  location: string | null;
+  facebook: string | null;
+  twitter: string | null;
+  threads: string | null;
+  bluesky: string | null;
+  mastodon: string | null;
+  tiktok: string | null;
+  youtube: string | null;
+  instagram: string | null;
+  linkedin: string | null;
+  accessibility: string | null;
+  status: string;
+  meta_title: string | null;
+  meta_description: string | null;
+  tour: string | null;
+  last_seen: string | null;
+  created_at: string;
+  updated_at: string;
+  comment_notifications: boolean;
+  free_member_signup_notification: boolean;
+  paid_subscription_canceled_notification: boolean;
+  paid_subscription_started_notification: boolean;
+  mention_notifications: boolean;
+  recommendation_notifications: boolean;
+  milestone_notifications: boolean;
+  donation_notifications: boolean;
+  gift_subscription_notifications: boolean;
+  roles: UserRole[];
+  url: string;
+};
 
 export interface UsersResponseType {
-    meta?: Meta;
-    users: User[];
+  meta?: Meta;
+  users: User[];
 }
 
 export interface UpdateUserRequestBody {
-    users: Array<User>;
+  users: Array<User>;
 }
 
 interface UpdatePasswordOptions {
-    newPassword: string;
-    confirmNewPassword: string;
-    userId: string;
-    oldPassword?: string;
+  newPassword: string;
+  confirmNewPassword: string;
+  userId: string;
+  oldPassword?: string;
 }
 
 export interface PasswordUpdateResponseType {
-    password: [{
-        message: string;
-    }];
+  password: [
+    {
+      message: string;
+    },
+  ];
 }
 
 export interface DeleteUserResponse {
-    meta: {
-        filename: string;
-    }
+  meta: {
+    filename: string;
+  };
 }
 
 // Requests
 
 const dataType = usersDataType;
 
-export const useBrowseUsers = createInfiniteQuery<UsersResponseType & {isEnd: boolean}>({
-    dataType,
-    path: '/users/',
-    defaultSearchParams: {limit: '100', include: 'roles'},
-    defaultNextPageParams: (lastPage, otherParams) => ({
-        ...otherParams,
-        page: (lastPage.meta?.pagination.next || 1).toString()
-    }),
-    returnData: (originalData) => {
-        const {pages} = originalData as InfiniteData<UsersResponseType>;
-        const users = pages.flatMap(page => page.users);
-        const meta = pages[pages.length - 1].meta;
+export const useBrowseUsers = createInfiniteQuery<UsersResponseType & { isEnd: boolean }>({
+  dataType,
+  path: '/users/',
+  defaultSearchParams: { limit: '100', include: 'roles' },
+  defaultNextPageParams: (lastPage, otherParams) => ({
+    ...otherParams,
+    page: (lastPage.meta?.pagination.next || 1).toString(),
+  }),
+  returnData: (originalData) => {
+    const { pages } = originalData as InfiniteData<UsersResponseType>;
+    const users = pages.flatMap((page) => page.users);
+    const meta = pages[pages.length - 1].meta;
 
-        return {
-            users: users,
-            meta,
-            isEnd: meta ? meta.pagination.pages === meta.pagination.page : true
-        };
-    }
+    return {
+      users: users,
+      meta,
+      isEnd: meta ? meta.pagination.pages === meta.pagination.page : true,
+    };
+  },
 });
 
 export const useGetUserBySlug = createQueryWithId<UsersResponseType>({
-    dataType,
-    path: slug => `/users/slug/${slug}/`,
-    defaultSearchParams: {include: 'roles'}
+  dataType,
+  path: (slug) => `/users/slug/${slug}/`,
+  defaultSearchParams: { include: 'roles' },
 });
 
 /** A user edit carries only the fields it changes, so it cannot revert the rest. */
 export type EditUserPayload = Partial<User> & Pick<User, 'id'>;
 
 export const useEditUser = createMutation<UsersResponseType, EditUserPayload>({
-    method: 'PUT',
-    path: user => `/users/${user.id}/`,
-    body: user => ({users: [user]}),
-    searchParams: () => ({include: 'roles'}),
-    updateQueries: {
-        dataType,
-        emberUpdateType: 'createOrUpdate',
-        update: updateQueryCache('users')
-    }
+  method: 'PUT',
+  path: (user) => `/users/${user.id}/`,
+  body: (user) => ({ users: [user] }),
+  searchParams: () => ({ include: 'roles' }),
+  updateQueries: {
+    dataType,
+    emberUpdateType: 'createOrUpdate',
+    update: updateQueryCache('users'),
+  },
 });
 
 export const useDeleteUser = createMutation<DeleteUserResponse, string>({
-    method: 'DELETE',
-    path: id => `/users/${id}/`,
-    updateQueries: {
-        dataType,
-        emberUpdateType: 'delete',
-        update: deleteFromQueryCache('users')
-    }
+  method: 'DELETE',
+  path: (id) => `/users/${id}/`,
+  updateQueries: {
+    dataType,
+    emberUpdateType: 'delete',
+    update: deleteFromQueryCache('users'),
+  },
 });
 
 export const useUpdatePassword = createMutation<PasswordUpdateResponseType, UpdatePasswordOptions>({
-    method: 'PUT',
-    path: () => '/users/password/',
-    body: ({newPassword, confirmNewPassword, userId, oldPassword}) => ({
-        password: [{
-            user_id: userId,
-            oldPassword: oldPassword || '',
-            newPassword: newPassword,
-            ne2Password: confirmNewPassword
-        }]
-    })
+  method: 'PUT',
+  path: () => '/users/password/',
+  body: ({ newPassword, confirmNewPassword, userId, oldPassword }) => ({
+    password: [
+      {
+        user_id: userId,
+        oldPassword: oldPassword || '',
+        newPassword: newPassword,
+        ne2Password: confirmNewPassword,
+      },
+    ],
+  }),
 });
 
 export const useMakeOwner = createMutation<UsersResponseType, string>({
-    method: 'PUT',
-    path: () => '/users/owner/',
-    body: userId => ({
-        owner: [{
-            id: userId
-        }]
-    }),
-    updateQueries: {
-        dataType,
-        emberUpdateType: 'createOrUpdate',
-        update: updateQueryCache('users')
-    }
+  method: 'PUT',
+  path: () => '/users/owner/',
+  body: (userId) => ({
+    owner: [
+      {
+        id: userId,
+      },
+    ],
+  }),
+  updateQueries: {
+    dataType,
+    emberUpdateType: 'createOrUpdate',
+    update: updateQueryCache('users'),
+  },
 });
 
 // Helpers
 
 type HasRoles = ReadonlyDeep<{
-    roles: Array<Pick<UserRole, 'name'>>;
+  roles: Array<Pick<UserRole, 'name'>>;
 }>;
 
 export function isOwnerUser(user: HasRoles) {
-    return user.roles.some(role => role.name === 'Owner');
+  return user.roles.some((role) => role.name === 'Owner');
 }
 
 export function isAdminUser(user: HasRoles) {
-    return user.roles.some(role => role.name === 'Administrator');
+  return user.roles.some((role) => role.name === 'Administrator');
 }
 
 export function isEditorUser(user: HasRoles) {
-    const isAnyEditor = user.roles.some(role => role.name === 'Editor')
-        || user.roles.some(role => role.name === 'Super Editor');
-    return isAnyEditor;
+  const isAnyEditor =
+    user.roles.some((role) => role.name === 'Editor') ||
+    user.roles.some((role) => role.name === 'Super Editor');
+  return isAnyEditor;
 }
 
 export function isSuperEditorUser(user: HasRoles) {
-    return user.roles.some(role => role.name === 'Super Editor');
+  return user.roles.some((role) => role.name === 'Super Editor');
 }
 
 export function isAuthorUser(user: HasRoles) {
-    return user.roles.some(role => role.name === 'Author');
+  return user.roles.some((role) => role.name === 'Author');
 }
 
 export function isContributorUser(user: HasRoles) {
-    return user.roles.some(role => role.name === 'Contributor');
+  return user.roles.some((role) => role.name === 'Contributor');
 }
 
 export function isAuthorOrContributor(user: HasRoles) {
-    return isAuthorUser(user) || isContributorUser(user);
+  return isAuthorUser(user) || isContributorUser(user);
 }
 
 export function canAccessSettings(user: HasRoles) {
-    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+  return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
 export function canManageMembers(user: HasRoles) {
-    // Owner, Admin, or Super Editor can manage members
-    return isOwnerUser(user) || isAdminUser(user) || isSuperEditorUser(user);
+  // Owner, Admin, or Super Editor can manage members
+  return isOwnerUser(user) || isAdminUser(user) || isSuperEditorUser(user);
 }
 
 export function canManageTags(user: HasRoles) {
-    // Owner, Admin or Editor can manage tags
-    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+  // Owner, Admin or Editor can manage tags
+  return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
 export function canManageGiftLinks(user: HasRoles) {
-    // Owner, Admin or Editor can manage gift links
-    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+  // Owner, Admin or Editor can manage gift links
+  return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
 export function hasAdminAccess(user: HasRoles) {
-    return isOwnerUser(user) || isAdminUser(user);
+  return isOwnerUser(user) || isAdminUser(user);
 }
 
 export function canManageAutomations(user: HasRoles) {
-    // Only Owner and Admin can edit automations. This matches the API permission rows,
-    // which grant automation browse/read/edit to Administrator + Admin Integration
-    // (the Owner role inherits all permissions). Super Editors can manage members but
-    // cannot edit automations, so we must not gate on canManageMembers here.
-    return isOwnerUser(user) || isAdminUser(user);
+  // Only Owner and Admin can edit automations. This matches the API permission rows,
+  // which grant automation browse/read/edit to Administrator + Admin Integration
+  // (the Owner role inherits all permissions). Super Editors can manage members but
+  // cannot edit automations, so we must not gate on canManageMembers here.
+  return isOwnerUser(user) || isAdminUser(user);
 }

--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -1,231 +1,227 @@
-import type { ReadonlyDeep } from 'type-fest';
-import { InfiniteData } from '@tanstack/react-query';
-import { Meta, createInfiniteQuery, createMutation, createQueryWithId } from '../utils/api/hooks';
-import { deleteFromQueryCache, updateQueryCache } from '../utils/api/update-queries';
-import { usersDataType } from './current-user';
-import { UserRole } from './roles';
+import type {ReadonlyDeep} from 'type-fest';
+import {InfiniteData} from '@tanstack/react-query';
+import {Meta, createInfiniteQuery, createMutation, createQueryWithId} from '../utils/api/hooks';
+import {deleteFromQueryCache, updateQueryCache} from '../utils/api/update-queries';
+import {usersDataType} from './current-user';
+import {UserRole} from './roles';
 
 // Types
 
 export type User = {
-  id: string;
-  name: string;
-  slug: string;
-  email: string;
-  profile_image: string | null;
-  cover_image: string | null;
-  bio: string | null;
-  website: string | null;
-  location: string | null;
-  facebook: string | null;
-  twitter: string | null;
-  threads: string | null;
-  bluesky: string | null;
-  mastodon: string | null;
-  tiktok: string | null;
-  youtube: string | null;
-  instagram: string | null;
-  linkedin: string | null;
-  accessibility: string | null;
-  status: string;
-  meta_title: string | null;
-  meta_description: string | null;
-  tour: string | null;
-  last_seen: string | null;
-  created_at: string;
-  updated_at: string;
-  comment_notifications: boolean;
-  free_member_signup_notification: boolean;
-  paid_subscription_canceled_notification: boolean;
-  paid_subscription_started_notification: boolean;
-  mention_notifications: boolean;
-  recommendation_notifications: boolean;
-  milestone_notifications: boolean;
-  donation_notifications: boolean;
-  gift_subscription_notifications: boolean;
-  roles: UserRole[];
-  url: string;
-};
+    id: string;
+    name: string;
+    slug: string;
+    email: string;
+    profile_image: string|null;
+    cover_image: string|null;
+    bio: string|null;
+    website: string|null;
+    location: string|null;
+    facebook: string|null;
+    twitter: string|null;
+    threads: string|null;
+    bluesky: string|null;
+    mastodon: string|null;
+    tiktok: string|null;
+    youtube: string|null;
+    instagram: string|null;
+    linkedin: string|null;
+    accessibility: string|null;
+    status: string;
+    meta_title: string|null;
+    meta_description: string|null;
+    tour: string|null;
+    last_seen: string|null;
+    created_at: string;
+    updated_at: string;
+    comment_notifications: boolean;
+    free_member_signup_notification: boolean;
+    paid_subscription_canceled_notification: boolean;
+    paid_subscription_started_notification: boolean;
+    mention_notifications: boolean;
+    recommendation_notifications: boolean;
+    milestone_notifications: boolean;
+    donation_notifications: boolean;
+    gift_subscription_notifications: boolean;
+    roles: UserRole[];
+    url: string;
+}
 
 export interface UsersResponseType {
-  meta?: Meta;
-  users: User[];
+    meta?: Meta;
+    users: User[];
 }
 
 export interface UpdateUserRequestBody {
-  users: Array<User>;
+    users: Array<User>;
 }
 
 interface UpdatePasswordOptions {
-  newPassword: string;
-  confirmNewPassword: string;
-  userId: string;
-  oldPassword?: string;
+    newPassword: string;
+    confirmNewPassword: string;
+    userId: string;
+    oldPassword?: string;
 }
 
 export interface PasswordUpdateResponseType {
-  password: [
-    {
-      message: string;
-    },
-  ];
+    password: [{
+        message: string;
+    }];
 }
 
 export interface DeleteUserResponse {
-  meta: {
-    filename: string;
-  };
+    meta: {
+        filename: string;
+    }
 }
 
 // Requests
 
 const dataType = usersDataType;
 
-export const useBrowseUsers = createInfiniteQuery<UsersResponseType & { isEnd: boolean }>({
-  dataType,
-  path: '/users/',
-  defaultSearchParams: { limit: '100', include: 'roles' },
-  defaultNextPageParams: (lastPage, otherParams) => ({
-    ...otherParams,
-    page: (lastPage.meta?.pagination.next || 1).toString(),
-  }),
-  returnData: (originalData) => {
-    const { pages } = originalData as InfiniteData<UsersResponseType>;
-    const users = pages.flatMap((page) => page.users);
-    const meta = pages[pages.length - 1].meta;
+export const useBrowseUsers = createInfiniteQuery<UsersResponseType & {isEnd: boolean}>({
+    dataType,
+    path: '/users/',
+    defaultSearchParams: {limit: '100', include: 'roles'},
+    defaultNextPageParams: (lastPage, otherParams) => ({
+        ...otherParams,
+        page: (lastPage.meta?.pagination.next || 1).toString()
+    }),
+    returnData: (originalData) => {
+        const {pages} = originalData as InfiniteData<UsersResponseType>;
+        const users = pages.flatMap(page => page.users);
+        const meta = pages[pages.length - 1].meta;
 
-    return {
-      users: users,
-      meta,
-      isEnd: meta ? meta.pagination.pages === meta.pagination.page : true,
-    };
-  },
+        return {
+            users: users,
+            meta,
+            isEnd: meta ? meta.pagination.pages === meta.pagination.page : true
+        };
+    }
 });
 
 export const useGetUserBySlug = createQueryWithId<UsersResponseType>({
-  dataType,
-  path: (slug) => `/users/slug/${slug}/`,
-  defaultSearchParams: { include: 'roles' },
+    dataType,
+    path: slug => `/users/slug/${slug}/`,
+    defaultSearchParams: {include: 'roles'}
 });
 
-export const useEditUser = createMutation<UsersResponseType, User>({
-  method: 'PUT',
-  path: (user) => `/users/${user.id}/`,
-  body: (user) => ({ users: [user] }),
-  searchParams: () => ({ include: 'roles' }),
-  updateQueries: {
-    dataType,
-    emberUpdateType: 'createOrUpdate',
-    update: updateQueryCache('users'),
-  },
+/** A user edit carries only the fields it changes, so it cannot revert the rest. */
+export type EditUserPayload = Partial<User> & Pick<User, 'id'>;
+
+export const useEditUser = createMutation<UsersResponseType, EditUserPayload>({
+    method: 'PUT',
+    path: user => `/users/${user.id}/`,
+    body: user => ({users: [user]}),
+    searchParams: () => ({include: 'roles'}),
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: updateQueryCache('users')
+    }
 });
 
 export const useDeleteUser = createMutation<DeleteUserResponse, string>({
-  method: 'DELETE',
-  path: (id) => `/users/${id}/`,
-  updateQueries: {
-    dataType,
-    emberUpdateType: 'delete',
-    update: deleteFromQueryCache('users'),
-  },
+    method: 'DELETE',
+    path: id => `/users/${id}/`,
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'delete',
+        update: deleteFromQueryCache('users')
+    }
 });
 
 export const useUpdatePassword = createMutation<PasswordUpdateResponseType, UpdatePasswordOptions>({
-  method: 'PUT',
-  path: () => '/users/password/',
-  body: ({ newPassword, confirmNewPassword, userId, oldPassword }) => ({
-    password: [
-      {
-        user_id: userId,
-        oldPassword: oldPassword || '',
-        newPassword: newPassword,
-        ne2Password: confirmNewPassword,
-      },
-    ],
-  }),
+    method: 'PUT',
+    path: () => '/users/password/',
+    body: ({newPassword, confirmNewPassword, userId, oldPassword}) => ({
+        password: [{
+            user_id: userId,
+            oldPassword: oldPassword || '',
+            newPassword: newPassword,
+            ne2Password: confirmNewPassword
+        }]
+    })
 });
 
 export const useMakeOwner = createMutation<UsersResponseType, string>({
-  method: 'PUT',
-  path: () => '/users/owner/',
-  body: (userId) => ({
-    owner: [
-      {
-        id: userId,
-      },
-    ],
-  }),
-  updateQueries: {
-    dataType,
-    emberUpdateType: 'createOrUpdate',
-    update: updateQueryCache('users'),
-  },
+    method: 'PUT',
+    path: () => '/users/owner/',
+    body: userId => ({
+        owner: [{
+            id: userId
+        }]
+    }),
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: updateQueryCache('users')
+    }
 });
 
 // Helpers
 
 type HasRoles = ReadonlyDeep<{
-  roles: Array<Pick<UserRole, 'name'>>;
+    roles: Array<Pick<UserRole, 'name'>>;
 }>;
 
 export function isOwnerUser(user: HasRoles) {
-  return user.roles.some((role) => role.name === 'Owner');
+    return user.roles.some(role => role.name === 'Owner');
 }
 
 export function isAdminUser(user: HasRoles) {
-  return user.roles.some((role) => role.name === 'Administrator');
+    return user.roles.some(role => role.name === 'Administrator');
 }
 
 export function isEditorUser(user: HasRoles) {
-  const isAnyEditor =
-    user.roles.some((role) => role.name === 'Editor') ||
-    user.roles.some((role) => role.name === 'Super Editor');
-  return isAnyEditor;
+    const isAnyEditor = user.roles.some(role => role.name === 'Editor')
+        || user.roles.some(role => role.name === 'Super Editor');
+    return isAnyEditor;
 }
 
 export function isSuperEditorUser(user: HasRoles) {
-  return user.roles.some((role) => role.name === 'Super Editor');
+    return user.roles.some(role => role.name === 'Super Editor');
 }
 
 export function isAuthorUser(user: HasRoles) {
-  return user.roles.some((role) => role.name === 'Author');
+    return user.roles.some(role => role.name === 'Author');
 }
 
 export function isContributorUser(user: HasRoles) {
-  return user.roles.some((role) => role.name === 'Contributor');
+    return user.roles.some(role => role.name === 'Contributor');
 }
 
 export function isAuthorOrContributor(user: HasRoles) {
-  return isAuthorUser(user) || isContributorUser(user);
+    return isAuthorUser(user) || isContributorUser(user);
 }
 
 export function canAccessSettings(user: HasRoles) {
-  return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
 export function canManageMembers(user: HasRoles) {
-  // Owner, Admin, or Super Editor can manage members
-  return isOwnerUser(user) || isAdminUser(user) || isSuperEditorUser(user);
+    // Owner, Admin, or Super Editor can manage members
+    return isOwnerUser(user) || isAdminUser(user) || isSuperEditorUser(user);
 }
 
 export function canManageTags(user: HasRoles) {
-  // Owner, Admin or Editor can manage tags
-  return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+    // Owner, Admin or Editor can manage tags
+    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
 export function canManageGiftLinks(user: HasRoles) {
-  // Owner, Admin or Editor can manage gift links
-  return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+    // Owner, Admin or Editor can manage gift links
+    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
 export function hasAdminAccess(user: HasRoles) {
-  return isOwnerUser(user) || isAdminUser(user);
+    return isOwnerUser(user) || isAdminUser(user);
 }
 
 export function canManageAutomations(user: HasRoles) {
-  // Only Owner and Admin can edit automations. This matches the API permission rows,
-  // which grant automation browse/read/edit to Administrator + Admin Integration
-  // (the Owner role inherits all permissions). Super Editors can manage members but
-  // cannot edit automations, so we must not gate on canManageMembers here.
-  return isOwnerUser(user) || isAdminUser(user);
+    // Only Owner and Admin can edit automations. This matches the API permission rows,
+    // which grant automation browse/read/edit to Administrator + Admin Integration
+    // (the Owner role inherits all permissions). Super Editors can manage members but
+    // cannot edit automations, so we must not gate on canManageMembers here.
+    return isOwnerUser(user) || isAdminUser(user);
 }

--- a/apps/admin/src/home.acceptance.test.tsx
+++ b/apps/admin/src/home.acceptance.test.tsx
@@ -1,92 +1,102 @@
-import {beforeEach, describe, expect, it} from "vitest";
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
-    allowUnhandledRequests,
-    currentRoute,
-    currentUserResponse,
-    fakePreferenceEdits,
-    renderAdminApp,
-    staffRole,
-    type CapturedEndpointRequest,
-    type RenderAdminAppOptions,
-} from "@test-utils/acceptance";
-import type {StaffRoleName} from "@tryghost/test-data";
-import {onboardingScreen} from "@/onboarding/onboarding.screen";
+  allowUnhandledRequests,
+  currentRoute,
+  currentUserResponse,
+  fakePreferenceEdits,
+  renderAdminApp,
+  staffRole,
+  type CapturedEndpointRequest,
+  type RenderAdminAppOptions,
+} from '@test-utils/acceptance';
+import type { StaffRoleName } from '@tryghost/test-data';
+import { onboardingScreen } from '@/onboarding/onboarding.screen';
 
 function asRole(name: StaffRoleName): RenderAdminAppOptions {
-    const me = currentUserResponse();
-    me.users[0].roles = [staffRole({name})];
-    return {boot: {browseMe: {response: me}}};
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name })];
+  return { boot: { browseMe: { response: me } } };
 }
 
-const homeHandoff = (): unknown => JSON.parse(document.body.dataset.externalNavigate ?? "null");
+const homeHandoff = (): unknown => JSON.parse(document.body.dataset.externalNavigate ?? 'null');
 
-function onboardingPreferencesOf(request: CapturedEndpointRequest | undefined): Record<string, unknown> | undefined {
-    const body = request?.body as {users?: Array<{accessibility?: string}>} | undefined;
-    const accessibility = body?.users?.[0]?.accessibility;
-    if (!accessibility) {
-        return undefined;
-    }
-    return (JSON.parse(accessibility) as {onboarding?: Record<string, unknown>}).onboarding;
+function onboardingPreferencesOf(
+  request: CapturedEndpointRequest | undefined,
+): Record<string, unknown> | undefined {
+  const body = request?.body as { users?: Array<{ accessibility?: string }> } | undefined;
+  const accessibility = body?.users?.[0]?.accessibility;
+  if (!accessibility) {
+    return undefined;
+  }
+  return (JSON.parse(accessibility) as { onboarding?: Record<string, unknown> }).onboarding;
 }
 
-describe("Home route", () => {
-    beforeEach(() => {
-        delete document.body.dataset.externalNavigate;
-    });
+describe('Home route', () => {
+  beforeEach(() => {
+    delete document.body.dataset.externalNavigate;
+  });
 
-    it("sends admins to Analytics", async () => {
-        // The analytics screens own their request graph; these specs assert only the dispatch.
-        allowUnhandledRequests();
-        await renderAdminApp("/", asRole("Administrator"));
+  it('sends admins to Analytics', async () => {
+    // The analytics screens own their request graph; these specs assert only the dispatch.
+    allowUnhandledRequests();
+    await renderAdminApp('/', asRole('Administrator'));
 
-        await expect.poll(currentRoute).toBe("/analytics");
-    });
+    await expect.poll(currentRoute).toBe('/analytics');
+  });
 
-    it("sends contributors to Posts", async () => {
-        await renderAdminApp("/", asRole("Contributor"));
+  it('sends contributors to Posts', async () => {
+    await renderAdminApp('/', asRole('Contributor'));
 
-        await expect.poll(homeHandoff).toMatchObject({route: "/posts", isExternal: true, replace: true});
-    });
+    await expect
+      .poll(homeHandoff)
+      .toMatchObject({ route: '/posts', isExternal: true, replace: true });
+  });
 
-    it("sends other staff roles to Site", async () => {
-        await renderAdminApp("/", asRole("Author"));
+  it('sends other staff roles to Site', async () => {
+    await renderAdminApp('/', asRole('Author'));
 
-        await expect.poll(homeHandoff).toMatchObject({route: "/site", isExternal: true, replace: true});
-    });
+    await expect
+      .poll(homeHandoff)
+      .toMatchObject({ route: '/site', isExternal: true, replace: true });
+  });
 
-    it("starts the owner checklist and continues to onboarding on firstStart", async () => {
-        const preferencesApi = fakePreferenceEdits();
-        await renderAdminApp("/?firstStart=true");
+  it('starts the owner checklist and continues to onboarding on firstStart', async () => {
+    const preferencesApi = fakePreferenceEdits();
+    await renderAdminApp('/?firstStart=true');
 
-        await expect.element(onboardingScreen.checklist()).toBeVisible();
-        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=/analytics");
-        await expect.poll(() => onboardingPreferencesOf(preferencesApi.lastRequest)).toMatchObject({
-            checklistState: "started",
-            completedSteps: [],
-        });
-        expect(typeof onboardingPreferencesOf(preferencesApi.lastRequest)?.startedAt).toBe("string");
-    });
+    await expect.element(onboardingScreen.checklist()).toBeVisible();
+    await expect.poll(currentRoute).toBe('/setup/onboarding?returnTo=/analytics');
+    await expect
+      .poll(() => onboardingPreferencesOf(preferencesApi.lastRequest))
+      .toMatchObject({
+        checklistState: 'started',
+        completedSteps: [],
+      });
+    expect(typeof onboardingPreferencesOf(preferencesApi.lastRequest)?.startedAt).toBe('string');
+  });
 
-    it("continues admins to Analytics without starting the checklist on firstStart", async () => {
-        allowUnhandledRequests();
-        const preferencesApi = fakePreferenceEdits();
-        await renderAdminApp("/?firstStart=true", asRole("Administrator"));
+  it('continues admins to Analytics without starting the checklist on firstStart', async () => {
+    allowUnhandledRequests();
+    const preferencesApi = fakePreferenceEdits();
+    await renderAdminApp('/?firstStart=true', asRole('Administrator'));
 
-        await expect.poll(currentRoute).toBe("/analytics");
-        // Unrelated preference writes (e.g. the what's-new init) may happen,
-        // but none of them may start the checklist for a non-owner.
-        const checklistStates = preferencesApi.requests.map(request => onboardingPreferencesOf(request)?.checklistState);
-        expect(checklistStates).not.toContain("started");
-    });
+    await expect.poll(currentRoute).toBe('/analytics');
+    // Unrelated preference writes (e.g. the what's-new init) may happen,
+    // but none of them may start the checklist for a non-owner.
+    const checklistStates = preferencesApi.requests.map(
+      (request) => onboardingPreferencesOf(request)?.checklistState,
+    );
+    expect(checklistStates).not.toContain('started');
+  });
 });
 
-describe("Dashboard route", () => {
-    it("redirects to Analytics", async () => {
-        // The analytics screens own their request graph; this spec asserts only the redirect.
-        allowUnhandledRequests();
-        await renderAdminApp("/dashboard");
+describe('Dashboard route', () => {
+  it('redirects to Analytics', async () => {
+    // The analytics screens own their request graph; this spec asserts only the redirect.
+    allowUnhandledRequests();
+    await renderAdminApp('/dashboard');
 
-        await expect.poll(currentRoute).toBe("/analytics");
-    });
+    await expect.poll(currentRoute).toBe('/analytics');
+  });
 });

--- a/apps/admin/src/home.acceptance.test.tsx
+++ b/apps/admin/src/home.acceptance.test.tsx
@@ -1,107 +1,92 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import {beforeEach, describe, expect, it} from "vitest";
 
 import {
-  allowUnhandledRequests,
-  currentRoute,
-  currentUserResponse,
-  fakeAdminEndpoint,
-  renderAdminApp,
-  staffRole,
-  type CapturedEndpointRequest,
-  type EndpointCapture,
-  type RenderAdminAppOptions,
-} from '@test-utils/acceptance';
-import type { StaffRoleName } from '@tryghost/test-data';
-import { onboardingScreen } from '@/onboarding/onboarding.screen';
+    allowUnhandledRequests,
+    currentRoute,
+    currentUserResponse,
+    fakePreferenceEdits,
+    renderAdminApp,
+    staffRole,
+    type CapturedEndpointRequest,
+    type RenderAdminAppOptions,
+} from "@test-utils/acceptance";
+import type {StaffRoleName} from "@tryghost/test-data";
+import {onboardingScreen} from "@/onboarding/onboarding.screen";
 
 function asRole(name: StaffRoleName): RenderAdminAppOptions {
-  const me = currentUserResponse();
-  me.users[0].roles = [staffRole({ name })];
-  return { boot: { browseMe: { response: me } } };
+    const me = currentUserResponse();
+    me.users[0].roles = [staffRole({name})];
+    return {boot: {browseMe: {response: me}}};
 }
 
-const homeHandoff = (): unknown => JSON.parse(document.body.dataset.externalNavigate ?? 'null');
+const homeHandoff = (): unknown => JSON.parse(document.body.dataset.externalNavigate ?? "null");
 
-function fakePreferenceEdits(): EndpointCapture {
-  return fakeAdminEndpoint('PUT', /^\/users\/\w+\/\?include=roles/, ({ body }) => body);
+function onboardingPreferencesOf(request: CapturedEndpointRequest | undefined): Record<string, unknown> | undefined {
+    const body = request?.body as {users?: Array<{accessibility?: string}>} | undefined;
+    const accessibility = body?.users?.[0]?.accessibility;
+    if (!accessibility) {
+        return undefined;
+    }
+    return (JSON.parse(accessibility) as {onboarding?: Record<string, unknown>}).onboarding;
 }
 
-function onboardingPreferencesOf(
-  request: CapturedEndpointRequest | undefined,
-): Record<string, unknown> | undefined {
-  const body = request?.body as { users?: Array<{ accessibility?: string }> } | undefined;
-  const accessibility = body?.users?.[0]?.accessibility;
-  if (!accessibility) {
-    return undefined;
-  }
-  return (JSON.parse(accessibility) as { onboarding?: Record<string, unknown> }).onboarding;
-}
+describe("Home route", () => {
+    beforeEach(() => {
+        delete document.body.dataset.externalNavigate;
+    });
 
-describe('Home route', () => {
-  beforeEach(() => {
-    delete document.body.dataset.externalNavigate;
-  });
+    it("sends admins to Analytics", async () => {
+        // The analytics screens own their request graph; these specs assert only the dispatch.
+        allowUnhandledRequests();
+        await renderAdminApp("/", asRole("Administrator"));
 
-  it('sends admins to Analytics', async () => {
-    // The analytics screens own their request graph; these specs assert only the dispatch.
-    allowUnhandledRequests();
-    await renderAdminApp('/', asRole('Administrator'));
+        await expect.poll(currentRoute).toBe("/analytics");
+    });
 
-    await expect.poll(currentRoute).toBe('/analytics');
-  });
+    it("sends contributors to Posts", async () => {
+        await renderAdminApp("/", asRole("Contributor"));
 
-  it('sends contributors to Posts', async () => {
-    await renderAdminApp('/', asRole('Contributor'));
+        await expect.poll(homeHandoff).toMatchObject({route: "/posts", isExternal: true, replace: true});
+    });
 
-    await expect
-      .poll(homeHandoff)
-      .toMatchObject({ route: '/posts', isExternal: true, replace: true });
-  });
+    it("sends other staff roles to Site", async () => {
+        await renderAdminApp("/", asRole("Author"));
 
-  it('sends other staff roles to Site', async () => {
-    await renderAdminApp('/', asRole('Author'));
+        await expect.poll(homeHandoff).toMatchObject({route: "/site", isExternal: true, replace: true});
+    });
 
-    await expect
-      .poll(homeHandoff)
-      .toMatchObject({ route: '/site', isExternal: true, replace: true });
-  });
+    it("starts the owner checklist and continues to onboarding on firstStart", async () => {
+        const preferencesApi = fakePreferenceEdits();
+        await renderAdminApp("/?firstStart=true");
 
-  it('starts the owner checklist and continues to onboarding on firstStart', async () => {
-    const preferencesApi = fakePreferenceEdits();
-    await renderAdminApp('/?firstStart=true');
+        await expect.element(onboardingScreen.checklist()).toBeVisible();
+        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=/analytics");
+        await expect.poll(() => onboardingPreferencesOf(preferencesApi.lastRequest)).toMatchObject({
+            checklistState: "started",
+            completedSteps: [],
+        });
+        expect(typeof onboardingPreferencesOf(preferencesApi.lastRequest)?.startedAt).toBe("string");
+    });
 
-    await expect.element(onboardingScreen.checklist()).toBeVisible();
-    await expect.poll(currentRoute).toBe('/setup/onboarding?returnTo=/analytics');
-    await expect
-      .poll(() => onboardingPreferencesOf(preferencesApi.lastRequest))
-      .toMatchObject({
-        checklistState: 'started',
-        completedSteps: [],
-      });
-    expect(typeof onboardingPreferencesOf(preferencesApi.lastRequest)?.startedAt).toBe('string');
-  });
+    it("continues admins to Analytics without starting the checklist on firstStart", async () => {
+        allowUnhandledRequests();
+        const preferencesApi = fakePreferenceEdits();
+        await renderAdminApp("/?firstStart=true", asRole("Administrator"));
 
-  it('continues admins to Analytics without starting the checklist on firstStart', async () => {
-    allowUnhandledRequests();
-    const preferencesApi = fakePreferenceEdits();
-    await renderAdminApp('/?firstStart=true', asRole('Administrator'));
-
-    await expect.poll(currentRoute).toBe('/analytics');
-    // Unrelated preference writes (e.g. the what's-new init) may happen,
-    // but none of them may start the checklist for a non-owner.
-    const checklistStates = preferencesApi.requests.map(
-      (request) => onboardingPreferencesOf(request)?.checklistState,
-    );
-    expect(checklistStates).not.toContain('started');
-  });
+        await expect.poll(currentRoute).toBe("/analytics");
+        // Unrelated preference writes (e.g. the what's-new init) may happen,
+        // but none of them may start the checklist for a non-owner.
+        const checklistStates = preferencesApi.requests.map(request => onboardingPreferencesOf(request)?.checklistState);
+        expect(checklistStates).not.toContain("started");
+    });
 });
 
-describe('Dashboard route', () => {
-  it('redirects to Analytics', async () => {
-    // The analytics screens own their request graph; this spec asserts only the redirect.
-    allowUnhandledRequests();
-    await renderAdminApp('/dashboard');
+describe("Dashboard route", () => {
+    it("redirects to Analytics", async () => {
+        // The analytics screens own their request graph; this spec asserts only the redirect.
+        allowUnhandledRequests();
+        await renderAdminApp("/dashboard");
 
-    await expect.poll(currentRoute).toBe('/analytics');
-  });
+        await expect.poll(currentRoute).toBe("/analytics");
+    });
 });

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -1,37 +1,46 @@
-import { test as baseTest, describe, expect } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
-import type { QueryClient } from "@tanstack/react-query";
-import { useUserPreferences, useEditUserPreferences, DEFAULT_NAVIGATION_PREFERENCES, DEFAULT_ONBOARDING_PREFERENCES } from "./user-preferences";
-import { HttpResponse, http } from "msw";
-import { mockUser } from "@test-utils/factories";
-import { waitForQuerySettled } from "@test-utils/test-helpers";
-import { serverFixture } from "@test-utils/fixtures/msw";
-import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
-import type { UpdateUserRequestBody, UsersResponseType, User } from "@tryghost/admin-x-framework/api/users";
-import type { SetupServer } from "msw/node";
+import { test as baseTest, describe, expect } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { QueryClient } from '@tanstack/react-query';
+import {
+  useUserPreferences,
+  useEditUserPreferences,
+  DEFAULT_NAVIGATION_PREFERENCES,
+  DEFAULT_ONBOARDING_PREFERENCES,
+} from './user-preferences';
+import { HttpResponse, http } from 'msw';
+import { mockUser } from '@test-utils/factories';
+import { waitForQuerySettled } from '@test-utils/test-helpers';
+import { serverFixture } from '@test-utils/fixtures/msw';
+import { queryClientFixtures, type TestWrapperComponent } from '@test-utils/fixtures/query-client';
+import type {
+  UpdateUserRequestBody,
+  UsersResponseType,
+  User,
+} from '@tryghost/admin-x-framework/api/users';
+import type { SetupServer } from 'msw/node';
 
 // Constants
-const USERS_API_URL = "/ghost/api/admin/users/me/";
-const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
+const USERS_API_URL = '/ghost/api/admin/users/me/';
+const USER_UPDATE_API_URL = '/ghost/api/admin/users/:id/';
 
 // Test fixtures
 const fixtures = {
-    emptyPreferences: {},
-    existingPreferences: {
-        existing: "value",
-        shared: "old",
-    },
-    newPreferences: {
-        shared: "new",
-        additional: "data",
-    },
-    singlePreference: {
-        setting: "value",
-    },
-    defaults: {
-        navigation: DEFAULT_NAVIGATION_PREFERENCES,
-        onboarding: DEFAULT_ONBOARDING_PREFERENCES,
-    }
+  emptyPreferences: {},
+  existingPreferences: {
+    existing: 'value',
+    shared: 'old',
+  },
+  newPreferences: {
+    shared: 'new',
+    additional: 'data',
+  },
+  singlePreference: {
+    setting: 'value',
+  },
+  defaults: {
+    navigation: DEFAULT_NAVIGATION_PREFERENCES,
+    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
+  },
 };
 
 // Setup functions
@@ -50,30 +59,30 @@ const fixtures = {
  * @returns The renderHook result with the query in a settled state
  */
 async function setupQuery(
-    server: SetupServer,
-    wrapper: TestWrapperComponent,
-    userOverrides: Partial<User> = {}
+  server: SetupServer,
+  wrapper: TestWrapperComponent,
+  userOverrides: Partial<User> = {},
 ) {
-    // Mock the user API endpoint with customizable user data
-    server.use(
-        http.get(USERS_API_URL, () => {
-            return HttpResponse.json({
-                users: [
-                    {
-                        ...mockUser,
-                        ...userOverrides,
-                    },
-                ],
-            });
-        })
-    );
+  // Mock the user API endpoint with customizable user data
+  server.use(
+    http.get(USERS_API_URL, () => {
+      return HttpResponse.json({
+        users: [
+          {
+            ...mockUser,
+            ...userOverrides,
+          },
+        ],
+      });
+    }),
+  );
 
-    // Render the hook and wait for it to finish loading
-    const { result } = renderHook(() => useUserPreferences(), {
-        wrapper,
-    });
-    await waitForQuerySettled(result);
-    return result;
+  // Render the hook and wait for it to finish loading
+  const { result } = renderHook(() => useUserPreferences(), {
+    wrapper,
+  });
+  await waitForQuerySettled(result);
+  return result;
 }
 
 /**
@@ -91,513 +100,540 @@ async function setupQuery(
  * @returns Both query and mutation hook results, ready for testing edits
  */
 async function setupEdit(
-    server: SetupServer,
-    wrapper: TestWrapperComponent,
-    initialUser: Partial<User> = {}
+  server: SetupServer,
+  wrapper: TestWrapperComponent,
+  initialUser: Partial<User> = {},
 ) {
-    // Mock both the GET endpoint (for reading preferences) and PUT endpoint (for edits)
-    server.use(
-        http.get(USERS_API_URL, () => {
-            return HttpResponse.json({
-                users: [
-                    {
-                        ...mockUser,
-                        ...initialUser,
-                    },
-                ],
-            });
-        }),
-        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
-            USER_UPDATE_API_URL,
-            async ({ request }) => {
-                const body = await request.json();
-                const accessibility = body.users[0]?.accessibility ?? "";
-                return HttpResponse.json({
-                    users: [
-                        {
-                            ...mockUser,
-                            accessibility,
-                        },
-                    ],
-                });
-            }
-        )
-    );
+  // Mock both the GET endpoint (for reading preferences) and PUT endpoint (for edits)
+  server.use(
+    http.get(USERS_API_URL, () => {
+      return HttpResponse.json({
+        users: [
+          {
+            ...mockUser,
+            ...initialUser,
+          },
+        ],
+      });
+    }),
+    http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+      USER_UPDATE_API_URL,
+      async ({ request }) => {
+        const body = await request.json();
+        const accessibility = body.users[0]?.accessibility ?? '';
+        return HttpResponse.json({
+          users: [
+            {
+              ...mockUser,
+              accessibility,
+            },
+          ],
+        });
+      },
+    ),
+  );
 
-    // Render the query hook and wait for initial data to load
-    const queryResult = renderHook(() => useUserPreferences(), {
-        wrapper,
-    });
-    await waitForQuerySettled(queryResult.result);
+  // Render the query hook and wait for initial data to load
+  const queryResult = renderHook(() => useUserPreferences(), {
+    wrapper,
+  });
+  await waitForQuerySettled(queryResult.result);
 
-    // Render the mutation hook (ready to call mutateAsync in tests)
-    const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
+  // Render the mutation hook (ready to call mutateAsync in tests)
+  const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
 
-    return {
-        query: queryResult.result,
-        mutation: mutationResult.result,
-    };
+  return {
+    query: queryResult.result,
+    mutation: mutationResult.result,
+  };
 }
 
 // Test extensions
 const queryTest = baseTest.extend<{
-    server: SetupServer;
-    queryClient: QueryClient;
-    wrapper: TestWrapperComponent;
-    setup: (userOverrides?: Partial<User>) => ReturnType<typeof setupQuery>;
+  server: SetupServer;
+  queryClient: QueryClient;
+  wrapper: TestWrapperComponent;
+  setup: (userOverrides?: Partial<User>) => ReturnType<typeof setupQuery>;
 }>({
-    ...serverFixture,
-    ...queryClientFixtures,
-    setup: async ({ server, wrapper }, provide) => {
-        await provide((userOverrides) => setupQuery(server, wrapper, userOverrides));
-    },
+  ...serverFixture,
+  ...queryClientFixtures,
+  setup: async ({ server, wrapper }, provide) => {
+    await provide((userOverrides) => setupQuery(server, wrapper, userOverrides));
+  },
 });
 
 const editTest = baseTest.extend<{
-    server: SetupServer;
-    queryClient: QueryClient;
-    wrapper: TestWrapperComponent;
-    setup: (initialUser?: Partial<User>) => ReturnType<typeof setupEdit>;
+  server: SetupServer;
+  queryClient: QueryClient;
+  wrapper: TestWrapperComponent;
+  setup: (initialUser?: Partial<User>) => ReturnType<typeof setupEdit>;
 }>({
-    ...serverFixture,
-    ...queryClientFixtures,
-    setup: async ({ server, wrapper }, provide) => {
-        await provide((initialUser) => setupEdit(server, wrapper, initialUser));
-    },
+  ...serverFixture,
+  ...queryClientFixtures,
+  setup: async ({ server, wrapper }, provide) => {
+    await provide((initialUser) => setupEdit(server, wrapper, initialUser));
+  },
 });
 
-describe("useUserPreferences", () => {
-    describe("initialization", () => {
-        [
-            {
-                scenario: "null",
-                accessibility: null,
-            },
-            {
-                scenario: "undefined",
-                accessibility: undefined,
-            },
-            {
-                scenario: "empty string",
-                accessibility: "",
-            },
-        ].forEach(({ scenario, accessibility }) => {
-            queryTest(`returns object with defaults when accessibility is ${scenario}`, async ({ setup }) => {
-                const result = await setup({ accessibility });
+describe('useUserPreferences', () => {
+  describe('initialization', () => {
+    [
+      {
+        scenario: 'null',
+        accessibility: null,
+      },
+      {
+        scenario: 'undefined',
+        accessibility: undefined,
+      },
+      {
+        scenario: 'empty string',
+        accessibility: '',
+      },
+    ].forEach(({ scenario, accessibility }) => {
+      queryTest(
+        `returns object with defaults when accessibility is ${scenario}`,
+        async ({ setup }) => {
+          const result = await setup({ accessibility });
 
-                expect(result.current.data).toEqual(fixtures.defaults);
-            });
-        });
-
-        queryTest("parses JSON from accessibility field", async ({ setup }) => {
-            const result = await setup({
-                accessibility: JSON.stringify(fixtures.existingPreferences),
-            });
-
-            expect(result.current.data).toEqual({
-                ...fixtures.defaults,
-                ...fixtures.existingPreferences,
-            });
-        });
-
-        queryTest("errors when invalid JSON", async ({ setup }) => {
-            const result = await setup({ accessibility: "{invalid json" });
-
-            expect(result.current.isError).toBe(true);
-            expect(result.current.error).toBeInstanceOf(Error);
-        });
-
-        queryTest("gracefully handles invalid schema values", async ({ setup }) => {
-            const result = await setup({
-                accessibility: JSON.stringify({
-                    onboarding: {
-                        checklistState: "unknown",
-                        completedSteps: "customize-design",
-                        startedAt: "not-a-valid-datetime",
-                    },
-                    whatsNew: {
-                        lastSeenDate: "not-a-valid-datetime",
-                    },
-                }),
-            });
-
-            // Should not error - catches and returns undefined for invalid fields
-            expect(result.current.isError).toBe(false);
-            expect(result.current.data).toEqual({
-                ...fixtures.defaults,
-                whatsNew: {
-                    lastSeenDate: undefined,
-                },
-            });
-        });
-
-        queryTest("parses onboarding startedAt into a date", async ({ setup }) => {
-            const result = await setup({
-                accessibility: JSON.stringify({
-                    onboarding: {
-                        completedSteps: ["customize-design"],
-                        checklistState: "started",
-                        startedAt: "2026-04-30T10:00:00.000Z",
-                    },
-                }),
-            });
-
-            expect(result.current.data?.onboarding).toEqual({
-                completedSteps: ["customize-design"],
-                checklistState: "started",
-                startedAt: new Date("2026-04-30T10:00:00.000Z"),
-            });
-        });
-
-        describe("nightShift migration", () => {
-            [
-                {scenario: "legacy boolean true", value: true, expected: "dark"},
-                {scenario: "legacy boolean false", value: false, expected: "light"},
-                {scenario: "dark string", value: "dark", expected: "dark"},
-                {scenario: "light string", value: "light", expected: "light"},
-                {scenario: "system string", value: "system", expected: "system"},
-                {scenario: "invalid value", value: "invalid", expected: "light"},
-            ].forEach(({scenario, value, expected}) => {
-                queryTest(`parses ${scenario}`, async ({ setup }) => {
-                    const result = await setup({
-                        accessibility: JSON.stringify({nightShift: value}),
-                    });
-
-                    expect(result.current.data?.nightShift).toBe(expected);
-                });
-            });
-
-            queryTest("omits nightShift when the preference is absent", async ({ setup }) => {
-                const result = await setup({
-                    accessibility: JSON.stringify({}),
-                });
-
-                // Absent stays absent so it isn't written back on unrelated saves;
-                // the display fallback to "light" lives in useTheme.
-                expect(result.current.data?.nightShift).toBeUndefined();
-            });
-
-            queryTest("preserves explicit system preference", async ({ setup }) => {
-                const result = await setup({
-                    accessibility: JSON.stringify({nightShift: "system"}),
-                });
-
-                expect(result.current.data?.nightShift).toBe("system");
-            });
-        });
-
-        queryTest("returns undefined when user is not loaded", async ({ server, wrapper }) => {
-            server.use(
-                http.get(USERS_API_URL, () => {
-                    return HttpResponse.json({ users: [] });
-                })
-            );
-
-            const { result } = renderHook(() => useUserPreferences(), {
-                wrapper,
-            });
-
-            await waitFor(() => {
-                expect(result.current.isFetching).toBe(false);
-            });
-
-            expect(result.current.data).toBeUndefined();
-        });
+          expect(result.current.data).toEqual(fixtures.defaults);
+        },
+      );
     });
 
-    describe("query options", () => {
-        queryTest("supports select option to transform data", async ({ server, wrapper }) => {
-            server.use(
-                http.get(USERS_API_URL, () => {
-                    return HttpResponse.json({
-                        users: [{
-                            ...mockUser,
-                            accessibility: JSON.stringify({
-                                navigation: {
-                                    expanded: { posts: false },
-                                    menu: { visible: true },
-                                },
-                                nightShift: "dark",
-                            }),
-                        }],
-                    });
-                })
-            );
+    queryTest('parses JSON from accessibility field', async ({ setup }) => {
+      const result = await setup({
+        accessibility: JSON.stringify(fixtures.existingPreferences),
+      });
 
-            const { result } = renderHook(() => useUserPreferences({
-                select: (data) => data.navigation,
-            }), { wrapper });
+      expect(result.current.data).toEqual({
+        ...fixtures.defaults,
+        ...fixtures.existingPreferences,
+      });
+    });
 
-            await waitForQuerySettled(result);
+    queryTest('errors when invalid JSON', async ({ setup }) => {
+      const result = await setup({ accessibility: '{invalid json' });
 
-            expect(result.current.data).toEqual({
-                expanded: { posts: false, members: true },
-                menu: { visible: true },
-            });
+      expect(result.current.isError).toBe(true);
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
+
+    queryTest('gracefully handles invalid schema values', async ({ setup }) => {
+      const result = await setup({
+        accessibility: JSON.stringify({
+          onboarding: {
+            checklistState: 'unknown',
+            completedSteps: 'customize-design',
+            startedAt: 'not-a-valid-datetime',
+          },
+          whatsNew: {
+            lastSeenDate: 'not-a-valid-datetime',
+          },
+        }),
+      });
+
+      // Should not error - catches and returns undefined for invalid fields
+      expect(result.current.isError).toBe(false);
+      expect(result.current.data).toEqual({
+        ...fixtures.defaults,
+        whatsNew: {
+          lastSeenDate: undefined,
+        },
+      });
+    });
+
+    queryTest('parses onboarding startedAt into a date', async ({ setup }) => {
+      const result = await setup({
+        accessibility: JSON.stringify({
+          onboarding: {
+            completedSteps: ['customize-design'],
+            checklistState: 'started',
+            startedAt: '2026-04-30T10:00:00.000Z',
+          },
+        }),
+      });
+
+      expect(result.current.data?.onboarding).toEqual({
+        completedSteps: ['customize-design'],
+        checklistState: 'started',
+        startedAt: new Date('2026-04-30T10:00:00.000Z'),
+      });
+    });
+
+    describe('nightShift migration', () => {
+      [
+        { scenario: 'legacy boolean true', value: true, expected: 'dark' },
+        { scenario: 'legacy boolean false', value: false, expected: 'light' },
+        { scenario: 'dark string', value: 'dark', expected: 'dark' },
+        { scenario: 'light string', value: 'light', expected: 'light' },
+        { scenario: 'system string', value: 'system', expected: 'system' },
+        { scenario: 'invalid value', value: 'invalid', expected: 'light' },
+      ].forEach(({ scenario, value, expected }) => {
+        queryTest(`parses ${scenario}`, async ({ setup }) => {
+          const result = await setup({
+            accessibility: JSON.stringify({ nightShift: value }),
+          });
+
+          expect(result.current.data?.nightShift).toBe(expected);
+        });
+      });
+
+      queryTest('omits nightShift when the preference is absent', async ({ setup }) => {
+        const result = await setup({
+          accessibility: JSON.stringify({}),
         });
 
-        queryTest("keeps previous data during unrelated accessibility updates", async ({ server, wrapper }) => {
-            server.use(
-                http.get(USERS_API_URL, () => {
-                    return HttpResponse.json({
-                        users: [
-                            {
-                                ...mockUser,
-                                accessibility: JSON.stringify({
-                                    navigation: DEFAULT_NAVIGATION_PREFERENCES,
-                                    whatsNew: {
-                                        lastSeenDate: "2025-01-01T00:00:00.000Z",
-                                    },
-                                }),
-                            },
-                        ],
-                    });
+        // Absent stays absent so it isn't written back on unrelated saves;
+        // the display fallback to "light" lives in useTheme.
+        expect(result.current.data?.nightShift).toBeUndefined();
+      });
+
+      queryTest('preserves explicit system preference', async ({ setup }) => {
+        const result = await setup({
+          accessibility: JSON.stringify({ nightShift: 'system' }),
+        });
+
+        expect(result.current.data?.nightShift).toBe('system');
+      });
+    });
+
+    queryTest('returns undefined when user is not loaded', async ({ server, wrapper }) => {
+      server.use(
+        http.get(USERS_API_URL, () => {
+          return HttpResponse.json({ users: [] });
+        }),
+      );
+
+      const { result } = renderHook(() => useUserPreferences(), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(result.current.data).toBeUndefined();
+    });
+  });
+
+  describe('query options', () => {
+    queryTest('supports select option to transform data', async ({ server, wrapper }) => {
+      server.use(
+        http.get(USERS_API_URL, () => {
+          return HttpResponse.json({
+            users: [
+              {
+                ...mockUser,
+                accessibility: JSON.stringify({
+                  navigation: {
+                    expanded: { posts: false },
+                    menu: { visible: true },
+                  },
+                  nightShift: 'dark',
                 }),
-                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(USER_UPDATE_API_URL, async ({ request }) => {
-                    const body = await request.json();
+              },
+            ],
+          });
+        }),
+      );
 
-                    await new Promise((resolve) => {
-                        setTimeout(resolve, 25);
-                    });
+      const { result } = renderHook(
+        () =>
+          useUserPreferences({
+            select: (data) => data.navigation,
+          }),
+        { wrapper },
+      );
 
-                    return HttpResponse.json({
-                        users: [
-                            {
-                                ...mockUser,
-                                accessibility: body.users[0]?.accessibility ?? "",
-                            },
-                        ],
-                    });
-                })
-            );
+      await waitForQuerySettled(result);
 
-            const snapshots: Array<ReturnType<typeof useUserPreferences>["data"]> = [];
+      expect(result.current.data).toEqual({
+        expanded: { posts: false, members: true },
+        menu: { visible: true },
+      });
+    });
 
-            const { result } = renderHook(() => {
-                const query = useUserPreferences();
-                const mutation = useEditUserPreferences();
-
-                snapshots.push(query.data);
-
-                return {query, mutation};
-            }, { wrapper });
-
-            await waitFor(() => {
-                expect(result.current.query.data).toEqual({
+    queryTest(
+      'keeps previous data during unrelated accessibility updates',
+      async ({ server, wrapper }) => {
+        server.use(
+          http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+              users: [
+                {
+                  ...mockUser,
+                  accessibility: JSON.stringify({
                     navigation: DEFAULT_NAVIGATION_PREFERENCES,
-                    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
                     whatsNew: {
-                        lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
+                      lastSeenDate: '2025-01-01T00:00:00.000Z',
                     },
-                });
+                  }),
+                },
+              ],
             });
+          }),
+          http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+            USER_UPDATE_API_URL,
+            async ({ request }) => {
+              const body = await request.json();
 
-            snapshots.length = 0;
+              await new Promise((resolve) => {
+                setTimeout(resolve, 25);
+              });
 
-            await act(async () => {
-                await result.current.mutation.mutateAsync({
-                    navigation: {
-                        expanded: {
-                            posts: false,
-                        },
-                    },
-                });
-            });
+              return HttpResponse.json({
+                users: [
+                  {
+                    ...mockUser,
+                    accessibility: body.users[0]?.accessibility ?? '',
+                  },
+                ],
+              });
+            },
+          ),
+        );
 
-            await waitFor(() => {
-                expect(result.current.query.data).toEqual({
-                    navigation: {
-                        ...DEFAULT_NAVIGATION_PREFERENCES,
-                        expanded: {
-                            ...DEFAULT_NAVIGATION_PREFERENCES.expanded,
-                            posts: false,
-                        },
-                    },
-                    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
-                    whatsNew: {
-                        lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
-                    },
-                });
-            });
+        const snapshots: Array<ReturnType<typeof useUserPreferences>['data']> = [];
 
-            expect(snapshots).not.toContain(undefined);
+        const { result } = renderHook(
+          () => {
+            const query = useUserPreferences();
+            const mutation = useEditUserPreferences();
+
+            snapshots.push(query.data);
+
+            return { query, mutation };
+          },
+          { wrapper },
+        );
+
+        await waitFor(() => {
+          expect(result.current.query.data).toEqual({
+            navigation: DEFAULT_NAVIGATION_PREFERENCES,
+            onboarding: DEFAULT_ONBOARDING_PREFERENCES,
+            whatsNew: {
+              lastSeenDate: new Date('2025-01-01T00:00:00.000Z'),
+            },
+          });
         });
-    });
+
+        snapshots.length = 0;
+
+        await act(async () => {
+          await result.current.mutation.mutateAsync({
+            navigation: {
+              expanded: {
+                posts: false,
+              },
+            },
+          });
+        });
+
+        await waitFor(() => {
+          expect(result.current.query.data).toEqual({
+            navigation: {
+              ...DEFAULT_NAVIGATION_PREFERENCES,
+              expanded: {
+                ...DEFAULT_NAVIGATION_PREFERENCES.expanded,
+                posts: false,
+              },
+            },
+            onboarding: DEFAULT_ONBOARDING_PREFERENCES,
+            whatsNew: {
+              lastSeenDate: new Date('2025-01-01T00:00:00.000Z'),
+            },
+          });
+        });
+
+        expect(snapshots).not.toContain(undefined);
+      },
+    );
+  });
 });
 
-describe("useEditUserPreferences", () => {
-    describe("editing preferences", () => {
-        editTest("merges new preferences with existing ones", async ({ setup }) => {
-            const { query, mutation } = await setup({
-                accessibility: JSON.stringify(fixtures.existingPreferences),
-            });
+describe('useEditUserPreferences', () => {
+  describe('editing preferences', () => {
+    editTest('merges new preferences with existing ones', async ({ setup }) => {
+      const { query, mutation } = await setup({
+        accessibility: JSON.stringify(fixtures.existingPreferences),
+      });
 
-            await act(async () => {
-                await mutation.current.mutateAsync(fixtures.newPreferences);
-            });
+      await act(async () => {
+        await mutation.current.mutateAsync(fixtures.newPreferences);
+      });
 
-            await waitFor(() => {
-                expect(query.current.data).toEqual({
-                    ...fixtures.defaults,
-                    existing: "value",
-                    shared: "new",
-                    additional: "data",
-                });
-            });
+      await waitFor(() => {
+        expect(query.current.data).toEqual({
+          ...fixtures.defaults,
+          existing: 'value',
+          shared: 'new',
+          additional: 'data',
         });
-
-        editTest("creates new accessibility object when none exists", async ({ setup }) => {
-            const { query, mutation } = await setup();
-
-            await act(async () => {
-                await mutation.current.mutateAsync(fixtures.singlePreference);
-            });
-
-            await waitFor(() => {
-                expect(query.current.data).toEqual({
-                    ...fixtures.defaults,
-                    ...fixtures.singlePreference,
-                });
-            });
-        });
-
-        editTest("throws error when user is not loaded", async ({ server, wrapper }) => {
-            server.use(
-                http.get(USERS_API_URL, () => {
-                    return HttpResponse.json({ users: [] });
-                })
-            );
-
-            const { result } = renderHook(() => useEditUserPreferences(), {
-                wrapper,
-            });
-
-            await expect(
-                act(async () => {
-                    await result.current.mutateAsync(fixtures.singlePreference);
-                })
-            ).rejects.toThrow("User is not loaded");
-        });
+      });
     });
 
-    describe("deep merge behavior", () => {
-        editTest("deep merges nested objects while preserving sibling properties", async ({ setup }) => {
-            const { query, mutation } = await setup({
-                accessibility: JSON.stringify({
-                    navigation: {
-                        expanded: { posts: false, members: false },
-                        menu: { visible: true },
-                    },
-                    onboarding: {
-                        completedSteps: ["customize-design"],
-                        checklistState: "started",
-                    },
-                    nightShift: "dark",
-                }),
-            });
+    editTest('creates new accessibility object when none exists', async ({ setup }) => {
+      const { query, mutation } = await setup();
 
-            await act(async () => {
-                await mutation.current.mutateAsync({
-                    navigation: { expanded: { posts: true } },
-                    onboarding: { completedSteps: ["customize-design", "first-post"] },
-                });
-            });
+      await act(async () => {
+        await mutation.current.mutateAsync(fixtures.singlePreference);
+      });
 
-            await waitFor(() => {
-                expect(query.current.data).toEqual({
-                    navigation: {
-                        expanded: { posts: true, members: false },
-                        menu: { visible: true }, // Preserved
-                    },
-                    onboarding: {
-                        completedSteps: ["customize-design", "first-post"],
-                        checklistState: "started",
-                    },
-                    nightShift: "dark", // Preserved
-                });
-            });
+      await waitFor(() => {
+        expect(query.current.data).toEqual({
+          ...fixtures.defaults,
+          ...fixtures.singlePreference,
         });
+      });
     });
 
-    describe("concurrent writers", () => {
-        editTest("merges over the server's preferences, not a stale cached copy", async ({ server, wrapper }) => {
-            let storedAccessibility = JSON.stringify({ nightShift: "light" });
-            const writtenAccessibility: string[] = [];
+    editTest('throws error when user is not loaded', async ({ server, wrapper }) => {
+      server.use(
+        http.get(USERS_API_URL, () => {
+          return HttpResponse.json({ users: [] });
+        }),
+      );
 
-            server.use(
-                http.get(USERS_API_URL, () => {
-                    return HttpResponse.json({
-                        users: [{ ...mockUser, accessibility: storedAccessibility }],
-                    });
-                }),
-                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
-                    USER_UPDATE_API_URL,
-                    async ({ request }) => {
-                        const body = await request.json();
-                        storedAccessibility = body.users[0]?.accessibility ?? "";
-                        writtenAccessibility.push(storedAccessibility);
-                        return HttpResponse.json({
-                            users: [{ ...mockUser, accessibility: storedAccessibility }],
-                        });
-                    }
-                )
-            );
+      const { result } = renderHook(() => useEditUserPreferences(), {
+        wrapper,
+      });
 
-            const queryResult = renderHook(() => useUserPreferences(), { wrapper });
-            await waitForQuerySettled(queryResult.result);
-
-            const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
-
-            // Another writer (a second tab, or Ember's feature service) stores a
-            // preference this client has never read.
-            storedAccessibility = JSON.stringify({ nightShift: "dark" });
-
-            await act(async () => {
-                await mutationResult.result.current.mutateAsync({
-                    navigation: { menu: { visible: false } },
-                });
-            });
-
-            expect(writtenAccessibility).toHaveLength(1);
-            expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
-                nightShift: "dark",
-                navigation: { menu: { visible: false } },
-            });
-        });
-
-        editTest("falls back to the cached user when the server's reply does not parse", async ({ server, setup }) => {
-            const { mutation } = await setup({
-                accessibility: JSON.stringify({ nightShift: "dark" }),
-            });
-
-            const writtenAccessibility: string[] = [];
-
-            // Everything is settled; from here the read this write depends on
-            // answers with a payload that cannot be trusted.
-            server.use(
-                http.get(USERS_API_URL, () => HttpResponse.json({ users: [{ id: 42 }] })),
-                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
-                    USER_UPDATE_API_URL,
-                    async ({ request }) => {
-                        const body = await request.json();
-                        writtenAccessibility.push(body.users[0]?.accessibility ?? "");
-                        return HttpResponse.json({ users: [{ ...mockUser }] });
-                    }
-                )
-            );
-
-            await act(async () => {
-                await mutation.current.mutateAsync({
-                    navigation: { menu: { visible: false } },
-                });
-            });
-
-            // The write still lands, merged over what the cache holds.
-            expect(writtenAccessibility).toHaveLength(1);
-            expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
-                nightShift: "dark",
-                navigation: { menu: { visible: false } },
-            });
-        });
+      await expect(
+        act(async () => {
+          await result.current.mutateAsync(fixtures.singlePreference);
+        }),
+      ).rejects.toThrow('User is not loaded');
     });
+  });
+
+  describe('deep merge behavior', () => {
+    editTest(
+      'deep merges nested objects while preserving sibling properties',
+      async ({ setup }) => {
+        const { query, mutation } = await setup({
+          accessibility: JSON.stringify({
+            navigation: {
+              expanded: { posts: false, members: false },
+              menu: { visible: true },
+            },
+            onboarding: {
+              completedSteps: ['customize-design'],
+              checklistState: 'started',
+            },
+            nightShift: 'dark',
+          }),
+        });
+
+        await act(async () => {
+          await mutation.current.mutateAsync({
+            navigation: { expanded: { posts: true } },
+            onboarding: { completedSteps: ['customize-design', 'first-post'] },
+          });
+        });
+
+        await waitFor(() => {
+          expect(query.current.data).toEqual({
+            navigation: {
+              expanded: { posts: true, members: false },
+              menu: { visible: true }, // Preserved
+            },
+            onboarding: {
+              completedSteps: ['customize-design', 'first-post'],
+              checklistState: 'started',
+            },
+            nightShift: 'dark', // Preserved
+          });
+        });
+      },
+    );
+  });
+
+  describe('concurrent writers', () => {
+    editTest(
+      "merges over the server's preferences, not a stale cached copy",
+      async ({ server, wrapper }) => {
+        let storedAccessibility = JSON.stringify({ nightShift: 'light' });
+        const writtenAccessibility: string[] = [];
+
+        server.use(
+          http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+              users: [{ ...mockUser, accessibility: storedAccessibility }],
+            });
+          }),
+          http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+            USER_UPDATE_API_URL,
+            async ({ request }) => {
+              const body = await request.json();
+              storedAccessibility = body.users[0]?.accessibility ?? '';
+              writtenAccessibility.push(storedAccessibility);
+              return HttpResponse.json({
+                users: [{ ...mockUser, accessibility: storedAccessibility }],
+              });
+            },
+          ),
+        );
+
+        const queryResult = renderHook(() => useUserPreferences(), { wrapper });
+        await waitForQuerySettled(queryResult.result);
+
+        const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
+
+        // Another writer (a second tab, or Ember's feature service) stores a
+        // preference this client has never read.
+        storedAccessibility = JSON.stringify({ nightShift: 'dark' });
+
+        await act(async () => {
+          await mutationResult.result.current.mutateAsync({
+            navigation: { menu: { visible: false } },
+          });
+        });
+
+        expect(writtenAccessibility).toHaveLength(1);
+        expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
+          nightShift: 'dark',
+          navigation: { menu: { visible: false } },
+        });
+      },
+    );
+
+    editTest(
+      "falls back to the cached user when the server's reply does not parse",
+      async ({ server, setup }) => {
+        const { mutation } = await setup({
+          accessibility: JSON.stringify({ nightShift: 'dark' }),
+        });
+
+        const writtenAccessibility: string[] = [];
+
+        // Everything is settled; from here the read this write depends on
+        // answers with a payload that cannot be trusted.
+        server.use(
+          http.get(USERS_API_URL, () => HttpResponse.json({ users: [{ id: 42 }] })),
+          http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+            USER_UPDATE_API_URL,
+            async ({ request }) => {
+              const body = await request.json();
+              writtenAccessibility.push(body.users[0]?.accessibility ?? '');
+              return HttpResponse.json({ users: [{ ...mockUser }] });
+            },
+          ),
+        );
+
+        await act(async () => {
+          await mutation.current.mutateAsync({
+            navigation: { menu: { visible: false } },
+          });
+        });
+
+        // The write still lands, merged over what the cache holds.
+        expect(writtenAccessibility).toHaveLength(1);
+        expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
+          nightShift: 'dark',
+          navigation: { menu: { visible: false } },
+        });
+      },
+    );
+  });
 });

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -1,46 +1,37 @@
-import { test as baseTest, describe, expect } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
-import type { QueryClient } from '@tanstack/react-query';
-import {
-  useUserPreferences,
-  useEditUserPreferences,
-  DEFAULT_NAVIGATION_PREFERENCES,
-  DEFAULT_ONBOARDING_PREFERENCES,
-} from './user-preferences';
-import { HttpResponse, http } from 'msw';
-import { mockUser } from '@test-utils/factories';
-import { waitForQuerySettled } from '@test-utils/test-helpers';
-import { serverFixture } from '@test-utils/fixtures/msw';
-import { queryClientFixtures, type TestWrapperComponent } from '@test-utils/fixtures/query-client';
-import type {
-  UpdateUserRequestBody,
-  UsersResponseType,
-  User,
-} from '@tryghost/admin-x-framework/api/users';
-import type { SetupServer } from 'msw/node';
+import { test as baseTest, describe, expect } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { QueryClient } from "@tanstack/react-query";
+import { useUserPreferences, useEditUserPreferences, DEFAULT_NAVIGATION_PREFERENCES, DEFAULT_ONBOARDING_PREFERENCES } from "./user-preferences";
+import { HttpResponse, http } from "msw";
+import { mockUser } from "@test-utils/factories";
+import { waitForQuerySettled } from "@test-utils/test-helpers";
+import { serverFixture } from "@test-utils/fixtures/msw";
+import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
+import type { UpdateUserRequestBody, UsersResponseType, User } from "@tryghost/admin-x-framework/api/users";
+import type { SetupServer } from "msw/node";
 
 // Constants
-const USERS_API_URL = '/ghost/api/admin/users/me/';
-const USER_UPDATE_API_URL = '/ghost/api/admin/users/:id/';
+const USERS_API_URL = "/ghost/api/admin/users/me/";
+const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
 
 // Test fixtures
 const fixtures = {
-  emptyPreferences: {},
-  existingPreferences: {
-    existing: 'value',
-    shared: 'old',
-  },
-  newPreferences: {
-    shared: 'new',
-    additional: 'data',
-  },
-  singlePreference: {
-    setting: 'value',
-  },
-  defaults: {
-    navigation: DEFAULT_NAVIGATION_PREFERENCES,
-    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
-  },
+    emptyPreferences: {},
+    existingPreferences: {
+        existing: "value",
+        shared: "old",
+    },
+    newPreferences: {
+        shared: "new",
+        additional: "data",
+    },
+    singlePreference: {
+        setting: "value",
+    },
+    defaults: {
+        navigation: DEFAULT_NAVIGATION_PREFERENCES,
+        onboarding: DEFAULT_ONBOARDING_PREFERENCES,
+    }
 };
 
 // Setup functions
@@ -59,30 +50,30 @@ const fixtures = {
  * @returns The renderHook result with the query in a settled state
  */
 async function setupQuery(
-  server: SetupServer,
-  wrapper: TestWrapperComponent,
-  userOverrides: Partial<User> = {},
+    server: SetupServer,
+    wrapper: TestWrapperComponent,
+    userOverrides: Partial<User> = {}
 ) {
-  // Mock the user API endpoint with customizable user data
-  server.use(
-    http.get(USERS_API_URL, () => {
-      return HttpResponse.json({
-        users: [
-          {
-            ...mockUser,
-            ...userOverrides,
-          },
-        ],
-      });
-    }),
-  );
+    // Mock the user API endpoint with customizable user data
+    server.use(
+        http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        ...userOverrides,
+                    },
+                ],
+            });
+        })
+    );
 
-  // Render the hook and wait for it to finish loading
-  const { result } = renderHook(() => useUserPreferences(), {
-    wrapper,
-  });
-  await waitForQuerySettled(result);
-  return result;
+    // Render the hook and wait for it to finish loading
+    const { result } = renderHook(() => useUserPreferences(), {
+        wrapper,
+    });
+    await waitForQuerySettled(result);
+    return result;
 }
 
 /**
@@ -100,452 +91,513 @@ async function setupQuery(
  * @returns Both query and mutation hook results, ready for testing edits
  */
 async function setupEdit(
-  server: SetupServer,
-  wrapper: TestWrapperComponent,
-  initialUser: Partial<User> = {},
+    server: SetupServer,
+    wrapper: TestWrapperComponent,
+    initialUser: Partial<User> = {}
 ) {
-  // Mock both the GET endpoint (for reading preferences) and PUT endpoint (for edits)
-  server.use(
-    http.get(USERS_API_URL, () => {
-      return HttpResponse.json({
-        users: [
-          {
-            ...mockUser,
-            ...initialUser,
-          },
-        ],
-      });
-    }),
-    http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
-      USER_UPDATE_API_URL,
-      async ({ request }) => {
-        const body = await request.json();
-        const accessibility = body.users[0]?.accessibility ?? '';
-        return HttpResponse.json({
-          users: [
-            {
-              ...mockUser,
-              accessibility,
-            },
-          ],
-        });
-      },
-    ),
-  );
+    // Mock both the GET endpoint (for reading preferences) and PUT endpoint (for edits)
+    server.use(
+        http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        ...initialUser,
+                    },
+                ],
+            });
+        }),
+        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+            USER_UPDATE_API_URL,
+            async ({ request }) => {
+                const body = await request.json();
+                const accessibility = body.users[0]?.accessibility ?? "";
+                return HttpResponse.json({
+                    users: [
+                        {
+                            ...mockUser,
+                            accessibility,
+                        },
+                    ],
+                });
+            }
+        )
+    );
 
-  // Render the query hook and wait for initial data to load
-  const queryResult = renderHook(() => useUserPreferences(), {
-    wrapper,
-  });
-  await waitForQuerySettled(queryResult.result);
+    // Render the query hook and wait for initial data to load
+    const queryResult = renderHook(() => useUserPreferences(), {
+        wrapper,
+    });
+    await waitForQuerySettled(queryResult.result);
 
-  // Render the mutation hook (ready to call mutateAsync in tests)
-  const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
+    // Render the mutation hook (ready to call mutateAsync in tests)
+    const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
 
-  return {
-    query: queryResult.result,
-    mutation: mutationResult.result,
-  };
+    return {
+        query: queryResult.result,
+        mutation: mutationResult.result,
+    };
 }
 
 // Test extensions
 const queryTest = baseTest.extend<{
-  server: SetupServer;
-  queryClient: QueryClient;
-  wrapper: TestWrapperComponent;
-  setup: (userOverrides?: Partial<User>) => ReturnType<typeof setupQuery>;
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+    setup: (userOverrides?: Partial<User>) => ReturnType<typeof setupQuery>;
 }>({
-  ...serverFixture,
-  ...queryClientFixtures,
-  setup: async ({ server, wrapper }, provide) => {
-    await provide((userOverrides) => setupQuery(server, wrapper, userOverrides));
-  },
+    ...serverFixture,
+    ...queryClientFixtures,
+    setup: async ({ server, wrapper }, provide) => {
+        await provide((userOverrides) => setupQuery(server, wrapper, userOverrides));
+    },
 });
 
 const editTest = baseTest.extend<{
-  server: SetupServer;
-  queryClient: QueryClient;
-  wrapper: TestWrapperComponent;
-  setup: (initialUser?: Partial<User>) => ReturnType<typeof setupEdit>;
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+    setup: (initialUser?: Partial<User>) => ReturnType<typeof setupEdit>;
 }>({
-  ...serverFixture,
-  ...queryClientFixtures,
-  setup: async ({ server, wrapper }, provide) => {
-    await provide((initialUser) => setupEdit(server, wrapper, initialUser));
-  },
+    ...serverFixture,
+    ...queryClientFixtures,
+    setup: async ({ server, wrapper }, provide) => {
+        await provide((initialUser) => setupEdit(server, wrapper, initialUser));
+    },
 });
 
-describe('useUserPreferences', () => {
-  describe('initialization', () => {
-    [
-      {
-        scenario: 'null',
-        accessibility: null,
-      },
-      {
-        scenario: 'undefined',
-        accessibility: undefined,
-      },
-      {
-        scenario: 'empty string',
-        accessibility: '',
-      },
-    ].forEach(({ scenario, accessibility }) => {
-      queryTest(
-        `returns object with defaults when accessibility is ${scenario}`,
-        async ({ setup }) => {
-          const result = await setup({ accessibility });
+describe("useUserPreferences", () => {
+    describe("initialization", () => {
+        [
+            {
+                scenario: "null",
+                accessibility: null,
+            },
+            {
+                scenario: "undefined",
+                accessibility: undefined,
+            },
+            {
+                scenario: "empty string",
+                accessibility: "",
+            },
+        ].forEach(({ scenario, accessibility }) => {
+            queryTest(`returns object with defaults when accessibility is ${scenario}`, async ({ setup }) => {
+                const result = await setup({ accessibility });
 
-          expect(result.current.data).toEqual(fixtures.defaults);
-        },
-      );
-    });
-
-    queryTest('parses JSON from accessibility field', async ({ setup }) => {
-      const result = await setup({
-        accessibility: JSON.stringify(fixtures.existingPreferences),
-      });
-
-      expect(result.current.data).toEqual({
-        ...fixtures.defaults,
-        ...fixtures.existingPreferences,
-      });
-    });
-
-    queryTest('errors when invalid JSON', async ({ setup }) => {
-      const result = await setup({ accessibility: '{invalid json' });
-
-      expect(result.current.isError).toBe(true);
-      expect(result.current.error).toBeInstanceOf(Error);
-    });
-
-    queryTest('gracefully handles invalid schema values', async ({ setup }) => {
-      const result = await setup({
-        accessibility: JSON.stringify({
-          onboarding: {
-            checklistState: 'unknown',
-            completedSteps: 'customize-design',
-            startedAt: 'not-a-valid-datetime',
-          },
-          whatsNew: {
-            lastSeenDate: 'not-a-valid-datetime',
-          },
-        }),
-      });
-
-      // Should not error - catches and returns undefined for invalid fields
-      expect(result.current.isError).toBe(false);
-      expect(result.current.data).toEqual({
-        ...fixtures.defaults,
-        whatsNew: {
-          lastSeenDate: undefined,
-        },
-      });
-    });
-
-    queryTest('parses onboarding startedAt into a date', async ({ setup }) => {
-      const result = await setup({
-        accessibility: JSON.stringify({
-          onboarding: {
-            completedSteps: ['customize-design'],
-            checklistState: 'started',
-            startedAt: '2026-04-30T10:00:00.000Z',
-          },
-        }),
-      });
-
-      expect(result.current.data?.onboarding).toEqual({
-        completedSteps: ['customize-design'],
-        checklistState: 'started',
-        startedAt: new Date('2026-04-30T10:00:00.000Z'),
-      });
-    });
-
-    describe('nightShift migration', () => {
-      [
-        { scenario: 'legacy boolean true', value: true, expected: 'dark' },
-        { scenario: 'legacy boolean false', value: false, expected: 'light' },
-        { scenario: 'dark string', value: 'dark', expected: 'dark' },
-        { scenario: 'light string', value: 'light', expected: 'light' },
-        { scenario: 'system string', value: 'system', expected: 'system' },
-        { scenario: 'invalid value', value: 'invalid', expected: 'light' },
-      ].forEach(({ scenario, value, expected }) => {
-        queryTest(`parses ${scenario}`, async ({ setup }) => {
-          const result = await setup({
-            accessibility: JSON.stringify({ nightShift: value }),
-          });
-
-          expect(result.current.data?.nightShift).toBe(expected);
-        });
-      });
-
-      queryTest('omits nightShift when the preference is absent', async ({ setup }) => {
-        const result = await setup({
-          accessibility: JSON.stringify({}),
-        });
-
-        // Absent stays absent so it isn't written back on unrelated saves;
-        // the display fallback to "light" lives in useTheme.
-        expect(result.current.data?.nightShift).toBeUndefined();
-      });
-
-      queryTest('preserves explicit system preference', async ({ setup }) => {
-        const result = await setup({
-          accessibility: JSON.stringify({ nightShift: 'system' }),
-        });
-
-        expect(result.current.data?.nightShift).toBe('system');
-      });
-    });
-
-    queryTest('returns undefined when user is not loaded', async ({ server, wrapper }) => {
-      server.use(
-        http.get(USERS_API_URL, () => {
-          return HttpResponse.json({ users: [] });
-        }),
-      );
-
-      const { result } = renderHook(() => useUserPreferences(), {
-        wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isFetching).toBe(false);
-      });
-
-      expect(result.current.data).toBeUndefined();
-    });
-  });
-
-  describe('query options', () => {
-    queryTest('supports select option to transform data', async ({ server, wrapper }) => {
-      server.use(
-        http.get(USERS_API_URL, () => {
-          return HttpResponse.json({
-            users: [
-              {
-                ...mockUser,
-                accessibility: JSON.stringify({
-                  navigation: {
-                    expanded: { posts: false },
-                    menu: { visible: true },
-                  },
-                  nightShift: 'dark',
-                }),
-              },
-            ],
-          });
-        }),
-      );
-
-      const { result } = renderHook(
-        () =>
-          useUserPreferences({
-            select: (data) => data.navigation,
-          }),
-        { wrapper },
-      );
-
-      await waitForQuerySettled(result);
-
-      expect(result.current.data).toEqual({
-        expanded: { posts: false, members: true },
-        menu: { visible: true },
-      });
-    });
-
-    queryTest(
-      'keeps previous data during unrelated accessibility updates',
-      async ({ server, wrapper }) => {
-        server.use(
-          http.get(USERS_API_URL, () => {
-            return HttpResponse.json({
-              users: [
-                {
-                  ...mockUser,
-                  accessibility: JSON.stringify({
-                    navigation: DEFAULT_NAVIGATION_PREFERENCES,
-                    whatsNew: {
-                      lastSeenDate: '2025-01-01T00:00:00.000Z',
-                    },
-                  }),
-                },
-              ],
+                expect(result.current.data).toEqual(fixtures.defaults);
             });
-          }),
-          http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
-            USER_UPDATE_API_URL,
-            async ({ request }) => {
-              const body = await request.json();
-
-              await new Promise((resolve) => {
-                setTimeout(resolve, 25);
-              });
-
-              return HttpResponse.json({
-                users: [
-                  {
-                    ...mockUser,
-                    accessibility: body.users[0]?.accessibility ?? '',
-                  },
-                ],
-              });
-            },
-          ),
-        );
-
-        const snapshots: Array<ReturnType<typeof useUserPreferences>['data']> = [];
-
-        const { result } = renderHook(
-          () => {
-            const query = useUserPreferences();
-            const mutation = useEditUserPreferences();
-
-            snapshots.push(query.data);
-
-            return { query, mutation };
-          },
-          { wrapper },
-        );
-
-        await waitFor(() => {
-          expect(result.current.query.data).toEqual({
-            navigation: DEFAULT_NAVIGATION_PREFERENCES,
-            onboarding: DEFAULT_ONBOARDING_PREFERENCES,
-            whatsNew: {
-              lastSeenDate: new Date('2025-01-01T00:00:00.000Z'),
-            },
-          });
         });
 
-        snapshots.length = 0;
+        queryTest("parses JSON from accessibility field", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify(fixtures.existingPreferences),
+            });
 
-        await act(async () => {
-          await result.current.mutation.mutateAsync({
-            navigation: {
-              expanded: {
-                posts: false,
-              },
-            },
-          });
+            expect(result.current.data).toEqual({
+                ...fixtures.defaults,
+                ...fixtures.existingPreferences,
+            });
         });
 
-        await waitFor(() => {
-          expect(result.current.query.data).toEqual({
-            navigation: {
-              ...DEFAULT_NAVIGATION_PREFERENCES,
-              expanded: {
-                ...DEFAULT_NAVIGATION_PREFERENCES.expanded,
-                posts: false,
-              },
-            },
-            onboarding: DEFAULT_ONBOARDING_PREFERENCES,
-            whatsNew: {
-              lastSeenDate: new Date('2025-01-01T00:00:00.000Z'),
-            },
-          });
+        queryTest("errors when invalid JSON", async ({ setup }) => {
+            const result = await setup({ accessibility: "{invalid json" });
+
+            expect(result.current.isError).toBe(true);
+            expect(result.current.error).toBeInstanceOf(Error);
         });
 
-        expect(snapshots).not.toContain(undefined);
-      },
-    );
-  });
+        queryTest("gracefully handles invalid schema values", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({
+                    onboarding: {
+                        checklistState: "unknown",
+                        completedSteps: "customize-design",
+                        startedAt: "not-a-valid-datetime",
+                    },
+                    whatsNew: {
+                        lastSeenDate: "not-a-valid-datetime",
+                    },
+                }),
+            });
+
+            // Should not error - catches and returns undefined for invalid fields
+            expect(result.current.isError).toBe(false);
+            expect(result.current.data).toEqual({
+                ...fixtures.defaults,
+                whatsNew: {
+                    lastSeenDate: undefined,
+                },
+            });
+        });
+
+        queryTest("parses onboarding startedAt into a date", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({
+                    onboarding: {
+                        completedSteps: ["customize-design"],
+                        checklistState: "started",
+                        startedAt: "2026-04-30T10:00:00.000Z",
+                    },
+                }),
+            });
+
+            expect(result.current.data?.onboarding).toEqual({
+                completedSteps: ["customize-design"],
+                checklistState: "started",
+                startedAt: new Date("2026-04-30T10:00:00.000Z"),
+            });
+        });
+
+        describe("nightShift migration", () => {
+            [
+                {scenario: "legacy boolean true", value: true, expected: "dark"},
+                {scenario: "legacy boolean false", value: false, expected: "light"},
+                {scenario: "dark string", value: "dark", expected: "dark"},
+                {scenario: "light string", value: "light", expected: "light"},
+                {scenario: "system string", value: "system", expected: "system"},
+                {scenario: "invalid value", value: "invalid", expected: "light"},
+            ].forEach(({scenario, value, expected}) => {
+                queryTest(`parses ${scenario}`, async ({ setup }) => {
+                    const result = await setup({
+                        accessibility: JSON.stringify({nightShift: value}),
+                    });
+
+                    expect(result.current.data?.nightShift).toBe(expected);
+                });
+            });
+
+            queryTest("omits nightShift when the preference is absent", async ({ setup }) => {
+                const result = await setup({
+                    accessibility: JSON.stringify({}),
+                });
+
+                // Absent stays absent so it isn't written back on unrelated saves;
+                // the display fallback to "light" lives in useTheme.
+                expect(result.current.data?.nightShift).toBeUndefined();
+            });
+
+            queryTest("preserves explicit system preference", async ({ setup }) => {
+                const result = await setup({
+                    accessibility: JSON.stringify({nightShift: "system"}),
+                });
+
+                expect(result.current.data?.nightShift).toBe("system");
+            });
+        });
+
+        queryTest("returns undefined when user is not loaded", async ({ server, wrapper }) => {
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({ users: [] });
+                })
+            );
+
+            const { result } = renderHook(() => useUserPreferences(), {
+                wrapper,
+            });
+
+            await waitFor(() => {
+                expect(result.current.isFetching).toBe(false);
+            });
+
+            expect(result.current.data).toBeUndefined();
+        });
+    });
+
+    describe("query options", () => {
+        queryTest("supports select option to transform data", async ({ server, wrapper }) => {
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({
+                        users: [{
+                            ...mockUser,
+                            accessibility: JSON.stringify({
+                                navigation: {
+                                    expanded: { posts: false },
+                                    menu: { visible: true },
+                                },
+                                nightShift: "dark",
+                            }),
+                        }],
+                    });
+                })
+            );
+
+            const { result } = renderHook(() => useUserPreferences({
+                select: (data) => data.navigation,
+            }), { wrapper });
+
+            await waitForQuerySettled(result);
+
+            expect(result.current.data).toEqual({
+                expanded: { posts: false, members: true },
+                menu: { visible: true },
+            });
+        });
+
+        queryTest("keeps previous data during unrelated accessibility updates", async ({ server, wrapper }) => {
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({
+                        users: [
+                            {
+                                ...mockUser,
+                                accessibility: JSON.stringify({
+                                    navigation: DEFAULT_NAVIGATION_PREFERENCES,
+                                    whatsNew: {
+                                        lastSeenDate: "2025-01-01T00:00:00.000Z",
+                                    },
+                                }),
+                            },
+                        ],
+                    });
+                }),
+                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(USER_UPDATE_API_URL, async ({ request }) => {
+                    const body = await request.json();
+
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 25);
+                    });
+
+                    return HttpResponse.json({
+                        users: [
+                            {
+                                ...mockUser,
+                                accessibility: body.users[0]?.accessibility ?? "",
+                            },
+                        ],
+                    });
+                })
+            );
+
+            const snapshots: Array<ReturnType<typeof useUserPreferences>["data"]> = [];
+
+            const { result } = renderHook(() => {
+                const query = useUserPreferences();
+                const mutation = useEditUserPreferences();
+
+                snapshots.push(query.data);
+
+                return {query, mutation};
+            }, { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.query.data).toEqual({
+                    navigation: DEFAULT_NAVIGATION_PREFERENCES,
+                    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
+                    whatsNew: {
+                        lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
+                    },
+                });
+            });
+
+            snapshots.length = 0;
+
+            await act(async () => {
+                await result.current.mutation.mutateAsync({
+                    navigation: {
+                        expanded: {
+                            posts: false,
+                        },
+                    },
+                });
+            });
+
+            await waitFor(() => {
+                expect(result.current.query.data).toEqual({
+                    navigation: {
+                        ...DEFAULT_NAVIGATION_PREFERENCES,
+                        expanded: {
+                            ...DEFAULT_NAVIGATION_PREFERENCES.expanded,
+                            posts: false,
+                        },
+                    },
+                    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
+                    whatsNew: {
+                        lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
+                    },
+                });
+            });
+
+            expect(snapshots).not.toContain(undefined);
+        });
+    });
 });
 
-describe('useEditUserPreferences', () => {
-  describe('editing preferences', () => {
-    editTest('merges new preferences with existing ones', async ({ setup }) => {
-      const { query, mutation } = await setup({
-        accessibility: JSON.stringify(fixtures.existingPreferences),
-      });
+describe("useEditUserPreferences", () => {
+    describe("editing preferences", () => {
+        editTest("merges new preferences with existing ones", async ({ setup }) => {
+            const { query, mutation } = await setup({
+                accessibility: JSON.stringify(fixtures.existingPreferences),
+            });
 
-      await act(async () => {
-        await mutation.current.mutateAsync(fixtures.newPreferences);
-      });
+            await act(async () => {
+                await mutation.current.mutateAsync(fixtures.newPreferences);
+            });
 
-      await waitFor(() => {
-        expect(query.current.data).toEqual({
-          ...fixtures.defaults,
-          existing: 'value',
-          shared: 'new',
-          additional: 'data',
+            await waitFor(() => {
+                expect(query.current.data).toEqual({
+                    ...fixtures.defaults,
+                    existing: "value",
+                    shared: "new",
+                    additional: "data",
+                });
+            });
         });
-      });
+
+        editTest("creates new accessibility object when none exists", async ({ setup }) => {
+            const { query, mutation } = await setup();
+
+            await act(async () => {
+                await mutation.current.mutateAsync(fixtures.singlePreference);
+            });
+
+            await waitFor(() => {
+                expect(query.current.data).toEqual({
+                    ...fixtures.defaults,
+                    ...fixtures.singlePreference,
+                });
+            });
+        });
+
+        editTest("throws error when user is not loaded", async ({ server, wrapper }) => {
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({ users: [] });
+                })
+            );
+
+            const { result } = renderHook(() => useEditUserPreferences(), {
+                wrapper,
+            });
+
+            await expect(
+                act(async () => {
+                    await result.current.mutateAsync(fixtures.singlePreference);
+                })
+            ).rejects.toThrow("User is not loaded");
+        });
     });
 
-    editTest('creates new accessibility object when none exists', async ({ setup }) => {
-      const { query, mutation } = await setup();
+    describe("deep merge behavior", () => {
+        editTest("deep merges nested objects while preserving sibling properties", async ({ setup }) => {
+            const { query, mutation } = await setup({
+                accessibility: JSON.stringify({
+                    navigation: {
+                        expanded: { posts: false, members: false },
+                        menu: { visible: true },
+                    },
+                    onboarding: {
+                        completedSteps: ["customize-design"],
+                        checklistState: "started",
+                    },
+                    nightShift: "dark",
+                }),
+            });
 
-      await act(async () => {
-        await mutation.current.mutateAsync(fixtures.singlePreference);
-      });
+            await act(async () => {
+                await mutation.current.mutateAsync({
+                    navigation: { expanded: { posts: true } },
+                    onboarding: { completedSteps: ["customize-design", "first-post"] },
+                });
+            });
 
-      await waitFor(() => {
-        expect(query.current.data).toEqual({
-          ...fixtures.defaults,
-          ...fixtures.singlePreference,
+            await waitFor(() => {
+                expect(query.current.data).toEqual({
+                    navigation: {
+                        expanded: { posts: true, members: false },
+                        menu: { visible: true }, // Preserved
+                    },
+                    onboarding: {
+                        completedSteps: ["customize-design", "first-post"],
+                        checklistState: "started",
+                    },
+                    nightShift: "dark", // Preserved
+                });
+            });
         });
-      });
     });
 
-    editTest('throws error when user is not loaded', async ({ server, wrapper }) => {
-      server.use(
-        http.get(USERS_API_URL, () => {
-          return HttpResponse.json({ users: [] });
-        }),
-      );
+    describe("concurrent writers", () => {
+        editTest("merges over the server's preferences, not a stale cached copy", async ({ server, wrapper }) => {
+            let storedAccessibility = JSON.stringify({ nightShift: "light" });
+            const writtenAccessibility: string[] = [];
 
-      const { result } = renderHook(() => useEditUserPreferences(), {
-        wrapper,
-      });
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({
+                        users: [{ ...mockUser, accessibility: storedAccessibility }],
+                    });
+                }),
+                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+                    USER_UPDATE_API_URL,
+                    async ({ request }) => {
+                        const body = await request.json();
+                        storedAccessibility = body.users[0]?.accessibility ?? "";
+                        writtenAccessibility.push(storedAccessibility);
+                        return HttpResponse.json({
+                            users: [{ ...mockUser, accessibility: storedAccessibility }],
+                        });
+                    }
+                )
+            );
 
-      await expect(
-        act(async () => {
-          await result.current.mutateAsync(fixtures.singlePreference);
-        }),
-      ).rejects.toThrow('User is not loaded');
+            const queryResult = renderHook(() => useUserPreferences(), { wrapper });
+            await waitForQuerySettled(queryResult.result);
+
+            const mutationResult = renderHook(() => useEditUserPreferences(), { wrapper });
+
+            // Another writer (a second tab, or Ember's feature service) stores a
+            // preference this client has never read.
+            storedAccessibility = JSON.stringify({ nightShift: "dark" });
+
+            await act(async () => {
+                await mutationResult.result.current.mutateAsync({
+                    navigation: { menu: { visible: false } },
+                });
+            });
+
+            expect(writtenAccessibility).toHaveLength(1);
+            expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
+                nightShift: "dark",
+                navigation: { menu: { visible: false } },
+            });
+        });
+
+        editTest("falls back to the cached user when the server's reply does not parse", async ({ server, setup }) => {
+            const { mutation } = await setup({
+                accessibility: JSON.stringify({ nightShift: "dark" }),
+            });
+
+            const writtenAccessibility: string[] = [];
+
+            // Everything is settled; from here the read this write depends on
+            // answers with a payload that cannot be trusted.
+            server.use(
+                http.get(USERS_API_URL, () => HttpResponse.json({ users: [{ id: 42 }] })),
+                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+                    USER_UPDATE_API_URL,
+                    async ({ request }) => {
+                        const body = await request.json();
+                        writtenAccessibility.push(body.users[0]?.accessibility ?? "");
+                        return HttpResponse.json({ users: [{ ...mockUser }] });
+                    }
+                )
+            );
+
+            await act(async () => {
+                await mutation.current.mutateAsync({
+                    navigation: { menu: { visible: false } },
+                });
+            });
+
+            // The write still lands, merged over what the cache holds.
+            expect(writtenAccessibility).toHaveLength(1);
+            expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
+                nightShift: "dark",
+                navigation: { menu: { visible: false } },
+            });
+        });
     });
-  });
-
-  describe('deep merge behavior', () => {
-    editTest(
-      'deep merges nested objects while preserving sibling properties',
-      async ({ setup }) => {
-        const { query, mutation } = await setup({
-          accessibility: JSON.stringify({
-            navigation: {
-              expanded: { posts: false, members: false },
-              menu: { visible: true },
-            },
-            onboarding: {
-              completedSteps: ['customize-design'],
-              checklistState: 'started',
-            },
-            nightShift: 'dark',
-          }),
-        });
-
-        await act(async () => {
-          await mutation.current.mutateAsync({
-            navigation: { expanded: { posts: true } },
-            onboarding: { completedSteps: ['customize-design', 'first-post'] },
-          });
-        });
-
-        await waitFor(() => {
-          expect(query.current.data).toEqual({
-            navigation: {
-              expanded: { posts: true, members: false },
-              menu: { visible: true }, // Preserved
-            },
-            onboarding: {
-              completedSteps: ['customize-design', 'first-post'],
-              checklistState: 'started',
-            },
-            nightShift: 'dark', // Preserved
-          });
-        });
-      },
-    );
-  });
 });

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -1,72 +1,51 @@
-import {
-  useQuery,
-  useMutation,
-  keepPreviousData,
-  type UseQueryResult,
-  type UseMutationResult,
-  type UseQueryOptions,
-} from '@tanstack/react-query';
-import { z } from 'zod';
-import { useQueryClient } from '@tryghost/admin-x-framework';
-import { currentUserQueryKey, useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
-import {
-  useEditUser,
-  type User,
-  type UsersResponseType,
-} from '@tryghost/admin-x-framework/api/users';
-import { isoDatetimeToDate } from '@/schemas/primitives';
-import { deepMerge, type DeepPartial } from '@/utils/deep-merge';
+import { useQuery, useMutation, keepPreviousData, type UseQueryResult, type UseMutationResult, type UseQueryOptions } from "@tanstack/react-query";
+import { z } from "zod";
+import { useQueryClient } from "@tryghost/admin-x-framework";
+import { currentUserQueryKey, useCurrentUser, useFetchCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
+import { useEditUser, type User, type UsersResponseType } from "@tryghost/admin-x-framework/api/users";
+import { isoDatetimeToDate } from "@/schemas/primitives";
+import { deepMerge, type DeepPartial } from "@/utils/deep-merge";
 
 const WhatsNewPreferencesSchema = z.looseObject({
-  lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
+    lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
 
 export const DEFAULT_ONBOARDING_PREFERENCES = {
-  completedSteps: [] as string[],
-  checklistState: 'pending' as const,
-  startedAt: undefined as Date | undefined,
+    completedSteps: [] as string[],
+    checklistState: "pending" as const,
+    startedAt: undefined as Date | undefined,
 };
 
 export const OnboardingPreferencesSchema = z.looseObject({
-  completedSteps: z
-    .array(z.string())
-    .default(DEFAULT_ONBOARDING_PREFERENCES.completedSteps)
-    .catch(DEFAULT_ONBOARDING_PREFERENCES.completedSteps),
-  checklistState: z
-    .enum(['pending', 'started', 'completed', 'dismissed'])
-    .default(DEFAULT_ONBOARDING_PREFERENCES.checklistState)
-    .catch(DEFAULT_ONBOARDING_PREFERENCES.checklistState),
-  startedAt: isoDatetimeToDate.optional().catch(DEFAULT_ONBOARDING_PREFERENCES.startedAt),
+    completedSteps: z.array(z.string()).default(DEFAULT_ONBOARDING_PREFERENCES.completedSteps).catch(DEFAULT_ONBOARDING_PREFERENCES.completedSteps),
+    checklistState: z.enum(["pending", "started", "completed", "dismissed"]).default(DEFAULT_ONBOARDING_PREFERENCES.checklistState).catch(DEFAULT_ONBOARDING_PREFERENCES.checklistState),
+    startedAt: isoDatetimeToDate.optional().catch(DEFAULT_ONBOARDING_PREFERENCES.startedAt),
 });
 
 export const DEFAULT_NAVIGATION_PREFERENCES = {
-  expanded: { posts: true, members: true },
-  menu: { visible: true },
+    expanded: { posts: true, members: true },
+    menu: { visible: true },
 } as const;
 
 export const NavigationPreferencesSchema = z.looseObject({
-  expanded: z.object({
-    posts: z.boolean(),
-    members: z.boolean().default(true),
-  }),
-  menu: z.object({
-    visible: z.boolean(),
-  }),
+    expanded: z.object({
+        posts: z.boolean(),
+        members: z.boolean().default(true),
+    }),
+    menu: z.object({
+        visible: z.boolean(),
+    }),
 });
 
 const PreferencesSchema = z.looseObject({
-  whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
-  // Optional (not defaulted) so an absent preference stays absent and isn't
-  // eagerly written back on unrelated preference saves. The display fallback to
-  // "light" lives at the read site (see useTheme). New users get "system" from
-  // the server default; legacy booleans are migrated to strings in the queryFn.
-  nightShift: z.enum(['light', 'dark', 'system']).optional().catch('light'),
-  onboarding: OnboardingPreferencesSchema.default(DEFAULT_ONBOARDING_PREFERENCES).catch(
-    DEFAULT_ONBOARDING_PREFERENCES,
-  ),
-  navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(
-    DEFAULT_NAVIGATION_PREFERENCES,
-  ),
+    whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
+    // Optional (not defaulted) so an absent preference stays absent and isn't
+    // eagerly written back on unrelated preference saves. The display fallback to
+    // "light" lives at the read site (see useTheme). New users get "system" from
+    // the server default; legacy booleans are migrated to strings in the queryFn.
+    nightShift: z.enum(["light", "dark", "system"]).optional().catch("light"),
+    onboarding: OnboardingPreferencesSchema.default(DEFAULT_ONBOARDING_PREFERENCES).catch(DEFAULT_ONBOARDING_PREFERENCES),
+    navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
@@ -74,89 +53,110 @@ export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
 export type OnboardingPreferences = z.infer<typeof OnboardingPreferencesSchema>;
 export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 
-const userPreferencesQueryKey = (user: User | undefined) =>
-  ['userPreferences', user?.id, user?.accessibility] as const;
+const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
 
-function parsePreferences(user: User): Preferences {
-  const raw = user.accessibility || '{}';
-  const parsedRaw: unknown = JSON.parse(raw);
-  const parsed: Record<string, unknown> =
-    parsedRaw && typeof parsedRaw === 'object' && !Array.isArray(parsedRaw)
-      ? (parsedRaw as Record<string, unknown>)
-      : {};
+// The write below depends on a user read straight from the API, so validate the
+// fields it uses before trusting them. A payload that does not parse is handled
+// like a read that failed.
+const CurrentUserResponseSchema = z.looseObject({
+    users: z.array(z.looseObject({
+        id: z.string(),
+        accessibility: z.string().nullish(),
+    })).min(1),
+});
 
-  if (parsed.nightShift === true) {
-    parsed.nightShift = 'dark';
-  } else if (parsed.nightShift === false) {
-    parsed.nightShift = 'light';
-  }
+/** What a preferences write reads off the user, whoever supplied it. */
+type PreferenceUser = z.infer<typeof CurrentUserResponseSchema>["users"][number];
 
-  return PreferencesSchema.parse(parsed);
+function parsePreferences(user: Pick<PreferenceUser, "accessibility">): Preferences {
+    const raw = user.accessibility || "{}";
+    const parsedRaw: unknown = JSON.parse(raw);
+    const parsed: Record<string, unknown> =
+        parsedRaw && typeof parsedRaw === "object" && !Array.isArray(parsedRaw)
+            ? parsedRaw as Record<string, unknown>
+            : {};
+
+    if (parsed.nightShift === true) {
+        parsed.nightShift = "dark";
+    } else if (parsed.nightShift === false) {
+        parsed.nightShift = "light";
+    }
+
+    return PreferencesSchema.parse(parsed);
 }
 
 export function useUserPreferences<TData = Preferences>(
-  options?: Omit<
-    UseQueryOptions<Preferences, Error, TData>,
-    'queryKey' | 'queryFn' | 'staleTime' | 'gcTime'
-  >,
+    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn' | 'staleTime' | 'gcTime'>
 ): UseQueryResult<TData> {
-  const { data: user } = useCurrentUser();
+    const { data: user } = useCurrentUser();
 
-  return useQuery<Preferences, Error, TData>({
-    ...options,
-    queryKey: userPreferencesQueryKey(user),
-    queryFn: () => {
-      if (!user) {
-        throw new Error('User not loaded');
-      }
+    return useQuery<Preferences, Error, TData>({
+        ...options,
+        queryKey: userPreferencesQueryKey(user),
+        queryFn: () => {
+            if (!user) {
+                throw new Error("User not loaded");
+            }
 
-      return parsePreferences(user);
-    },
-    enabled: !!user,
-    placeholderData: keepPreviousData,
-    staleTime: Infinity,
-    // Query key includes user?.accessibility to automatically react to changes from ANY source
-    // (our mutation, other code calling editUser, external updates, etc.). When accessibility
-    // changes, the query key changes, making the old cache entry inactive. gcTime: 0 ensures
-    // orphaned entries are immediately garbage collected, preventing memory leaks while keeping
-    // the current active entry cached indefinitely.
-    gcTime: 0,
-  });
+            return parsePreferences(user);
+        },
+        enabled: !!user,
+        placeholderData: keepPreviousData,
+        staleTime: Infinity,
+        // Query key includes user?.accessibility to automatically react to changes from ANY source
+        // (our mutation, other code calling editUser, external updates, etc.). When accessibility
+        // changes, the query key changes, making the old cache entry inactive. gcTime: 0 ensures
+        // orphaned entries are immediately garbage collected, preventing memory leaks while keeping
+        // the current active entry cached indefinitely.
+        gcTime: 0,
+    });
 }
 
-export const useEditUserPreferences = (): UseMutationResult<
-  void,
-  Error,
-  DeepPartial<Preferences>,
-  unknown
-> => {
-  const queryClient = useQueryClient();
-  const { data: user } = useCurrentUser();
-  const { mutateAsync: editUser } = useEditUser();
+export const useEditUserPreferences = (): UseMutationResult<void, Error, DeepPartial<Preferences>, unknown> => {
+    const queryClient = useQueryClient();
+    const { data: user } = useCurrentUser();
+    const { mutateAsync: editUser } = useEditUser();
+    const fetchCurrentUser = useFetchCurrentUser();
 
-  return useMutation({
-    // Preference edits write the whole accessibility blob from a merge of
-    // the current state; the shared scope serializes concurrent edits so
-    // the later one merges on top of the earlier write instead of racing.
-    scope: { id: 'user-preferences' },
-    mutationFn: async (updatedPreferences: DeepPartial<Preferences>) => {
-      // Read the user at run time (not from the render closure): a
-      // serialized mutation must merge on top of the previous write.
-      const latestUser =
-        queryClient.getQueryData<UsersResponseType>(currentUserQueryKey)?.users[0] ?? user;
+    return useMutation({
+        // Preference edits write the whole accessibility blob from a merge of
+        // the current state; the shared scope serializes concurrent edits so
+        // the later one merges on top of the earlier write instead of racing.
+        scope: { id: "user-preferences" },
+        mutationFn: async (updatedPreferences: DeepPartial<Preferences>) => {
+            // Merge over the server's blob, not the cached one. Ember's feature
+            // and onboarding services write this same field, as does Admin in
+            // another tab, and the cached user is not refetched on mount or on
+            // window focus, so a merge over the cache silently reverts whatever
+            // those writers stored. Read around the cache: writing the pre-write
+            // user into it would flip the UI back until this write lands.
+            //
+            // A read that fails falls through to the cache, which is what this
+            // merged over before. Dropping the user's change is worse than a
+            // merge that might be stale, and every caller here floats the
+            // promise, so a dropped write is silent.
+            const serverUser = await fetchCurrentUser()
+                .then(response => CurrentUserResponseSchema.parse(response).users[0])
+                .catch(() => undefined);
 
-      if (!latestUser) {
-        throw new Error('User is not loaded');
-      }
+            // The cache carries the previous write of a serialized mutation;
+            // the render closure is the last resort.
+            const latestUser: PreferenceUser | undefined = serverUser ?? queryClient.getQueryData<UsersResponseType>(currentUserQueryKey)?.users[0] ?? user;
 
-      const newPreferences = deepMerge(parsePreferences(latestUser), updatedPreferences);
+            if (!latestUser) {
+                throw new Error("User is not loaded");
+            }
 
-      const encodedForStorage = PreferencesSchema.encode(newPreferences);
+            const newPreferences = deepMerge(parsePreferences(latestUser), updatedPreferences);
 
-      await editUser({
-        ...latestUser,
-        accessibility: JSON.stringify(encodedForStorage),
-      });
-    },
-  });
+            const encodedForStorage = PreferencesSchema.encode(newPreferences);
+
+            // Send the blob alone: a whole-user payload built from a read taken
+            // moments ago would revert a name or a role changed in between.
+            await editUser({
+                id: latestUser.id,
+                accessibility: JSON.stringify(encodedForStorage),
+            });
+        },
+    });
 };

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -1,51 +1,76 @@
-import { useQuery, useMutation, keepPreviousData, type UseQueryResult, type UseMutationResult, type UseQueryOptions } from "@tanstack/react-query";
-import { z } from "zod";
-import { useQueryClient } from "@tryghost/admin-x-framework";
-import { currentUserQueryKey, useCurrentUser, useFetchCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
-import { useEditUser, type User, type UsersResponseType } from "@tryghost/admin-x-framework/api/users";
-import { isoDatetimeToDate } from "@/schemas/primitives";
-import { deepMerge, type DeepPartial } from "@/utils/deep-merge";
+import {
+  useQuery,
+  useMutation,
+  keepPreviousData,
+  type UseQueryResult,
+  type UseMutationResult,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import { z } from 'zod';
+import { useQueryClient } from '@tryghost/admin-x-framework';
+import {
+  currentUserQueryKey,
+  useCurrentUser,
+  useFetchCurrentUser,
+} from '@tryghost/admin-x-framework/api/current-user';
+import {
+  useEditUser,
+  type User,
+  type UsersResponseType,
+} from '@tryghost/admin-x-framework/api/users';
+import { isoDatetimeToDate } from '@/schemas/primitives';
+import { deepMerge, type DeepPartial } from '@/utils/deep-merge';
 
 const WhatsNewPreferencesSchema = z.looseObject({
-    lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
+  lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
 
 export const DEFAULT_ONBOARDING_PREFERENCES = {
-    completedSteps: [] as string[],
-    checklistState: "pending" as const,
-    startedAt: undefined as Date | undefined,
+  completedSteps: [] as string[],
+  checklistState: 'pending' as const,
+  startedAt: undefined as Date | undefined,
 };
 
 export const OnboardingPreferencesSchema = z.looseObject({
-    completedSteps: z.array(z.string()).default(DEFAULT_ONBOARDING_PREFERENCES.completedSteps).catch(DEFAULT_ONBOARDING_PREFERENCES.completedSteps),
-    checklistState: z.enum(["pending", "started", "completed", "dismissed"]).default(DEFAULT_ONBOARDING_PREFERENCES.checklistState).catch(DEFAULT_ONBOARDING_PREFERENCES.checklistState),
-    startedAt: isoDatetimeToDate.optional().catch(DEFAULT_ONBOARDING_PREFERENCES.startedAt),
+  completedSteps: z
+    .array(z.string())
+    .default(DEFAULT_ONBOARDING_PREFERENCES.completedSteps)
+    .catch(DEFAULT_ONBOARDING_PREFERENCES.completedSteps),
+  checklistState: z
+    .enum(['pending', 'started', 'completed', 'dismissed'])
+    .default(DEFAULT_ONBOARDING_PREFERENCES.checklistState)
+    .catch(DEFAULT_ONBOARDING_PREFERENCES.checklistState),
+  startedAt: isoDatetimeToDate.optional().catch(DEFAULT_ONBOARDING_PREFERENCES.startedAt),
 });
 
 export const DEFAULT_NAVIGATION_PREFERENCES = {
-    expanded: { posts: true, members: true },
-    menu: { visible: true },
+  expanded: { posts: true, members: true },
+  menu: { visible: true },
 } as const;
 
 export const NavigationPreferencesSchema = z.looseObject({
-    expanded: z.object({
-        posts: z.boolean(),
-        members: z.boolean().default(true),
-    }),
-    menu: z.object({
-        visible: z.boolean(),
-    }),
+  expanded: z.object({
+    posts: z.boolean(),
+    members: z.boolean().default(true),
+  }),
+  menu: z.object({
+    visible: z.boolean(),
+  }),
 });
 
 const PreferencesSchema = z.looseObject({
-    whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
-    // Optional (not defaulted) so an absent preference stays absent and isn't
-    // eagerly written back on unrelated preference saves. The display fallback to
-    // "light" lives at the read site (see useTheme). New users get "system" from
-    // the server default; legacy booleans are migrated to strings in the queryFn.
-    nightShift: z.enum(["light", "dark", "system"]).optional().catch("light"),
-    onboarding: OnboardingPreferencesSchema.default(DEFAULT_ONBOARDING_PREFERENCES).catch(DEFAULT_ONBOARDING_PREFERENCES),
-    navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
+  whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
+  // Optional (not defaulted) so an absent preference stays absent and isn't
+  // eagerly written back on unrelated preference saves. The display fallback to
+  // "light" lives at the read site (see useTheme). New users get "system" from
+  // the server default; legacy booleans are migrated to strings in the queryFn.
+  nightShift: z.enum(['light', 'dark', 'system']).optional().catch('light'),
+  onboarding: OnboardingPreferencesSchema.default(DEFAULT_ONBOARDING_PREFERENCES).catch(
+    DEFAULT_ONBOARDING_PREFERENCES,
+  ),
+  navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(
+    DEFAULT_NAVIGATION_PREFERENCES,
+  ),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
@@ -53,110 +78,126 @@ export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
 export type OnboardingPreferences = z.infer<typeof OnboardingPreferencesSchema>;
 export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 
-const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
+const userPreferencesQueryKey = (user: User | undefined) =>
+  ['userPreferences', user?.id, user?.accessibility] as const;
 
 // The write below depends on a user read straight from the API, so validate the
 // fields it uses before trusting them. A payload that does not parse is handled
 // like a read that failed.
 const CurrentUserResponseSchema = z.looseObject({
-    users: z.array(z.looseObject({
+  users: z
+    .array(
+      z.looseObject({
         id: z.string(),
         accessibility: z.string().nullish(),
-    })).min(1),
+      }),
+    )
+    .min(1),
 });
 
 /** What a preferences write reads off the user, whoever supplied it. */
-type PreferenceUser = z.infer<typeof CurrentUserResponseSchema>["users"][number];
+type PreferenceUser = z.infer<typeof CurrentUserResponseSchema>['users'][number];
 
-function parsePreferences(user: Pick<PreferenceUser, "accessibility">): Preferences {
-    const raw = user.accessibility || "{}";
-    const parsedRaw: unknown = JSON.parse(raw);
-    const parsed: Record<string, unknown> =
-        parsedRaw && typeof parsedRaw === "object" && !Array.isArray(parsedRaw)
-            ? parsedRaw as Record<string, unknown>
-            : {};
+function parsePreferences(user: Pick<PreferenceUser, 'accessibility'>): Preferences {
+  const raw = user.accessibility || '{}';
+  const parsedRaw: unknown = JSON.parse(raw);
+  const parsed: Record<string, unknown> =
+    parsedRaw && typeof parsedRaw === 'object' && !Array.isArray(parsedRaw)
+      ? (parsedRaw as Record<string, unknown>)
+      : {};
 
-    if (parsed.nightShift === true) {
-        parsed.nightShift = "dark";
-    } else if (parsed.nightShift === false) {
-        parsed.nightShift = "light";
-    }
+  if (parsed.nightShift === true) {
+    parsed.nightShift = 'dark';
+  } else if (parsed.nightShift === false) {
+    parsed.nightShift = 'light';
+  }
 
-    return PreferencesSchema.parse(parsed);
+  return PreferencesSchema.parse(parsed);
 }
 
 export function useUserPreferences<TData = Preferences>(
-    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn' | 'staleTime' | 'gcTime'>
+  options?: Omit<
+    UseQueryOptions<Preferences, Error, TData>,
+    'queryKey' | 'queryFn' | 'staleTime' | 'gcTime'
+  >,
 ): UseQueryResult<TData> {
-    const { data: user } = useCurrentUser();
+  const { data: user } = useCurrentUser();
 
-    return useQuery<Preferences, Error, TData>({
-        ...options,
-        queryKey: userPreferencesQueryKey(user),
-        queryFn: () => {
-            if (!user) {
-                throw new Error("User not loaded");
-            }
+  return useQuery<Preferences, Error, TData>({
+    ...options,
+    queryKey: userPreferencesQueryKey(user),
+    queryFn: () => {
+      if (!user) {
+        throw new Error('User not loaded');
+      }
 
-            return parsePreferences(user);
-        },
-        enabled: !!user,
-        placeholderData: keepPreviousData,
-        staleTime: Infinity,
-        // Query key includes user?.accessibility to automatically react to changes from ANY source
-        // (our mutation, other code calling editUser, external updates, etc.). When accessibility
-        // changes, the query key changes, making the old cache entry inactive. gcTime: 0 ensures
-        // orphaned entries are immediately garbage collected, preventing memory leaks while keeping
-        // the current active entry cached indefinitely.
-        gcTime: 0,
-    });
+      return parsePreferences(user);
+    },
+    enabled: !!user,
+    placeholderData: keepPreviousData,
+    staleTime: Infinity,
+    // Query key includes user?.accessibility to automatically react to changes from ANY source
+    // (our mutation, other code calling editUser, external updates, etc.). When accessibility
+    // changes, the query key changes, making the old cache entry inactive. gcTime: 0 ensures
+    // orphaned entries are immediately garbage collected, preventing memory leaks while keeping
+    // the current active entry cached indefinitely.
+    gcTime: 0,
+  });
 }
 
-export const useEditUserPreferences = (): UseMutationResult<void, Error, DeepPartial<Preferences>, unknown> => {
-    const queryClient = useQueryClient();
-    const { data: user } = useCurrentUser();
-    const { mutateAsync: editUser } = useEditUser();
-    const fetchCurrentUser = useFetchCurrentUser();
+export const useEditUserPreferences = (): UseMutationResult<
+  void,
+  Error,
+  DeepPartial<Preferences>,
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  const { data: user } = useCurrentUser();
+  const { mutateAsync: editUser } = useEditUser();
+  const fetchCurrentUser = useFetchCurrentUser();
 
-    return useMutation({
-        // Preference edits write the whole accessibility blob from a merge of
-        // the current state; the shared scope serializes concurrent edits so
-        // the later one merges on top of the earlier write instead of racing.
-        scope: { id: "user-preferences" },
-        mutationFn: async (updatedPreferences: DeepPartial<Preferences>) => {
-            // Merge over the server's blob, not the cached one. Ember's feature
-            // and onboarding services write this same field, as does Admin in
-            // another tab, and the cached user is not refetched on mount or on
-            // window focus, so a merge over the cache silently reverts whatever
-            // those writers stored. Read around the cache: writing the pre-write
-            // user into it would flip the UI back until this write lands.
-            //
-            // A read that fails falls through to the cache, which is what this
-            // merged over before. Dropping the user's change is worse than a
-            // merge that might be stale, and every caller here floats the
-            // promise, so a dropped write is silent.
-            const serverUser = await fetchCurrentUser()
-                .then(response => CurrentUserResponseSchema.parse(response).users[0])
-                .catch(() => undefined);
+  return useMutation({
+    // Preference edits write the whole accessibility blob from a merge of
+    // the current state; the shared scope serializes concurrent edits so
+    // the later one merges on top of the earlier write instead of racing.
+    scope: { id: 'user-preferences' },
+    mutationFn: async (updatedPreferences: DeepPartial<Preferences>) => {
+      // Merge over the server's blob, not the cached one. Ember's feature
+      // and onboarding services write this same field, as does Admin in
+      // another tab, and the cached user is not refetched on mount or on
+      // window focus, so a merge over the cache silently reverts whatever
+      // those writers stored. Read around the cache: writing the pre-write
+      // user into it would flip the UI back until this write lands.
+      //
+      // A read that fails falls through to the cache, which is what this
+      // merged over before. Dropping the user's change is worse than a
+      // merge that might be stale, and every caller here floats the
+      // promise, so a dropped write is silent.
+      const serverUser = await fetchCurrentUser()
+        .then((response) => CurrentUserResponseSchema.parse(response).users[0])
+        .catch(() => undefined);
 
-            // The cache carries the previous write of a serialized mutation;
-            // the render closure is the last resort.
-            const latestUser: PreferenceUser | undefined = serverUser ?? queryClient.getQueryData<UsersResponseType>(currentUserQueryKey)?.users[0] ?? user;
+      // The cache carries the previous write of a serialized mutation;
+      // the render closure is the last resort.
+      const latestUser: PreferenceUser | undefined =
+        serverUser ??
+        queryClient.getQueryData<UsersResponseType>(currentUserQueryKey)?.users[0] ??
+        user;
 
-            if (!latestUser) {
-                throw new Error("User is not loaded");
-            }
+      if (!latestUser) {
+        throw new Error('User is not loaded');
+      }
 
-            const newPreferences = deepMerge(parsePreferences(latestUser), updatedPreferences);
+      const newPreferences = deepMerge(parsePreferences(latestUser), updatedPreferences);
 
-            const encodedForStorage = PreferencesSchema.encode(newPreferences);
+      const encodedForStorage = PreferencesSchema.encode(newPreferences);
 
-            // Send the blob alone: a whole-user payload built from a read taken
-            // moments ago would revert a name or a role changed in between.
-            await editUser({
-                id: latestUser.id,
-                accessibility: JSON.stringify(encodedForStorage),
-            });
-        },
-    });
+      // Send the blob alone: a whole-user payload built from a read taken
+      // moments ago would revert a name or a role changed in between.
+      await editUser({
+        id: latestUser.id,
+        accessibility: JSON.stringify(encodedForStorage),
+      });
+    },
+  });
 };

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.test.tsx
@@ -1,71 +1,74 @@
-import { test as baseTest, describe, expect } from "vitest";
-import { renderHook, act } from "@testing-library/react";
-import type { QueryClient } from "@tanstack/react-query";
-import { HttpResponse, http } from "msw";
-import type { SetupServer } from "msw/node";
-import { mockUser } from "@test-utils/factories";
-import { waitForQuerySettled } from "@test-utils/test-helpers";
-import { serverFixture } from "@test-utils/fixtures/msw";
-import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
-import type { UpdateUserRequestBody, UsersResponseType } from "@tryghost/admin-x-framework/api/users";
-import { useUserPreferences } from "@/hooks/user-preferences";
-import { useNavigationExpanded } from "./use-navigation-preferences";
+import { test as baseTest, describe, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { QueryClient } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import type { SetupServer } from 'msw/node';
+import { mockUser } from '@test-utils/factories';
+import { waitForQuerySettled } from '@test-utils/test-helpers';
+import { serverFixture } from '@test-utils/fixtures/msw';
+import { queryClientFixtures, type TestWrapperComponent } from '@test-utils/fixtures/query-client';
+import type {
+  UpdateUserRequestBody,
+  UsersResponseType,
+} from '@tryghost/admin-x-framework/api/users';
+import { useUserPreferences } from '@/hooks/user-preferences';
+import { useNavigationExpanded } from './use-navigation-preferences';
 
-const USERS_API_URL = "/ghost/api/admin/users/me/";
-const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
+const USERS_API_URL = '/ghost/api/admin/users/me/';
+const USER_UPDATE_API_URL = '/ghost/api/admin/users/:id/';
 
 const navigationPreferences = (expanded: { posts: boolean; members: boolean }) =>
-    JSON.stringify({
-        navigation: { expanded, menu: { visible: true } },
-    });
+  JSON.stringify({
+    navigation: { expanded, menu: { visible: true } },
+  });
 
 const navigationTest = baseTest.extend<{
-    server: SetupServer;
-    queryClient: QueryClient;
-    wrapper: TestWrapperComponent;
+  server: SetupServer;
+  queryClient: QueryClient;
+  wrapper: TestWrapperComponent;
 }>({
-    ...serverFixture,
-    ...queryClientFixtures,
+  ...serverFixture,
+  ...queryClientFixtures,
 });
 
-describe("useNavigationExpanded", () => {
-    navigationTest("leaves the other groups as the server has them", async ({ server, wrapper }) => {
-        let storedAccessibility = navigationPreferences({ posts: true, members: true });
-        const writtenAccessibility: string[] = [];
+describe('useNavigationExpanded', () => {
+  navigationTest('leaves the other groups as the server has them', async ({ server, wrapper }) => {
+    let storedAccessibility = navigationPreferences({ posts: true, members: true });
+    const writtenAccessibility: string[] = [];
 
-        server.use(
-            http.get(USERS_API_URL, () => {
-                return HttpResponse.json({
-                    users: [{ ...mockUser, accessibility: storedAccessibility }],
-                });
-            }),
-            http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
-                USER_UPDATE_API_URL,
-                async ({ request }) => {
-                    const body = await request.json();
-                    storedAccessibility = body.users[0]?.accessibility ?? "";
-                    writtenAccessibility.push(storedAccessibility);
-                    return HttpResponse.json({
-                        users: [{ ...mockUser, accessibility: storedAccessibility }],
-                    });
-                }
-            )
-        );
-
-        const preferences = renderHook(() => useUserPreferences(), { wrapper });
-        await waitForQuerySettled(preferences.result);
-
-        const { result } = renderHook(() => useNavigationExpanded("posts"), { wrapper });
-
-        // Another writer collapses a group this client has never read.
-        storedAccessibility = navigationPreferences({ posts: true, members: false });
-
-        await act(async () => {
-            await result.current[1](false);
+    server.use(
+      http.get(USERS_API_URL, () => {
+        return HttpResponse.json({
+          users: [{ ...mockUser, accessibility: storedAccessibility }],
         });
+      }),
+      http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+        USER_UPDATE_API_URL,
+        async ({ request }) => {
+          const body = await request.json();
+          storedAccessibility = body.users[0]?.accessibility ?? '';
+          writtenAccessibility.push(storedAccessibility);
+          return HttpResponse.json({
+            users: [{ ...mockUser, accessibility: storedAccessibility }],
+          });
+        },
+      ),
+    );
 
-        expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
-            navigation: { expanded: { posts: false, members: false } },
-        });
+    const preferences = renderHook(() => useUserPreferences(), { wrapper });
+    await waitForQuerySettled(preferences.result);
+
+    const { result } = renderHook(() => useNavigationExpanded('posts'), { wrapper });
+
+    // Another writer collapses a group this client has never read.
+    storedAccessibility = navigationPreferences({ posts: true, members: false });
+
+    await act(async () => {
+      await result.current[1](false);
     });
+
+    expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
+      navigation: { expanded: { posts: false, members: false } },
+    });
+  });
 });

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.test.tsx
@@ -1,0 +1,71 @@
+import { test as baseTest, describe, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { QueryClient } from "@tanstack/react-query";
+import { HttpResponse, http } from "msw";
+import type { SetupServer } from "msw/node";
+import { mockUser } from "@test-utils/factories";
+import { waitForQuerySettled } from "@test-utils/test-helpers";
+import { serverFixture } from "@test-utils/fixtures/msw";
+import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
+import type { UpdateUserRequestBody, UsersResponseType } from "@tryghost/admin-x-framework/api/users";
+import { useUserPreferences } from "@/hooks/user-preferences";
+import { useNavigationExpanded } from "./use-navigation-preferences";
+
+const USERS_API_URL = "/ghost/api/admin/users/me/";
+const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
+
+const navigationPreferences = (expanded: { posts: boolean; members: boolean }) =>
+    JSON.stringify({
+        navigation: { expanded, menu: { visible: true } },
+    });
+
+const navigationTest = baseTest.extend<{
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+}>({
+    ...serverFixture,
+    ...queryClientFixtures,
+});
+
+describe("useNavigationExpanded", () => {
+    navigationTest("leaves the other groups as the server has them", async ({ server, wrapper }) => {
+        let storedAccessibility = navigationPreferences({ posts: true, members: true });
+        const writtenAccessibility: string[] = [];
+
+        server.use(
+            http.get(USERS_API_URL, () => {
+                return HttpResponse.json({
+                    users: [{ ...mockUser, accessibility: storedAccessibility }],
+                });
+            }),
+            http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+                USER_UPDATE_API_URL,
+                async ({ request }) => {
+                    const body = await request.json();
+                    storedAccessibility = body.users[0]?.accessibility ?? "";
+                    writtenAccessibility.push(storedAccessibility);
+                    return HttpResponse.json({
+                        users: [{ ...mockUser, accessibility: storedAccessibility }],
+                    });
+                }
+            )
+        );
+
+        const preferences = renderHook(() => useUserPreferences(), { wrapper });
+        await waitForQuerySettled(preferences.result);
+
+        const { result } = renderHook(() => useNavigationExpanded("posts"), { wrapper });
+
+        // Another writer collapses a group this client has never read.
+        storedAccessibility = navigationPreferences({ posts: true, members: false });
+
+        await act(async () => {
+            await result.current[1](false);
+        });
+
+        expect(JSON.parse(writtenAccessibility[0])).toMatchObject({
+            navigation: { expanded: { posts: false, members: false } },
+        });
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,65 +1,55 @@
-import {
-  DEFAULT_NAVIGATION_PREFERENCES,
-  useEditUserPreferences,
-  useUserPreferences,
-  type NavigationPreferences,
-} from '@/hooks/user-preferences';
-import { useMutation, type UseMutationResult, type UseQueryResult } from '@tanstack/react-query';
+import { useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
+import { useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
+import type { DeepPartial } from "@/utils/deep-merge";
+
 
 export const useNavigationPreferences = (): UseQueryResult<NavigationPreferences> => {
-  return useUserPreferences({
-    select: (data) => data.navigation,
-  });
-};
-
-export const useEditNavigationPreferences = (): UseMutationResult<
-  void,
-  Error,
-  Partial<NavigationPreferences>,
-  unknown
-> => {
-  const { mutateAsync: editPreferences } = useEditUserPreferences();
-
-  return useMutation({
-    mutationFn: async (updatedNavigationPreferences: Partial<NavigationPreferences>) => {
-      await editPreferences({
-        navigation: updatedNavigationPreferences,
-      });
-    },
-  });
-};
-
-export const useNavigationExpanded = (
-  expandedKey: keyof NavigationPreferences['expanded'],
-): [boolean, (value: boolean) => Promise<void>] => {
-  const { data: navigationPreferences } = useNavigationPreferences();
-  const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
-
-  const expanded = navigationPreferences?.expanded[expandedKey];
-
-  const setExpanded = async (value: boolean) => {
-    return editNavigationPreferences({
-      expanded: {
-        ...(navigationPreferences?.expanded ?? DEFAULT_NAVIGATION_PREFERENCES.expanded),
-        [expandedKey]: value,
-      },
+    return useUserPreferences({
+        select: (data) => data.navigation,
     });
-  };
+};
 
-  return [expanded ?? true, setExpanded];
+export const useEditNavigationPreferences = (): UseMutationResult<void, Error, DeepPartial<NavigationPreferences>, unknown> => {
+    const { mutateAsync: editPreferences } = useEditUserPreferences();
+
+    return useMutation({
+        mutationFn: async (updatedNavigationPreferences: DeepPartial<NavigationPreferences>) => {
+            await editPreferences({
+                navigation: updatedNavigationPreferences,
+            });
+        },
+    });
+};
+
+export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['expanded']): [boolean, (value: boolean) => Promise<void>] => {
+    const { data: navigationPreferences } = useNavigationPreferences();
+    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+
+    const expanded = navigationPreferences?.expanded[expandedKey];
+
+    const setExpanded = async (value: boolean) => {
+        // Send the one key that changed. Spreading this tab's other keys into
+        // the payload would carry their stale values over whatever another
+        // writer stored, which the merge underneath cannot undo.
+        return editNavigationPreferences({
+            expanded: { [expandedKey]: value },
+        });
+    };
+
+    return [expanded ?? true, setExpanded];
 };
 
 export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => Promise<void>] => {
-  const { data: navigationPreferences } = useNavigationPreferences();
-  const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+    const { data: navigationPreferences } = useNavigationPreferences();
+    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
-  const visible = navigationPreferences?.menu.visible;
+    const visible = navigationPreferences?.menu.visible;
 
-  const setVisible = async (value: boolean) => {
-    return editNavigationPreferences({
-      menu: { visible: value },
-    });
-  };
+    const setVisible = async (value: boolean) => {
+        return editNavigationPreferences({
+            menu: { visible: value },
+        });
+    };
 
-  return [visible ?? true, setVisible];
+    return [visible ?? true, setVisible];
 };

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,55 +1,65 @@
-import { useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
-import { useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
-import type { DeepPartial } from "@/utils/deep-merge";
-
+import {
+  useEditUserPreferences,
+  useUserPreferences,
+  type NavigationPreferences,
+} from '@/hooks/user-preferences';
+import { useMutation, type UseMutationResult, type UseQueryResult } from '@tanstack/react-query';
+import type { DeepPartial } from '@/utils/deep-merge';
 
 export const useNavigationPreferences = (): UseQueryResult<NavigationPreferences> => {
-    return useUserPreferences({
-        select: (data) => data.navigation,
-    });
+  return useUserPreferences({
+    select: (data) => data.navigation,
+  });
 };
 
-export const useEditNavigationPreferences = (): UseMutationResult<void, Error, DeepPartial<NavigationPreferences>, unknown> => {
-    const { mutateAsync: editPreferences } = useEditUserPreferences();
+export const useEditNavigationPreferences = (): UseMutationResult<
+  void,
+  Error,
+  DeepPartial<NavigationPreferences>,
+  unknown
+> => {
+  const { mutateAsync: editPreferences } = useEditUserPreferences();
 
-    return useMutation({
-        mutationFn: async (updatedNavigationPreferences: DeepPartial<NavigationPreferences>) => {
-            await editPreferences({
-                navigation: updatedNavigationPreferences,
-            });
-        },
-    });
+  return useMutation({
+    mutationFn: async (updatedNavigationPreferences: DeepPartial<NavigationPreferences>) => {
+      await editPreferences({
+        navigation: updatedNavigationPreferences,
+      });
+    },
+  });
 };
 
-export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['expanded']): [boolean, (value: boolean) => Promise<void>] => {
-    const { data: navigationPreferences } = useNavigationPreferences();
-    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+export const useNavigationExpanded = (
+  expandedKey: keyof NavigationPreferences['expanded'],
+): [boolean, (value: boolean) => Promise<void>] => {
+  const { data: navigationPreferences } = useNavigationPreferences();
+  const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
-    const expanded = navigationPreferences?.expanded[expandedKey];
+  const expanded = navigationPreferences?.expanded[expandedKey];
 
-    const setExpanded = async (value: boolean) => {
-        // Send the one key that changed. Spreading this tab's other keys into
-        // the payload would carry their stale values over whatever another
-        // writer stored, which the merge underneath cannot undo.
-        return editNavigationPreferences({
-            expanded: { [expandedKey]: value },
-        });
-    };
+  const setExpanded = async (value: boolean) => {
+    // Send the one key that changed. Spreading this tab's other keys into
+    // the payload would carry their stale values over whatever another
+    // writer stored, which the merge underneath cannot undo.
+    return editNavigationPreferences({
+      expanded: { [expandedKey]: value },
+    });
+  };
 
-    return [expanded ?? true, setExpanded];
+  return [expanded ?? true, setExpanded];
 };
 
 export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => Promise<void>] => {
-    const { data: navigationPreferences } = useNavigationPreferences();
-    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+  const { data: navigationPreferences } = useNavigationPreferences();
+  const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
-    const visible = navigationPreferences?.menu.visible;
+  const visible = navigationPreferences?.menu.visible;
 
-    const setVisible = async (value: boolean) => {
-        return editNavigationPreferences({
-            menu: { visible: value },
-        });
-    };
+  const setVisible = async (value: boolean) => {
+    return editNavigationPreferences({
+      menu: { visible: value },
+    });
+  };
 
-    return [visible ?? true, setVisible];
+  return [visible ?? true, setVisible];
 };

--- a/apps/admin/src/members/multiple-active-subscriptions.test.ts
+++ b/apps/admin/src/members/multiple-active-subscriptions.test.ts
@@ -1,85 +1,95 @@
 import {
-    MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
-    buildDismissedMultipleActiveSubscriptionsPreference,
-    buildUserWithDismissedMultipleActiveSubscriptionsBanner,
-    getMultipleActiveSubscriptionsBannerPreference,
-    isMultipleActiveSubscriptionsFilter,
-    parseAccessibilityPreferences
+  MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
+  buildDismissedMultipleActiveSubscriptionsPreference,
+  buildUserWithDismissedMultipleActiveSubscriptionsBanner,
+  getMultipleActiveSubscriptionsBannerPreference,
+  isMultipleActiveSubscriptionsFilter,
+  parseAccessibilityPreferences,
 } from './multiple-active-subscriptions';
-import {describe, expect, it} from 'vitest';
-import type {User} from '@tryghost/admin-x-framework/api/users';
+import { describe, expect, it } from 'vitest';
+import type { User } from '@tryghost/admin-x-framework/api/users';
 
 describe('multiple active subscriptions helpers', () => {
-    it('matches only the exact raw filter used by the banner', () => {
-        expect(isMultipleActiveSubscriptionsFilter(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER)).toBe(true);
-        expect(isMultipleActiveSubscriptionsFilter(`${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER}+status:paid`)).toBe(false);
-        expect(isMultipleActiveSubscriptionsFilter(undefined)).toBe(false);
+  it('matches only the exact raw filter used by the banner', () => {
+    expect(isMultipleActiveSubscriptionsFilter(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER)).toBe(true);
+    expect(
+      isMultipleActiveSubscriptionsFilter(`${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER}+status:paid`),
+    ).toBe(false);
+    expect(isMultipleActiveSubscriptionsFilter(undefined)).toBe(false);
+  });
+
+  it('parses invalid accessibility JSON as empty preferences', () => {
+    expect(parseAccessibilityPreferences('{invalid json')).toEqual({});
+    expect(getMultipleActiveSubscriptionsBannerPreference('{invalid json')).toEqual({});
+  });
+
+  it('ignores invalid dismissal preference values', () => {
+    const accessibility = JSON.stringify({
+      multipleActiveSubscriptionsBanner: {
+        dismissedCount: 'abc',
+        dismissedAt: 123,
+        customFutureKey: 'preserved',
+      },
     });
 
-    it('parses invalid accessibility JSON as empty preferences', () => {
-        expect(parseAccessibilityPreferences('{invalid json')).toEqual({});
-        expect(getMultipleActiveSubscriptionsBannerPreference('{invalid json')).toEqual({});
+    expect(getMultipleActiveSubscriptionsBannerPreference(accessibility)).toEqual({
+      dismissedCount: undefined,
+      dismissedAt: undefined,
+      customFutureKey: 'preserved',
+    });
+  });
+
+  it('preserves unknown accessibility keys when writing dismissal state', () => {
+    const accessibility = JSON.stringify({
+      nightShift: true,
+      onboarding: {
+        checklistState: 'started',
+      },
+      multipleActiveSubscriptionsBanner: {
+        dismissedCount: 1,
+        customFutureKey: 'preserved',
+      },
     });
 
-    it('ignores invalid dismissal preference values', () => {
-        const accessibility = JSON.stringify({
-            multipleActiveSubscriptionsBanner: {
-                dismissedCount: 'abc',
-                dismissedAt: 123,
-                customFutureKey: 'preserved'
-            }
-        });
-
-        expect(getMultipleActiveSubscriptionsBannerPreference(accessibility)).toEqual({
-            dismissedCount: undefined,
-            dismissedAt: undefined,
-            customFutureKey: 'preserved'
-        });
+    expect(
+      JSON.parse(
+        buildDismissedMultipleActiveSubscriptionsPreference(
+          accessibility,
+          3,
+          '2026-05-28T12:34:56.000Z',
+        ),
+      ),
+    ).toEqual({
+      nightShift: true,
+      onboarding: {
+        checklistState: 'started',
+      },
+      multipleActiveSubscriptionsBanner: {
+        dismissedCount: 3,
+        dismissedAt: '2026-05-28T12:34:56.000Z',
+        customFutureKey: 'preserved',
+      },
     });
+  });
 
-    it('preserves unknown accessibility keys when writing dismissal state', () => {
-        const accessibility = JSON.stringify({
-            nightShift: true,
-            onboarding: {
-                checklistState: 'started'
-            },
-            multipleActiveSubscriptionsBanner: {
-                dismissedCount: 1,
-                customFutureKey: 'preserved'
-            }
-        });
+  it('dismisses the banner without carrying the rest of the user', () => {
+    const user = {
+      id: 'user-1',
+      name: 'Owner',
+      email: 'owner@example.com',
+      accessibility: JSON.stringify({ nightShift: 'dark' }),
+    } as User;
 
-        expect(JSON.parse(buildDismissedMultipleActiveSubscriptionsPreference(
-            accessibility,
-            3,
-            '2026-05-28T12:34:56.000Z'
-        ))).toEqual({
-            nightShift: true,
-            onboarding: {
-                checklistState: 'started'
-            },
-            multipleActiveSubscriptionsBanner: {
-                dismissedCount: 3,
-                dismissedAt: '2026-05-28T12:34:56.000Z',
-                customFutureKey: 'preserved'
-            }
-        });
+    const payload = buildUserWithDismissedMultipleActiveSubscriptionsBanner(
+      user,
+      2,
+      '2026-05-28T12:34:56.000Z',
+    );
+
+    expect(Object.keys(payload).sort()).toEqual(['accessibility', 'id']);
+    expect(JSON.parse(payload.accessibility as string)).toMatchObject({
+      nightShift: 'dark',
+      multipleActiveSubscriptionsBanner: { dismissedCount: 2 },
     });
-
-    it('dismisses the banner without carrying the rest of the user', () => {
-        const user = {
-            id: 'user-1',
-            name: 'Owner',
-            email: 'owner@example.com',
-            accessibility: JSON.stringify({nightShift: 'dark'})
-        } as User;
-
-        const payload = buildUserWithDismissedMultipleActiveSubscriptionsBanner(user, 2, '2026-05-28T12:34:56.000Z');
-
-        expect(Object.keys(payload).sort()).toEqual(['accessibility', 'id']);
-        expect(JSON.parse(payload.accessibility as string)).toMatchObject({
-            nightShift: 'dark',
-            multipleActiveSubscriptionsBanner: {dismissedCount: 2}
-        });
-    });
+  });
 });

--- a/apps/admin/src/members/multiple-active-subscriptions.test.ts
+++ b/apps/admin/src/members/multiple-active-subscriptions.test.ts
@@ -1,72 +1,85 @@
 import {
-  MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
-  buildDismissedMultipleActiveSubscriptionsPreference,
-  getMultipleActiveSubscriptionsBannerPreference,
-  isMultipleActiveSubscriptionsFilter,
-  parseAccessibilityPreferences,
+    MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
+    buildDismissedMultipleActiveSubscriptionsPreference,
+    buildUserWithDismissedMultipleActiveSubscriptionsBanner,
+    getMultipleActiveSubscriptionsBannerPreference,
+    isMultipleActiveSubscriptionsFilter,
+    parseAccessibilityPreferences
 } from './multiple-active-subscriptions';
-import { describe, expect, it } from 'vitest';
+import {describe, expect, it} from 'vitest';
+import type {User} from '@tryghost/admin-x-framework/api/users';
 
 describe('multiple active subscriptions helpers', () => {
-  it('matches only the exact raw filter used by the banner', () => {
-    expect(isMultipleActiveSubscriptionsFilter(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER)).toBe(true);
-    expect(
-      isMultipleActiveSubscriptionsFilter(`${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER}+status:paid`),
-    ).toBe(false);
-    expect(isMultipleActiveSubscriptionsFilter(undefined)).toBe(false);
-  });
-
-  it('parses invalid accessibility JSON as empty preferences', () => {
-    expect(parseAccessibilityPreferences('{invalid json')).toEqual({});
-    expect(getMultipleActiveSubscriptionsBannerPreference('{invalid json')).toEqual({});
-  });
-
-  it('ignores invalid dismissal preference values', () => {
-    const accessibility = JSON.stringify({
-      multipleActiveSubscriptionsBanner: {
-        dismissedCount: 'abc',
-        dismissedAt: 123,
-        customFutureKey: 'preserved',
-      },
+    it('matches only the exact raw filter used by the banner', () => {
+        expect(isMultipleActiveSubscriptionsFilter(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER)).toBe(true);
+        expect(isMultipleActiveSubscriptionsFilter(`${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER}+status:paid`)).toBe(false);
+        expect(isMultipleActiveSubscriptionsFilter(undefined)).toBe(false);
     });
 
-    expect(getMultipleActiveSubscriptionsBannerPreference(accessibility)).toEqual({
-      dismissedCount: undefined,
-      dismissedAt: undefined,
-      customFutureKey: 'preserved',
-    });
-  });
-
-  it('preserves unknown accessibility keys when writing dismissal state', () => {
-    const accessibility = JSON.stringify({
-      nightShift: true,
-      onboarding: {
-        checklistState: 'started',
-      },
-      multipleActiveSubscriptionsBanner: {
-        dismissedCount: 1,
-        customFutureKey: 'preserved',
-      },
+    it('parses invalid accessibility JSON as empty preferences', () => {
+        expect(parseAccessibilityPreferences('{invalid json')).toEqual({});
+        expect(getMultipleActiveSubscriptionsBannerPreference('{invalid json')).toEqual({});
     });
 
-    expect(
-      JSON.parse(
-        buildDismissedMultipleActiveSubscriptionsPreference(
-          accessibility,
-          3,
-          '2026-05-28T12:34:56.000Z',
-        ),
-      ),
-    ).toEqual({
-      nightShift: true,
-      onboarding: {
-        checklistState: 'started',
-      },
-      multipleActiveSubscriptionsBanner: {
-        dismissedCount: 3,
-        dismissedAt: '2026-05-28T12:34:56.000Z',
-        customFutureKey: 'preserved',
-      },
+    it('ignores invalid dismissal preference values', () => {
+        const accessibility = JSON.stringify({
+            multipleActiveSubscriptionsBanner: {
+                dismissedCount: 'abc',
+                dismissedAt: 123,
+                customFutureKey: 'preserved'
+            }
+        });
+
+        expect(getMultipleActiveSubscriptionsBannerPreference(accessibility)).toEqual({
+            dismissedCount: undefined,
+            dismissedAt: undefined,
+            customFutureKey: 'preserved'
+        });
     });
-  });
+
+    it('preserves unknown accessibility keys when writing dismissal state', () => {
+        const accessibility = JSON.stringify({
+            nightShift: true,
+            onboarding: {
+                checklistState: 'started'
+            },
+            multipleActiveSubscriptionsBanner: {
+                dismissedCount: 1,
+                customFutureKey: 'preserved'
+            }
+        });
+
+        expect(JSON.parse(buildDismissedMultipleActiveSubscriptionsPreference(
+            accessibility,
+            3,
+            '2026-05-28T12:34:56.000Z'
+        ))).toEqual({
+            nightShift: true,
+            onboarding: {
+                checklistState: 'started'
+            },
+            multipleActiveSubscriptionsBanner: {
+                dismissedCount: 3,
+                dismissedAt: '2026-05-28T12:34:56.000Z',
+                customFutureKey: 'preserved'
+            }
+        });
+    });
+
+    it('dismisses the banner without carrying the rest of the user', () => {
+        const user = {
+            id: 'user-1',
+            name: 'Owner',
+            email: 'owner@example.com',
+            accessibility: JSON.stringify({nightShift: 'dark'})
+        } as User;
+
+        const payload = buildUserWithDismissedMultipleActiveSubscriptionsBanner(user, 2, '2026-05-28T12:34:56.000Z');
+
+        expect(Object.keys(payload).sort()).toEqual(['accessibility', 'id']);
+        expect(JSON.parse(payload.accessibility as string)).toMatchObject({
+            nightShift: 'dark',
+            multipleActiveSubscriptionsBanner: {dismissedCount: 2}
+        });
+    });
 });

--- a/apps/admin/src/members/multiple-active-subscriptions.ts
+++ b/apps/admin/src/members/multiple-active-subscriptions.ts
@@ -1,62 +1,67 @@
-import {z} from 'zod';
-import type {EditUserPayload, User} from '@tryghost/admin-x-framework/api/users';
+import { z } from 'zod';
+import type { EditUserPayload, User } from '@tryghost/admin-x-framework/api/users';
 
 export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD = 'count.active_stripe_customers';
 export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:>1`;
 export const NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:<2`;
 
 const MultipleActiveSubscriptionsBannerPreferenceSchema = z.looseObject({
-    dismissedCount: z.number().finite().optional().catch(undefined),
-    dismissedAt: z.string().optional().catch(undefined)
+  dismissedCount: z.number().finite().optional().catch(undefined),
+  dismissedAt: z.string().optional().catch(undefined),
 });
 
 const AccessibilityPreferencesSchema = z.looseObject({
-    multipleActiveSubscriptionsBanner: MultipleActiveSubscriptionsBannerPreferenceSchema.optional().catch(undefined)
+  multipleActiveSubscriptionsBanner:
+    MultipleActiveSubscriptionsBannerPreferenceSchema.optional().catch(undefined),
 });
 
 export type AccessibilityPreferences = z.infer<typeof AccessibilityPreferencesSchema>;
-export type MultipleActiveSubscriptionsBannerPreference = z.infer<typeof MultipleActiveSubscriptionsBannerPreferenceSchema>;
+export type MultipleActiveSubscriptionsBannerPreference = z.infer<
+  typeof MultipleActiveSubscriptionsBannerPreferenceSchema
+>;
 
 export function isMultipleActiveSubscriptionsFilter(nql: string | undefined): boolean {
-    return nql === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER;
+  return nql === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER;
 }
 
-export function parseAccessibilityPreferences(accessibility: string | null | undefined): AccessibilityPreferences {
-    if (!accessibility) {
-        return AccessibilityPreferencesSchema.parse({});
-    }
+export function parseAccessibilityPreferences(
+  accessibility: string | null | undefined,
+): AccessibilityPreferences {
+  if (!accessibility) {
+    return AccessibilityPreferencesSchema.parse({});
+  }
 
-    try {
-        const parsed: unknown = JSON.parse(accessibility);
-        return AccessibilityPreferencesSchema.parse(parsed);
-    } catch {
-        return AccessibilityPreferencesSchema.parse({});
-    }
+  try {
+    const parsed: unknown = JSON.parse(accessibility);
+    return AccessibilityPreferencesSchema.parse(parsed);
+  } catch {
+    return AccessibilityPreferencesSchema.parse({});
+  }
 }
 
 export function getMultipleActiveSubscriptionsBannerPreference(
-    accessibility: string | null | undefined
+  accessibility: string | null | undefined,
 ): MultipleActiveSubscriptionsBannerPreference {
-    const preferences = parseAccessibilityPreferences(accessibility);
-    return preferences.multipleActiveSubscriptionsBanner ?? {};
+  const preferences = parseAccessibilityPreferences(accessibility);
+  return preferences.multipleActiveSubscriptionsBanner ?? {};
 }
 
 export function buildDismissedMultipleActiveSubscriptionsPreference(
-    accessibility: string | null | undefined,
-    dismissedCount: number,
-    dismissedAt: string
+  accessibility: string | null | undefined,
+  dismissedCount: number,
+  dismissedAt: string,
 ): string {
-    const preferences = parseAccessibilityPreferences(accessibility);
-    const currentBannerPreference = getMultipleActiveSubscriptionsBannerPreference(accessibility);
+  const preferences = parseAccessibilityPreferences(accessibility);
+  const currentBannerPreference = getMultipleActiveSubscriptionsBannerPreference(accessibility);
 
-    return JSON.stringify({
-        ...preferences,
-        multipleActiveSubscriptionsBanner: {
-            ...currentBannerPreference,
-            dismissedCount,
-            dismissedAt
-        }
-    });
+  return JSON.stringify({
+    ...preferences,
+    multipleActiveSubscriptionsBanner: {
+      ...currentBannerPreference,
+      dismissedCount,
+      dismissedAt,
+    },
+  });
 }
 
 /**
@@ -64,16 +69,16 @@ export function buildDismissedMultipleActiveSubscriptionsPreference(
  * role that changed since this user was read.
  */
 export function buildUserWithDismissedMultipleActiveSubscriptionsBanner(
-    user: User,
-    dismissedCount: number,
-    dismissedAt: string
+  user: User,
+  dismissedCount: number,
+  dismissedAt: string,
 ): EditUserPayload {
-    return {
-        id: user.id,
-        accessibility: buildDismissedMultipleActiveSubscriptionsPreference(
-            user.accessibility,
-            dismissedCount,
-            dismissedAt
-        )
-    };
+  return {
+    id: user.id,
+    accessibility: buildDismissedMultipleActiveSubscriptionsPreference(
+      user.accessibility,
+      dismissedCount,
+      dismissedAt,
+    ),
+  };
 }

--- a/apps/admin/src/members/multiple-active-subscriptions.ts
+++ b/apps/admin/src/members/multiple-active-subscriptions.ts
@@ -1,80 +1,79 @@
-import { z } from 'zod';
-import type { User } from '@tryghost/admin-x-framework/api/users';
+import {z} from 'zod';
+import type {EditUserPayload, User} from '@tryghost/admin-x-framework/api/users';
 
 export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD = 'count.active_stripe_customers';
 export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:>1`;
 export const NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:<2`;
 
 const MultipleActiveSubscriptionsBannerPreferenceSchema = z.looseObject({
-  dismissedCount: z.number().finite().optional().catch(undefined),
-  dismissedAt: z.string().optional().catch(undefined),
+    dismissedCount: z.number().finite().optional().catch(undefined),
+    dismissedAt: z.string().optional().catch(undefined)
 });
 
 const AccessibilityPreferencesSchema = z.looseObject({
-  multipleActiveSubscriptionsBanner:
-    MultipleActiveSubscriptionsBannerPreferenceSchema.optional().catch(undefined),
+    multipleActiveSubscriptionsBanner: MultipleActiveSubscriptionsBannerPreferenceSchema.optional().catch(undefined)
 });
 
 export type AccessibilityPreferences = z.infer<typeof AccessibilityPreferencesSchema>;
-export type MultipleActiveSubscriptionsBannerPreference = z.infer<
-  typeof MultipleActiveSubscriptionsBannerPreferenceSchema
->;
+export type MultipleActiveSubscriptionsBannerPreference = z.infer<typeof MultipleActiveSubscriptionsBannerPreferenceSchema>;
 
 export function isMultipleActiveSubscriptionsFilter(nql: string | undefined): boolean {
-  return nql === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER;
+    return nql === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER;
 }
 
-export function parseAccessibilityPreferences(
-  accessibility: string | null | undefined,
-): AccessibilityPreferences {
-  if (!accessibility) {
-    return AccessibilityPreferencesSchema.parse({});
-  }
+export function parseAccessibilityPreferences(accessibility: string | null | undefined): AccessibilityPreferences {
+    if (!accessibility) {
+        return AccessibilityPreferencesSchema.parse({});
+    }
 
-  try {
-    const parsed: unknown = JSON.parse(accessibility);
-    return AccessibilityPreferencesSchema.parse(parsed);
-  } catch {
-    return AccessibilityPreferencesSchema.parse({});
-  }
+    try {
+        const parsed: unknown = JSON.parse(accessibility);
+        return AccessibilityPreferencesSchema.parse(parsed);
+    } catch {
+        return AccessibilityPreferencesSchema.parse({});
+    }
 }
 
 export function getMultipleActiveSubscriptionsBannerPreference(
-  accessibility: string | null | undefined,
+    accessibility: string | null | undefined
 ): MultipleActiveSubscriptionsBannerPreference {
-  const preferences = parseAccessibilityPreferences(accessibility);
-  return preferences.multipleActiveSubscriptionsBanner ?? {};
+    const preferences = parseAccessibilityPreferences(accessibility);
+    return preferences.multipleActiveSubscriptionsBanner ?? {};
 }
 
 export function buildDismissedMultipleActiveSubscriptionsPreference(
-  accessibility: string | null | undefined,
-  dismissedCount: number,
-  dismissedAt: string,
+    accessibility: string | null | undefined,
+    dismissedCount: number,
+    dismissedAt: string
 ): string {
-  const preferences = parseAccessibilityPreferences(accessibility);
-  const currentBannerPreference = getMultipleActiveSubscriptionsBannerPreference(accessibility);
+    const preferences = parseAccessibilityPreferences(accessibility);
+    const currentBannerPreference = getMultipleActiveSubscriptionsBannerPreference(accessibility);
 
-  return JSON.stringify({
-    ...preferences,
-    multipleActiveSubscriptionsBanner: {
-      ...currentBannerPreference,
-      dismissedCount,
-      dismissedAt,
-    },
-  });
+    return JSON.stringify({
+        ...preferences,
+        multipleActiveSubscriptionsBanner: {
+            ...currentBannerPreference,
+            dismissedCount,
+            dismissedAt
+        }
+    });
 }
 
+/**
+ * Carries the preference alone: a whole-user payload would revert a name or a
+ * role that changed since this user was read.
+ */
 export function buildUserWithDismissedMultipleActiveSubscriptionsBanner(
-  user: User,
-  dismissedCount: number,
-  dismissedAt: string,
-): User {
-  return {
-    ...user,
-    accessibility: buildDismissedMultipleActiveSubscriptionsPreference(
-      user.accessibility,
-      dismissedCount,
-      dismissedAt,
-    ),
-  };
+    user: User,
+    dismissedCount: number,
+    dismissedAt: string
+): EditUserPayload {
+    return {
+        id: user.id,
+        accessibility: buildDismissedMultipleActiveSubscriptionsPreference(
+            user.accessibility,
+            dismissedCount,
+            dismissedAt
+        )
+    };
 }

--- a/apps/admin/src/onboarding/onboarding.acceptance.test.tsx
+++ b/apps/admin/src/onboarding/onboarding.acceptance.test.tsx
@@ -1,90 +1,94 @@
-import {describe, expect, it} from "vitest";
+import { describe, expect, it } from 'vitest';
 
 import {
-    currentRoute,
-    currentUserResponse,
-    fakeMembers,
-    fakePreferenceEdits,
-    renderAdminApp,
-    type CurrentUserResponse,
-    type EndpointCapture,
-} from "@test-utils/acceptance";
-import {onboardingScreen} from "./onboarding.screen";
+  currentRoute,
+  currentUserResponse,
+  fakeMembers,
+  fakePreferenceEdits,
+  renderAdminApp,
+  type CurrentUserResponse,
+  type EndpointCapture,
+} from '@test-utils/acceptance';
+import { onboardingScreen } from './onboarding.screen';
 
-type ChecklistState = "pending" | "started" | "completed" | "dismissed";
+type ChecklistState = 'pending' | 'started' | 'completed' | 'dismissed';
 
-const activeStartedAt = "2026-05-01T00:00:00.000Z";
+const activeStartedAt = '2026-05-01T00:00:00.000Z';
 
 function onboardingUser(
-    checklistState: ChecklistState,
-    completedSteps: string[] = [],
-    startedAt: string | null | undefined = checklistState === "started" ? activeStartedAt : undefined
+  checklistState: ChecklistState,
+  completedSteps: string[] = [],
+  startedAt: string | null | undefined = checklistState === 'started' ? activeStartedAt : undefined,
 ): CurrentUserResponse {
-    const response = currentUserResponse();
-    response.users[0].accessibility = JSON.stringify({
-        onboarding: {
-            checklistState,
-            completedSteps,
-            ...(startedAt && {startedAt}),
-        },
-    });
-    return response;
+  const response = currentUserResponse();
+  response.users[0].accessibility = JSON.stringify({
+    onboarding: {
+      checklistState,
+      completedSteps,
+      ...(startedAt && { startedAt }),
+    },
+  });
+  return response;
 }
 
 function sentOnboardingPreferences(capture: EndpointCapture): Record<string, unknown> | undefined {
-    const body = capture.lastRequest?.body as {users?: Array<{accessibility?: string}>} | undefined;
-    const accessibility = body?.users?.[0]?.accessibility;
-    if (!accessibility) {
-        return undefined;
-    }
-    return (JSON.parse(accessibility) as {onboarding?: Record<string, unknown>}).onboarding;
+  const body = capture.lastRequest?.body as
+    | { users?: Array<{ accessibility?: string }> }
+    | undefined;
+  const accessibility = body?.users?.[0]?.accessibility;
+  if (!accessibility) {
+    return undefined;
+  }
+  return (JSON.parse(accessibility) as { onboarding?: Record<string, unknown> }).onboarding;
 }
 
-describe("Onboarding redirects", () => {
-    it("redirects active onboarding from Analytics", async () => {
-        await renderAdminApp("/analytics", {
-            boot: {browseMe: {response: onboardingUser("started")}},
-        });
-
-        await expect.element(onboardingScreen.checklist()).toBeVisible();
-        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=%2Fanalytics");
+describe('Onboarding redirects', () => {
+  it('redirects active onboarding from Analytics', async () => {
+    await renderAdminApp('/analytics', {
+      boot: { browseMe: { response: onboardingUser('started') } },
     });
 
-    it("preserves the Analytics subroute when redirecting", async () => {
-        await renderAdminApp("/analytics/web", {
-            boot: {browseMe: {response: onboardingUser("started")}},
-        });
+    await expect.element(onboardingScreen.checklist()).toBeVisible();
+    await expect.poll(currentRoute).toBe('/setup/onboarding?returnTo=%2Fanalytics');
+  });
 
-        await expect.element(onboardingScreen.checklist()).toBeVisible();
-        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=%2Fanalytics%2Fweb");
+  it('preserves the Analytics subroute when redirecting', async () => {
+    await renderAdminApp('/analytics/web', {
+      boot: { browseMe: { response: onboardingUser('started') } },
     });
 
+    await expect.element(onboardingScreen.checklist()).toBeVisible();
+    await expect.poll(currentRoute).toBe('/setup/onboarding?returnTo=%2Fanalytics%2Fweb');
+  });
 });
 
-describe("Onboarding checklist", () => {
-    it("build-audience marks complete and navigates to Members", async () => {
-        fakeMembers([]);
-        const preferencesApi = fakePreferenceEdits();
-        await renderAdminApp("/setup/onboarding?returnTo=%2Fanalytics", {
-            boot: {browseMe: {response: onboardingUser("started")}},
-        });
-
-        await onboardingScreen.step("build-audience").click();
-
-        await expect.poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps).toEqual(["build-audience"]);
-        await expect.poll(currentRoute).toBe("/members");
+describe('Onboarding checklist', () => {
+  it('build-audience marks complete and navigates to Members', async () => {
+    fakeMembers([]);
+    const preferencesApi = fakePreferenceEdits();
+    await renderAdminApp('/setup/onboarding?returnTo=%2Fanalytics', {
+      boot: { browseMe: { response: onboardingUser('started') } },
     });
 
-    it("opens the share dialog and marks the share step complete", async () => {
-        const preferencesApi = fakePreferenceEdits();
-        await renderAdminApp("/setup/onboarding?returnTo=%2Fanalytics", {
-            boot: {browseMe: {response: onboardingUser("started")}},
-        });
+    await onboardingScreen.step('build-audience').click();
 
-        await onboardingScreen.step("share-publication").click();
+    await expect
+      .poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps)
+      .toEqual(['build-audience']);
+    await expect.poll(currentRoute).toBe('/members');
+  });
 
-        await expect.element(onboardingScreen.shareModal()).toBeVisible();
-        await expect.poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps).toEqual(["share-publication"]);
+  it('opens the share dialog and marks the share step complete', async () => {
+    const preferencesApi = fakePreferenceEdits();
+    await renderAdminApp('/setup/onboarding?returnTo=%2Fanalytics', {
+      boot: { browseMe: { response: onboardingUser('started') } },
     });
 
+    await onboardingScreen.step('share-publication').click();
+
+    await expect.element(onboardingScreen.shareModal()).toBeVisible();
+    await expect
+      .poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps)
+      .toEqual(['share-publication']);
+  });
 });

--- a/apps/admin/src/onboarding/onboarding.acceptance.test.tsx
+++ b/apps/admin/src/onboarding/onboarding.acceptance.test.tsx
@@ -1,98 +1,90 @@
-import { describe, expect, it } from 'vitest';
+import {describe, expect, it} from "vitest";
 
 import {
-  currentRoute,
-  currentUserResponse,
-  fakeAdminEndpoint,
-  fakeMembers,
-  renderAdminApp,
-  type CurrentUserResponse,
-  type EndpointCapture,
-} from '@test-utils/acceptance';
-import { onboardingScreen } from './onboarding.screen';
+    currentRoute,
+    currentUserResponse,
+    fakeMembers,
+    fakePreferenceEdits,
+    renderAdminApp,
+    type CurrentUserResponse,
+    type EndpointCapture,
+} from "@test-utils/acceptance";
+import {onboardingScreen} from "./onboarding.screen";
 
-type ChecklistState = 'pending' | 'started' | 'completed' | 'dismissed';
+type ChecklistState = "pending" | "started" | "completed" | "dismissed";
 
-const activeStartedAt = '2026-05-01T00:00:00.000Z';
+const activeStartedAt = "2026-05-01T00:00:00.000Z";
 
 function onboardingUser(
-  checklistState: ChecklistState,
-  completedSteps: string[] = [],
-  startedAt: string | null | undefined = checklistState === 'started' ? activeStartedAt : undefined,
+    checklistState: ChecklistState,
+    completedSteps: string[] = [],
+    startedAt: string | null | undefined = checklistState === "started" ? activeStartedAt : undefined
 ): CurrentUserResponse {
-  const response = currentUserResponse();
-  response.users[0].accessibility = JSON.stringify({
-    onboarding: {
-      checklistState,
-      completedSteps,
-      ...(startedAt && { startedAt }),
-    },
-  });
-  return response;
-}
-
-function fakePreferenceEdits(): EndpointCapture {
-  return fakeAdminEndpoint('PUT', /^\/users\/\w+\/\?include=roles/, ({ body }) => body);
+    const response = currentUserResponse();
+    response.users[0].accessibility = JSON.stringify({
+        onboarding: {
+            checklistState,
+            completedSteps,
+            ...(startedAt && {startedAt}),
+        },
+    });
+    return response;
 }
 
 function sentOnboardingPreferences(capture: EndpointCapture): Record<string, unknown> | undefined {
-  const body = capture.lastRequest?.body as
-    | { users?: Array<{ accessibility?: string }> }
-    | undefined;
-  const accessibility = body?.users?.[0]?.accessibility;
-  if (!accessibility) {
-    return undefined;
-  }
-  return (JSON.parse(accessibility) as { onboarding?: Record<string, unknown> }).onboarding;
+    const body = capture.lastRequest?.body as {users?: Array<{accessibility?: string}>} | undefined;
+    const accessibility = body?.users?.[0]?.accessibility;
+    if (!accessibility) {
+        return undefined;
+    }
+    return (JSON.parse(accessibility) as {onboarding?: Record<string, unknown>}).onboarding;
 }
 
-describe('Onboarding redirects', () => {
-  it('redirects active onboarding from Analytics', async () => {
-    await renderAdminApp('/analytics', {
-      boot: { browseMe: { response: onboardingUser('started') } },
+describe("Onboarding redirects", () => {
+    it("redirects active onboarding from Analytics", async () => {
+        await renderAdminApp("/analytics", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
+
+        await expect.element(onboardingScreen.checklist()).toBeVisible();
+        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=%2Fanalytics");
     });
 
-    await expect.element(onboardingScreen.checklist()).toBeVisible();
-    await expect.poll(currentRoute).toBe('/setup/onboarding?returnTo=%2Fanalytics');
-  });
+    it("preserves the Analytics subroute when redirecting", async () => {
+        await renderAdminApp("/analytics/web", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
 
-  it('preserves the Analytics subroute when redirecting', async () => {
-    await renderAdminApp('/analytics/web', {
-      boot: { browseMe: { response: onboardingUser('started') } },
+        await expect.element(onboardingScreen.checklist()).toBeVisible();
+        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=%2Fanalytics%2Fweb");
     });
 
-    await expect.element(onboardingScreen.checklist()).toBeVisible();
-    await expect.poll(currentRoute).toBe('/setup/onboarding?returnTo=%2Fanalytics%2Fweb');
-  });
 });
 
-describe('Onboarding checklist', () => {
-  it('build-audience marks complete and navigates to Members', async () => {
-    fakeMembers([]);
-    const preferencesApi = fakePreferenceEdits();
-    await renderAdminApp('/setup/onboarding?returnTo=%2Fanalytics', {
-      boot: { browseMe: { response: onboardingUser('started') } },
+describe("Onboarding checklist", () => {
+    it("build-audience marks complete and navigates to Members", async () => {
+        fakeMembers([]);
+        const preferencesApi = fakePreferenceEdits();
+        await renderAdminApp("/setup/onboarding?returnTo=%2Fanalytics", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
+
+        await onboardingScreen.step("build-audience").click();
+
+        await expect.poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps).toEqual(["build-audience"]);
+        await expect.poll(currentRoute).toBe("/members");
     });
 
-    await onboardingScreen.step('build-audience').click();
+    it("opens the share dialog and marks the share step complete", async () => {
+        const preferencesApi = fakePreferenceEdits();
+        await renderAdminApp("/setup/onboarding?returnTo=%2Fanalytics", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
 
-    await expect
-      .poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps)
-      .toEqual(['build-audience']);
-    await expect.poll(currentRoute).toBe('/members');
-  });
+        await onboardingScreen.step("share-publication").click();
 
-  it('opens the share dialog and marks the share step complete', async () => {
-    const preferencesApi = fakePreferenceEdits();
-    await renderAdminApp('/setup/onboarding?returnTo=%2Fanalytics', {
-      boot: { browseMe: { response: onboardingUser('started') } },
+        await expect.element(onboardingScreen.shareModal()).toBeVisible();
+        await expect.poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps).toEqual(["share-publication"]);
     });
 
-    await onboardingScreen.step('share-publication').click();
-
-    await expect.element(onboardingScreen.shareModal()).toBeVisible();
-    await expect
-      .poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps)
-      .toEqual(['share-publication']);
-  });
 });

--- a/apps/admin/src/whats-new/hooks/use-whats-new.ts
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.ts
@@ -1,88 +1,100 @@
-import { useEffect } from "react";
-import { useQuery, useMutation, type UseQueryResult, type UseMutationResult } from "@tanstack/react-query";
+import { useEffect } from 'react';
+import {
+  useQuery,
+  useMutation,
+  type UseQueryResult,
+  type UseMutationResult,
+} from '@tanstack/react-query';
 
 import {
-    useUserPreferences,
-    useEditUserPreferences,
-    type Preferences,
-    type WhatsNewPreferences,
-} from "@/hooks/user-preferences";
-import { useChangelog, type ChangelogEntry } from "./use-changelog";
+  useUserPreferences,
+  useEditUserPreferences,
+  type Preferences,
+  type WhatsNewPreferences,
+} from '@/hooks/user-preferences';
+import { useChangelog, type ChangelogEntry } from './use-changelog';
 
 function getDefaultWhatsNewPreferences(): WhatsNewPreferences {
-    return {
-        lastSeenDate: new Date(),
-    };
+  return {
+    lastSeenDate: new Date(),
+  };
 }
 
 interface WhatsNewData {
-    hasNew: boolean;
+  hasNew: boolean;
 }
 
-const whatsNewQueryKey = (preferences: Preferences | undefined, latestEntry: ChangelogEntry | undefined) =>
-    ["whatsNew", preferences?.whatsNew?.lastSeenDate?.toISOString(), latestEntry?.publishedAt.toISOString()] as const;
+const whatsNewQueryKey = (
+  preferences: Preferences | undefined,
+  latestEntry: ChangelogEntry | undefined,
+) =>
+  [
+    'whatsNew',
+    preferences?.whatsNew?.lastSeenDate?.toISOString(),
+    latestEntry?.publishedAt.toISOString(),
+  ] as const;
 
 export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
-    const { data: preferences, isSuccess: isPreferencesLoaded } = useUserPreferences();
-    const { data: changelog, isSuccess: isChangelogLoaded } = useChangelog();
-    const { mutateAsync: updatePreferences } = useEditUserPreferences();
+  const { data: preferences, isSuccess: isPreferencesLoaded } = useUserPreferences();
+  const { data: changelog, isSuccess: isChangelogLoaded } = useChangelog();
+  const { mutateAsync: updatePreferences } = useEditUserPreferences();
 
-    const hasWhatsNewPreferences = !!preferences?.whatsNew?.lastSeenDate;
+  const hasWhatsNewPreferences = !!preferences?.whatsNew?.lastSeenDate;
 
-    // Stores today as the last seen date for a user who has none, so entries
-    // published before they arrived never read as new. Every mounted reader
-    // runs this, and the duplicate writes each merge over the stored blob, so
-    // they settle on the same state instead of overwriting one another.
-    useEffect(() => {
-        if (!hasWhatsNewPreferences && isPreferencesLoaded) {
-            void updatePreferences({
-                whatsNew: getDefaultWhatsNewPreferences(),
-            });
-        }
-    }, [hasWhatsNewPreferences, isPreferencesLoaded, updatePreferences]);
+  // Stores today as the last seen date for a user who has none, so entries
+  // published before they arrived never read as new. Every mounted reader
+  // runs this, and the duplicate writes each merge over the stored blob, so
+  // they settle on the same state instead of overwriting one another.
+  useEffect(() => {
+    if (!hasWhatsNewPreferences && isPreferencesLoaded) {
+      void updatePreferences({
+        whatsNew: getDefaultWhatsNewPreferences(),
+      });
+    }
+  }, [hasWhatsNewPreferences, isPreferencesLoaded, updatePreferences]);
 
-    const latestEntry = changelog?.entries[0];
+  const latestEntry = changelog?.entries[0];
 
-    return useQuery({
-        queryKey: whatsNewQueryKey(preferences, latestEntry),
-        queryFn: () => {
-            if (!latestEntry) {
-                return { hasNew: false };
-            }
+  return useQuery({
+    queryKey: whatsNewQueryKey(preferences, latestEntry),
+    queryFn: () => {
+      if (!latestEntry) {
+        return { hasNew: false };
+      }
 
-            // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
-            // and the effect above stores a valid lastSeenDate
-            const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
+      // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
+      // and the effect above stores a valid lastSeenDate
+      const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
 
-            const hasNew = latestEntry.publishedAt > lastSeenDate;
+      const hasNew = latestEntry.publishedAt > lastSeenDate;
 
-            return { hasNew };
-        },
-        enabled: isChangelogLoaded && hasWhatsNewPreferences,
-        staleTime: Infinity,
-        gcTime: 0,
-    });
+      return { hasNew };
+    },
+    enabled: isChangelogLoaded && hasWhatsNewPreferences,
+    staleTime: Infinity,
+    gcTime: 0,
+  });
 };
 
 export const useDismissWhatsNew = (): UseMutationResult<void, Error, void, unknown> => {
-    const { data: changelog } = useChangelog();
-    const { mutateAsync: updatePreferences } = useEditUserPreferences();
+  const { data: changelog } = useChangelog();
+  const { mutateAsync: updatePreferences } = useEditUserPreferences();
 
-    return useMutation({
-        mutationFn: async () => {
-            const latestEntry = changelog?.entries[0];
+  return useMutation({
+    mutationFn: async () => {
+      const latestEntry = changelog?.entries[0];
 
-            if (!latestEntry) {
-                return;
-            }
+      if (!latestEntry) {
+        return;
+      }
 
-            const newPreferences: WhatsNewPreferences = {
-                lastSeenDate: latestEntry.publishedAt,
-            };
+      const newPreferences: WhatsNewPreferences = {
+        lastSeenDate: latestEntry.publishedAt,
+      };
 
-            await updatePreferences({
-                whatsNew: newPreferences,
-            });
-        },
-    });
+      await updatePreferences({
+        whatsNew: newPreferences,
+      });
+    },
+  });
 };

--- a/apps/admin/src/whats-new/hooks/use-whats-new.ts
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.ts
@@ -1,97 +1,88 @@
-import { useEffect } from 'react';
-import {
-  useQuery,
-  useMutation,
-  type UseQueryResult,
-  type UseMutationResult,
-} from '@tanstack/react-query';
+import { useEffect } from "react";
+import { useQuery, useMutation, type UseQueryResult, type UseMutationResult } from "@tanstack/react-query";
 
 import {
-  useUserPreferences,
-  useEditUserPreferences,
-  type Preferences,
-  type WhatsNewPreferences,
-} from '@/hooks/user-preferences';
-import { useChangelog, type ChangelogEntry } from './use-changelog';
+    useUserPreferences,
+    useEditUserPreferences,
+    type Preferences,
+    type WhatsNewPreferences,
+} from "@/hooks/user-preferences";
+import { useChangelog, type ChangelogEntry } from "./use-changelog";
 
 function getDefaultWhatsNewPreferences(): WhatsNewPreferences {
-  return {
-    lastSeenDate: new Date(),
-  };
+    return {
+        lastSeenDate: new Date(),
+    };
 }
 
 interface WhatsNewData {
-  hasNew: boolean;
+    hasNew: boolean;
 }
 
-const whatsNewQueryKey = (
-  preferences: Preferences | undefined,
-  latestEntry: ChangelogEntry | undefined,
-) =>
-  [
-    'whatsNew',
-    preferences?.whatsNew?.lastSeenDate?.toISOString(),
-    latestEntry?.publishedAt.toISOString(),
-  ] as const;
+const whatsNewQueryKey = (preferences: Preferences | undefined, latestEntry: ChangelogEntry | undefined) =>
+    ["whatsNew", preferences?.whatsNew?.lastSeenDate?.toISOString(), latestEntry?.publishedAt.toISOString()] as const;
 
 export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
-  const { data: preferences, isSuccess: isPreferencesLoaded } = useUserPreferences();
-  const { data: changelog, isSuccess: isChangelogLoaded } = useChangelog();
-  const { mutateAsync: updatePreferences } = useEditUserPreferences();
+    const { data: preferences, isSuccess: isPreferencesLoaded } = useUserPreferences();
+    const { data: changelog, isSuccess: isChangelogLoaded } = useChangelog();
+    const { mutateAsync: updatePreferences } = useEditUserPreferences();
 
-  const hasWhatsNewPreferences = !!preferences?.whatsNew?.lastSeenDate;
+    const hasWhatsNewPreferences = !!preferences?.whatsNew?.lastSeenDate;
 
-  // Initialize default whatsNewPreferences if missing or invalid
-  useEffect(() => {
-    if (!hasWhatsNewPreferences && isPreferencesLoaded) {
-      void updatePreferences({
-        whatsNew: getDefaultWhatsNewPreferences(),
-      });
-    }
-  }, [hasWhatsNewPreferences, isPreferencesLoaded, updatePreferences]);
+    // Stores today as the last seen date for a user who has none, so entries
+    // published before they arrived never read as new. Every mounted reader
+    // runs this, and the duplicate writes each merge over the stored blob, so
+    // they settle on the same state instead of overwriting one another.
+    useEffect(() => {
+        if (!hasWhatsNewPreferences && isPreferencesLoaded) {
+            void updatePreferences({
+                whatsNew: getDefaultWhatsNewPreferences(),
+            });
+        }
+    }, [hasWhatsNewPreferences, isPreferencesLoaded, updatePreferences]);
 
-  const latestEntry = changelog?.entries[0];
+    const latestEntry = changelog?.entries[0];
 
-  return useQuery({
-    queryKey: whatsNewQueryKey(preferences, latestEntry),
-    queryFn: () => {
-      if (!latestEntry) {
-        return { hasNew: false };
-      }
+    return useQuery({
+        queryKey: whatsNewQueryKey(preferences, latestEntry),
+        queryFn: () => {
+            if (!latestEntry) {
+                return { hasNew: false };
+            }
 
-      // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
-      // and useEffect ensures whatsNew is initialized with a valid lastSeenDate
-      const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
+            // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
+            // and the effect above stores a valid lastSeenDate
+            const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
 
-      const hasNew = latestEntry.publishedAt > lastSeenDate;
+            const hasNew = latestEntry.publishedAt > lastSeenDate;
 
-      return { hasNew };
-    },
-    enabled: isChangelogLoaded && hasWhatsNewPreferences,
-    staleTime: Infinity,
-    gcTime: 0,
-  });
+            return { hasNew };
+        },
+        enabled: isChangelogLoaded && hasWhatsNewPreferences,
+        staleTime: Infinity,
+        gcTime: 0,
+    });
 };
 
 export const useDismissWhatsNew = (): UseMutationResult<void, Error, void, unknown> => {
-  const { data: changelog } = useChangelog();
-  const { mutateAsync: updatePreferences } = useEditUserPreferences();
+    const { data: changelog } = useChangelog();
+    const { mutateAsync: updatePreferences } = useEditUserPreferences();
 
-  return useMutation({
-    mutationFn: async () => {
-      const latestEntry = changelog?.entries[0];
+    return useMutation({
+        mutationFn: async () => {
+            const latestEntry = changelog?.entries[0];
 
-      if (!latestEntry) {
-        return;
-      }
+            if (!latestEntry) {
+                return;
+            }
 
-      const newPreferences: WhatsNewPreferences = {
-        lastSeenDate: latestEntry.publishedAt,
-      };
+            const newPreferences: WhatsNewPreferences = {
+                lastSeenDate: latestEntry.publishedAt,
+            };
 
-      await updatePreferences({
-        whatsNew: newPreferences,
-      });
-    },
-  });
+            await updatePreferences({
+                whatsNew: newPreferences,
+            });
+        },
+    });
 };

--- a/apps/admin/src/whats-new/whats-new.acceptance.test.tsx
+++ b/apps/admin/src/whats-new/whats-new.acceptance.test.tsx
@@ -1,170 +1,163 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
 import {
-  changelogEntry,
-  currentUserResponse,
-  fakeAdminEndpoint,
-  fakeEndpoint,
-  fakeTags,
-  renderAdminApp,
-  type CurrentUserResponse,
-} from '@test-utils/acceptance';
-import { sidebarScreen } from '@/layout/sidebar.screen';
-import { tagsScreen } from '@/tags/tags.screen';
-import { whatsNewScreen } from './whats-new.screen';
+    changelogEntry,
+    currentUserResponse,
+    fakeEndpoint,
+    fakePreferenceEdits,
+    fakeTags,
+    renderAdminApp,
+    type CurrentUserResponse,
+} from "@test-utils/acceptance";
+import { sidebarScreen } from "@/layout/sidebar.screen";
+import { tagsScreen } from "@/tags/tags.screen";
+import { whatsNewScreen } from "./whats-new.screen";
 
-const LAST_SEEN = '2025-01-01T00:00:00.000Z';
-const NEWER_THAN_LAST_SEEN = '2025-06-01T00:00:00.000Z';
+const LAST_SEEN = "2025-01-01T00:00:00.000Z";
+const NEWER_THAN_LAST_SEEN = "2025-06-01T00:00:00.000Z";
 
 function userWhoLastSawChangelogAt(lastSeenDate: string): CurrentUserResponse {
-  const me = currentUserResponse();
-  me.users[0].accessibility = JSON.stringify({ whatsNew: { lastSeenDate } });
-  return me;
+    const me = currentUserResponse();
+    me.users[0].accessibility = JSON.stringify({ whatsNew: { lastSeenDate } });
+    return me;
 }
 
 describe("What's new banner", () => {
-  it('shows no banner when the changelog feed is empty', async () => {
-    // The default boot serves an empty changelog feed.
-    fakeTags([]);
-    await renderAdminApp('/tags');
+    it("shows no banner when the changelog feed is empty", async () => {
+        // The default boot serves an empty changelog feed.
+        fakeTags([]);
+        await renderAdminApp("/tags");
 
-    // Prove absence only after the page has settled.
-    await expect.element(tagsScreen.emptyStateHeading()).toBeVisible();
-    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-  });
-
-  it("shows the banner when an entry is newer than the user's last seen date", async () => {
-    fakeTags([]);
-    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
-      posts: [
-        changelogEntry({
-          title: 'New Update',
-          custom_excerpt: 'This is an exciting new feature',
-          published_at: NEWER_THAN_LAST_SEEN,
-        }),
-      ],
-    });
-    await renderAdminApp('/tags', {
-      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        // Prove absence only after the page has settled.
+        await expect.element(tagsScreen.emptyStateHeading()).toBeVisible();
+        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
     });
 
-    await expect.element(whatsNewScreen.banner()).toBeVisible();
-    await expect.element(whatsNewScreen.bannerTitle()).toHaveTextContent('New Update');
-    await expect
-      .element(whatsNewScreen.bannerExcerpt())
-      .toHaveTextContent('This is an exciting new feature');
-  });
+    it("shows the banner when an entry is newer than the user's last seen date", async () => {
+        fakeTags([]);
+        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
+            posts: [
+                changelogEntry({
+                    title: "New Update",
+                    custom_excerpt: "This is an exciting new feature",
+                    published_at: NEWER_THAN_LAST_SEEN,
+                }),
+            ],
+        });
+        await renderAdminApp("/tags", {
+            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        });
 
-  it("dismissing the banner persists the entry's date as last seen", async () => {
-    fakeTags([]);
-    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
-      posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+        await expect.element(whatsNewScreen.banner()).toBeVisible();
+        await expect.element(whatsNewScreen.bannerTitle()).toHaveTextContent("New Update");
+        await expect.element(whatsNewScreen.bannerExcerpt()).toHaveTextContent("This is an exciting new feature");
     });
-    // Echo the PUT so the client's write persists (see boot.ts's editUserPreferences).
-    const prefsApi = fakeAdminEndpoint('PUT', /^\/users\/\w+\//, ({ body }) => body);
-    await renderAdminApp('/tags', {
-      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+
+    it("dismissing the banner persists the entry's date as last seen", async () => {
+        fakeTags([]);
+        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
+            posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+        });
+        const prefsApi = fakePreferenceEdits();
+        await renderAdminApp("/tags", {
+            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        });
+
+        await expect.element(whatsNewScreen.banner()).toBeVisible();
+        await whatsNewScreen.dismissButton().click();
+
+        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+        await expect
+            .poll(() => {
+                const body = prefsApi.lastRequest?.body as { users: Array<{ accessibility: string }> } | undefined;
+                if (!body) {
+                    return undefined;
+                }
+                const preferences = JSON.parse(body.users[0].accessibility) as { whatsNew?: { lastSeenDate?: string } };
+                return preferences.whatsNew?.lastSeenDate;
+            })
+            .toBe(NEWER_THAN_LAST_SEEN);
     });
-
-    await expect.element(whatsNewScreen.banner()).toBeVisible();
-    await whatsNewScreen.dismissButton().click();
-
-    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-    await expect
-      .poll(() => {
-        const body = prefsApi.lastRequest?.body as
-          | { users: Array<{ accessibility: string }> }
-          | undefined;
-        if (!body) {
-          return undefined;
-        }
-        const preferences = JSON.parse(body.users[0].accessibility) as {
-          whatsNew?: { lastSeenDate?: string };
-        };
-        return preferences.whatsNew?.lastSeenDate;
-      })
-      .toBe(NEWER_THAN_LAST_SEEN);
-  });
 });
 
 describe("What's new menu", () => {
-  it("shows the changelog entries in the What's new modal", async () => {
-    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
-      posts: [
-        changelogEntry({
-          title: 'Latest Update',
-          custom_excerpt: 'Latest feature',
-          published_at: NEWER_THAN_LAST_SEEN,
-          // Non-blocklisted host: image requests bypass the worker.
-          feature_image: 'https://static.test/latest-update.jpg',
-        }),
-        changelogEntry({
-          title: 'Previous Update',
-          custom_excerpt: 'Previous feature',
-          published_at: LAST_SEEN,
-        }),
-      ],
-    });
-    await renderAdminApp('/site');
+    it("shows the changelog entries in the What's new modal", async () => {
+        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
+            posts: [
+                changelogEntry({
+                    title: "Latest Update",
+                    custom_excerpt: "Latest feature",
+                    published_at: NEWER_THAN_LAST_SEEN,
+                    // Non-blocklisted host: image requests bypass the worker.
+                    feature_image: "https://static.test/latest-update.jpg",
+                }),
+                changelogEntry({
+                    title: "Previous Update",
+                    custom_excerpt: "Previous feature",
+                    published_at: LAST_SEEN,
+                }),
+            ],
+        });
+        await renderAdminApp("/site");
 
-    await sidebarScreen.userMenuTrigger().click();
-    await whatsNewScreen.menuItem().click();
+        await sidebarScreen.userMenuTrigger().click();
+        await whatsNewScreen.menuItem().click();
 
-    await expect.element(whatsNewScreen.dialog()).toBeVisible();
-    await expect(whatsNewScreen.entries()).toHaveCount(2);
-    await expect.element(whatsNewScreen.entry(0)).toHaveTextContent('Latest Update');
-    await expect.element(whatsNewScreen.entry(0)).toHaveTextContent('Latest feature');
-    await expect.element(whatsNewScreen.entryImage(0)).toBeVisible();
-    await expect.element(whatsNewScreen.entry(1)).toHaveTextContent('Previous Update');
-    await expect.element(whatsNewScreen.entry(1)).toHaveTextContent('Previous feature');
-  });
-
-  it("shows badges when an entry is newer than the user's last seen date", async () => {
-    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
-      posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
-    });
-    await renderAdminApp('/site', {
-      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        await expect.element(whatsNewScreen.dialog()).toBeVisible();
+        await expect(whatsNewScreen.entries()).toHaveCount(2);
+        await expect.element(whatsNewScreen.entry(0)).toHaveTextContent("Latest Update");
+        await expect.element(whatsNewScreen.entry(0)).toHaveTextContent("Latest feature");
+        await expect.element(whatsNewScreen.entryImage(0)).toBeVisible();
+        await expect.element(whatsNewScreen.entry(1)).toHaveTextContent("Previous Update");
+        await expect.element(whatsNewScreen.entry(1)).toHaveTextContent("Previous feature");
     });
 
-    await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
+    it("shows badges when an entry is newer than the user's last seen date", async () => {
+        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
+            posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+        });
+        await renderAdminApp("/site", {
+            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        });
 
-    await sidebarScreen.userMenuTrigger().click();
-    await expect.element(whatsNewScreen.menuBadge()).toBeVisible();
-  });
+        await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
 
-  it('shows no banner or badges for entries from before the user joined', async () => {
-    // A user with no stored what's-new state is initialized to the present day.
-    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
-      posts: [changelogEntry({ published_at: '2020-01-01T00:00:00.000Z' })],
-    });
-    await renderAdminApp('/site');
-
-    await sidebarScreen.userMenuTrigger().click();
-    await expect.element(whatsNewScreen.menuItem()).toBeVisible();
-    await expect.element(whatsNewScreen.menuBadge()).not.toBeInTheDocument();
-    await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
-    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-  });
-
-  it("clears the banner and badges when the What's new modal is opened", async () => {
-    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
-      posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
-    });
-    await renderAdminApp('/site', {
-      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        await sidebarScreen.userMenuTrigger().click();
+        await expect.element(whatsNewScreen.menuBadge()).toBeVisible();
     });
 
-    await expect.element(whatsNewScreen.banner()).toBeVisible();
-    await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
+    it("shows no banner or badges for entries from before the user joined", async () => {
+        // A user with no stored what's-new state is initialized to the present day.
+        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
+            posts: [changelogEntry({ published_at: "2020-01-01T00:00:00.000Z" })],
+        });
+        await renderAdminApp("/site");
 
-    await sidebarScreen.userMenuTrigger().click();
-    await whatsNewScreen.menuItem().click();
-    await expect.element(whatsNewScreen.dialog()).toBeVisible();
-    await whatsNewScreen.closeDialog();
+        await sidebarScreen.userMenuTrigger().click();
+        await expect.element(whatsNewScreen.menuItem()).toBeVisible();
+        await expect.element(whatsNewScreen.menuBadge()).not.toBeInTheDocument();
+        await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
+        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+    });
 
-    await expect.element(whatsNewScreen.dialog()).not.toBeInTheDocument();
-    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-    await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
-  });
+    it("clears the banner and badges when the What's new modal is opened", async () => {
+        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
+            posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+        });
+        await renderAdminApp("/site", {
+            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
+        });
+
+        await expect.element(whatsNewScreen.banner()).toBeVisible();
+        await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
+
+        await sidebarScreen.userMenuTrigger().click();
+        await whatsNewScreen.menuItem().click();
+        await expect.element(whatsNewScreen.dialog()).toBeVisible();
+        await whatsNewScreen.closeDialog();
+
+        await expect.element(whatsNewScreen.dialog()).not.toBeInTheDocument();
+        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+        await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
+    });
 });

--- a/apps/admin/src/whats-new/whats-new.acceptance.test.tsx
+++ b/apps/admin/src/whats-new/whats-new.acceptance.test.tsx
@@ -1,163 +1,169 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
 import {
-    changelogEntry,
-    currentUserResponse,
-    fakeEndpoint,
-    fakePreferenceEdits,
-    fakeTags,
-    renderAdminApp,
-    type CurrentUserResponse,
-} from "@test-utils/acceptance";
-import { sidebarScreen } from "@/layout/sidebar.screen";
-import { tagsScreen } from "@/tags/tags.screen";
-import { whatsNewScreen } from "./whats-new.screen";
+  changelogEntry,
+  currentUserResponse,
+  fakeEndpoint,
+  fakePreferenceEdits,
+  fakeTags,
+  renderAdminApp,
+  type CurrentUserResponse,
+} from '@test-utils/acceptance';
+import { sidebarScreen } from '@/layout/sidebar.screen';
+import { tagsScreen } from '@/tags/tags.screen';
+import { whatsNewScreen } from './whats-new.screen';
 
-const LAST_SEEN = "2025-01-01T00:00:00.000Z";
-const NEWER_THAN_LAST_SEEN = "2025-06-01T00:00:00.000Z";
+const LAST_SEEN = '2025-01-01T00:00:00.000Z';
+const NEWER_THAN_LAST_SEEN = '2025-06-01T00:00:00.000Z';
 
 function userWhoLastSawChangelogAt(lastSeenDate: string): CurrentUserResponse {
-    const me = currentUserResponse();
-    me.users[0].accessibility = JSON.stringify({ whatsNew: { lastSeenDate } });
-    return me;
+  const me = currentUserResponse();
+  me.users[0].accessibility = JSON.stringify({ whatsNew: { lastSeenDate } });
+  return me;
 }
 
 describe("What's new banner", () => {
-    it("shows no banner when the changelog feed is empty", async () => {
-        // The default boot serves an empty changelog feed.
-        fakeTags([]);
-        await renderAdminApp("/tags");
+  it('shows no banner when the changelog feed is empty', async () => {
+    // The default boot serves an empty changelog feed.
+    fakeTags([]);
+    await renderAdminApp('/tags');
 
-        // Prove absence only after the page has settled.
-        await expect.element(tagsScreen.emptyStateHeading()).toBeVisible();
-        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+    // Prove absence only after the page has settled.
+    await expect.element(tagsScreen.emptyStateHeading()).toBeVisible();
+    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+  });
+
+  it("shows the banner when an entry is newer than the user's last seen date", async () => {
+    fakeTags([]);
+    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
+      posts: [
+        changelogEntry({
+          title: 'New Update',
+          custom_excerpt: 'This is an exciting new feature',
+          published_at: NEWER_THAN_LAST_SEEN,
+        }),
+      ],
+    });
+    await renderAdminApp('/tags', {
+      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
     });
 
-    it("shows the banner when an entry is newer than the user's last seen date", async () => {
-        fakeTags([]);
-        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
-            posts: [
-                changelogEntry({
-                    title: "New Update",
-                    custom_excerpt: "This is an exciting new feature",
-                    published_at: NEWER_THAN_LAST_SEEN,
-                }),
-            ],
-        });
-        await renderAdminApp("/tags", {
-            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
-        });
+    await expect.element(whatsNewScreen.banner()).toBeVisible();
+    await expect.element(whatsNewScreen.bannerTitle()).toHaveTextContent('New Update');
+    await expect
+      .element(whatsNewScreen.bannerExcerpt())
+      .toHaveTextContent('This is an exciting new feature');
+  });
 
-        await expect.element(whatsNewScreen.banner()).toBeVisible();
-        await expect.element(whatsNewScreen.bannerTitle()).toHaveTextContent("New Update");
-        await expect.element(whatsNewScreen.bannerExcerpt()).toHaveTextContent("This is an exciting new feature");
+  it("dismissing the banner persists the entry's date as last seen", async () => {
+    fakeTags([]);
+    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
+      posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+    });
+    const prefsApi = fakePreferenceEdits();
+    await renderAdminApp('/tags', {
+      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
     });
 
-    it("dismissing the banner persists the entry's date as last seen", async () => {
-        fakeTags([]);
-        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
-            posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
-        });
-        const prefsApi = fakePreferenceEdits();
-        await renderAdminApp("/tags", {
-            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
-        });
+    await expect.element(whatsNewScreen.banner()).toBeVisible();
+    await whatsNewScreen.dismissButton().click();
 
-        await expect.element(whatsNewScreen.banner()).toBeVisible();
-        await whatsNewScreen.dismissButton().click();
-
-        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-        await expect
-            .poll(() => {
-                const body = prefsApi.lastRequest?.body as { users: Array<{ accessibility: string }> } | undefined;
-                if (!body) {
-                    return undefined;
-                }
-                const preferences = JSON.parse(body.users[0].accessibility) as { whatsNew?: { lastSeenDate?: string } };
-                return preferences.whatsNew?.lastSeenDate;
-            })
-            .toBe(NEWER_THAN_LAST_SEEN);
-    });
+    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+    await expect
+      .poll(() => {
+        const body = prefsApi.lastRequest?.body as
+          | { users: Array<{ accessibility: string }> }
+          | undefined;
+        if (!body) {
+          return undefined;
+        }
+        const preferences = JSON.parse(body.users[0].accessibility) as {
+          whatsNew?: { lastSeenDate?: string };
+        };
+        return preferences.whatsNew?.lastSeenDate;
+      })
+      .toBe(NEWER_THAN_LAST_SEEN);
+  });
 });
 
 describe("What's new menu", () => {
-    it("shows the changelog entries in the What's new modal", async () => {
-        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
-            posts: [
-                changelogEntry({
-                    title: "Latest Update",
-                    custom_excerpt: "Latest feature",
-                    published_at: NEWER_THAN_LAST_SEEN,
-                    // Non-blocklisted host: image requests bypass the worker.
-                    feature_image: "https://static.test/latest-update.jpg",
-                }),
-                changelogEntry({
-                    title: "Previous Update",
-                    custom_excerpt: "Previous feature",
-                    published_at: LAST_SEEN,
-                }),
-            ],
-        });
-        await renderAdminApp("/site");
+  it("shows the changelog entries in the What's new modal", async () => {
+    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
+      posts: [
+        changelogEntry({
+          title: 'Latest Update',
+          custom_excerpt: 'Latest feature',
+          published_at: NEWER_THAN_LAST_SEEN,
+          // Non-blocklisted host: image requests bypass the worker.
+          feature_image: 'https://static.test/latest-update.jpg',
+        }),
+        changelogEntry({
+          title: 'Previous Update',
+          custom_excerpt: 'Previous feature',
+          published_at: LAST_SEEN,
+        }),
+      ],
+    });
+    await renderAdminApp('/site');
 
-        await sidebarScreen.userMenuTrigger().click();
-        await whatsNewScreen.menuItem().click();
+    await sidebarScreen.userMenuTrigger().click();
+    await whatsNewScreen.menuItem().click();
 
-        await expect.element(whatsNewScreen.dialog()).toBeVisible();
-        await expect(whatsNewScreen.entries()).toHaveCount(2);
-        await expect.element(whatsNewScreen.entry(0)).toHaveTextContent("Latest Update");
-        await expect.element(whatsNewScreen.entry(0)).toHaveTextContent("Latest feature");
-        await expect.element(whatsNewScreen.entryImage(0)).toBeVisible();
-        await expect.element(whatsNewScreen.entry(1)).toHaveTextContent("Previous Update");
-        await expect.element(whatsNewScreen.entry(1)).toHaveTextContent("Previous feature");
+    await expect.element(whatsNewScreen.dialog()).toBeVisible();
+    await expect(whatsNewScreen.entries()).toHaveCount(2);
+    await expect.element(whatsNewScreen.entry(0)).toHaveTextContent('Latest Update');
+    await expect.element(whatsNewScreen.entry(0)).toHaveTextContent('Latest feature');
+    await expect.element(whatsNewScreen.entryImage(0)).toBeVisible();
+    await expect.element(whatsNewScreen.entry(1)).toHaveTextContent('Previous Update');
+    await expect.element(whatsNewScreen.entry(1)).toHaveTextContent('Previous feature');
+  });
+
+  it("shows badges when an entry is newer than the user's last seen date", async () => {
+    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
+      posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+    });
+    await renderAdminApp('/site', {
+      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
     });
 
-    it("shows badges when an entry is newer than the user's last seen date", async () => {
-        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
-            posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
-        });
-        await renderAdminApp("/site", {
-            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
-        });
+    await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
 
-        await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
+    await sidebarScreen.userMenuTrigger().click();
+    await expect.element(whatsNewScreen.menuBadge()).toBeVisible();
+  });
 
-        await sidebarScreen.userMenuTrigger().click();
-        await expect.element(whatsNewScreen.menuBadge()).toBeVisible();
+  it('shows no banner or badges for entries from before the user joined', async () => {
+    // A user with no stored what's-new state is initialized to the present day.
+    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
+      posts: [changelogEntry({ published_at: '2020-01-01T00:00:00.000Z' })],
+    });
+    await renderAdminApp('/site');
+
+    await sidebarScreen.userMenuTrigger().click();
+    await expect.element(whatsNewScreen.menuItem()).toBeVisible();
+    await expect.element(whatsNewScreen.menuBadge()).not.toBeInTheDocument();
+    await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
+    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+  });
+
+  it("clears the banner and badges when the What's new modal is opened", async () => {
+    fakeEndpoint('GET', 'https://ghost.org/changelog.json', {
+      posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
+    });
+    await renderAdminApp('/site', {
+      boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
     });
 
-    it("shows no banner or badges for entries from before the user joined", async () => {
-        // A user with no stored what's-new state is initialized to the present day.
-        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
-            posts: [changelogEntry({ published_at: "2020-01-01T00:00:00.000Z" })],
-        });
-        await renderAdminApp("/site");
+    await expect.element(whatsNewScreen.banner()).toBeVisible();
+    await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
 
-        await sidebarScreen.userMenuTrigger().click();
-        await expect.element(whatsNewScreen.menuItem()).toBeVisible();
-        await expect.element(whatsNewScreen.menuBadge()).not.toBeInTheDocument();
-        await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
-        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-    });
+    await sidebarScreen.userMenuTrigger().click();
+    await whatsNewScreen.menuItem().click();
+    await expect.element(whatsNewScreen.dialog()).toBeVisible();
+    await whatsNewScreen.closeDialog();
 
-    it("clears the banner and badges when the What's new modal is opened", async () => {
-        fakeEndpoint("GET", "https://ghost.org/changelog.json", {
-            posts: [changelogEntry({ published_at: NEWER_THAN_LAST_SEEN })],
-        });
-        await renderAdminApp("/site", {
-            boot: { browseMe: { response: userWhoLastSawChangelogAt(LAST_SEEN) } },
-        });
-
-        await expect.element(whatsNewScreen.banner()).toBeVisible();
-        await expect.element(whatsNewScreen.avatarBadge()).toBeVisible();
-
-        await sidebarScreen.userMenuTrigger().click();
-        await whatsNewScreen.menuItem().click();
-        await expect.element(whatsNewScreen.dialog()).toBeVisible();
-        await whatsNewScreen.closeDialog();
-
-        await expect.element(whatsNewScreen.dialog()).not.toBeInTheDocument();
-        await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
-        await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
-    });
+    await expect.element(whatsNewScreen.dialog()).not.toBeInTheDocument();
+    await expect.element(whatsNewScreen.banner()).not.toBeInTheDocument();
+    await expect.element(whatsNewScreen.avatarBadge()).not.toBeInTheDocument();
+  });
 });

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -1,14 +1,67 @@
-import { HttpResponse } from 'msw';
+import { HttpResponse } from "msw";
 import {
-  activeThemeResponse,
-  browseResponse,
-  configResponse,
-  currentUserResponse,
-  settingsResponse,
-  siteResponse,
-} from '@tryghost/test-data';
+    activeThemeResponse,
+    browseResponse,
+    configResponse,
+    currentUserResponse,
+    settingsResponse,
+    siteResponse,
+} from "@tryghost/test-data";
 
-import { registerAdminApiHandler, registerRoute } from './worker';
+import { fakeAdminEndpoint, registerAdminApiHandler, registerRoute, type EndpointCapture } from "./worker";
+
+type CurrentUser = ReturnType<typeof currentUserResponse>;
+
+// Ghost persists a user edit, so a client that re-reads before writing sees its
+// own earlier writes. Hold the faked user for the duration of one test rather
+// than minting a fresh copy per request, or a second write would be based on a
+// user missing the first.
+let currentUser: CurrentUser | null = null;
+
+function fakedCurrentUser(): CurrentUser {
+    currentUser ??= currentUserResponse();
+    return currentUser;
+}
+
+/**
+ * Replaces the faked user, so a boot override and later writes share one copy.
+ * Takes a copy: a spec builds its user objects up front and reuses them in its
+ * assertions, which a faked write must not reach into.
+ */
+export function seedFakedCurrentUser(response: CurrentUser): void {
+    currentUser = structuredClone(response);
+}
+
+/**
+ * Applies a faked user edit, the way Ghost persists one.
+ *
+ * Only an edit of the current user is kept: a staff edit of somebody else that
+ * reaches this handler would otherwise assign that user's fields, id included,
+ * over the one `/users/me/` serves for the rest of the test.
+ */
+export function applyFakedUserEdit(body: unknown, url?: string): CurrentUser {
+    const edited = (body as { users?: Array<Record<string, unknown>> } | undefined)?.users?.[0] ?? {};
+    const user = fakedCurrentUser().users[0];
+
+    if (url && !editsCurrentUser(url, user)) {
+        return { users: [{ ...user, ...edited }] };
+    }
+
+    Object.assign(user, edited);
+
+    return { users: [user] };
+}
+
+function editsCurrentUser(url: string, user: { id?: string }): boolean {
+    const editedId = /\/users\/([^/]+)\//.exec(url)?.[1];
+
+    return editedId === undefined || editedId === "me" || editedId === user.id;
+}
+
+/** Drops the faked user's state between tests. */
+export function resetFakedCurrentUser(): void {
+    currentUser = null;
+}
 
 /**
  * The requests the admin shell fires on boot regardless of route, handled by
@@ -18,115 +71,125 @@ import { registerAdminApiHandler, registerRoute } from './worker';
  * data from admin-x-framework.
  */
 export interface BootRequestConfig {
-  method: string;
-  path: string | RegExp;
-  /** The JSON response — or a function of the request for the rare entry that must react to its payload. */
-  response: unknown;
-  responseStatus?: number;
+    method: string;
+    path: string | RegExp;
+    /** The JSON response — or a function of the request for the rare entry that must react to its payload. */
+    response: unknown;
+    responseStatus?: number;
 }
 
 // A function so every lookup serves freshly-minted responses — mutations
 // can't leak between tests.
 export function defaultBootRequests() {
-  return {
-    browseSettings: {
-      method: 'GET',
-      path: /^\/settings\/\?group=/,
-      response: settingsResponse(),
-    },
-    browseConfig: {
-      method: 'GET',
-      path: '/config/',
-      response: configResponse(),
-    },
-    browseSite: {
-      method: 'GET',
-      path: '/site/',
-      response: siteResponse(),
-    },
-    browseMe: {
-      method: 'GET',
-      path: '/users/me/?include=roles',
-      response: currentUserResponse(),
-    },
-    browseMembersCount: {
-      method: 'GET',
-      path: '/members/?limit=1',
-      response: browseResponse('members', [], { limit: 1 }),
-    },
-    browseActiveTheme: {
-      method: 'GET',
-      path: '/themes/active/',
-      response: activeThemeResponse(),
-    },
-    editUserPreferences: {
-      method: 'PUT',
-      path: /^\/users\/\w+\/\?include=roles/,
-      // The framework caches this response as the current user, so a
-      // canned reply would wipe the client's write — echo the body.
-      response: async (request: Request) => {
-        const body = (await request.clone().json()) as { users?: Array<Record<string, unknown>> };
-        const { users } = currentUserResponse();
-        return { users: [{ ...users[0], ...body.users?.[0] }] };
-      },
-    },
-  } satisfies Record<string, BootRequestConfig>;
+    return {
+        browseSettings: {
+            method: "GET",
+            path: /^\/settings\/\?group=/,
+            response: settingsResponse(),
+        },
+        browseConfig: {
+            method: "GET",
+            path: "/config/",
+            response: configResponse(),
+        },
+        browseSite: {
+            method: "GET",
+            path: "/site/",
+            response: siteResponse(),
+        },
+        browseMe: {
+            method: "GET",
+            path: "/users/me/?include=roles",
+            response: () => fakedCurrentUser(),
+        },
+        browseMembersCount: {
+            method: "GET",
+            path: "/members/?limit=1",
+            response: browseResponse("members", [], { limit: 1 }),
+        },
+        browseActiveTheme: {
+            method: "GET",
+            path: "/themes/active/",
+            response: activeThemeResponse(),
+        },
+        editUserPreferences: {
+            method: "PUT",
+            path: /^\/users\/\w+\/\?include=roles/,
+            // The framework caches this response as the current user, so a
+            // canned reply would wipe the client's write — echo the body, and
+            // keep it for the reads that follow.
+            response: async (request: Request) => applyFakedUserEdit(await request.clone().json(), request.url),
+        },
+    } satisfies Record<string, BootRequestConfig>;
 }
 
 export type BootRequestName = keyof ReturnType<typeof defaultBootRequests>;
 
 /** Per-entry overrides, merged onto the named default; the default's method/path stay. */
-export type BootOverrides = Partial<
-  Record<BootRequestName, Partial<Pick<BootRequestConfig, 'response' | 'responseStatus'>>>
->;
+export type BootOverrides = Partial<Record<BootRequestName, Partial<Pick<BootRequestConfig, "response" | "responseStatus">>>>;
+
+/**
+ * Captures the preference writes a spec wants to assert on, and keeps them, so
+ * the reads that follow serve the written state like Ghost does. A capture that
+ * only echoed the body would leave Admin re-reading a user without its own
+ * earlier writes.
+ */
+export function fakePreferenceEdits(): EndpointCapture {
+    return fakeAdminEndpoint("PUT", /^\/users\/\w+\/\?include=roles/, ({body, url}) => applyFakedUserEdit(body, url));
+}
 
 /** "METHOD path" descriptions of the boot table, for the worker's 418 route listing. */
 export function defaultBootRoutes(): string[] {
-  return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
+    return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
 }
 
 function matches(config: BootRequestConfig, method: string, apiPath: string): boolean {
-  if (config.method !== method) {
-    return false;
-  }
-  return typeof config.path === 'string' ? config.path === apiPath : config.path.test(apiPath);
+    if (config.method !== method) {
+        return false;
+    }
+    return typeof config.path === "string" ? config.path === apiPath : config.path.test(apiPath);
 }
 
 async function respond(config: BootRequestConfig, request: Request): Promise<Response> {
-  const body =
-    typeof config.response === 'function'
-      ? await (config.response as (request: Request) => Promise<unknown>)(request)
-      : config.response;
+    const body =
+        typeof config.response === "function"
+            ? await (config.response as (request: Request) => Promise<unknown>)(request)
+            : config.response;
 
-  return HttpResponse.json(body as Record<string, unknown>, {
-    status: config.responseStatus ?? 200,
-  });
+    return HttpResponse.json(body as Record<string, unknown>, {
+        status: config.responseStatus ?? 200,
+    });
 }
 
 /** The persistent lowest-priority resolver for the boot table; runtime handlers and overrides win. */
-export async function defaultBootResolver(
-  request: Request,
-  apiPath: string,
-): Promise<Response | undefined> {
-  const config = Object.values(defaultBootRequests()).find((entry) =>
-    matches(entry, request.method, apiPath),
-  );
-  return config ? await respond(config, request) : undefined;
+export async function defaultBootResolver(request: Request, apiPath: string): Promise<Response | undefined> {
+    const config = Object.values(defaultBootRequests()).find((entry) => matches(entry, request.method, apiPath));
+    return config ? await respond(config, request) : undefined;
 }
 
 /** Register per-test boot overrides (higher priority than the defaults). */
-export function installBootOverrides(overrides: BootOverrides): void {
-  const defaults = defaultBootRequests();
-  const entries = Object.entries(overrides)
-    .filter(([, override]) => Boolean(override))
-    .map(([name, override]) => ({ ...defaults[name as BootRequestName], ...override }));
+export function installBootOverrides(requestedOverrides: BootOverrides): void {
+    let overrides = requestedOverrides;
+    // A spec that overrides the user hands over a static response object; seed
+    // the mutable copy from it and serve that, so the writes that follow are
+    // visible to the reads that follow them.
+    const seededUser = overrides.browseMe?.response;
+    if (seededUser && typeof seededUser !== "function") {
+        seedFakedCurrentUser(seededUser as CurrentUser);
+        overrides = {...overrides, browseMe: {...overrides.browseMe, response: () => fakedCurrentUser()}};
+    }
 
-  for (const config of entries) {
-    registerRoute(config.method, config.path);
-  }
+    const defaults = defaultBootRequests();
+    const entries = Object.entries(overrides)
+        .filter(([, override]) => Boolean(override))
+        .map(([name, override]) => ({ ...defaults[name as BootRequestName], ...override }));
 
-  registerAdminApiHandler(async (request, apiPath) => {
-    const config = entries.find((entry) => matches(entry, request.method, apiPath));
-    return config ? await respond(config, request) : undefined;
-  });
+    for (const config of entries) {
+        registerRoute(config.method, config.path);
+    }
+
+    registerAdminApiHandler(async (request, apiPath) => {
+        const config = entries.find((entry) => matches(entry, request.method, apiPath));
+        return config ? await respond(config, request) : undefined;
+    });
 }

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -1,14 +1,19 @@
-import { HttpResponse } from "msw";
+import { HttpResponse } from 'msw';
 import {
-    activeThemeResponse,
-    browseResponse,
-    configResponse,
-    currentUserResponse,
-    settingsResponse,
-    siteResponse,
-} from "@tryghost/test-data";
+  activeThemeResponse,
+  browseResponse,
+  configResponse,
+  currentUserResponse,
+  settingsResponse,
+  siteResponse,
+} from '@tryghost/test-data';
 
-import { fakeAdminEndpoint, registerAdminApiHandler, registerRoute, type EndpointCapture } from "./worker";
+import {
+  fakeAdminEndpoint,
+  registerAdminApiHandler,
+  registerRoute,
+  type EndpointCapture,
+} from './worker';
 
 type CurrentUser = ReturnType<typeof currentUserResponse>;
 
@@ -19,8 +24,8 @@ type CurrentUser = ReturnType<typeof currentUserResponse>;
 let currentUser: CurrentUser | null = null;
 
 function fakedCurrentUser(): CurrentUser {
-    currentUser ??= currentUserResponse();
-    return currentUser;
+  currentUser ??= currentUserResponse();
+  return currentUser;
 }
 
 /**
@@ -29,7 +34,7 @@ function fakedCurrentUser(): CurrentUser {
  * assertions, which a faked write must not reach into.
  */
 export function seedFakedCurrentUser(response: CurrentUser): void {
-    currentUser = structuredClone(response);
+  currentUser = structuredClone(response);
 }
 
 /**
@@ -40,27 +45,27 @@ export function seedFakedCurrentUser(response: CurrentUser): void {
  * over the one `/users/me/` serves for the rest of the test.
  */
 export function applyFakedUserEdit(body: unknown, url?: string): CurrentUser {
-    const edited = (body as { users?: Array<Record<string, unknown>> } | undefined)?.users?.[0] ?? {};
-    const user = fakedCurrentUser().users[0];
+  const edited = (body as { users?: Array<Record<string, unknown>> } | undefined)?.users?.[0] ?? {};
+  const user = fakedCurrentUser().users[0];
 
-    if (url && !editsCurrentUser(url, user)) {
-        return { users: [{ ...user, ...edited }] };
-    }
+  if (url && !editsCurrentUser(url, user)) {
+    return { users: [{ ...user, ...edited }] };
+  }
 
-    Object.assign(user, edited);
+  Object.assign(user, edited);
 
-    return { users: [user] };
+  return { users: [user] };
 }
 
 function editsCurrentUser(url: string, user: { id?: string }): boolean {
-    const editedId = /\/users\/([^/]+)\//.exec(url)?.[1];
+  const editedId = /\/users\/([^/]+)\//.exec(url)?.[1];
 
-    return editedId === undefined || editedId === "me" || editedId === user.id;
+  return editedId === undefined || editedId === 'me' || editedId === user.id;
 }
 
 /** Drops the faked user's state between tests. */
 export function resetFakedCurrentUser(): void {
-    currentUser = null;
+  currentUser = null;
 }
 
 /**
@@ -71,62 +76,65 @@ export function resetFakedCurrentUser(): void {
  * data from admin-x-framework.
  */
 export interface BootRequestConfig {
-    method: string;
-    path: string | RegExp;
-    /** The JSON response — or a function of the request for the rare entry that must react to its payload. */
-    response: unknown;
-    responseStatus?: number;
+  method: string;
+  path: string | RegExp;
+  /** The JSON response — or a function of the request for the rare entry that must react to its payload. */
+  response: unknown;
+  responseStatus?: number;
 }
 
 // A function so every lookup serves freshly-minted responses — mutations
 // can't leak between tests.
 export function defaultBootRequests() {
-    return {
-        browseSettings: {
-            method: "GET",
-            path: /^\/settings\/\?group=/,
-            response: settingsResponse(),
-        },
-        browseConfig: {
-            method: "GET",
-            path: "/config/",
-            response: configResponse(),
-        },
-        browseSite: {
-            method: "GET",
-            path: "/site/",
-            response: siteResponse(),
-        },
-        browseMe: {
-            method: "GET",
-            path: "/users/me/?include=roles",
-            response: () => fakedCurrentUser(),
-        },
-        browseMembersCount: {
-            method: "GET",
-            path: "/members/?limit=1",
-            response: browseResponse("members", [], { limit: 1 }),
-        },
-        browseActiveTheme: {
-            method: "GET",
-            path: "/themes/active/",
-            response: activeThemeResponse(),
-        },
-        editUserPreferences: {
-            method: "PUT",
-            path: /^\/users\/\w+\/\?include=roles/,
-            // The framework caches this response as the current user, so a
-            // canned reply would wipe the client's write — echo the body, and
-            // keep it for the reads that follow.
-            response: async (request: Request) => applyFakedUserEdit(await request.clone().json(), request.url),
-        },
-    } satisfies Record<string, BootRequestConfig>;
+  return {
+    browseSettings: {
+      method: 'GET',
+      path: /^\/settings\/\?group=/,
+      response: settingsResponse(),
+    },
+    browseConfig: {
+      method: 'GET',
+      path: '/config/',
+      response: configResponse(),
+    },
+    browseSite: {
+      method: 'GET',
+      path: '/site/',
+      response: siteResponse(),
+    },
+    browseMe: {
+      method: 'GET',
+      path: '/users/me/?include=roles',
+      response: () => fakedCurrentUser(),
+    },
+    browseMembersCount: {
+      method: 'GET',
+      path: '/members/?limit=1',
+      response: browseResponse('members', [], { limit: 1 }),
+    },
+    browseActiveTheme: {
+      method: 'GET',
+      path: '/themes/active/',
+      response: activeThemeResponse(),
+    },
+    editUserPreferences: {
+      method: 'PUT',
+      path: /^\/users\/\w+\/\?include=roles/,
+      // The framework caches this response as the current user, so a
+      // canned reply would wipe the client's write — echo the body, and
+      // keep it for the reads that follow.
+      response: async (request: Request) =>
+        applyFakedUserEdit(await request.clone().json(), request.url),
+    },
+  } satisfies Record<string, BootRequestConfig>;
 }
 
 export type BootRequestName = keyof ReturnType<typeof defaultBootRequests>;
 
 /** Per-entry overrides, merged onto the named default; the default's method/path stay. */
-export type BootOverrides = Partial<Record<BootRequestName, Partial<Pick<BootRequestConfig, "response" | "responseStatus">>>>;
+export type BootOverrides = Partial<
+  Record<BootRequestName, Partial<Pick<BootRequestConfig, 'response' | 'responseStatus'>>>
+>;
 
 /**
  * Captures the preference writes a spec wants to assert on, and keeps them, so
@@ -135,61 +143,71 @@ export type BootOverrides = Partial<Record<BootRequestName, Partial<Pick<BootReq
  * earlier writes.
  */
 export function fakePreferenceEdits(): EndpointCapture {
-    return fakeAdminEndpoint("PUT", /^\/users\/\w+\/\?include=roles/, ({body, url}) => applyFakedUserEdit(body, url));
+  return fakeAdminEndpoint('PUT', /^\/users\/\w+\/\?include=roles/, ({ body, url }) =>
+    applyFakedUserEdit(body, url),
+  );
 }
 
 /** "METHOD path" descriptions of the boot table, for the worker's 418 route listing. */
 export function defaultBootRoutes(): string[] {
-    return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
+  return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
 }
 
 function matches(config: BootRequestConfig, method: string, apiPath: string): boolean {
-    if (config.method !== method) {
-        return false;
-    }
-    return typeof config.path === "string" ? config.path === apiPath : config.path.test(apiPath);
+  if (config.method !== method) {
+    return false;
+  }
+  return typeof config.path === 'string' ? config.path === apiPath : config.path.test(apiPath);
 }
 
 async function respond(config: BootRequestConfig, request: Request): Promise<Response> {
-    const body =
-        typeof config.response === "function"
-            ? await (config.response as (request: Request) => Promise<unknown>)(request)
-            : config.response;
+  const body =
+    typeof config.response === 'function'
+      ? await (config.response as (request: Request) => Promise<unknown>)(request)
+      : config.response;
 
-    return HttpResponse.json(body as Record<string, unknown>, {
-        status: config.responseStatus ?? 200,
-    });
+  return HttpResponse.json(body as Record<string, unknown>, {
+    status: config.responseStatus ?? 200,
+  });
 }
 
 /** The persistent lowest-priority resolver for the boot table; runtime handlers and overrides win. */
-export async function defaultBootResolver(request: Request, apiPath: string): Promise<Response | undefined> {
-    const config = Object.values(defaultBootRequests()).find((entry) => matches(entry, request.method, apiPath));
-    return config ? await respond(config, request) : undefined;
+export async function defaultBootResolver(
+  request: Request,
+  apiPath: string,
+): Promise<Response | undefined> {
+  const config = Object.values(defaultBootRequests()).find((entry) =>
+    matches(entry, request.method, apiPath),
+  );
+  return config ? await respond(config, request) : undefined;
 }
 
 /** Register per-test boot overrides (higher priority than the defaults). */
 export function installBootOverrides(requestedOverrides: BootOverrides): void {
-    let overrides = requestedOverrides;
-    // A spec that overrides the user hands over a static response object; seed
-    // the mutable copy from it and serve that, so the writes that follow are
-    // visible to the reads that follow them.
-    const seededUser = overrides.browseMe?.response;
-    if (seededUser && typeof seededUser !== "function") {
-        seedFakedCurrentUser(seededUser as CurrentUser);
-        overrides = {...overrides, browseMe: {...overrides.browseMe, response: () => fakedCurrentUser()}};
-    }
+  let overrides = requestedOverrides;
+  // A spec that overrides the user hands over a static response object; seed
+  // the mutable copy from it and serve that, so the writes that follow are
+  // visible to the reads that follow them.
+  const seededUser = overrides.browseMe?.response;
+  if (seededUser && typeof seededUser !== 'function') {
+    seedFakedCurrentUser(seededUser as CurrentUser);
+    overrides = {
+      ...overrides,
+      browseMe: { ...overrides.browseMe, response: () => fakedCurrentUser() },
+    };
+  }
 
-    const defaults = defaultBootRequests();
-    const entries = Object.entries(overrides)
-        .filter(([, override]) => Boolean(override))
-        .map(([name, override]) => ({ ...defaults[name as BootRequestName], ...override }));
+  const defaults = defaultBootRequests();
+  const entries = Object.entries(overrides)
+    .filter(([, override]) => Boolean(override))
+    .map(([name, override]) => ({ ...defaults[name as BootRequestName], ...override }));
 
-    for (const config of entries) {
-        registerRoute(config.method, config.path);
-    }
+  for (const config of entries) {
+    registerRoute(config.method, config.path);
+  }
 
-    registerAdminApiHandler(async (request, apiPath) => {
-        const config = entries.find((entry) => matches(entry, request.method, apiPath));
-        return config ? await respond(config, request) : undefined;
-    });
+  registerAdminApiHandler(async (request, apiPath) => {
+    const config = entries.find((entry) => matches(entry, request.method, apiPath));
+    return config ? await respond(config, request) : undefined;
+  });
 }

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,16 +1,150 @@
 /** Acceptance-harness public surface — see README.md for the spec anatomy. */
-export { fakeAnalyticsOverview } from "./analytics";
-export { fakePreferenceEdits } from "./boot";
-export { currentRoute, renderAdminApp } from "./render-admin-app";
-export type { RenderAdminAppOptions } from "./render-admin-app";
-export { defineResource, fakeActions, fakeAutomations, fakeComments, fakeEditSettings, fakeIntegrations, fakeInvites, fakeLabels, fakeMembers, fakeNewsletters, fakeOffers, fakePosts, fakeRoles, fakeSettingsScreens, fakeTags, fakeThemes, fakeTiers, fakeUsers } from "./resources";
-export type { BrowseQuery, EditSettingsCapture, FakeMembersOptions, ResourceCapture, ResourceOptions, ResourceSemantics, RespondWith } from "./resources";
-export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint, fakeSitePreview } from "./worker";
-export type { CapturedEndpointRequest, EndpointCapture, FakeAdminEndpointResponse, FakeEndpointOptions, SitePreviewCapture, SitePreviewRequest } from "./worker";
-export { TINYBIRD_SITE_UUID, fakeTinybirdPipe, fakeTinybirdToken, webAnalyticsBootOverrides } from "./tinybird";
-export type { TinybirdPipeCapture, TinybirdPipeQuery } from "./tinybird";
-export { fakeAdminStats } from "./stats";
+export { fakeAnalyticsOverview } from './analytics';
+export { fakePreferenceEdits } from './boot';
+export { currentRoute, renderAdminApp } from './render-admin-app';
+export type { RenderAdminAppOptions } from './render-admin-app';
+export {
+  defineResource,
+  fakeActions,
+  fakeAutomations,
+  fakeComments,
+  fakeEditSettings,
+  fakeIntegrations,
+  fakeInvites,
+  fakeLabels,
+  fakeMembers,
+  fakeNewsletters,
+  fakeOffers,
+  fakePosts,
+  fakeRoles,
+  fakeSettingsScreens,
+  fakeTags,
+  fakeThemes,
+  fakeTiers,
+  fakeUsers,
+} from './resources';
+export type {
+  BrowseQuery,
+  EditSettingsCapture,
+  FakeMembersOptions,
+  ResourceCapture,
+  ResourceOptions,
+  ResourceSemantics,
+  RespondWith,
+} from './resources';
+export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint, fakeSitePreview } from './worker';
+export type {
+  CapturedEndpointRequest,
+  EndpointCapture,
+  FakeAdminEndpointResponse,
+  FakeEndpointOptions,
+  SitePreviewCapture,
+  SitePreviewRequest,
+} from './worker';
+export {
+  TINYBIRD_SITE_UUID,
+  fakeTinybirdPipe,
+  fakeTinybirdToken,
+  webAnalyticsBootOverrides,
+} from './tinybird';
+export type { TinybirdPipeCapture, TinybirdPipeQuery } from './tinybird';
+export { fakeAdminStats } from './stats';
 
 // Test-data re-exports, so a spec needs a single import surface.
-export { activeThemeResponse, analyticsActiveVisitors, analyticsDevice, analyticsGiftLinkVisits, analyticsKpi, analyticsLocation, analyticsSource, analyticsUtmCampaign, analyticsUtmContent, analyticsUtmMedium, analyticsUtmSource, analyticsUtmTerm, automation, browseResponse, changelogEntry, comment, commentThread, configResponse, currentUserResponse, defaultThemesResponse, label, member, memberStatusStat, mrrHistoryStat, newsletter, newsletterBasicStat, newsletterClickStat, newsletterSubscriberStat, newsletterSubscriberValue, offer, post, postGrowthStat, postReferrerStat, postStats, reply, retentionOffer, settingsResponse, siteResponse, staffInvite, staffRole, staffUser, subscriptionStat, tag, theme, tier, topContentStat, topPostStat, topPostViewsStat } from "@tryghost/test-data";
-export type { ActiveThemeResponse, AnalyticsActiveVisitors, AnalyticsDevice, AnalyticsGiftLinkVisits, AnalyticsKpi, AnalyticsLocation, AnalyticsSource, AnalyticsUtmCampaign, AnalyticsUtmContent, AnalyticsUtmMedium, AnalyticsUtmSource, AnalyticsUtmTerm, Automation, ChangelogEntry, Comment, CommentThread, CurrentUserResponse, Label, Member, MemberStatusStat, MrrHistoryStat, Newsletter, NewsletterBasicStat, NewsletterClickStat, NewsletterSubscriberStat, Offer, Post, PostGrowthStat, PostReferrerStat, PostStats, ReplySpec, SettingsResponse, StaffInvite, StaffRole, StaffRoleName, StaffUser, SubscriptionStat, Tag, Theme, Tier, TinybirdPipeName, TinybirdPipeRows, TopContentStat, TopPostStat, TopPostViewsStat } from "@tryghost/test-data";
+export {
+  activeThemeResponse,
+  analyticsActiveVisitors,
+  analyticsDevice,
+  analyticsGiftLinkVisits,
+  analyticsKpi,
+  analyticsLocation,
+  analyticsSource,
+  analyticsUtmCampaign,
+  analyticsUtmContent,
+  analyticsUtmMedium,
+  analyticsUtmSource,
+  analyticsUtmTerm,
+  automation,
+  browseResponse,
+  changelogEntry,
+  comment,
+  commentThread,
+  configResponse,
+  currentUserResponse,
+  defaultThemesResponse,
+  label,
+  member,
+  memberStatusStat,
+  mrrHistoryStat,
+  newsletter,
+  newsletterBasicStat,
+  newsletterClickStat,
+  newsletterSubscriberStat,
+  newsletterSubscriberValue,
+  offer,
+  post,
+  postGrowthStat,
+  postReferrerStat,
+  postStats,
+  reply,
+  retentionOffer,
+  settingsResponse,
+  siteResponse,
+  staffInvite,
+  staffRole,
+  staffUser,
+  subscriptionStat,
+  tag,
+  theme,
+  tier,
+  topContentStat,
+  topPostStat,
+  topPostViewsStat,
+} from '@tryghost/test-data';
+export type {
+  ActiveThemeResponse,
+  AnalyticsActiveVisitors,
+  AnalyticsDevice,
+  AnalyticsGiftLinkVisits,
+  AnalyticsKpi,
+  AnalyticsLocation,
+  AnalyticsSource,
+  AnalyticsUtmCampaign,
+  AnalyticsUtmContent,
+  AnalyticsUtmMedium,
+  AnalyticsUtmSource,
+  AnalyticsUtmTerm,
+  Automation,
+  ChangelogEntry,
+  Comment,
+  CommentThread,
+  CurrentUserResponse,
+  Label,
+  Member,
+  MemberStatusStat,
+  MrrHistoryStat,
+  Newsletter,
+  NewsletterBasicStat,
+  NewsletterClickStat,
+  NewsletterSubscriberStat,
+  Offer,
+  Post,
+  PostGrowthStat,
+  PostReferrerStat,
+  PostStats,
+  ReplySpec,
+  SettingsResponse,
+  StaffInvite,
+  StaffRole,
+  StaffRoleName,
+  StaffUser,
+  SubscriptionStat,
+  Tag,
+  Theme,
+  Tier,
+  TinybirdPipeName,
+  TinybirdPipeRows,
+  TopContentStat,
+  TopPostStat,
+  TopPostViewsStat,
+} from '@tryghost/test-data';

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,149 +1,16 @@
 /** Acceptance-harness public surface — see README.md for the spec anatomy. */
-export { fakeAnalyticsOverview } from './analytics';
-export { currentRoute, renderAdminApp } from './render-admin-app';
-export type { RenderAdminAppOptions } from './render-admin-app';
-export {
-  defineResource,
-  fakeActions,
-  fakeAutomations,
-  fakeComments,
-  fakeEditSettings,
-  fakeIntegrations,
-  fakeInvites,
-  fakeLabels,
-  fakeMembers,
-  fakeNewsletters,
-  fakeOffers,
-  fakePosts,
-  fakeRoles,
-  fakeSettingsScreens,
-  fakeTags,
-  fakeThemes,
-  fakeTiers,
-  fakeUsers,
-} from './resources';
-export type {
-  BrowseQuery,
-  EditSettingsCapture,
-  FakeMembersOptions,
-  ResourceCapture,
-  ResourceOptions,
-  ResourceSemantics,
-  RespondWith,
-} from './resources';
-export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint, fakeSitePreview } from './worker';
-export type {
-  CapturedEndpointRequest,
-  EndpointCapture,
-  FakeAdminEndpointResponse,
-  FakeEndpointOptions,
-  SitePreviewCapture,
-  SitePreviewRequest,
-} from './worker';
-export {
-  TINYBIRD_SITE_UUID,
-  fakeTinybirdPipe,
-  fakeTinybirdToken,
-  webAnalyticsBootOverrides,
-} from './tinybird';
-export type { TinybirdPipeCapture, TinybirdPipeQuery } from './tinybird';
-export { fakeAdminStats } from './stats';
+export { fakeAnalyticsOverview } from "./analytics";
+export { fakePreferenceEdits } from "./boot";
+export { currentRoute, renderAdminApp } from "./render-admin-app";
+export type { RenderAdminAppOptions } from "./render-admin-app";
+export { defineResource, fakeActions, fakeAutomations, fakeComments, fakeEditSettings, fakeIntegrations, fakeInvites, fakeLabels, fakeMembers, fakeNewsletters, fakeOffers, fakePosts, fakeRoles, fakeSettingsScreens, fakeTags, fakeThemes, fakeTiers, fakeUsers } from "./resources";
+export type { BrowseQuery, EditSettingsCapture, FakeMembersOptions, ResourceCapture, ResourceOptions, ResourceSemantics, RespondWith } from "./resources";
+export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint, fakeSitePreview } from "./worker";
+export type { CapturedEndpointRequest, EndpointCapture, FakeAdminEndpointResponse, FakeEndpointOptions, SitePreviewCapture, SitePreviewRequest } from "./worker";
+export { TINYBIRD_SITE_UUID, fakeTinybirdPipe, fakeTinybirdToken, webAnalyticsBootOverrides } from "./tinybird";
+export type { TinybirdPipeCapture, TinybirdPipeQuery } from "./tinybird";
+export { fakeAdminStats } from "./stats";
 
 // Test-data re-exports, so a spec needs a single import surface.
-export {
-  activeThemeResponse,
-  analyticsActiveVisitors,
-  analyticsDevice,
-  analyticsGiftLinkVisits,
-  analyticsKpi,
-  analyticsLocation,
-  analyticsSource,
-  analyticsUtmCampaign,
-  analyticsUtmContent,
-  analyticsUtmMedium,
-  analyticsUtmSource,
-  analyticsUtmTerm,
-  automation,
-  browseResponse,
-  changelogEntry,
-  comment,
-  commentThread,
-  configResponse,
-  currentUserResponse,
-  defaultThemesResponse,
-  label,
-  member,
-  memberStatusStat,
-  mrrHistoryStat,
-  newsletter,
-  newsletterBasicStat,
-  newsletterClickStat,
-  newsletterSubscriberStat,
-  newsletterSubscriberValue,
-  offer,
-  post,
-  postGrowthStat,
-  postReferrerStat,
-  postStats,
-  reply,
-  retentionOffer,
-  settingsResponse,
-  siteResponse,
-  staffInvite,
-  staffRole,
-  staffUser,
-  subscriptionStat,
-  tag,
-  theme,
-  tier,
-  topContentStat,
-  topPostStat,
-  topPostViewsStat,
-} from '@tryghost/test-data';
-export type {
-  ActiveThemeResponse,
-  AnalyticsActiveVisitors,
-  AnalyticsDevice,
-  AnalyticsGiftLinkVisits,
-  AnalyticsKpi,
-  AnalyticsLocation,
-  AnalyticsSource,
-  AnalyticsUtmCampaign,
-  AnalyticsUtmContent,
-  AnalyticsUtmMedium,
-  AnalyticsUtmSource,
-  AnalyticsUtmTerm,
-  Automation,
-  ChangelogEntry,
-  Comment,
-  CommentThread,
-  CurrentUserResponse,
-  Label,
-  Member,
-  MemberStatusStat,
-  MrrHistoryStat,
-  Newsletter,
-  NewsletterBasicStat,
-  NewsletterClickStat,
-  NewsletterSubscriberStat,
-  Offer,
-  Post,
-  PostGrowthStat,
-  PostReferrerStat,
-  PostStats,
-  ReplySpec,
-  SettingsResponse,
-  StaffInvite,
-  StaffRole,
-  StaffRoleName,
-  StaffUser,
-  SubscriptionStat,
-  Tag,
-  Theme,
-  Tier,
-  TinybirdPipeName,
-  TinybirdPipeRows,
-  TopContentStat,
-  TopPostStat,
-  TopPostViewsStat,
-} from '@tryghost/test-data';
+export { activeThemeResponse, analyticsActiveVisitors, analyticsDevice, analyticsGiftLinkVisits, analyticsKpi, analyticsLocation, analyticsSource, analyticsUtmCampaign, analyticsUtmContent, analyticsUtmMedium, analyticsUtmSource, analyticsUtmTerm, automation, browseResponse, changelogEntry, comment, commentThread, configResponse, currentUserResponse, defaultThemesResponse, label, member, memberStatusStat, mrrHistoryStat, newsletter, newsletterBasicStat, newsletterClickStat, newsletterSubscriberStat, newsletterSubscriberValue, offer, post, postGrowthStat, postReferrerStat, postStats, reply, retentionOffer, settingsResponse, siteResponse, staffInvite, staffRole, staffUser, subscriptionStat, tag, theme, tier, topContentStat, topPostStat, topPostViewsStat } from "@tryghost/test-data";
+export type { ActiveThemeResponse, AnalyticsActiveVisitors, AnalyticsDevice, AnalyticsGiftLinkVisits, AnalyticsKpi, AnalyticsLocation, AnalyticsSource, AnalyticsUtmCampaign, AnalyticsUtmContent, AnalyticsUtmMedium, AnalyticsUtmSource, AnalyticsUtmTerm, Automation, ChangelogEntry, Comment, CommentThread, CurrentUserResponse, Label, Member, MemberStatusStat, MrrHistoryStat, Newsletter, NewsletterBasicStat, NewsletterClickStat, NewsletterSubscriberStat, Offer, Post, PostGrowthStat, PostReferrerStat, PostStats, ReplySpec, SettingsResponse, StaffInvite, StaffRole, StaffRoleName, StaffUser, SubscriptionStat, Tag, Theme, Tier, TinybirdPipeName, TinybirdPipeRows, TopContentStat, TopPostStat, TopPostViewsStat } from "@tryghost/test-data";

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -1,27 +1,27 @@
-import { afterEach, beforeAll } from "vitest";
-import { cleanup } from "vitest-browser-react";
+import { afterEach, beforeAll } from 'vitest';
+import { cleanup } from 'vitest-browser-react';
 
-import "./matchers";
-import { defaultBootResolver, defaultBootRoutes, resetFakedCurrentUser } from "./boot";
-import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from "./worker";
+import './matchers';
+import { defaultBootResolver, defaultBootRoutes, resetFakedCurrentUser } from './boot';
+import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from './worker';
 
 beforeAll(async () => {
-    await startFakeApi({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
+  await startFakeApi({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
 });
 
 afterEach(async () => {
-    // Order is load-bearing: unmount first (a live app refetches against a
-    // reset worker); drain before the reset (stragglers must hit their
-    // declared fakes) and before the verification (late 418s belong to the
-    // test that caused them); finally so a drain timeout can't leak handlers
-    // or 418 records into the next test.
-    await cleanup();
-    try {
-        await settleRequests();
-    } finally {
-        resetFakeApi();
-        resetFakedCurrentUser();
-        window.location.hash = "";
-        verifyNoUnhandledRequests();
-    }
+  // Order is load-bearing: unmount first (a live app refetches against a
+  // reset worker); drain before the reset (stragglers must hit their
+  // declared fakes) and before the verification (late 418s belong to the
+  // test that caused them); finally so a drain timeout can't leak handlers
+  // or 418 records into the next test.
+  await cleanup();
+  try {
+    await settleRequests();
+  } finally {
+    resetFakeApi();
+    resetFakedCurrentUser();
+    window.location.hash = '';
+    verifyNoUnhandledRequests();
+  }
 });

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -1,26 +1,27 @@
-import { afterEach, beforeAll } from 'vitest';
-import { cleanup } from 'vitest-browser-react';
+import { afterEach, beforeAll } from "vitest";
+import { cleanup } from "vitest-browser-react";
 
-import './matchers';
-import { defaultBootResolver, defaultBootRoutes } from './boot';
-import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from './worker';
+import "./matchers";
+import { defaultBootResolver, defaultBootRoutes, resetFakedCurrentUser } from "./boot";
+import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from "./worker";
 
 beforeAll(async () => {
-  await startFakeApi({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
+    await startFakeApi({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
 });
 
 afterEach(async () => {
-  // Order is load-bearing: unmount first (a live app refetches against a
-  // reset worker); drain before the reset (stragglers must hit their
-  // declared fakes) and before the verification (late 418s belong to the
-  // test that caused them); finally so a drain timeout can't leak handlers
-  // or 418 records into the next test.
-  await cleanup();
-  try {
-    await settleRequests();
-  } finally {
-    resetFakeApi();
-    window.location.hash = '';
-    verifyNoUnhandledRequests();
-  }
+    // Order is load-bearing: unmount first (a live app refetches against a
+    // reset worker); drain before the reset (stragglers must hit their
+    // declared fakes) and before the verification (late 418s belong to the
+    // test that caused them); finally so a drain timeout can't leak handlers
+    // or 418 records into the next test.
+    await cleanup();
+    try {
+        await settleRequests();
+    } finally {
+        resetFakeApi();
+        resetFakedCurrentUser();
+        window.location.hash = "";
+        verifyNoUnhandledRequests();
+    }
 });

--- a/e2e/tests/admin/user-preferences.test.ts
+++ b/e2e/tests/admin/user-preferences.test.ts
@@ -1,0 +1,84 @@
+import {SidebarPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import type {Page} from '@playwright/test';
+
+test.use({isolation: 'per-test'});
+
+async function getPreferences(page: Page) {
+    const response = await page.request.get('/ghost/api/admin/users/me/?include=roles');
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+    const user = body.users[0];
+
+    return user.accessibility ? JSON.parse(user.accessibility) : {};
+}
+
+test.describe('Ghost Admin - User Preferences', () => {
+    test('a preference set in one tab survives a preference write in another', async ({page}) => {
+        const firstTab = new SidebarPage(page);
+        await firstTab.goto('/ghost/#/analytics');
+        await expect(firstTab.postsToggle).toBeVisible();
+
+        // Reading stored state here is synchronisation, not the assertion: let
+        // Admin's own initialising write land before the choice below is made.
+        await expect.poll(async () => Boolean((await getPreferences(page)).whatsNew?.lastSeenDate)).toBe(true);
+
+        const secondPage = await page.context().newPage();
+        const secondTab = new SidebarPage(secondPage);
+        await secondTab.goto('/ghost/#/analytics');
+        await expect(secondTab.postsToggle).toBeVisible();
+
+        await secondTab.userDropdownTrigger.click();
+        await secondTab.appearanceMenuItem.click();
+        await secondTab.themeDarkOption.click();
+        await secondTab.waitForDarkMode(true);
+        await expect.poll(async () => (await getPreferences(secondPage)).nightShift).toBe('dark');
+
+        // An unrelated preference write in the first tab, whose loaded state
+        // predates the appearance change above.
+        await page.bringToFront();
+        await firstTab.collapsePostsSubmenu();
+        await expect.poll(async () => (await getPreferences(page)).navigation?.expanded?.posts).toBe(false);
+
+        // The choice is still in effect where it was made.
+        await secondPage.reload({waitUntil: 'load'});
+        await expect(secondTab.postsToggle).toBeVisible();
+        await secondTab.waitForDarkMode(true);
+    });
+
+    test('an appearance choice is read back after a reload', async ({page}) => {
+        const sidebar = new SidebarPage(page);
+        await sidebar.goto('/ghost/#/analytics');
+        await expect(sidebar.postsToggle).toBeVisible();
+
+        await sidebar.userDropdownTrigger.click();
+        await sidebar.appearanceMenuItem.click();
+        await sidebar.themeDarkOption.click();
+        await sidebar.waitForDarkMode(true);
+
+        // Synchronisation, not the assertion: reload only once the choice is
+        // stored, so this measures what Admin reads back rather than a write
+        // still in flight.
+        await expect.poll(async () => (await getPreferences(page)).nightShift).toBe('dark');
+        await page.reload({waitUntil: 'load'});
+
+        await expect(sidebar.postsToggle).toBeVisible();
+        await sidebar.waitForDarkMode(true);
+    });
+
+    test('a collapsed sidebar group is read back after a reload', async ({page}) => {
+        const sidebar = new SidebarPage(page);
+        await sidebar.goto('/ghost/#/analytics');
+        await expect(sidebar.postsToggle).toBeVisible();
+
+        await sidebar.collapsePostsSubmenu();
+        // Synchronisation, as above.
+        await expect.poll(async () => (await getPreferences(page)).navigation?.expanded?.posts).toBe(false);
+
+        await page.reload({waitUntil: 'load'});
+
+        await expect(sidebar.postsToggle).toBeVisible();
+        await expect(sidebar.postsToggle).toHaveAttribute('aria-expanded', 'false');
+    });
+});

--- a/e2e/tests/admin/user-preferences.test.ts
+++ b/e2e/tests/admin/user-preferences.test.ts
@@ -1,84 +1,90 @@
-import {SidebarPage} from '@/admin-pages';
-import {expect, test} from '@/helpers/playwright';
-import type {Page} from '@playwright/test';
+import { SidebarPage } from '@/admin-pages';
+import { expect, test } from '@/helpers/playwright';
+import type { Page } from '@playwright/test';
 
-test.use({isolation: 'per-test'});
+test.use({ isolation: 'per-test' });
 
 async function getPreferences(page: Page) {
-    const response = await page.request.get('/ghost/api/admin/users/me/?include=roles');
-    expect(response.ok()).toBe(true);
+  const response = await page.request.get('/ghost/api/admin/users/me/?include=roles');
+  expect(response.ok()).toBe(true);
 
-    const body = await response.json();
-    const user = body.users[0];
+  const body = await response.json();
+  const user = body.users[0];
 
-    return user.accessibility ? JSON.parse(user.accessibility) : {};
+  return user.accessibility ? JSON.parse(user.accessibility) : {};
 }
 
 test.describe('Ghost Admin - User Preferences', () => {
-    test('a preference set in one tab survives a preference write in another', async ({page}) => {
-        const firstTab = new SidebarPage(page);
-        await firstTab.goto('/ghost/#/analytics');
-        await expect(firstTab.postsToggle).toBeVisible();
+  test('a preference set in one tab survives a preference write in another', async ({ page }) => {
+    const firstTab = new SidebarPage(page);
+    await firstTab.goto('/ghost/#/analytics');
+    await expect(firstTab.postsToggle).toBeVisible();
 
-        // Reading stored state here is synchronisation, not the assertion: let
-        // Admin's own initialising write land before the choice below is made.
-        await expect.poll(async () => Boolean((await getPreferences(page)).whatsNew?.lastSeenDate)).toBe(true);
+    // Reading stored state here is synchronisation, not the assertion: let
+    // Admin's own initialising write land before the choice below is made.
+    await expect
+      .poll(async () => Boolean((await getPreferences(page)).whatsNew?.lastSeenDate))
+      .toBe(true);
 
-        const secondPage = await page.context().newPage();
-        const secondTab = new SidebarPage(secondPage);
-        await secondTab.goto('/ghost/#/analytics');
-        await expect(secondTab.postsToggle).toBeVisible();
+    const secondPage = await page.context().newPage();
+    const secondTab = new SidebarPage(secondPage);
+    await secondTab.goto('/ghost/#/analytics');
+    await expect(secondTab.postsToggle).toBeVisible();
 
-        await secondTab.userDropdownTrigger.click();
-        await secondTab.appearanceMenuItem.click();
-        await secondTab.themeDarkOption.click();
-        await secondTab.waitForDarkMode(true);
-        await expect.poll(async () => (await getPreferences(secondPage)).nightShift).toBe('dark');
+    await secondTab.userDropdownTrigger.click();
+    await secondTab.appearanceMenuItem.click();
+    await secondTab.themeDarkOption.click();
+    await secondTab.waitForDarkMode(true);
+    await expect.poll(async () => (await getPreferences(secondPage)).nightShift).toBe('dark');
 
-        // An unrelated preference write in the first tab, whose loaded state
-        // predates the appearance change above.
-        await page.bringToFront();
-        await firstTab.collapsePostsSubmenu();
-        await expect.poll(async () => (await getPreferences(page)).navigation?.expanded?.posts).toBe(false);
+    // An unrelated preference write in the first tab, whose loaded state
+    // predates the appearance change above.
+    await page.bringToFront();
+    await firstTab.collapsePostsSubmenu();
+    await expect
+      .poll(async () => (await getPreferences(page)).navigation?.expanded?.posts)
+      .toBe(false);
 
-        // The choice is still in effect where it was made.
-        await secondPage.reload({waitUntil: 'load'});
-        await expect(secondTab.postsToggle).toBeVisible();
-        await secondTab.waitForDarkMode(true);
-    });
+    // The choice is still in effect where it was made.
+    await secondPage.reload({ waitUntil: 'load' });
+    await expect(secondTab.postsToggle).toBeVisible();
+    await secondTab.waitForDarkMode(true);
+  });
 
-    test('an appearance choice is read back after a reload', async ({page}) => {
-        const sidebar = new SidebarPage(page);
-        await sidebar.goto('/ghost/#/analytics');
-        await expect(sidebar.postsToggle).toBeVisible();
+  test('an appearance choice is read back after a reload', async ({ page }) => {
+    const sidebar = new SidebarPage(page);
+    await sidebar.goto('/ghost/#/analytics');
+    await expect(sidebar.postsToggle).toBeVisible();
 
-        await sidebar.userDropdownTrigger.click();
-        await sidebar.appearanceMenuItem.click();
-        await sidebar.themeDarkOption.click();
-        await sidebar.waitForDarkMode(true);
+    await sidebar.userDropdownTrigger.click();
+    await sidebar.appearanceMenuItem.click();
+    await sidebar.themeDarkOption.click();
+    await sidebar.waitForDarkMode(true);
 
-        // Synchronisation, not the assertion: reload only once the choice is
-        // stored, so this measures what Admin reads back rather than a write
-        // still in flight.
-        await expect.poll(async () => (await getPreferences(page)).nightShift).toBe('dark');
-        await page.reload({waitUntil: 'load'});
+    // Synchronisation, not the assertion: reload only once the choice is
+    // stored, so this measures what Admin reads back rather than a write
+    // still in flight.
+    await expect.poll(async () => (await getPreferences(page)).nightShift).toBe('dark');
+    await page.reload({ waitUntil: 'load' });
 
-        await expect(sidebar.postsToggle).toBeVisible();
-        await sidebar.waitForDarkMode(true);
-    });
+    await expect(sidebar.postsToggle).toBeVisible();
+    await sidebar.waitForDarkMode(true);
+  });
 
-    test('a collapsed sidebar group is read back after a reload', async ({page}) => {
-        const sidebar = new SidebarPage(page);
-        await sidebar.goto('/ghost/#/analytics');
-        await expect(sidebar.postsToggle).toBeVisible();
+  test('a collapsed sidebar group is read back after a reload', async ({ page }) => {
+    const sidebar = new SidebarPage(page);
+    await sidebar.goto('/ghost/#/analytics');
+    await expect(sidebar.postsToggle).toBeVisible();
 
-        await sidebar.collapsePostsSubmenu();
-        // Synchronisation, as above.
-        await expect.poll(async () => (await getPreferences(page)).navigation?.expanded?.posts).toBe(false);
+    await sidebar.collapsePostsSubmenu();
+    // Synchronisation, as above.
+    await expect
+      .poll(async () => (await getPreferences(page)).navigation?.expanded?.posts)
+      .toBe(false);
 
-        await page.reload({waitUntil: 'load'});
+    await page.reload({ waitUntil: 'load' });
 
-        await expect(sidebar.postsToggle).toBeVisible();
-        await expect(sidebar.postsToggle).toHaveAttribute('aria-expanded', 'false');
-    });
+    await expect(sidebar.postsToggle).toBeVisible();
+    await expect(sidebar.postsToggle).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/e2e/tests/admin/whats-new.test.ts
+++ b/e2e/tests/admin/whats-new.test.ts
@@ -1,96 +1,101 @@
-import {SidebarPage, WhatsNewBanner} from '@/admin-pages';
-import {expect, test} from '@/helpers/playwright/fixture';
-import type {Page} from '@playwright/test';
+import { SidebarPage, WhatsNewBanner } from '@/admin-pages';
+import { expect, test } from '@/helpers/playwright/fixture';
+import type { Page } from '@playwright/test';
 
 // Local type definition matching the API response format
 type RawChangelogEntry = {
-    slug: string;
-    title: string;
-    custom_excerpt: string;
-    published_at: string;
-    url: string;
-    featured: string;
-    feature_image?: string;
-    html?: string;
+  slug: string;
+  title: string;
+  custom_excerpt: string;
+  published_at: string;
+  url: string;
+  featured: string;
+  feature_image?: string;
+  html?: string;
 };
 
 function daysFromNow(days: number): Date {
-    const date = new Date();
-    date.setDate(date.getDate() + days);
-    return date;
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date;
 }
 
-function createEntry(publishedAt: Date, options: {
+function createEntry(
+  publishedAt: Date,
+  options: {
     featured?: boolean;
     title?: string;
     excerpt?: string;
     feature_image?: string;
-} = {}): RawChangelogEntry {
-    const title = options.title ?? 'Test Update';
-    const slug = title.toLowerCase().replace(/\s+/g, '-');
-    return {
-        slug,
-        title,
-        custom_excerpt: options.excerpt ?? 'Test feature',
-        published_at: publishedAt.toISOString(),
-        url: `https://ghost.org/changelog/${slug}`,
-        featured: (options.featured ?? false) ? 'true' : 'false',
-        ...(options.feature_image && {feature_image: options.feature_image})
-    };
+  } = {},
+): RawChangelogEntry {
+  const title = options.title ?? 'Test Update';
+  const slug = title.toLowerCase().replace(/\s+/g, '-');
+  return {
+    slug,
+    title,
+    custom_excerpt: options.excerpt ?? 'Test feature',
+    published_at: publishedAt.toISOString(),
+    url: `https://ghost.org/changelog/${slug}`,
+    featured: (options.featured ?? false) ? 'true' : 'false',
+    ...(options.feature_image && { feature_image: options.feature_image }),
+  };
 }
 
 async function mockChangelog(page: Page, entries: RawChangelogEntry[]): Promise<void> {
-    await page.route('https://ghost.org/changelog.json', async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({
-                posts: entries,
-                changelogUrl: 'https://ghost.org/changelog/'
-            })
-        });
+  await page.route('https://ghost.org/changelog.json', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        posts: entries,
+        changelogUrl: 'https://ghost.org/changelog/',
+      }),
     });
+  });
 }
 
 // Single-boot cases live in apps/admin/src/whats-new/whats-new.acceptance.test.tsx;
 // this case stays because the banner link opens a real popup window.
-test.describe('Ghost Admin - What\'s New Banner', () => {
-    test.describe('banner notification', () => {
-        test.describe('dismissal behavior', () => {
-            test('hides banner immediately when link is clicked', async ({page}) => {
-                await mockChangelog(page, [createEntry(daysFromNow(1))]);
+test.describe("Ghost Admin - What's New Banner", () => {
+  test.describe('banner notification', () => {
+    test.describe('dismissal behavior', () => {
+      test('hides banner immediately when link is clicked', async ({ page }) => {
+        await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
-                const banner = new WhatsNewBanner(page);
-                await banner.goto();
-                await banner.waitForBanner();
+        const banner = new WhatsNewBanner(page);
+        await banner.goto();
+        await banner.waitForBanner();
 
-                await expect(banner.container).toBeVisible();
+        await expect(banner.container).toBeVisible();
 
-                await banner.clickLinkAndClosePopup();
+        await banner.clickLinkAndClosePopup();
 
-                await expect(banner.container).toBeHidden();
-            });
+        await expect(banner.container).toBeHidden();
+      });
 
-            test('stays dismissed after a reload', async ({page}) => {
-                await mockChangelog(page, [createEntry(daysFromNow(1))]);
+      test('stays dismissed after a reload', async ({ page }) => {
+        await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
-                const banner = new WhatsNewBanner(page);
-                await banner.goto();
-                await banner.waitForBanner();
+        const banner = new WhatsNewBanner(page);
+        await banner.goto();
+        await banner.waitForBanner();
 
-                // Dismissing stores the entry's date; wait for that write so the
-                // reload below measures what Admin reads back.
-                await Promise.all([
-                    page.waitForResponse(response => response.request().method() === 'PUT' && /\/users\//.test(response.url())),
-                    banner.dismiss()
-                ]);
+        // Dismissing stores the entry's date; wait for that write so the
+        // reload below measures what Admin reads back.
+        await Promise.all([
+          page.waitForResponse(
+            (response) => response.request().method() === 'PUT' && /\/users\//.test(response.url()),
+          ),
+          banner.dismiss(),
+        ]);
 
-                await page.reload({waitUntil: 'load'});
+        await page.reload({ waitUntil: 'load' });
 
-                // Prove absence only once the page has settled.
-                await expect(new SidebarPage(page).postsToggle).toBeVisible();
-                await expect(banner.container).toBeHidden();
-            });
-        });
+        // Prove absence only once the page has settled.
+        await expect(new SidebarPage(page).postsToggle).toBeVisible();
+        await expect(banner.container).toBeHidden();
+      });
     });
+  });
 });

--- a/e2e/tests/admin/whats-new.test.ts
+++ b/e2e/tests/admin/whats-new.test.ts
@@ -1,78 +1,96 @@
-import { WhatsNewBanner } from '@/admin-pages';
-import { expect, test } from '@/helpers/playwright/fixture';
-import type { Page } from '@playwright/test';
+import {SidebarPage, WhatsNewBanner} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright/fixture';
+import type {Page} from '@playwright/test';
 
 // Local type definition matching the API response format
 type RawChangelogEntry = {
-  slug: string;
-  title: string;
-  custom_excerpt: string;
-  published_at: string;
-  url: string;
-  featured: string;
-  feature_image?: string;
-  html?: string;
+    slug: string;
+    title: string;
+    custom_excerpt: string;
+    published_at: string;
+    url: string;
+    featured: string;
+    feature_image?: string;
+    html?: string;
 };
 
 function daysFromNow(days: number): Date {
-  const date = new Date();
-  date.setDate(date.getDate() + days);
-  return date;
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    return date;
 }
 
-function createEntry(
-  publishedAt: Date,
-  options: {
+function createEntry(publishedAt: Date, options: {
     featured?: boolean;
     title?: string;
     excerpt?: string;
     feature_image?: string;
-  } = {},
-): RawChangelogEntry {
-  const title = options.title ?? 'Test Update';
-  const slug = title.toLowerCase().replace(/\s+/g, '-');
-  return {
-    slug,
-    title,
-    custom_excerpt: options.excerpt ?? 'Test feature',
-    published_at: publishedAt.toISOString(),
-    url: `https://ghost.org/changelog/${slug}`,
-    featured: (options.featured ?? false) ? 'true' : 'false',
-    ...(options.feature_image && { feature_image: options.feature_image }),
-  };
+} = {}): RawChangelogEntry {
+    const title = options.title ?? 'Test Update';
+    const slug = title.toLowerCase().replace(/\s+/g, '-');
+    return {
+        slug,
+        title,
+        custom_excerpt: options.excerpt ?? 'Test feature',
+        published_at: publishedAt.toISOString(),
+        url: `https://ghost.org/changelog/${slug}`,
+        featured: (options.featured ?? false) ? 'true' : 'false',
+        ...(options.feature_image && {feature_image: options.feature_image})
+    };
 }
 
 async function mockChangelog(page: Page, entries: RawChangelogEntry[]): Promise<void> {
-  await page.route('https://ghost.org/changelog.json', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        posts: entries,
-        changelogUrl: 'https://ghost.org/changelog/',
-      }),
+    await page.route('https://ghost.org/changelog.json', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                posts: entries,
+                changelogUrl: 'https://ghost.org/changelog/'
+            })
+        });
     });
-  });
 }
 
 // Single-boot cases live in apps/admin/src/whats-new/whats-new.acceptance.test.tsx;
 // this case stays because the banner link opens a real popup window.
-test.describe("Ghost Admin - What's New Banner", () => {
-  test.describe('banner notification', () => {
-    test.describe('dismissal behavior', () => {
-      test('hides banner immediately when link is clicked', async ({ page }) => {
-        await mockChangelog(page, [createEntry(daysFromNow(1))]);
+test.describe('Ghost Admin - What\'s New Banner', () => {
+    test.describe('banner notification', () => {
+        test.describe('dismissal behavior', () => {
+            test('hides banner immediately when link is clicked', async ({page}) => {
+                await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
-        const banner = new WhatsNewBanner(page);
-        await banner.goto();
-        await banner.waitForBanner();
+                const banner = new WhatsNewBanner(page);
+                await banner.goto();
+                await banner.waitForBanner();
 
-        await expect(banner.container).toBeVisible();
+                await expect(banner.container).toBeVisible();
 
-        await banner.clickLinkAndClosePopup();
+                await banner.clickLinkAndClosePopup();
 
-        await expect(banner.container).toBeHidden();
-      });
+                await expect(banner.container).toBeHidden();
+            });
+
+            test('stays dismissed after a reload', async ({page}) => {
+                await mockChangelog(page, [createEntry(daysFromNow(1))]);
+
+                const banner = new WhatsNewBanner(page);
+                await banner.goto();
+                await banner.waitForBanner();
+
+                // Dismissing stores the entry's date; wait for that write so the
+                // reload below measures what Admin reads back.
+                await Promise.all([
+                    page.waitForResponse(response => response.request().method() === 'PUT' && /\/users\//.test(response.url())),
+                    banner.dismiss()
+                ]);
+
+                await page.reload({waitUntil: 'load'});
+
+                // Prove absence only once the page has settled.
+                await expect(new SidebarPage(page).postsToggle).toBeVisible();
+                await expect(banner.container).toBeHidden();
+            });
+        });
     });
-  });
 });


### PR DESCRIPTION
## Problem

Admin keeps every user preference in one JSON blob on the user, and stored a change by writing that whole blob merged over the user it had cached when the page loaded. The cached user is not refetched on mount or on window focus, so it can be minutes stale, and every other writer of the same field, another Admin tab, Ember's feature service and its onboarding service, was silently reverted by the next preference write.

Two admin tabs is the case a user would notice. Set dark mode in one tab, collapse a sidebar group in the other, and the appearance goes back to what the second tab last read. No error, no conflict, last writer wins.

## Solution

A preference write now reads the user from the server as the base of the merge, falling back to the cached user only when that read fails, and sends only the field it changes rather than a whole user built from a read taken moments earlier. Collapsing a sidebar group sends only that group, so a stale sibling key cannot ride along in the payload. Dismissing the multiple active subscriptions banner sends only its preference too, so it no longer reverts a name or a role changed since Admin read that user.

A new E2E test drives the two-tab case through the UI. It failed five times out of five before this change and passes now.

## What this does not fix

The read and the write are still two requests, so two clients that both read before either writes can still overwrite each other. The window shrinks from the lifetime of a cached user to roughly one round trip. Closing it needs the server to merge the field or to reject a stale write, and Ghost has neither today.

Every mounted What's New reader still queues its own write of the initial last seen date, so a first page load stores it several times over. Those writes now merge over the stored blob and settle on the same state rather than overwriting one another, which is a redundancy rather than a correctness problem.

The multiple active subscriptions banner still builds its preference from the user Admin has cached, and still writes outside the shared preference mutation, so it can revert a preference another writer stored and it can interleave with a write from elsewhere in Admin. It has its own preferences module and schema, so routing it through the shared write belongs in its own change.

The same shape exists outside this blob: the labs feature toggle writes its whole JSON setting from the copy in the query cache, so two people toggling different flags still revert each other.
