### PR TITLE
🐛 Fixed header card asset exclusions

### DIFF
--- a/ghost/core/scripts/build-card-assets.mjs
+++ b/ghost/core/scripts/build-card-assets.mjs
@@ -3,7 +3,7 @@
 /**
  * Builds the card asset manifest.
  *
- * Every card ships one optional CSS file and one optional JS file in
+ * Every card ships optional CSS and JS source files in
  * core/frontend/src/cards. A theme picks a subset of them via its `card_assets`
  * config, and Ghost serves that subset as /public/cards.min.{css,js}.
  *
@@ -32,12 +32,12 @@ const LOADERS = {
     js: {loader: 'js', target: ['es2020']}
 };
 
-// Some cards have multiple source files but a single public `card_assets` name.
-// Keep this mapping explicit so unrelated names that share a prefix are not
-// accidentally grouped together.
-const CARD_ASSET_GROUPS = {
-    header_v2: 'header'
-};
+// header_v2.css is a second stylesheet for the public `header` card, not a
+// separate configurable card. This exact path override is intentional — `_vN`
+// filename suffixes are not a convention for grouping card assets.
+const PUBLIC_CARD_ASSET_NAMES = new Map([
+    ['css/header_v2.css', 'header']
+]);
 
 export async function buildType(type, sourceDir = srcDir) {
     const dir = path.join(sourceDir, type);
@@ -49,12 +49,13 @@ export async function buildType(type, sourceDir = srcDir) {
         const contents = fs.readFileSync(path.join(dir, file), 'utf8');
         const {code} = await esbuild.transform(contents, {minify: true, ...LOADERS[type]});
         const sourceName = file.slice(0, -suffix.length);
-        const cardName = CARD_ASSET_GROUPS[sourceName] || sourceName;
+        const cardName = PUBLIC_CARD_ASSET_NAMES.get(`${type}/${file}`) || sourceName;
 
         if (Object.hasOwn(chunks, cardName)) {
             // Match the separator used when the runtime service concatenates
             // separate chunks, keeping the default bundle bytes stable.
-            chunks[cardName] += `\n${code}`;
+            const separator = type === 'js' ? ';\n' : '\n';
+            chunks[cardName] += `${separator}${code}`;
         } else {
             chunks[cardName] = code;
         }

--- a/ghost/core/scripts/build-card-assets.mjs
+++ b/ghost/core/scripts/build-card-assets.mjs
@@ -32,8 +32,15 @@ const LOADERS = {
     js: {loader: 'js', target: ['es2020']}
 };
 
-async function buildType(type) {
-    const dir = path.join(srcDir, type);
+// Some cards have multiple source files but a single public `card_assets` name.
+// Keep this mapping explicit so unrelated names that share a prefix are not
+// accidentally grouped together.
+const CARD_ASSET_GROUPS = {
+    header_v2: 'header'
+};
+
+export async function buildType(type, sourceDir = srcDir) {
+    const dir = path.join(sourceDir, type);
     const suffix = `.${type}`;
     const files = fs.readdirSync(dir).filter(file => file.endsWith(suffix)).sort();
 
@@ -41,7 +48,16 @@ async function buildType(type) {
     for (const file of files) {
         const contents = fs.readFileSync(path.join(dir, file), 'utf8');
         const {code} = await esbuild.transform(contents, {minify: true, ...LOADERS[type]});
-        chunks[file.slice(0, -suffix.length)] = code;
+        const sourceName = file.slice(0, -suffix.length);
+        const cardName = CARD_ASSET_GROUPS[sourceName] || sourceName;
+
+        if (Object.hasOwn(chunks, cardName)) {
+            // Match the separator used when the runtime service concatenates
+            // separate chunks, keeping the default bundle bytes stable.
+            chunks[cardName] += `\n${code}`;
+        } else {
+            chunks[cardName] = code;
+        }
     }
 
     logging.debug(`✓ ${files.length} card ${type} files minified`);
@@ -49,12 +65,18 @@ async function buildType(type) {
     return chunks;
 }
 
-const manifest = {};
-for (const type of Object.keys(LOADERS)) {
-    manifest[type] = await buildType(type);
+export async function buildCardAssets() {
+    const manifest = {};
+    for (const type of Object.keys(LOADERS)) {
+        manifest[type] = await buildType(type);
+    }
+
+    fs.mkdirSync(path.dirname(destFile), {recursive: true});
+    fs.writeFileSync(destFile, JSON.stringify(manifest));
+
+    logging.debug(`Card asset manifest written to ${destFile}`);
 }
 
-fs.mkdirSync(path.dirname(destFile), {recursive: true});
-fs.writeFileSync(destFile, JSON.stringify(manifest));
-
-logging.debug(`Card asset manifest written to ${destFile}`);
+if (import.meta.main) {
+    await buildCardAssets();
+}

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -23,6 +23,61 @@ const MANIFEST = {
 
 const expectedHash = content => crypto.createHash('sha256').update(content).digest('base64url').substring(0, 16);
 
+describe('Card Asset Manifest Builder', function () {
+    let testDir,
+        manifestPath,
+        manifest;
+
+    beforeAll(async function () {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghost-card-assets-builder-tests-'));
+        manifestPath = path.join(testDir, 'cards.manifest.json');
+
+        const cssDir = path.join(testDir, 'css');
+        await fs.mkdir(cssDir);
+        await Promise.all([
+            fs.writeFile(path.join(cssDir, 'gallery.css'), '.gallery { color: red; }'),
+            fs.writeFile(path.join(cssDir, 'header.css'), '.kg-header-card { color: blue; }'),
+            fs.writeFile(path.join(cssDir, 'header_v2.css'), '.kg-header-card.kg-v2 { color: green; }')
+        ]);
+
+        const {buildType} = await import('../../../../scripts/build-card-assets.mjs');
+        manifest = {css: await buildType('css', testDir)};
+        await fs.writeFile(manifestPath, JSON.stringify(manifest));
+    });
+
+    afterAll(async function () {
+        await fs.rm(testDir, {recursive: true});
+    });
+
+    it('groups every source file for a card under its public card name', function () {
+        assert.deepEqual(Object.keys(manifest.css), ['gallery', 'header']);
+        assert.match(manifest.css.header, /\.kg-header-card\{/);
+        assert.match(manifest.css.header, /\.kg-header-card\.kg-v2\{/);
+        assert.ok(manifest.css.header.indexOf('.kg-header-card{') < manifest.css.header.indexOf('.kg-header-card.kg-v2{'));
+    });
+
+    it('excludes every grouped chunk by the public card name', function () {
+        const cardAssets = new CardAssetService({
+            manifest: manifestPath,
+            config: {exclude: ['header']}
+        });
+
+        assert.deepEqual(cardAssets.getCardNames('css'), ['gallery']);
+        assert.doesNotMatch(cardAssets.getBundle('css').content, /\.kg-header-card/);
+    });
+
+    it('includes every grouped chunk by the public card name', function () {
+        const cardAssets = new CardAssetService({
+            manifest: manifestPath,
+            config: {include: ['header']}
+        });
+
+        assert.deepEqual(cardAssets.getCardNames('css'), ['header']);
+        assert.match(cardAssets.getBundle('css').content, /\.kg-header-card\{/);
+        assert.match(cardAssets.getBundle('css').content, /\.kg-header-card\.kg-v2\{/);
+    });
+});
+
 describe('Card Asset Service', function () {
     let testDir,
         manifestPath;

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -26,22 +26,42 @@ const expectedHash = content => crypto.createHash('sha256').update(content).dige
 describe('Card Asset Manifest Builder', function () {
     let testDir,
         manifestPath,
-        manifest;
+        manifest,
+        ungroupedCssManifest,
+        shippedCssManifest;
 
     beforeAll(async function () {
         testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghost-card-assets-builder-tests-'));
         manifestPath = path.join(testDir, 'cards.manifest.json');
 
         const cssDir = path.join(testDir, 'css');
-        await fs.mkdir(cssDir);
+        const jsDir = path.join(testDir, 'js');
+        const ungroupedCssDir = path.join(testDir, 'ungrouped', 'css');
+        await Promise.all([
+            fs.mkdir(cssDir),
+            fs.mkdir(jsDir),
+            fs.mkdir(ungroupedCssDir, {recursive: true})
+        ]);
         await Promise.all([
             fs.writeFile(path.join(cssDir, 'gallery.css'), '.gallery { color: red; }'),
             fs.writeFile(path.join(cssDir, 'header.css'), '.kg-header-card { color: blue; }'),
-            fs.writeFile(path.join(cssDir, 'header_v2.css'), '.kg-header-card.kg-v2 { color: green; }')
+            fs.writeFile(path.join(cssDir, 'header_v2.css'), '.kg-header-card.kg-v2 { color: green; }'),
+            fs.writeFile(path.join(jsDir, 'header.js'), 'window.header = true;'),
+            fs.writeFile(path.join(jsDir, 'header_v2.js'), 'window.headerV2 = true;'),
+            fs.writeFile(path.join(ungroupedCssDir, 'gallery.css'), '.gallery { color: red; }'),
+            fs.writeFile(path.join(ungroupedCssDir, 'header.css'), '.kg-header-card { color: blue; }'),
+            // This sorts directly after header.css without triggering the path override,
+            // reconstructing the previous separately-keyed bundle for comparison.
+            fs.writeFile(path.join(ungroupedCssDir, 'headerz.css'), '.kg-header-card.kg-v2 { color: green; }')
         ]);
 
         const {buildType} = await import('../../../../scripts/build-card-assets.mjs');
-        manifest = {css: await buildType('css', testDir)};
+        manifest = {
+            css: await buildType('css', testDir),
+            js: await buildType('js', testDir)
+        };
+        ungroupedCssManifest = await buildType('css', path.join(testDir, 'ungrouped'));
+        shippedCssManifest = await buildType('css');
         await fs.writeFile(manifestPath, JSON.stringify(manifest));
     });
 
@@ -49,14 +69,29 @@ describe('Card Asset Manifest Builder', function () {
         await fs.rm(testDir, {recursive: true});
     });
 
-    it('groups every source file for a card under its public card name', function () {
+    it('maps header v2 CSS to the public header card name', function () {
         assert.deepEqual(Object.keys(manifest.css), ['gallery', 'header']);
         assert.match(manifest.css.header, /\.kg-header-card\{/);
         assert.match(manifest.css.header, /\.kg-header-card\.kg-v2\{/);
         assert.ok(manifest.css.header.indexOf('.kg-header-card{') < manifest.css.header.indexOf('.kg-header-card.kg-v2{'));
     });
 
-    it('excludes every grouped chunk by the public card name', function () {
+    it('does not infer public card names from version suffixes', function () {
+        assert.deepEqual(Object.keys(manifest.js), ['header', 'header_v2']);
+    });
+
+    it('does not expose a versioned header card name from the shipped CSS', function () {
+        assert.deepEqual(Object.keys(shippedCssManifest).filter(name => name.startsWith('header')), ['header']);
+    });
+
+    it('preserves the default bundle bytes when combining the header chunks', function () {
+        const cardAssets = new CardAssetService({manifest: manifestPath, config: true});
+        const previousContent = Object.values(ungroupedCssManifest).join('\n');
+
+        assert.equal(cardAssets.getBundle('css').content, previousContent);
+    });
+
+    it('excludes both header styles by the public header card name', function () {
         const cardAssets = new CardAssetService({
             manifest: manifestPath,
             config: {exclude: ['header']}
@@ -66,7 +101,7 @@ describe('Card Asset Manifest Builder', function () {
         assert.doesNotMatch(cardAssets.getBundle('css').content, /\.kg-header-card/);
     });
 
-    it('includes every grouped chunk by the public card name', function () {
+    it('includes both header styles by the public header card name', function () {
         const cardAssets = new CardAssetService({
             manifest: manifestPath,
             config: {include: ['header']}


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/30102

## What changed

- Maps the exact source path `css/header_v2.css` to the documented public `header` card when building the card asset manifest.
- Keeps the versioned source files separate while combining both stylesheets under one logical manifest key.
- Preserves the existing source order and separator so the default all-card bundle remains byte-for-byte identical.
- Makes the manifest builder importable without executing it and adds regression coverage for mapping, inclusion, exclusion, and asset-type isolation.

## Why

The prebuilt manifest refactor keyed every card asset by its filename stem. The header card has separate v1 and v2 CSS source files for compatibility with stored content, so this produced `header` and `header_v2` manifest keys even though themes configure a single documented `header` card.

As a result, `"exclude": ["header"]` removed the legacy CSS but left the v2 rules in `cards.min.css`, which could override a theme's custom header styles. Sites using the default `card_assets: true` configuration are unaffected; the regression is limited to themes selectively excluding the header card assets.

The override is intentionally type- and path-specific. It does not strip `_vN` suffixes or establish a filename convention: a future versioned asset requires an explicit public-name decision. A synthetic `js/header_v2.js` remains a separate key.

This also makes `"include": ["header"]` include both supported header renderers. `header_v2` was an undocumented implementation key; the documented public configuration remains `header`.

## Validation

- `pnpm check`
- Focused card-assets tests: 35 passing
- Verified the shipped CSS manifest exposes only one header key and contains selectors from both source files.
- Verified the default CSS bundle remains 46,231 bytes with the same SHA-256: `270d37df813e03cbe9b96766c0bd18761e131f09ec3d9b0848f7634c3539b260`
