### PR TITLE
Cleaned up the admin-x naming left in the settings shell

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -20,12 +20,13 @@
     height: 100%;
 }
 
-/* Keep admin-x heading line-height consistent with pre-migration settings render. */
-.admin-x-base h1,
-.admin-x-base h2,
-.admin-x-base h3,
-.admin-x-base h4,
-.admin-x-base h5 {
+/* Settings' raw h1-h5 still expect the 1.25em admin-x heading line-height; Shade's base gives 1.5.
+   Remove once those headings carry an explicit leading. */
+.settings-app h1,
+.settings-app h2,
+.settings-app h3,
+.settings-app h4,
+.settings-app h5 {
     line-height: 1.25em;
 }
 

--- a/apps/admin/src/settings/components/selectors/unsplash-selector.tsx
+++ b/apps/admin/src/settings/components/selectors/unsplash-selector.tsx
@@ -10,7 +10,7 @@ type UnsplashSelectorModalProps = {
 
 const UnsplashSelector : React.FC<UnsplashSelectorModalProps> = ({unsplashProviderConfig, onClose, onImageInsert}) => {
     return (
-        <Portal classNames='admin-x-settings'>
+        <Portal classNames='settings-app'>
             <UnsplashSearchModal
                 unsplashProviderConfig={unsplashProviderConfig}
                 onClose={onClose}

--- a/apps/admin/src/settings/hooks/scroll-section-provider.tsx
+++ b/apps/admin/src/settings/hooks/scroll-section-provider.tsx
@@ -4,7 +4,7 @@ import {ScrollSectionContext} from './use-scroll-section';
 const scrollMargin = 193;
 
 const scrollToSection = (element: HTMLDivElement, doneInitialScroll: boolean) => {
-    const root = document.getElementById('admin-x-settings-scroller')!;
+    const root = document.getElementById('settings-scroller')!;
     const top = element.getBoundingClientRect().top + root.scrollTop;
 
     root.scrollTo({
@@ -14,8 +14,7 @@ const scrollToSection = (element: HTMLDivElement, doneInitialScroll: boolean) =>
 };
 
 const scrollSidebarNav = (navElement: HTMLLIElement, doneInitialScroll: boolean) => {
-    // const sidebar = document.getElementById('admin-x-settings-sidebar')!;
-    const sidebar = document.getElementById('admin-x-settings-sidebar-scroller')!;
+    const sidebar = document.getElementById('settings-sidebar-scroller')!;
 
     const bounds = navElement.getBoundingClientRect();
 

--- a/apps/admin/src/settings/layout/app.tsx
+++ b/apps/admin/src/settings/layout/app.tsx
@@ -28,7 +28,7 @@ function SettingsLocationSync() {
 export function App({upgradeStatus}: AppProps) {
     return (
         <SettingsAppProvider upgradeStatus={upgradeStatus}>
-            <div className='admin-x-base admin-x-settings [--color-focus-ring:var(--color-green-500)] [--focus-ring:var(--color-green-500)]'>
+            <div className='settings-app [--color-focus-ring:var(--color-green-500)] [--focus-ring:var(--color-green-500)]'>
                 <ConfirmationProvider>
                     <DialogPortalProvider>
                         <SettingsLocationSync />

--- a/apps/admin/src/settings/layout/main-content.tsx
+++ b/apps/admin/src/settings/layout/main-content.tsx
@@ -19,7 +19,7 @@ const Page: React.FC<{children: ReactNode}> = ({children}) => {
         <div className='fixed top-2 right-0 z-50 m-8 flex justify-end bg-transparent tablet:fixed tablet:top-0' id="done-button-container">
             <ExitSettingsButton />
         </div>
-        <div className="fixed top-0 left-0 flex size-full bg-grey-50 dark:bg-grey-950 dark:tablet:bg-[#101114]" id="admin-x-settings-content">
+        <div className="fixed top-0 left-0 flex size-full bg-grey-50 dark:bg-grey-950 dark:tablet:bg-[#101114]" id="settings-content">
             {children}
         </div>
     </>;
@@ -74,7 +74,7 @@ const MainContent: React.FC = () => {
         return (
             <Page>
                 <div className='flex-1 bg-white dark:bg-grey-950'>
-                    <div className='h-full overflow-y-auto overscroll-y-contain' id="admin-x-settings-scroller">
+                    <div className='h-full overflow-y-auto overscroll-y-contain' id="settings-scroller">
                         <div className='mx-auto max-w-5xl px-[5vmin] tablet:mt-16 xl:mt-10'>
                             <Text as='h1' className='mb-[5vmin] text-4xl' leading='supertight' weight='bold'>Settings</Text>
                             <Users highlight={false} keywords={EMPTY_KEYWORDS} />
@@ -88,13 +88,13 @@ const MainContent: React.FC = () => {
 
     return (
         <Page>
-            <div className="fixed inset-x-0 top-0 z-[35] max-w-[calc(100%-16px)] flex-1 basis-[320px] overscroll-y-contain bg-white p-8 tablet:relative tablet:inset-x-auto tablet:top-auto tablet:h-full tablet:overflow-y-scroll tablet:bg-grey-50 tablet:py-0 dark:bg-grey-950 dark:tablet:bg-[#101114]" id="admin-x-settings-sidebar-scroller">
+            <div className="fixed inset-x-0 top-0 z-[35] max-w-[calc(100%-16px)] flex-1 basis-[320px] overscroll-y-contain bg-white p-8 tablet:relative tablet:inset-x-auto tablet:top-auto tablet:h-full tablet:overflow-y-scroll tablet:bg-grey-50 tablet:py-0 dark:bg-grey-950 dark:tablet:bg-[#101114]" id="settings-sidebar-scroller">
                 <div className="relative w-full">
                     <Sidebar />
                 </div>
             </div>
             <div className="h-full flex-1 bg-white tablet:basis-[800px] dark:bg-grey-950 dark:tablet:bg-black">
-                <div className="relative h-full overflow-y-scroll overscroll-y-contain pt-13" id="admin-x-settings-scroller">
+                <div className="relative h-full overflow-y-scroll overscroll-y-contain pt-13" id="settings-scroller">
                     <Settings />
                 </div>
             </div>

--- a/apps/admin/src/settings/layout/sidebar.tsx
+++ b/apps/admin/src/settings/layout/sidebar.tsx
@@ -207,7 +207,7 @@ const Sidebar: React.FC = () => {
         setFilter(e.target.value);
 
         if (e.target.value) {
-            document.querySelector('.admin-x-settings')?.scrollTo({top: 0, left: 0});
+            document.querySelector('.settings-app')?.scrollTo({top: 0, left: 0});
         }
     };
 
@@ -243,7 +243,7 @@ const Sidebar: React.FC = () => {
                     </InputGroupAddon>
                 </InputGroup>
             </div>
-            <nav className={navClasses} id='admin-x-settings-sidebar'>
+            <nav className={navClasses} id='settings-sidebar'>
                 {noResult &&
                 <div className='ml-2 text-base text-grey-700'>
                     <h2 className='mb-2 text-base font-semibold tracking-normal text-black dark:text-white'>No result</h2>

--- a/apps/admin/src/settings/providers/settings-app-provider.tsx
+++ b/apps/admin/src/settings/providers/settings-app-provider.tsx
@@ -2,13 +2,13 @@ import GlobalDataProvider from './global-data-provider';
 import useSearchService from '@/settings/utils/search';
 import {type ReactNode, useState} from 'react';
 import {ScrollSectionProvider} from '@/settings/hooks/scroll-section-provider';
-import {SettingsAppContext, type SettingsAppContextType, type Sorting} from './settings-app-context';
+import {SettingsAppContext, type Sorting, type UpgradeStatusType} from './settings-app-context';
 import {officialThemes} from '@/settings/data/official-themes';
 import {zapierTemplates} from '@/settings/data/zapier-templates';
 
-type SettingsAppProviderProps = Partial<Omit<SettingsAppContextType, 'search'>> & {children: ReactNode};
+type SettingsAppProviderProps = {upgradeStatus?: UpgradeStatusType; children: ReactNode};
 
-const SettingsAppProvider: React.FC<SettingsAppProviderProps> = ({children, ...props}) => {
+const SettingsAppProvider: React.FC<SettingsAppProviderProps> = ({children, upgradeStatus}) => {
     const search = useSearchService();
 
     // a few sane defaults for keeping a sorting state
@@ -22,10 +22,9 @@ const SettingsAppProvider: React.FC<SettingsAppProviderProps> = ({children, ...p
 
     return (
         <SettingsAppContext.Provider value={{
-            // Use local data as default, allow props to override (for backward compatibility)
             officialThemes,
             zapierTemplates,
-            ...props,
+            upgradeStatus,
             search,
             sortingState,
             setSortingState,


### PR DESCRIPTION
no ref

Tail of the settings integration:

- `admin-x-settings-{content,sidebar,sidebar-scroller,scroller}` element ids → `settings-*`; the `admin-x-base admin-x-settings` wrapper class → `settings-app` (and the heading line-height rule in `index.css` follows). Nothing outside `apps/admin/src/settings` referenced any of them (checked Ember, e2e, shade, test-utils); no id collisions with Ember's DOM.
- `SettingsAppProvider` typed every context field as an optional prop but overwrote `sortingState`/`setSortingState`/`offersShowArchived`/`setOffersShowArchived` after spreading them (the CodeRabbit note on #30113 — pre-existing). It now takes only `upgradeStatus`, the one prop its caller passes.

## Verification

- `pnpm test:acceptance` layout, navigation-history, routing, search, permissions, design, offers — 29/29
- admin unit 1594/1594; `tsc -b` + eslint clean