### PR TITLE
Added an unsaved-changes guard for back/forward navigation in settings

### DIFF
--- a/apps/admin-x-framework/src/providers/router-provider.tsx
+++ b/apps/admin-x-framework/src/providers/router-provider.tsx
@@ -129,16 +129,6 @@ export function RouterProvider({
         });
     }, [routes, prefix, errorElement, children]);
 
-    // Native hash navigations (plain `<a href="#/…">` anchors, Ember) create
-    // history entries without the router's state, and the router cannot block a
-    // POP onto such an entry (it can't compute the delta to undo it). Stamp them
-    // the way the router stamps its initial entry so back-navigation blockers work.
-    useEffect(() => router.subscribe((state) => {
-        if (state.historyAction === 'POP' && (window.history.state as {idx?: number} | null)?.idx === undefined) {
-            window.history.replaceState({...(window.history.state as object | null), idx: 0}, '');
-        }
-    }), [router]);
-
     return (
         <ReactRouterProvider router={router} />
     );

--- a/apps/admin-x-framework/src/providers/router-provider.tsx
+++ b/apps/admin-x-framework/src/providers/router-provider.tsx
@@ -129,6 +129,16 @@ export function RouterProvider({
         });
     }, [routes, prefix, errorElement, children]);
 
+    // Native hash navigations (plain `<a href="#/…">` anchors, Ember) create
+    // history entries without the router's state, and the router cannot block a
+    // POP onto such an entry (it can't compute the delta to undo it). Stamp them
+    // the way the router stamps its initial entry so back-navigation blockers work.
+    useEffect(() => router.subscribe((state) => {
+        if (state.historyAction === 'POP' && (window.history.state as {idx?: number} | null)?.idx === undefined) {
+            window.history.replaceState({...(window.history.state as object | null), idx: 0}, '');
+        }
+    }), [router]);
+
     return (
         <ReactRouterProvider router={router} />
     );

--- a/apps/admin/src/settings/layout/app.tsx
+++ b/apps/admin/src/settings/layout/app.tsx
@@ -1,4 +1,5 @@
 import MainContent from './main-content';
+import {DirtyNavigationGuard} from './dirty-navigation-guard';
 import SettingsAppProvider from '@/settings/providers/settings-app-provider';
 import {type UpgradeStatusType} from '@/settings/providers/settings-app-context';
 import {ConfirmationProvider} from '@/settings/providers/confirmation-provider';
@@ -34,6 +35,7 @@ export function App({upgradeStatus}: AppProps) {
                         <SettingsLocationSync />
                         <MainContent />
                         <Outlet />
+                        <DirtyNavigationGuard />
                     </DialogPortalProvider>
                 </ConfirmationProvider>
             </div>

--- a/apps/admin/src/settings/layout/dirty-navigation-guard-identity.ts
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard-identity.ts
@@ -5,7 +5,7 @@ import {type SettingsRouteHandle, settingsRouteChildren} from '@/settings/routes
 // dialog instance (tabs/steps) for the same record, any other leaf route is its own,
 // and section roots or anything outside settings count as leaving every dialog.
 export const dialogIdentity = (pathname: string): string => {
-    if (!pathname.startsWith('/settings')) {
+    if (pathname !== '/settings' && !pathname.startsWith('/settings/')) {
         return 'outside';
     }
     const match = matchRoutes(settingsRouteChildren, pathname.slice('/settings'.length) || '/')?.at(-1);

--- a/apps/admin/src/settings/layout/dirty-navigation-guard-identity.ts
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard-identity.ts
@@ -1,0 +1,18 @@
+import {matchRoutes} from '@tryghost/admin-x-framework';
+import {type SettingsRouteHandle, settingsRouteChildren} from '@/settings/routes';
+
+// Which dialog a settings path renders: routes sharing a `handle.dialogGroup` are one
+// dialog instance (tabs/steps) for the same record, any other leaf route is its own,
+// and section roots or anything outside settings count as leaving every dialog.
+export const dialogIdentity = (pathname: string): string => {
+    if (!pathname.startsWith('/settings')) {
+        return 'outside';
+    }
+    const match = matchRoutes(settingsRouteChildren, pathname.slice('/settings'.length) || '/')?.at(-1);
+    if (!match?.route.lazy) {
+        return 'settings';
+    }
+    const group = (match.route.handle as SettingsRouteHandle | undefined)?.dialogGroup;
+    const routeIdentity = group ? `group:${group}` : `route:${match.route.path ?? ''}`;
+    return `${routeIdentity}:${JSON.stringify(match.params)}`;
+};

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.test.ts
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, it} from 'vitest';
+
+import {dialogIdentity} from './dirty-navigation-guard-identity';
+
+describe('dialogIdentity', () => {
+    it('keeps tabs for one staff record grouped', () => {
+        expect(dialogIdentity('/settings/staff/owner')).toBe(dialogIdentity('/settings/staff/owner/social-links'));
+    });
+
+    it('distinguishes different records using the same dialog route', () => {
+        expect(dialogIdentity('/settings/staff/owner')).not.toBe(dialogIdentity('/settings/staff/author'));
+        expect(dialogIdentity('/settings/newsletters/first')).not.toBe(dialogIdentity('/settings/newsletters/second'));
+    });
+});

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.test.ts
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.test.ts
@@ -11,4 +11,9 @@ describe('dialogIdentity', () => {
         expect(dialogIdentity('/settings/staff/owner')).not.toBe(dialogIdentity('/settings/staff/author'));
         expect(dialogIdentity('/settings/newsletters/first')).not.toBe(dialogIdentity('/settings/newsletters/second'));
     });
+
+    it('only classifies paths within the exact settings boundary', () => {
+        expect(dialogIdentity('/settings')).toBe('settings');
+        expect(dialogIdentity('/settings-other')).toBe('outside');
+    });
 });

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -1,25 +1,12 @@
 import {DirtyConfirmDialog} from '@tryghost/shade/patterns';
 import {NavigationType, useBlocker, useLocation} from 'react-router';
-import {matchRoutes} from '@tryghost/admin-x-framework';
-import {type SettingsRouteHandle, settingsRouteChildren} from '@/settings/routes';
 import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
 import {useEffect, useRef} from 'react';
+import {z} from 'zod';
+import {dialogIdentity} from './dirty-navigation-guard-identity';
 
-// Which dialog a settings path renders: routes sharing a `handle.dialogGroup` are one
-// dialog instance (tabs/steps), any other leaf route is its own, and section roots
-// or anything outside settings count as leaving every dialog.
-const dialogIdentity = (pathname: string): string => {
-    if (!pathname.startsWith('/settings')) {
-        return 'outside';
-    }
-    const leaf = matchRoutes(settingsRouteChildren, pathname.slice('/settings'.length) || '/')?.at(-1)?.route;
-    if (!leaf?.lazy) {
-        return 'settings';
-    }
-    const group = (leaf.handle as SettingsRouteHandle | undefined)?.dialogGroup;
-    return group ? `group:${group}` : `route:${leaf.path ?? ''}`;
-};
+const historyStateSchema = z.record(z.string(), z.unknown()).nullable();
 
 // Only history (back/forward) navigations are blocked: every in-app way out of a
 // dirty settings dialog already runs its own dirty confirmation before navigating.
@@ -31,7 +18,8 @@ export const DirtyNavigationGuard: React.FC = () => {
     // remember whether the entry being left was created by the router (it has a key).
     const onRouterEntryRef = useRef(false);
     useEffect(() => {
-        onRouterEntryRef.current = typeof (window.history.state as {key?: unknown} | null)?.key === 'string';
+        const historyState = historyStateSchema.safeParse(window.history.state);
+        onRouterEntryRef.current = historyState.success && typeof historyState.data?.key === 'string';
     }, [location]);
 
     useConfirmUnload(isDirty);

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -6,18 +6,19 @@ import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
 import {useEffect, useRef} from 'react';
 
-// Sibling dialog routes that share a component (staff tabs, offers steps, design/theme)
-// keep their state across navigation, so only leaving a dialog's route family counts.
-const dialogFamily = (pathname: string): string => {
-    if (!pathname.startsWith('/settings/')) {
-        return pathname.startsWith('/settings') ? 'settings' : 'outside';
+// Which dialog a settings path renders: routes sharing a `handle.dialogGroup` are one
+// dialog instance (tabs/steps), any other leaf route is its own, and section roots
+// or anything outside settings count as leaving every dialog.
+const dialogIdentity = (pathname: string): string => {
+    if (!pathname.startsWith('/settings')) {
+        return 'outside';
     }
-    const relative = pathname.slice('/settings'.length);
-    const leaf = matchRoutes(settingsRouteChildren, relative)?.at(-1)?.route;
+    const leaf = matchRoutes(settingsRouteChildren, pathname.slice('/settings'.length) || '/')?.at(-1)?.route;
     if (!leaf?.lazy) {
         return 'settings';
     }
-    return relative.split('/')[1];
+    const group = (leaf.handle as {dialogGroup?: string} | undefined)?.dialogGroup;
+    return group ? `group:${group}` : `route:${leaf.path ?? ''}`;
 };
 
 // Only history (back/forward) navigations are blocked: every in-app way out of a
@@ -44,7 +45,7 @@ export const DirtyNavigationGuard: React.FC = () => {
         if (!onRouterEntryRef.current) {
             return false;
         }
-        return dialogFamily(currentLocation.pathname) !== dialogFamily(nextLocation.pathname);
+        return dialogIdentity(currentLocation.pathname) !== dialogIdentity(nextLocation.pathname);
     });
     const isBlocked = blocker.state === 'blocked';
 

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -1,7 +1,7 @@
 import {DirtyConfirmDialog} from '@tryghost/shade/patterns';
 import {NavigationType, useBlocker, useLocation} from 'react-router';
 import {matchRoutes} from '@tryghost/admin-x-framework';
-import {settingsRouteChildren} from '@/settings/routes';
+import {type SettingsRouteHandle, settingsRouteChildren} from '@/settings/routes';
 import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
 import {useEffect, useRef} from 'react';
@@ -17,7 +17,7 @@ const dialogIdentity = (pathname: string): string => {
     if (!leaf?.lazy) {
         return 'settings';
     }
-    const group = (leaf.handle as {dialogGroup?: string} | undefined)?.dialogGroup;
+    const group = (leaf.handle as SettingsRouteHandle | undefined)?.dialogGroup;
     return group ? `group:${group}` : `route:${leaf.path ?? ''}`;
 };
 

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -1,0 +1,43 @@
+import {DirtyConfirmDialog} from '@tryghost/shade/patterns';
+import {NavigationType, useBlocker} from 'react-router';
+import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
+import {useGlobalDirtyState} from '@tryghost/shade/utils';
+import {useRef} from 'react';
+
+// Only history (back/forward) navigations are blocked: every in-app way out of a
+// dirty settings dialog already runs its own dirty confirmation before navigating.
+export const DirtyNavigationGuard: React.FC = () => {
+    const {isDirty} = useGlobalDirtyState();
+    const leaveConfirmedRef = useRef(false);
+
+    useConfirmUnload(isDirty);
+
+    const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => (
+        isDirty && historyAction === NavigationType.Pop && currentLocation.pathname !== nextLocation.pathname
+    ));
+    const isBlocked = blocker.state === 'blocked';
+
+    return (
+        <DirtyConfirmDialog
+            open={isBlocked}
+            onConfirm={() => {
+                leaveConfirmedRef.current = true;
+                blocker.proceed?.();
+            }}
+            onOpenChange={(open) => {
+                if (open) {
+                    return;
+                }
+                // Leave closes the dialog while the blocker still reads as blocked;
+                // don't reset the navigation the user just confirmed.
+                if (leaveConfirmedRef.current) {
+                    leaveConfirmedRef.current = false;
+                    return;
+                }
+                if (isBlocked) {
+                    blocker.reset?.();
+                }
+            }}
+        />
+    );
+};

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -6,7 +6,9 @@ import {useEffect, useRef} from 'react';
 import {z} from 'zod';
 import {dialogIdentity} from './dirty-navigation-guard-identity';
 
-const historyStateSchema = z.record(z.string(), z.unknown()).nullable();
+const historyStateSchema = z.looseObject({
+    idx: z.number().int().nonnegative().optional()
+}).nullable();
 
 // Only history (back/forward) navigations are blocked: every in-app way out of a
 // dirty settings dialog already runs its own dirty confirmation before navigating.
@@ -15,11 +17,11 @@ export const DirtyNavigationGuard: React.FC = () => {
     const leaveConfirmedRef = useRef(false);
     const location = useLocation();
     // history.state already belongs to the target entry when the blocker runs, so
-    // remember whether the entry being left was created by the router (it has a key).
+    // remember whether the entry being left was tracked by the router (it has an index).
     const onRouterEntryRef = useRef(false);
     useEffect(() => {
         const historyState = historyStateSchema.safeParse(window.history.state);
-        onRouterEntryRef.current = historyState.success && typeof historyState.data?.key === 'string';
+        onRouterEntryRef.current = historyState.success && historyState.data?.idx !== undefined;
     }, [location]);
 
     useConfirmUnload(isDirty);

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -1,20 +1,51 @@
 import {DirtyConfirmDialog} from '@tryghost/shade/patterns';
-import {NavigationType, useBlocker} from 'react-router';
+import {NavigationType, useBlocker, useLocation} from 'react-router';
+import {matchRoutes} from '@tryghost/admin-x-framework';
+import {settingsRouteChildren} from '@/settings/routes';
 import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
-import {useRef} from 'react';
+import {useEffect, useRef} from 'react';
+
+// Sibling dialog routes that share a component (staff tabs, offers steps, design/theme)
+// keep their state across navigation, so only leaving a dialog's route family counts.
+const dialogFamily = (pathname: string): string => {
+    if (!pathname.startsWith('/settings/')) {
+        return pathname.startsWith('/settings') ? 'settings' : 'outside';
+    }
+    const relative = pathname.slice('/settings'.length);
+    const leaf = matchRoutes(settingsRouteChildren, relative)?.at(-1)?.route;
+    if (!leaf?.lazy) {
+        return 'settings';
+    }
+    return relative.split('/')[1];
+};
 
 // Only history (back/forward) navigations are blocked: every in-app way out of a
 // dirty settings dialog already runs its own dirty confirmation before navigating.
 export const DirtyNavigationGuard: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
     const leaveConfirmedRef = useRef(false);
+    const location = useLocation();
+    // history.state already belongs to the target entry when the blocker runs, so
+    // remember whether the entry being left was created by the router (it has a key).
+    const onRouterEntryRef = useRef(false);
+    useEffect(() => {
+        onRouterEntryRef.current = typeof (window.history.state as {key?: unknown} | null)?.key === 'string';
+    }, [location]);
 
     useConfirmUnload(isDirty);
 
-    const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => (
-        isDirty && historyAction === NavigationType.Pop && currentLocation.pathname !== nextLocation.pathname
-    ));
+    const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => {
+        if (!isDirty || historyAction !== NavigationType.Pop) {
+            return false;
+        }
+        // The router can only undo a POP from an entry it created; from a native
+        // hash-navigation entry it would miscount the delta and reload instead.
+        if (!onRouterEntryRef.current) {
+            return false;
+        }
+        return dialogFamily(currentLocation.pathname) !== dialogFamily(nextLocation.pathname);
+    });
     const isBlocked = blocker.state === 'blocked';
 
     return (

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -53,6 +53,33 @@ describe("Settings navigation history", () => {
         await expect.element(modal).not.toBeInTheDocument();
     });
 
+    it("confirms before leaving a dirty direct-load dialog with the forward button", async () => {
+        const {boot, currentUser} = fakeStaffWorld();
+        await renderAdminApp(`/settings/staff/${currentUser.slug}`, {boot});
+
+        const modal = settingsScreen.userDetailModal();
+        await modal.getByRole("button", { name: "Close" }).click();
+        await expect.poll(currentRoute).toBe("/settings/staff");
+
+        window.history.back();
+        await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
+        await modal.getByLabelText("Location").fill("Somewhere new");
+        await flushEffects();
+
+        window.history.forward();
+
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/leave/i);
+        await settingsScreen.confirmationAction("Stay").click();
+        await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
+        await expect.element(modal).toBeVisible();
+
+        window.history.forward();
+
+        await settingsScreen.confirmationAction("Leave").click();
+        await expect.poll(currentRoute).toBe("/settings/staff");
+        await expect.element(modal).not.toBeInTheDocument();
+    });
+
     it("does not prompt when the back button only switches a dirty dialog's tab", async () => {
         const {boot, currentUser} = fakeStaffWorld();
         await renderAdminApp(`/settings/staff/${currentUser.slug}`, {boot});

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { currentRoute, fakeAnalyticsOverview, fakeSettingsScreens, renderAdminApp } from "@test-utils/acceptance";
 import { settingsScreen } from "./settings.screen";
+import { fakeStaffWorld } from "./general/staff.test-helpers";
+
+const flushEffects = () => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
+});
 
 // Settings navigations are real router pushes; these specs pin the history
 // semantics the router swap introduced.
@@ -18,6 +23,34 @@ describe("Settings navigation history", () => {
 
         await expect.poll(currentRoute).toBe("/settings");
         await expect.element(settingsScreen.portalModal()).not.toBeInTheDocument();
+    });
+
+    it("confirms before the back button closes a dirty dialog", async () => {
+        const {boot, currentUser} = fakeStaffWorld();
+        await renderAdminApp("/settings", {boot});
+
+        await settingsScreen.users().getByTestId("owner-user").click();
+        const modal = settingsScreen.userDetailModal();
+        await expect.element(modal).toBeVisible();
+        await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
+        await modal.getByLabelText("Location").fill("Somewhere new");
+        // The dirty flag reaches the history blocker through passive effects
+        // (dialog → global dirty state → guard re-render); let them flush.
+        await flushEffects();
+
+        window.history.back();
+
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/leave/i);
+        await settingsScreen.confirmationAction("Stay").click();
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(modal).toBeVisible();
+        await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
+
+        window.history.back();
+
+        await settingsScreen.confirmationAction("Leave").click();
+        await expect.poll(currentRoute).toBe("/settings");
+        await expect.element(modal).not.toBeInTheDocument();
     });
 
     it("returns to settings with the back button after exiting", async () => {

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -53,28 +53,6 @@ describe("Settings navigation history", () => {
         await expect.element(modal).not.toBeInTheDocument();
     });
 
-    it("confirms before the back button closes a dirty dialog when settings was entered by a hash link", async () => {
-        const {boot} = fakeStaffWorld();
-        fakeAnalyticsOverview();
-        await renderAdminApp("/analytics", {boot});
-
-        // The admin sidebar's Settings item is a plain hash anchor, not a router link.
-        window.location.hash = "#/settings";
-        await expect.element(settingsScreen.users()).toBeVisible();
-        await settingsScreen.users().getByTestId("owner-user").click();
-        const modal = settingsScreen.userDetailModal();
-        await expect.element(modal).toBeVisible();
-        await modal.getByLabelText("Location").fill("Somewhere new");
-        await flushEffects();
-
-        window.history.back();
-
-        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/leave/i);
-        await settingsScreen.confirmationAction("Leave").click();
-        await expect.poll(currentRoute).toBe("/settings");
-        await expect.element(modal).not.toBeInTheDocument();
-    });
-
     it("does not prompt when the back button only switches a dirty dialog's tab", async () => {
         const {boot, currentUser} = fakeStaffWorld();
         await renderAdminApp(`/settings/staff/${currentUser.slug}`, {boot});

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -53,6 +53,47 @@ describe("Settings navigation history", () => {
         await expect.element(modal).not.toBeInTheDocument();
     });
 
+    it("confirms before the back button closes a dirty dialog when settings was entered by a hash link", async () => {
+        const {boot} = fakeStaffWorld();
+        fakeAnalyticsOverview();
+        await renderAdminApp("/analytics", {boot});
+
+        // The admin sidebar's Settings item is a plain hash anchor, not a router link.
+        window.location.hash = "#/settings";
+        await expect.element(settingsScreen.users()).toBeVisible();
+        await settingsScreen.users().getByTestId("owner-user").click();
+        const modal = settingsScreen.userDetailModal();
+        await expect.element(modal).toBeVisible();
+        await modal.getByLabelText("Location").fill("Somewhere new");
+        await flushEffects();
+
+        window.history.back();
+
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/leave/i);
+        await settingsScreen.confirmationAction("Leave").click();
+        await expect.poll(currentRoute).toBe("/settings");
+        await expect.element(modal).not.toBeInTheDocument();
+    });
+
+    it("does not prompt when the back button only switches a dirty dialog's tab", async () => {
+        const {boot, currentUser} = fakeStaffWorld();
+        await renderAdminApp(`/settings/staff/${currentUser.slug}`, {boot});
+
+        const modal = settingsScreen.userDetailModal();
+        await modal.getByLabelText("Location").fill("Somewhere new");
+        await modal.getByRole("tab", { name: "Social Links" }).click();
+        await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}/social-links`);
+        await flushEffects();
+
+        window.history.back();
+
+        await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(modal).toBeVisible();
+        await modal.getByRole("tab", { name: "Profile" }).click();
+        await expect.element(modal.getByLabelText("Location")).toHaveValue("Somewhere new");
+    });
+
     it("returns to settings with the back button after exiting", async () => {
         fakeSettingsScreens();
         fakeAnalyticsOverview();

--- a/apps/admin/src/settings/routes.tsx
+++ b/apps/admin/src/settings/routes.tsx
@@ -5,24 +5,26 @@ import {type RouteObject, Navigate, lazyComponent} from '@tryghost/admin-x-frame
 // settings providers and chrome — routed dialogs render through its Outlet.
 // Paths mirror the legacy modal-route contract exactly; route ranking (static
 // over dynamic over splat) resolves overlaps like offers/edit/retention vs
-// offers/edit/:offerId.
+// offers/edit/:offerId. `handle.dialogGroup` marks sibling routes rendered by
+// one dialog instance, so the history guard treats moving between them as a
+// tab switch rather than leaving the dialog.
 export const settingsRouteChildren: RouteObject[] = [
     // Design and theme share one container across four entry paths; it reads
     // the path to pick its internal view.
-    {path: 'design/change-theme', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
-    {path: 'design/edit', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
-    {path: 'theme/install', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
-    {path: 'theme/edit/:themeName', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'design/change-theme', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'design/edit', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'theme/install', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'theme/edit/:themeName', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
     // Theme names may contain %2F; anything deeper than one segment is not a
     // valid editor URL.
     {path: 'theme/edit/*', element: <Navigate to="/settings/theme" replace />},
     {path: 'navigation/edit', lazy: lazyComponent(() => import('./site/navigation-modal'))},
     {path: 'announcement-bar/edit', lazy: lazyComponent(() => import('./site/announcement-bar-modal'))},
     {path: 'staff/invite', lazy: lazyComponent(() => import('./general/invite-user-modal'))},
-    {path: 'staff/:slug', lazy: lazyComponent(() => import('./general/user-detail-modal'))},
-    {path: 'staff/:slug/edit', lazy: lazyComponent(() => import('./general/user-detail-modal'))},
-    {path: 'staff/:slug/social-links', lazy: lazyComponent(() => import('./general/user-detail-modal'))},
-    {path: 'staff/:slug/email-notifications', lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug/edit', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug/social-links', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug/email-notifications', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
     {path: 'portal/edit', lazy: lazyComponent(() => import('./membership/portal/portal-modal'))},
     {path: 'tiers/add', lazy: lazyComponent(() => import('./membership/tiers/tier-detail-modal'))},
     {path: 'tiers/:tierId', lazy: lazyComponent(() => import('./membership/tiers/tier-detail-modal'))},
@@ -46,11 +48,11 @@ export const settingsRouteChildren: RouteObject[] = [
     {path: 'embed-signup-form/show', lazy: lazyComponent(() => import('./growth/embed-signup/embed-signup-form-modal'))},
     // The offers container owns list/add/edit/retention/success views and
     // reads the path to pick between them.
-    {path: 'offers/new', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/edit', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/edit/:offerId', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/edit/retention/:offerId', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/success/:offerId', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/new', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/edit', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/edit/:offerId', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/edit/retention/:offerId', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/success/:offerId', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
     {path: 'explore/testimonial', lazy: lazyComponent(() => import('./growth/explore/testimonials-modal'))},
     {path: 'about', lazy: lazyComponent(() => import('./general/about'))},
     // The lock-site setting was merged into the Access section.

--- a/apps/admin/src/settings/routes.tsx
+++ b/apps/admin/src/settings/routes.tsx
@@ -9,6 +9,9 @@ import {type RouteObject, Navigate, lazyComponent} from '@tryghost/admin-x-frame
 // one dialog instance (the staff tabs), so the history guard treats moving
 // between them as a tab switch rather than leaving the dialog; containers that
 // swap child components per route (offers, design/theme) stay ungrouped.
+/** Sibling routes with the same group are rendered by one dialog instance. */
+export type SettingsRouteHandle = {dialogGroup?: string};
+
 export const settingsRouteChildren: RouteObject[] = [
     // Design and theme share one container across four entry paths; it reads
     // the path to pick its internal view.
@@ -22,10 +25,10 @@ export const settingsRouteChildren: RouteObject[] = [
     {path: 'navigation/edit', lazy: lazyComponent(() => import('./site/navigation-modal'))},
     {path: 'announcement-bar/edit', lazy: lazyComponent(() => import('./site/announcement-bar-modal'))},
     {path: 'staff/invite', lazy: lazyComponent(() => import('./general/invite-user-modal'))},
-    {path: 'staff/:slug', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
-    {path: 'staff/:slug/edit', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
-    {path: 'staff/:slug/social-links', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
-    {path: 'staff/:slug/email-notifications', handle: {dialogGroup: 'staff'}, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug', handle: {dialogGroup: 'staff'} satisfies SettingsRouteHandle, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug/edit', handle: {dialogGroup: 'staff'} satisfies SettingsRouteHandle, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug/social-links', handle: {dialogGroup: 'staff'} satisfies SettingsRouteHandle, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
+    {path: 'staff/:slug/email-notifications', handle: {dialogGroup: 'staff'} satisfies SettingsRouteHandle, lazy: lazyComponent(() => import('./general/user-detail-modal'))},
     {path: 'portal/edit', lazy: lazyComponent(() => import('./membership/portal/portal-modal'))},
     {path: 'tiers/add', lazy: lazyComponent(() => import('./membership/tiers/tier-detail-modal'))},
     {path: 'tiers/:tierId', lazy: lazyComponent(() => import('./membership/tiers/tier-detail-modal'))},

--- a/apps/admin/src/settings/routes.tsx
+++ b/apps/admin/src/settings/routes.tsx
@@ -6,15 +6,16 @@ import {type RouteObject, Navigate, lazyComponent} from '@tryghost/admin-x-frame
 // Paths mirror the legacy modal-route contract exactly; route ranking (static
 // over dynamic over splat) resolves overlaps like offers/edit/retention vs
 // offers/edit/:offerId. `handle.dialogGroup` marks sibling routes rendered by
-// one dialog instance, so the history guard treats moving between them as a
-// tab switch rather than leaving the dialog.
+// one dialog instance (the staff tabs), so the history guard treats moving
+// between them as a tab switch rather than leaving the dialog; containers that
+// swap child components per route (offers, design/theme) stay ungrouped.
 export const settingsRouteChildren: RouteObject[] = [
     // Design and theme share one container across four entry paths; it reads
     // the path to pick its internal view.
-    {path: 'design/change-theme', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
-    {path: 'design/edit', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
-    {path: 'theme/install', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
-    {path: 'theme/edit/:themeName', handle: {dialogGroup: 'design'}, lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'design/change-theme', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'design/edit', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'theme/install', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
+    {path: 'theme/edit/:themeName', lazy: lazyComponent(() => import('./site/design-and-theme-modal'))},
     // Theme names may contain %2F; anything deeper than one segment is not a
     // valid editor URL.
     {path: 'theme/edit/*', element: <Navigate to="/settings/theme" replace />},
@@ -48,11 +49,11 @@ export const settingsRouteChildren: RouteObject[] = [
     {path: 'embed-signup-form/show', lazy: lazyComponent(() => import('./growth/embed-signup/embed-signup-form-modal'))},
     // The offers container owns list/add/edit/retention/success views and
     // reads the path to pick between them.
-    {path: 'offers/new', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/edit', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/edit/:offerId', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/edit/retention/:offerId', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
-    {path: 'offers/success/:offerId', handle: {dialogGroup: 'offers'}, lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/new', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/edit', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/edit/:offerId', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/edit/retention/:offerId', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
+    {path: 'offers/success/:offerId', lazy: lazyComponent(() => import('./growth/offers/offers-container-modal'))},
     {path: 'explore/testimonial', lazy: lazyComponent(() => import('./growth/explore/testimonials-modal'))},
     {path: 'about', lazy: lazyComponent(() => import('./general/about'))},
     // The lock-site setting was merged into the Access section.


### PR DESCRIPTION
no ref

Closing a dirty settings dialog through Escape, its buttons, the exit button or a sidebar link already confirms before discarding changes; the browser **back/forward buttons did not** — the router swap lost the route-transition guard Ember settings had, and tags/members already guard this with `useBlocker`.

- `layout/dirty-navigation-guard.tsx`: `useBlocker` on the global dirty state, wired to the shared `DirtyConfirmDialog` (Leave → `proceed`, Stay → `reset`). Only `POP` navigations are blocked — every in-app exit already runs its own dirty confirmation, so blocking PUSH/REPLACE would double-prompt. Also registers `useConfirmUnload` while dirty, like the other guarded screens. Mounted beside `<Outlet />` in `layout/app.tsx` so contributors' profile dialog is covered too.
- Blocks only when the entry being left was **router-created** (`history.state.key`). React Router can only undo a POP from an entry it created; from a native hash-navigation entry it miscounts the delta and can call `history.go(0)` (reload) — found during review, so the guard deliberately stays out of that case.
- Compares matched dialog routes, not pathnames: sibling routes rendered by one dialog instance declare `handle: {dialogGroup}` in `settings/routes.tsx` (currently the staff-profile tabs) so back between tabs doesn't prompt; every other route change out of a dialog does. Offers and design/theme containers swap child components per route, so they are intentionally *not* grouped.

**Known limit (follow-up):** settings entered via the admin sidebar is a native hash anchor, which leaves the `/settings` history entry without router state — React Router refuses to block a POP onto such an entry, so back from a dirty dialog isn't guarded on that entry path yet. Fix belongs in the sidebar (router `Link` for React-owned routes); it also closes the same hole for the tags/members blockers. Multi-entry jumps via the back-button long-press picker across an untracked entry likewise stay unguarded. Both go away once sidebar entries are router-created.

## Verification

- `pnpm test:acceptance src/settings` — 337/337 (new: back on dirty staff dialog → Stay keeps it / Leave closes it, verified failing without the guard; back between dirty staff tabs → no prompt, verified failing without the `dialogGroup`)
- admin unit 1594/1594; `tsc -b` + eslint clean