### PR TITLE
Added per-task timing logs to server shutdown

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -145,7 +145,7 @@ async function initCore({ghostServer, config}) {
 
         ghostServer.registerCleanupTask(async () => {
             await jobService.shutdown();
-        });
+        }, 'Job Service');
         debug('End: Job Service');
 
         // Mentions Job Service allows mentions to be processed in the background
@@ -158,7 +158,7 @@ async function initCore({ghostServer, config}) {
 
         ghostServer.registerCleanupTask(async () => {
             await mentionsJobService.shutdown();
-        });
+        }, 'Mentions Job Service');
         debug('End: Mentions Job Service');
 
         debug('Begin: Jobs Service');
@@ -166,7 +166,7 @@ async function initCore({ghostServer, config}) {
 
         ghostServer.registerCleanupTask(async () => {
             await jobsService.shutdown({timeoutMs: config.get('server:shutdownTimeout')});
-        });
+        }, 'Jobs Service (in-memory)');
         debug('End: Jobs Service');
     }
 
@@ -580,7 +580,7 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
                 if (prometheusClient) {
                     prometheusClient.stop();
                 }
-            });
+            }, 'Prometheus client');
             debug('End: load server + minimal app');
         }
 

--- a/ghost/core/core/server/ghost-server.js
+++ b/ghost/core/core/server/ghost-server.js
@@ -200,9 +200,11 @@ class GhostServer {
 
     /**
      * Add a task that should be called on shutdown
+     * @param {() => Promise<any>} task
+     * @param {string} [label] - name used in shutdown timing logs
      */
-    registerCleanupTask(task) {
-        this.cleanupTasks.push(task);
+    registerCleanupTask(task, label) {
+        this.cleanupTasks.push({task, label: label || `cleanup task #${this.cleanupTasks.length + 1}`});
     }
 
     /**
@@ -217,12 +219,24 @@ class GhostServer {
      */
     async _stopServer() {
         const util = require('util');
-        return util.promisify(this.httpServer.stop)();
+        const startTime = Date.now();
+        try {
+            return await util.promisify(this.httpServer.stop)();
+        } finally {
+            logging.info(`Shutdown: stopped HTTP server in ${Date.now() - startTime}ms`);
+        }
     }
 
     async _cleanup() {
-        // Wait for all cleanup tasks to finish
-        return Promise.all(this.cleanupTasks.map(task => task()));
+        // Wait for all cleanup tasks to finish, timing each so a slow one is identifiable
+        return Promise.all(this.cleanupTasks.map(async ({task, label}) => {
+            const startTime = Date.now();
+            try {
+                return await task();
+            } finally {
+                logging.info(`Shutdown: ${label} finished in ${Date.now() - startTime}ms`);
+            }
+        }));
     }
 
     /**

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -136,7 +136,7 @@ class EmailServiceWrapper {
         });
 
         if (ghostServer) {
-            ghostServer.registerCleanupTask(() => batchSendingService.onShutdown());
+            ghostServer.registerCleanupTask(() => batchSendingService.onShutdown(), 'Email batch sending');
         }
 
         this.renderer = emailRenderer;


### PR DESCRIPTION
no ref

Ghost shuts down slowly on some sites and the cleanup tasks were anonymous closures, so there was no way to tell which task (or the HTTP server stop itself) was hanging. This labels each cleanup task and logs how long it and _stopServer take, so a single SIGTERM on the affected environment names the culprit instead of requiring a bisect.