### PR TITLE
Changed sidebar links to React-owned routes to navigate through the router

### DIFF
--- a/apps/admin/src/hooks/use-hash-link-navigation-guard.ts
+++ b/apps/admin/src/hooks/use-hash-link-navigation-guard.ts
@@ -13,10 +13,13 @@ import React from 'react';
  * back to the caller to confirm. Links rendered by react-router (marked with
  * `data-discover`) are left alone — the router's own blocker guards those.
  */
-export function useHashLinkNavigationGuard(when: boolean) {
+export function useHashLinkNavigationGuard(when: boolean, onBlocked?: () => void) {
     const [blockedHref, setBlockedHref] = React.useState<string | null>(null);
+    const blockedHrefRef = React.useRef<string | null>(null);
     const whenRef = React.useRef(when);
     whenRef.current = when;
+    const onBlockedRef = React.useRef(onBlocked);
+    onBlockedRef.current = onBlocked;
 
     React.useEffect(() => {
         const onClick = (event: MouseEvent) => {
@@ -34,7 +37,10 @@ export function useHashLinkNavigationGuard(when: boolean) {
             }
             event.preventDefault();
             event.stopPropagation();
-            setBlockedHref(anchor.getAttribute('href'));
+            const href = anchor.getAttribute('href');
+            blockedHrefRef.current = href;
+            onBlockedRef.current?.();
+            setBlockedHref(href);
         };
 
         document.addEventListener('click', onClick, true);
@@ -46,12 +52,17 @@ export function useHashLinkNavigationGuard(when: boolean) {
         isBlocked: blockedHref !== null,
         /** Confirm leaving: performs the intercepted navigation for real. */
         proceed: () => {
-            if (blockedHref) {
+            const href = blockedHrefRef.current;
+            if (href) {
+                blockedHrefRef.current = null;
                 setBlockedHref(null);
-                window.location.hash = blockedHref;
+                window.location.hash = href;
             }
         },
         /** Cancel leaving: drops the intercepted navigation. */
-        reset: () => setBlockedHref(null)
+        reset: () => {
+            blockedHrefRef.current = null;
+            setBlockedHref(null);
+        }
     };
 }

--- a/apps/admin/src/layout/app-sidebar/nav-menu-item.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-menu-item.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {Button, SidebarMenuButton, SidebarMenuItem, useSidebar} from '@tryghost/shade/components';
 import {cn, LucideIcon} from '@tryghost/shade/utils';
 import { useIsActiveLink } from './use-is-active-link';
+import { Link } from '@tryghost/admin-x-framework';
+import { isEmberOwnedRoute } from '@/routes';
 
 function NavMenuItem({ children, ...props }: React.ComponentProps<typeof SidebarMenuItem>) {
     return (
@@ -114,10 +116,12 @@ function NavMenuLink({
     children,
     ...props
 }: NavMenuLinkProps) {
-    const href = `#/${to?.replace(/^\/?#\//, '')}`;
+    const path = `/${to?.replace(/^\/?#\//, '')}`;
     const computedIsActive = useIsActiveLink({ path: to, activeOnSubpath });
     const isActive = controlledIsActive !== undefined ? controlledIsActive : computedIsActive;
     const { isMobile, setOpenMobile } = useSidebar();
+    const isExternal = target === '_blank';
+    const useRouterLink = !isExternal && !isEmberOwnedRoute(path.split('?')[0]);
 
     const handleClick = () => {
         if (isMobile) {
@@ -130,15 +134,27 @@ function NavMenuLink({
             isActive={isActive}
             asChild
             {...props}>
-            <a
-                aria-current={isActive ? 'page' : undefined}
-                href={target === '_blank' ? to : href}
-                rel={target === '_blank' ? rel ?? 'noopener noreferrer' : rel}
-                target={target}
-                onClick={handleClick}
-            >
-                {children}
-            </a>
+            {useRouterLink ? (
+                <Link
+                    aria-current={isActive ? 'page' : undefined}
+                    rel={rel}
+                    target={target}
+                    to={path}
+                    onClick={handleClick}
+                >
+                    {children}
+                </Link>
+            ) : (
+                <a
+                    aria-current={isActive ? 'page' : undefined}
+                    href={isExternal ? to : `#${path}`}
+                    rel={isExternal ? rel ?? 'noopener noreferrer' : rel}
+                    target={target}
+                    onClick={handleClick}
+                >
+                    {children}
+                </a>
+            )}
         </SidebarMenuButton>
     )
 }

--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -56,6 +56,22 @@ describe("Sidebar navigation", () => {
         await expect.element(sidebarScreen.navLink("Tags")).not.toHaveAttribute("aria-current");
     });
 
+    it("uses router navigation for React-owned routes and hash anchors for Ember-owned ones", async () => {
+        fakeTags([]);
+        await renderAdminApp("/site");
+
+        // Router links carry the router's history state (the unsaved-changes
+        // blockers rely on it); Ember's router only follows hashchange, so its
+        // links must stay native anchors.
+        await sidebarScreen.navLink("Tags").click();
+        await expect.poll(currentRoute).toBe("/tags");
+        expect(typeof (window.history.state as {key?: unknown} | null)?.key).toBe("string");
+
+        await sidebarScreen.navLink("Posts").click();
+        await expect.poll(currentRoute).toBe("/posts");
+        expect((window.history.state as {key?: unknown} | null)?.key).toBeUndefined();
+    });
+
     it("clicking Posts and Pages navigates to the Ember-owned lists", async () => {
         // Posts/Pages active states come from the Ember routing bridge, absent in this tier.
         await renderAdminApp("/site");

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,4 +1,4 @@
-import {type AdminRouteHandle, type RouteObject, Outlet, lazyComponent, redirect} from "@tryghost/admin-x-framework";
+import {type AdminRouteHandle, type RouteObject, Outlet, lazyComponent, matchRoutes, redirect} from "@tryghost/admin-x-framework";
 
 // ActivityPub
 import { FeatureFlagsProvider, routes as activityPubRoutes } from "@tryghost/activitypub/api";
@@ -213,3 +213,14 @@ export const routes: RouteObject[] = [
         ],
     },
 ];
+
+// Ember's router only learns about a URL change from `hashchange`, which the
+// React router's pushState navigation does not fire, so links into Ember-owned
+// routes must stay native hash anchors. Everything else can be a router link
+// (and so gets router history state, which the unsaved-changes blockers need).
+const EMBER_ROUTE_COMPONENTS = new Set<unknown>([EmberFallback, EmberListWithGiftLinks, TagDetailGate]);
+
+export function isEmberOwnedRoute(pathname: string): boolean {
+    const leaf = matchRoutes(routes, pathname)?.at(-1)?.route;
+    return !leaf || EMBER_ROUTE_COMPONENTS.has(leaf.Component);
+}

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
 
 import { currentRoute, fakeAnalyticsOverview, fakeSettingsScreens, renderAdminApp } from "@test-utils/acceptance";
 import { settingsScreen } from "./settings.screen";
@@ -77,6 +78,25 @@ describe("Settings navigation history", () => {
 
         await settingsScreen.confirmationAction("Leave").click();
         await expect.poll(currentRoute).toBe("/settings/staff");
+    });
+
+    it("confirms before the back button closes a dirty dialog when settings was entered from the sidebar", async () => {
+        const {boot} = fakeStaffWorld();
+        await renderAdminApp("/site", {boot});
+
+        await page.getByRole("link", { name: "Settings" }).click();
+        await expect.element(settingsScreen.users()).toBeVisible();
+        await settingsScreen.users().getByTestId("owner-user").click();
+        const modal = settingsScreen.userDetailModal();
+        await expect.element(modal).toBeVisible();
+        await modal.getByLabelText("Location").fill("Somewhere new");
+        await flushEffects();
+
+        window.history.back();
+
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/leave/i);
+        await settingsScreen.confirmationAction("Leave").click();
+        await expect.poll(currentRoute).toBe("/settings");
         await expect.element(modal).not.toBeInTheDocument();
     });
 

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -69,7 +69,7 @@ const TagDetail: React.FC = () => {
     // Lets our own post-save redirect through the unsaved-changes blocker.
     const bypassGuardRef = React.useRef(false);
     const blockedNavigationRef = React.useRef(false);
-    const proceedBlockedNavigationRef = React.useRef<() => void>(() => {});
+    const proceedBlockedNavigationAfterSaveRef = React.useRef(false);
     const [saveStatus, setSaveStatus] = React.useState<SaveStatus>('idle');
     const [showDelete, setShowDelete] = React.useState(false);
     const [isDeleting, setIsDeleting] = React.useState(false);
@@ -112,6 +112,7 @@ const TagDetail: React.FC = () => {
     React.useEffect(() => {
         bypassGuardRef.current = false;
         blockedNavigationRef.current = false;
+        proceedBlockedNavigationAfterSaveRef.current = false;
         setShowDelete(false);
         setIsDeleting(false);
         setBusyImageFields(new Set());
@@ -227,7 +228,7 @@ const TagDetail: React.FC = () => {
             touchedFieldsRef.current.clear();
             setSaveStatus('success');
             if (blockedNavigationRef.current) {
-                proceedBlockedNavigationRef.current();
+                proceedBlockedNavigationAfterSaveRef.current = true;
                 return;
             }
             // Move `/tags/new` to the saved tag and follow slug renames. A
@@ -280,21 +281,38 @@ const TagDetail: React.FC = () => {
 
     const shouldGuardNavigation = activeMutation.isPending || hasPendingImageUpload || isDeleting || hasUnsavedChanges;
     useConfirmUnload(shouldGuardNavigation);
-    const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && shouldGuardNavigation && currentLocation.pathname !== nextLocation.pathname);
+    const blocker = useBlocker(({currentLocation, nextLocation}) => {
+        const shouldBlock = !bypassGuardRef.current && shouldGuardNavigation && currentLocation.pathname !== nextLocation.pathname;
+        if (shouldBlock) {
+            // The mutation can resolve before React rerenders with a blocked
+            // state, so record the navigation synchronously in the blocker.
+            blockedNavigationRef.current = true;
+        }
+        return shouldBlock;
+    });
     // Native `<a href="#/…">` navigations (the sidebar, links into Ember
     // routes) never reach the react-router blocker above. Ember's own guard
     // can't cover this screen either: with `tagDetailsReact` on, the Ember tag
     // route aborts and never registers into the `unsaved-changes` service.
-    const anchorGuard = useHashLinkNavigationGuard(shouldGuardNavigation);
+    const anchorGuard = useHashLinkNavigationGuard(shouldGuardNavigation, () => {
+        blockedNavigationRef.current = true;
+    });
     const isBlocked = blocker.state === 'blocked' || anchorGuard.isBlocked;
-    blockedNavigationRef.current = isBlocked;
-    proceedBlockedNavigationRef.current = () => {
+    if (isBlocked) {
+        blockedNavigationRef.current = true;
+    }
+    React.useEffect(() => {
+        if (!proceedBlockedNavigationAfterSaveRef.current || activeMutation.isPending || !isBlocked) {
+            return;
+        }
+        proceedBlockedNavigationAfterSaveRef.current = false;
+        blockedNavigationRef.current = false;
         if (anchorGuard.isBlocked) {
             anchorGuard.proceed();
         } else {
             blocker.proceed?.();
         }
-    };
+    }, [activeMutation.isPending, anchorGuard, blocker, isBlocked]);
     // DirtyConfirmDialog's confirm action auto-closes the dialog, firing
     // onOpenChange(false) while the blocker still reads as blocked; without
     // this flag the close handler would reset the very navigation the user
@@ -441,6 +459,8 @@ const TagDetail: React.FC = () => {
                     open={isBlocked && !activeMutation.isPending}
                     onConfirm={() => {
                         leaveConfirmedRef.current = true;
+                        blockedNavigationRef.current = false;
+                        proceedBlockedNavigationAfterSaveRef.current = false;
                         if (anchorGuard.isBlocked) {
                             anchorGuard.proceed();
                         } else {
@@ -456,6 +476,8 @@ const TagDetail: React.FC = () => {
                             return;
                         }
                         if (isBlocked) {
+                            blockedNavigationRef.current = false;
+                            proceedBlockedNavigationAfterSaveRef.current = false;
                             blocker.reset?.();
                             anchorGuard.reset();
                         }


### PR DESCRIPTION
no ref

Follow-up from the review of #30119. The admin sidebar rendered every destination as a plain `<a href="#/…">`. Those navigations bypass the React router, so the history entries they create carry no router state and React Router refuses to block a browser back onto them (`delta == null`) — the `useBlocker` guards on tags, members and settings never fire when the screen was entered from the sidebar, and from some entry shapes the router miscounts the delta and calls `history.go(0)` (reload) instead of stepping back.

- `NavMenuLink` renders a router `Link` for React-owned routes and keeps a native anchor for Ember-owned ones. Ember's `HashLocation` only follows `hashchange`, which the router's `pushState` doesn't fire, so Ember targets must stay anchors.
- Ownership comes from the route table at runtime (`isEmberOwnedRoute(path)` in `routes.tsx`: leaf route served by `EmberFallback` / `EmberListWithGiftLinks` / `TagDetailGate`), so flag-gated routes follow the same rule without a hand-maintained list. Query strings (`posts?type=…`, member views) are preserved either way.
- External (`target="_blank"`) links unchanged.

Not in this PR: other native anchors into React routes (tag list rows, comment → member links) — same hole, can follow the same helper.

## Verification

- `pnpm test:acceptance` (full admin) — 493/493 after rebuilding workspace deps; new sidebar test asserts Tags → router-created entry (`history.state.key`), Posts → native entry
- admin unit 1598/1598; `tsc -b` + eslint clean