### PR TITLE
Fixed a members import mapping being discarded without asking

### DIFF
--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -15,7 +15,7 @@ import {createInitialImportState, importReducer} from '@/members/components/bulk
 import {isImportMembersCompleteResponse, useImportMembers} from '@tryghost/admin-x-framework/api/members';
 import {memberCustomFieldCsvColumns, useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {parseCSV} from '@/members/components/bulk-action-modals/import-members/csv';
-import {useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef} from 'react';
 import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 import {useLabelPicker} from '@/members/hooks/use-label-picker';
 
@@ -82,7 +82,7 @@ export function ImportMembersModal({
     const labelPicker = useLabelPicker({
         selectedSlugs: state.selectedLabelSlugs,
         onSelectionChange: (slugs: string[]) => {
-            setHasEdits(true);
+            hasEditsRef.current = true;
             dispatch({type: 'SET_SELECTED_LABEL_SLUGS', selectedLabelSlugs: slugs});
         }
     });
@@ -100,7 +100,7 @@ export function ImportMembersModal({
         revokeErrorCsvUrl();
         // The modal is never unmounted (members-actions keeps it mounted and toggles `open`),
         // so anything held outside the reducer outlives Start over unless it is cleared here.
-        setHasEdits(false);
+        hasEditsRef.current = false;
         dispatch({type: 'RESET'});
     }, [revokeErrorCsvUrl]);
 
@@ -115,10 +115,14 @@ export function ImportMembersModal({
     // a mapped file: which columns are in, what each fills, the labels chosen. So dismissal
     // asks first, using the same confirmation the settings modals use.
     const {confirm, dialogProps} = useDirtyConfirmation();
-    // Whether anything would actually be lost by leaving. A file that has only been parsed is
-    // not worth asking about: re-uploading it reproduces the same detected mapping. What cannot
-    // be reproduced is what the publisher changed since, so that is what this tracks.
-    const [hasEdits, setHasEdits] = useState(false);
+    // Tracks mapping changes that would be lost on close. Parsing a file does not count because
+    // re-uploading it recreates the detected mapping.
+    //
+    // Radix refreshes its onOpenChange callback ref in a passive effect, and handles Escape on
+    // document outside React's event dispatch. Escape can therefore call the old closure before
+    // React commits the edit. Nothing renders from this flag, so a ref gives the handler the current
+    // value.
+    const hasEditsRef = useRef(false);
 
     const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen && state.status === 'UPLOADING') {
@@ -127,7 +131,7 @@ export function ImportMembersModal({
         if (!isOpen) {
             // Only the mapping step holds anything: every other one is either empty or shows a
             // result that closing is the natural end of.
-            confirm(state.status === 'MAPPING' && hasEdits, () => {
+            confirm(state.status === 'MAPPING' && hasEditsRef.current, () => {
                 const importResponse = state.importResponse ?? undefined;
                 reset();
                 onClose?.(importResponse);
@@ -136,7 +140,7 @@ export function ImportMembersModal({
             return;
         }
         onOpenChange(isOpen);
-    }, [confirm, hasEdits, onClose, onOpenChange, reset, state.importResponse, state.status]);
+    }, [confirm, onClose, onOpenChange, reset, state.importResponse, state.status]);
 
     useEffect(() => {
         if (!state.file || !customFieldsReady) {
@@ -231,7 +235,7 @@ export function ImportMembersModal({
             return;
         }
 
-        setHasEdits(true);
+        hasEditsRef.current = true;
 
         const nextMapping = state.mapping.updateMapping(from, to);
         const nextError = state.fileData && state.fileData.length === 0
@@ -411,7 +415,9 @@ export function ImportMembersModal({
                     showMappingErrors={state.showMappingErrors}
                     status={state.status}
                     targets={targets}
-                    onColumnsChanged={() => setHasEdits(true)}
+                    onColumnsChanged={() => {
+                        hasEditsRef.current = true;
+                    }}
                     onDataPreviewIndexChange={(nextIndex) => {
                         dispatch({
                             type: 'SET_DATA_PREVIEW_INDEX',

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -641,4 +641,19 @@ describe('Import members custom fields', () => {
         await expect.element(fieldSelect('email')).not.toBeInTheDocument();
     });
 
+    // Fire both DOM events in one task to cover Escape arriving before React commits the edit.
+    // userEvent adds task boundaries that let React settle and hide this race.
+    it('asks even when the dismissal lands before React has settled', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+        await expect.element(fieldSelect('email')).toBeVisible();
+
+        const toggle = importToggle('nickname').element() as HTMLElement;
+        toggle.click();
+        document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape', bubbles: true}));
+
+        await expect.element(page.getByText('Leave without importing?')).toBeVisible();
+    });
+
 });


### PR DESCRIPTION
no issue

The custom fields import dialog should ask before closing when the mapping has been changed. It could miss that check if Escape was pressed immediately after an edit and close without showing "Leave without importing?"

`hasEdits` was React state read from the `handleOpenChange` render closure. Radix keeps `onOpenChange` in a callback ref that it updates in a passive effect, while its Escape listener runs on `document` outside React event dispatch. If Escape arrived before React committed and flushed the edit, Radix could call the old closure and see `hasEdits` as false.

Nothing renders from this flag, so it now uses a ref. The edit updates the ref immediately, and `handleOpenChange` reads the current value.

This caused [the flaky acceptance test on main](https://github.com/TryGhost/Ghost/actions/runs/32269198232/job/96122010486). The regression test sends the click and Escape DOM events in one task because `userEvent` gives React time to settle between them and hides the bug.
