### PR TITLE
Changed in-app links to React-owned routes to use the router

### DIFF
--- a/apps/admin/src/comments/components/comment-menu.tsx
+++ b/apps/admin/src/comments/components/comment-menu.tsx
@@ -3,6 +3,7 @@ import {type Comment, usePinComment, useUnpinComment} from '@tryghost/admin-x-fr
 import {DisableCommentingDialog} from './disable-commenting-dialog';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {useDisableMemberCommenting, useEnableMemberCommenting} from '@tryghost/admin-x-framework/api/members';
+import {Link} from '@tryghost/admin-x-framework';
 import {useState} from 'react';
 
 interface CommentMenuProps {
@@ -64,10 +65,10 @@ export function CommentMenu({
                     )}
                     {memberId && (
                         <DropdownMenuItem asChild>
-                            <a href={`#/members/${memberId}`}>
+                            <Link to={`/members/${memberId}`}>
                                 <LucideIcon.User className="size-4" />
                                 View member
-                            </a>
+                            </Link>
                         </DropdownMenuItem>
 
                     )}

--- a/apps/admin/src/flag-gated-route.tsx
+++ b/apps/admin/src/flag-gated-route.tsx
@@ -1,6 +1,6 @@
-import { EmberFallback, useEmberFeatureFlag } from "./ember-bridge";
+import { EmberFallback } from "./ember-bridge";
+import { useFlagGatedRouteOwner } from "./use-flag-gated-route-owner";
 import { Suspense, type ComponentType, type LazyExoticComponent } from "react";
-import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
 
 /**
  * Chooses which implementation serves a route while a screen migrates from
@@ -28,34 +28,17 @@ export function FlagGatedRoute({ flag, component: Component }: {
     flag: string;
     component: LazyExoticComponent<ComponentType>;
 }) {
-    const { data: config, isError, isLoading } = useBrowseConfig();
-    const emberFlag = useEmberFeatureFlag(flag);
+    const owner = useFlagGatedRouteOwner(flag);
 
-    const renderReact = () => (
+    if (owner === 'pending') {
+        return null;
+    }
+    if (owner === 'ember') {
+        return <EmberFallback />;
+    }
+    return (
         <Suspense fallback={null}>
             <Component />
         </Suspense>
     );
-
-    if (typeof emberFlag === 'boolean') {
-        return emberFlag ? renderReact() : <EmberFallback />;
-    }
-
-    if (emberFlag === null) {
-        return null;
-    }
-
-    if (isLoading) {
-        return null;
-    }
-
-    if (isError || !config) {
-        return <EmberFallback />;
-    }
-
-    if (config.config.labs?.[flag] !== true) {
-        return <EmberFallback />;
-    }
-
-    return renderReact();
 }

--- a/apps/admin/src/hooks/use-router-history-entry.ts
+++ b/apps/admin/src/hooks/use-router-history-entry.ts
@@ -1,0 +1,25 @@
+import {useEffect, useRef} from 'react';
+import {useLocation} from 'react-router';
+import {z} from 'zod';
+
+const historyStateSchema = z.looseObject({
+    idx: z.number().int().nonnegative().optional()
+}).nullable();
+
+/**
+ * Whether the current history entry was created by the router (it carries a
+ * router index). `history.state` already belongs to the target entry by the
+ * time a `useBlocker` callback runs, so this records it per location change.
+ * The router can only undo a POP from an entry it created; from a native
+ * hash-navigation entry it miscounts the delta and jumps or reloads instead,
+ * so blockers should not block POPs while this is false.
+ */
+export function useIsOnRouterHistoryEntry(): React.RefObject<boolean> {
+    const location = useLocation();
+    const onRouterEntryRef = useRef(false);
+    useEffect(() => {
+        const historyState = historyStateSchema.safeParse(window.history.state);
+        onRouterEntryRef.current = historyState.success && historyState.data?.idx !== undefined;
+    }, [location]);
+    return onRouterEntryRef;
+}

--- a/apps/admin/src/hooks/use-router-history-entry.ts
+++ b/apps/admin/src/hooks/use-router-history-entry.ts
@@ -1,5 +1,3 @@
-import {useEffect, useRef} from 'react';
-import {useLocation} from 'react-router';
 import {z} from 'zod';
 
 const historyStateSchema = z.looseObject({
@@ -7,19 +5,12 @@ const historyStateSchema = z.looseObject({
 }).nullable();
 
 /**
- * Whether the current history entry was created by the router (it carries a
- * router index). `history.state` already belongs to the target entry by the
- * time a `useBlocker` callback runs, so this records it per location change.
- * The router can only undo a POP from an entry it created; from a native
- * hash-navigation entry it miscounts the delta and jumps or reloads instead,
- * so blockers should not block POPs while this is false.
+ * Whether the active history entry was created by the router (it carries a
+ * router index). During a POP, `history.state` already belongs to the target
+ * entry by the time a `useBlocker` callback runs, so this must be read
+ * synchronously from inside the blocker rather than cached per location.
  */
-export function useIsOnRouterHistoryEntry(): React.RefObject<boolean> {
-    const location = useLocation();
-    const onRouterEntryRef = useRef(false);
-    useEffect(() => {
-        const historyState = historyStateSchema.safeParse(window.history.state);
-        onRouterEntryRef.current = historyState.success && historyState.data?.idx !== undefined;
-    }, [location]);
-    return onRouterEntryRef;
+export function isOnRouterHistoryEntry(): boolean {
+    const historyState = historyStateSchema.safeParse(window.history.state);
+    return historyState.success && historyState.data?.idx !== undefined;
 }

--- a/apps/admin/src/layout/app-sidebar/nav-menu-item.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-menu-item.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {Button, SidebarMenuButton, SidebarMenuItem, useSidebar} from '@tryghost/shade/components';
 import {cn, LucideIcon} from '@tryghost/shade/utils';
 import { useIsActiveLink } from './use-is-active-link';
-import { Link } from '@tryghost/admin-x-framework';
-import { isEmberOwnedRoute } from '@/routes';
+import { AdminLink } from '@/shared/admin-link';
 
 function NavMenuItem({ children, ...props }: React.ComponentProps<typeof SidebarMenuItem>) {
     return (
@@ -121,7 +120,6 @@ function NavMenuLink({
     const isActive = controlledIsActive !== undefined ? controlledIsActive : computedIsActive;
     const { isMobile, setOpenMobile } = useSidebar();
     const isExternal = target === '_blank';
-    const useRouterLink = !isExternal && !isEmberOwnedRoute(path.split('?')[0]);
 
     const handleClick = () => {
         if (isMobile) {
@@ -134,26 +132,25 @@ function NavMenuLink({
             isActive={isActive}
             asChild
             {...props}>
-            {useRouterLink ? (
-                <Link
-                    aria-current={isActive ? 'page' : undefined}
-                    rel={rel}
-                    target={target}
-                    to={path}
-                    onClick={handleClick}
-                >
-                    {children}
-                </Link>
-            ) : (
+            {isExternal ? (
                 <a
                     aria-current={isActive ? 'page' : undefined}
-                    href={isExternal ? to : `#${path}`}
-                    rel={isExternal ? rel ?? 'noopener noreferrer' : rel}
+                    href={to}
+                    rel={rel ?? 'noopener noreferrer'}
                     target={target}
                     onClick={handleClick}
                 >
                     {children}
                 </a>
+            ) : (
+                <AdminLink
+                    aria-current={isActive ? 'page' : undefined}
+                    rel={rel}
+                    to={path}
+                    onClick={handleClick}
+                >
+                    {children}
+                </AdminLink>
             )}
         </SidebarMenuButton>
     )

--- a/apps/admin/src/members/components/members-empty-state.tsx
+++ b/apps/admin/src/members/components/members-empty-state.tsx
@@ -4,6 +4,7 @@ import {LucideIcon} from '@tryghost/shade/utils';
 import {toast} from 'sonner';
 import {useAddMember} from '@tryghost/admin-x-framework/api/members';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {Link} from '@tryghost/admin-x-framework';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 interface MembersEmptyStateProps {
@@ -58,7 +59,7 @@ const MembersEmptyState: React.FC<MembersEmptyStateProps> = ({membershipsEnabled
                     <div className="flex flex-col items-center gap-3">
                         <div className="flex flex-col items-center gap-2 sm:flex-row">
                             <Button asChild>
-                                <a href="#/members/new?back=%2Fmembers">New member</a>
+                                <Link to="/members/new?back=%2Fmembers">New member</Link>
                             </Button>
                             <Button
                                 disabled={isAdding || isCurrentUserLoading || !currentUser}

--- a/apps/admin/src/members/components/members-empty-state.tsx
+++ b/apps/admin/src/members/components/members-empty-state.tsx
@@ -70,7 +70,7 @@ const MembersEmptyState: React.FC<MembersEmptyStateProps> = ({membershipsEnabled
                             </Button>
                         </div>
                         <p className="text-sm leading-tight text-pretty text-muted-foreground">
-                            Already have members? <a className="font-medium text-foreground underline-offset-4 hover:underline" href="#/members/import">Import with CSV</a>
+                            Already have members? <Link className="font-medium text-foreground underline-offset-4 hover:underline" to="/members/import">Import with CSV</Link>
                         </p>
                     </div>
                 }

--- a/apps/admin/src/members/components/members-list-item.tsx
+++ b/apps/admin/src/members/components/members-list-item.tsx
@@ -6,6 +6,7 @@ import {buildMemberDetailPath} from '@/members/member-detail-hash';
 import {cn, formatPercentage} from '@tryghost/shade/utils';
 import type {MemberActiveColumn} from '@/members/member-query-params';
 import {forwardRef, type CSSProperties} from 'react';
+import {Link} from '@tryghost/admin-x-framework';
 import type {MemberTableColumnStyles} from './member-table-layout';
 
 const PINNED_EDGE_FADE_POSITION_STYLE = {
@@ -77,9 +78,9 @@ function MembersListItemName({item, backPath, onClick}: { item: Member; backPath
                 src={item.avatar_image}
             />
             <div className="min-w-0">
-                <a
+                <Link
                     className="block min-w-0 cursor-pointer"
-                    href={`#${buildMemberDetailPath(item.id, backPath)}`}
+                    to={buildMemberDetailPath(item.id, backPath)}
                     onClick={onClick ? (e) => {
                         if (isModifiedClick(e)) {
                             e.stopPropagation();
@@ -93,7 +94,7 @@ function MembersListItemName({item, backPath, onClick}: { item: Member; backPath
                     <span className="block truncate text-md font-semibold">
                         {item.name || item.email || 'Anonymous'}
                     </span>
-                </a>
+                </Link>
                 {item.name && item.email && (
                     <div
                         className="truncate text-muted-foreground"

--- a/apps/admin/src/members/components/members-list.tsx
+++ b/apps/admin/src/members/components/members-list.tsx
@@ -5,6 +5,7 @@ import {MembersTableColGroup, MembersTableHeader, PinnedMemberHeader} from './me
 import {Table, TableBody, TableCell, TableRow} from '@tryghost/shade/components';
 import {buildMemberDetailPath} from '@/members/member-detail-hash';
 import {forwardRef, useEffect, useMemo, useRef, useState} from 'react';
+import {useNavigate} from '@tryghost/admin-x-framework';
 import {getMemberTableLayout, getMemberTableLayoutStyles} from './member-table-layout';
 import type {MemberActiveColumn} from '@/members/member-query-params';
 import type {RefObject} from 'react';
@@ -184,12 +185,13 @@ function MembersList({
         estimateSize: () => 72 // Approximate row height
     });
 
+    const navigate = useNavigate();
+
     const handleRowClick = (memberId: string) => {
         if (onRowClick) {
             onRowClick(memberId);
         } else {
-            // Default: Navigate to Ember member detail page
-            window.location.hash = buildMemberDetailPath(memberId, backPath);
+            navigate(buildMemberDetailPath(memberId, backPath));
         }
     };
 

--- a/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
@@ -87,4 +87,22 @@ describe('Member detail leave guard', () => {
         await page.getByRole('button', {name: 'Leave'}).click();
         await expect.poll(currentRoute).toBe('/members');
     });
+
+    it('allows a back navigation to an untracked history entry', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m);
+        await renderAdminApp('/members');
+
+        // Native hash navigations do not carry react-router's history index.
+        // Preserve that legacy target shape before opening the React detail.
+        window.history.replaceState({}, '');
+        await page.getByRole('link', {name: 'Ada Lovelace'}).click();
+        await expect.poll(currentRoute).toMatch(new RegExp(`^/members/${m.id}`));
+        await page.getByLabelText('Name').fill('Ada B');
+
+        window.history.back();
+
+        await expect.poll(currentRoute).toBe('/members');
+        expect(page.getByText('Discard unsaved changes?').query()).toBeNull();
+    });
 });

--- a/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
@@ -1,7 +1,8 @@
 import {describe, expect, it} from 'vitest';
 import {page} from 'vitest/browser';
 
-import {fakeAdminEndpoint, fakeMembers, member, renderAdminApp, type Member} from '@test-utils/acceptance';
+import {currentRoute, fakeAdminEndpoint, fakeMembers, member, renderAdminApp, type Member} from '@test-utils/acceptance';
+import {sidebarScreen} from '@/layout/sidebar.screen';
 
 function fakeMemberDetailWorld(m: Member) {
     fakeMembers([m]);
@@ -59,5 +60,31 @@ describe('Member detail leave guard', () => {
         await page.getByRole('link', {name: 'Members'}).first().click();
         await page.getByRole('button', {name: 'Leave'}).click();
         await expect.element(page.getByText('New member')).toBeVisible();
+    });
+
+    it('confirms before the back button leaves a dirty member opened from the list', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m);
+        await renderAdminApp('/site');
+
+        await sidebarScreen.navLink('Members').click();
+        await expect.poll(currentRoute).toBe('/members');
+        await page.getByRole('link', {name: 'Ada Lovelace'}).click();
+        await expect.poll(currentRoute).toMatch(new RegExp(`^/members/${m.id}`));
+        await page.getByLabelText('Name').fill('Ada B');
+        await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
+        });
+
+        window.history.back();
+
+        await expect.element(page.getByText('Discard unsaved changes?')).toBeVisible();
+        await page.getByRole('button', {name: 'Keep editing'}).click();
+        await expect.poll(currentRoute).toMatch(new RegExp(`^/members/${m.id}`));
+        await expect.element(page.getByLabelText('Name')).toHaveValue('Ada B');
+
+        window.history.back();
+        await page.getByRole('button', {name: 'Leave'}).click();
+        await expect.poll(currentRoute).toBe('/members');
     });
 });

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -19,7 +19,7 @@ import {getMember, useAddMember, useEditMember} from '@tryghost/admin-x-framewor
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {NavigationType, useBlocker} from 'react-router';
-import {useIsOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
+import {isOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
@@ -282,11 +282,10 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
     };
 
     useConfirmUnload(activeMutation.isPending || hasUnsavedChanges);
-    const onRouterEntryRef = useIsOnRouterHistoryEntry();
     const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => {
         // A POP can only be undone from a router-created entry; elsewhere the router
         // would miscount the delta and jump or reload, so let those through.
-        if (historyAction === NavigationType.Pop && !onRouterEntryRef.current) {
+        if (historyAction === NavigationType.Pop && !isOnRouterHistoryEntry()) {
             return false;
         }
         return !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname;

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -18,7 +18,8 @@ import {formatMemberName} from '@tryghost/shade/app';
 import {getMember, useAddMember, useEditMember} from '@tryghost/admin-x-framework/api/members';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
-import {useBlocker} from 'react-router';
+import {NavigationType, useBlocker} from 'react-router';
+import {useIsOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
@@ -281,7 +282,15 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
     };
 
     useConfirmUnload(activeMutation.isPending || hasUnsavedChanges);
-    const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname);
+    const onRouterEntryRef = useIsOnRouterHistoryEntry();
+    const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => {
+        // A POP can only be undone from a router-created entry; elsewhere the router
+        // would miscount the delta and jump or reload, so let those through.
+        if (historyAction === NavigationType.Pop && !onRouterEntryRef.current) {
+            return false;
+        }
+        return !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname;
+    });
     // Native `<a href="#/…">` navigations (the sidebar, links into Ember
     // routes) never reach the react-router blocker above — see the hook.
     // Ember's own guard (`trailing-hash.js`) can't cover this screen either,

--- a/apps/admin/src/posts/analytics/newsletter/components/feedback.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/components/feedback.tsx
@@ -76,7 +76,7 @@ const Feedback: React.FC<FeedbackProps> = ({feedbackStats}) => {
                             <div className='flex w-full flex-col py-3'>
                                 {paginatedFeedback.map(item => (
                                     <div key={item.id} className='flex h-10 w-full items-center justify-between gap-3 rounded-sm border-none px-2 text-sm hover:cursor-pointer hover:bg-accent' onClick={() => {
-                                        navigate(`/members/${item.member.id}`, {crossApp: true});
+                                        navigate(`/members/${item.member.id}`);
                                     }}>
                                         <div className='flex items-center gap-2 font-medium'>
                                             <Avatar className='size-7'>

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -14,6 +14,7 @@ import type { RouteHandle } from "./ember-bridge";
 import HomeRedirect from "./home-redirect";
 import { EmberListWithGiftLinks } from "./gift-link-modal-host";
 import { TagDetailGate } from "./tag-detail-gate";
+import { useFlagGatedRouteOwner } from "./use-flag-gated-route-owner";
 import { OnboardingRedirect } from "./onboarding/onboarding-redirect";
 import { type AccessRouteHandle, RouteAccessGuard } from "./route-access-guard";
 import { canAccessSettingsRoute } from "./settings/settings-access";
@@ -218,9 +219,16 @@ export const routes: RouteObject[] = [
 // React router's pushState navigation does not fire, so links into Ember-owned
 // routes must stay native hash anchors. Everything else can be a router link
 // (and so gets router history state, which the unsaved-changes blockers need).
-const EMBER_ROUTE_COMPONENTS = new Set<unknown>([EmberFallback, EmberListWithGiftLinks, TagDetailGate]);
+const EMBER_ROUTE_COMPONENTS = new Set<unknown>([EmberFallback, EmberListWithGiftLinks]);
 
-export function isEmberOwnedRoute(pathname: string): boolean {
+export function useIsEmberOwnedRoute(pathname: string): boolean {
+    const tagDetailOwner = useFlagGatedRouteOwner("tagDetailsReact");
     const leaf = matchRoutes(routes, pathname)?.at(-1)?.route;
-    return !leaf || EMBER_ROUTE_COMPONENTS.has(leaf.Component);
+    if (!leaf) {
+        return true;
+    }
+    if (leaf.Component === TagDetailGate) {
+        return tagDetailOwner !== "react";
+    }
+    return EMBER_ROUTE_COMPONENTS.has(leaf.Component);
 }

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -1,28 +1,17 @@
 import {DirtyConfirmDialog} from '@tryghost/shade/patterns';
-import {NavigationType, useBlocker, useLocation} from 'react-router';
+import {NavigationType, useBlocker} from 'react-router';
 import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
-import {useEffect, useRef} from 'react';
-import {z} from 'zod';
+import {useIsOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
+import {useRef} from 'react';
 import {dialogIdentity} from './dirty-navigation-guard-identity';
-
-const historyStateSchema = z.looseObject({
-    idx: z.number().int().nonnegative().optional()
-}).nullable();
 
 // Only history (back/forward) navigations are blocked: every in-app way out of a
 // dirty settings dialog already runs its own dirty confirmation before navigating.
 export const DirtyNavigationGuard: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
     const leaveConfirmedRef = useRef(false);
-    const location = useLocation();
-    // history.state already belongs to the target entry when the blocker runs, so
-    // remember whether the entry being left was tracked by the router (it has an index).
-    const onRouterEntryRef = useRef(false);
-    useEffect(() => {
-        const historyState = historyStateSchema.safeParse(window.history.state);
-        onRouterEntryRef.current = historyState.success && historyState.data?.idx !== undefined;
-    }, [location]);
+    const onRouterEntryRef = useIsOnRouterHistoryEntry();
 
     useConfirmUnload(isDirty);
 
@@ -30,8 +19,6 @@ export const DirtyNavigationGuard: React.FC = () => {
         if (!isDirty || historyAction !== NavigationType.Pop) {
             return false;
         }
-        // The router can only undo a POP from an entry it created; from a native
-        // hash-navigation entry it would miscount the delta and reload instead.
         if (!onRouterEntryRef.current) {
             return false;
         }

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -2,7 +2,7 @@ import {DirtyConfirmDialog} from '@tryghost/shade/patterns';
 import {NavigationType, useBlocker} from 'react-router';
 import {useConfirmUnload} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
-import {useIsOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
+import {isOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
 import {useRef} from 'react';
 import {dialogIdentity} from './dirty-navigation-guard-identity';
 
@@ -11,15 +11,13 @@ import {dialogIdentity} from './dirty-navigation-guard-identity';
 export const DirtyNavigationGuard: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
     const leaveConfirmedRef = useRef(false);
-    const onRouterEntryRef = useIsOnRouterHistoryEntry();
-
     useConfirmUnload(isDirty);
 
     const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => {
         if (!isDirty || historyAction !== NavigationType.Pop) {
             return false;
         }
-        if (!onRouterEntryRef.current) {
+        if (!isOnRouterHistoryEntry()) {
             return false;
         }
         return dialogIdentity(currentLocation.pathname) !== dialogIdentity(nextLocation.pathname);

--- a/apps/admin/src/shared/admin-link.tsx
+++ b/apps/admin/src/shared/admin-link.tsx
@@ -1,0 +1,18 @@
+import {Link} from '@tryghost/admin-x-framework';
+import {forwardRef} from 'react';
+import {useIsEmberOwnedRoute} from '@/routes';
+
+type AdminLinkProps = Omit<React.ComponentProps<'a'>, 'href'> & {
+    /** In-app path, e.g. `/tags/news` or `/members?filter=…` */
+    to: string;
+};
+
+// Ember only follows hashchange, which the router's pushState navigation does not
+// fire, so links into Ember-owned routes stay native hash anchors. Everything else
+// goes through the router so the entry carries router state for the history blockers.
+export const AdminLink = forwardRef<HTMLAnchorElement, AdminLinkProps>(function AdminLink({to, children, ...props}, ref) {
+    const isEmberOwned = useIsEmberOwnedRoute(to.split('?')[0]);
+    return isEmberOwned
+        ? <a ref={ref} href={`#${to}`} {...props}>{children}</a>
+        : <Link ref={ref} to={to} {...props}>{children}</Link>;
+});

--- a/apps/admin/src/tags/components/tags-list.tsx
+++ b/apps/admin/src/tags/components/tags-list.tsx
@@ -2,7 +2,9 @@ import {Button, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} f
 import {LoadMoreButton, useInfiniteVirtualScroll, useVirtualListWindow} from '@/shared/virtual-list';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import type {Tag} from '@tryghost/admin-x-framework/api/tags';
-import {forwardRef, useRef} from 'react';
+import {Link} from '@tryghost/admin-x-framework';
+import React, {forwardRef, useRef} from 'react';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 
 const SpacerRow = ({height}: { height: number }) => (
     <tr aria-hidden="true" className="flex lg:table-row">
@@ -28,6 +30,15 @@ const PlaceholderRow = forwardRef<HTMLTableRowElement>(function PlaceholderRow(
         </TableRow>
     );
 });
+
+// Tag detail is served by React or Ember depending on the tagDetailsReact flag;
+// Ember only follows hashchange, so only the React branch may use a router link.
+export function TagLink({slug, className, children}: {slug: string; className?: string; children: React.ReactNode}) {
+    const tagDetailsReact = useFeatureFlag('tagDetailsReact');
+    return tagDetailsReact
+        ? <Link className={className} to={`/tags/${slug}`}>{children}</Link>
+        : <a className={className} href={`#/tags/${slug}`}>{children}</a>;
+}
 
 function TagsList({
     items,
@@ -89,14 +100,11 @@ function TagsList({
                                 data-testid="tag-list-row"
                             >
                                 <TableCell className="static col-start-1 col-end-1 row-start-1 row-end-1 flex min-w-0 flex-col p-0 md:relative lg:table-cell lg:w-1/2 lg:p-4 xl:w-3/5">
-                                    <a
-                                        className="before:absolute before:top-0 before:left-0 before:z-10 before:h-full before:w-[100vw]"
-                                        href={`#/tags/${item.slug}`}
-                                    >
+                                    <TagLink className="before:absolute before:top-0 before:left-0 before:z-10 before:h-full before:w-[100vw]" slug={item.slug}>
                                         <span className="block truncate text-base text-md font-semibold">
                                             {item.name}
                                         </span>
-                                    </a>
+                                    </TagLink>
                                     <span className="block truncate text-muted-foreground">
                                         {item.description}
                                     </span>

--- a/apps/admin/src/tags/components/tags-list.tsx
+++ b/apps/admin/src/tags/components/tags-list.tsx
@@ -2,9 +2,8 @@ import {Button, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} f
 import {LoadMoreButton, useInfiniteVirtualScroll, useVirtualListWindow} from '@/shared/virtual-list';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import type {Tag} from '@tryghost/admin-x-framework/api/tags';
-import {Link} from '@tryghost/admin-x-framework';
-import React, {forwardRef, useRef} from 'react';
-import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
+import {forwardRef, useRef} from 'react';
+import {AdminLink} from '@/shared/admin-link';
 
 const SpacerRow = ({height}: { height: number }) => (
     <tr aria-hidden="true" className="flex lg:table-row">
@@ -30,15 +29,6 @@ const PlaceholderRow = forwardRef<HTMLTableRowElement>(function PlaceholderRow(
         </TableRow>
     );
 });
-
-// Tag detail is served by React or Ember depending on the tagDetailsReact flag;
-// Ember only follows hashchange, so only the React branch may use a router link.
-export function TagLink({slug, className, children}: {slug: string; className?: string; children: React.ReactNode}) {
-    const tagDetailsReact = useFeatureFlag('tagDetailsReact');
-    return tagDetailsReact
-        ? <Link className={className} to={`/tags/${slug}`}>{children}</Link>
-        : <a className={className} href={`#/tags/${slug}`}>{children}</a>;
-}
 
 function TagsList({
     items,
@@ -100,11 +90,11 @@ function TagsList({
                                 data-testid="tag-list-row"
                             >
                                 <TableCell className="static col-start-1 col-end-1 row-start-1 row-end-1 flex min-w-0 flex-col p-0 md:relative lg:table-cell lg:w-1/2 lg:p-4 xl:w-3/5">
-                                    <TagLink className="before:absolute before:top-0 before:left-0 before:z-10 before:h-full before:w-[100vw]" slug={item.slug}>
+                                    <AdminLink className="before:absolute before:top-0 before:left-0 before:z-10 before:h-full before:w-[100vw]" to={`/tags/${item.slug}`}>
                                         <span className="block truncate text-base text-md font-semibold">
                                             {item.name}
                                         </span>
-                                    </TagLink>
+                                    </AdminLink>
                                     <span className="block truncate text-muted-foreground">
                                         {item.description}
                                     </span>

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -3,6 +3,7 @@ import {page, userEvent} from 'vitest/browser';
 
 import {deferred} from '@/utils/deferred';
 import {configResponse, currentRoute, fakeAdminEndpoint, fakeEndpoint, fakeTags, renderAdminApp, tag, type Tag} from '@test-utils/acceptance';
+import {sidebarScreen} from '@/layout/sidebar.screen';
 
 const FLAGS = {labs: {tagDetailsReact: true}};
 
@@ -567,6 +568,35 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.element(page.getByLabelText('Name', {exact: true})).toHaveValue('Renamed');
 
         await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+        await page.getByRole('button', {name: 'Leave'}).click();
+        await expect.poll(currentRoute).toBe('/tags');
+    });
+});
+
+describe('Tag detail history guard', () => {
+    it('confirms before the back button leaves a dirty tag opened from the list', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        fakeTags([t]);
+        fakeTagWorld(t);
+        await renderAdminApp('/site', FLAGS);
+
+        await sidebarScreen.navLink('Tags').click();
+        await expect.poll(currentRoute).toBe('/tags');
+        await page.getByTestId('tag-list-row').getByRole('link', {name: 'News'}).click();
+        await expect.poll(currentRoute).toBe('/tags/news');
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
+        });
+
+        window.history.back();
+
+        await expect.element(page.getByText('Are you sure you want to leave this page?')).toBeVisible();
+        await page.getByRole('button', {name: 'Stay'}).click();
+        await expect.poll(currentRoute).toBe('/tags/news');
+        await expect.element(page.getByLabelText('Name', {exact: true})).toHaveValue('Renamed');
+
+        window.history.back();
         await page.getByRole('button', {name: 'Leave'}).click();
         await expect.poll(currentRoute).toBe('/tags');
     });

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -12,7 +12,8 @@ import {buildTagSavePayload, generateSlugFromName, getTagEditableSlice, getTagUr
 import {dequal} from 'dequal';
 import {getTagBySlug, useAddTag, useEditTag} from '@tryghost/admin-x-framework/api/tags';
 import {toast} from 'sonner';
-import {useBlocker} from 'react-router';
+import {NavigationType, useBlocker} from 'react-router';
+import {useIsOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
 import type {TagsResponseType} from '@tryghost/admin-x-framework/api/tags';
@@ -281,7 +282,13 @@ const TagDetail: React.FC = () => {
 
     const shouldGuardNavigation = activeMutation.isPending || hasPendingImageUpload || isDeleting || hasUnsavedChanges;
     useConfirmUnload(shouldGuardNavigation);
-    const blocker = useBlocker(({currentLocation, nextLocation}) => {
+    const onRouterEntryRef = useIsOnRouterHistoryEntry();
+    const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => {
+        // A POP can only be undone from a router-created entry; elsewhere the router
+        // would miscount the delta and jump or reload, so let those through.
+        if (historyAction === NavigationType.Pop && !onRouterEntryRef.current) {
+            return false;
+        }
         const shouldBlock = !bypassGuardRef.current && shouldGuardNavigation && currentLocation.pathname !== nextLocation.pathname;
         if (shouldBlock) {
             // The mutation can resolve before React rerenders with a blocked

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -13,7 +13,7 @@ import {dequal} from 'dequal';
 import {getTagBySlug, useAddTag, useEditTag} from '@tryghost/admin-x-framework/api/tags';
 import {toast} from 'sonner';
 import {NavigationType, useBlocker} from 'react-router';
-import {useIsOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
+import {isOnRouterHistoryEntry} from '@/hooks/use-router-history-entry';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
 import type {TagsResponseType} from '@tryghost/admin-x-framework/api/tags';
@@ -282,11 +282,10 @@ const TagDetail: React.FC = () => {
 
     const shouldGuardNavigation = activeMutation.isPending || hasPendingImageUpload || isDeleting || hasUnsavedChanges;
     useConfirmUnload(shouldGuardNavigation);
-    const onRouterEntryRef = useIsOnRouterHistoryEntry();
     const blocker = useBlocker(({currentLocation, nextLocation, historyAction}) => {
         // A POP can only be undone from a router-created entry; elsewhere the router
         // would miscount the delta and jump or reload, so let those through.
-        if (historyAction === NavigationType.Pop && !onRouterEntryRef.current) {
+        if (historyAction === NavigationType.Pop && !isOnRouterHistoryEntry()) {
             return false;
         }
         const shouldBlock = !bypassGuardRef.current && shouldGuardNavigation && currentLocation.pathname !== nextLocation.pathname;

--- a/apps/admin/src/tags/tags.acceptance.test.tsx
+++ b/apps/admin/src/tags/tags.acceptance.test.tsx
@@ -6,7 +6,7 @@ import { tagsScreen } from "./tags.screen";
 describe("Tags list", () => {
     it("lists public tags with description and posts count", async () => {
         fakeTags([
-            tag({ name: "News", description: "News description", count: { posts: 1 } }),
+            tag({ name: "News", slug: "news", description: "News description", count: { posts: 1 } }),
         ]);
         await renderAdminApp("/tags");
 
@@ -15,6 +15,7 @@ describe("Tags list", () => {
         await expect.element(row).toHaveTextContent("News");
         await expect.element(row).toHaveTextContent("News description");
         await expect.element(row).toHaveTextContent("1 post");
+        await expect.element(tagsScreen.link("News")).toHaveAttribute("href", "#/tags/news");
 
         // The tabs are a single-select toggle group: role="radio" + aria-checked.
         await expect.element(tagsScreen.publicTab()).toHaveAttribute("aria-checked", "true");
@@ -47,12 +48,14 @@ describe("Tags list", () => {
 
         await expect.element(tagsScreen.emptyStateHeading()).toBeVisible();
         await expect.element(tagsScreen.createNewTagLink()).toBeVisible();
+        await expect.element(tagsScreen.createNewTagLink()).toHaveAttribute("href", "#/tags/new");
     });
 
     it("navigates to the new tag editor from the header button", async () => {
         fakeTags([]);
         await renderAdminApp("/tags");
 
+        await expect.element(tagsScreen.newTagLink()).toHaveAttribute("href", "#/tags/new");
         await tagsScreen.newTagLink().click();
 
         // /tags/new is Ember-owned; the shell records the route and defers.

--- a/apps/admin/src/tags/tags.tsx
+++ b/apps/admin/src/tags/tags.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TagsList from './components/tags-list';
+import TagsList, {TagLink} from './components/tags-list';
 import {Box, Container} from '@tryghost/shade/primitives';
 import {Button, DropdownMenuCheckboxItem, EmptyIndicator, LoadingIndicator, ToggleGroup, ToggleGroupItem} from '@tryghost/shade/components';
 import {Link, useSearchParams} from '@tryghost/admin-x-framework';
@@ -68,10 +68,10 @@ const Tags: React.FC = () => {
                             </PageHeader.ActionGroup>
                             <PageHeader.ActionGroup>
                                 <Button asChild>
-                                    <a className="font-bold" href="#/tags/new">
+                                    <TagLink className="font-bold" slug="new">
                                         <LucideIcon.Plus className='size-4' />
                                         <span className='hidden sm:inline'>New tag</span>
-                                    </a>
+                                    </TagLink>
                                 </Button>
                             </PageHeader.ActionGroup>
                         </PageHeader.Actions>
@@ -99,7 +99,7 @@ const Tags: React.FC = () => {
                             <EmptyIndicator
                                 actions={
                                     <Button asChild>
-                                        <a href="#/tags/new">Create a new tag</a>
+                                        <TagLink slug="new">Create a new tag</TagLink>
                                     </Button>
                                 }
                                 title="Start organizing your content"

--- a/apps/admin/src/tags/tags.tsx
+++ b/apps/admin/src/tags/tags.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import TagsList, {TagLink} from './components/tags-list';
+import TagsList from './components/tags-list';
+import {AdminLink} from '@/shared/admin-link';
 import {Box, Container} from '@tryghost/shade/primitives';
 import {Button, DropdownMenuCheckboxItem, EmptyIndicator, LoadingIndicator, ToggleGroup, ToggleGroupItem} from '@tryghost/shade/components';
 import {Link, useSearchParams} from '@tryghost/admin-x-framework';
@@ -68,10 +69,10 @@ const Tags: React.FC = () => {
                             </PageHeader.ActionGroup>
                             <PageHeader.ActionGroup>
                                 <Button asChild>
-                                    <TagLink className="font-bold" slug="new">
+                                    <AdminLink className="font-bold" to="/tags/new">
                                         <LucideIcon.Plus className='size-4' />
                                         <span className='hidden sm:inline'>New tag</span>
-                                    </TagLink>
+                                    </AdminLink>
                                 </Button>
                             </PageHeader.ActionGroup>
                         </PageHeader.Actions>
@@ -99,7 +100,7 @@ const Tags: React.FC = () => {
                             <EmptyIndicator
                                 actions={
                                     <Button asChild>
-                                        <TagLink slug="new">Create a new tag</TagLink>
+                                        <AdminLink to="/tags/new">Create a new tag</AdminLink>
                                     </Button>
                                 }
                                 title="Start organizing your content"

--- a/apps/admin/src/use-flag-gated-route-owner.ts
+++ b/apps/admin/src/use-flag-gated-route-owner.ts
@@ -1,0 +1,23 @@
+import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
+import { useEmberFeatureFlag } from "./ember-bridge";
+
+/**
+ * Who serves a flag-gated route right now: Ember's Labs state is authoritative
+ * when Ember is present; a standalone React admin falls back to the config
+ * query. `pending` while either is still loading.
+ */
+export function useFlagGatedRouteOwner(flag: string): 'react' | 'ember' | 'pending' {
+    const { data: config, isError, isLoading } = useBrowseConfig();
+    const emberFlag = useEmberFeatureFlag(flag);
+
+    if (typeof emberFlag === 'boolean') {
+        return emberFlag ? 'react' : 'ember';
+    }
+    if (emberFlag === null || isLoading) {
+        return 'pending';
+    }
+    if (isError || !config) {
+        return 'ember';
+    }
+    return config.config.labs?.[flag] === true ? 'react' : 'ember';
+}

--- a/e2e/tests/admin/members/virtual-window.test.ts
+++ b/e2e/tests/admin/members/virtual-window.test.ts
@@ -85,6 +85,7 @@ test.describe('Ghost Admin - Members Virtual Window', () => {
 
         const renderedCount = await reactMemberRows.count();
         const targetRowLocator = reactMemberRows.nth(Math.max(0, renderedCount - 5));
+        await targetRowLocator.scrollIntoViewIfNeeded();
         const targetRow = {
             index: Number(await targetRowLocator.getAttribute('data-index')),
             text: await targetRowLocator.textContent(),

--- a/e2e/tests/admin/members/virtual-window.test.ts
+++ b/e2e/tests/admin/members/virtual-window.test.ts
@@ -84,17 +84,21 @@ test.describe('Ghost Admin - Members Virtual Window', () => {
         expect(maxRenderedIndex).toBeGreaterThan(1000);
 
         const renderedCount = await reactMemberRows.count();
-        const targetRowLocator = reactMemberRows.nth(Math.max(0, renderedCount - 5));
-        await targetRowLocator.scrollIntoViewIfNeeded();
+        const candidateRowLocator = reactMemberRows.nth(Math.max(0, renderedCount - 5));
+        const targetIndex = Number(await candidateRowLocator.getAttribute('data-index'));
+        const targetRowLocator = page.getByTestId('members-list').locator(`[data-testid="members-list-item"][data-index="${targetIndex}"]`);
+        const targetLinkLocator = targetRowLocator.getByRole('link');
+
+        await targetLinkLocator.scrollIntoViewIfNeeded();
         const targetRow = {
-            index: Number(await targetRowLocator.getAttribute('data-index')),
+            index: targetIndex,
             text: await targetRowLocator.textContent(),
             scrollTop: await membersPage.getScrollParentScrollTop()
         };
 
         expect(targetRow.index).toBeGreaterThan(1000);
 
-        await targetRowLocator.getByRole('link').click();
+        await targetLinkLocator.click();
 
         await expect(memberDetailsPage.nameInput).toBeVisible();
 


### PR DESCRIPTION
no ref

Follow-up to #30122. Reproduced on `main`: sidebar → Tags → tag row (plain anchor) → edit → back — the tag-detail blocker prompts, but **Stay lands on `/site`**: the router can't compute the delta for the untracked `/tags/:slug` entry it's leaving, so its revert jumps the wrong way. Before #30122 this was a silent unblock; after, a wrong jump (or a `history.go(0)` reload when the target is the first entry). Same shape on the members list, whose rows navigated with `window.location.hash`.

**One decision, one place**
- `useIsEmberOwnedRoute(path)` (`routes.tsx`): reads the route table; for the flag-gated tag detail it uses the new `useFlagGatedRouteOwner` hook — the *same* owner logic `FlagGatedRoute` now uses (review caught the tag link previously reading the flag from a different source than the gate).
- `AdminLink` (`shared/admin-link.tsx`): router `Link` for React-owned targets, native `<a href="#/…">` for Ember-owned ones (Ember only follows `hashchange`). Used by the sidebar (`NavMenuLink`), tag rows and new-tag buttons.
- Members rows: `navigate()` + `Link`; comment menu → member, members empty state "New member"/"Import with CSV": `Link`; analytics feedback list drops `crossApp` for `/members/:id`.

**Blockers defend themselves**
- `useIsOnRouterHistoryEntry()` (`hooks/use-router-history-entry.ts`, extracted from the settings guard) — tag-detail and member-detail now skip blocking **POP**s when the entry being left wasn't router-created (PUSH/REPLACE blocking unchanged). Residual untracked sources (typed URLs, Ember `debug.hbs` anchors, Ember's trailing-hash confirm path) now fall through to a silent no-prompt instead of a wrong jump/reload.

Not in this PR (follow-ups): analytics `crossApp`/`isExternal` hops to React-owned routes (no blockers on those targets), `design-and-theme-modal`'s `history.replaceState({})` stripping router state, Ember search → tag transition no-op with the flag on.

## Verification
- new acceptance tests: tag and member "confirms before the back button leaves a dirty … opened from the list" (Stay keeps the detail route; fails on main)
- full admin acceptance 499/499; admin unit 1601/1601; `tsc -b` + eslint clean
- two independent review rounds; second pass: nothing blocking