### PR TITLE
Fixed admin acceptance flake from clicks on animating dialogs

### DIFF
--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -27,6 +27,8 @@ await expect.poll(() => document.documentElement.classList.contains("dark")).toB
 
 **One render per test.** Each `renderAdminApp` gets a fresh QueryClient and the fake API resets between tests — there is no reload. State that would be persisted on a real server (user preferences, settings) is _represented_ by boot overrides; a journey that genuinely needs persistence across reloads belongs in `e2e/`.
 
+**No animations.** The harness zeroes every animation and transition duration (`setup.ts`), so an element is at its final position the moment it renders. Enter animations are the classic acceptance flake: Playwright's `stable` actionability check only needs one pair of consecutive animation frames with an identical bounding box on Chromium, so a dropped frame on a loaded CI runner lets a click be aimed at a position the element has already left. A sheet is outside the viewport for much of its slide-in, so those clicks land on nothing — no handler runs, no anchor navigates, and the call still reports success. Gesture straight at a dialog or sheet as soon as its content is visible; never wait for one to settle.
+
 **Host page.** `renderAdminApp` mounts into a stand-in of the production host page (the `react-admin` body class + `#root` from index.html), so the shell's viewport-bounded grid applies and scroll-driven behaviors — virtualized lists, infinite paging — work like production.
 
 **What can't port.** UI fed by the Ember state-bridge (`window.EmberBridge` events) is unreachable by network fakes — there is no Ember app in this tier. Examples: nav active states from the routing bridge (`useEmberRouting`), the upgrade banner from `subscriptionChange`. Grep the component's hooks for `ember-bridge` before porting; those behaviors stay in `e2e/`.

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -5,7 +5,33 @@ import './matchers';
 import { defaultBootResolver, defaultBootRoutes } from './boot';
 import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from './worker';
 
+/**
+ * Freeze CSS motion. Chromium's Playwright stability check accepts a single
+ * unchanged pair of animation frames, so a dropped frame can mark a
+ * still-moving element actionable — and a sheet mid-slide-in is outside the
+ * viewport, so the click is dispatched into empty space. Nothing receives it,
+ * nothing navigates, and the call still reports success, which is what makes
+ * this failure mode expensive to diagnose.
+ *
+ * Zero the durations rather than blanking `animation`: Radix's `Presence`
+ * reads the computed animation NAME to decide whether an exiting element stays
+ * mounted until `animationend`, so removing the name would route every exit
+ * down a different path than production takes.
+ */
+function freezeAnimations(): void {
+  const style = document.createElement('style');
+
+  style.textContent = `*, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }`;
+  document.head.appendChild(style);
+}
+
 beforeAll(async () => {
+  freezeAnimations();
   await startFakeApi({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
 });
 


### PR DESCRIPTION
no ref

Chromium's Playwright `stable` actionability check requires only one pair of consecutive animation frames with an identical bounding box before it treats an element as clickable. On a loaded CI runner a dropped frame can satisfy that mid-animation, so a click gets aimed at a position a Radix Sheet already left during its 500ms slide-in — the sheet is outside the 1280px viewport for much of that time. The click lands on empty space: no error, no pointer event reaches the page, no React Router handler runs, no anchor navigation fires, and the call still reports success. This surfaced as an intermittent CI-only failure in `comments.acceptance.test.tsx` ("navigates within threads and shows the replied-to context"), where the URL never picked up `thread=is:<id>` and a 5s poll expired.

- Root cause confirmed empirically: forcing the losing frame ordering with a stepped slide-in reproduced the exact silent no-op every time (40/40), with the click reporting success while zero pointer events reached the page and the URL stayed untouched.
- The hazard isn't specific to this test — it's generic to every dialog, sheet, popover, and dropdown across the acceptance suite (496 tests); this spec just lost the dice roll first. A per-test fix (waiting for the animation, i.e. a longer timeout) papers over the harness gap rather than closing it.
- Fixed by zeroing `animation-duration`/`animation-delay`/`transition-duration`/`transition-delay` for all elements in the acceptance test harness (`apps/admin/test-utils/acceptance/setup.ts`), so elements are at their final position the instant they render. This mirrors the CSS already used in `e2e/visual-regression/capture-baselines.spec.ts`.
- Durations are zeroed rather than setting `animation: none`, because Radix's `Presence` branches on the computed animation *name* to decide whether an exiting element stays mounted until `animationend`. Blanking the name would route every exit down a different code path than production takes; a zero-duration animation still fires `animationstart`/`animationend` so `Presence` behaves the same as in production.
- Documented the new invariant in `apps/admin/test-utils/acceptance/README.md` so future specs gesture straight at dialogs/sheets as soon as they render instead of waiting for them to settle.

Verified: the original failure would not reproduce naturally after 75+ local iterations (including under forced CPU saturation) — it's genuinely a CI-load-dependent race. Forcing the losing frame ordering gave a byte-identical failure signature 40/40 times before the fix and 40/40 passes after. Ran the full admin acceptance suite twice post-fix (60 files / 470 tests), matching the pre-change baseline.
