### PR TITLE
🐛 Fixed navigation markup changing for themes without the icons flag

### DIFF
--- a/ghost/core/core/frontend/helpers/navigation.js
+++ b/ghost/core/core/frontend/helpers/navigation.js
@@ -172,6 +172,8 @@ module.exports = function navigation(options) {
     // CASE: The navigation helper will forward attributes passed to it.
     _.merge(this, options.hash);
     const data = createFrame(options.data);
+    // The template only wraps labels/renders icons when the flag is on, so pre-flag markup is unchanged
+    data.navigationIcons = navigationIconsEnabled;
 
     return templates.execute('navigation', this, {data});
 };

--- a/ghost/core/core/frontend/helpers/tpl/navigation.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/navigation.hbs
@@ -1,5 +1,5 @@
 <ul class="nav">
     {{#foreach navigation}}
-    <li class="{{link_class for=(url) class=(concat "nav-" slug)}}"><a href="{{url absolute="true"}}">{{#if icon}}<img class="nav-icon" src="{{icon}}" alt="{{iconAlt}}">{{/if}}{{#if label}}<span class="nav-label">{{label}}</span>{{/if}}</a></li>
+    <li class="{{link_class for=(url) class=(concat "nav-" slug)}}"><a href="{{url absolute="true"}}">{{#if @navigationIcons}}{{#if icon}}<img class="nav-icon" src="{{icon}}" alt="{{iconAlt}}">{{/if}}{{#if label}}<span class="nav-label">{{label}}</span>{{/if}}{{else}}{{label}}{{/if}}</a></li>
     {{/foreach}}
 </ul>

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -327,7 +327,8 @@ describe('{{navigation}} helper', function () {
 
             assertExists(rendered);
             assert(!rendered.string.includes('class="nav-icon"'));
-            assert(rendered.string.includes('<span class="nav-label">Foo</span>'));
+            assert(!rendered.string.includes('class="nav-label"'));
+            assert(rendered.string.includes('/foo">Foo</a>'));
         });
 
         it('does not filter items by visibility', function () {
@@ -339,8 +340,20 @@ describe('{{navigation}} helper', function () {
             const rendered = runHelper(optionsData);
 
             assertExists(rendered);
-            assert(rendered.string.includes('<span class="nav-label">Hidden</span>'));
-            assert(rendered.string.includes('<span class="nav-label">Paid</span>'));
+            assert(rendered.string.includes('/hidden">Hidden</a>'));
+            assert(rendered.string.includes('/paid">Paid</a>'));
+        });
+
+        it('renders the same markup as before the flag existed', function () {
+            optionsData.data.site.navigation = [{label: 'Foo', url: '/foo'}];
+
+            const rendered = runHelper(optionsData);
+
+            assertExists(rendered);
+            assert.equal(
+                rendered.string.trim(),
+                '<ul class="nav">\n    <li class="nav-foo"><a href="' + configUtils.config.get('url') + '/foo">Foo</a></li>\n</ul>'
+            );
         });
     });
 


### PR DESCRIPTION
no ref

#28368 added icons and visibility controls to navigation behind the `navigationIcons` lab flag, but one part of it shipped ungated: the built-in navigation partial started wrapping every label in `<span class="nav-label">`.

That affects every theme that uses `{{navigation}}` without shipping its own `partials/navigation.hbs`, whether or not the flag is on. CSS and JS that target the anchor's text directly — `.nav a` flex/gap layouts, `::before` tricks, truncation on the anchor, `a.textContent` reads — see different markup than before.

The helper now passes the flag to the template as `@navigationIcons`, and the template renders the icon plus the label wrapper only when it is set. With the flag off, output is byte-identical to the pre-#28368 markup.

The flag-off tests now assert the bare label, plus a new test that asserts the full rendered string matches the old markup exactly.