### PR TITLE
🐛 Fixed migrations failing on MySQL older than 8.0.28

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-21-22-48-rename-email-batches-provider-id.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-21-22-48-rename-email-batches-provider-id.js
@@ -4,5 +4,5 @@ module.exports = createRenameColumnMigration(
     'email_batches',
     'provider_id',
     'mailgun_message_id',
-    {algorithm: 'instant'}
+    {algorithm: 'auto'}
 );

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -99,6 +99,38 @@ function dropNullable(tableName, column, transaction = db.knex) {
     });
 }
 
+// MySQL raises these when an explicit ALGORITHM isn't supported for the operation,
+// which varies by server version (RENAME COLUMN only accepts INSTANT from 8.0.28).
+const UNSUPPORTED_ALGORITHM_ERRORS = new Set([
+    'ER_ALTER_OPERATION_NOT_SUPPORTED',
+    'ER_ALTER_OPERATION_NOT_SUPPORTED_REASON'
+]);
+
+/**
+ * Runs an ALTER TABLE with an explicit MySQL algorithm, retrying without it if the
+ * server doesn't support that algorithm for the operation.
+ *
+ * @param {import('knex').Knex} transaction
+ * @param {string} sql - ALTER statement without a trailing semicolon or algorithm clause
+ * @param {'instant'|'inplace'|'copy'|'auto'} [algorithm]
+ */
+async function rawWithAlgorithm(transaction, sql, algorithm) {
+    if (!algorithm || algorithm === 'auto') {
+        return await transaction.raw(sql);
+    }
+
+    try {
+        return await transaction.raw(`${sql}, algorithm=${algorithm}`);
+    } catch (err) {
+        if (!UNSUPPORTED_ALGORITHM_ERRORS.has(err.code)) {
+            throw err;
+        }
+
+        logging.warn(`ALGORITHM=${algorithm} is not supported by this server for: ${sql} - retrying without it`);
+        return await transaction.raw(sql);
+    }
+}
+
 /**
  * @param {string} tableName
  * @param {string} column
@@ -120,19 +152,15 @@ async function addColumn(tableName, column, transaction = db.knex, columnSpec, o
     }
 
     for (const sqlQuery of addColumnBuilder.toSQL()) {
-        let sql = sqlQuery.sql;
-
-        if (DatabaseInfo.isMySQL(transaction)) {
-            // Guard against an ending semicolon
-            sql = sql.replace(/;\s*$/, '');
-            if (options?.algorithm !== 'auto') {
-                // default to copy if not specified
-                const algorithm = options?.algorithm || 'copy';
-                sql += `, algorithm=${algorithm}`;
-            }
+        if (!DatabaseInfo.isMySQL(transaction)) {
+            await transaction.raw(sqlQuery.sql);
+            continue;
         }
 
-        await transaction.raw(sql);
+        // Guard against an ending semicolon
+        const sql = sqlQuery.sql.replace(/;\s*$/, '');
+        // default to copy if not specified
+        await rawWithAlgorithm(transaction, sql, options?.algorithm || 'copy');
     }
 }
 
@@ -162,19 +190,15 @@ async function dropColumn(tableName, column, transaction = db.knex, columnSpec =
     }
 
     for (const sqlQuery of dropColumnBuilder.toSQL()) {
-        let sql = sqlQuery.sql;
-
-        if (DatabaseInfo.isMySQL(transaction)) {
-            // Guard against an ending semicolon
-            sql = sql.replace(/;\s*$/, '');
-            if (options?.algorithm !== 'auto') {
-                // default to copy if not specified
-                const algorithm = options?.algorithm || 'copy';
-                sql += `, algorithm=${algorithm}`;
-            }
+        if (!DatabaseInfo.isMySQL(transaction)) {
+            await transaction.raw(sqlQuery.sql);
+            continue;
         }
 
-        await transaction.raw(sql);
+        // Guard against an ending semicolon
+        const sql = sqlQuery.sql.replace(/;\s*$/, '');
+        // default to copy if not specified
+        await rawWithAlgorithm(transaction, sql, options?.algorithm || 'copy');
     }
 }
 
@@ -191,8 +215,8 @@ async function renameColumn(tableName, from, to, transaction = db.knex, options 
 
     if (DatabaseInfo.isMySQL(transaction)) {
         // The knex helper does a lot of interesting things with foreign keys that are slow on bigger MySQL clusters
-        const algorithm = options.algorithm && options.algorithm !== 'auto' ? `, algorithm=${options.algorithm}` : '';
-        return await transaction.raw(`ALTER TABLE \`${tableName}\` RENAME COLUMN \`${from}\` TO \`${to}\`${algorithm};`);
+        const sql = `ALTER TABLE \`${tableName}\` RENAME COLUMN \`${from}\` TO \`${to}\``;
+        return await rawWithAlgorithm(transaction, sql, options.algorithm);
     }
 
     return await transaction.schema.table(tableName, function (table) {

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -154,7 +154,7 @@ describe('schema commands', function () {
             await commands.renameColumn('email_batches', 'provider_id', 'mailgun_message_id', fakeKnex, {algorithm: 'instant'});
 
             assert.deepEqual(rawStatements, [
-                'ALTER TABLE `email_batches` RENAME COLUMN `provider_id` TO `mailgun_message_id`, algorithm=instant;'
+                'ALTER TABLE `email_batches` RENAME COLUMN `provider_id` TO `mailgun_message_id`, algorithm=instant'
             ]);
         });
 
@@ -171,8 +171,53 @@ describe('schema commands', function () {
             await commands.renameColumn('table', 'old_column', 'new_column', fakeKnex);
 
             assert.deepEqual(rawStatements, [
-                'ALTER TABLE `table` RENAME COLUMN `old_column` TO `new_column`;'
+                'ALTER TABLE `table` RENAME COLUMN `old_column` TO `new_column`'
             ]);
+        });
+
+        it('retries without the algorithm when the server does not support it', async function () {
+            const rawStatements = [];
+            const fakeKnex = {
+                client: {config: {client: 'mysql2'}},
+                raw: (sql) => {
+                    rawStatements.push(sql);
+
+                    if (sql.includes('algorithm=')) {
+                        const error = new Error('ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.');
+                        error.code = 'ER_ALTER_OPERATION_NOT_SUPPORTED';
+                        return Promise.reject(error);
+                    }
+
+                    return Promise.resolve();
+                }
+            };
+
+            await commands.renameColumn('email_batches', 'provider_id', 'mailgun_message_id', fakeKnex, {algorithm: 'instant'});
+
+            assert.deepEqual(rawStatements, [
+                'ALTER TABLE `email_batches` RENAME COLUMN `provider_id` TO `mailgun_message_id`, algorithm=instant',
+                'ALTER TABLE `email_batches` RENAME COLUMN `provider_id` TO `mailgun_message_id`'
+            ]);
+        });
+
+        it('does not retry on unrelated errors', async function () {
+            const rawStatements = [];
+            const fakeKnex = {
+                client: {config: {client: 'mysql2'}},
+                raw: (sql) => {
+                    rawStatements.push(sql);
+                    const error = new Error("Table 'email_batches' doesn't exist");
+                    error.code = 'ER_NO_SUCH_TABLE';
+                    return Promise.reject(error);
+                }
+            };
+
+            await assert.rejects(
+                commands.renameColumn('email_batches', 'provider_id', 'mailgun_message_id', fakeKnex, {algorithm: 'instant'}),
+                /doesn't exist/
+            );
+
+            assert.equal(rawStatements.length, 1);
         });
     });
 });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/30100

The 6.58 rename of `email_batches.provider_id` asked for `ALGORITHM=INSTANT`, which MySQL only accepts for `RENAME COLUMN` from 8.0.28 onwards. Anyone on an older 8.0 server — still supported per our docs — hit `ER_ALTER_OPERATION_NOT_SUPPORTED` and could not upgrade past 6.58.

## Retroactive fix

The migration now asks for `auto`, matching every other algorithm-bearing migration in the tree (it was the only one using `instant`). This costs nothing: a plain `RENAME COLUMN` is metadata-only on `INPLACE` too, and 8.0.28+ servers still pick `INSTANT` themselves under `auto`.

Editing an already-shipped migration is safe here — knex-migrator tracks migrations by `(name, version, currentVersion)` with no checksum or content hash, so sites that already ran it skip it by name and never re-read the file, while stuck sites run the fixed version. `createRenameColumnMigration` also guards with `hasColumn`, so a re-run would be a no-op regardless.

## Systemic guard

`schema/commands.js` now retries an `ALTER` without the algorithm clause when the server rejects it (`ER_ALTER_OPERATION_NOT_SUPPORTED` / `ER_ALTER_OPERATION_NOT_SUPPORTED_REASON`), covering `renameColumn`, `addColumn`, and `dropColumn`.

I went with reacting to the server's own error rather than gating on `SELECT VERSION()`, because `INSTANT` support is per-operation — `ADD COLUMN` 8.0.12, `RENAME COLUMN` 8.0.28, `DROP COLUMN` 8.0.29 — so a version gate means maintaining a version matrix in the migration utils plus MariaDB version-string parsing, and a roundtrip per DDL. The error-driven approach is version- and vendor-agnostic and costs nothing on the happy path.

## Verification

Ran the real `commands.js` code paths against MySQL 8.0.21 and 8.4 containers:

| | 8.0.21 | 8.4 |
|---|---|---|
| rename + `instant` | warn, retry, succeeds | direct, no retry |
| rename + `auto` | succeeds | succeeds |
| addColumn `instant` | native (8.0.12+) | native |
| dropColumn `instant` | warn, retry, succeeds | native |

Unit tests pass (2 added — the retry path, and no-retry on an unrelated error), migration integration tests pass, eslint clean.

## Not included

- `addColumn`/`dropColumn` default to `algorithm=copy` when no option is passed, while `renameColumn` defaults to no clause. Left alone — changing that default alters DDL behaviour across every migration and deserves its own PR.
- The issue also asks us to clarify the documented minimum MySQL version. That's a docs change, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)