### PR TITLE
Fixed icon-only navigation items rendering as empty links

### DIFF
--- a/ghost/core/core/frontend/helpers/navigation.js
+++ b/ghost/core/core/frontend/helpers/navigation.js
@@ -157,11 +157,13 @@ module.exports = function navigation(options) {
             out.current = isCurrentNavigationUrl(e.url, currentUrl);
             out.icon = icon || null;
             out.iconAlt = hasLabel ? '' : iconName;
-            out.label = e.label;
+            out.label = hasLabel ? e.label : null;
             out.slug = slugify(hasLabel ? e.label : iconName);
             out.url = e.url;
             return out;
-        });
+        })
+        // Nothing to render: an icon-only item with the icons flag off would be an empty link
+        .filter(item => item.icon || item.label);
 
     if (output.length === 0) {
         return new SafeString('');

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -344,6 +344,44 @@ describe('{{navigation}} helper', function () {
             assert(rendered.string.includes('/paid">Paid</a>'));
         });
 
+        it('drops icon-only items rather than rendering an empty link', function () {
+            optionsData.data.site.navigation = [
+                {url: '/icon-only', icon: 'https://example.com/icon.svg'},
+                {label: 'Foo', url: '/foo'}
+            ];
+
+            const rendered = runHelper(optionsData);
+
+            assertExists(rendered);
+            assert(!rendered.string.includes('/icon-only'));
+            assert(!rendered.string.includes('class="nav-"'));
+            assert(rendered.string.includes('/foo">Foo</a>'));
+        });
+
+        it('drops items whose label is only whitespace', function () {
+            optionsData.data.site.navigation = [
+                {label: '   ', url: '/blank', icon: 'https://example.com/icon.svg'},
+                {label: 'Foo', url: '/foo'}
+            ];
+
+            const rendered = runHelper(optionsData);
+
+            assertExists(rendered);
+            assert(!rendered.string.includes('/blank'));
+            assert(rendered.string.includes('/foo">Foo</a>'));
+        });
+
+        it('renders empty nav when every item is icon-only', function () {
+            optionsData.data.site.navigation = [
+                {url: '/icon-only', icon: 'https://example.com/icon.svg'}
+            ];
+
+            const rendered = runHelper(optionsData);
+
+            assertExists(rendered);
+            assert.equal(rendered.string, '');
+        });
+
         it('renders the same markup as before the flag existed', function () {
             optionsData.data.site.navigation = [{label: 'Foo', url: '/foo'}];
 


### PR DESCRIPTION
no ref

Follow-up to #30129.

The navigation settings validator accepts an item with an icon and no label regardless of the `navigationIcons` flag. So enabling the flag, adding an icon-only item, then disabling the flag leaves the front end rendering `<li class="nav-"><a href="/foo"></a></li>` — an empty, unlabelled link, since the icon is dropped when the flag is off.

Before #28368 that data threw an `IncorrectUsageError`, which is the worse option: it 500s the whole front end for data Admin allowed to be saved. So items with nothing to render are now dropped instead, and a nav where every item drops out renders nothing, matching the existing empty-nav behaviour.

A whitespace-only label hits the same case — the validator accepts it as long as the item has an icon. The helper already treats a blank label as no label when building the slug and the icon alt text, so it is now normalised to null and falls out the same way.

Note this also drops an item with a null or blank label and no icon, which previously rendered the same empty link. Those shapes are only reachable by writing to the database directly — Admin has always required a label (now label-or-icon).

Tests: an icon-only item and a whitespace-labelled item are both dropped while a sibling label item still renders, and an all-icon-only nav renders an empty string. Flag-on icon-only rendering is unchanged and still covered.