### PR TITLE
Changed automation status pill copy from Live to On

### DIFF
--- a/apps/admin/src/automations/automations.acceptance.test.tsx
+++ b/apps/admin/src/automations/automations.acceptance.test.tsx
@@ -49,7 +49,7 @@ describe("Automations list", () => {
         await expect.element(row).toHaveTextContent("Welcome new free members after they sign up.");
         await expect.element(row).toHaveTextContent("1,432");
         await expect.element(row).toHaveTextContent("118");
-        await expect.element(row).toHaveTextContent("Live");
+        await expect.element(row).toHaveTextContent("On");
         // Stripe is disconnected in the default boot, which hides the paid welcome flow.
         await expect(automationsScreen.rows()).toHaveCount(1);
     });

--- a/apps/admin/src/automations/components/automation-status-badge.tsx
+++ b/apps/admin/src/automations/components/automation-status-badge.tsx
@@ -7,7 +7,7 @@ const AutomationStatusBadge: React.FC<{status: Automation['status']}> = ({status
         return (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-green/20 px-2 py-0.5 text-xs font-medium text-green uppercase">
                 <span className="size-1.5 rounded-full bg-green" />
-                Live
+                On
             </span>
         );
     case 'inactive':

--- a/apps/admin/src/automations/components/automations-list.test.tsx
+++ b/apps/admin/src/automations/components/automations-list.test.tsx
@@ -46,7 +46,7 @@ describe('AutomationsList', () => {
         expect(screen.getByText('Welcome new free members after they sign up.')).toBeInTheDocument();
         expect(screen.getByText('Paid member welcome flow')).toBeInTheDocument();
         expect(screen.getByText('Welcome new paid members after they start their subscription.')).toBeInTheDocument();
-        expect(screen.getByText('Live')).toBeInTheDocument();
+        expect(screen.getByText('On')).toBeInTheDocument();
         expect(screen.getByText('Off')).toBeInTheDocument();
         expect(screen.getByRole('columnheader', {name: 'Last entry'})).toBeInTheDocument();
         expect(screen.getByRole('columnheader', {name: 'Total entries'})).toBeInTheDocument();


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1538/update-automation-status-pill-copy-from-live-to-on

On reads more clearly as the counterpart to Off for enabled automations. The pill styling and status behaviour are unchanged; only the label and its test expectations were updated.

list view before/after:
<img width="1182" height="492" alt="image" src="https://github.com/user-attachments/assets/66e4b54e-2f0e-4579-ab1f-ca6f2e7b604f" />


single automation view before/after:
<img width="482" height="184" alt="image" src="https://github.com/user-attachments/assets/8e870aec-12d9-421b-8a9a-a823bf8c2b0b" />

