### PR TITLE
Added post export permissions to the backup integration

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.60/2026-08-20-12-50-04-add-post-export-permissions-to-backup-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/6.60/2026-08-20-12-50-04-add-post-export-permissions-to-backup-integration.js
@@ -1,0 +1,6 @@
+const {addPermissionToRole} = require('../../utils');
+
+module.exports = addPermissionToRole({
+    permission: 'Browse posts',
+    role: 'DB Backup Integration'
+});

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -997,7 +997,8 @@
                 },
                 "DB Backup Integration": {
                     "db": "all",
-                    "member": "browse"
+                    "member": "browse",
+                    "post": "browse"
                 },
                 "Scheduler Integration": {
                     "post": "publish",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/backup.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/backup.test.js.snap
@@ -49,6 +49,18 @@ Object {
 }
 `;
 
+exports[`Backup Integration Backup API Backup Integration Can export post analytics CSV 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Backup Integration Backup API Editor: User authentication Cannot create a DB backup 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/backup.test.js
+++ b/ghost/core/test/e2e-api/admin/backup.test.js
@@ -88,6 +88,22 @@ describe('Backup Integration', function () {
                         assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
                     });
             });
+
+            it('Can export post analytics CSV', async function () {
+                // The trailing slash is what exempts this endpoint from the max
+                // limit cap, so `limit=all` is only honoured in this exact form.
+                await agent
+                    .get('posts/export/?limit=all')
+                    .expectStatus(200)
+                    .expectEmptyBody()
+                    .matchHeaderSnapshot({
+                        'content-version': anyContentVersion,
+                        'content-disposition': stringMatching(/^Attachment; filename="(?:[a-z0-9-]+\.)?ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
+                    })
+                    .expect(({text}) => {
+                        assert.match(text, /^id,title,url/);
+                    });
+            });
         });
 
         describe('Zapier Integration', function () {

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -105,7 +105,7 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Add notifications', ['Administrator', 'Admin Integration']);
             assertHavePermission(permissions, 'Delete notifications', ['Administrator', 'Editor', 'Admin Integration', 'Super Editor']);
 
-            assertHavePermission(permissions, 'Browse posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
+            assertHavePermission(permissions, 'Browse posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'DB Backup Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Read posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Edit posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Add posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -398,7 +398,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 149;
+            const FIXTURE_COUNT = 150;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '091d0105868c689120d75dcc553282e7';
-    const currentFixturesHash = 'd4c9e4fabcec3365c42d37642216021b';
+    const currentFixturesHash = '84c2ea9677201ec4e59ca893f3a9f2c1';
     const currentSettingsHash = 'f57245b22af55ea5fc1e5e20913de9bb';
     const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -1151,7 +1151,8 @@
                 },
                 "DB Backup Integration": {
                     "db": "all",
-                    "member": "browse"
+                    "member": "browse",
+                    "post": "browse"
                 },
                 "Scheduler Integration": {
                     "post": "publish",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/GVA-907/

- Ghost(Pro) archives are gaining a `post-analytics.csv` alongside the existing `members.csv`, fetched from `GET /ghost/api/admin/posts/export/` with the `ghost-backup` integration key, and that endpoint is gated on `browse post`
- There is no explicit export posts permission, so we use browse posts - exactly how `browse member` was added to this role in v5.121.0 to allow the members export
- This grants no data the key could not already reach, in either half of that CSV. Post content: `posts` is in the exporter's `TABLES_ALLOWLIST`, so a plain `GET /db/` already returns every post's title, html and lexical. The analytics counts: they derive from `emails`, `email_recipients`, `members_click_events` and `members_feedback`, none of which are in that allowlist - but `exportContent` accepts an `include` option validated against `BACKUP_TABLES` (`db.js:45-56`), which contains all of them, so `GET /db/?include=emails,members_click_events` works with today's key
- So what the permission actually adds is a presentation: asking Ghost to join those tables into a CSV, rather than dumping them and joining them by hand
- It does open `/posts/` browse generally rather than only the export route, since permissions are per action type rather than per endpoint
- Applied in fixtures and with a migration so both new and existing sites get the update, and mirrored into the test fixtures
- Verified against a site created before this change, so fixtures never re-ran and only the migration could have applied it: the role gains `post|browse`, and the `ghost-backup` key then gets a 200 from `/posts/export/?limit=all`. A Zapier key is still refused on `/db/`
