### PR TITLE
🎨 Improved the emoji picker search field

### DIFF
--- a/.changeset/plenty-moons-smile.md
+++ b/.changeset/plenty-moons-smile.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/koenig-lexical": patch
+---
+
+Improved the emoji picker search field, which had text that was too light to read. Clicking outside the picker now closes it.

--- a/koenig/koenig-lexical/src/components/ui/EmojiPicker.shadow.css
+++ b/koenig/koenig-lexical/src/components/ui/EmojiPicker.shadow.css
@@ -1,0 +1,59 @@
+/*
+ * Search field in the emoji picker, matching Shade's input; each value names the
+ * Shade token behind it. emoji-mart hardcodes this chrome inside its shadow DOM
+ * with no variables to hook into, so EmojiPicker.tsx appends this file to the
+ * shadow root — light-DOM rules can't reach it.
+ *
+ * Colours come from --kg-emoji-search-* in koenig-lexical.css, so the field
+ * follows the same .dark class as the rest of the picker.
+ *
+ * Two things that look removable but aren't: [data-theme] is specificity, not
+ * theming — it's what beats emoji-mart's [dir="rtl"] padding and icon rules; and
+ * lengths are px because rem here resolves against the host document (16px in
+ * the demo, 10px in Admin).
+ */
+
+[data-theme] .search input[type="search"] {
+    height: 32px; /* --control-height */
+    border: 1px solid var(--kg-emoji-search-border); /* --control-border */
+    border-radius: 6px; /* --radius-md */
+    background-color: var(--kg-emoji-search-bg); /* --control-surface */
+    padding-block: 0;
+    padding-inline: 36px 12px; /* pl-3 (12) + size-4 icon (16) + gap-2 (8), then px-3 */
+    font-size: 13px; /* --text-control */
+    transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+        background-color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+        border-color 150ms cubic-bezier(0.4, 0, 0.2, 1); /* transition-colors */
+}
+
+[data-theme] .search input[type="search"]::placeholder {
+    color: var(--kg-emoji-search-muted); /* placeholder:text-muted-foreground */
+    opacity: 1; /* emoji-mart dims its own placeholder to .6 */
+}
+
+[data-theme] .search input[type="search"]:focus-visible {
+    border-color: var(--kg-emoji-search-focus-border); /* focus-visible:border-focus-ring */
+    outline: none;
+    box-shadow: 0 0 0 2px var(--kg-emoji-search-focus-ring); /* ring-2 ring-focus-ring/25 */
+    background-color: var(--kg-emoji-search-bg); /* holds still — emoji-mart swaps it on :focus */
+}
+
+/* InputGroupAddon */
+[data-theme] .search .icon {
+    color: var(--kg-emoji-search-muted);
+}
+
+[data-theme] .search .icon svg {
+    width: 16px; /* size-4 */
+    height: 16px;
+}
+
+[data-theme] .search .loupe {
+    inset-inline-start: 12px; /* pl-3 */
+    inset-inline-end: auto;
+}
+
+[data-theme] .search .delete {
+    inset-inline-start: auto;
+    inset-inline-end: 12px; /* pr-3 */
+}

--- a/koenig/koenig-lexical/src/components/ui/EmojiPicker.tsx
+++ b/koenig/koenig-lexical/src/components/ui/EmojiPicker.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useRef} from 'react';
+import shadowStyles from './EmojiPicker.shadow.css?inline';
 import {Picker} from 'emoji-mart';
 
 export default function EmojiPicker({setInstanceRef, ...props}) {
@@ -21,7 +22,18 @@ export default function EmojiPicker({setInstanceRef, ...props}) {
         // copy's class gets registered with customElements.define(). Instantiating
         // an unregistered class throws "Illegal constructor".
         const RegisteredPicker = customElements.get('em-emoji-picker') || Picker;
-        setInstance(new RegisteredPicker({...props, ref}));
+        const newInstance = new RegisteredPicker({...props, ref});
+
+        // emoji-mart renders into an open shadow root and injects its own stylesheet
+        // as the first child, so light-DOM rules can't reach the search input.
+        // Appending ours here lets it win on source order at equal specificity.
+        if (newInstance.shadowRoot) {
+            const style = document.createElement('style');
+            style.textContent = shadowStyles;
+            newInstance.shadowRoot.appendChild(style);
+        }
+
+        setInstance(newInstance);
 
         return () => {
             setInstance(null);

--- a/koenig/koenig-lexical/src/components/ui/EmojiPickerPortal.tsx
+++ b/koenig/koenig-lexical/src/components/ui/EmojiPickerPortal.tsx
@@ -4,9 +4,11 @@ import Portal from './Portal';
 import PropTypes from 'prop-types';
 import React from 'react';
 import defaultData from '@emoji-mart/data';
+import {useClickOutside} from '../../hooks/useClickOutside';
 
 const EmojiPickerPortal = ({
     onEmojiClick,
+    onClickOutside,
     positionRef,
     data = defaultData,
     autoFocus = true,
@@ -30,7 +32,14 @@ const EmojiPickerPortal = ({
     ...props
 }) => {
     const [position, setPosition] = React.useState(null);
+    const pickerRef = React.useRef(null);
     const {darkMode} = React.useContext(KoenigComposerContext);
+
+    // the picker renders in a portal so the trigger button sits outside of it,
+    // include it here to avoid closing and immediately re-opening on trigger click
+    const clickOutsideRefs = React.useMemo(() => [pickerRef, positionRef], [positionRef]);
+
+    useClickOutside(!!onClickOutside, clickOutsideRefs, onClickOutside);
 
     const shiftPixels = 35; // how many pixels we want to move it up when it's at the bottom of the screen
     const handleScroll = React.useCallback(() => {
@@ -101,7 +110,7 @@ const EmojiPickerPortal = ({
 
     return (
         <Portal>
-            <div className='z-20 mr-9 mt-10 rounded-md bg-white' data-testid="emoji-picker-container" style={style} onClick={handleClick}>
+            <div ref={pickerRef} className='z-20 mr-9 mt-10 rounded-md bg-white' data-testid="emoji-picker-container" style={style} onClick={handleClick}>
                 <div className=''>
                     <Picker // https://github.com/missive/emoji-mart#-picker
                         data={data}
@@ -118,6 +127,7 @@ export default EmojiPickerPortal;
 
 EmojiPickerPortal.propTypes = {
     onEmojiClick: PropTypes.func.isRequired,
+    onClickOutside: PropTypes.func,
     positionRef: PropTypes.object,
     data: PropTypes.array,
     autoFocus: PropTypes.bool,

--- a/koenig/koenig-lexical/src/components/ui/cards/CallToActionCard.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/CallToActionCard.tsx
@@ -382,7 +382,7 @@ export function CallToActionCard({
                             initialEditorState={htmlEditorInitialState}
                             initialTheme={theme}
                             nodes='basic'
-                            placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 `}
+                            placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl text-grey-500 dark:text-grey-800`}
                             placeholderText="Write something worth clicking..."
                             textClassName={clsx(
                                 'koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200',

--- a/koenig/koenig-lexical/src/components/ui/cards/CalloutCard.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/CalloutCard.tsx
@@ -125,7 +125,7 @@ export function CalloutCard({
                             isEditing && showEmojiPicker && (
                                 <EmojiPickerPortal
                                     positionRef={emojiButtonRef}
-                                    togglePortal={toggleEmojiPicker}
+                                    onClickOutside={() => setShowEmojiPicker(false)}
                                     onEmojiClick={changeEmoji} />
                             )
                         }
@@ -137,7 +137,7 @@ export function CalloutCard({
                     initialEditor={textEditor}
                     initialEditorState={textEditorInitialState}
                     nodes='minimal'
-                    placeholderClassName={`font-serif text-xl font-normal tracking-wide text-grey-500 !dark:text-white opacity-30`}
+                    placeholderClassName={`font-serif text-xl font-normal tracking-wide text-grey-500 dark:text-grey-800`}
                     placeholderText={'Callout text...'}
                     singleParagraph={true}
                     textClassName={`!my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal ${CALLOUT_TEXT_COLORS[color]}`}

--- a/koenig/koenig-lexical/src/hooks/useClickOutside.ts
+++ b/koenig/koenig-lexical/src/hooks/useClickOutside.ts
@@ -1,18 +1,28 @@
 import React from 'react';
 
-export function useClickOutside(enabled, ref, handler) {
+export function useClickOutside(enabled, refs, handler) {
     React.useEffect(() => {
         if (!enabled) {
             return;
         }
 
+        // accept a single ref or a list of them, e.g. when a popover renders in a
+        // portal its trigger button lives outside of the popover element
+        const refList = Array.isArray(refs) ? refs : [refs];
+
         const handleClickOutside = (event) => {
-            if (ref.current && !ref.current.contains(event.target)) {
+            // do nothing until something is actually mounted, otherwise the very
+            // first event would read as a click outside of everything
+            if (!refList.some(ref => ref.current)) {
+                return;
+            }
+
+            if (!refList.some(ref => ref.current?.contains(event.target))) {
                 handler();
             }
         };
 
         window.addEventListener('mousedown', handleClickOutside, {capture: true});
         return () => window.removeEventListener('mousedown', handleClickOutside, {capture: true});
-    }, [enabled, handler, ref]);
+    }, [enabled, handler, refs]);
 }

--- a/koenig/koenig-lexical/src/styles/components/koenig-lexical.css
+++ b/koenig/koenig-lexical/src/styles/components/koenig-lexical.css
@@ -62,10 +62,17 @@
         --rgb-accent: 48, 207, 67;
         /* --grey-950 */
         --rgb-background: 35, 41, 47;
-        /* --grey-300 */
-        --rgb-color: 221, 225, 229;
+        /* --grey-200, matches Shade's dark --foreground */
+        --rgb-color: 235, 238, 240;
         /* --grey-900 */
         --rgb-input: 57, 64, 71;
+
+        /* Search field, dark values — see the light block */
+        --kg-emoji-search-border: color-mix(in oklab, var(--grey-900) 70%, transparent);
+        --kg-emoji-search-bg: transparent;
+        --kg-emoji-search-muted: var(--grey-600);
+        --kg-emoji-search-focus-border: var(--grey-900);
+        --kg-emoji-search-focus-ring: color-mix(in srgb, var(--grey-900) 25%, transparent);
       }
 }
 
@@ -92,7 +99,17 @@ em-emoji-picker {
     /* --background-rgb: 85, 170, 255; */
     --font-size: 13px;
     --rgb-accent: 57, 64, 71;
-    --rgb-color: 174, 183, 193;
+    /* --black, matches Shade's light --foreground */
+    --rgb-color: 21, 23, 26;
+
+    /* Search field — read by EmojiPicker.shadow.css from inside the picker's
+       shadow root, which only custom properties reach. Here so the field follows
+       .dark like the rest of the picker. */
+    --kg-emoji-search-border: color-mix(in oklab, var(--grey-200), var(--grey-300));
+    --kg-emoji-search-bg: var(--white);
+    --kg-emoji-search-muted: var(--grey-700);
+    --kg-emoji-search-focus-border: var(--grey-600);
+    --kg-emoji-search-focus-ring: color-mix(in srgb, var(--grey-600) 25%, transparent);
     --em-rgb-accent: (255,0,0)
     /* --rgb-input: 255, 235, 235; */;
     --shadow: 0 0 1px rgba(0,0,0,.05), 0 5px 18px rgba(0,0,0,.08);
@@ -102,14 +119,6 @@ em-emoji-picker {
 
   em-emoji-picker #nav button[aria-selected] svg {
     fill: red;
-  }
-
-  em-emoji-picker .search input[type="search"] {
-    border-radius: 5px;
-  }
-
-  .search input, .search button {
-    font-size: 20px !important;
   }
 
   /* HTML card */


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1037/regression-input-field-text-color-in-callout-emoji-picker-is-too-light

The search field in the callout card's emoji picker is now aligned with Shade's input.

Clicking outside the picker now closes it, using the same useClickOutside hook as the other popovers. The hook takes a list of refs so the picker, which renders in a portal, can also count its trigger button as inside.

While I was there I also updated the placeholder of the callout card so that it's consistent with the call to action card.

| Before | After |
|--------|--------|
| <img width="535" height="437" alt="Screenshot 2026-08-20 at 14 36 58" src="https://github.com/user-attachments/assets/cea706bd-f105-4da4-8cfa-60d162fea40e" /> | <img width="517" height="446" alt="Screenshot 2026-08-20 at 14 34 07" src="https://github.com/user-attachments/assets/25ab7617-f20d-4c8a-a335-8eea6dce4b61" /> | 
| <img width="538" height="435" alt="Screenshot 2026-08-20 at 14 37 32" src="https://github.com/user-attachments/assets/3f9f460f-348c-405d-9977-7ccc98c65d36" /> | <img width="549" height="436" alt="Screenshot 2026-08-20 at 14 38 05" src="https://github.com/user-attachments/assets/29b2dce5-f94e-4642-93fe-1909bb677efa" /> | 