### PR TITLE
Changed programmatic navigation to React-owned routes to use the router

### DIFF
--- a/apps/activitypub/src/components/layout/error/error.tsx
+++ b/apps/activitypub/src/components/layout/error/error.tsx
@@ -12,7 +12,7 @@ const Error = ({statusCode, errorCode}: {statusCode?: number, errorCode?: string
 
     const toAnalytics = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        navigate('/analytics/', {crossApp: true});
+        navigate('/analytics/');
     };
 
     if (routeError) {

--- a/apps/activitypub/src/components/layout/error/error.tsx
+++ b/apps/activitypub/src/components/layout/error/error.tsx
@@ -12,7 +12,9 @@ const Error = ({statusCode, errorCode}: {statusCode?: number, errorCode?: string
 
     const toAnalytics = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        navigate('/analytics/');
+        // This component is also used by the standalone ActivityPub app, whose
+        // router does not own the Admin analytics route.
+        navigate('/analytics/', {crossApp: true});
     };
 
     if (routeError) {

--- a/apps/activitypub/test/acceptance/error.test.ts
+++ b/apps/activitypub/test/acceptance/error.test.ts
@@ -1,0 +1,23 @@
+import {expect, test} from '@playwright/test';
+import {mockInitialApiRequests} from '../utils/initial-api-requests';
+
+test.describe('Error page', () => {
+    test.beforeEach(async ({page}) => {
+        await mockInitialApiRequests(page);
+    });
+
+    test('hands the analytics action back to the Admin host', async ({page}) => {
+        await page.goto('#/does-not-exist');
+
+        await page.getByText('Back to the homepage').click();
+
+        await expect.poll(async () => {
+            return await page.locator('body').evaluate((body) => {
+                return JSON.parse(body.dataset.externalNavigate ?? 'null');
+            });
+        }).toMatchObject({
+            route: '/analytics/',
+            isExternal: true
+        });
+    });
+});

--- a/apps/admin/src/analytics/utils/url-helpers.test.ts
+++ b/apps/admin/src/analytics/utils/url-helpers.test.ts
@@ -223,10 +223,10 @@ describe('url-helpers', () => {
     });
 
     describe('getClickHandler', () => {
-        let mockNavigate: ReturnType<typeof vi.fn<(path: string, options?: {crossApp?: boolean}) => void>>;
+        let mockNavigate: ReturnType<typeof vi.fn<(path: string) => void>>;
 
         beforeEach(() => {
-            mockNavigate = vi.fn<(path: string, options?: {crossApp?: boolean}) => void>();
+            mockNavigate = vi.fn<(path: string) => void>();
             mockWindowOpen.mockClear();
         });
 
@@ -234,7 +234,7 @@ describe('url-helpers', () => {
             const handler = getClickHandler('/my-post/', 'post-123', 'https://example.com', mockNavigate, 'post');
             handler();
 
-            expect(mockNavigate).toHaveBeenCalledWith('/posts/analytics/post-123', {crossApp: true});
+            expect(mockNavigate).toHaveBeenCalledWith('/posts/analytics/post-123');
             expect(mockWindowOpen).not.toHaveBeenCalled();
         });
 

--- a/apps/admin/src/analytics/utils/url-helpers.ts
+++ b/apps/admin/src/analytics/utils/url-helpers.ts
@@ -96,13 +96,13 @@ export function getClickHandler(
     attributionUrl: string,
     postId: string | null | undefined,
     siteUrl: string,
-    navigate: (path: string, options?: {crossApp?: boolean}) => void,
+    navigate: (path: string) => void,
     attributionType?: string
 ) {
     return () => {
         // For posts with analytics, go to analytics page
         if (postId && attributionUrl && attributionType === 'post') {
-            navigate(`/posts/analytics/${postId}`, {crossApp: true});
+            navigate(`/posts/analytics/${postId}`);
             return;
         }
 

--- a/apps/admin/src/analytics/views/stats/newsletters/components/newsletters-kpis.tsx
+++ b/apps/admin/src/analytics/views/stats/newsletters/components/newsletters-kpis.tsx
@@ -362,7 +362,7 @@ const NewsletterKPIs: React.FC<{
                                                 // Recharts types activePayload as `any`; narrow the row we read.
                                                 const activePostId = (e.activePayload?.[0] as {payload?: {post_id?: string}} | undefined)?.payload?.post_id;
                                                 if (activePostId) {
-                                                    navigate(`/posts/analytics/${activePostId}`, {crossApp: true});
+                                                    navigate(`/posts/analytics/${activePostId}`);
                                                 }
                                             }}
                                             onMouseLeave={() => setIsHoveringClickable(false)}

--- a/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
+++ b/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
@@ -80,7 +80,7 @@ const NewsletterTableRows: React.FC<{
                                 <div className='group/link inline-flex items-center gap-2'>
                                     {post.post_id ?
                                         <Button className='h-auto p-0 text-left whitespace-normal hover:underline!' title="View post analytics" variant='link' onClick={() => {
-                                            navigate(`/posts/analytics/${post.post_id}/`, {crossApp: true});
+                                            navigate(`/posts/analytics/${post.post_id}/`);
                                         }}>
                                             {post.post_title}
                                         </Button>

--- a/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
@@ -7,6 +7,7 @@ import {type Post, getPostMetricsToDisplay} from '@tryghost/admin-x-framework';
 import {getPostDestination} from '@/analytics/utils/url-helpers';
 import {trackEvent, useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useAnalyticsData} from '@/shared/analytics/use-analytics-data';
+import {useIsEmberOwnedRoute} from '@/routes';
 
 // Import the interface from the hook
 import {type LatestPostWithStats} from '@/analytics/hooks/use-latest-post-stats';
@@ -64,6 +65,8 @@ const LatestPost: React.FC<LatestPostProps> = ({
     const hasEmailData = Boolean(latestPostStats?.email);
     const postDestination = getPostDestination({postId: latestPostStats?.id, hasEmailData, analytics: {webAnalytics, membersTrackSources}});
     const shouldGoToEditor = postDestination.startsWith('/editor/');
+    // Editor destinations are still Ember-owned and need a hash navigation.
+    const destinationIsEmberOwned = useIsEmberOwnedRoute(postDestination);
 
     return (
         <Card className='group/card' data-testid='latest-post'>
@@ -118,7 +121,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                             <div className='flex grow flex-col items-start justify-center self-stretch'>
                                 <div className='text-md leading-tighter font-semibold tracking-tight hover:cursor-pointer hover:opacity-75' onClick={() => {
                                     if (!isLoading && latestPostStats) {
-                                        navigate(postDestination, {crossApp: true});
+                                        navigate(postDestination, {crossApp: destinationIsEmberOwned});
                                     }
                                 }}>
                                     {latestPostStats.title}
@@ -155,7 +158,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                         className={latestPostStats.email_only ? 'w-full' : ''}
                                         variant='outline'
                                         onClick={() => {
-                                            navigate(postDestination, {crossApp: true});
+                                            navigate(postDestination, {crossApp: destinationIsEmberOwned});
                                         }}
                                     >
                                         {shouldGoToEditor ? (
@@ -181,7 +184,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                 {/* Web metrics - only for published posts */}
                                 {metricsToShow.showWebMetrics && webAnalytics &&
                                     <div className={metricClassName} data-testid='latest-post-visitors' onClick={() => {
-                                        navigate(`/posts/analytics/${latestPostStats.id}/web`, {crossApp: true});
+                                        navigate(`/posts/analytics/${latestPostStats.id}/web`);
                                     }}>
                                         <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                                             <LucideIcon.Globe size={16} strokeWidth={1.25} />
@@ -205,7 +208,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                             (metricsToShow.showEmailMetrics && (!metricsToShow.showWebMetrics || !webAnalytics)) && 'col-[1/2] row-[2/3]'
                                         )
                                     } data-testid='latest-post-members' onClick={() => {
-                                        navigate(`/posts/analytics/${latestPostStats.id}/growth`, {crossApp: true});
+                                        navigate(`/posts/analytics/${latestPostStats.id}/growth`);
                                     }}>
                                         <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                                             <LucideIcon.UserPlus size={16} strokeWidth={1.25} />
@@ -227,7 +230,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                     <>
                                         {emailTrackOpensEnabled && (
                                             <div className={metricClassName} onClick={() => {
-                                                navigate(`/posts/analytics/${latestPostStats.id}/newsletter`, {crossApp: true});
+                                                navigate(`/posts/analytics/${latestPostStats.id}/newsletter`);
                                             }}>
                                                 <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                                                     <LucideIcon.MailOpen size={16} strokeWidth={1.25} />
@@ -243,7 +246,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                         )}
                                         {emailTrackClicksEnabled && (
                                             <div className={metricClassName} onClick={() => {
-                                                navigate(`/posts/analytics/${latestPostStats.id}/newsletter`, {crossApp: true});
+                                                navigate(`/posts/analytics/${latestPostStats.id}/newsletter`);
                                             }}>
                                                 <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                                                     <LucideIcon.MousePointerClick size={16} strokeWidth={1.25} />

--- a/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
@@ -96,14 +96,16 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                 return (
                                     <div key={post.post_id} className='group relative flex w-full items-start justify-between gap-5 border-t border-border/50 py-4 before:absolute before:-inset-x-4 before:inset-y-0 before:z-0 before:hidden before:rounded-md before:bg-table-row-hover before:content-[""] first:border-border! hover:cursor-pointer hover:border-transparent hover:before:block md:items-center [&+div]:hover:border-transparent'>
                                         <div className='z-10 flex min-w-[160px] grow items-start gap-4 md:items-center lg:min-w-[320px]' onClick={() => {
-                                            navigate(getPostDestination({
+                                            const destination = getPostDestination({
                                                 postId: post.post_id,
                                                 hasEmailData: post.sent_count !== null,
                                                 analytics: {
                                                     webAnalytics: showWebAnalytics,
                                                     membersTrackSources
                                                 }
-                                            }), {crossApp: true});
+                                            });
+                                            // `/editor/*` is still Ember-owned (EMBER_ROUTES) and needs a hash navigation.
+                                            navigate(destination, {crossApp: destination.startsWith('/editor/')});
                                         }}>
                                             {post.feature_image ?
                                                 <div className='hidden aspect-[16/10] w-[80px] shrink-0 rounded-sm bg-cover bg-center sm:visible! sm:block! lg:w-[100px]' style={{
@@ -126,7 +128,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                             {showWebAnalytics &&
                                                 <div className='group/tooltip relative flex w-[66px] lg:w-[92px]' data-testid='statistics-visitors' onClick={(e) => {
                                                     e.stopPropagation();
-                                                    navigate(`/posts/analytics/${post.post_id}/web`, {crossApp: true});
+                                                    navigate(`/posts/analytics/${post.post_id}/web`);
                                                 }}>
                                                     <PostListTooltip
                                                         metrics={[
@@ -147,7 +149,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                             {post.sent_count !== null &&
                                                 <div className='group/tooltip relative flex w-[66px] lg:w-[92px]' onClick={(e) => {
                                                     e.stopPropagation();
-                                                    navigate(`/posts/analytics/${post.post_id}/newsletter`, {crossApp: true});
+                                                    navigate(`/posts/analytics/${post.post_id}/newsletter`);
                                                 }}>
                                                     <PostListTooltip
                                                         className={`${!membersTrackSources ? 'right-0 left-auto translate-x-0' : ''}`}
@@ -208,7 +210,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                             {membersTrackSources &&
                                                 <div className='group/tooltip relative flex w-[66px] lg:w-[92px]' data-testid='statistics-members' onClick={(e) => {
                                                     e.stopPropagation();
-                                                    navigate(`/posts/analytics/${post.post_id}/growth`, {crossApp: true});
+                                                    navigate(`/posts/analytics/${post.post_id}/growth`);
                                                 }}>
                                                     <PostListTooltip
                                                         className='right-0 left-auto translate-x-0'

--- a/apps/admin/src/posts/analytics/components/post-analytics-header.tsx
+++ b/apps/admin/src/posts/analytics/components/post-analytics-header.tsx
@@ -123,7 +123,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                             <button
                                                 className='cursor-pointer rounded-sm focus-visible:ring-1 focus-visible:ring-focus-ring focus-visible:outline-hidden'
                                                 type='button'
-                                                onClick={() => navigate('/analytics/', {crossApp: true})}
+                                                onClick={() => navigate('/analytics/')}
                                             >
                                                 Analytics
                                             </button>

--- a/apps/admin/src/posts/analytics/newsletter/components/feedback.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/components/feedback.tsx
@@ -115,7 +115,7 @@ const Feedback: React.FC<FeedbackProps> = ({feedbackStats}) => {
                             const positiveFilterParam = `${encodeURIComponent(positiveFilter)}&post=${postId}`;
                             const negativeFilterParam = `${encodeURIComponent(negativeFilter)}&post=${postId}`;
 
-                            navigate(`/members?filter=${activeFeedbackTab === 'positive' ? positiveFilterParam : negativeFilterParam}`, {crossApp: true});
+                            navigate(`/members?filter=${activeFeedbackTab === 'positive' ? positiveFilterParam : negativeFilterParam}`);
                         }}>
                             View all
                             <LucideIcon.TableOfContents />

--- a/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
@@ -77,7 +77,7 @@ const Newsletter: React.FC = () => {
 
     // Use shared post data from context
     const {post, isPostLoading, postId} = usePostAnalytics();
-    const navigateToMembers = (filter: string) => navigate(buildMembersUrl({filter}), {crossApp: true});
+    const navigateToMembers = (filter: string) => navigate(buildMembersUrl({filter}));
     const typedPost = post as Post;
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(typedPost);

--- a/apps/admin/src/route-access-guard.test.tsx
+++ b/apps/admin/src/route-access-guard.test.tsx
@@ -10,8 +10,9 @@ const {mockUseCurrentUser, mockUseMatches} = vi.hoisted(() => ({
 
 vi.mock('@tryghost/admin-x-framework', () => ({
     Outlet: () => React.createElement('div', {'data-testid': 'outlet'}),
-    Navigate: ({crossApp, to}: {crossApp?: boolean; to: string}) => React.createElement('div', {
+    Navigate: ({crossApp, replace, to}: {crossApp?: boolean; replace?: boolean; to: string}) => React.createElement('div', {
         'data-cross-app': String(Boolean(crossApp)),
+        'data-replace': String(Boolean(replace)),
         'data-testid': 'navigate',
         'data-to': to
     }),
@@ -50,7 +51,8 @@ describe('RouteAccessGuard', () => {
         render(<RouteAccessGuard />);
 
         expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/');
-        expect(screen.getByTestId('navigate')).toHaveAttribute('data-cross-app', 'true');
+        expect(screen.getByTestId('navigate')).toHaveAttribute('data-cross-app', 'false');
+        expect(screen.getByTestId('navigate')).toHaveAttribute('data-replace', 'true');
     });
 
     it('renders unguarded routes without waiting for the current user', () => {

--- a/apps/admin/src/route-access-guard.tsx
+++ b/apps/admin/src/route-access-guard.tsx
@@ -42,14 +42,14 @@ export function RouteAccessGuard() {
 
     if (!currentUser) {
         if (isError || !isLoading) {
-            return <Navigate to="/" crossApp />;
+            return <Navigate to="/" replace />;
         }
 
         return null;
     }
 
     if (!rules.every(rule => rule(currentUser, location))) {
-        return <Navigate to="/" crossApp />;
+        return <Navigate to="/" replace />;
     }
 
     return <Outlet />;

--- a/apps/admin/src/route-access.acceptance.test.tsx
+++ b/apps/admin/src/route-access.acceptance.test.tsx
@@ -17,8 +17,8 @@ function asRole(name: StaffRoleName): RenderAdminAppOptions {
     return { boot: { browseMe: { response: me } } };
 }
 
-// Denied routes hand off to the home route with a cross-app navigation (a
-// hash update both routers observe) rather than a React-internal one.
+// Denied routes redirect to the home route through the router; only the home
+// dispatch itself may then hand off cross-app (asserted in home.acceptance).
 const homeHandoff = (): unknown => JSON.parse(document.body.dataset.externalNavigate ?? "null");
 
 const OWNER_SLUG = currentUserResponse().users[0].slug as string;
@@ -32,7 +32,7 @@ describe("Route access", () => {
     it("redirects a contributor away from settings", async () => {
         await renderAdminApp("/settings/design", asRole("Contributor"));
 
-        await expect.poll(homeHandoff).toMatchObject({ route: "/", isExternal: true });
+        await expect.poll(currentRoute).toBe("/");
     });
 
     it("keeps a contributor on their own profile settings", async () => {
@@ -47,19 +47,19 @@ describe("Route access", () => {
     it("redirects an author away from another staff member's profile settings", async () => {
         await renderAdminApp("/settings/staff/someone-else", asRole("Author"));
 
-        await expect.poll(homeHandoff).toMatchObject({ route: "/", isExternal: true });
+        await expect.poll(currentRoute).toBe("/");
     });
 
     it("redirects a contributor away from tags", async () => {
         await renderAdminApp("/tags", asRole("Contributor"));
 
-        await expect.poll(homeHandoff).toMatchObject({ route: "/", isExternal: true });
+        await expect.poll(currentRoute).toBe("/");
     });
 
     it("redirects an editor away from members", async () => {
         await renderAdminApp("/members", asRole("Editor"));
 
-        await expect.poll(homeHandoff).toMatchObject({ route: "/", isExternal: true });
+        await expect.poll(currentRoute).toBe("/");
     });
 
     it("leaves an authorized user on the route", async () => {

--- a/apps/admin/src/settings/email/email-settings.acceptance.test.tsx
+++ b/apps/admin/src/settings/email/email-settings.acceptance.test.tsx
@@ -78,6 +78,19 @@ describe("Email settings", () => {
         expect(verifyApi.lastRequest?.body).toEqual({token: "fake-token"});
     });
 
+    it("redeems a welcome-email verification token and clears it from the route", async () => {
+        fakeSettingsScreens();
+        const verifyApi = fakeAdminEndpoint("PUT", "/automated_emails/verifications/", {
+            automated_emails: [],
+            meta: {email_verified: "sender_reply_to"},
+        });
+        await renderAdminApp("/settings/memberemails?verifyEmail=fake-token");
+
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent("Reply-to address verified");
+        expect(verifyApi.lastRequest?.body).toEqual({token: "fake-token"});
+        await expect.poll(currentRoute).toBe("/settings/memberemails");
+    });
+
     it("finds transactional email settings in search", async () => {
         fakeSettingsScreens();
         await renderAdminApp("/settings", {labs: {automations: true}});

--- a/apps/admin/src/settings/general/user-detail-modal.tsx
+++ b/apps/admin/src/settings/general/user-detail-modal.tsx
@@ -13,7 +13,7 @@ import {HostLimitError, useLimiter} from '@/settings/hooks/use-limiter';
 import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {Pencil, Trash2} from 'lucide-react';
-import {useLocation, useParams} from '@tryghost/admin-x-framework';
+import {useLocation, useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
 import {useUpgradeRoute} from '@/settings/hooks/use-upgrade-route';
 import {SOCIAL_PLATFORM_CONFIGS, SOCIAL_PLATFORM_KEYS, getSocialValidationError} from '@/settings/utils/social-urls/index';
@@ -76,6 +76,7 @@ export interface UserDetailProps {
 
 const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDeleting: boolean) => void}> = ({user, onDeletingUserChange}) => {
     const {updateRoute} = useSettingsNavigation();
+    const navigate = useNavigate();
     const upgradeRoute = useUpgradeRoute();
     const location = useLocation();
 
@@ -162,10 +163,10 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
         if (canAccessSettings(currentUser)) {
             updateRoute('staff');
         } else {
-            // Contributors can't access settings, exit to let the shell handle navigation
-            updateRoute({isExternal: true, route: ''});
+            // Contributors can't access settings; the home route resolves their landing view
+            navigate('/');
         }
-    }, [currentUser, updateRoute]);
+    }, [currentUser, navigate, updateRoute]);
 
     const confirmSuspend = async (_user: User) => {
         if (_user.status === 'inactive' && _user.roles[0].name !== 'Contributor') {
@@ -465,6 +466,7 @@ const UserDetailModal: React.FC = () => {
     const {slug} = useParams();
     const {currentUser} = useGlobalData();
     const {updateRoute} = useSettingsNavigation();
+    const navigate = useNavigate();
     const handleError = useHandleError();
     const [isDeletingUser, setIsDeletingUser] = useState(false);
 
@@ -518,9 +520,9 @@ const UserDetailModal: React.FC = () => {
             // to the dead URL and redirect again
             updateRoute({route: 'staff', replace: true});
         } else {
-            updateRoute({isExternal: true, route: ''});
+            navigate('/');
         }
-    }, [notFoundSlug, isDeletingUser, currentUser, updateRoute]);
+    }, [notFoundSlug, isDeletingUser, currentUser, navigate, updateRoute]);
 
     return displayUser ? <UserDetailModalContent user={displayUser} onDeletingUserChange={setIsDeletingUser} /> : null;
 };

--- a/apps/admin/src/settings/membership/member-emails.tsx
+++ b/apps/admin/src/settings/membership/member-emails.tsx
@@ -11,6 +11,7 @@ import {WELCOME_EMAIL_SLUGS, type WelcomeEmailType, getDefaultWelcomeEmailRecord
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail, useVerifyAutomatedEmailSender} from '@tryghost/admin-x-framework/api/automated-emails';
+import {useSearchParams} from '@tryghost/admin-x-framework';
 import {useConfirmation} from '@/settings/providers/confirmation-context';
 import {useGlobalData} from '@/settings/providers/global-data-context';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -139,6 +140,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings, config} = useGlobalData();
     const [siteTitle] = getSettingValues<string>(settings, ['title']);
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
+    const [, setSearchParams] = useSearchParams();
 
     const {data: automatedEmailsData, isLoading} = useBrowseAutomatedEmails();
     const {mutateAsync: addAutomatedEmail, isPending: isAddingAutomatedEmail} = useAddAutomatedEmail();
@@ -176,12 +178,10 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
         submittedTokenRef.current = verifyEmailToken;
 
         const clearVerifyEmailFromRoute = () => {
-            const hash = window.location.hash.slice(1);
-            const url = new URL(hash || '/memberemails', window.location.origin);
-            url.searchParams.delete('verifyEmail');
-
-            const nextHash = url.search ? `#${url.pathname}${url.search}` : `#${url.pathname}`;
-            window.history.replaceState(null, '', `${window.location.pathname}${nextHash}`);
+            setSearchParams((params) => {
+                params.delete('verifyEmail');
+                return params;
+            }, {replace: true});
         };
 
         const verify = async () => {
@@ -225,7 +225,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
         };
 
         void verify();
-    }, [confirm, handleError, verifyEmailToken, verifySenderUpdate]);
+    }, [confirm, handleError, setSearchParams, verifyEmailToken, verifySenderUpdate]);
 
     const handleToggle = async (emailType: 'free' | 'paid') => {
         const existing = automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS[emailType]);

--- a/apps/admin/src/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin/src/settings/site/design-and-theme-modal.tsx
@@ -142,20 +142,9 @@ const DesignAndThemeModal: React.FC = () => {
         const handleThemeLimitError = (error: string) => {
             // Immediately prevent any installation attempts
             setInstallationAllowed(false);
-
-            if (noThemeChangesAllowed) {
-                // Single theme - show limit modal and redirect to /theme
-                showThemeLimitModal(error);
-                // Strip the query from the history entry so back doesn't re-trigger the install
-                updateRoute({route: 'theme/install', replace: true});
-                updateRoute('theme');
-            } else {
-                // Multiple themes allowed - show limit modal and then redirect
-                showThemeLimitModal(error);
-                // Don't redirect to change-theme modal - just stay on current route
-                // This prevents both modals from being visible at the same time
-                updateRoute('theme');
-            }
+            showThemeLimitModal(error);
+            // Replace the install entry so back doesn't re-trigger it
+            updateRoute({route: 'theme', replace: true});
         };
 
         const checkThemeInstallation = async () => {

--- a/apps/admin/src/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin/src/settings/site/design-and-theme-modal.tsx
@@ -146,8 +146,8 @@ const DesignAndThemeModal: React.FC = () => {
             if (noThemeChangesAllowed) {
                 // Single theme - show limit modal and redirect to /theme
                 showThemeLimitModal(error);
-                // Clear URL parameters
-                window.history.replaceState({}, '', window.location.pathname + window.location.hash.split('?')[0]);
+                // Strip the query from the history entry so back doesn't re-trigger the install
+                updateRoute({route: 'theme/install', replace: true});
                 updateRoute('theme');
             } else {
                 // Multiple themes allowed - show limit modal and then redirect

--- a/apps/admin/src/settings/site/design-modal.tsx
+++ b/apps/admin/src/settings/site/design-modal.tsx
@@ -9,6 +9,7 @@ import {PreviewChrome, Tabs, TabsContent, TabsList, TabsTrigger, ToggleGroup, To
 import {PreviewModalContent} from '@/settings/components/preview-modal';
 import {type Setting, type SettingValue, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
+import {useNavigate} from '@tryghost/admin-x-framework';
 import {useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {type Dirtyable, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalData} from '@/settings/providers/global-data-context';
@@ -72,6 +73,7 @@ const DesignModal: React.FC = () => {
     const [selectedPreviewTab, setSelectedPreviewTab] = useState('homepage');
     const [previewDevice, setPreviewDevice] = useState<'desktop' | 'mobile'>('desktop');
     const {updateRoute} = useSettingsNavigation();
+    const navigate = useNavigate();
 
     const refParam = useQueryParams().getParam('ref');
 
@@ -225,7 +227,7 @@ const DesignModal: React.FC = () => {
         title='Design'
         onClose={() => {
             if (refParam === 'setup') {
-                updateRoute({isExternal: true, route: 'analytics'});
+                navigate('/analytics');
             } else {
                 updateRoute('design');
             }

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
 
 import {
@@ -424,6 +424,22 @@ describe("Theme settings", () => {
             await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
             expect(installApi.requests).toHaveLength(0);
         }
+    });
+
+    it("replaces a blocked marketplace installation in history", async () => {
+        fakeThemeWorld();
+        fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "taste" })] });
+        const replaceState = vi.spyOn(window.history, "replaceState");
+        await renderAdminApp(
+            "/settings/theme/install?source=github&ref=TryGhost/Taste",
+            themeLimits(["casper"], "Upgrade to use custom themes")
+        );
+
+        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
+        await expect.poll(currentRoute).toBe("/settings/theme");
+
+        expect(replaceState.mock.calls.some(([, , url]) => String(url).endsWith("#/settings/theme"))).toBe(true);
+        replaceState.mockRestore();
     });
 
     it("confirms before discarding editor changes", async () => {

--- a/apps/admin/src/shared/analytics/disabled-sources-indicator.tsx
+++ b/apps/admin/src/shared/analytics/disabled-sources-indicator.tsx
@@ -17,7 +17,7 @@ const DisabledSourcesIndicator: React.FC<DisabledSourcesIndicatorProps> = ({clas
     return (
         <EmptyIndicator
             actions={
-                <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
+                <Button variant='outline' onClick={() => navigate('/settings/analytics')}>
                     Open settings
                 </Button>
             }


### PR DESCRIPTION
Cross-app navigations write `location.hash` directly, which the React router never sees: they create untracked history entries, bypass the `useBlocker` unsaved-changes guards, and are recorded rather than performed by the acceptance harness, leaving those flows untestable. Only Ember-owned targets (the editor, posts list, `/site`, `/pro`, `/migrate/*`) need the hash write, because Ember only observes `hashchange`.

- Analytics + post-analytics: metric tiles, chart clicks, post links and breadcrumbs to `/posts/analytics/*`, `/analytics/`, `/members?filter=…` and `/settings/analytics` now navigate through the router (also the ActivityPub error page's `/analytics/` action). Ember-owned targets keep `crossApp`.
- The two mixed-destination post links (`getPostDestination` returns `/editor/post/:id` or `/posts/analytics/:id`) pick `crossApp` per destination — `useIsEmberOwnedRoute` where the destination is in render scope, a `startsWith('/editor/')` check inside the per-row handler.
- `RouteAccessGuard` denied redirects switch from a hash write to `<Navigate to="/" replace />`, so blocked access no longer stacks a history entry; its unit and acceptance specs now assert the real resulting route.
- Settings: `design-modal`'s setup-flow close and `user-detail-modal`'s close/not-found now navigate to `/analytics` / `/` through the router instead of `isExternal` hash writes.
- Two raw `history.replaceState` calls that stripped a query from the hash wiped react-router's own history state (breaking later navigations): `design-and-theme-modal` now strips via `updateRoute({replace: true})` preserving the original history shape, and `member-emails` clears its `verifyEmail` token via `setSearchParams(..., {replace: true})`. The member-emails path had no coverage before — a new non-automations acceptance spec verifies the token submit + clean `/settings/memberemails` end state.

19 files, +73/−49.

**Verification:** admin `tsc -b`, eslint, full `pnpm test:unit` (135 files / 1604 tests); targeted acceptance runs green — route-access/home/email-settings (19 tests), `src/settings/site` + `src/analytics` + `src/posts` (65), `src/settings/general` + `src/settings/membership` (161); activitypub `test:unit` (135 tests).