### PR TITLE
🐛 Fixed Pintura config detection reading the wrong config path

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -32,6 +32,10 @@ export type Config = {
         apiKey?: string | null;
         contentFilter?: string;
     };
+    pintura?: {
+        js?: string;
+        css?: string;
+    };
     hostSettings?: {
         siteId?: string;
         forceUpgrade?: boolean;
@@ -103,10 +107,6 @@ export type Config = {
                     keywords?: string
                 }[]
             }
-        },
-        pintura?: {
-            js?: string
-            css?: string
         },
         managedEmail?: {
             enabled?: boolean

--- a/apps/admin-x-framework/src/hooks/use-pintura-config.ts
+++ b/apps/admin-x-framework/src/hooks/use-pintura-config.ts
@@ -34,7 +34,7 @@ export function usePinturaConfig(): { jsUrl: string; cssUrl: string } | null {
     const {data: settingsData} = useBrowseSettings();
 
     const config = configData?.config;
-    const pinturaConfig = config?.hostSettings?.pintura;
+    const pinturaConfig = config?.pintura;
     const settings = settingsData?.settings ?? null;
 
     const [isEnabled, fallbackJsUrl, fallbackCssUrl] = getSettingValues<unknown>(settings, [

--- a/apps/admin-x-framework/test/unit/hooks/use-pintura-config.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-pintura-config.test.ts
@@ -88,11 +88,9 @@ describe('usePinturaConfig', () => {
         mockUseBrowseConfig.mockReturnValue({
             data: {
                 config: {
-                    hostSettings: {
-                        pintura: {
-                            js: 'https://config.example.com/pintura.js',
-                            css: 'https://config.example.com/pintura.css'
-                        }
+                    pintura: {
+                        js: 'https://config.example.com/pintura.js',
+                        css: 'https://config.example.com/pintura.css'
                     }
                 }
             }
@@ -111,11 +109,9 @@ describe('usePinturaConfig', () => {
         mockUseBrowseConfig.mockReturnValue({
             data: {
                 config: {
-                    hostSettings: {
-                        pintura: {
-                            js: '/pintura/pintura-umd.js',
-                            css: '/pintura/pintura.css'
-                        }
+                    pintura: {
+                        js: '/pintura/pintura-umd.js',
+                        css: '/pintura/pintura.css'
                     }
                 }
             }


### PR DESCRIPTION
The server emits `pintura` at the top level of the public config (`ghost/core/core/server/services/public-config/config.js`) and Ember Admin reads it there (`config.pintura?.js || settings.pinturaJsUrl`). The framework's `usePinturaConfig` looked under `config.hostSettings.pintura`, which nothing emits — a repo-wide grep finds that path only in the hook itself.

Consequence: hosts that configure Pintura via server config fell back to the `pintura_js_url`/`pintura_css_url` settings; when those are unset, Pintura silently failed to open for the framework-hook consumers — the tag feature image editor, the member welcome-email editor, and the automations email editor.

Changes:
- `use-pintura-config.ts` reads top-level `config.pintura`; the settings-URL fallback is unchanged
- The `pintura?: {js?, css?}` field on the `Config` type moves out of the `hostSettings` block to the top level, matching what the server sends
- Hook test fixtures updated to the top-level shape; the case proving the settings-URL fallback (config without `pintura`) stays

3 files, +11/−15.

**Verification:** framework `pnpm build` + `pnpm test:unit` (38 files / 506 tests) + `pnpm lint` green; admin `tsc -b` + `pnpm test:unit src/hooks` (28 tests) green; activitypub `tsc --noEmit` green.