### PR TITLE
Fixed the admin nx task graph

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -100,6 +100,11 @@
             "playwright"
         ],
         "targets": {
+            "test:unit": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
             "test:acceptance": {
                 "dependsOn": [
                     "^build"
@@ -121,7 +126,7 @@
             },
             "build:dev": {
                 "dependsOn": [
-                    "build",
+                    "^build",
                     {
                         "projects": [
                             "ghost-admin"
@@ -146,7 +151,7 @@
                     "{workspaceRoot}/ghost/core/core/built/admin"
                 ],
                 "dependsOn": [
-                    "build",
+                    "^build",
                     {
                         "projects": [
                             "ghost-admin"


### PR DESCRIPTION
Two wiring problems in `@tryghost/admin`'s nx targets, both fixed in its `package.json` only (root `nx.json` untouched):

- The bare `"build"` entry in `build.dependsOn` was a self-reference that nx silently drops, so the target had no `^build` — the workspace libraries (admin-x-framework, shade, koenig-lexical, activitypub) were only built transitively because `ghost-admin:build` happens to depend on them. `build:dev` had the same bare `"build"` entry, which there resolved to admin's own full prod build target instead. Both now use `^build` (the explicit `ghost-admin` entries stay — the ember-assets plugin consumes its output).
- `test:unit` inherited the root targetDefaults `dependsOn: ["build"]`, building admin's full prod bundle plus the Ember app before running jsdom unit tests that only need the workspace libraries' output. A project-level override makes it depend on `^build` only.

Resolved graphs verified with `nx show project` and `--graph` dumps: the unit-test graph no longer contains `@tryghost/admin:build`; the build graph is unchanged in effect (same 15 tasks, now via explicit `^build`).

Known leftover, noted rather than hacked around: `^build` still pulls `ghost-admin:build` for `test:unit`/`test:acceptance` through the `ghost-admin` devDependency edge, and nx's `dependsOn` syntax has no per-dependency exclusion. It is nx-cached, so in practice it's a cache hit.

**Verification:** `pnpm nx run @tryghost/admin:test:unit` end-to-end — 135 files / 1604 tests pass (15 tasks, 14 cache hits, ~30s); `pnpm nx run @tryghost/admin:build` from clean outputs — `apps/admin/dist/` and `ghost/core/core/built/admin/` both produced with the composed Ember+React index.html.