### PR TITLE
Fixed member commenting mutations not refreshing the members list

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -295,7 +295,7 @@ export const useDisableMemberCommenting = createMutation<
         hide_comments: hideComments
     }),
     invalidateQueries: {
-        dataType: 'CommentsResponseType'
+        dataType: ['CommentsResponseType', dataType]
     }
 });
 
@@ -307,7 +307,7 @@ export const useEnableMemberCommenting = createMutation<
     path: ({id}) => `/members/${id}/commenting/enable`,
     body: () => ({}),
     invalidateQueries: {
-        dataType: 'CommentsResponseType'
+        dataType: ['CommentsResponseType', dataType]
     }
 });
 

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -116,7 +116,7 @@ interface MutationOptions<ResponseData, Payload> extends Omit<QueryOptions<Respo
     headers?: Record<string, string>;
     body?: (payload: Payload) => FormData | object;
     searchParams?: (payload: Payload) => { [key: string]: string; };
-    invalidateQueries?: { dataType: string; } | {
+    invalidateQueries?: { dataType: string | string[]; } | {
         filters?: InvalidateQueryFilters,
         options?: InvalidateOptions,
     };
@@ -154,8 +154,11 @@ export const createMutation = <ResponseData, Payload>({path, searchParams, defau
 
     const afterMutate = useCallback((newData: ResponseData, payload: Payload) => {
         if (invalidateQueries && 'dataType' in invalidateQueries) {
-            queryClient.invalidateQueries({queryKey: [invalidateQueries.dataType]});
-            onInvalidate(invalidateQueries.dataType);
+            const dataTypes = Array.isArray(invalidateQueries.dataType) ? invalidateQueries.dataType : [invalidateQueries.dataType];
+            for (const dataType of dataTypes) {
+                queryClient.invalidateQueries({queryKey: [dataType]});
+                onInvalidate(dataType);
+            }
         } else if (invalidateQueries) {
             queryClient.invalidateQueries(invalidateQueries.filters, invalidateQueries.options);
         }

--- a/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
@@ -459,6 +459,57 @@ describe('API hooks', () => {
             });
         });
 
+        it('can invalidate multiple dataTypes', async () => {
+            await withMockFetch({
+                json: {test: 1}
+            }, async () => {
+                queryClient.setQueryData(['FirstDataType', '1'], {test: 1});
+                queryClient.setQueryData(['SecondDataType', '1'], {test: 2});
+                queryClient.setQueryData(['OtherDataType', '1'], {test: 3});
+
+                const onInvalidate = vi.fn();
+                const spyWrapper: React.FC<{ children: ReactNode }> = ({children}) => (
+                    <FrameworkProvider
+                        externalNavigate={() => {}}
+                        ghostVersion='5.x'
+                        sentryDSN=''
+                        unsplashConfig={{
+                            Authorization: '',
+                            'Accept-Version': '',
+                            'Content-Type': '',
+                            'App-Pragma': '',
+                            'X-Unsplash-Cache': true
+                        }}
+                        onDelete={() => {}}
+                        onInvalidate={onInvalidate}
+                        onUpdate={() => {}}
+                    >
+                        <QueryClientProvider client={queryClient}>
+                            {children}
+                        </QueryClientProvider>
+                    </FrameworkProvider>
+                );
+
+                const useTestMutation = createMutation({
+                    path: () => '/test/',
+                    method: 'PUT',
+                    invalidateQueries: {dataType: ['FirstDataType', 'SecondDataType']}
+                });
+
+                const {result} = renderHook(() => useTestMutation(), {wrapper: spyWrapper});
+
+                await result.current.mutateAsync({});
+
+                expect(queryClient.getQueryState(['FirstDataType', '1'])?.isInvalidated).toBe(true);
+                expect(queryClient.getQueryState(['SecondDataType', '1'])?.isInvalidated).toBe(true);
+                expect(queryClient.getQueryState(['OtherDataType', '1'])?.isInvalidated).toBe(false);
+
+                expect(onInvalidate).toHaveBeenCalledTimes(2);
+                expect(onInvalidate).toHaveBeenNthCalledWith(1, 'FirstDataType');
+                expect(onInvalidate).toHaveBeenNthCalledWith(2, 'SecondDataType');
+            });
+        });
+
         it('can update queries in the cache', async () => {
             await withMockFetch({
                 json: {test: 10}

--- a/apps/admin/src/members/detail/member-actions-menu.tsx
+++ b/apps/admin/src/members/detail/member-actions-menu.tsx
@@ -10,7 +10,6 @@ import {getMemberCommentingActionLabel, isMemberCommentingDisabled} from './memb
 import {toast} from 'sonner';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
 import {useEnableMemberCommenting, useMembersFetching} from '@tryghost/admin-x-framework/api/members';
-import {useQueryClient} from '@tanstack/react-query';
 import type {Member} from '@tryghost/admin-x-framework/api/members';
 
 interface MemberActionsMenuProps {
@@ -29,7 +28,6 @@ interface MemberActionsMenuProps {
  * Impersonate, Sign out of all devices, Disable/Enable commenting, Delete member.
  */
 const MemberActionsMenu: React.FC<MemberActionsMenuProps> = ({member, allowLeaveWithUnsavedChanges}) => {
-    const queryClient = useQueryClient();
     const {data: currentUser} = useCurrentUser();
     const [showImpersonate, setShowImpersonate] = React.useState(false);
     const [showLogout, setShowLogout] = React.useState(false);
@@ -62,13 +60,7 @@ const MemberActionsMenu: React.FC<MemberActionsMenuProps> = ({member, allowLeave
             toast.success(`Commenting has been enabled for ${displayName}.`);
         } catch {
             toast.error('Couldn’t enable commenting. Please try again.');
-            return;
         }
-        // Fire-and-forget the extra members-cache refresh so the menu label
-        // flips back on the next render. Not awaited: a follow-up refetch
-        // failure must NOT flip the toast to an error (the enable itself
-        // succeeded and is already reflected server-side).
-        void queryClient.invalidateQueries({queryKey: ['MembersResponseType']});
     };
 
     return (

--- a/apps/admin/src/members/detail/member-disable-commenting-modal.tsx
+++ b/apps/admin/src/members/detail/member-disable-commenting-modal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, LoadingIndicator, Switch} from '@tryghost/shade/components';
 import {toast} from 'sonner';
 import {useDisableMemberCommenting} from '@tryghost/admin-x-framework/api/members';
-import {useQueryClient} from '@tanstack/react-query';
 import type {Member} from '@tryghost/admin-x-framework/api/members';
 
 interface MemberDisableCommentingModalProps {
@@ -25,7 +24,6 @@ const DISABLE_REASON = 'Disabled from member settings';
  * changes the outcome, not just a yes/no choice.
  */
 const MemberDisableCommentingModal: React.FC<MemberDisableCommentingModalProps> = ({open, onOpenChange, member}) => {
-    const queryClient = useQueryClient();
     const disable = useDisableMemberCommenting();
     const [hideComments, setHideComments] = React.useState(false);
 
@@ -46,16 +44,8 @@ const MemberDisableCommentingModal: React.FC<MemberDisableCommentingModalProps> 
             toast.error('Couldn’t disable commenting. Please try again.');
             return;
         }
-        // Commit the success UX first, then fire-and-forget the extra
-        // members-cache refresh. If the follow-up refetch fails we do NOT
-        // want to flip an already-shown success toast to an error — the
-        // disable itself succeeded and is reflected server-side.
         toast.success(`Commenting has been disabled for ${displayName}.`);
         onOpenChange(false);
-        // The framework hook only invalidates CommentsResponseType; refresh
-        // the members cache so the actions-menu label flips to "Enable
-        // commenting" on the next render.
-        void queryClient.invalidateQueries({queryKey: ['MembersResponseType']});
     };
 
     return (


### PR DESCRIPTION
`createMutation`'s `invalidateQueries` option could name exactly one dataType, so `useDisableMemberCommenting`/`useEnableMemberCommenting` invalidated only `CommentsResponseType` — and the two screens that flip commenting (member detail modal, member actions menu) carried manual `queryClient.invalidateQueries(['MembersResponseType'])` workarounds to refresh the members list.

- `invalidateQueries`' dataType form now accepts `string | string[]`; the existing behaviour (queryKey-prefix invalidation + one Ember-bridge `onInvalidate` per dataType) loops per entry. The `{filters, options}` form is untouched, and the 34 existing single-dataType declarations behave identically.
- The commenting hooks declare both `CommentsResponseType` and `MembersResponseType`. No third dataType is needed: the single-member read (`getMember`) registers under the same `MembersResponseType` dataType, so the prefix invalidation covers list + detail.
- The two manual workarounds (and their `useQueryClient` imports) are deleted.
- Ember bridge: both dataTypes are already in `state-bridge.js`'s `emberDataTypeMapping` (mapped to `null`, React-only), so the per-dataType `onInvalidate` no-ops rather than throws.
- New framework unit case proves multi-dataType invalidation: both listed dataTypes' cached queries invalidate, an unrelated one does not, `onInvalidate` fires once per dataType.

5 files.

**Verification:** framework `pnpm build` + `test:unit` (38 files / 494 tests) + lint green; admin `tsc -b`, eslint, full `test:unit` (135 files / 1604 tests) green; `pnpm test:acceptance src/members` (8 files / 61 tests) green first run.