### PR TITLE
Added dunning modal alongside overdue banner

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -46,6 +46,11 @@
       "import": "./dist/utils/get-site-timezone.js",
       "require": "./dist/utils/get-site-timezone.cjs"
     },
+    "./utils/dunning-intervention": {
+      "types": "./types/utils/dunning-intervention.d.ts",
+      "import": "./dist/utils/dunning-intervention.js",
+      "require": "./dist/utils/dunning-intervention.cjs"
+    },
     "./vite": {
       "types": "./types/vite.d.ts",
       "import": "./dist/vite.js",

--- a/apps/admin-x-framework/src/utils/dunning-intervention.ts
+++ b/apps/admin-x-framework/src/utils/dunning-intervention.ts
@@ -1,0 +1,65 @@
+export type DunningAudience = 'owner' | 'staff';
+export type DunningCopyVariant = 'owner-counted' | 'owner-generic' | 'staff';
+
+export interface DunningInterventionInput {
+  isGrace: unknown;
+  paymentAttempts: unknown;
+  forceUpgrade: boolean;
+  audience: DunningAudience;
+  modalDismissed: boolean;
+}
+
+export interface DunningInterventionDecision {
+  reminderModalVisible: boolean;
+  copyVariant: DunningCopyVariant | null;
+  visiblePaymentAttempts: number | null;
+  showBillingAction: boolean;
+}
+
+function getVisiblePaymentAttempts(
+  paymentAttempts: unknown,
+  audience: DunningAudience,
+): number | null {
+  if (audience !== 'owner') {
+    return null;
+  }
+
+  if (!Number.isSafeInteger(paymentAttempts) || (paymentAttempts as number) <= 0) {
+    return null;
+  }
+
+  return paymentAttempts as number;
+}
+
+export function decideDunningIntervention({
+  isGrace,
+  paymentAttempts,
+  forceUpgrade,
+  audience,
+  modalDismissed,
+}: DunningInterventionInput): DunningInterventionDecision {
+  if (isGrace !== true) {
+    return {
+      reminderModalVisible: false,
+      copyVariant: null,
+      visiblePaymentAttempts: null,
+      showBillingAction: false,
+    };
+  }
+
+  const visiblePaymentAttempts = getVisiblePaymentAttempts(paymentAttempts, audience);
+  const copyVariant =
+    audience === 'staff'
+      ? 'staff'
+      : visiblePaymentAttempts === null
+        ? 'owner-generic'
+        : 'owner-counted';
+  const reminderModalVisible = !forceUpgrade && !modalDismissed;
+
+  return {
+    reminderModalVisible,
+    copyVariant,
+    visiblePaymentAttempts,
+    showBillingAction: reminderModalVisible && audience === 'owner',
+  };
+}

--- a/apps/admin-x-framework/test/unit/utils/dunning-intervention.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/dunning-intervention.test.ts
@@ -1,0 +1,88 @@
+import { decideDunningIntervention } from '../../../src/utils/dunning-intervention';
+
+const ownerInput = {
+  isGrace: true,
+  paymentAttempts: 3,
+  forceUpgrade: false,
+  audience: 'owner' as const,
+  modalDismissed: false,
+};
+
+describe('decideDunningIntervention', () => {
+  it('shows the pre-lock reminder when Billing reports grace', () => {
+    expect(decideDunningIntervention(ownerInput)).toEqual({
+      reminderModalVisible: true,
+      copyVariant: 'owner-counted',
+      visiblePaymentAttempts: 3,
+      showBillingAction: true,
+    });
+  });
+
+  it.each([undefined, null, false, '', 0, 'true'])(
+    'does not intervene for non-true Billing grace value %s',
+    (isGrace) => {
+      expect(decideDunningIntervention({ ...ownerInput, isGrace })).toEqual({
+        reminderModalVisible: false,
+        copyVariant: null,
+        visiblePaymentAttempts: null,
+        showBillingAction: false,
+      });
+    },
+  );
+
+  it('suppresses the reminder and its Billing action after the shared gate activates', () => {
+    expect(
+      decideDunningIntervention({ ...ownerInput, paymentAttempts: 5, forceUpgrade: true }),
+    ).toEqual({
+      reminderModalVisible: false,
+      copyVariant: 'owner-counted',
+      visiblePaymentAttempts: 5,
+      showBillingAction: false,
+    });
+  });
+
+  it('uses the shared gate rather than the attempt count during config convergence', () => {
+    expect(
+      decideDunningIntervention({ ...ownerInput, paymentAttempts: 5, forceUpgrade: false }),
+    ).toMatchObject({
+      reminderModalVisible: true,
+      showBillingAction: true,
+    });
+  });
+
+  it('keeps the reminder dismissed for the current Admin session', () => {
+    expect(decideDunningIntervention({ ...ownerInput, modalDismissed: true })).toMatchObject({
+      reminderModalVisible: false,
+      showBillingAction: false,
+    });
+  });
+
+  it.each([undefined, null, 0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, '3'])(
+    'uses generic owner copy for invalid attempt count %s',
+    (paymentAttempts) => {
+      expect(decideDunningIntervention({ ...ownerInput, paymentAttempts })).toMatchObject({
+        copyVariant: 'owner-generic',
+        visiblePaymentAttempts: null,
+      });
+    },
+  );
+
+  it('never exposes attempt data or a pre-lock Billing action to staff', () => {
+    expect(decideDunningIntervention({ ...ownerInput, audience: 'staff' })).toEqual({
+      reminderModalVisible: true,
+      copyVariant: 'staff',
+      visiblePaymentAttempts: null,
+      showBillingAction: false,
+    });
+  });
+
+  it('suppresses the reminder for staff after the shared gate activates', () => {
+    expect(
+      decideDunningIntervention({ ...ownerInput, audience: 'staff', forceUpgrade: true }),
+    ).toMatchObject({
+      reminderModalVisible: false,
+      visiblePaymentAttempts: null,
+      showBillingAction: false,
+    });
+  });
+});

--- a/apps/admin/src/app.tsx
+++ b/apps/admin/src/app.tsx
@@ -5,6 +5,7 @@ import { EmberProvider, EmberFallback, EmberRoot } from './ember-bridge';
 import { AdminLayout } from './layout/admin-layout';
 import { useEmberAuthSync, useEmberDataSync } from './ember-bridge';
 import { DocsBotWidgetHost } from './docsbot-widget-host';
+import { DunningModal } from './dunning-modal';
 
 function App() {
   const { data: currentUser } = useCurrentUser();
@@ -18,11 +19,14 @@ function App() {
   return (
     <EmberProvider>
       {currentUser ? (
-        <AdminLayout>
-          <Outlet />
-          <EmberRoot />
-          <DocsBotWidgetHost />
-        </AdminLayout>
+        <>
+          <AdminLayout>
+            <Outlet />
+            <EmberRoot />
+            <DocsBotWidgetHost />
+          </AdminLayout>
+          <DunningModal currentUser={currentUser} />
+        </>
       ) : (
         <>
           <EmberFallback />

--- a/apps/admin/src/dunning-modal.test.tsx
+++ b/apps/admin/src/dunning-modal.test.tsx
@@ -1,0 +1,324 @@
+import { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StateBridge, StateBridgeEventMap, SubscriptionState } from './ember-bridge';
+import { DunningModal } from './dunning-modal';
+
+const navigateTo = vi.fn();
+const { mockUseBrowseConfig } = vi.hoisted(() => ({
+  mockUseBrowseConfig: vi.fn(),
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/config', () => ({
+  useBrowseConfig: mockUseBrowseConfig,
+}));
+
+vi.mock('./utils/navigation', () => ({
+  navigateTo: (route: string) => {
+    navigateTo(route);
+    return true;
+  },
+}));
+
+const owner = { roles: [{ name: 'Owner' as const }] };
+const staff = { roles: [{ name: 'Administrator' as const }] };
+
+function createStateBridge(subscriptionState: SubscriptionState | null) {
+  const listeners = new Set<(state: SubscriptionState) => void>();
+  const routeListeners = new Set<(event: StateBridgeEventMap['routeChange']) => void>();
+  let activeRoute = 'posts';
+  const stateBridge: StateBridge & {
+    emit: (state: SubscriptionState) => void;
+    setActiveRoute: (routeName: string) => void;
+  } = {
+    subscriptionState,
+    onUpdate: vi.fn(),
+    onInvalidate: vi.fn(),
+    onDelete: vi.fn(),
+    on: vi.fn(
+      <K extends keyof StateBridgeEventMap>(
+        event: K,
+        callback: (payload: StateBridgeEventMap[K]) => void,
+      ) => {
+        if (event === 'subscriptionChange') {
+          listeners.add(callback as (state: SubscriptionState) => void);
+        }
+        if (event === 'routeChange') {
+          routeListeners.add(callback as (event: StateBridgeEventMap['routeChange']) => void);
+        }
+      },
+    ),
+    off: vi.fn(
+      <K extends keyof StateBridgeEventMap>(
+        event: K,
+        callback: (payload: StateBridgeEventMap[K]) => void,
+      ) => {
+        if (event === 'subscriptionChange') {
+          listeners.delete(callback as (state: SubscriptionState) => void);
+        }
+        if (event === 'routeChange') {
+          routeListeners.delete(callback as (event: StateBridgeEventMap['routeChange']) => void);
+        }
+      },
+    ),
+    sidebarVisible: true,
+    getRouteUrl: vi.fn(),
+    isRouteActive: vi.fn((routeNames: string | string[]) => {
+      const routes = Array.isArray(routeNames) ? routeNames : routeNames.split(' ');
+      return routes.includes(activeRoute);
+    }),
+    emit(state) {
+      this.subscriptionState = state;
+      listeners.forEach((listener) => listener(state));
+    },
+    setActiveRoute(routeName) {
+      activeRoute = routeName;
+      routeListeners.forEach((listener) => listener({ routeName, queryParams: {} }));
+    },
+  };
+
+  window.EmberBridge = { state: stateBridge };
+  return stateBridge;
+}
+
+function overdueState(
+  overrides: Partial<NonNullable<SubscriptionState['subscription']>> = {},
+): SubscriptionState {
+  return {
+    isGrace: true,
+    subscription: {
+      status: 'past_due',
+      paymentAttempts: 3,
+      forceUpgrade: false,
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(() => {
+  navigateTo.mockReset();
+  mockUseBrowseConfig.mockReturnValue({
+    data: {
+      config: {
+        hostSettings: {
+          billing: {
+            enabled: true,
+          },
+        },
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  delete window.EmberBridge;
+});
+
+describe('DunningModal', () => {
+  it.each([
+    ['disabled', { data: { config: { hostSettings: { billing: { enabled: false } } } } }],
+    ['missing', { data: { config: { hostSettings: {} } } }],
+    ['still loading', { data: undefined }],
+  ])('does not render when hosted Billing is %s', (_case, configResult) => {
+    mockUseBrowseConfig.mockReturnValue(configResult);
+    createStateBridge(overdueState());
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows counted owner copy when Billing reports grace', () => {
+    createStateBridge(overdueState());
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(
+      screen.getByRole('dialog', { name: 'Your payment has failed 3 times' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update payment details' })).toBeInTheDocument();
+  });
+
+  it('does not render on the Pro route where Billing already owns the payment modal', () => {
+    const stateBridge = createStateBridge(overdueState());
+    stateBridge.setActiveRoute('pro');
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('tracks navigation into and away from the Pro route', () => {
+    const stateBridge = createStateBridge(overdueState());
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    act(() => stateBridge.setActiveRoute('pro'));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => stateBridge.setActiveRoute('posts'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('follows Billing grace changes without inferring from subscription status', () => {
+    const stateBridge = createStateBridge({
+      isGrace: false,
+      subscription: {
+        status: 'past_due',
+        paymentAttempts: 3,
+        forceUpgrade: false,
+      },
+    });
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => stateBridge.emit(overdueState()));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    act(() => stateBridge.emit({ ...overdueState(), isGrace: false }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it.each(['past_due', 'unpaid'])(
+    'does not infer dunning from the %s subscription status',
+    (status) => {
+      createStateBridge({
+        isGrace: false,
+        subscription: {
+          status,
+          paymentAttempts: 3,
+          forceUpgrade: false,
+        },
+      });
+
+      render(<DunningModal currentUser={owner} />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    },
+  );
+
+  it('keeps the dialog fixed to the viewport', () => {
+    createStateBridge(overdueState());
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.getByRole('dialog')).toHaveClass('fixed');
+    expect(screen.getByRole('dialog')).not.toHaveClass('relative');
+  });
+
+  it.each([null, 0])('uses generic owner copy for attempt count %s', (paymentAttempts) => {
+    createStateBridge(overdueState({ paymentAttempts }));
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.getByRole('dialog', { name: 'Your payment has failed' })).toBeInTheDocument();
+  });
+
+  it('uses singular copy for the first failed payment attempt', () => {
+    createStateBridge(overdueState({ paymentAttempts: 1 }));
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(
+      screen.getByRole('dialog', { name: 'Your payment has failed 1 time' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows non-sensitive staff copy without attempts or Billing controls', () => {
+    createStateBridge(overdueState({ paymentAttempts: 5 }));
+
+    render(<DunningModal currentUser={staff} />);
+
+    expect(
+      screen.getByRole('dialog', { name: 'This site’s billing needs attention' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/5/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Update payment details' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show the reminder after forceUpgrade activates', () => {
+    createStateBridge(overdueState({ forceUpgrade: true }));
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows the reminder when Billing clears forceUpgrade in the live subscription state', () => {
+    const stateBridge = createStateBridge(overdueState({ forceUpgrade: true }));
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => stateBridge.emit(overdueState({ forceUpgrade: false })));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('stays dismissed through later subscription events in the same Admin load', () => {
+    const stateBridge = createStateBridge(overdueState());
+    render(<DunningModal currentUser={owner} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss for now' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => stateBridge.emit(overdueState({ paymentAttempts: 4 })));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('dismisses with Escape', () => {
+    createStateBridge(overdueState());
+    render(<DunningModal currentUser={owner} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('does not dismiss from a backdrop interaction', async () => {
+    createStateBridge(overdueState());
+    render(<DunningModal currentUser={owner} />);
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.parentElement?.firstElementChild;
+
+    expect(backdrop).toBeTruthy();
+
+    // Radix registers its outside-pointer listener on the next task so that
+    // the interaction which opened a dialog cannot immediately close it.
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        }),
+    );
+
+    fireEvent.pointerDown(backdrop!);
+    fireEvent.click(backdrop!);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('can show again after a full React host remount', () => {
+    createStateBridge(overdueState());
+    const firstLoad = render(<DunningModal currentUser={owner} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss for now' }));
+    firstLoad.unmount();
+
+    render(<DunningModal currentUser={owner} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('dismisses before handing an owner to Billing', () => {
+    createStateBridge(overdueState());
+    render(<DunningModal currentUser={owner} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update payment details' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(navigateTo).toHaveBeenCalledWith('/pro');
+  });
+});

--- a/apps/admin/src/dunning-modal.tsx
+++ b/apps/admin/src/dunning-modal.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
+import { decideDunningIntervention } from '@tryghost/admin-x-framework/utils/dunning-intervention';
+import { isOwnerUser } from '@tryghost/admin-x-framework/api/users';
+import type { UserRoleType } from '@tryghost/admin-x-framework/api/roles';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@tryghost/shade/components';
+import { LucideIcon, formatNumber } from '@tryghost/shade/utils';
+import { useEmberRouting, useSubscriptionStatus } from './ember-bridge';
+import { navigateTo } from './utils/navigation';
+
+const DUNNING_MODAL_COPY = {
+  owner: {
+    title: 'Your payment has failed',
+    description:
+      'Update your payment details to pay the outstanding balance on your account and avoid canceling your subscription. Your site is still online.',
+  },
+  staff: {
+    title: 'This site’s billing needs attention',
+    description:
+      'Ask the site owner to update the payment details to avoid canceling the subscription. The site is still online.',
+  },
+} as const;
+
+interface DunningModalProps {
+  currentUser: {
+    roles: Array<{ name: UserRoleType }>;
+  };
+}
+
+function getTitle(
+  copyVariant: 'owner-counted' | 'owner-generic' | 'staff',
+  paymentAttempts: number | null,
+): string {
+  if (copyVariant === 'staff') {
+    return DUNNING_MODAL_COPY.staff.title;
+  }
+
+  if (copyVariant === 'owner-counted' && paymentAttempts !== null) {
+    const attemptLabel = paymentAttempts === 1 ? 'time' : 'times';
+    return `${DUNNING_MODAL_COPY.owner.title} ${formatNumber(paymentAttempts)} ${attemptLabel}`;
+  }
+
+  return DUNNING_MODAL_COPY.owner.title;
+}
+
+export function DunningModal({ currentUser }: DunningModalProps) {
+  const { data: configData } = useBrowseConfig();
+  const subscriptionState = useSubscriptionStatus();
+  const { isRouteActive } = useEmberRouting();
+  const [dismissed, setDismissed] = useState(false);
+  const audience = isOwnerUser(currentUser) ? 'owner' : 'staff';
+  const forceUpgrade = subscriptionState?.subscription?.forceUpgrade === true;
+  const decision = decideDunningIntervention({
+    isGrace: subscriptionState?.isGrace,
+    paymentAttempts: subscriptionState?.subscription?.paymentAttempts,
+    forceUpgrade,
+    audience,
+    modalDismissed: dismissed,
+  });
+
+  const billingEnabled = configData?.config.hostSettings?.billing?.enabled === true;
+  const billingOwnsModal = !forceUpgrade && isRouteActive('pro');
+
+  if (!billingEnabled || billingOwnsModal || !decision.copyVariant) {
+    return null;
+  }
+
+  const title = getTitle(decision.copyVariant, decision.visiblePaymentAttempts);
+  const description = DUNNING_MODAL_COPY[audience].description;
+
+  const dismiss = () => setDismissed(true);
+  const openBilling = () => {
+    dismiss();
+    navigateTo('/pro');
+  };
+
+  return (
+    <Dialog
+      open={decision.reminderModalVisible}
+      onOpenChange={(open) => {
+        if (!open) {
+          dismiss();
+        }
+      }}
+    >
+      <DialogContent onPointerDownOutside={(event) => event.preventDefault()}>
+        <Button
+          aria-label="Close"
+          className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={dismiss}
+        >
+          <LucideIcon.X />
+        </Button>
+        <DialogHeader className="pr-8">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={dismiss}>
+            Dismiss for now
+          </Button>
+          {decision.showBillingAction && (
+            <Button type="button" onClick={openBilling}>
+              Update payment details
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -39,6 +39,7 @@ export interface StateBridge {
     routeNames: string | string[],
     queryParams?: Record<string, string | null> | null,
   ) => boolean;
+  subscriptionState?: SubscriptionState | null;
 }
 
 declare global {
@@ -59,11 +60,14 @@ export interface EmberAuthChangeEvent {
 }
 
 export interface SubscriptionState {
-  subscription?: {
-    isActiveTrial: boolean;
-    trial_end: string | null;
+  isGrace: boolean;
+  subscription: {
+    isActiveTrial?: boolean;
+    trial_end?: string | null;
     status: string;
-  };
+    paymentAttempts: number | null;
+    forceUpgrade: boolean;
+  } | null;
 }
 
 export interface SidebarVisibilityChangeEvent {
@@ -213,18 +217,25 @@ export function useEmberAuthSync() {
   }, [queryClient]);
 }
 
-export function useSubscriptionStatus() {
-  const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionState | null>(null);
+function subscribeSubscriptionStatus(callback: () => void): () => void {
+  return onEmberStateBridgeEvent('subscriptionChange', callback, callback);
+}
 
-  useEffect(() => {
-    const handleSubscriptionChange = (payload: SubscriptionState) => {
-      setSubscriptionStatus(payload);
-    };
+/**
+ * Read the cached bridge value rather than relying on the event alone. Ember
+ * can publish Billing's initial subscription state before React mounts, so an
+ * event-only effect can miss the update for the rest of the Admin session.
+ */
+function getSubscriptionStatusSnapshot(): SubscriptionState | null {
+  return window.EmberBridge?.state.subscriptionState ?? null;
+}
 
-    return onEmberStateBridgeEvent('subscriptionChange', handleSubscriptionChange);
-  }, []);
-
-  return subscriptionStatus;
+export function useSubscriptionStatus(): SubscriptionState | null {
+  return useSyncExternalStore(
+    subscribeSubscriptionStatus,
+    getSubscriptionStatusSnapshot,
+    getSubscriptionStatusSnapshot,
+  );
 }
 
 /**

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -22,4 +22,7 @@ export type {
   EmberDataChangeEvent,
   EmberRouting,
   OpenGiftLinkModalEvent,
+  StateBridge,
+  StateBridgeEventMap,
+  SubscriptionState,
 } from './ember-bridge';

--- a/apps/admin/src/ember-bridge/subscription-state.test.tsx
+++ b/apps/admin/src/ember-bridge/subscription-state.test.tsx
@@ -1,0 +1,126 @@
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StateBridge, StateBridgeEventMap, SubscriptionState } from './ember-bridge';
+
+type SubscriptionListener = (state: SubscriptionState) => void;
+
+function createStateBridge(subscriptionState: SubscriptionState | null): StateBridge & {
+  emitSubscriptionChange: (state: SubscriptionState) => void;
+  offSpy: ReturnType<typeof vi.fn>;
+} {
+  let listener: SubscriptionListener | null = null;
+  const offSpy = vi.fn();
+
+  return {
+    subscriptionState,
+    onUpdate: vi.fn(),
+    onInvalidate: vi.fn(),
+    onDelete: vi.fn(),
+    on: vi.fn(
+      <K extends keyof StateBridgeEventMap>(
+        event: K,
+        callback: (payload: StateBridgeEventMap[K]) => void,
+      ) => {
+        if (event === 'subscriptionChange') {
+          listener = callback as SubscriptionListener;
+        }
+      },
+    ),
+    off: offSpy,
+    offSpy,
+    sidebarVisible: true,
+    getRouteUrl: vi.fn(),
+    isRouteActive: vi.fn(),
+    emitSubscriptionChange(state) {
+      this.subscriptionState = state;
+      listener?.(state);
+    },
+  };
+}
+
+function overdueSnapshot(): SubscriptionState {
+  return {
+    isGrace: true,
+    subscription: {
+      status: 'past_due',
+      paymentAttempts: 3,
+      forceUpgrade: false,
+    },
+  };
+}
+
+let useSubscriptionStatus: typeof import('./ember-bridge').useSubscriptionStatus;
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ useSubscriptionStatus } = await import('./ember-bridge'));
+});
+
+afterEach(() => {
+  delete window.EmberBridge;
+  vi.useRealTimers();
+});
+
+describe('useSubscriptionStatus', () => {
+  it('reads a subscription snapshot published before React subscribes', () => {
+    const snapshot = overdueSnapshot();
+    const stateBridge = createStateBridge(snapshot);
+    window.EmberBridge = { state: stateBridge };
+
+    const { result } = renderHook(() => useSubscriptionStatus());
+
+    expect(result.current).toBe(snapshot);
+  });
+
+  it('updates from later subscription changes', () => {
+    const stateBridge = createStateBridge(null);
+    window.EmberBridge = { state: stateBridge };
+    const { result } = renderHook(() => useSubscriptionStatus());
+
+    act(() => {
+      stateBridge.emitSubscriptionChange({
+        isGrace: true,
+        subscription: {
+          status: 'unpaid',
+          paymentAttempts: 4,
+          forceUpgrade: false,
+        },
+      });
+    });
+
+    expect(result.current).toEqual({
+      isGrace: true,
+      subscription: {
+        status: 'unpaid',
+        paymentAttempts: 4,
+        forceUpgrade: false,
+      },
+    });
+  });
+
+  it('reads the current snapshot when the Ember bridge becomes available after mounting', async () => {
+    vi.useFakeTimers();
+    const snapshot = overdueSnapshot();
+    const { result } = renderHook(() => useSubscriptionStatus());
+
+    expect(result.current).toBeNull();
+
+    window.EmberBridge = { state: createStateBridge(snapshot) };
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current).toBe(snapshot);
+  });
+
+  it('unsubscribes from subscription changes on unmount', () => {
+    const stateBridge = createStateBridge(overdueSnapshot());
+    window.EmberBridge = { state: stateBridge };
+
+    const { unmount } = renderHook(() => useSubscriptionStatus());
+    unmount();
+
+    expect(stateBridge.offSpy).toHaveBeenCalledWith('subscriptionChange', expect.any(Function));
+  });
+});

--- a/apps/ember-admin/app/components/gh-billing-iframe.js
+++ b/apps/ember-admin/app/components/gh-billing-iframe.js
@@ -147,7 +147,10 @@ export default class GhBillingIframe extends Component {
         // Reload the limit service to ensure all admin pages can enforce limits
         this.limit.reload();
 
-        this.stateBridge.triggerSubscriptionChange(data);
+        this.stateBridge.triggerSubscriptionChange({
+            ...data,
+            forceUpgrade: this.config.hostSettings?.forceUpgrade === true
+        });
 
         // Invalidate React Query cache for config data in the React admin (settings)
         if (window?.adminXQueryClient?.refetchQueries && typeof window.adminXQueryClient.refetchQueries === 'function') {
@@ -165,8 +168,9 @@ export default class GhBillingIframe extends Component {
             this.config.hostSettings.forceUpgrade = false;
         }
 
-        // Detect if the current subscription is in a grace state and render a notification
-        if (data.subscription.status === 'past_due' || data.subscription.status === 'unpaid') {
+        // Billing owns the dunning lifecycle and reports it through isGrace.
+        // React owns the separate reminder modal and its per-session dismissal state.
+        if (data?.isGrace === true) {
             // This notification needs to be shown to every user regardless their permissions to see billing
             this.notifications.showAlert(htmlSafe(`Your billing details need updating. The site owner must <a href="${this.billing.billingRouteRoot}">update payment information</a> to avoid suspension.`), {type: 'error', key: 'billing.overdue'});
         } else {

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -306,7 +306,8 @@ export default Route.extend(ShortcutsRoute, {
         // Notify React of the initial subscription state
         // React uses this to derive forceUpgrade state (config.forceUpgrade && subscription.status !== 'active')
         this.stateBridge.triggerSubscriptionChange({
-            subscription: this.billing.subscription
+            subscription: this.billing.subscription,
+            forceUpgrade: this.config.hostSettings?.forceUpgrade === true
         });
     }
 

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -40,6 +40,8 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     @inject config;
 
+    subscriptionState = null;
+
     /**
      * Gives React the same synchronous Labs route-ownership decision Ember
      * uses. Both routers must share one authority or they can each defer to
@@ -240,7 +242,27 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     @action
     triggerSubscriptionChange(data) {
-        this.trigger('subscriptionChange', data);
+        // Cache a minimal snapshot before emitting. React may mount after this
+        // event, and retaining the full Billing payload here would expose user
+        // and customer details that the Admin intervention does not need.
+        const status = typeof data?.subscription?.status === 'string' ? data.subscription.status : null;
+        const paymentAttempts = this.session.user?.isOwnerOnly === true
+            && Number.isSafeInteger(data?.user?.payment_attempts)
+            && data.user.payment_attempts >= 0
+            ? data.user.payment_attempts
+            : null;
+
+        this.subscriptionState = {
+            isGrace: data?.isGrace === true,
+            subscription: status ? {
+                status,
+                isActiveTrial: data.subscription?.isActiveTrial === true,
+                trial_end: typeof data.subscription?.trial_end === 'string' ? data.subscription.trial_end : null,
+                paymentAttempts,
+                forceUpgrade: data?.forceUpgrade === true
+            } : null
+        };
+        this.trigger('subscriptionChange', this.subscriptionState);
     }
 
     @action

--- a/apps/ember-admin/tests/integration/components/gh-billing-iframe-dunning-test.js
+++ b/apps/ember-admin/tests/integration/components/gh-billing-iframe-dunning-test.js
@@ -1,0 +1,91 @@
+import GhBillingIframe from 'ghost-admin/components/gh-billing-iframe';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find, render, settled} from '@ember/test-helpers';
+import {setupRenderingTest} from 'ember-mocha';
+
+describe('Integration: Component: gh-billing-iframe dunning state', function () {
+    setupRenderingTest();
+
+    let billing;
+    let config;
+    let notifications;
+    let triggerSubscriptionChange;
+
+    async function postBillingData(data) {
+        const iframe = find('#billing-frame');
+        window.dispatchEvent(new MessageEvent('message', {
+            data,
+            origin: 'https://billing.example.test',
+            source: iframe.contentWindow
+        }));
+        await settled();
+    }
+
+    beforeEach(function () {
+        billing = this.owner.lookup('service:billing');
+        config = this.owner.lookup('config:main');
+        notifications = this.owner.lookup('service:notifications');
+        triggerSubscriptionChange = sinon.spy();
+
+        sinon.spy(GhBillingIframe.prototype, '_handleSubscriptionUpdate');
+        sinon.stub(GhBillingIframe.prototype, 'stateBridge').get(() => ({triggerSubscriptionChange}));
+        sinon.stub(billing, 'getIframeURL').returns('https://billing.example.test/pro');
+        sinon.stub(billing, 'startBillingAppLoadMonitor');
+        sinon.stub(this.owner.lookup('service:config-manager'), 'fetch').resolves();
+        sinon.stub(this.owner.lookup('service:limit'), 'reload');
+        sinon.stub(notifications, 'showAlert');
+        sinon.stub(notifications, 'closeAlerts');
+    });
+
+    afterEach(function () {
+        billing.clearBillingAppLoadMonitor();
+        sinon.restore();
+    });
+
+    it('keeps the overdue banner and forwards an atomic forceUpgrade snapshot', async function () {
+        config.hostSettings = {...config.hostSettings, forceUpgrade: true};
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingData({
+            isGrace: true,
+            subscription: {status: 'past_due'},
+            user: {payment_attempts: 5}
+        });
+
+        expect(notifications.showAlert.calledOnce).to.be.true;
+        expect(notifications.showAlert.firstCall.args[1]).to.include({
+            type: 'error',
+            key: 'billing.overdue'
+        });
+        expect(triggerSubscriptionChange.calledWithMatch({
+            isGrace: true,
+            subscription: {status: 'past_due'},
+            user: {payment_attempts: 5},
+            forceUpgrade: true
+        })).to.be.true;
+    });
+
+    it('closes the overdue banner when Billing reports grace has ended', async function () {
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingData({
+            isGrace: false,
+            subscription: {status: 'past_due'}
+        });
+
+        expect(notifications.showAlert.called).to.be.false;
+        expect(notifications.closeAlerts.calledWith('billing.overdue')).to.be.true;
+    });
+
+    it('does not infer dunning from the subscription status', async function () {
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingData({subscription: {status: 'unpaid'}});
+
+        expect(notifications.showAlert.called).to.be.false;
+        expect(notifications.closeAlerts.calledWith('billing.overdue')).to.be.true;
+    });
+});

--- a/apps/ember-admin/tests/unit/services/state-bridge-subscription-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-subscription-test.js
@@ -1,0 +1,100 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Service: state-bridge subscription snapshot', function () {
+    setupTest();
+
+    beforeEach(function () {
+        this.owner.lookup('service:session').user = {isOwnerOnly: true};
+    });
+
+    it('stores only normalized dunning state before notifying React', function () {
+        const stateBridge = this.owner.lookup('service:state-bridge');
+        let stateObservedByListener;
+        stateBridge.on('subscriptionChange', () => {
+            stateObservedByListener = stateBridge.subscriptionState;
+        });
+
+        stateBridge.triggerSubscriptionChange({
+            isGrace: true,
+            subscription: {
+                status: 'past_due',
+                id: 'sensitive-subscription-id'
+            },
+            user: {
+                payment_attempts: 3,
+                email_address: 'billing@example.com'
+            },
+            forceUpgrade: false,
+            customer: {
+                email: 'customer@example.com'
+            }
+        });
+
+        expect(stateBridge.subscriptionState).to.deep.equal({
+            isGrace: true,
+            subscription: {
+                status: 'past_due',
+                isActiveTrial: false,
+                trial_end: null,
+                paymentAttempts: 3,
+                forceUpgrade: false
+            }
+        });
+        expect(stateObservedByListener).to.equal(stateBridge.subscriptionState);
+    });
+
+    it('normalizes malformed and missing values without throwing', function () {
+        const stateBridge = this.owner.lookup('service:state-bridge');
+
+        stateBridge.triggerSubscriptionChange({
+            subscription: null,
+            user: {payment_attempts: 'unknown'},
+            forceUpgrade: 'true'
+        });
+
+        expect(stateBridge.subscriptionState).to.deep.equal({
+            isGrace: false,
+            subscription: null
+        });
+    });
+
+    it('preserves a numeric zero payment-attempt count', function () {
+        const stateBridge = this.owner.lookup('service:state-bridge');
+
+        stateBridge.triggerSubscriptionChange({
+            isGrace: true,
+            subscription: {status: 'past_due'},
+            user: {payment_attempts: 0},
+            forceUpgrade: false
+        });
+
+        expect(stateBridge.subscriptionState.subscription.paymentAttempts).to.equal(0);
+    });
+
+    it('does not expose payment-attempt counts to staff', function () {
+        const stateBridge = this.owner.lookup('service:state-bridge');
+        this.owner.lookup('service:session').user = {isOwnerOnly: false};
+
+        stateBridge.triggerSubscriptionChange({
+            isGrace: true,
+            subscription: {status: 'past_due'},
+            user: {payment_attempts: 3},
+            forceUpgrade: false
+        });
+
+        expect(stateBridge.subscriptionState.subscription.paymentAttempts).to.be.null;
+    });
+
+    it('normalizes the Billing grace flag without deriving it from status', function () {
+        const stateBridge = this.owner.lookup('service:state-bridge');
+
+        stateBridge.triggerSubscriptionChange({
+            subscription: {status: 'unpaid'},
+            isGrace: 'true'
+        });
+
+        expect(stateBridge.subscriptionState.isGrace).to.be.false;
+    });
+});

--- a/e2e/tests/admin/billing/dunning-intervention.test.ts
+++ b/e2e/tests/admin/billing/dunning-intervention.test.ts
@@ -1,0 +1,95 @@
+import { BillingPage, SidebarPage } from '@/helpers/pages';
+import { expect, test } from '@/helpers/playwright';
+
+const MOCK_BILLING_URL = 'https://billing.mock.test';
+
+const DUNNING_BMA_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>Billing</title></head>
+<body>
+<script>
+    window.parent.postMessage({
+        isGrace: true,
+        subscription: {
+            isActiveTrial: false,
+            status: 'past_due'
+        },
+        user: {
+            payment_attempts: 3
+        }
+    }, '*');
+</script>
+</body>
+</html>
+`;
+
+test.describe('Ghost Admin - Dunning Intervention', () => {
+  test.use({
+    config: {
+      hostSettings__billing__enabled: 'true',
+      hostSettings__billing__url: MOCK_BILLING_URL,
+      hostSettings__forceUpgrade: 'false',
+    },
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.route(`${MOCK_BILLING_URL}/**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: DUNNING_BMA_HTML,
+      });
+    });
+    await page.reload();
+    await expect(
+      page.getByText('Your billing details need updating.', { exact: false }),
+    ).toBeVisible();
+  });
+
+  test('shows the reminder once per Admin load while retaining the overdue banner', async ({
+    page,
+  }) => {
+    const sidebarPage = new SidebarPage(page);
+    const billingPage = new BillingPage(page);
+    const reminder = page.getByRole('dialog', { name: 'Your payment has failed 3 times' });
+    const overdueBanner = page.getByText('Your billing details need updating.', { exact: false });
+
+    await sidebarPage.goto('/ghost/#/posts');
+
+    await expect(reminder).toBeVisible();
+    await expect(overdueBanner).toBeVisible();
+
+    await reminder.getByRole('button', { name: 'Dismiss for now' }).click();
+    await expect(reminder).toBeHidden();
+    await expect(overdueBanner).toBeVisible();
+
+    await sidebarPage.getNavLink('Members').click();
+    await expect(page).toHaveURL(/#\/members/);
+    await expect(reminder).toBeHidden();
+    await expect(overdueBanner).toBeVisible();
+
+    await page.reload();
+    await expect(reminder).toBeVisible();
+
+    await reminder.getByRole('button', { name: 'Update payment details' }).click();
+    await expect(reminder).toBeHidden();
+    await expect(page).toHaveURL(/#\/pro/);
+    await expect(await billingPage.waitForBillingIframe()).toBeVisible();
+  });
+
+  test('leaves payment recovery to Billing on the Pro route', async ({ page }) => {
+    const sidebarPage = new SidebarPage(page);
+    const billingPage = new BillingPage(page);
+    const reminder = page.getByRole('dialog', { name: 'Your payment has failed 3 times' });
+
+    await sidebarPage.goto('/ghost/#/pro');
+
+    await expect(page).toHaveURL(/#\/pro/);
+    await expect(await billingPage.waitForBillingIframe()).toBeVisible();
+    await expect(reminder).toBeHidden();
+    await expect(
+      page.getByText('Your billing details need updating.', { exact: false }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/tests/admin/billing/force-upgrade.test.ts
+++ b/e2e/tests/admin/billing/force-upgrade.test.ts
@@ -20,6 +20,7 @@ const FORCE_UPGRADE_BMA_HTML = `
     });
 
     window.parent.postMessage({
+        isGrace: true,
         subscription: {
             isActiveTrial: false,
             status: 'past_due'
@@ -47,6 +48,15 @@ test.describe('Ghost Admin - Force Upgrade Mode', () => {
         body: FORCE_UPGRADE_BMA_HTML,
       });
     });
+  });
+
+  test('shows the overdue banner without the dunning modal', async ({ page }) => {
+    await page.reload();
+
+    await expect(
+      page.getByText('Your billing details need updating.', { exact: false }),
+    ).toBeVisible();
+    await expect(page.getByRole('dialog', { name: /Your payment has failed/ })).toBeHidden();
   });
 
   test('sidebar navigation is blocked by billing iframe', async ({ page }) => {


### PR DESCRIPTION
closes [GVA-972](https://linear.app/ghost/issue/GVA-972/ghost-add-the-dunning-modal-alongside-the-existing-overdue-banner)

## What changed

- consumes Billing's top-level `isGrace` postMessage property as the sole dunning authority for both the retained Ember banner and the React modal; Ghost no longer derives dunning from subscription statuses
- adds a React-owned Shade reminder modal while retaining the existing Ember overdue banner
- renders a positive `user.payment_attempts` count for owners, with generic payment-failure copy when the count is missing, malformed, or zero
- provides non-sensitive staff presentation without payment-attempt details or Billing controls when staff dunning state becomes available
- strips payment-attempt counts at the Ember bridge boundary for non-owner sessions rather than relying on presentation code to hide them
- dismisses the modal for the current Admin load while leaving the banner visible; a full reload can show the modal again
- routes the owner payment action to `/pro`
- suppresses the modal while the existing `forceUpgrade` gate is active, without suppressing the overdue banner
- caches and replays a minimal Ember-to-React subscription snapshot so an initial Billing update cannot race the React host
- adds browser coverage for ordinary dunning and the locked `forceUpgrade` state

Missing, false, or malformed `isGrace` values fail closed. Subscription status remains in the bridge only for the separate stale-`forceUpgrade` recovery safeguard.

## Deliberate spec exception

GVA-972 asks Admin not to optimistically clear `forceUpgrade`. We are deliberately retaining the existing clearing behavior after Billing reports an active subscription because hosted config can lag the actual recovered subscription. This was confirmed as required for production recovery cases.

## Dependency boundaries

- [GVA-980](https://linear.app/ghost/issue/GVA-980/billing-guarantee-payment-attempts-in-ghost-subscription-updates) still owns Billing guaranteeing `user.payment_attempts`. Ghost preserves the numeric field at the owner-only bridge boundary, including zero, but only positive values are presented as attempt counts.
- [GVA-981](https://linear.app/ghost/issue/GVA-981/discovery-define-secure-staff-access-to-site-dunning-state) still owns secure live delivery of dunning state to ordinary staff. The privacy-safe staff presentation is implemented and tested for when that state is supplied.

## Testing

- framework decision tests: 20 passed
- React modal and subscription bridge tests: 19 passed
- focused Ember bridge and Billing iframe tests: 8 passed
- Admin typecheck and scoped lint: passed
- framework source declaration build and scoped lint: passed
- E2E typecheck and scoped lint: passed
- dunning intervention E2E: passed
- locked `forceUpgrade` banner-without-modal E2E: passed
- `pnpm check`: reached formatting and stopped on unrelated pre-existing untracked/generated app artifacts in the shared workspace; all in-scope files pass formatter checks
- full framework test typecheck remains blocked by pre-existing `member-custom-fields.test.ts` fixture errors unrelated to this change
