### PR TITLE
Changed the user menu sign-out to use the framework session API

### DIFF
--- a/apps/admin-x-framework/src/api/session.ts
+++ b/apps/admin-x-framework/src/api/session.ts
@@ -1,0 +1,7 @@
+import {createMutation} from '../utils/api/hooks';
+
+// The server replies 204 No Content on sign-out, so the mutation resolves with no data.
+export const useDeleteSession = createMutation<void, null>({
+    method: 'DELETE',
+    path: () => '/session/'
+});

--- a/apps/admin-x-framework/test/unit/api/session.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/session.test.tsx
@@ -1,0 +1,23 @@
+import {act} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+import {renderHookWithProviders} from '../../../src/test/test-utils';
+import {useDeleteSession} from '../../../src/api/session';
+import {withMockFetch} from '../../utils/mock-fetch';
+
+describe('session api', () => {
+    it('signs out via DELETE and resolves the 204 with no data', async () => {
+        await withMockFetch({status: 204}, async (mock) => {
+            const {result} = renderHookWithProviders(() => useDeleteSession());
+
+            let response: unknown = 'unset';
+            await act(async () => {
+                response = await result.current.mutateAsync(null);
+            });
+
+            expect(mock.calls[0][0]).toBe('http://localhost:3000/ghost/api/admin/session/');
+            expect(mock.calls[0][1].method).toBe('DELETE');
+            expect(mock.calls[0][1].credentials).toBe('include');
+            expect(response).toBeUndefined();
+        });
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -3,7 +3,9 @@ import React from "react"
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger, Indicator, SidebarMenuButton} from "@tryghost/shade/components"
 import {LucideIcon} from "@tryghost/shade/utils"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
+import { useDeleteSession } from "@tryghost/admin-x-framework/api/session";
 import { getGhostPaths } from "@tryghost/admin-x-framework/helpers";
+import { toast } from "sonner";
 import { useTheme, type ThemeMode } from "@/hooks/use-theme";
 import { useWhatsNew } from "@/whats-new/hooks/use-whats-new";
 import { useUpgradeStatus } from "./hooks/use-upgrade-status";
@@ -77,22 +79,25 @@ function UserMenuAppearance() {
 }
 
 function UserMenuSignOut() {
-    const handleSignOut = () => {
-        const {apiRoot, adminRoot} = getGhostPaths();
-        fetch(`${apiRoot}/session`, {
-            method: "DELETE",
-        }).then(() => {
-            window.location.href = adminRoot;
-        }).catch((error) => {
-            // eslint-disable-next-line no-console
-            console.error(error);
-        });
+    const {mutateAsync: deleteSession} = useDeleteSession();
+
+    const handleSignOut = async () => {
+        try {
+            await deleteSession(null);
+            // Full page load, not a router navigation: the session is gone, so
+            // the app must reboot unauthenticated
+            window.location.href = getGhostPaths().adminRoot;
+        } catch {
+            toast.error("Couldn't sign out. Please try again.");
+        }
     };
 
     return (
         <UserMenuItem
             asChild={false}
-            onSelect={handleSignOut}
+            onSelect={() => {
+                void handleSignOut();
+            }}
         >
             <LucideIcon.LogOut />
             <UserMenuItem.Label>Sign out</UserMenuItem.Label>

--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -153,6 +153,19 @@ describe("Sidebar user menu", () => {
         await expect.poll(currentRoute).toMatch(/^\/settings\/staff\//);
     });
 
+    it("signs out through the session API and surfaces a failed sign-out", async () => {
+        // Success intentionally navigates to /ghost/ after the session is
+        // deleted; an error response keeps the page alive for assertions.
+        const api = fakeAdminEndpoint("DELETE", "/session/", { errors: [{ message: "stop after request" }] }, { status: 400 });
+        await renderAdminApp("/site");
+
+        await sidebarScreen.userMenuTrigger().click();
+        await sidebarScreen.signOutMenuItem().click();
+
+        await expect.poll(() => api.requests.length).toBe(1);
+        await expect.element(sidebarScreen.errorToast()).toHaveTextContent("Couldn't sign out. Please try again.");
+    });
+
     it("switches the appearance and shows the current choice", async () => {
         // Without the Ember bridge the app itself toggles the root dark class.
         const isDarkMode = () => document.documentElement.classList.contains("dark");

--- a/apps/admin/src/layout/sidebar.screen.ts
+++ b/apps/admin/src/layout/sidebar.screen.ts
@@ -35,6 +35,7 @@ export const sidebarScreen = {
     appearanceMenuItem: () => page.getByRole("menuitem", { name: appearanceMenuItem }),
     appearanceOption: (option: "dark" | "light" | "system") =>
         page.getByRole("menuitem", { name: appearanceOptions[option] }),
+    errorToast: () => page.getByRole("region", { name: /Notifications/ }).getByRole("listitem"),
     themeErrorsBanner: () => page.getByRole("status").filter({ hasText: themeErrorsBannerText }),
     themeErrorsDialog: () => page.getByRole("dialog", { name: themeErrorsDialog }),
 


### PR DESCRIPTION
The React user menu signed out with a bare `fetch` that skipped the framework fetch layer's credentials/headers/retry/typed-error handling, and a failure only logged to the console.

- New `admin-x-framework/src/api/session.ts` resource: `useDeleteSession` via `createMutation` (`DELETE /session/`). The server replies 204 No Content (`session/middleware.js` → `sendStatus(204)`), which the fetch layer's 204 branch resolves as no data. The trailing-slash path still matches fetch-api's session-request detection, so a 401 during sign-out throws a plain error instead of triggering the session-expiry redirect loop. No `updateQueries`/`invalidateQueries` — matches the neighbor pattern for action mutations followed by a full page load (`useDeleteAllContent`, `useResetAuth`).
- `user-menu.tsx` uses the hook; success keeps the full-page `window.location.href = adminRoot` reload (the app must reboot unauthenticated), failure surfaces `toast.error("Couldn't sign out. Please try again.")` instead of a silent `console.error`.
- Framework unit test mirrors the `db.test.tsx` idiom (URL, method, credentials, 204 → undefined). One new acceptance case in the sidebar spec exercises the failure path (400 fake → request captured + error toast), following the auth-reset precedent — the success path intentionally navigates away, which would kill the browser-mode page.

**Verification:** framework `pnpm build` + `test:unit` (495 tests) + lint green; admin `tsc -b`, eslint, `test:unit` (1604) green; `pnpm test:acceptance src/layout` 19/19 first run.