### PR TITLE
Deduplicated viem in the production image and added image size reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1819,6 +1819,152 @@ jobs:
           path: docker-image-e2e.tar.gz
           retention-days: 1
 
+      # `Inspect image size and layers` above only runs on the artifact path, where
+      # the image is loaded into the local daemon. On the push path nothing is
+      # loaded, so size comes from the registry manifest instead — and is compared
+      # against the image CI built for the base commit, which is what makes a
+      # dependency's cost visible on the PR that adds it.
+      #
+      # Last in the job on purpose: these steps are informational, and job_docker
+      # gates the e2e lane and the release lane. They never delay the e2e image, and
+      # on tag runs they never strand a half-published release.
+      - name: Report image size
+        if: steps.strategy.outputs.should-push == 'true'
+        continue-on-error: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        env:
+          CORE_IMAGE: ${{ steps.strategy.outputs.image-core-name }}
+          FULL_IMAGE: ${{ steps.strategy.outputs.image-full-name }}
+          CORE_TAGS: ${{ steps.meta-core.outputs.tags }}
+          FULL_TAGS: ${{ steps.meta-full.outputs.tags }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -uo pipefail
+
+          # Sum of compressed layer sizes — what a pull actually costs. buildx
+          # attaches a provenance manifest, so a tag resolves to an index: pick the
+          # real platform manifest out of it before summing.
+          layer_bytes() { # <image> <tag>
+            local image="$1" raw digest
+            raw=$(docker buildx imagetools inspect "${image}:$2" --raw 2>/dev/null) || return 1
+            if jq -e 'has("manifests")' <<< "$raw" > /dev/null 2>&1; then
+              digest=$(jq -r 'first(.manifests[] | select((.platform.architecture // "unknown") != "unknown") | .digest) // empty' <<< "$raw")
+              [ -n "$digest" ] || return 1
+              raw=$(docker buildx imagetools inspect "${image}@${digest}" --raw 2>/dev/null) || return 1
+            fi
+            jq -e '[.layers[].size] | add' <<< "$raw" 2>/dev/null
+          }
+
+          mib() { awk -v b="$1" 'BEGIN {printf "%.1f MiB", b / 1048576}'; }
+          delta() { awk -v b="$1" 'BEGIN {printf "%s%.1f MiB", (b < 0 ? "-" : "+"), (b < 0 ? -b : b) / 1048576}'; }
+
+          # Every main build tags `sha-<short>` (metadata-action type=sha), so the
+          # PR base commit / previous main commit is an exact like-for-like baseline.
+          # The zero SHA is what a branch's first push reports as `before`.
+          BASE_TAG=""
+          case "$BASE_SHA" in
+            ""|0000000*) ;;
+            *) BASE_TAG="sha-${BASE_SHA:0:7}" ;;
+          esac
+
+          {
+            echo "## Docker image size"
+            echo ""
+            echo "Compressed layer totals from the registry manifest."
+            echo ""
+            echo "| Image | This build | \`${BASE_TAG:-no baseline}\` | Delta |"
+            echo "|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          report() { # <label> <image> <tag-list>
+            local label="$1" image="$2" tag size base
+            tag=$(head -n1 <<< "$3")
+            tag="${tag##*:}"
+
+            if ! size=$(layer_bytes "$image" "$tag"); then
+              echo "| $label | inspect failed | | |" >> "$GITHUB_STEP_SUMMARY"
+              return
+            fi
+
+            if [ -n "$BASE_TAG" ] && base=$(layer_bytes "$image" "$BASE_TAG"); then
+              echo "| $label | $(mib "$size") | $(mib "$base") | **$(delta $((size - base)))** |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $label | $(mib "$size") | not built | - |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
+          report core "$CORE_IMAGE" "$CORE_TAGS"
+          report full "$FULL_IMAGE" "$FULL_TAGS"
+
+      # Image bytes are gzipped, which flattens exactly the regression this is meant
+      # to catch: a peer-forked duplicate of a large dependency reads as a couple of
+      # megabytes. The report stage carries per-package sizes and file counts of the
+      # pruned production node_modules, so the diff below names the dependency.
+      #
+      # Every layer under `report` is already cached from the core build, so this is
+      # an export rather than a rebuild. The output goes to RUNNER_TEMP for the same
+      # reason the other artifacts do: a stray file in the repo root would change the
+      # `.` context and bust the deploy-stage COPY cache.
+      - name: Build dependency size report
+        if: steps.strategy.outputs.should-push == 'true'
+        continue-on-error: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile.production
+          target: report
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+          outputs: type=local,dest=${{ runner.temp }}/image-report
+          cache-from: type=registry,ref=${{ steps.strategy.outputs.image-core-name }}:cache-main
+
+      - name: Upload dependency size report
+        if: steps.strategy.outputs.should-push == 'true'
+        continue-on-error: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: image-report
+          path: ${{ runner.temp }}/image-report/image-report.json
+          if-no-files-found: error
+
+      # This job deliberately has no pnpm setup (the build is in-container), but the
+      # comparison is a plain node script with no dependencies — node alone is enough.
+      - name: Set up Node.js
+        if: steps.strategy.outputs.should-push == 'true'
+        continue-on-error: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Compare dependency sizes against base commit
+        if: steps.strategy.outputs.should-push == 'true'
+        continue-on-error: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -uo pipefail
+
+          # The base commit's own CI run uploaded this artifact. Missing is normal —
+          # the run may have expired, been skipped, or predate this step — and the
+          # script renders totals without a baseline in that case.
+          ARGS=(
+            "--current=${RUNNER_TEMP}/image-report/image-report.json"
+            "--baseline-label=${BASE_SHA:0:7}"
+          )
+
+          RUN_ID=$(gh run list --commit "$BASE_SHA" --workflow ci.yml --limit 1 \
+            --json databaseId --jq '.[0].databaseId' 2>/dev/null) || RUN_ID=""
+
+          if [ -n "$RUN_ID" ] && gh run download "$RUN_ID" --name image-report \
+            --dir "${RUNNER_TEMP}/baseline-report" 2>/dev/null; then
+            ARGS+=("--baseline=${RUNNER_TEMP}/baseline-report/image-report.json")
+          fi
+
+          node scripts/compare-image-report.js "${ARGS[@]}" >> "$GITHUB_STEP_SUMMARY"
+
+
     outputs:
       use-artifact: ${{ steps.strategy.outputs.use-artifact }}
       image-core-tags: ${{ steps.meta-core.outputs.tags }}

--- a/.pnpmfile.mjs
+++ b/.pnpmfile.mjs
@@ -97,6 +97,16 @@ function readPackage(pkg) {
         delete pkg.peerDependenciesMeta?.typescript;
     }
 
+    // abitype's zod peer is only used by its `abitype/zod` subpath, which nothing
+    // in the tree imports. Left in place it peer-forks abitype and everything
+    // above it: mppx resolves that chain against zod 4 and @x402/* against zod 3,
+    // so ghost's production closure carried two identical copies of viem (~2.9k
+    // files each), ox and abitype.
+    if (pkg.name === 'abitype') {
+        delete pkg.peerDependencies?.zod;
+        delete pkg.peerDependenciesMeta?.zod;
+    }
+
     return pkg;
 }
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -4,6 +4,7 @@
 # Targets:
 #   deploy — build the prod dependency closure + a self-contained /home/ghost
 #            (build-only stage, never shipped)
+#   report — per-package sizes of that closure, for CI (build-only, not shipped)
 #   core — server + production deps, no admin (Ghost-Pro base)
 #   full — core + built admin (self-hosting)
 #
@@ -78,11 +79,20 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
 # ghost/core/scripts/prune.mts for the rules and the exclusions they carry. The COPY
 # layer below is extracted single-threaded, once per CI E2E shard, and that cost
 # scales with file count: this removes roughly half of them.
-RUN node ghost/core/scripts/prune.mts /home/ghost --profile=image
+RUN node ghost/core/scripts/prune.mts /home/ghost --profile=image --report=/image-report.json
 
 # Fail the build now if the native module didn't install correctly (missing/broken
 # prebuilt binary) rather than at container runtime.
 RUN cd /home/ghost && node -e "require('better-sqlite3'); console.log('better-sqlite3 OK')"
+
+# ---- report: per-package sizes of the shipped node_modules (build-only) ----
+# CI extracts this with `--target=report --output=type=local` and diffs it against
+# the base commit's report, so a dependency that duplicates a large package (a
+# peer-forked viem, say) is visible on the PR that adds it. Every layer in `deploy`
+# is already cached by the core build, so this target costs an export, not a build.
+FROM scratch AS report
+
+COPY --from=deploy /image-report.json /
 
 # ---- Core: server + production deps ----
 FROM node:$NODE_VERSION-bookworm-slim AS core

--- a/ghost/core/scripts/prune.mts
+++ b/ghost/core/scripts/prune.mts
@@ -40,15 +40,32 @@ interface Rule {
     match: (rel: string) => boolean;
 }
 
+interface Stats {
+    files: number;
+    bytes: number;
+}
+
 export interface PruneResult {
     total: number;
     removed: number;
     bytes: number;
-    byRule: Record<string, {files: number, bytes: number}>;
+    byRule: Record<string, Stats>;
+    /** Surviving bytes per package, present only when `measure` was set. */
+    kept?: Record<string, Stats>;
 }
 
 // Path of this file, relative to the roots both profiles are pointed at.
 const SELF = 'scripts/prune.mts';
+
+/**
+ * Which package a file belongs to. pnpm's virtual store directory name carries
+ * name@version plus any peer suffix, so two peer-forked copies of one version
+ * bucket separately — that duplication is what the report exists to surface.
+ */
+const bucketOf = (rel: string): string => {
+    const match = /^node_modules\/\.pnpm\/([^/]+)\//.exec(rel);
+    return match ? match[1] : '(app)';
+};
 
 // Script files are never build inputs, whatever directory they sit in.
 const isScript = (base: string): boolean => /\.(js|json|mjs|cjs|node)$/.test(base);
@@ -137,13 +154,14 @@ async function* walk(dir: string, prefix = ''): AsyncGenerator<string> {
     }
 }
 
-export async function prune(target: string, {profile, dryRun = false}: {profile: Profile, dryRun?: boolean}): Promise<PruneResult> {
+export async function prune(target: string, {profile, dryRun = false, measure = false}: {profile: Profile, dryRun?: boolean, measure?: boolean}): Promise<PruneResult> {
     if (!PROFILES.includes(profile)) {
         throw new Error(`Unknown profile "${profile}" (expected one of: ${PROFILES.join(', ')})`);
     }
 
     const rules = RULES.filter(rule => rule.profiles.includes(profile));
     const byRule = Object.fromEntries(rules.map(rule => [rule.name, {files: 0, bytes: 0}]));
+    const kept: Record<string, Stats> = {};
     let total = 0;
     let removed = 0;
     let bytes = 0;
@@ -152,6 +170,11 @@ export async function prune(target: string, {profile, dryRun = false}: {profile:
         total += 1;
         const rule = rules.find(r => r.match(rel));
         if (!rule) {
+            if (measure) {
+                const bucket = kept[bucketOf(rel)] ??= {files: 0, bytes: 0};
+                bucket.files += 1;
+                bucket.bytes += (await fs.stat(path.join(target, rel))).size;
+            }
             continue;
         }
 
@@ -167,7 +190,7 @@ export async function prune(target: string, {profile, dryRun = false}: {profile:
         bytes += size;
     }
 
-    return {total, removed, bytes, byRule};
+    return {total, removed, bytes, byRule, ...(measure ? {kept} : {})};
 }
 
 const mib = (value: number): string => `${(value / 1024 / 1024).toFixed(1)} MiB`;
@@ -191,18 +214,30 @@ if (import.meta.main) {
         allowPositionals: true,
         options: {
             profile: {type: 'string'},
-            'dry-run': {type: 'boolean', default: false}
+            'dry-run': {type: 'boolean', default: false},
+            // Per-package sizes of what survives, for the CI image-size diff.
+            report: {type: 'string'}
         }
     });
 
     const [target] = positionals;
     const profile = values.profile as Profile | undefined;
     if (!target || !profile) {
-        console.error('Usage: prune.mts <target-dir> --profile=<image|archive> [--dry-run]');
+        console.error('Usage: prune.mts <target-dir> --profile=<image|archive> [--dry-run] [--report=<file>]');
         process.exit(1);
     }
 
     console.log(`Pruning ${target} (profile: ${profile})`);
-    const result = await prune(path.resolve(target), {profile, dryRun: values['dry-run']});
+    const result = await prune(path.resolve(target), {profile, dryRun: values['dry-run'], measure: Boolean(values.report)});
     reportPrune(result, {dryRun: values['dry-run']});
+
+    if (values.report && result.kept) {
+        const packages = result.kept;
+        const total = Object.values(packages).reduce(
+            (acc, stats) => ({files: acc.files + stats.files, bytes: acc.bytes + stats.bytes}),
+            {files: 0, bytes: 0}
+        );
+        await fs.writeFile(values.report, `${JSON.stringify({profile, total, packages}, null, 2)}\n`);
+        console.log(`  wrote ${values.report} (${Object.keys(packages).length} packages, ${total.files} files, ${mib(total.bytes)})`);
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,7 +576,7 @@ overrides:
 
 packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
 
-pnpmfileChecksum: sha256-vX5m8UV/5UV1RC2MtGGtGPIhxO5dALiZpI8kj5FiogI=
+pnpmfileChecksum: sha256-4tExOaScfF/Xe/itfeX6QEi9DhOvj8PQhpwiCXRO8bk=
 
 importers:
 
@@ -2622,7 +2622,7 @@ importers:
         version: 0.5.45
       mppx:
         specifier: 'catalog:'
-        version: 0.6.20(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11(zod@4.4.3))
+        version: 0.6.20(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11)
       multer:
         specifier: 2.2.0
         version: 2.2.0
@@ -10483,19 +10483,9 @@ packages:
 
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
-    peerDependencies:
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   abitype@1.3.0:
     resolution: {integrity: sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==}
-    peerDependencies:
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -27816,11 +27806,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.2.0(viem@2.55.11(zod@4.4.3))':
+  '@signinwithethereum/siwe@4.2.0(viem@2.55.11)':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.2.0
     optionalDependencies:
-      viem: 2.55.11(zod@4.4.3)
+      viem: 2.55.11
 
   '@simple-dom/document@1.4.0':
     dependencies:
@@ -30542,7 +30532,7 @@ snapshots:
   '@x402/evm@2.12.0':
     dependencies:
       '@x402/core': 2.12.0
-      viem: 2.55.11(zod@3.25.76)
+      viem: 2.55.11
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -30552,12 +30542,12 @@ snapshots:
     dependencies:
       '@noble/curves': 1.9.7
       '@scure/base': 1.2.6
-      '@signinwithethereum/siwe': 4.2.0(viem@2.55.11(zod@4.4.3))
+      '@signinwithethereum/siwe': 4.2.0(viem@2.55.11)
       '@x402/core': 2.12.0
       ajv: 8.20.0
       jose: 5.10.0
       tweetnacl: 1.0.3
-      viem: 2.55.11(zod@3.25.76)
+      viem: 2.55.11
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -30619,21 +30609,9 @@ snapshots:
 
   abbrev@5.0.0: {}
 
-  abitype@1.2.3(zod@3.25.76):
-    optionalDependencies:
-      zod: 3.25.76
+  abitype@1.2.3: {}
 
-  abitype@1.2.3(zod@4.4.3):
-    optionalDependencies:
-      zod: 4.4.3
-
-  abitype@1.3.0(zod@3.25.76):
-    optionalDependencies:
-      zod: 3.25.76
-
-  abitype@1.3.0(zod@4.4.3):
-    optionalDependencies:
-      zod: 4.4.3
+  abitype@1.3.0: {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -41213,11 +41191,11 @@ snapshots:
       rimraf: 2.7.1
       run-queue: 1.0.3
 
-  mppx@0.6.20(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11(zod@4.4.3)):
+  mppx@0.6.20(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11):
     dependencies:
       incur: 0.4.26
-      ox: 0.14.20(zod@4.4.3)
-      viem: 2.55.11(zod@4.4.3)
+      ox: 0.14.20
+      viem: 2.55.11
       zod: 4.4.3
     optionalDependencies:
       express: 4.22.2(supports-color@10.2.2)
@@ -41979,7 +41957,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.20(zod@4.4.3):
+  ox@0.14.20:
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -41987,12 +41965,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.3.0(zod@4.4.3)
+      abitype: 1.3.0
       eventemitter3: 5.0.1
-    transitivePeerDependencies:
-      - zod
 
-  ox@0.14.33(zod@3.25.76):
+  ox@0.14.33:
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -42000,23 +41976,8 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.3.0(zod@3.25.76)
+      abitype: 1.3.0
       eventemitter3: 5.0.1
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.14.33(zod@4.4.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.3.0(zod@4.4.3)
-      eventemitter3: 5.0.1
-    transitivePeerDependencies:
-      - zod
 
   oxc-parser@0.127.0:
     dependencies:
@@ -46560,35 +46521,19 @@ snapshots:
 
   video-extensions@2.0.0: {}
 
-  viem@2.55.11(zod@3.25.76):
+  viem@2.55.11:
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(zod@3.25.76)
+      abitype: 1.2.3
       isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.33(zod@3.25.76)
+      ox: 0.14.33
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-      - zod
-
-  viem@2.55.11(zod@4.4.3):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(zod@4.4.3)
-      isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.33(zod@4.4.3)
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
 
   vinyl-contents@2.0.0:
     dependencies:

--- a/scripts/compare-image-report.js
+++ b/scripts/compare-image-report.js
@@ -1,0 +1,207 @@
+// Diffs two image reports written by ghost/core/scripts/prune.mts --report and
+// renders the result as markdown for a CI step summary.
+//
+// The reports measure what actually ships: per-package byte and file counts of
+// the pruned production node_modules. Image bytes alone hide this — gzip makes a
+// duplicated 2.9k-file copy of viem look like a couple of megabytes — so the
+// per-package view is what tells you *which* dependency moved the number.
+//
+// Runs on bare node in job_docker, which has no pnpm install: node builtins only.
+
+import fs from 'node:fs/promises';
+import {parseArgs} from 'node:util';
+
+/**
+ * @typedef {{files: number, bytes: number}} Stats
+ * @typedef {{profile: string, total: Stats, packages: Record<string, Stats>}} Report
+ */
+
+const EMPTY = {files: 0, bytes: 0};
+
+/** Packages listed individually in the diff table. */
+const TOP_N = 15;
+
+/**
+ * pnpm's virtual store directory name is `name@version` plus a `_`-separated
+ * suffix for each peer it was resolved against. Two ids that share an identity
+ * but differ in suffix are the same published tarball unpacked twice.
+ *
+ * Splitting on the first `_` is wrong — `string_decoder` and the `lodash._*`
+ * family carry one in the name — so find the version separator first. A scoped
+ * name is written `@scope+pkg`, which puts its own `@` in front of the version's.
+ *
+ * @param {string} id - a virtual store directory name, e.g. `viem@2.55.11_zod@3.25.76`
+ * @returns {string}
+ */
+export function identityOf(id) {
+    const versionAt = id.indexOf('@', id.startsWith('@') ? 1 : 0);
+    if (versionAt === -1) {
+        return id;
+    }
+
+    const suffixAt = id.indexOf('_', versionAt);
+    return suffixAt === -1 ? id : id.slice(0, suffixAt);
+}
+
+const mib = bytes => `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+const signed = (value, format) => `${value > 0 ? '+' : value < 0 ? '−' : '±'}${format(Math.abs(value))}`;
+const signedMib = bytes => signed(bytes, mib);
+const signedCount = count => signed(count, String);
+
+/**
+ * Per-package deltas, largest absolute byte change first.
+ *
+ * @param {Report} current
+ * @param {Report} baseline
+ * @returns {Array<{id: string, bytes: number, files: number, status: 'added'|'removed'|'changed'}>}
+ */
+export function diffPackages(current, baseline) {
+    const ids = new Set([...Object.keys(current.packages), ...Object.keys(baseline.packages)]);
+
+    return [...ids]
+        .map((id) => {
+            const now = current.packages[id] ?? EMPTY;
+            const before = baseline.packages[id] ?? EMPTY;
+            const status = !(id in baseline.packages) ? 'added' : !(id in current.packages) ? 'removed' : 'changed';
+            return {id, bytes: now.bytes - before.bytes, files: now.files - before.files, status};
+        })
+        .filter(entry => entry.bytes !== 0 || entry.files !== 0)
+        .sort((a, b) => Math.abs(b.bytes) - Math.abs(a.bytes));
+}
+
+/**
+ * Packages unpacked more than once because a peer forked them. Reported for the
+ * current build only — it is a standing property of the tree, not a delta.
+ *
+ * @param {Report} report
+ * @returns {Array<{identity: string, instances: string[], bytes: number}>}
+ */
+export function duplicateInstances(report) {
+    /** @type {Map<string, string[]>} */
+    const byIdentity = new Map();
+    for (const id of Object.keys(report.packages)) {
+        if (id === '(app)') {
+            continue;
+        }
+        const identity = identityOf(id);
+        byIdentity.set(identity, [...(byIdentity.get(identity) ?? []), id]);
+    }
+
+    return [...byIdentity]
+        .filter(([, instances]) => instances.length > 1)
+        .map(([identity, instances]) => ({
+            identity,
+            instances: instances.sort(),
+            // What deduplicating would save: everything past the first copy.
+            bytes: instances
+                .map(id => report.packages[id].bytes)
+                .sort((a, b) => b - a)
+                .slice(1)
+                .reduce((sum, bytes) => sum + bytes, 0)
+        }))
+        .sort((a, b) => b.bytes - a.bytes);
+}
+
+/**
+ * @param {Report} current
+ * @param {Report | null} baseline
+ * @param {{baselineLabel?: string}} [options]
+ * @returns {string}
+ */
+export function render(current, baseline, {baselineLabel = 'base'} = {}) {
+    const lines = ['## Production dependency size', ''];
+
+    if (baseline) {
+        const bytes = current.total.bytes - baseline.total.bytes;
+        const files = current.total.files - baseline.total.files;
+
+        lines.push(
+            `| | This build | \`${baselineLabel}\` | Delta |`,
+            '|---|---|---|---|',
+            `| Size | ${mib(current.total.bytes)} | ${mib(baseline.total.bytes)} | **${signedMib(bytes)}** |`,
+            `| Files | ${current.total.files} | ${baseline.total.files} | **${signedCount(files)}** |`,
+            ''
+        );
+
+        const changed = diffPackages(current, baseline);
+        if (changed.length === 0) {
+            lines.push('No package-level changes.', '');
+        } else {
+            lines.push(
+                `### Changed packages (${changed.length})`,
+                '',
+                '| Package | Size | Files | |',
+                '|---|---|---|---|'
+            );
+            for (const entry of changed.slice(0, TOP_N)) {
+                const note = entry.status === 'changed' ? '' : entry.status;
+                lines.push(`| \`${entry.id}\` | ${signedMib(entry.bytes)} | ${signedCount(entry.files)} | ${note} |`);
+            }
+            if (changed.length > TOP_N) {
+                lines.push(`| _… ${changed.length - TOP_N} more_ | | | |`);
+            }
+            lines.push('');
+        }
+    } else {
+        lines.push(
+            `No baseline report for \`${baselineLabel}\` — showing totals only.`,
+            '',
+            `**Size:** ${mib(current.total.bytes)} across ${current.total.files} files in ${Object.keys(current.packages).length} packages.`,
+            ''
+        );
+    }
+
+    const duplicates = duplicateInstances(current);
+    if (duplicates.length > 0) {
+        const wasted = duplicates.reduce((sum, entry) => sum + entry.bytes, 0);
+        lines.push(
+            `### Duplicated packages (${duplicates.length}, ${mib(wasted)} recoverable)`,
+            '',
+            'Same version unpacked more than once because a peer dependency forked it.',
+            '',
+            '| Package | Copies | Recoverable |',
+            '|---|---|---|'
+        );
+        for (const entry of duplicates.slice(0, TOP_N)) {
+            lines.push(`| \`${entry.identity}\` | ${entry.instances.length} | ${mib(entry.bytes)} |`);
+        }
+        lines.push('');
+    }
+
+    return lines.join('\n');
+}
+
+const readReport = async (file) => {
+    try {
+        return JSON.parse(await fs.readFile(file, 'utf8'));
+    } catch {
+        return null;
+    }
+};
+
+if (import.meta.main) {
+    const {values} = parseArgs({
+        options: {
+            current: {type: 'string'},
+            baseline: {type: 'string'},
+            'baseline-label': {type: 'string'}
+        }
+    });
+
+    if (!values.current) {
+        console.error('Usage: compare-image-report.js --current=<file> [--baseline=<file>] [--baseline-label=<text>]');
+        process.exit(1);
+    }
+
+    const current = await readReport(values.current);
+    if (!current) {
+        console.error(`Could not read image report: ${values.current}`);
+        process.exit(1);
+    }
+
+    // A missing baseline is normal (first build on a branch, base commit never
+    // pushed an image) and must not fail the build — render totals instead.
+    const baseline = values.baseline ? await readReport(values.baseline) : null;
+
+    console.log(render(current, baseline, {baselineLabel: values['baseline-label']}));
+}

--- a/scripts/test/compare-image-report.test.js
+++ b/scripts/test/compare-image-report.test.js
@@ -1,0 +1,136 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert';
+import {diffPackages, duplicateInstances, identityOf, render} from '../compare-image-report.js';
+
+const report = packages => ({
+    profile: 'image',
+    total: Object.values(packages).reduce(
+        (acc, stats) => ({files: acc.files + stats.files, bytes: acc.bytes + stats.bytes}),
+        {files: 0, bytes: 0}
+    ),
+    packages
+});
+
+const MIB = 1024 * 1024;
+
+describe('identityOf', () => {
+    it('keeps a plain name@version intact', () => {
+        assert.strictEqual(identityOf('viem@2.55.11'), 'viem@2.55.11');
+    });
+
+    it('strips the peer suffix', () => {
+        assert.strictEqual(identityOf('viem@2.55.11_zod@3.25.76'), 'viem@2.55.11');
+    });
+
+    it('handles scoped packages, which pnpm writes with a +', () => {
+        assert.strictEqual(identityOf('@x402+hono@2.12.0_hono@4.12.18'), '@x402+hono@2.12.0');
+    });
+
+    it('does not mistake an underscore in the package name for a peer suffix', () => {
+        assert.strictEqual(identityOf('string_decoder@1.3.0'), 'string_decoder@1.3.0');
+        assert.strictEqual(identityOf('lodash._basecopy@3.0.0'), 'lodash._basecopy@3.0.0');
+    });
+
+    it('stops at the first peer of a multi-peer suffix', () => {
+        assert.strictEqual(
+            identityOf('mppx@0.6.20_express@4.22.2_supports-color@10.2.2__hono@4.12.18'),
+            'mppx@0.6.20'
+        );
+    });
+
+    it('handles an injected workspace package, which has no version separator to speak of', () => {
+        assert.strictEqual(
+            identityOf('@tryghost+i18n@file++++build+packages+i18n'),
+            '@tryghost+i18n@file++++build+packages+i18n'
+        );
+    });
+});
+
+describe('diffPackages', () => {
+    const baseline = report({'viem@2.55.11': {files: 2894, bytes: 7 * MIB}});
+
+    it('marks packages missing from the baseline as added', () => {
+        const [entry] = diffPackages(
+            report({
+                'viem@2.55.11': {files: 2894, bytes: 7 * MIB},
+                'zod@3.25.76': {files: 266, bytes: MIB}
+            }),
+            baseline
+        );
+
+        assert.deepStrictEqual(entry, {id: 'zod@3.25.76', bytes: MIB, files: 266, status: 'added'});
+    });
+
+    it('marks packages missing from the current report as removed', () => {
+        const [entry] = diffPackages(report({}), baseline);
+
+        assert.strictEqual(entry.status, 'removed');
+        assert.strictEqual(entry.bytes, -7 * MIB);
+        assert.strictEqual(entry.files, -2894);
+    });
+
+    it('omits packages whose size and file count are unchanged', () => {
+        assert.deepStrictEqual(diffPackages(baseline, baseline), []);
+    });
+
+    it('sorts by absolute byte change, largest first', () => {
+        const changed = diffPackages(
+            report({
+                'small@1.0.0': {files: 1, bytes: MIB},
+                'large@1.0.0': {files: 1, bytes: 5 * MIB},
+                'viem@2.55.11': {files: 2894, bytes: 7 * MIB}
+            }),
+            baseline
+        );
+
+        assert.deepStrictEqual(changed.map(entry => entry.id), ['large@1.0.0', 'small@1.0.0']);
+    });
+});
+
+describe('duplicateInstances', () => {
+    it('finds one version unpacked under two peer suffixes', () => {
+        const duplicates = duplicateInstances(report({
+            'viem@2.55.11_zod@3.25.76': {files: 2894, bytes: 7 * MIB},
+            'viem@2.55.11_zod@4.4.3': {files: 2894, bytes: 7 * MIB},
+            'zod@3.25.76': {files: 266, bytes: MIB}
+        }));
+
+        assert.strictEqual(duplicates.length, 1);
+        assert.strictEqual(duplicates[0].identity, 'viem@2.55.11');
+        // Only the copies past the first are recoverable.
+        assert.strictEqual(duplicates[0].bytes, 7 * MIB);
+    });
+
+    it('does not treat genuinely different versions as duplicates', () => {
+        assert.deepStrictEqual(duplicateInstances(report({
+            'ox@0.14.20': {files: 437, bytes: 3 * MIB},
+            'ox@0.14.33': {files: 437, bytes: 3 * MIB}
+        })), []);
+    });
+
+    it('ignores the app bucket', () => {
+        assert.deepStrictEqual(duplicateInstances(report({'(app)': {files: 10, bytes: MIB}})), []);
+    });
+});
+
+describe('render', () => {
+    const current = report({
+        'viem@2.55.11_zod@3.25.76': {files: 2894, bytes: 7 * MIB},
+        'viem@2.55.11_zod@4.4.3': {files: 2894, bytes: 7 * MIB}
+    });
+
+    it('reports totals and duplicates without a baseline', () => {
+        const output = render(current, null, {baselineLabel: 'abc1234'});
+
+        assert.match(output, /No baseline report for `abc1234`/);
+        assert.match(output, /Duplicated packages \(1, 7\.0 MiB recoverable\)/);
+    });
+
+    it('reports a signed delta against a baseline', () => {
+        const output = render(current, report({'viem@2.55.11_zod@4.4.3': {files: 2894, bytes: 7 * MIB}}));
+
+        assert.match(output, /\| Size \| 14\.0 MiB \| 7\.0 MiB \| \*\*\+7\.0 MiB\*\* \|/);
+        assert.match(output, /\| Files \| 5788 \| 2894 \| \*\*\+2894\*\* \|/);
+        assert.match(output, /`viem@2\.55\.11_zod@3\.25\.76` \| \+7\.0 MiB \| \+2894 \| added \|/);
+    });
+});


### PR DESCRIPTION
`@x402/*` landed as a second machine-payments rail and, like `mppx` before it, pulls in `viem`. It did not share the copy `mppx` already had — the production image carried two.

## Why there were two

`abitype` declares `zod` as an optional peer, used only by its `abitype/zod` subpath, which nothing in the tree imports. pnpm resolved it anyway and the peer suffix propagated up through `ox` and `viem` to their dependents:

- `mppx` → `zod@4.4.3` → `viem@2.55.11(zod@4.4.3)`
- `@x402/evm`, `@x402/extensions` → `zod@3.25.76` → `viem@2.55.11(zod@3.25.76)`

Same version, two byte-identical unpacks. Same for `ox@0.14.33`, `abitype@1.2.3` and `abitype@1.3.0`.

Dropping the peer in `.pnpmfile.mjs` (the same hook already used for `consolidate`, `knex` and the `typescript` peer on these very packages) collapses each to one instance. Both zod majors stay installed — that is a genuine version conflict between `mppx` and `@x402/*`, not a peer artefact.

Measured across two full `Dockerfile.production` builds:

| | before | after | delta |
|---|---|---|---|
| shipped production tree | 195.9 MiB | 184.9 MiB | **−11.1 MiB** |
| files | 32,245 | 28,763 | **−3,482** |

`viem` alone is 7.4 MiB and 2,894 of those files. File count matters as much as bytes: the deploy `COPY` layer is extracted single-threaded, once per CI E2E shard.

Verified with a real install — the four `@x402/*` and `mppx` entrypoints load, and the 50 machine-payments unit tests pass.

## Why CI did not catch it

`Inspect image size and layers` is gated on the artifact path — forks and cross-repo PRs, where the image is loaded into the local daemon. Canonical PRs push straight to GHCR and never load, so the PRs that actually change the image reported nothing.

Two additions, both at the end of `job_docker` so they delay neither the e2e image nor anything downstream, and both `continue-on-error` on tags so an informational step can never strand a half-published release:

- **`Report image size`** sums compressed layer sizes from the registry manifest for the core and full images, against the `sha-<short>` tag CI already publishes for the PR base commit.
- **A `report` build stage** carries per-package byte and file counts of the pruned production `node_modules` (`prune.mts --report`), diffed against the base commit's uploaded report by `scripts/compare-image-report.js`.

The per-package view is there because image bytes hide the regression worth catching: a peer-forked duplicate of `viem` is ~2.9k files but gzips to roughly 2 MB of a 152 MB pull, which reads as noise. Run against the tree from before the first commit, the diff names it outright:

```
### Duplicated packages (4, 11.1 MiB recoverable)

| Package          | Copies | Recoverable |
|------------------|--------|-------------|
| `viem@2.55.11`   | 2      | 7.4 MiB     |
| `ox@0.14.33`     | 2      | 3.0 MiB     |
| `abitype@1.3.0`  | 2      | 0.4 MiB     |
| `abitype@1.2.3`  | 2      | 0.4 MiB     |
```

Every layer under the `report` target is already cached from the core build, so the extra build is an export rather than a rebuild.

## Notes

- The first PR after this merges will show "no baseline" — the base commit's run predates the artifact. Self-corrects.
- `actionlint` reports no new findings; `scripts` lint is clean and its 109 tests pass, including 15 new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)