### PR TITLE
Changed theme editor requests to use the framework fetch layer

### DIFF
--- a/apps/admin-x-framework/src/api/themes.ts
+++ b/apps/admin-x-framework/src/api/themes.ts
@@ -112,9 +112,10 @@ export const useInstallTheme = createMutation<ThemesInstallResponseType, string>
     }
 });
 
-export const useUploadTheme = createMutation<ThemesInstallResponseType, {file: File}>({
+export const useUploadTheme = createMutation<ThemesInstallResponseType, {file: File; copySettingsFrom?: string}>({
     method: 'POST',
     path: () => '/themes/upload/',
+    searchParams: ({copySettingsFrom}): Record<string, string> => (copySettingsFrom ? {copy_settings_from: copySettingsFrom} : {}),
     body: ({file}) => {
         const formData = new FormData();
         formData.append('file', file);
@@ -123,11 +124,12 @@ export const useUploadTheme = createMutation<ThemesInstallResponseType, {file: F
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',
-        // Assume that all invite queries should include this new one
+        // Uploading can replace an existing theme, so swap it out by name
+        // instead of appending a duplicate entry
         update: (newData, currentData) => (currentData && {
             ...(currentData as ThemesResponseType),
             themes: [
-                ...((currentData as ThemesResponseType).themes),
+                ...((currentData as ThemesResponseType).themes).filter(theme => !newData.themes.some(({name}) => name === theme.name)),
                 ...newData.themes
             ]
         })

--- a/apps/admin-x-framework/src/helpers.ts
+++ b/apps/admin-x-framework/src/helpers.ts
@@ -1,2 +1,2 @@
 export * from './utils/helpers';
-
+export {apiUrl} from './utils/api/fetch-api';

--- a/apps/admin-x-framework/src/hooks.ts
+++ b/apps/admin-x-framework/src/hooks.ts
@@ -9,3 +9,5 @@ export {useKoenigFetchEmbed} from './hooks/use-koenig-fetch-embed';
 export type {KoenigFileUploadType} from './hooks/use-koenig-file-upload';
 export {useKoenigLinkSuggestions} from './hooks/use-koenig-link-suggestions';
 export {usePinturaConfig} from './hooks/use-pintura-config';
+export {useFetchApi} from './utils/api/fetch-api';
+export type {RequestOptions} from './utils/api/fetch-api';

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {useFramework} from '../../providers/framework-provider';
 import {APIError, MaintenanceError, ServerUnreachableError, SessionExpiredError, TimeoutError, UnauthorizedError} from '../errors';
 import {getGhostPaths} from '../helpers';
-import handleResponse from './handle-response';
+import handleResponse, {ResponseType} from './handle-response';
 
 export interface RequestOptions {
     method?: string;
@@ -14,6 +14,8 @@ export interface RequestOptions {
     credentials?: 'include' | 'omit' | 'same-origin';
     timeout?: number;
     retry?: boolean;
+    /** Resolve the raw response body instead of parsing it as JSON/text */
+    responseType?: ResponseType;
     onUploadProgress?: (progress: number) => void;
 }
 
@@ -164,6 +166,7 @@ export const useFetchApi = () => {
             credentials = 'include',
             timeout,
             retry = true,
+            responseType,
             onUploadProgress
         }: RequestOptions = {}
     ): Promise<ResponseData> => {
@@ -221,7 +224,7 @@ export const useFetchApi = () => {
                 try {
                     const response = await fetchFn(endpoint, requestInit);
                     // Awaited so response errors reject inside the try/catch
-                    return await handleResponse(response) as ResponseData;
+                    return await handleResponse(response, {responseType}) as ResponseData;
                 } catch (error) {
                     retryingMs = Date.now() - startTime;
 

--- a/apps/admin-x-framework/src/utils/api/handle-response.ts
+++ b/apps/admin-x-framework/src/utils/api/handle-response.ts
@@ -1,6 +1,13 @@
 import {APIError, EmailError, ErrorResponse, HostLimitError, JSONError, MaintenanceError, RequestEntityTooLargeError, ServerUnreachableError, ThemeValidationError, UnauthorizedError, UnsupportedMediaTypeError, ValidationError, VersionMismatchError} from '../errors';
 
-const handleResponse = async (response: Response) => {
+export type ResponseType = 'blob' | 'arraybuffer';
+
+// The API serves YAML files (routes, redirects) as application/yaml
+const isTextContentType = (contentType: string | null) => {
+    return !!contentType && (contentType.startsWith('text/') || contentType.includes('application/yaml'));
+};
+
+const handleResponse = async (response: Response, {responseType}: {responseType?: ResponseType} = {}) => {
     if (response.status === 0) {
         throw new ServerUnreachableError();
     } else if (response.status === 503) {
@@ -40,7 +47,11 @@ const handleResponse = async (response: Response) => {
         }
     } else if (response.status === 204) {
         return;
-    } else if (response.headers.get('content-type')?.includes('text/csv')) {
+    } else if (responseType === 'blob') {
+        return await response.blob();
+    } else if (responseType === 'arraybuffer') {
+        return await response.arrayBuffer();
+    } else if (isTextContentType(response.headers.get('content-type'))) {
         return await response.text();
     } else {
         return await response.json();

--- a/apps/admin-x-framework/test/unit/utils/api/fetch-api.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/fetch-api.test.tsx
@@ -59,13 +59,30 @@ describe('useFetchApi', () => {
                 if (url.includes('slow')) {
                     await sleep(100);
                 }
-                res.writeHead(200, {
-                    'Content-Type': 'application/json',
-                    // jsdom's `XMLHttpRequest` needs these CORS headers.
+
+                // jsdom's `XMLHttpRequest` needs these CORS headers.
+                const corsHeaders = {
                     'Access-Control-Allow-Origin': req.headers.origin || '*',
                     'Access-Control-Allow-Methods': '*',
                     'Access-Control-Allow-Headers': '*',
                     'Access-Control-Allow-Credentials': 'true'
+                };
+
+                if (url.includes('yaml')) {
+                    res.writeHead(200, {'Content-Type': 'application/yaml', ...corsHeaders});
+                    res.end('routes:\n');
+                    return;
+                }
+
+                if (url.includes('binary')) {
+                    res.writeHead(200, {'Content-Type': 'application/zip', ...corsHeaders});
+                    res.end(Buffer.from([80, 75, 3, 4]));
+                    return;
+                }
+
+                res.writeHead(200, {
+                    'Content-Type': 'application/json',
+                    ...corsHeaders
                 });
                 res.end(JSON.stringify({
                     method: req.method,
@@ -106,6 +123,39 @@ describe('useFetchApi', () => {
         expect(data.headers['app-pragma']).toBe('no-cache');
         expect(data.headers['content-type']).toBe('application/json');
         expect(data.body).toBe('test');
+    });
+
+    it('returns text for yaml responses', async () => {
+        const {result} = renderHook(() => useFetchApi(), {wrapper});
+
+        const data = await result.current<string>(`${baseUrl}/ghost/api/admin/yaml/`, {retry: false});
+
+        expect(data).toBe('routes:\n');
+    });
+
+    it('resolves the raw ArrayBuffer when responseType is arraybuffer', async () => {
+        const {result} = renderHook(() => useFetchApi(), {wrapper});
+
+        const data = await result.current<ArrayBuffer>(`${baseUrl}/ghost/api/admin/binary/`, {
+            retry: false,
+            responseType: 'arraybuffer'
+        });
+
+        expect(data).toBeInstanceOf(ArrayBuffer);
+        expect(Array.from(new Uint8Array(data))).toEqual([80, 75, 3, 4]);
+    });
+
+    it('resolves the raw Blob when responseType is blob', async () => {
+        const {result} = renderHook(() => useFetchApi(), {wrapper});
+
+        const data = await result.current<Blob>(`${baseUrl}/ghost/api/admin/binary/`, {
+            retry: false,
+            responseType: 'blob'
+        });
+
+        // instanceof fails across realms (undici Blob vs jsdom Blob), so assert shape
+        expect(data.constructor.name).toBe('Blob');
+        expect(Array.from(new Uint8Array(await data.arrayBuffer()))).toEqual([80, 75, 3, 4]);
     });
 
     it('retries maintenance errors until the API recovers', async () => {

--- a/apps/admin-x-framework/test/unit/utils/api/handle-response.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/api/handle-response.test.ts
@@ -1,0 +1,74 @@
+import handleResponse from '../../../../src/utils/api/handle-response';
+import {JSONError, ThemeValidationError, UnsupportedMediaTypeError} from '../../../../src/utils/errors';
+
+const response = (body: BodyInit | null, contentType: string, status = 200) => (
+    new Response(body, {status, headers: {'Content-Type': contentType}})
+);
+
+describe('handleResponse', () => {
+    it('parses JSON responses', async () => {
+        await expect(handleResponse(response('{"themes": []}', 'application/json'))).resolves.toEqual({themes: []});
+    });
+
+    it('returns undefined for 204 responses', async () => {
+        await expect(handleResponse(new Response(null, {status: 204}))).resolves.toBeUndefined();
+    });
+
+    it('returns text for text/csv responses', async () => {
+        await expect(handleResponse(response('id,email\n', 'text/csv'))).resolves.toBe('id,email\n');
+    });
+
+    it('returns text for other text/* responses', async () => {
+        await expect(handleResponse(response('routes:\n', 'text/yaml; charset=utf-8'))).resolves.toBe('routes:\n');
+    });
+
+    it('returns text for application/yaml responses', async () => {
+        await expect(handleResponse(response('routes:\n', 'application/yaml'))).resolves.toBe('routes:\n');
+    });
+
+    it('returns a Blob when responseType is blob', async () => {
+        const result = await handleResponse(response('binary', 'application/zip'), {responseType: 'blob'}) as Blob;
+
+        // instanceof fails across realms (undici Blob vs jsdom Blob), so assert shape
+        expect(result.constructor.name).toBe('Blob');
+        expect(result.type).toBe('application/zip');
+        await expect(result.text()).resolves.toBe('binary');
+    });
+
+    it('returns an ArrayBuffer when responseType is arraybuffer', async () => {
+        const result = await handleResponse(response('binary', 'application/zip'), {responseType: 'arraybuffer'});
+
+        expect(result).toBeInstanceOf(ArrayBuffer);
+        expect(new TextDecoder().decode(result as ArrayBuffer)).toBe('binary');
+    });
+
+    it('returns undefined for 204 responses when responseType is set', async () => {
+        await expect(handleResponse(new Response(null, {status: 204}), {responseType: 'blob'})).resolves.toBeUndefined();
+    });
+
+    it('throws API errors even when responseType is set', async () => {
+        const body = JSON.stringify({errors: [{type: 'ThemeValidationError', message: 'Invalid theme'}]});
+
+        const promise = handleResponse(response(body, 'application/json', 422), {responseType: 'arraybuffer'});
+
+        await expect(promise).rejects.toBeInstanceOf(ThemeValidationError);
+    });
+
+    it('throws JSONError with the parsed body for untyped JSON errors', async () => {
+        const body = JSON.stringify({errors: [{message: 'Nope'}]});
+
+        const promise = handleResponse(response(body, 'application/json', 422));
+
+        await expect(promise).rejects.toBeInstanceOf(JSONError);
+        await expect(promise).rejects.toMatchObject({data: {errors: [{message: 'Nope'}]}});
+    });
+
+    it('throws UnsupportedMediaTypeError with the raw text for 415 responses', async () => {
+        const body = JSON.stringify({errors: [{code: 'ENTRY_TOO_LARGE'}]});
+
+        const promise = handleResponse(response(body, 'application/json', 415));
+
+        await expect(promise).rejects.toBeInstanceOf(UnsupportedMediaTypeError);
+        await expect(promise).rejects.toMatchObject({data: body});
+    });
+});

--- a/apps/admin/src/settings/advanced/labs/yaml-file-editor-modal.tsx
+++ b/apps/admin/src/settings/advanced/labs/yaml-file-editor-modal.tsx
@@ -4,9 +4,9 @@ import {APIError, JSONError} from '@tryghost/admin-x-framework/errors';
 import {Button} from '@tryghost/shade/components';
 import {Inline, Text} from '@tryghost/shade/primitives';
 import {SettingsModal} from '@tryghost/shade/patterns';
-import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {apiUrl} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useFetchApi, useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 export interface YamlFileEditorModalProps {
     title: string;
@@ -41,6 +41,7 @@ const YamlFileEditorModal: React.FC<YamlFileEditorModalProps> = ({
     onUpload,
     onClose
 }) => {
+    const fetchApi = useFetchApi();
     const handleError = useHandleError();
 
     const [content, setContent] = useState('');
@@ -59,25 +60,19 @@ const YamlFileEditorModal: React.FC<YamlFileEditorModalProps> = ({
             setLoadError(null);
 
             try {
-                const {apiRoot} = getGhostPaths();
-                const response = await fetch(`${apiRoot}${downloadPath}`, {
-                    credentials: 'include',
-                    headers: {
-                        Accept: 'text/yaml, text/plain, */*'
-                    }
-                });
-
-                if (!response.ok) {
-                    throw new Error(`Failed to load ${uploadFilename} (${response.status})`);
-                }
-
-                const text = await response.text();
+                const text = await fetchApi<string>(apiUrl(downloadPath));
 
                 if (isMounted) {
                     setContent(text);
                 }
             } catch (error) {
-                if (isMounted) {
+                if (!isMounted) {
+                    return;
+                }
+
+                if (error instanceof APIError && error.response) {
+                    setLoadError(`Failed to load ${uploadFilename} (${error.response.status})`);
+                } else {
                     setLoadError(error instanceof Error ? error.message : `Failed to load ${uploadFilename}`);
                 }
             } finally {
@@ -92,7 +87,7 @@ const YamlFileEditorModal: React.FC<YamlFileEditorModalProps> = ({
         return () => {
             isMounted = false;
         };
-    }, [downloadPath, uploadFilename]);
+    }, [downloadPath, uploadFilename, fetchApi]);
 
     const handleSave = async () => {
         if (isSaving || isLoading || loadError) {

--- a/apps/admin/src/settings/site/change-theme.tsx
+++ b/apps/admin/src/settings/site/change-theme.tsx
@@ -5,7 +5,7 @@ import {LucideIcon} from '@tryghost/shade/utils';
 import {SettingGroupContent} from '@tryghost/shade/patterns';
 import {Text} from '@tryghost/shade/primitives';
 import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
-import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {downloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '@/settings/hooks/use-check-theme-limit-error';
 import {useConfirmation} from '@/settings/providers/confirmation-context';
 import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
@@ -72,8 +72,7 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
             return;
         }
 
-        const {apiRoot} = getGhostPaths();
-        downloadFile(`${apiRoot}/themes/${activeTheme.name}/download`);
+        downloadFromEndpoint(`/themes/${activeTheme.name}/download`);
     };
 
     const values = (

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -285,6 +285,28 @@ describe("Theme settings", () => {
         await expect.element(settingsScreen.errorToast()).toHaveTextContent(/1\.0 MB/);
     });
 
+    it("falls back to the generic API error for malformed archive limit details", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{
+                message: "Zip entry exceeds maximum uncompressed size.",
+                errorType: "UnsupportedMediaTypeError",
+                code: "ENTRY_TOO_LARGE",
+                errorDetails: { entryName: "partials/huge.hbs", limitBytes: "not-a-number" },
+            }],
+        }, { status: 415 });
+        await renderAdminApp("/settings/theme/edit/edition");
+
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent("Request contains an unknown or unsupported file type.");
+        await expect.element(settingsScreen.errorToast()).not.toHaveTextContent("NaN");
+    });
+
     it("keeps the code editor open and reports blocking validation errors on save", async () => {
         fakeThemeWorld();
         await fakeThemeDownload("edition");
@@ -303,6 +325,22 @@ describe("Theme settings", () => {
         await expect.element(errorModal).toHaveTextContent("Missing default.hbs");
         await expect(errorModal.getByRole("button", { name: "Retry" })).toHaveCount(0);
         await userEvent.keyboard("{Escape}");
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+    });
+
+    it("falls back to the generic API error for an empty validation payload", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", { errors: [] }, { status: 422 });
+        await renderAdminApp("/settings/theme/edit/edition");
+
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/Something went wrong/i);
         await expect(settingsScreen.confirmationModal()).toHaveCount(0);
         await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
     });

--- a/apps/admin/src/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin/src/settings/site/theme/advanced-theme-settings.tsx
@@ -6,7 +6,7 @@ import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {ModalPage} from '@tryghost/shade/page-templates';
 import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
-import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {downloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
 import {useCheckThemeLimitError} from '@/settings/hooks/use-check-theme-limit-error';
 import {useConfirmation} from '@/settings/providers/confirmation-context';
@@ -83,8 +83,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     };
 
     const handleDownload = () => {
-        const {apiRoot} = getGhostPaths();
-        downloadFile(`${apiRoot}/themes/${theme.name}/download`);
+        downloadFromEndpoint(`/themes/${theme.name}/download`);
     };
 
     const handleDelete = () => {

--- a/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
@@ -18,21 +18,20 @@ import {
     normaliseRelativePath,
     packThemeArchive
 } from './theme-editor-utils';
-import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {APIError, JSONError} from '@tryghost/admin-x-framework/errors';
+import {apiUrl} from '@tryghost/admin-x-framework/helpers';
 import {oneDark} from '@codemirror/theme-one-dark';
 import {search} from '@codemirror/search';
 
 import {toast} from 'sonner';
-import {useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useQueryClient} from '@tanstack/react-query';
+import {useBrowseThemes, useUploadTheme} from '@tryghost/admin-x-framework/api/themes';
+import {useFetchApi, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
 import type {SelectedNode} from './theme-file-tree';
 import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
 import type {ThemeEditorFile} from './theme-editor-utils';
 import type {ThemeEditorInputModalProps} from './theme-editor-input-modal';
-import type {ThemesInstallResponseType} from '@tryghost/admin-x-framework/api/themes';
 
 const getLanguageExtension = (path: string) => {
     const extension = getExtension(path);
@@ -212,6 +211,32 @@ const formatLimitBytes = (bytes: number | undefined) => {
     return `${Math.round(bytes / 1024)} KB`;
 };
 
+// Size-limit failures are 415s, which the fetch layer surfaces as an
+// UnsupportedMediaTypeError carrying the raw response text
+const getUploadSizeLimitError = (error: unknown): (UploadSizeLimitError & {code: string}) | null => {
+    if (!(error instanceof APIError)) {
+        return null;
+    }
+
+    let data: unknown = error.data;
+
+    if (typeof data === 'string') {
+        try {
+            data = JSON.parse(data);
+        } catch {
+            return null;
+        }
+    }
+
+    const serverError = (data as {errors?: UploadSizeLimitError[]} | undefined)?.errors?.[0];
+
+    if (serverError?.code && UPLOAD_SIZE_LIMIT_TITLES[serverError.code]) {
+        return serverError as UploadSizeLimitError & {code: string};
+    }
+
+    return null;
+};
+
 const buildUploadSizeLimitMessage = (err: UploadSizeLimitError) => {
     const {entryName, limitBytes} = err.errorDetails ?? {};
     const limit = formatLimitBytes(limitBytes);
@@ -245,9 +270,10 @@ const editorSelectionTheme = EditorView.theme({
 
 const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const {updateRoute} = useSettingsNavigation();
-    const queryClient = useQueryClient();
+    const fetchApi = useFetchApi();
     const handleError = useHandleError();
     const {data: themesData} = useBrowseThemes();
+    const {mutateAsync: uploadTheme} = useUploadTheme();
 
     const [currentThemeName, setCurrentThemeName] = useState(themeName);
     const [baseFiles, setBaseFiles] = useState<Record<string, ThemeEditorFile>>({});
@@ -283,19 +309,9 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             resetLoadedTheme();
 
             try {
-                const {apiRoot} = getGhostPaths();
-                const response = await fetch(`${apiRoot}/themes/${encodeURIComponent(themeName)}/download/`, {
-                    credentials: 'include',
-                    headers: {
-                        Accept: 'application/zip, application/octet-stream, */*'
-                    }
+                const archive = await fetchApi<ArrayBuffer>(apiUrl(`/themes/${encodeURIComponent(themeName)}/download/`), {
+                    responseType: 'arraybuffer'
                 });
-
-                if (!response.ok) {
-                    throw new Error(`Failed to load theme "${themeName}" (${response.status})`);
-                }
-
-                const archive = await response.arrayBuffer();
                 const snapshot = await extractThemeArchive(archive);
                 const nextFiles = cloneThemeFiles(snapshot.files);
                 const nextSelection = getDefaultSelection(nextFiles);
@@ -315,7 +331,11 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                     return;
                 }
 
-                setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
+                if (error instanceof APIError && error.response) {
+                    setLoadError(`Failed to load theme "${themeName}" (${error.response.status})`);
+                } else {
+                    setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
+                }
             } finally {
                 if (isMounted) {
                     setIsLoading(false);
@@ -328,7 +348,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         return () => {
             isMounted = false;
         };
-    }, [themeName]);
+    }, [themeName, fetchApi]);
 
     useEffect(() => {
         const previousOverflow = document.body.style.overflow;
@@ -790,39 +810,12 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 rootPrefix
             });
 
-            const formData = new FormData();
-            formData.append('file', blob, `${nextThemeName}.zip`);
-
-            // when saving under a new name, carry over the original theme's
-            // settings so activating the copy keeps the site's design
-            const uploadQuery = isSaveAs ? `?copy_settings_from=${encodeURIComponent(previousThemeName)}` : '';
-
-            const response = await fetch(`${getGhostPaths().apiRoot}/themes/upload/${uploadQuery}`, {
-                method: 'POST',
-                credentials: 'include',
-                headers: {
-                    Accept: 'application/json'
-                },
-                body: formData
+            const data = await uploadTheme({
+                file: new File([blob], `${nextThemeName}.zip`, {type: 'application/zip'}),
+                // when saving under a new name, carry over the original theme's
+                // settings so activating the copy keeps the site's design
+                copySettingsFrom: isSaveAs ? previousThemeName : undefined
             });
-
-            const data = await response.json().catch(() => null) as ThemesInstallResponseType & {errors?: FatalErrors};
-
-            if (!response.ok) {
-                if (response.status === 422 && data?.errors) {
-                    setSaveErrors(data.errors);
-                    return;
-                }
-
-                const serverError = (data as {errors?: Array<UploadSizeLimitError>} | null)?.errors?.[0];
-
-                if (serverError?.code && UPLOAD_SIZE_LIMIT_TITLES[serverError.code]) {
-                    toast.error(UPLOAD_SIZE_LIMIT_TITLES[serverError.code], {description: buildUploadSizeLimitMessage(serverError)});
-                    return;
-                }
-
-                throw new Error(serverError?.message || 'Theme upload failed.');
-            }
 
             const uploadedTheme = data.themes[0];
             const returnRoute = getReturnRouteFromHash();
@@ -835,8 +828,6 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
             }
 
-            await queryClient.invalidateQueries({queryKey: ['ThemesResponseType']});
-
             if (isSaveAs || uploadedTheme.errors?.length || uploadedTheme.warnings?.length) {
                 setInstalledModal({
                     title: isSaveAs ? 'Theme saved' : 'Theme updated',
@@ -847,6 +838,18 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 toast.success('Theme saved', {description: <div><span className='capitalize'>{uploadedTheme.name}</span> has been updated.</div>});
             }
         } catch (error) {
+            if (error instanceof JSONError && error.response?.status === 422 && error.data?.errors) {
+                setSaveErrors(error.data.errors as unknown as FatalErrors);
+                return;
+            }
+
+            const sizeLimitError = getUploadSizeLimitError(error);
+
+            if (sizeLimitError) {
+                toast.error(UPLOAD_SIZE_LIMIT_TITLES[sizeLimitError.code], {description: buildUploadSizeLimitMessage(sizeLimitError)});
+                return;
+            }
+
             handleError(error);
         } finally {
             setIsSaving(false);

--- a/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
@@ -6,6 +6,7 @@ import ThemeEditorInputModal from './theme-editor-input-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
 import ThemeFileTree from './theme-file-tree';
 import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme-installed-modal';
+import {parseFatalErrors} from './theme-validation-issues';
 import {TextWrap, Undo2} from 'lucide-react';
 import {
     cloneThemeFiles,
@@ -18,7 +19,7 @@ import {
     normaliseRelativePath,
     packThemeArchive
 } from './theme-editor-utils';
-import {APIError, JSONError} from '@tryghost/admin-x-framework/errors';
+import {APIError, JSONError, UnsupportedMediaTypeError} from '@tryghost/admin-x-framework/errors';
 import {apiUrl} from '@tryghost/admin-x-framework/helpers';
 import {oneDark} from '@codemirror/theme-one-dark';
 import {search} from '@codemirror/search';
@@ -28,6 +29,7 @@ import {useBrowseThemes, useUploadTheme} from '@tryghost/admin-x-framework/api/t
 import {useFetchApi, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
+import {z} from 'zod';
 import type {SelectedNode} from './theme-file-tree';
 import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
 import type {ThemeEditorFile} from './theme-editor-utils';
@@ -174,16 +176,6 @@ const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string
 // stripping on Windows when the archive is later unzipped.
 const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
 
-type UploadSizeLimitError = {
-    message?: string;
-    code?: string;
-    errorDetails?: {
-        entryName?: string;
-        observedBytes?: number;
-        limitBytes?: number;
-    };
-};
-
 type ThemeEditorDialogRequest = {
     type: 'confirmation';
     props: ThemeEditorConfirmModalProps;
@@ -194,11 +186,28 @@ type ThemeEditorDialogRequest = {
     resolve: (result: string | null) => void;
 };
 
-const UPLOAD_SIZE_LIMIT_TITLES: Record<string, string> = {
+const UPLOAD_SIZE_LIMIT_CODES = ['COMPRESSED_TOO_LARGE', 'ENTRY_TOO_LARGE', 'TOTAL_TOO_LARGE'] as const;
+
+const UPLOAD_SIZE_LIMIT_TITLES: Record<typeof UPLOAD_SIZE_LIMIT_CODES[number], string> = {
     COMPRESSED_TOO_LARGE: 'Theme too large to upload',
     ENTRY_TOO_LARGE: 'File too large',
     TOTAL_TOO_LARGE: 'Theme contents too large'
 };
+
+const uploadSizeLimitErrorSchema = z.object({
+    message: z.string().optional(),
+    code: z.enum(UPLOAD_SIZE_LIMIT_CODES),
+    errorDetails: z.object({
+        entryName: z.string().optional(),
+        limitBytes: z.number().positive().finite().optional()
+    }).optional()
+});
+
+const uploadSizeLimitResponseSchema = z.object({
+    errors: z.array(uploadSizeLimitErrorSchema).min(1)
+});
+
+type UploadSizeLimitError = z.infer<typeof uploadSizeLimitErrorSchema>;
 
 const formatLimitBytes = (bytes: number | undefined) => {
     if (!bytes || bytes <= 0) {
@@ -213,8 +222,8 @@ const formatLimitBytes = (bytes: number | undefined) => {
 
 // Size-limit failures are 415s, which the fetch layer surfaces as an
 // UnsupportedMediaTypeError carrying the raw response text
-const getUploadSizeLimitError = (error: unknown): (UploadSizeLimitError & {code: string}) | null => {
-    if (!(error instanceof APIError)) {
+const getUploadSizeLimitError = (error: unknown): UploadSizeLimitError | null => {
+    if (!(error instanceof UnsupportedMediaTypeError)) {
         return null;
     }
 
@@ -228,10 +237,10 @@ const getUploadSizeLimitError = (error: unknown): (UploadSizeLimitError & {code:
         }
     }
 
-    const serverError = (data as {errors?: UploadSizeLimitError[]} | undefined)?.errors?.[0];
+    const parsed = uploadSizeLimitResponseSchema.safeParse(data);
 
-    if (serverError?.code && UPLOAD_SIZE_LIMIT_TITLES[serverError.code]) {
-        return serverError as UploadSizeLimitError & {code: string};
+    if (parsed.success) {
+        return parsed.data.errors[0] ?? null;
     }
 
     return null;
@@ -838,9 +847,13 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 toast.success('Theme saved', {description: <div><span className='capitalize'>{uploadedTheme.name}</span> has been updated.</div>});
             }
         } catch (error) {
-            if (error instanceof JSONError && error.response?.status === 422 && error.data?.errors) {
-                setSaveErrors(error.data.errors as unknown as FatalErrors);
-                return;
+            if (error instanceof JSONError && error.response?.status === 422) {
+                const fatalErrors = parseFatalErrors(error.data?.errors);
+
+                if (fatalErrors) {
+                    setSaveErrors(fatalErrors);
+                    return;
+                }
             }
 
             const sizeLimitError = getUploadSizeLimitError(error);

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.test.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.test.ts
@@ -1,0 +1,48 @@
+import {fatalErrorsSchema, getIssuesFromFatalErrors, parseFatalErrors} from './theme-validation-issues';
+
+const problem = {
+    code: 'GS030-NO-DEFAULT-TEMPLATE',
+    details: 'The theme must have a default.hbs template.',
+    failures: [{ref: 'default.hbs'}],
+    fatal: true,
+    level: 'error' as const,
+    rule: 'A default template is required.'
+};
+
+describe('fatalErrorsSchema', () => {
+    it('parses string and structured validation details', () => {
+        const result = fatalErrorsSchema.safeParse([
+            {details: 'Missing default.hbs'},
+            {details: {errors: [problem]}}
+        ]);
+
+        expect(result.success).toBe(true);
+
+        if (result.success) {
+            expect(getIssuesFromFatalErrors(result.data)).toEqual({
+                blockingProblems: [problem],
+                secondaryProblems: [],
+                stringErrors: ['Missing default.hbs']
+            });
+        }
+    });
+
+    it('rejects malformed theme problems', () => {
+        const result = fatalErrorsSchema.safeParse([
+            {details: {errors: [{...problem, fatal: 'yes'}]}}
+        ]);
+
+        expect(result.success).toBe(false);
+    });
+
+    it('does not treat empty or non-blocking payloads as fatal errors', () => {
+        expect(parseFatalErrors([])).toBeNull();
+        expect(parseFatalErrors([{details: {}}])).toBeNull();
+        expect(parseFatalErrors([{
+            details: {
+                warnings: [{...problem, fatal: false, level: 'warning'}]
+            }
+        }])).toBeNull();
+        expect(parseFatalErrors([{details: '   '}])).toBeNull();
+    });
+});

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -1,15 +1,32 @@
 import {type InstalledTheme, type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+import {z} from 'zod';
 
-type ThemeValidationErrorDetails = {
-    errors?: ThemeProblem[];
-    warnings?: ThemeProblem[];
-};
+const themeProblemSchema = z.object({
+    code: z.string(),
+    details: z.string(),
+    failures: z.array(z.object({
+        ref: z.string(),
+        message: z.string().optional(),
+        rule: z.string().optional()
+    })),
+    fatal: z.boolean(),
+    level: z.enum(['error', 'warning', 'recommendation']),
+    rule: z.string()
+});
 
-type ThemeValidationError = {
-    details: ThemeValidationErrorDetails | string;
-};
+const themeValidationErrorDetailsSchema = z.object({
+    errors: z.array(themeProblemSchema).optional(),
+    warnings: z.array(themeProblemSchema).optional()
+});
 
-export type FatalErrors = ThemeValidationError[];
+export const fatalErrorsSchema = z.array(z.object({
+    details: z.union([themeValidationErrorDetailsSchema, z.string().trim().min(1)])
+}));
+
+type ThemeValidationErrorDetails = z.infer<typeof themeValidationErrorDetailsSchema>;
+type ThemeValidationError = z.infer<typeof fatalErrorsSchema>[number];
+
+export type FatalErrors = z.infer<typeof fatalErrorsSchema>;
 
 type IssueSummary = {
     blockingProblems: ThemeProblem[];
@@ -45,6 +62,17 @@ export function getIssuesFromFatalErrors(fatalErrors: FatalErrors = []): IssueSu
     });
 
     return {blockingProblems, secondaryProblems, stringErrors};
+}
+
+export function parseFatalErrors(data: unknown): FatalErrors | null {
+    const parsed = fatalErrorsSchema.safeParse(data);
+
+    if (!parsed.success) {
+        return null;
+    }
+
+    const {blockingProblems, stringErrors} = getIssuesFromFatalErrors(parsed.data);
+    return blockingProblems.length > 0 || stringErrors.length > 0 ? parsed.data : null;
 }
 
 export function getIssuesFromInstalledTheme(installedTheme: InstalledTheme): ThemeProblem[] {


### PR DESCRIPTION
## Summary

This is a cleanup of Admin API request handling. The theme editor and Labs YAML editor needed text or binary responses, so they bypassed `admin-x-framework` with bare `fetch` calls and repeated URL construction, credentials, error handling, and cache invalidation.

This change moves those requests onto the shared fetch layer. It does not add a new workflow, control, or API endpoint.

## Cleanup

- Teach `handleResponse` to return `text/*` and `application/yaml` responses as text.
- Add `blob` and `arraybuffer` response types for successful binary responses while preserving existing error and `204` handling.
- Move the theme editor's ZIP download and upload onto the framework request and mutation helpers.
- Move the Labs YAML download onto the framework text-response path.
- Build theme download URLs through `downloadFromEndpoint` instead of manually combining `apiRoot` paths.
- Remove the theme editor's manual query-cache invalidation.

To preserve correct cache behavior after removing that invalidation, `useUploadTheme` now replaces an existing theme with the same name instead of appending a duplicate. It also accepts the editor's existing `copy_settings_from` parameter through a typed `copySettingsFrom` option.

Upload error payloads are runtime-validated before showing the existing 422 validation modal or 415 size-limit messages. Malformed payloads fall back to the standard API error handler.

## Verification

- Full `pnpm check`
- `admin-x-framework` unit tests: 508 passed
- Theme validation schema tests: 3 passed
- Theme acceptance tests: 31 passed
- GitHub required checks, including Admin acceptance and the full E2E matrix
