### PR TITLE
Made gift service initialization synchronous

### DIFF
--- a/ghost/core/core/server/services/gifts/index.ts
+++ b/ghost/core/core/server/services/gifts/index.ts
@@ -28,7 +28,7 @@ export let deliveryService: GiftDeliveryService | undefined;
 // of boot-time rebuilds (same contract post scheduling honours in boot.js).
 let rescheduleDeliveriesOnBoot = true;
 
-export async function init(options: GiftServiceInitOptions): Promise<void> {
+export function init(options: GiftServiceInitOptions): void {
   if (service) {
     return;
   }

--- a/ghost/core/test/integration/services/members/send-gift-reminders.test.js
+++ b/ghost/core/test/integration/services/members/send-gift-reminders.test.js
@@ -25,7 +25,7 @@ describe('Gift reminder processing', function () {
     await agent.loginAsOwner();
 
     giftService = require('../../../../core/server/services/gifts');
-    await giftService.init();
+    giftService.init();
 
     paidTier = await models.Product.findOne({ type: 'paid' }, { require: true });
   });


### PR DESCRIPTION
no ref

This change should have no user impact.

I think this is a useful change on its own, but it'll make an upcoming change easier too.