### PR TITLE
Injected gift delivery dep into email analytics service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -368,6 +368,7 @@ async function initServices({ ghostServer, config, prometheusClient }) {
   const adapterManager = require('./server/services/adapter-manager').default;
   const { withErrorCapture } = require('./server/adapters/scheduling/error-capture');
 
+  const assert = require('node:assert/strict');
   const metrics = require('@tryghost/metrics');
   const db = require('./server/data/db');
   const models = require('./server/models');
@@ -381,6 +382,13 @@ async function initServices({ ghostServer, config, prometheusClient }) {
   const schedulerAdapter = withErrorCapture(adapterManager.getAdapter('scheduling'));
   schedulerAdapter.run();
   await stripe.init();
+  giftService.init({
+    apiUrl,
+    schedulerAdapter,
+    internalKeys,
+  });
+  const giftDeliveryService = giftService.deliveryService;
+  assert(giftDeliveryService, 'Gift delivery service should be not initialized');
 
   await Promise.all([
     identityTokens.init(),
@@ -403,6 +411,7 @@ async function initServices({ ghostServer, config, prometheusClient }) {
       db,
       domainEvents,
       emailSuppressionList,
+      giftDeliveryService,
       membersRepository: members.api.members,
       models,
       metrics,
@@ -420,11 +429,6 @@ async function initServices({ ghostServer, config, prometheusClient }) {
     recommendationsService.init(),
     statsService.init(),
     explorePingService.init(),
-    giftService.init({
-      apiUrl,
-      schedulerAdapter,
-      internalKeys,
-    }),
     machinePaymentsService.init(),
     automationsService.init({
       domainEvents,

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -388,7 +388,7 @@ async function initServices({ ghostServer, config, prometheusClient }) {
     internalKeys,
   });
   const giftDeliveryService = giftService.deliveryService;
-  assert(giftDeliveryService, 'Gift delivery service should be not initialized');
+  assert(giftDeliveryService, 'Gift delivery service should be initialized');
 
   await Promise.all([
     identityTokens.init(),

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -28,7 +28,7 @@ import type * as AutomationsApi from '../automations/automations-api';
 import { AutomationEmailAnalyticsBatchProcessor } from './automation-email-analytics-batch-processor';
 import { GiftEmailAnalyticsBatchProcessor } from './gift-email-analytics-batch-processor';
 import { StartGiftEmailAnalyticsJobEvent } from './events/start-gift-email-analytics-job-event';
-import { deliveryService as giftDeliveryService } from '../gifts';
+import type { GiftDeliveryService } from '../gifts/gift-delivery-service';
 import { GIFT_DELIVERY_EMAIL_TAG } from '../gifts/constants';
 
 export const newsletters = new EmailAnalyticsServiceWrapper({
@@ -49,6 +49,7 @@ export const init = ({
   db,
   domainEvents,
   emailSuppressionList,
+  giftDeliveryService,
   membersRepository,
   models: { Email, EmailRecipientFailure, EmailSpamComplaintEvent },
   metrics,
@@ -63,6 +64,7 @@ export const init = ({
   db: { knex: Knex };
   domainEvents: Pick<DomainEvents, 'subscribe'>;
   emailSuppressionList: Pick<typeof EmailSuppressionList, 'removeComplaint' | 'removeUnsubscribe'>;
+  giftDeliveryService: Pick<GiftDeliveryService, 'recordOutcome'>;
   membersRepository: Pick<typeof membersService.api.members, 'get' | 'update'>;
   models: {
     Email: Email;
@@ -182,11 +184,6 @@ export const init = ({
     },
     metrics,
     settingsCache,
-    createEventProcessor: () =>
-      new GiftEmailAnalyticsBatchProcessor({
-        giftDeliveryService: {
-          recordOutcome: (data) => giftDeliveryService!.recordOutcome(data),
-        },
-      }),
+    createEventProcessor: () => new GiftEmailAnalyticsBatchProcessor({ giftDeliveryService }),
   });
 };

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -20,6 +20,7 @@ describe('email analytics service', function () {
   const domainEvents = { subscribe: sinon.stub() };
   const metrics = { metric: sinon.stub() };
   const settingsCache = { get: sinon.stub() };
+  const giftDeliveryService = { recordOutcome: sinon.stub() };
 
   let newslettersInit: sinon.SinonStub;
   let automationsInit: sinon.SinonStub;
@@ -49,6 +50,7 @@ describe('email analytics service', function () {
         removeComplaint: sinon.stub(),
         removeUnsubscribe: sinon.stub(),
       },
+      giftDeliveryService,
       membersRepository: {
         get: sinon.stub(),
         update: sinon.stub(),


### PR DESCRIPTION
no ref

This refactor maintains "clean" dependency injection for the email analytics service, instead of reaching into globals in one spot.