### PR TITLE
🐛 Fixed cleanup behavior of batch email sending

### DIFF
--- a/ghost/core/core/server/ghost-server.js
+++ b/ghost/core/core/server/ghost-server.js
@@ -59,6 +59,9 @@ class GhostServer {
 
         // Tasks that should be run before the server exits
         this.cleanupTasks = [];
+
+        // Tasks that should be run at the very start of shutdown
+        this.preStopTasks = [];
     }
 
     /**
@@ -167,6 +170,10 @@ class GhostServer {
      */
     async stop() {
         try {
+            // Signal "stop taking new work" before the HTTP server drain, so background
+            // workers aren't still claiming tasks during it
+            this._preStop();
+
             // If we never fully started, there's nothing to stop
             if (this.httpServer && this.httpServer.listening) {
                 // Time how long it takes to close all in-flight requests
@@ -207,6 +214,17 @@ class GhostServer {
     }
 
     /**
+     * Add a task that runs at the very start of shutdown, before the HTTP server drain.
+     * Synchronous on purpose: this is the shutdown critical path, so it's for cheap "stop
+     * claiming new work" signals only. Draining belongs in a cleanup task.
+     * @param {() => void} task
+     * @param {string} [label] - name used in shutdown timing logs
+     */
+    registerPreStopTask(task, label) {
+        this.preStopTasks.push({task, label: label || `pre-stop task #${this.preStopTasks.length + 1}`});
+    }
+
+    /**
      * ### Stop Server
      * Does the work of stopping the server using stoppable
      * This handles closing connections:
@@ -226,16 +244,52 @@ class GhostServer {
         }
     }
 
+    /**
+     * Best-effort: a throwing task must not skip the ones after it, nor the drain and
+     * cleanup that follow.
+     */
+    _preStop() {
+        for (const {task, label} of this.preStopTasks) {
+            try {
+                task();
+            } catch (error) {
+                logging.error(new errors.InternalServerError({
+                    err: error,
+                    message: `Shutdown: ${label} failed`
+                }));
+            }
+        }
+    }
+
+    /**
+     * Runs cleanup tasks concurrently, timing each so a slow one is identifiable.
+     * Every task runs to completion regardless of its siblings: a rejection escaping the
+     * map would exit the process mid-drain and orphan email batches in `submitting`.
+     */
     async _cleanup() {
-        // Wait for all cleanup tasks to finish, timing each so a slow one is identifiable
-        return Promise.all(this.cleanupTasks.map(async ({task, label}) => {
+        const failed = [];
+
+        await Promise.all(this.cleanupTasks.map(async ({task, label}) => {
             const startTime = Date.now();
             try {
-                return await task();
+                await task();
+            } catch (error) {
+                failed.push(label);
+                logging.error(new errors.InternalServerError({
+                    err: error,
+                    message: `Shutdown: ${label} failed`
+                }));
             } finally {
                 logging.info(`Shutdown: ${label} finished in ${Date.now() - startTime}ms`);
             }
         }));
+
+        // Surface a non-zero exit, but only once every task has settled
+        if (failed.length > 0) {
+            throw new errors.InternalServerError({
+                message: `Shutdown: ${failed.length} cleanup task(s) failed: ${failed.join(', ')}`
+            });
+        }
     }
 
     /**

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -42,6 +42,13 @@ class BatchSendingService {
     #AFTER_RETRY_CONFIG = {maxRetries: 20, maxTime: 30 * 60 * 1000, sleep: 2000};
     #MAILGUN_API_RETRY_CONFIG = {sleep: 10 * 1000, maxRetries: 6};
 
+    // The normal budgets (up to 30 minutes) outlive the container's grace period, so
+    // retrying just holds a batch in `submitting` until the process is killed, turning a
+    // recoverable `failed` into an orphan. Give up fast, except on the terminal status
+    // write, which has to land.
+    #SHUTDOWN_RETRY_CONFIG = {maxRetries: 0};
+    #SHUTDOWN_AFTER_RETRY_CONFIG = {maxRetries: 3, maxTime: 10 * 1000, sleep: 250};
+
     /**
      * @param {Object} dependencies
      * @param {EmailRenderer} dependencies.emailRenderer
@@ -112,15 +119,60 @@ class BatchSendingService {
         }
     }
 
+    // Each config carries the policy to switch to on shutdown. retryDb applies it per
+    // attempt, so a shutdown starting mid-retry collapses the remaining budget too.
     #getBeforeRetryConfig(email) {
-        if (email._retryCutOffTime) {
-            return {...this.#BEFORE_RETRY_CONFIG, stopAfterDate: email._retryCutOffTime};
+        if (email?._retryCutOffTime) {
+            return {...this.#BEFORE_RETRY_CONFIG, stopAfterDate: email._retryCutOffTime, shutdownConfig: this.#SHUTDOWN_RETRY_CONFIG};
         }
-        return this.#BEFORE_RETRY_CONFIG;
+        return {...this.#BEFORE_RETRY_CONFIG, shutdownConfig: this.#SHUTDOWN_RETRY_CONFIG};
+    }
+
+    #getAfterRetryConfig() {
+        return {...this.#AFTER_RETRY_CONFIG, shutdownConfig: this.#SHUTDOWN_AFTER_RETRY_CONFIG};
+    }
+
+    #getMailgunRetryConfig() {
+        return {...this.#MAILGUN_API_RETRY_CONFIG, shutdownConfig: this.#SHUTDOWN_RETRY_CONFIG};
     }
 
     /**
-     * Stops the batch workers and waits for any in-flight sends to finish.
+     * Normalises retry options for a single attempt: swaps in the shutdown policy once a
+     * shutdown has started, then pins the deadline implied by maxTime (shortest wins).
+     */
+    #resolveRetryOptions(options) {
+        let resolved = options;
+
+        if (this.#shuttingDown && resolved.shutdownConfig && !resolved.shutdownPolicyApplied) {
+            resolved = {
+                ...resolved,
+                ...resolved.shutdownConfig,
+                shutdownConfig: resolved.shutdownConfig,
+                shutdownPolicyApplied: true
+            };
+        }
+
+        if (resolved.maxTime !== undefined) {
+            const stopAfterDate = new Date(Date.now() + resolved.maxTime);
+            if (!resolved.stopAfterDate || stopAfterDate < resolved.stopAfterDate) {
+                resolved = {...resolved, stopAfterDate};
+            }
+        }
+
+        return resolved;
+    }
+
+    /**
+     * Signals the batch workers to stop claiming new batches. Runs before the HTTP
+     * server drain, so no batch is claimed in a window we can't finish it in.
+     * Synchronous — draining is onShutdown's job. Idempotent.
+     */
+    onPreStop() {
+        this.#shuttingDown = true;
+    }
+
+    /**
+     * Waits for any in-flight sends to finish.
      * Called by the cleanup pipeline when the container is shutting down. Idempotent.
      */
     async onShutdown() {
@@ -161,7 +213,7 @@ class BatchSendingService {
             async () => {
                 return await this.updateStatusLock(this.#models.Email, emailId, 'submitting', ['pending', 'failed']);
             },
-            {...this.#BEFORE_RETRY_CONFIG, description: `updateStatusLock email ${emailId} -> submitting`}
+            {...this.#getBeforeRetryConfig(), description: `updateStatusLock email ${emailId} -> submitting`}
         );
         if (!email) {
             logging.error(`Tried sending email that is not pending or failed ${emailId}`);
@@ -185,9 +237,12 @@ class BatchSendingService {
                     submitted_at: new Date(),
                     error: null
                 }, {patch: true, autoRefresh: false});
-            }, {...this.#AFTER_RETRY_CONFIG, description: `email ${emailId} -> submitted`});
+            }, {...this.#getAfterRetryConfig(), description: `email ${emailId} -> submitted`});
         } catch (e) {
-            if (e && e.code === SHUTDOWN_CODE) {
+            // Any failure while shutting down counts as interrupted, not failed:
+            // collapsed budgets surface transient errors as hard failures, and `failed`
+            // drops the email out of the boot resume scan.
+            if ((e && e.code === SHUTDOWN_CODE) || this.#shuttingDown) {
                 logging.info(`Email ${email.id} send stopped because the container is shutting down — leaving status=submitting so it can resume on next boot`);
                 return;
             }
@@ -209,7 +264,7 @@ class BatchSendingService {
                     status: 'failed',
                     error: e.message || 'Something went wrong while sending the email'
                 }, {patch: true, autoRefresh: false});
-            }, {...this.#AFTER_RETRY_CONFIG, description: `email ${emailId} -> failed`});
+            }, {...this.#getAfterRetryConfig(), description: `email ${emailId} -> failed`});
         }
     }
 
@@ -509,8 +564,12 @@ class BatchSendingService {
             }
         };
 
-        // Run maximum MAX_SENDING_CONCURRENCY at the same time
-        await Promise.all(new Array(MAX_SENDING_CONCURRENCY).fill(0).map(() => runWorker()));
+        // Run maximum MAX_SENDING_CONCURRENCY at the same time.
+        // allSettled so one worker throwing doesn't detach the others: the drain must not
+        // resolve while a sibling's terminal status write is still in flight.
+        const workerResults = await Promise.allSettled(
+            new Array(MAX_SENDING_CONCURRENCY).fill(0).map(() => runWorker())
+        );
 
         logging.info(`Email ${email.id} send done: ${succeededCount}/${batches.length} batches succeeded, ${queue.length} unstarted`);
 
@@ -519,6 +578,11 @@ class BatchSendingService {
                 code: SHUTDOWN_CODE,
                 message: 'Email send stopped because the container is shutting down'
             });
+        }
+
+        const failedWorker = workerResults.find(result => result.status === 'rejected');
+        if (failedWorker) {
+            throw failedWorker.reason;
         }
 
         if (succeededCount < batches.length) {
@@ -604,7 +668,7 @@ class BatchSendingService {
                     deliveryTime,
                     emailBodyCache
                 });
-            }, {...this.#MAILGUN_API_RETRY_CONFIG, description: `Sending email batch ${originalBatch.id} ${deliveryTime ? `with delivery time ${deliveryTime}` : ''}`});
+            }, {...this.#getMailgunRetryConfig(), description: `Sending email batch ${originalBatch.id} ${deliveryTime ? `with delivery time ${deliveryTime}` : ''}`});
             succeeded = true;
 
             await this.retryDb(
@@ -618,7 +682,7 @@ class BatchSendingService {
                         error_data: null
                     }, {patch: true, require: false, autoRefresh: false});
                 },
-                {...this.#AFTER_RETRY_CONFIG, description: `save batch ${originalBatch.id} -> submitted`}
+                {...this.#getAfterRetryConfig(), description: `save batch ${originalBatch.id} -> submitted`}
             );
         } catch (err) {
             if (err.code && err.code === 'BULK_EMAIL_SEND_FAILED') {
@@ -653,8 +717,13 @@ class BatchSendingService {
                             error_data: err.errorDetails ?? null
                         }, {patch: true, require: false, autoRefresh: false});
                     },
-                    {...this.#AFTER_RETRY_CONFIG, description: `save batch ${originalBatch.id} -> failed`}
+                    {...this.#getAfterRetryConfig(), description: `save batch ${originalBatch.id} -> failed`}
                 );
+            } else if (this.#shuttingDown) {
+                // Sent, but the `submitted` write didn't land in the collapsed budget.
+                // Returning success would mark the email submitted with this row left in
+                // `submitting`, which the boot resume scan never looks at.
+                throw err;
             }
         }
 
@@ -665,7 +734,7 @@ class BatchSendingService {
                     .where({batch_id: batch.id})
                     .save({processed_at: new Date()}, {patch: true, require: false, autoRefresh: false});
             },
-            {...this.#AFTER_RETRY_CONFIG, description: `save EmailRecipients ${originalBatch.id} processed_at`}
+            {...this.#getAfterRetryConfig(), description: `save EmailRecipients ${originalBatch.id} processed_at`}
         );
 
         return succeeded;
@@ -744,12 +813,7 @@ class BatchSendingService {
      * @returns {Promise<T>}
      */
     async retryDb(func, options) {
-        if (options.maxTime !== undefined) {
-            const stopAfterDate = new Date(Date.now() + options.maxTime);
-            if (!options.stopAfterDate || stopAfterDate < options.stopAfterDate) {
-                options = {...options, stopAfterDate};
-            }
-        }
+        options = this.#resolveRetryOptions(options);
         const retryCount = (options.retryCount ?? 0);
 
         try {
@@ -765,6 +829,10 @@ class BatchSendingService {
 
             return response;
         } catch (e) {
+            // Shutdown may have started while this attempt was pending — re-resolve so
+            // the collapsed budget decides whether we retry at all
+            options = this.#resolveRetryOptions(options);
+
             const sleep = (options.sleep ?? 0);
             if (retryCount >= options.maxRetries || (options.stopAfterDate && (new Date(Date.now() + sleep)) > options.stopAfterDate)) {
                 if (retryCount > 0) {
@@ -794,7 +862,16 @@ class BatchSendingService {
                     setTimeout(resolve, sleep);
                 });
             }
-            return await this.retryDb(func, {...options, retryCount: retryCount + 1, sleep: sleep * 2});
+
+            // Budget is only checked after a failure, so recursing always spends another
+            // attempt first. Re-check here, or a shutdown that began during the backoff
+            // gets one more go — a fresh Mailgun send well into a shutdown.
+            const nextOptions = this.#resolveRetryOptions({...options, retryCount: retryCount + 1, sleep: sleep * 2});
+            if (nextOptions.retryCount > nextOptions.maxRetries || (nextOptions.stopAfterDate && new Date() > nextOptions.stopAfterDate)) {
+                throw e;
+            }
+
+            return await this.retryDb(func, nextOptions);
         }
     }
 

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -136,6 +136,10 @@ class EmailServiceWrapper {
         });
 
         if (ghostServer) {
+            // Two phases: stop claiming batches immediately, drain in-flight ones later.
+            // Draining alone would leave workers claiming new batches for the whole HTTP
+            // server drain, each a fresh orphan candidate.
+            ghostServer.registerPreStopTask(() => batchSendingService.onPreStop(), 'Email batch sending (stop claiming)');
             ghostServer.registerCleanupTask(() => batchSendingService.onShutdown(), 'Email batch sending');
         }
 

--- a/ghost/core/test/unit/server/ghost-server.test.js
+++ b/ghost/core/test/unit/server/ghost-server.test.js
@@ -1,0 +1,73 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+
+const GhostServer = require('../../../core/server/ghost-server');
+
+describe('GhostServer', function () {
+    let server;
+
+    beforeEach(function () {
+        sinon.stub(logging, 'info');
+        sinon.stub(logging, 'warn');
+        sinon.stub(logging, 'error');
+        server = new GhostServer({url: 'http://localhost:2368', env: 'testing', serverConfig: {}});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('_cleanup', function () {
+        it('runs every task even when one rejects', async function () {
+            const slow = sinon.stub().resolves();
+            server.registerCleanupTask(() => Promise.reject(new Error('nope')), 'failing task');
+            server.registerCleanupTask(slow, 'Email batch sending');
+
+            // Rejects so the exit code still reflects the failure...
+            await assert.rejects(server._cleanup(), /1 cleanup task\(s\) failed: failing task/);
+
+            // ...but only after the sibling ran to completion. Rejecting early would
+            // exit the process mid-drain and orphan email batches in `submitting`.
+            sinon.assert.calledOnce(slow);
+        });
+
+        it('resolves when every task succeeds', async function () {
+            server.registerCleanupTask(() => Promise.resolve(), 'a');
+            server.registerCleanupTask(() => Promise.resolve(), 'b');
+
+            await server._cleanup();
+        });
+    });
+
+    describe('_preStop', function () {
+        it('runs every task before the server drain, isolating failures', function () {
+            const second = sinon.stub();
+            server.registerPreStopTask(() => {
+                throw new Error('nope');
+            }, 'failing signal');
+            server.registerPreStopTask(second, 'Email batch sending (stop claiming)');
+
+            // Must not throw — a bad signal cannot skip the drain and cleanup that follow.
+            server._preStop();
+
+            sinon.assert.calledOnce(second);
+        });
+
+        it('has run before the HTTP server is stopped', async function () {
+            const order = [];
+            server.registerPreStopTask(() => order.push('pre-stop'), 'stop claiming');
+            server.registerCleanupTask(async () => {
+                order.push('cleanup');
+            }, 'drain');
+            sinon.stub(server, '_stopServer').callsFake(async () => {
+                order.push('stop-server');
+            });
+            server.httpServer = {listening: true};
+
+            await server.stop();
+
+            assert.deepEqual(order, ['pre-stop', 'stop-server', 'cleanup']);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -1254,6 +1254,44 @@ describe('Batch Sending Service', function () {
             assert.equal(members.length, 2);
         });
 
+        it('Propagates a failed submitted-status write during shutdown', async function () {
+            const sendingService = {
+                send: sinon.stub().resolves({id: 'providerid@example.com'}),
+                getMaximumRecipients: () => 5
+            };
+            const service = new BatchSendingService({
+                models: {EmailRecipient},
+                sendingService
+            });
+            const batch = createModel({status: 'pending', member_segment: null});
+            const save = sinon.stub(batch, 'save').rejects(new Error('deadlock'));
+            sinon.stub(service, 'updateStatusLock').resolves(batch);
+
+            service.onPreStop();
+
+            const clock = sinon.useFakeTimers();
+            const promise = service.sendBatch({
+                email: createModel({}),
+                batch: createModel({}),
+                post: createModel({}),
+                newsletter: createModel({})
+            });
+            // Drain the collapsed shutdown retry budget without waiting in real time
+            const assertion = assert.rejects(promise);
+            await clock.tickAsync(30000);
+            await assertion;
+            clock.restore();
+
+            // Mailgun accepted the batch, so reporting success would let the parent email
+            // be saved as `submitted` with this row left behind in `submitting`
+            sinon.assert.calledOnce(sendingService.send);
+            assert.ok(save.callCount > 0);
+            assert.ok(
+                save.getCalls().every(call => call.args[0].status === 'submitted'),
+                'batch must never be downgraded to failed once Mailgun has accepted it'
+            );
+        });
+
         it('Does send with a deliverytime', async function () {
             const EmailBatch = createModelClass({
                 findOne: {
@@ -2133,6 +2171,207 @@ describe('Batch Sending Service', function () {
             assert.equal(afterEmailModel.get('error'), undefined, 'No error field should be written when send stops on shutdown');
             // logging.info was stubbed in the outer beforeEach — confirm the shutdown breadcrumb was emitted.
             sinon.assert.calledWithMatch(logging.info, /send stopped because the container is shutting down/);
+        });
+
+        it('emailJob leaves email in submitting status for any error once shutting down', async function () {
+            const Email = createModelClass({
+                findOne: {
+                    status: 'pending'
+                }
+            });
+            const service = new BatchSendingService({
+                models: {Email}
+            });
+            let afterEmailModel;
+            // A plain transient error, not SHUTDOWN_CODE — the kind the collapsed
+            // shutdown retry budgets stop absorbing.
+            sinon.stub(service, 'sendEmail').callsFake((email) => {
+                afterEmailModel = email;
+                return Promise.reject(new Error('connection lost'));
+            });
+            service.onPreStop();
+
+            await service.emailJob({emailId: '123'});
+
+            assert.equal(afterEmailModel.get('status'), 'submitting', 'Email must stay submitting so the boot resume scan picks it up');
+            assert.equal(afterEmailModel.get('error'), undefined);
+        });
+
+        it('onPreStop stops workers claiming new batches without waiting for in-flight ones', async function () {
+            const clock = sinon.useFakeTimers(new Date());
+            const service = new BatchSendingService({
+                sendingService: {
+                    getTargetDeliveryWindow() {
+                        return 0;
+                    }
+                }
+            });
+            const sendBatch = sinon.stub(service, 'sendBatch').callsFake(async () => {
+                await simulateSleep(5, clock);
+                return true;
+            });
+            // 6 batches, 2 workers: the first 2 are claimed immediately, 4 stay queued.
+            const batches = new Array(6).fill(0).map(() => createModel({}));
+            const sendPromise = service.sendBatches({
+                email: createModel({}),
+                batches,
+                post: createModel({}),
+                newsletter: createModel({})
+            });
+
+            // Synchronous — must not await the in-flight batches.
+            service.onPreStop();
+
+            await assert.rejects(
+                sendPromise,
+                err => err.code === BatchSendingService.SHUTDOWN_CODE
+            );
+            sinon.assert.callCount(sendBatch, 2);
+            clock.restore();
+        });
+
+        it('collapses pre-send retries once shutting down', async function () {
+            const buildService = () => {
+                const service = new BatchSendingService({
+                    models: {EmailBatch: createModelClass({findOne: {status: 'pending'}})},
+                    BEFORE_RETRY_CONFIG: {maxRetries: 3, sleep: 0}
+                });
+                const updateStatusLock = sinon.stub(service, 'updateStatusLock').rejects(new Error('deadlock'));
+                return {service, updateStatusLock};
+            };
+            const args = () => ({
+                email: createModel({}),
+                batch: createModel({status: 'pending'}),
+                post: createModel({}),
+                newsletter: createModel({})
+            });
+
+            // Baseline: the configured budget is spent trying to claim the batch.
+            const baseline = buildService();
+            await assert.rejects(baseline.service.sendBatch(args()));
+            sinon.assert.callCount(baseline.updateStatusLock, 4);
+
+            // Shutting down: give up on the first failure instead of holding the batch
+            // in `submitting` until the container is killed.
+            const shuttingDown = buildService();
+            shuttingDown.service.onPreStop();
+            await assert.rejects(shuttingDown.service.sendBatch(args()));
+            sinon.assert.callCount(shuttingDown.updateStatusLock, 1);
+        });
+
+        it('collapses retries for a shutdown that starts while an attempt is pending', async function () {
+            const service = new BatchSendingService({});
+            const func = sinon.stub().callsFake(async () => {
+                // Shutdown begins mid-attempt, after the caller already picked its policy
+                service.onPreStop();
+                throw new Error('deadlock');
+            });
+
+            await assert.rejects(service.retryDb(func, {
+                maxRetries: 10,
+                maxTime: 10 * 60 * 1000,
+                sleep: 0,
+                shutdownConfig: {maxRetries: 0},
+                description: 'mid-flight shutdown'
+            }));
+
+            // The captured 10-retry budget must not survive the shutdown
+            sinon.assert.callCount(func, 1);
+        });
+
+        it('waits for every worker to settle when one throws', async function () {
+            const service = new BatchSendingService({
+                sendingService: {
+                    getTargetDeliveryWindow() {
+                        return 0;
+                    }
+                }
+            });
+
+            let slowBatchSettled = false;
+            let releaseSlowBatch;
+            const slowBatch = new Promise((resolve) => {
+                releaseSlowBatch = resolve;
+            });
+
+            sinon.stub(service, 'sendBatch').callsFake(async ({batch}) => {
+                if (batch.get('member_segment') === 'throws') {
+                    throw new Error('lock timeout');
+                }
+                await slowBatch;
+                slowBatchSettled = true;
+                return true;
+            });
+
+            let outcome = null;
+            const tracked = service.sendBatches({
+                email: createModel({}),
+                batches: [createModel({member_segment: 'throws'}), createModel({member_segment: 'slow'})],
+                post: createModel({}),
+                newsletter: createModel({})
+            }).then(
+                () => {
+                    outcome = 'fulfilled';
+                },
+                (err) => {
+                    outcome = err;
+                }
+            );
+
+            // Let every pending microtask and timer callback run. The throwing worker has
+            // rejected by now; with Promise.all that alone settled sendBatches, leaving
+            // the sibling's status write in flight while the drain reported itself done.
+            await new Promise((resolve) => {
+                setImmediate(resolve);
+            });
+            assert.equal(outcome, null, 'sendBatches must not settle while a worker is still in flight');
+            assert.equal(slowBatchSettled, false);
+
+            releaseSlowBatch();
+            await tracked;
+
+            assert.equal(slowBatchSettled, true);
+            assert.match(outcome.message, /lock timeout/, 'the worker failure must still surface');
+        });
+
+        it('does not retry when shutdown starts during the backoff sleep', async function () {
+            const service = new BatchSendingService({});
+            const func = sinon.stub().rejects(new Error('mailgun 500'));
+
+            const promise = service.retryDb(func, {
+                maxRetries: 6,
+                sleep: 20,
+                shutdownConfig: {maxRetries: 0},
+                description: 'shutdown during backoff'
+            });
+
+            // First attempt has already failed and retryDb is now sleeping before the
+            // next one — the window where a Mailgun send would otherwise fire again.
+            await new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            });
+            service.onPreStop();
+
+            await assert.rejects(promise);
+            sinon.assert.callCount(func, 1);
+        });
+
+        it('keeps a short retry budget for terminal status writes during shutdown', async function () {
+            const service = new BatchSendingService({});
+            const func = sinon.stub().rejects(new Error('deadlock'));
+            service.onPreStop();
+
+            await assert.rejects(service.retryDb(func, {
+                maxRetries: 20,
+                maxTime: 30 * 60 * 1000,
+                sleep: 0,
+                shutdownConfig: {maxRetries: 3, maxTime: 10 * 1000, sleep: 0},
+                description: 'terminal write'
+            }));
+
+            // Collapsed to the shutdown budget, but not to zero — this write is the one
+            // that has to land, or the batch orphans in `submitting`
+            sinon.assert.callCount(func, 4);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1954
- add preStopTasks array for tasks that should run prior to server drain
- wire up email batch shutdown to preStop
- fix error handling in cleanup tasks
- prevent batch email send retries after shutdown