### PR TITLE
🎨 Added a file size check before uploads start in the editor

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -56,6 +56,10 @@ export type Config = {
                 max?: number
                 error?: string
             },
+            uploads?: {
+                max?: number // Maximum accepted upload size, in bytes
+                error?: string
+            },
             customThemes?: {
                 allowlist?: string[],
                 error?: string

--- a/apps/admin-x-framework/src/hooks.ts
+++ b/apps/admin-x-framework/src/hooks.ts
@@ -4,7 +4,7 @@ export {default as useForm} from './hooks/use-form';
 export type {Dirtyable, ErrorMessages, FormHook, OkProps, SaveHandler, SaveState} from './hooks/use-form';
 export {default as useHandleError} from './hooks/use-handle-error';
 export {useFeatureFlag} from './hooks/use-feature-flag';
-export {useKoenigFileUpload, koenigFileUploadTypes} from './hooks/use-koenig-file-upload';
+export {useKoenigFileUpload, koenigFileUploadTypes, createKoenigFileUploader} from './hooks/use-koenig-file-upload';
 export {useKoenigFetchEmbed} from './hooks/use-koenig-fetch-embed';
 export type {KoenigFileUploadType} from './hooks/use-koenig-file-upload';
 export {useKoenigLinkSuggestions} from './hooks/use-koenig-link-suggestions';

--- a/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
+++ b/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
@@ -82,8 +82,11 @@ interface KoenigFileUploadOptions {
      * Checked before the request is made, which the server-side limit cannot do:
      * a reverse proxy in front of Ghost may reject an oversized body before it
      * ever reaches the API, so the host limit's error never gets a chance to run.
+     *
+     * Accepts the raw config value: limits configured through environment
+     * variables arrive as strings, and are normalised here.
      */
-    maxUploadSize?: number;
+    maxUploadSize?: number | string;
     /**
      * Message from `hostSettings.limits.uploads.error`, shown in place of the
      * default when the size check fails.
@@ -92,8 +95,8 @@ interface KoenigFileUploadOptions {
 }
 
 // Config can reach the browser via environment variables, where every value is a
-// string, so coerce before comparing against `File.size`.
-const resolveUploadLimit = (limit: undefined | number): null | number => {
+// string, so normalise here rather than trusting the declared config type.
+const resolveUploadLimit = (limit: undefined | number | string): null | number => {
     const bytes = Number(limit);
     return Number.isFinite(bytes) && bytes > 0 ? bytes : null;
 };
@@ -300,7 +303,7 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image', {maxUp
  * applied. Memoize the result on `maxUploadSize` so the editor's context value
  * stays stable across renders.
  */
-export const createKoenigFileUploader = (maxUploadSize: undefined | number, maxUploadError?: string) => ({
+export const createKoenigFileUploader = (maxUploadSize: undefined | number | string, maxUploadError?: string) => ({
     fileTypes: koenigFileUploadTypes,
     useFileUpload: function useFileUpload(type: KoenigFileUploadType = 'image') {
         return useKoenigFileUpload(type, {maxUploadSize, maxUploadError});

--- a/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
+++ b/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
@@ -84,6 +84,11 @@ interface KoenigFileUploadOptions {
      * ever reaches the API, so the host limit's error never gets a chance to run.
      */
     maxUploadSize?: number;
+    /**
+     * Message from `hostSettings.limits.uploads.error`, shown in place of the
+     * default when the size check fails.
+     */
+    maxUploadError?: string;
 }
 
 // Config can reach the browser via environment variables, where every value is a
@@ -97,7 +102,21 @@ const resolveUploadLimit = (limit: undefined | number): null | number => {
 // back rather than switching to mebibytes.
 const formatUploadLimit = (bytes: number): string => `${Math.round((bytes / 1000000) * 10) / 10}MB`;
 
-export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image', {maxUploadSize}: KoenigFileUploadOptions = {}): FileUploadHook => {
+// Configured limit errors are templates that @tryghost/limit-service interpolates
+// when it raises the error on the server, so the same placeholders have to be
+// filled in here — otherwise the message reaches the user with a raw `{{max}}` in
+// it. Mirrors the interpolation pattern the limit service uses.
+const interpolateUploadError = (error: string, limitBytes: number, fileBytes: number): string => {
+    const values: Record<string, string> = {
+        max: formatUploadLimit(limitBytes),
+        count: formatUploadLimit(fileBytes),
+        name: 'uploads'
+    };
+
+    return error.replace(/{{([\s\S]+?)}}/g, (_match, token) => values[token.trim()] ?? '');
+};
+
+export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image', {maxUploadSize, maxUploadError}: KoenigFileUploadOptions = {}): FileUploadHook => {
     const [progress, setProgress] = useState(0);
     const [isLoading, setLoading] = useState(false);
     const [errors, setErrors] = useState<UploadError[]>([]);
@@ -129,7 +148,9 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image', {maxUp
         // Size is checked ahead of the early return below: the file card accepts
         // any file type, and is the one most likely to be handed something huge.
         if (uploadLimit !== null && file.size > uploadLimit) {
-            return `The file you uploaded is larger than the maximum file size of ${formatUploadLimit(uploadLimit)}.`;
+            return maxUploadError
+                ? interpolateUploadError(maxUploadError, uploadLimit, file.size)
+                : `The file you uploaded is larger than the maximum file size of ${formatUploadLimit(uploadLimit)}.`;
         }
 
         // if type is file we don't need to validate since the card can accept any file type
@@ -279,9 +300,9 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image', {maxUp
  * applied. Memoize the result on `maxUploadSize` so the editor's context value
  * stays stable across renders.
  */
-export const createKoenigFileUploader = (maxUploadSize: undefined | number) => ({
+export const createKoenigFileUploader = (maxUploadSize: undefined | number, maxUploadError?: string) => ({
     fileTypes: koenigFileUploadTypes,
     useFileUpload: function useFileUpload(type: KoenigFileUploadType = 'image') {
-        return useKoenigFileUpload(type, {maxUploadSize});
+        return useKoenigFileUpload(type, {maxUploadSize, maxUploadError});
     }
 });

--- a/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
+++ b/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
@@ -76,7 +76,28 @@ const getStringAtPath = (maybeObj: unknown, path: Iterable<PropertyKey>): null |
     return (typeof current === 'string') ? current : null;
 };
 
-export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileUploadHook => {
+interface KoenigFileUploadOptions {
+    /**
+     * Maximum accepted file size in bytes, from `hostSettings.limits.uploads.max`.
+     * Checked before the request is made, which the server-side limit cannot do:
+     * a reverse proxy in front of Ghost may reject an oversized body before it
+     * ever reaches the API, so the host limit's error never gets a chance to run.
+     */
+    maxUploadSize?: number;
+}
+
+// Config can reach the browser via environment variables, where every value is a
+// string, so coerce before comparing against `File.size`.
+const resolveUploadLimit = (limit: undefined | number): null | number => {
+    const bytes = Number(limit);
+    return Number.isFinite(bytes) && bytes > 0 ? bytes : null;
+};
+
+// The limit service reports upload limits in decimal MB, so quote the same unit
+// back rather than switching to mebibytes.
+const formatUploadLimit = (bytes: number): string => `${Math.round((bytes / 1000000) * 10) / 10}MB`;
+
+export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image', {maxUploadSize}: KoenigFileUploadOptions = {}): FileUploadHook => {
     const [progress, setProgress] = useState(0);
     const [isLoading, setLoading] = useState(false);
     const [errors, setErrors] = useState<UploadError[]>([]);
@@ -85,6 +106,7 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileU
     const progressTracker = useRef(new Map());
 
     const fetchApi = useFetchApi();
+    const uploadLimit = resolveUploadLimit(maxUploadSize);
 
     function updateProgress() {
         if (progressTracker.current.size === 0) {
@@ -104,6 +126,12 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileU
     // we only check the file extension by default because IE doesn't always
     // expose the mime-type, we'll rely on the API for final validation
     const defaultValidator = (file: File): true | string => {
+        // Size is checked ahead of the early return below: the file card accepts
+        // any file type, and is the one most likely to be handed something huge.
+        if (uploadLimit !== null && file.size > uploadLimit) {
+            return `The file you uploaded is larger than the maximum file size of ${formatUploadLimit(uploadLimit)}.`;
+        }
+
         // if type is file we don't need to validate since the card can accept any file type
         if (type === 'file') {
             return true;
@@ -245,3 +273,15 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileU
 
     return {progress, isLoading, upload, errors, filesNumber};
 };
+
+/**
+ * Builds the `fileUploader` object Koenig expects, with an upload size limit
+ * applied. Memoize the result on `maxUploadSize` so the editor's context value
+ * stays stable across renders.
+ */
+export const createKoenigFileUploader = (maxUploadSize: undefined | number) => ({
+    fileTypes: koenigFileUploadTypes,
+    useFileUpload: function useFileUpload(type: KoenigFileUploadType = 'image') {
+        return useKoenigFileUpload(type, {maxUploadSize});
+    }
+});

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -17,7 +17,7 @@ export {useTinybirdToken} from './hooks/use-tinybird-token';
 export type {UseTinybirdTokenResult} from './hooks/use-tinybird-token';
 export {useTinybirdQuery} from './hooks/use-tinybird-query';
 export type {UseTinybirdQueryOptions} from './hooks/use-tinybird-query';
-export {useKoenigFileUpload, koenigFileUploadTypes} from './hooks/use-koenig-file-upload';
+export {useKoenigFileUpload, koenigFileUploadTypes, createKoenigFileUploader} from './hooks/use-koenig-file-upload';
 export {useKoenigFetchEmbed} from './hooks/use-koenig-fetch-embed';
 export {useKoenigLinkSuggestions} from './hooks/use-koenig-link-suggestions';
 export {useFeaturebase} from './hooks/use-featurebase';

--- a/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
@@ -10,6 +10,16 @@ function makeFile(name: string, type = 'image/jpeg'): File {
     return new File(['content'], name, {type});
 }
 
+const MB = 1000000;
+
+// A real File reports the size of its own contents, so stub the size rather
+// than allocating hundreds of megabytes per test.
+function makeFileOfSize(name: string, bytes: number, type = 'image/jpeg'): File {
+    const file = makeFile(name, type);
+    Object.defineProperty(file, 'size', {value: bytes});
+    return file;
+}
+
 interface UploadResponse {
     body: Record<string, unknown>;
     status?: number;
@@ -322,5 +332,89 @@ describe('useKoenigFileUpload', () => {
             // Each valid extension should produce a successful upload result
             expect(uploadResult).not.toBeNull();
         }
+    });
+
+    it('rejects a file larger than the configured limit without sending it', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: 200 * MB}));
+
+        const file = makeFileOfSize('huge.jpg', 250 * MB);
+        const uploadResult = await act(async () => (
+            await result.current.upload([file])
+        ));
+
+        expect(uploadResult).toBeNull();
+        expect(requestLog.find(request => request.method === 'POST')).toBeUndefined();
+        expect(result.current.errors).toHaveLength(1);
+        expect(result.current.errors[0].fileName).toBe('huge.jpg');
+        expect(result.current.errors[0].message).toBe(
+            'The file you uploaded is larger than the maximum file size of 200MB.'
+        );
+    });
+
+    it('uploads a file that fits within the configured limit', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: 200 * MB}));
+
+        const file = makeFileOfSize('photo.jpg', 199 * MB);
+        const uploadResult = await act(async () => (
+            await result.current.upload([file])
+        ));
+
+        expect(uploadResult).not.toBeNull();
+        expect(result.current.errors).toHaveLength(0);
+    });
+
+    it('applies the limit to the file type, which skips extension validation', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('file', {maxUploadSize: 1 * MB}));
+
+        const file = makeFileOfSize('archive.zip', 2 * MB, 'application/zip');
+        const uploadResult = await act(async () => (
+            await result.current.upload([file])
+        ));
+
+        expect(uploadResult).toBeNull();
+        expect(requestLog.find(request => request.method === 'POST')).toBeUndefined();
+        expect(result.current.errors[0].message).toBe(
+            'The file you uploaded is larger than the maximum file size of 1MB.'
+        );
+    });
+
+    it('does not check size when no limit is configured', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('image'));
+
+        const file = makeFileOfSize('huge.jpg', 1000 * MB);
+        const uploadResult = await act(async () => (
+            await result.current.upload([file])
+        ));
+
+        expect(uploadResult).not.toBeNull();
+        expect(result.current.errors).toHaveLength(0);
+    });
+
+    it('ignores a limit that is not a usable size', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: 0}));
+
+        const file = makeFileOfSize('huge.jpg', 1000 * MB);
+        const uploadResult = await act(async () => (
+            await result.current.upload([file])
+        ));
+
+        expect(uploadResult).not.toBeNull();
+    });
+
+    it('accepts a limit that arrives as a string', async () => {
+        // Self-hosters configure limits through environment variables, where
+        // every value reaches the config as a string.
+        const stringLimit = String(200 * MB) as unknown as number;
+        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: stringLimit}));
+
+        const file = makeFileOfSize('huge.jpg', 250 * MB);
+        await act(async () => {
+            await result.current.upload([file]);
+        });
+
+        expect(requestLog.find(request => request.method === 'POST')).toBeUndefined();
+        expect(result.current.errors[0].message).toBe(
+            'The file you uploaded is larger than the maximum file size of 200MB.'
+        );
     });
 });

--- a/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
@@ -417,4 +417,33 @@ describe('useKoenigFileUpload', () => {
             'The file you uploaded is larger than the maximum file size of 200MB.'
         );
     });
+    it('accepts a file sized exactly at the limit', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: 200 * MB}));
+
+        const file = makeFileOfSize('photo.jpg', 200 * MB);
+        const uploadResult = await act(async () => (
+            await result.current.upload([file])
+        ));
+
+        expect(uploadResult).not.toBeNull();
+        expect(result.current.errors).toHaveLength(0);
+    });
+
+    it('fills in the placeholders in a configured limit error', async () => {
+        const {result} = renderHook(() => useKoenigFileUpload('image', {
+            maxUploadSize: 200 * MB,
+            // hostSettings.limits.uploads.error is a template that
+            // @tryghost/limit-service interpolates when it raises the error
+            // server-side, so the placeholders must not reach the user raw.
+            maxUploadError: 'This file is {{count}}, above your {{max}} limit.'
+        }));
+
+        const file = makeFileOfSize('huge.jpg', 250 * MB);
+        await act(async () => {
+            await result.current.upload([file]);
+        });
+
+        expect(requestLog.find(request => request.method === 'POST')).toBeUndefined();
+        expect(result.current.errors[0].message).toBe('This file is 250MB, above your 200MB limit.');
+    });
 });

--- a/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
@@ -404,8 +404,7 @@ describe('useKoenigFileUpload', () => {
     it('accepts a limit that arrives as a string', async () => {
         // Self-hosters configure limits through environment variables, where
         // every value reaches the config as a string.
-        const stringLimit = String(200 * MB) as unknown as number;
-        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: stringLimit}));
+        const {result} = renderHook(() => useKoenigFileUpload('image', {maxUploadSize: String(200 * MB)}));
 
         const file = makeFileOfSize('huge.jpg', 250 * MB);
         await act(async () => {

--- a/apps/admin/src/automations/components/email-modal/email-editor.tsx
+++ b/apps/admin/src/automations/components/email-modal/email-editor.tsx
@@ -4,7 +4,7 @@ import {LoadingIndicator} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
 import {focusKoenigEditorOnBottomClick, useFramework} from '@tryghost/admin-x-framework';
 import {getSettingValues, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
-import {koenigFileUploadTypes, useKoenigFetchEmbed, useKoenigFileUpload, usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
+import {createKoenigFileUploader, useKoenigFetchEmbed, usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useEmailLinkSuggestions} from './use-link-suggestions';
 import {useFocusContext} from '@tryghost/shade/app';
@@ -18,11 +18,6 @@ export interface EmailEditorProps {
 
 // The editor API handle, typed as whatever focusKoenigEditorOnBottomClick accepts.
 type KoenigAPI = Parameters<typeof focusKoenigEditorOnBottomClick>[0];
-
-const fileUploader = {
-    useFileUpload: useKoenigFileUpload,
-    fileTypes: koenigFileUploadTypes
-};
 
 // @tryghost/koenig-lexical ships no type declarations, so its runtime module
 // resolves as `any`. Declare just the EmailEditor surface we use so the lazy
@@ -112,6 +107,8 @@ const EmailEditor: React.FC<EmailEditorProps> = ({
     const {data: configData} = useBrowseConfig();
     const settings = settingsData?.settings || [];
     const config = configData?.config;
+    const maxUploadSize = config?.hostSettings?.limits?.uploads?.max;
+    const fileUploader = useMemo(() => createKoenigFileUploader(maxUploadSize), [maxUploadSize]);
     const {fetchAutocompleteLinks, searchLinks} = useEmailLinkSuggestions();
     const fetchEmbed = useKoenigFetchEmbed();
     const klipyConfig = config?.klipy?.apiKey ? config.klipy : null;

--- a/apps/admin/src/automations/components/email-modal/email-editor.tsx
+++ b/apps/admin/src/automations/components/email-modal/email-editor.tsx
@@ -108,7 +108,8 @@ const EmailEditor: React.FC<EmailEditorProps> = ({
     const settings = settingsData?.settings || [];
     const config = configData?.config;
     const maxUploadSize = config?.hostSettings?.limits?.uploads?.max;
-    const fileUploader = useMemo(() => createKoenigFileUploader(maxUploadSize), [maxUploadSize]);
+    const maxUploadError = config?.hostSettings?.limits?.uploads?.error;
+    const fileUploader = useMemo(() => createKoenigFileUploader(maxUploadSize, maxUploadError), [maxUploadError, maxUploadSize]);
     const {fetchAutocompleteLinks, searchLinks} = useEmailLinkSuggestions();
     const fetchEmbed = useKoenigFetchEmbed();
     const klipyConfig = config?.klipy?.apiKey ? config.klipy : null;

--- a/apps/admin/src/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin/src/settings/membership/member-emails/member-email-editor.tsx
@@ -5,7 +5,7 @@ import {LoadingIndicator} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
 import {focusKoenigEditorOnBottomClick, useFramework} from '@tryghost/admin-x-framework';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
-import {koenigFileUploadTypes, useKoenigFetchEmbed, useKoenigFileUpload, usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
+import {createKoenigFileUploader, useKoenigFetchEmbed, usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
 import {useFocusContext} from '@tryghost/shade/app';
 import {useGlobalData} from '@/settings/providers/global-data-context';
 import {useWelcomeEmailLinkSuggestions} from '@/settings/hooks/use-welcome-email-link-suggestions';
@@ -16,11 +16,6 @@ export interface MemberEmailsEditorProps {
     className?: string;
     onChange?: (value: string) => void;
 }
-
-const fileUploader = {
-    useFileUpload: useKoenigFileUpload,
-    fileTypes: koenigFileUploadTypes
-};
 
 type EditorResource = ReturnType<typeof loadKoenig>;
 
@@ -86,6 +81,9 @@ const EmailEditorInner: React.FC<{
     onChange: (data: unknown) => void;
 }> = ({editor, darkMode, cardConfig, initialEditorState, placeholder, className, registerAPI, onChange}) => {
     const {EmailEditor} = editor.read();
+    const {config} = useGlobalData();
+    const maxUploadSize = config?.hostSettings?.limits?.uploads?.max;
+    const fileUploader = useMemo(() => createKoenigFileUploader(maxUploadSize), [maxUploadSize]);
 
     return (
         <div className={cn('koenig-react-editor w-full', baseEditorStyles, className)}>

--- a/apps/admin/src/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin/src/settings/membership/member-emails/member-email-editor.tsx
@@ -83,7 +83,8 @@ const EmailEditorInner: React.FC<{
     const {EmailEditor} = editor.read();
     const {config} = useGlobalData();
     const maxUploadSize = config?.hostSettings?.limits?.uploads?.max;
-    const fileUploader = useMemo(() => createKoenigFileUploader(maxUploadSize), [maxUploadSize]);
+    const maxUploadError = config?.hostSettings?.limits?.uploads?.error;
+    const fileUploader = useMemo(() => createKoenigFileUploader(maxUploadSize, maxUploadError), [maxUploadError, maxUploadSize]);
 
     return (
         <div className={cn('koenig-react-editor w-full', baseEditorStyles, className)}>

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -3,9 +3,9 @@ import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import moment from 'moment-timezone';
 import {action} from '@ember/object';
+import {createKoenigFileUploader} from '@tryghost/admin-x-framework/hooks';
 import {didCancel, task} from 'ember-concurrency';
 import {inject} from 'ghost-admin/decorators/inject';
-import {koenigFileUploadTypes, useKoenigFileUpload} from '@tryghost/admin-x-framework/hooks';
 import {inject as service} from '@ember/service';
 
 function LockIcon({...props}) {
@@ -182,20 +182,17 @@ const TKCountPlugin = ({editorResource, ...props}) => {
     return <_TKCountPlugin {...props} />;
 };
 
-const FILE_UPLOADER = {
-    useFileUpload: useKoenigFileUpload,
-    fileTypes: koenigFileUploadTypes
-};
-
 const NOOP = () => {};
 
-const KGEditorComponent = ({cardConfig, darkMode, editorArgs, editorResource, isInitInstance, onError}) => {
+const KGEditorComponent = ({cardConfig, darkMode, editorArgs, editorResource, isInitInstance, maxUploadSize, onError}) => {
+    const fileUploader = React.useMemo(() => createKoenigFileUploader(maxUploadSize), [maxUploadSize]);
+
     return (
         <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {display: 'none'} : {}}>
             <KoenigComposer
                 editorResource={editorResource}
                 cardConfig={cardConfig}
-                fileUploader={FILE_UPLOADER}
+                fileUploader={fileUploader}
                 initialEditorState={editorArgs.lexical}
                 onError={onError}
                 darkMode={darkMode}
@@ -520,6 +517,7 @@ export default class KoenigLexicalEditor extends Component {
             darkMode: this.feature.nightShift,
             editorArgs: this.args,
             editorResource: this.editorResource,
+            maxUploadSize: this.config.hostSettings?.limits?.uploads?.max,
             onError: this.onError
         };
 

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -184,8 +184,8 @@ const TKCountPlugin = ({editorResource, ...props}) => {
 
 const NOOP = () => {};
 
-const KGEditorComponent = ({cardConfig, darkMode, editorArgs, editorResource, isInitInstance, maxUploadSize, onError}) => {
-    const fileUploader = React.useMemo(() => createKoenigFileUploader(maxUploadSize), [maxUploadSize]);
+const KGEditorComponent = ({cardConfig, darkMode, editorArgs, editorResource, isInitInstance, maxUploadError, maxUploadSize, onError}) => {
+    const fileUploader = React.useMemo(() => createKoenigFileUploader(maxUploadSize, maxUploadError), [maxUploadError, maxUploadSize]);
 
     return (
         <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {display: 'none'} : {}}>
@@ -517,6 +517,7 @@ export default class KoenigLexicalEditor extends Component {
             darkMode: this.feature.nightShift,
             editorArgs: this.args,
             editorResource: this.editorResource,
+            maxUploadError: this.config.hostSettings?.limits?.uploads?.error,
             maxUploadSize: this.config.hostSettings?.limits?.uploads?.max,
             onError: this.onError
         };


### PR DESCRIPTION
no ref

The editor validated only file extensions, so an oversized file was rejected after the whole request had already been sent − and often not by Ghost at all. A reverse proxy in front of Ghost cuts an oversized body off at the edge, so `hostSettings.limits.uploads` never runs and the message it configures never reaches the user. `File.size` is available as soon as a file is picked or dropped, so the limit can be applied before any bytes leave the browser.

- checks the size ahead of the file-type early return, since the file card accepts any type and is the one most likely to be handed something huge
- takes the limit as a hook option supplied by each host rather than reading config inside the hook: `useKoenigFileUpload` is shared with the Ember post editor, which renders Koenig outside `FrameworkProvider` and so has no react-query context to read config from
- coerces the limit before comparing, since limits configured through environment variables reach the browser as strings
- adds `createKoenigFileUploader` so each host builds Koenig's `fileUploader` with a stable identity across renders

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
