### PR TITLE
🐛 Fixed Safari automation row links

### DIFF
--- a/apps/admin/src/automations/components/automations-list.test.tsx
+++ b/apps/admin/src/automations/components/automations-list.test.tsx
@@ -1,8 +1,8 @@
 import AutomationsList from './automations-list';
 import React from 'react';
-import {MemoryRouter} from 'react-router';
+import {MemoryRouter, Route, Routes, useParams} from 'react-router';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
 const automations = [{
     id: 'automation-id-1',
@@ -27,6 +27,21 @@ const automations = [{
 }];
 
 const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const AutomationEditorRoute = () => {
+    const {id} = useParams();
+
+    return <div>Automation editor: {id}</div>;
+};
+
+const renderWithRoutes = () => render(
+    <MemoryRouter initialEntries={['/automations']}>
+        <Routes>
+            <Route element={<AutomationsList automations={automations} showRunAnalytics={true} />} path="/automations" />
+            <Route element={<AutomationEditorRoute />} path="/automations/:id" />
+        </Routes>
+    </MemoryRouter>
+);
 
 describe('AutomationsList', () => {
     beforeEach(() => {
@@ -78,6 +93,33 @@ describe('AutomationsList', () => {
         expect(screen.getAllByRole('rowheader')).toHaveLength(2);
         expect(screen.getByRole('link', {name: 'Free member welcome flow'})).toHaveAttribute('href', '/automations/automation-id-1');
         expect(screen.getByRole('link', {name: 'Paid member welcome flow'})).toHaveAttribute('href', '/automations/automation-id-2');
+    });
+
+    it('follows the row link when clicking another cell', () => {
+        renderWithRoutes();
+
+        fireEvent.click(screen.getByText('1,432'));
+
+        expect(screen.getByText('Automation editor: automation-id-1')).toBeInTheDocument();
+    });
+
+    it('lets the existing row link handle its own navigation', () => {
+        renderWithRoutes();
+
+        fireEvent.click(screen.getByRole('link', {name: 'Free member welcome flow'}));
+
+        expect(screen.getByText('Automation editor: automation-id-1')).toBeInTheDocument();
+    });
+
+    it('does not follow the row link when the click is default-prevented', () => {
+        renderWithRoutes();
+        const analyticsCell = screen.getByText('1,432');
+        analyticsCell.addEventListener('click', event => event.preventDefault(), {once: true});
+
+        fireEvent.click(analyticsCell);
+
+        expect(screen.queryByText('Automation editor: automation-id-1')).not.toBeInTheDocument();
+        expect(analyticsCell).toBeInTheDocument();
     });
 
     it('renders a table skeleton while loading', () => {

--- a/apps/admin/src/automations/components/automations-list.tsx
+++ b/apps/admin/src/automations/components/automations-list.tsx
@@ -17,6 +17,14 @@ const AUTOMATION_STAT_COLUMNS = [
     {key: 'inProgressEntries', label: 'In progress', widthClassName: 'w-32', skeletonWidthClassName: 'w-10'}
 ] as const;
 
+const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>) => {
+    if (event.defaultPrevented || !(event.target instanceof Element) || event.target.closest('a, button, input, select, textarea')) {
+        return;
+    }
+
+    event.currentTarget.querySelector('a')?.click();
+};
+
 interface AutomationsListProps {
     automations?: AutomationBrowseItem[];
     isLoading?: boolean;
@@ -94,12 +102,13 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
                     return (
                         <TableRow
                             key={automation.slug}
-                            className="grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 p-2 hover:bg-table-row-hover lg:table-row lg:p-0"
+                            className="grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 p-2 hover:bg-table-row-hover has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-[-2px] has-[:focus-visible]:outline-focus-ring lg:table-row lg:p-0"
                             data-testid="automation-list-row"
+                            onClick={handleRowClick}
                         >
-                            <TableHead className="static h-auto min-w-0 p-0 text-left text-base font-normal tracking-normal text-foreground lg:table-cell lg:p-4" scope="row">
+                            <TableHead className="h-auto min-w-0 p-0 text-left text-base font-normal tracking-normal text-foreground lg:table-cell lg:p-4" scope="row">
                                 <Link
-                                    className="before:absolute before:inset-0 before:z-10 before:rounded-sm focus-visible:outline-hidden focus-visible:before:ring-2 focus-visible:before:ring-focus-ring"
+                                    className="rounded-sm focus-visible:outline-hidden"
                                     to={`/automations/${automation.id}`}
                                 >
                                     <span className="block text-md font-semibold">


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1541

Adding the automation analytics columns restored display: table-row at desktop. Safari does not use a positioned table row as the containing block for the absolutely positioned link overlay, so the last row's overlay covered the preceding rows.

Removed the pseudo-element and kept the native table layout and column sizing. Pointer clicks elsewhere in a row delegate to the existing Link in its row header, while the Link remains the only semantic focus target. This preserves valid table markup, native Tab and Enter behavior, and screen-reader header associations without turning <tr> into a fake link. The link's :focus-visible state draws a WebKit-compatible outline around the row.

gif shows it working correctly on safari now. hover state still works right, and you can still click anywhere in the row to go to the correct page, and the table still works right on mobile (notwithstanding other UI improvements we're planning to make there).
<img width="1646" height="822" alt="safari-fix" src="https://github.com/user-attachments/assets/557edf93-20d6-4edd-abcf-3aee3e8d4f71" />

I also double-checked chrome still works correctly, and that things still work correctly with the flag off.

Worth noting that keyboard navigation also still works, but safari doesn't honor the outline styles (that was true before as well)


References:

MDN <tr> content model: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr

MDN native link keyboard behavior: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a