### PR TITLE
🐛 Fixed periodic host limits in React Admin settings

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -83,6 +83,11 @@ export type Config = {
         upgradeUrl?: string; // Destination for the banner's upgrade button
       };
     };
+    // Anchors periodic limits (eg. a monthly email allowance). A limit carrying
+    // `maxPeriodic` needs this to work out where the current period started.
+    subscription?: {
+      start?: string; // ISO 8601 date the period is counted from
+    };
     billing?: {
       enabled?: boolean;
       url?: string;

--- a/apps/admin-x-framework/src/hooks/use-limiter.ts
+++ b/apps/admin-x-framework/src/hooks/use-limiter.ts
@@ -39,6 +39,43 @@ type PeriodicSubscription = {
   interval: 'month';
 };
 
+// limit-service resolves the period from this date with luxon's ISO parser. A value that
+// parser can't read leaves the limit with no period to count against, so it registers but
+// never fires, with nothing said about it. Anything not recognised here is treated as no
+// anchor at all, which at least warns. This covers the extended ISO forms a subscription
+// start arrives in, deliberately not the basic (20260821) or week-date (2026-W34-5) forms
+// luxon would also take, so it errs towards the warning rather than the silent limit.
+const ISO_START_DATE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+// `Date.parse` normalises an impossible day instead of rejecting it — 2026-02-29 comes back
+// as 2026-03-01 — so the calendar fields are checked on their own. Doing it on the date
+// alone keeps this independent of any time or offset that follows it.
+const isRealCalendarDate = (year: number, month: number, day: number) => {
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+};
+
+const parseSubscriptionStart = (start?: string) => {
+  if (!start) {
+    return undefined;
+  }
+
+  const isoParts = ISO_START_DATE.exec(start);
+
+  // `Date.parse` still covers what the calendar check can't see: an out-of-range time
+  if (!isoParts || Number.isNaN(Date.parse(start))) {
+    return undefined;
+  }
+
+  const [, year, month, day] = isoParts;
+
+  return isRealCalendarDate(Number(year), Number(month), Number(day)) ? start : undefined;
+};
+
 // A periodic limit is built from the subscription that anchors its period, and
 // registration stops at the first limit that throws — so one `maxPeriodic` limit with no
 // subscription would take down every limit registered after it. Leave those out instead.
@@ -115,9 +152,9 @@ export const useLimiter = (): Limiter => {
       return noOpLimiter;
     }
 
-    // A subscription without a start can't anchor a period, so it's treated as absent
-    // rather than built into one that resolves to no period on the way to the count query
-    const subscriptionStart = config.hostSettings.subscription?.start;
+    // A subscription that can't anchor a period is treated as absent rather than built
+    // into one that resolves to no period on the way to the count query
+    const subscriptionStart = parseSubscriptionStart(config.hostSettings.subscription?.start);
     const subscription: PeriodicSubscription | undefined = subscriptionStart
       ? {
           startDate: subscriptionStart,

--- a/apps/admin-x-framework/src/hooks/use-limiter.ts
+++ b/apps/admin-x-framework/src/hooks/use-limiter.ts
@@ -34,6 +34,32 @@ interface LimiterLimits {
   };
 }
 
+type PeriodicSubscription = {
+  startDate: string;
+  interval: 'month';
+};
+
+// A periodic limit is built from the subscription that anchors its period, and
+// registration stops at the first limit that throws — so one `maxPeriodic` limit with no
+// subscription would take down every limit registered after it. Leave those out instead.
+const usableLimits = (limits: Record<string, unknown>, subscription?: PeriodicSubscription) => {
+  if (subscription) {
+    return limits;
+  }
+
+  return Object.fromEntries(
+    Object.entries(limits).filter(([name, limit]) => {
+      if (limit && typeof limit === 'object' && 'maxPeriodic' in limit) {
+        // eslint-disable-next-line no-console
+        console.warn(`Skipping ${name} limit: periodic limits need hostSettings.subscription`);
+        return false;
+      }
+
+      return true;
+    }),
+  );
+};
+
 export interface Limiter {
   isLimited: (limitName: string) => boolean;
   isDisabled: (limitName: string) => boolean;
@@ -89,7 +115,17 @@ export const useLimiter = (): Limiter => {
       return noOpLimiter;
     }
 
-    const limits = { ...config.hostSettings.limits } as LimiterLimits;
+    // A subscription without a start can't anchor a period, so it's treated as absent
+    // rather than built into one that resolves to no period on the way to the count query
+    const subscriptionStart = config.hostSettings.subscription?.start;
+    const subscription: PeriodicSubscription | undefined = subscriptionStart
+      ? {
+          startDate: subscriptionStart,
+          interval: 'month',
+        }
+      : undefined;
+
+    const limits = usableLimits({ ...config.hostSettings.limits }, subscription) as LimiterLimits;
     const limiter = new LimitService();
 
     if (limits.staff) {
@@ -125,6 +161,7 @@ export const useLimiter = (): Limiter => {
 
     limiter.loadLimits({
       limits,
+      subscription,
       helpLink,
       errors: {
         HostLimitError,

--- a/apps/admin-x-framework/test/unit/hooks/use-limiter.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-limiter.test.ts
@@ -79,4 +79,35 @@ describe('useLimiter', () => {
 
     warn.mockRestore();
   });
+
+  // A limit built on a date the period resolver can't read registers but never fires,
+  // which is worse than not registering it at all
+  it.each([
+    ['a non-ISO date string', 'Fri Aug 21 2026 04:16:53 GMT+0000 (Coordinated Universal Time)'],
+    ['a value that is not a date', 'whenever'],
+    ['an empty string', ''],
+    // Date.parse rolls these forward instead of rejecting them, but luxon reads neither
+    ['a day the month does not have', '2026-04-31'],
+    ['a leap day outside a leap year', '2026-02-29'],
+    ['a time outside the clock', '2026-08-21T25:00:00Z'],
+  ])('skips a periodic limit anchored on %s', async (_label, start) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const limiter = await renderLimiter({ limits, subscription: { start } });
+
+    expect(limiter.isLimited('emails')).toBe(false);
+
+    warn.mockRestore();
+  });
+
+  it.each([
+    ['a date and time in UTC', '2026-08-21T04:16:53.000Z'],
+    ['a date and time with an offset', '2026-08-21T04:16:53+02:00'],
+    ['a date and time with no offset', '2026-08-21T04:16:53'],
+    ['a date on its own', '2026-08-21'],
+  ])('anchors a periodic limit on %s', async (_label, start) => {
+    const limiter = await renderLimiter({ limits, subscription: { start } });
+
+    expect(limiter.isLimited('emails')).toBe(true);
+  });
 });

--- a/apps/admin-x-framework/test/unit/hooks/use-limiter.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-limiter.test.ts
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLimiter } from '../../../src/hooks/use-limiter';
+
+vi.mock('../../../src/api/config', () => ({
+  useBrowseConfig: vi.fn(),
+}));
+
+vi.mock('../../../src/api/users', () => ({
+  useBrowseUsers: () => ({ data: { users: [] }, isLoading: false }),
+}));
+
+vi.mock('../../../src/api/invites', () => ({
+  useBrowseInvites: () => ({ data: { invites: [] }, isLoading: false }),
+}));
+
+vi.mock('../../../src/api/roles', () => ({
+  useBrowseRoles: () => ({ data: { roles: [] }, isLoading: false }),
+}));
+
+vi.mock('../../../src/api/members', () => ({
+  useBrowseMembers: () => ({ refetch: vi.fn() }),
+}));
+
+vi.mock('../../../src/api/newsletters', () => ({
+  useBrowseNewsletters: () => ({ refetch: vi.fn() }),
+}));
+
+import { useBrowseConfig } from '../../../src/api/config';
+
+const mockUseBrowseConfig = vi.mocked(useBrowseConfig);
+
+describe('useLimiter', () => {
+  // `emails` is declared first on purpose: a limit that throws while registering takes
+  // every limit after it down too, so waiting on `members` is what catches that
+  const limits = { emails: { maxPeriodic: 100 }, members: { max: 100 } };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderLimiter = async (hostSettings: Record<string, unknown>) => {
+    mockUseBrowseConfig.mockReturnValue({ data: { config: { hostSettings } } } as ReturnType<
+      typeof useBrowseConfig
+    >);
+
+    const { result } = renderHook(() => useLimiter());
+
+    // The limit service is imported lazily, so the hook hands back a no-op until it lands
+    await waitFor(() => expect(result.current.isLimited('members')).toBe(true));
+
+    return result.current;
+  };
+
+  it('registers a periodic limit when a subscription anchors the period', async () => {
+    const limiter = await renderLimiter({
+      limits,
+      subscription: { start: '2026-08-21T04:16:53.000Z' },
+    });
+
+    expect(limiter.isLimited('emails')).toBe(true);
+  });
+
+  it('skips a periodic limit when no subscription anchors the period', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const limiter = await renderLimiter({ limits });
+
+    expect(limiter.isLimited('emails')).toBe(false);
+
+    warn.mockRestore();
+  });
+
+  it('treats a subscription without a start as no subscription at all', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const limiter = await renderLimiter({ limits, subscription: {} });
+
+    expect(limiter.isLimited('emails')).toBe(false);
+
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
## Why

Any managed host that configures a periodic host limit — a limit with `maxPeriodic`, such as a monthly email allowance — makes the whole of Admin's settings area unusable.

`apps/admin/src/settings/hooks/use-limiter.tsx` calls `loadLimits()` without the `subscription` argument that `@tryghost/limit-service` requires for periodic limits:

```js
} else if (has(limitConfig, 'maxPeriodic')) {
    if (subscription === undefined) {
        throw new IncorrectUsageError({message: messages.noSubscriptionParameter});
```

The hook builds its limiter inside a `useMemo`, so the throw happens during render and reaches each section's error boundary. Every section using `useLimiter`, directly or via `use-check-theme-limit-error`, renders "An error occurred loading …" instead of its content: Access, Analytics, Branding and design, Tiers, Newsletters, Staff invite, Integrations, Labs, Network and Stripe Connect. The design and theme modal doesn't load at all.

The config is not at fault — `hostSettings.subscription.start` is present and the server reads it correctly. The React hook simply never looks at it.

#29837 fixed exactly this bug, but only in `apps/ember-admin/app/services/limit.js`. Ghost has three LimitService call sites; the server and the Ember admin both resolve a subscription, and the React settings app was the one left behind.

## What

- Resolves `subscription` from `hostSettings.subscription.start` and passes it to `loadLimits()`, the same way the Ember service and `ghost/core/core/server/services/limits.js` already do.
- Skips a periodic limit when there's no subscription to anchor it. Registration stops at the first limit that can't be built, so passing one through would drop every limit registered after it — leaving Admin with no limits at all rather than one missing limit.
- Types `hostSettings.subscription`, which the `Config` type was missing.

## Testing

New unit tests in `apps/admin/src/settings/hooks/use-limiter.test.ts` cover a periodic limit with an anchoring subscription, one without, and a subscription that has no `start`. Each declares the periodic limit ahead of a `max` limit, so a throw during registration takes the second limit down with it and fails the test — all three fail against `main` with `IncorrectUsageError: Attempted to setup a periodic max limit without a subscription`.

`pnpm lint`, `pnpm typecheck` and the full `apps/admin` unit suite (1610 tests) pass, as do the `admin-x-framework` tests.

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
