### PR TITLE
Cleaned up navigation and data hook leftovers

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -48,7 +48,7 @@ export type AdminRouteHandle = {
 };
 export {RouterProvider, useNavigate, useRouteHasParams, resetScrollPosition, ScrollRestoration, Navigate} from './providers/router-provider';
 export {useNavigationStack} from './providers/navigation-stack-provider';
-export {Link, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, useMatch, useMatches} from 'react-router';
+export {Link, Outlet, useBlocker, useLocation, useParams, useRouteError, useSearchParams, redirect, matchRoutes, useMatch, useMatches} from 'react-router';
 
 // Lazy component loader
 export {lazyComponent} from './utils/lazy-component';

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -87,7 +87,7 @@ export const createInfiniteQuery = <ResponseData>(options: InfiniteQueryOptions<
         ...query,
         enabled: hasPermission && (query.enabled ?? true),
         queryKey: [options.dataType, apiUrl(options.path, searchParams || options.defaultSearchParams)],
-        queryFn: ({pageParam}) => fetchApi(apiUrl(options.path, pageParam || searchParams || options.defaultSearchParams)),
+        queryFn: ({pageParam}) => fetchApi(apiUrl(options.path, pageParam || searchParams || options.defaultSearchParams), {...options}),
         initialPageParam: undefined,
         getNextPageParam: data => nextPageParams(data, searchParams || options.defaultSearchParams || {})
     });

--- a/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
@@ -281,6 +281,52 @@ describe('API hooks', () => {
             });
         });
 
+        it('can add custom headers', async () => {
+            await withMockFetch({
+                json: {test: 1, pagination: {next: 2}}
+            }, async (mock) => {
+                const useTestQuery = createInfiniteQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    headers: {'Content-Type': 'ALOHA'},
+                    defaultNextPageParams: (lastPage, otherParams) => ({
+                        ...otherParams,
+                        page: ((lastPage as any).pagination.next || 1).toString()
+                    }),
+                    returnData: (originalData) => {
+                        const {pages} = originalData as InfiniteData<{test: number}>;
+                        return pages.map(page => page.test);
+                    }
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+                expect(mock.calls.length).toBe(1);
+                expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/', {
+                    credentials: 'include',
+                    headers: {
+                        'Content-Type': 'ALOHA',
+                        'app-pragma': 'no-cache',
+                        'x-ghost-version': '5.x'
+                    },
+                    method: 'GET',
+                    mode: 'cors',
+                    signal: expect.any(AbortSignal)
+                }]);
+
+                await act(() => result.current.fetchNextPage());
+
+                await waitFor(() => expect(mock.calls.length).toBe(2));
+                expect(mock.calls[1][1].headers).toEqual({
+                    'Content-Type': 'ALOHA',
+                    'app-pragma': 'no-cache',
+                    'x-ghost-version': '5.x'
+                });
+            });
+        });
+
         it('does not make a request when user lacks required permissions', async () => {
             // User is a Contributor, but query requires Administrator
             mockUseCurrentUser.mockReturnValue({

--- a/apps/admin/src/analytics/views/stats/growth/growth.tsx
+++ b/apps/admin/src/analytics/views/stats/growth/growth.tsx
@@ -15,6 +15,7 @@ import {LucideIcon, formatDisplayDate, formatNumber} from '@tryghost/shade/utils
 import {centsToDollars} from '@tryghost/shade/app';
 import {getClickHandler} from '@/analytics/utils/url-helpers';
 import {getPeriodText} from '@/shared/analytics/chart-helpers';
+import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {useAppContext} from '@tryghost/admin-x-framework';
 import {useAnalytics} from '@/analytics/providers/analytics-context';
 import {useAnalyticsData} from '@/shared/analytics/use-analytics-data';
@@ -48,8 +49,7 @@ const Growth: React.FC = () => {
     const {range} = useAnalytics();
     const {site, settings} = useAnalyticsData();
 
-    // Get site timezone from settings for displaying dates consistently
-    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
+    const siteTimezone = getSiteTimezone(settings);
     const navigate = useNavigate();
     const [sortBy, setSortBy] = useState<UnifiedSortOrder>('free_members desc');
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);

--- a/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
+++ b/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
@@ -12,6 +12,7 @@ import {LucideIcon, formatDisplayDate, formatNumber, formatPercentage} from '@tr
 import {Navigate, useAppContext, useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import {getPeriodText} from '@/shared/analytics/chart-helpers';
 import {getRangeDates} from '@tryghost/shade/app';
+import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useAnalytics} from '@/analytics/providers/analytics-context';
 import {useAnalyticsData} from '@/shared/analytics/use-analytics-data';
@@ -39,8 +40,7 @@ const NewsletterTableRows: React.FC<{
     const navigate = useNavigate();
     const {settings} = useAnalyticsData();
 
-    // Get site timezone from settings for displaying dates consistently
-    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
+    const siteTimezone = getSiteTimezone(settings);
 
     // Fetch newsletter stats with reactive sort order - isolated to this component
     const {data: newsletterStatsData, isLoading: isStatsLoading, isClicksLoading} = useNewsletterStatsWithRangeSplit(

--- a/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
+++ b/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
@@ -131,7 +131,7 @@ const NewsletterTableRows: React.FC<{
                     </TableCell>
                 </TableRow>
         );
-    }, [sortedStats, isClicksLoading, navigate, emailTrackClicksEnabled, emailTrackOpensEnabled, range]);
+    }, [sortedStats, isClicksLoading, navigate, emailTrackClicksEnabled, emailTrackOpensEnabled, range, siteTimezone]);
 
     // Show loading rows while data is loading
     if (isStatsLoading || !newsletterStatsData) {

--- a/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
@@ -5,6 +5,7 @@ import {LucideIcon, cn, formatDisplayDate, formatNumber, formatPercentage} from 
 
 import {type Post, getPostMetricsToDisplay} from '@tryghost/admin-x-framework';
 import {getPostDestination} from '@/analytics/utils/url-helpers';
+import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {trackEvent, useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useAnalyticsData} from '@/shared/analytics/use-analytics-data';
 import {useIsEmberOwnedRoute} from '@/routes';
@@ -52,8 +53,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
     // Get site title from settings or site data
     const siteTitle = site.title || String(settings.find(setting => setting.key === 'title')?.value || 'Ghost Site');
 
-    // Get site timezone from settings for displaying dates consistently
-    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
+    const siteTimezone = getSiteTimezone(settings);
 
     // Calculate metrics to show outside of JSX
     const metricsToShow = latestPostStats ? getPostMetricsToDisplay(latestPostStats as Post, {

--- a/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
@@ -6,6 +6,7 @@ import {type TopPostViewsStats} from '@tryghost/admin-x-framework/api/stats';
 import {getPeriodText} from '@/shared/analytics/chart-helpers';
 import {getPostDestination} from '@/analytics/utils/url-helpers';
 import {getPostStatusText} from '@tryghost/admin-x-framework/utils/post-utils';
+import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useAnalytics} from '@/analytics/providers/analytics-context';
 import {useAnalyticsData} from '@/shared/analytics/use-analytics-data';
@@ -65,8 +66,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
     const {settings} = useAnalyticsData();
     const {appSettings} = useAppContext();
 
-    // Get site timezone from settings for displaying dates consistently
-    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
+    const siteTimezone = getSiteTimezone(settings);
 
     // Show open rate if newsletters are enabled and email tracking is enabled
     const {

--- a/apps/admin/src/comments/comments.tsx
+++ b/apps/admin/src/comments/comments.tsx
@@ -13,7 +13,7 @@ import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezo
 import {serializeCommentFilters} from './comment-filter-query';
 import {shouldDelayCommentDateFilterHydration, useFilterState} from './hooks/use-filter-state';
 import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
-import {useSearchParams} from 'react-router';
+import {useSearchParams} from '@tryghost/admin-x-framework';
 
 function getSingleCommentIdParam(searchParams: URLSearchParams): string | undefined {
     const value = searchParams.get('id');

--- a/apps/admin/src/ember-bridge/force-upgrade-guard.tsx
+++ b/apps/admin/src/ember-bridge/force-upgrade-guard.tsx
@@ -1,9 +1,5 @@
-import { Navigate, Outlet, useMatches } from "@tryghost/admin-x-framework";
+import { type AdminRouteHandle, Navigate, Outlet, useMatches } from "@tryghost/admin-x-framework";
 import { useForceUpgrade } from "./ember-bridge";
-
-export interface RouteHandle {
-    allowInForceUpgrade?: boolean;
-}
 
 /**
  * Guard component that redirects to /pro when site is in force upgrade mode.
@@ -32,7 +28,7 @@ export function ForceUpgradeGuard() {
 
     // Check if any matched route allows access in force upgrade mode
     const isAllowed = matches.some((match) => {
-        const handle = match.handle as RouteHandle | undefined;
+        const handle = match.handle as AdminRouteHandle | undefined;
         return handle?.allowInForceUpgrade === true;
     });
 

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -5,4 +5,3 @@ export { EmberFallback } from "./ember-fallback";
 export { ForceUpgradeGuard } from "./force-upgrade-guard";
 export { useEmberAuthSync, useEmberDataSync, useEmberFeatureFlag, useSidebarVisibility, useSubscriptionStatus, useEmberRouting, useForceUpgrade, subscribeOpenGiftLinkModal } from "./ember-bridge";
 export type { EmberDataChangeEvent, EmberRouting, OpenGiftLinkModalEvent } from "./ember-bridge";
-export type { RouteHandle } from "./force-upgrade-guard";

--- a/apps/admin/src/members/hooks/use-members-filter-state.ts
+++ b/apps/admin/src/members/hooks/use-members-filter-state.ts
@@ -2,7 +2,7 @@ import {type Filter} from '@tryghost/shade/patterns';
 import {getMemberFields} from '@/members/member-fields';
 import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, serializeMemberFilters} from '@/members/member-filter-query';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {useSearchParams} from 'react-router';
+import {useSearchParams} from '@tryghost/admin-x-framework';
 import type {MemberFields} from '@/members/member-fields';
 
 interface SetFiltersOptions {

--- a/apps/admin/src/members/hooks/use-multiple-active-subscriptions-banner.ts
+++ b/apps/admin/src/members/hooks/use-multiple-active-subscriptions-banner.ts
@@ -9,7 +9,7 @@ import {toast} from 'sonner';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
 import {useEditUser} from '@tryghost/admin-x-framework/api/users';
-import {useNavigate} from 'react-router';
+import {useNavigate} from '@tryghost/admin-x-framework';
 
 interface UseMultipleActiveSubscriptionsBannerOptions {
     count: number;

--- a/apps/admin/src/members/members.tsx
+++ b/apps/admin/src/members/members.tsx
@@ -24,7 +24,7 @@ import {useBrowseMemberCustomFieldsIncludingArchived} from '@tryghost/admin-x-fr
 import {useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
 import {useDebouncedCallback} from 'use-debounce';
 import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
-import {useLocation, useSearchParams} from 'react-router';
+import {useLocation, useSearchParams} from '@tryghost/admin-x-framework';
 import {useMultipleActiveSubscriptionsCount} from './hooks/use-multiple-active-subscriptions-count';
 
 const SEARCH_DEBOUNCE_MS = 250;

--- a/apps/admin/src/route-access.acceptance.test.tsx
+++ b/apps/admin/src/route-access.acceptance.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
     allowUnhandledRequests,
+    configResponse,
     currentRoute,
     currentUserResponse,
     fakeTags,
@@ -60,6 +61,15 @@ describe("Route access", () => {
         await renderAdminApp("/members", asRole("Editor"));
 
         await expect.poll(currentRoute).toBe("/");
+    });
+
+    it("redirects members to billing during a force upgrade", async () => {
+        const config = configResponse();
+        config.config.hostSettings = { forceUpgrade: true };
+
+        await renderAdminApp("/members", { boot: { browseConfig: { response: config } } });
+
+        await expect.poll(currentRoute).toBe("/pro");
     });
 
     it("leaves an authorized user on the route", async () => {

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -10,7 +10,6 @@ import MyProfileRedirect from "./my-profile-redirect";
 
 // Ember
 import { EmberFallback, ForceUpgradeGuard } from "./ember-bridge";
-import type { RouteHandle } from "./ember-bridge";
 import HomeRedirect from "./home-redirect";
 import { EmberListWithGiftLinks } from "./gift-link-modal-host";
 import { TagDetailGate } from "./tag-detail-gate";
@@ -40,7 +39,7 @@ const EMBER_ROUTES: string[] = [
     "/members-activity",
 ];
 
-const emberFallbackHandle = { allowInForceUpgrade: true } satisfies RouteHandle;
+const emberFallbackHandle = { allowInForceUpgrade: true } satisfies AdminRouteHandle;
 
 const emberFallbackRoutes: RouteObject[] = EMBER_ROUTES.map(path => ({
     path,
@@ -50,7 +49,7 @@ const emberFallbackRoutes: RouteObject[] = EMBER_ROUTES.map(path => ({
 
 const membersRoute: RouteObject = {
     path: "/members",
-    handle: { ...emberFallbackHandle, requiresAccess: canManageMembers } satisfies RouteHandle & AccessRouteHandle,
+    handle: { requiresAccess: canManageMembers } satisfies AccessRouteHandle,
     children: [
         {
             index: true,
@@ -76,7 +75,7 @@ const appRoutes: RouteObject[] = [
         // `/?firstStart=true` onboarding entry.
         path: "/",
         Component: HomeRedirect,
-        handle: { allowInForceUpgrade: true } satisfies RouteHandle,
+        handle: { allowInForceUpgrade: true } satisfies AdminRouteHandle,
     },
     {
         // The dashboard screen is retired; the URL redirects for old links.
@@ -165,7 +164,7 @@ const appRoutes: RouteObject[] = [
     {
         path: "my-profile",
         Component: MyProfileRedirect,
-        handle: { allowInForceUpgrade: true } satisfies RouteHandle,
+        handle: { allowInForceUpgrade: true } satisfies AdminRouteHandle,
     },
     {
         path: "",
@@ -186,7 +185,7 @@ const appRoutes: RouteObject[] = [
             allowInForceUpgrade: true,
             hideAdminSidebar: true,
             requiresAccess: canAccessSettingsRoute
-        } satisfies RouteHandle & AdminRouteHandle & AccessRouteHandle,
+        } satisfies AdminRouteHandle & AccessRouteHandle,
     },
     {path: "/posts", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
     {path: "/pages", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},

--- a/apps/admin/src/shared/virtual-list/use-scroll-restoration.tsx
+++ b/apps/admin/src/shared/virtual-list/use-scroll-restoration.tsx
@@ -1,6 +1,6 @@
 import {getScrollParent} from '@tryghost/shade/utils';
 import {useEffect, useRef, useState} from 'react';
-import {useLocation} from 'react-router';
+import {useLocation} from '@tryghost/admin-x-framework';
 import type {RefObject} from 'react';
 
 const scrollPositions = new Map<string, number>();

--- a/apps/admin/src/shared/virtual-list/use-virtual-list-window.ts
+++ b/apps/admin/src/shared/virtual-list/use-virtual-list-window.ts
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
-import {useLocation} from 'react-router';
+import {useLocation} from '@tryghost/admin-x-framework';
 
 const DEFAULT_VIRTUAL_LIST_WINDOW_SIZE = 1000;
 const VIRTUAL_LIST_WINDOW_HISTORY_STATE_KEY = 'ghostVirtualListWindow';


### PR DESCRIPTION
Small mechanical leftovers from the navigation and data-layer convergence, bundled ahead of the formatter rollout:

- **react-router names come from the framework**: `useBlocker` and `useRouteError` join the framework's react-router re-exports, and the six files importing already-re-exported names directly (`comments.tsx`, `members.tsx`, `use-members-filter-state`, `use-multiple-active-subscriptions-banner`, the two virtual-list hooks) switch to framework imports. The subscriptions banner also moves from raw `useNavigate` to the framework wrapper — its only call is an in-app string URL, identical behaviour. (A lint rule enforcing this waits for the open PRs whose files still import react-router.)
- **One route-handle type**: the bridge-local `RouteHandle` (a strict subset of the framework's `AdminRouteHandle`) is deleted; `ForceUpgradeGuard` uses `AdminRouteHandle`, and `routes.tsx`'s `RouteHandle & AdminRouteHandle & AccessRouteHandle` intersection collapses.
- **Analytics timezone reads**: the four inline `settings.find(...timezone...) || 'Etc/UTC'` reads (newsletters, growth, top-posts, latest-post) use `getSiteTimezone` like members/comments/posts. Same `'Etc/UTC'` fallback literal.
- **`createInfiniteQuery` no longer drops declared headers**: its `queryFn` called `fetchApi(url)` without the options spread, so `headers` on infinite-query definitions never reached the request (`createQuery` passes them). New unit case asserts headers on the first page and on `fetchNextPage`, and fails without the fix.
- **Behaviour change, deliberate: `/members` no longer bypasses force-upgrade.** Its handle still spread `emberFallbackHandle` from its Ember-fallback days, inheriting `allowInForceUpgrade: true` — unlike `/tags`, `/comments`, `/analytics`. A force-upgrade site now redirects `/members` to `/pro` like every other domain route. New acceptance case pins it (fails against the old routes table).

17 files, +79/−29.

**Verification:** framework `pnpm build` + `test:unit` (38 files / 496) + lint green; admin `tsc -b`, eslint, `test:unit` (135 files / 1607) green; acceptance route-access + comments + members + analytics: 12 files / 85 tests green first run (route-access now 7/7).