### PR TITLE
Fixed settings dirty-navigation test synchronization

### DIFF
--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -1,13 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { page } from "vitest/browser";
 
 import { currentRoute, fakeAnalyticsOverview, fakeSettingsScreens, renderAdminApp } from "@test-utils/acceptance";
 import { settingsScreen } from "./settings.screen";
 import { fakeStaffWorld } from "./general/staff.test-helpers";
 
-const flushEffects = () => new Promise<void>((resolve) => {
-    requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
-});
+const markDirtyAndWaitForGuard = async (markDirty: () => Promise<unknown>) => {
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    try {
+        await markDirty();
+        await expect.poll(() => addEventListener.mock.calls.some(([type]) => type === "beforeunload")).toBe(true);
+    } finally {
+        addEventListener.mockRestore();
+    }
+};
 
 // Settings navigations are real router pushes; these specs pin the history
 // semantics the router swap introduced.
@@ -34,10 +40,10 @@ describe("Settings navigation history", () => {
         const modal = settingsScreen.userDetailModal();
         await expect.element(modal).toBeVisible();
         await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
-        await modal.getByLabelText("Location").fill("Somewhere new");
         // The dirty flag reaches the history blocker through passive effects
-        // (dialog → global dirty state → guard re-render); let them flush.
-        await flushEffects();
+        // (dialog → global dirty state → guard re-render). The unload guard is
+        // enabled by the same state, so it is an observable readiness signal.
+        await markDirtyAndWaitForGuard(() => modal.getByLabelText("Location").fill("Somewhere new"));
 
         window.history.back();
 
@@ -64,8 +70,7 @@ describe("Settings navigation history", () => {
 
         window.history.back();
         await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
-        await modal.getByLabelText("Location").fill("Somewhere new");
-        await flushEffects();
+        await markDirtyAndWaitForGuard(() => modal.getByLabelText("Location").fill("Somewhere new"));
 
         window.history.forward();
 
@@ -89,8 +94,7 @@ describe("Settings navigation history", () => {
         await settingsScreen.users().getByTestId("owner-user").click();
         const modal = settingsScreen.userDetailModal();
         await expect.element(modal).toBeVisible();
-        await modal.getByLabelText("Location").fill("Somewhere new");
-        await flushEffects();
+        await markDirtyAndWaitForGuard(() => modal.getByLabelText("Location").fill("Somewhere new"));
 
         window.history.back();
 
@@ -105,10 +109,9 @@ describe("Settings navigation history", () => {
         await renderAdminApp(`/settings/staff/${currentUser.slug}`, {boot});
 
         const modal = settingsScreen.userDetailModal();
-        await modal.getByLabelText("Location").fill("Somewhere new");
+        await markDirtyAndWaitForGuard(() => modal.getByLabelText("Location").fill("Somewhere new"));
         await modal.getByRole("tab", { name: "Social Links" }).click();
         await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}/social-links`);
-        await flushEffects();
 
         window.history.back();
 


### PR DESCRIPTION
## Why

The Admin acceptance run in [this CI job](https://github.com/TryGhost/Ghost/actions/runs/32480196695/job/96764988709) intermittently missed the dirty-navigation confirmation after calling `window.history.forward()`. The test waited for two animation frames, but on a loaded runner the dirty state could still be moving through passive effects when the history traversal began.

## What changed

The history tests now wait for the `beforeunload` listener to be registered before traversing history. That listener is enabled from the same global dirty state as the router blocker, giving the test an observable readiness signal instead of a fixed timing delay. Production code is unchanged.

## Verification

- Forward-history case: 10 consecutive passes
- Complete navigation-history file: 5 consecutive passes (35/35), plus a post-rebase pass (7/7)
- Admin ESLint and typecheck passed
- Repository lint passed
- The full repository test run had one unrelated `ghost:test` failure; an immediate uncached retry passed 8,093/8,093 and Nx classified the target as flaky

- [x] I have read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I have explained my change
- [x] I have updated the automated test to prove the synchronization works