### PR TITLE
🎨 Improved theme upload dialog layout and copy

### DIFF
--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -1,149 +1,141 @@
-import React, { useState } from 'react';
+import React, {useState} from 'react';
 import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  Button,
-  type ButtonProps,
-  LoadingIndicator,
-  StickyFooter,
+    AlertDialog,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    Button,
+    type ButtonProps,
+    LoadingIndicator,
+    StickyFooter
 } from '@tryghost/shade/components';
-import { cn } from '@tryghost/shade/utils';
+import {cn} from '@tryghost/shade/utils';
 
 export interface ConfirmationModalProps {
-  title?: React.ReactNode;
-  prompt?: React.ReactNode;
-  cancelLabel?: string;
-  okLabel?: string;
-  okRunningLabel?: string;
-  okVariant?: ButtonProps['variant'];
-  onCancel?: () => void;
-  onOk?: (modal?: { remove: () => void }) => void | Promise<void>;
-  customFooter?: React.ReactNode;
-  formSheet?: boolean;
-  stickyFooter?: boolean;
-  testId?: string;
+    title?: React.ReactNode;
+    prompt?: React.ReactNode;
+    cancelLabel?: string;
+    okLabel?: string;
+    okRunningLabel?: string;
+    okVariant?: ButtonProps['variant'];
+    onCancel?: () => void;
+    onOk?: (modal?: {
+        remove: () => void;
+    }) => void | Promise<void>;
+    customFooter?: React.ReactNode;
+    formSheet?: boolean;
+    stickyFooter?: boolean;
+    testId?: string;
 }
 
 export type ConfirmationHostProps = {
-  visible?: boolean;
-  onRemove: () => void;
+    visible?: boolean;
+    onRemove: () => void;
 };
 
 export const ConfirmationModalContent: React.FC<ConfirmationModalProps & ConfirmationHostProps> = ({
-  visible = true,
-  onRemove,
-  title = 'Are you sure?',
-  prompt,
-  cancelLabel = 'Cancel',
-  okLabel = 'OK',
-  okRunningLabel,
-  okVariant = 'default',
-  onCancel,
-  onOk,
-  customFooter,
-  formSheet = true,
-  stickyFooter = false,
-  testId = 'confirmation-modal',
+    visible = true,
+    onRemove,
+    title = 'Are you sure?',
+    prompt,
+    cancelLabel = 'Cancel',
+    okLabel = 'OK',
+    okRunningLabel,
+    okVariant = 'default',
+    onCancel,
+    onOk,
+    customFooter,
+    formSheet = true,
+    stickyFooter = false,
+    testId = 'confirmation-modal'
 }) => {
-  const [taskState, setTaskState] = useState<'running' | ''>('');
-  const isRunning = taskState === 'running';
-  const runningLabel = okRunningLabel || okLabel;
+    const [taskState, setTaskState] = useState<'running' | ''>('');
+    const isRunning = taskState === 'running';
+    const runningLabel = okRunningLabel || okLabel;
 
-  const handleCancel = () => {
-    if (isRunning) {
-      return;
-    }
+    const handleCancel = () => {
+        if (isRunning) {
+            return;
+        }
 
-    if (onCancel) {
-      onCancel();
-    } else {
-      onRemove();
-    }
-  };
+        if (onCancel) {
+            onCancel();
+        } else {
+            onRemove();
+        }
+    };
 
-  const handleConfirm = async () => {
-    setTaskState('running');
+    const handleConfirm = async () => {
+        setTaskState('running');
 
-    try {
-      await onOk?.({ remove: onRemove });
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'Unhandled Promise Rejection. Make sure you catch errors in your onOk handler.',
-        error,
-      );
-    }
+        try {
+            await onOk?.({remove: onRemove});
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Unhandled Promise Rejection. Make sure you catch errors in your onOk handler.', error);
+        }
 
-    setTaskState('');
-  };
+        setTaskState('');
+    };
 
-  const defaultFooter = (
-    <AlertDialogFooter>
-      {cancelLabel && (
-        <Button
-          data-testid="cancel-modal"
-          disabled={isRunning}
-          type="button"
-          variant="outline"
-          onClick={handleCancel}
-        >
-          {cancelLabel}
-        </Button>
-      )}
-      {okLabel && (
-        <Button
-          aria-busy={isRunning}
-          data-testid="ok-modal"
-          disabled={isRunning}
-          type="button"
-          variant={okVariant}
-          onClick={() => void handleConfirm()}
-        >
-          {isRunning && <LoadingIndicator color="current" size="sm" />}
-          {isRunning ? runningLabel : okLabel}
-        </Button>
-      )}
-    </AlertDialogFooter>
-  );
+    const defaultFooter = (
+        // Inside the sticky footer the row is stretched to full width, so below
+        // `sm` its column-reverse buttons would otherwise touch.
+        <AlertDialogFooter className={cn(stickyFooter && 'gap-2')}>
+            {cancelLabel && (
+                <Button data-testid='cancel-modal' disabled={isRunning} type='button' variant='outline' onClick={handleCancel}>
+                    {cancelLabel}
+                </Button>
+            )}
+            {okLabel && (
+                <Button aria-busy={isRunning} data-testid='ok-modal' disabled={isRunning} type='button' variant={okVariant} onClick={() => void handleConfirm()}>
+                    {isRunning && <LoadingIndicator color='current' size='sm' />}
+                    {isRunning ? runningLabel : okLabel}
+                </Button>
+            )}
+        </AlertDialogFooter>
+    );
 
-  const footer = customFooter === undefined ? defaultFooter : customFooter;
+    const footer = customFooter === undefined ? defaultFooter : customFooter;
 
-  return (
-    <AlertDialog open={visible} onOpenChange={(open) => !open && handleCancel()}>
-      <AlertDialogContent
-        className={cn(
-          'z-[1100] max-h-[calc(100dvh-4rem)] w-[calc(100%-2rem)] overflow-y-auto bg-background',
-        )}
-        data-testid={testId}
-        overlayClassName={cn(
-          'z-[1100] bg-foreground/20! backdrop-blur-[3px]',
-          formSheet && 'bg-foreground/10!',
-        )}
-        onEscapeKeyDown={(event) => event.stopPropagation()}
-      >
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription asChild>
-            <div className="text-left text-foreground">{prompt}</div>
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        {footer &&
-          (stickyFooter ? (
-            <StickyFooter
-              className="-mx-6 -mb-6 w-[calc(100%+3rem)]"
-              contentClassName="px-6"
-              height={84}
+    return (
+        <AlertDialog open={visible} onOpenChange={open => !open && handleCancel()}>
+            <AlertDialogContent
+                className={cn(
+                    'z-[1100] max-h-[calc(100dvh-4rem)] w-[calc(100%-2rem)] overflow-y-auto bg-background',
+                    // A sticky grid item is boxed in by its own grid area and never
+                    // sticks, so the footer needs a flex column to stick within.
+                    // Sticky offsets resolve against the scroll container's content
+                    // box, so any bottom padding here becomes dead space the footer
+                    // can never reach — the footer supplies its own instead.
+                    stickyFooter && 'flex flex-col pb-0'
+                )}
+                data-testid={testId}
+                overlayClassName={cn(
+                    'z-[1100] bg-foreground/20! backdrop-blur-[3px]',
+                    formSheet && 'bg-foreground/10!'
+                )}
+                onEscapeKeyDown={event => event.stopPropagation()}
             >
-              {footer}
-            </StickyFooter>
-          ) : (
-            footer
-          ))}
-      </AlertDialogContent>
-    </AlertDialog>
-  );
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    <AlertDialogDescription asChild>
+                        <div className='text-left text-foreground'>{prompt}</div>
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                {footer && (stickyFooter ? (
+                    // StickyFooter sizes its own box in raw pixels (`height + 24`)
+                    // but spaces its parts with `h-6`/`-mb-6`, which Shade's
+                    // `--spacing: 0.4rem` scale renders as 38.4px. Pin those three
+                    // offsets back to the 24px the component's own maths assumes,
+                    // and bleed it across the dialog's horizontal padding.
+                    <StickyFooter className='-mx-6 w-auto [&>div:first-child]:h-[24px] [&>div:last-child]:h-[24px]' contentClassName='px-6 mb-[-24px] *:w-full' height={84}>
+                        {footer}
+                    </StickyFooter>
+                ) : footer)}
+            </AlertDialogContent>
+        </AlertDialog>
+    );
 };

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -27,6 +27,8 @@ export interface ConfirmationModalProps {
   customFooter?: React.ReactNode;
   formSheet?: boolean;
   stickyFooter?: boolean;
+  /** Widens the dialog past its default `max-w-lg` for content that needs it. */
+  contentClassName?: string;
   testId?: string;
 }
 
@@ -49,6 +51,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
   customFooter,
   formSheet = true,
   stickyFooter = false,
+  contentClassName,
   testId = 'confirmation-modal',
 }) => {
   const [taskState, setTaskState] = useState<'running' | ''>('');
@@ -122,6 +125,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
           // A sticky element never sticks inside a grid item, so the footer
           // needs a flex column to stick within.
           stickyFooter && 'flex flex-col gap-0 pb-0',
+          contentClassName,
         )}
         data-testid={testId}
         overlayClassName={cn(

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -13,6 +13,12 @@ import {
 } from '@tryghost/shade/components';
 import { cn } from '@tryghost/shade/utils';
 
+/**
+ * Names the sticky footer box so tests can address it without depending on the
+ * z-index utilities Shade happens to draw it with.
+ */
+export const STICKY_FOOTER_TESTID = 'modal-sticky-footer';
+
 export interface ConfirmationModalProps {
   title?: React.ReactNode;
   prompt?: React.ReactNode;
@@ -172,6 +178,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
             <StickyFooter
               className="-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:hidden"
               contentClassName="px-6 mb-0 *:w-full"
+              data-testid={STICKY_FOOTER_TESTID}
               height={84}
               style={{ bottom: 0, height: '84px' }}
             >

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -110,8 +110,8 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
                     // Sticky offsets resolve against the scroll container's content
                     // box, so any bottom padding here becomes dead space the footer
                     // can never reach — the footer supplies its own instead. The
-                    // row gap goes too: StickyFooter already opens with a 24px
-                    // spacer, and stacking the two left a visible hole above it.
+                    // row gap goes too: it lands between the issue list and the
+                    // footer and reads as an empty band above the buttons.
                     stickyFooter && 'flex flex-col gap-0 pb-0'
                 )}
                 data-testid={testId}
@@ -130,9 +130,8 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
                 {footer && (stickyFooter ? (
                     // StickyFooter sizes its own box in raw pixels but spaces its
                     // parts with `h-6`/`-mb-6`, which Shade's `--spacing: 0.4rem`
-                    // scale renders as 38.4px — so the shadow rule and the content
-                    // div's negative margin are pinned back to the 24px the
-                    // component's own maths assumes, and the whole thing bleeds
+                    // scale renders as 38.4px rather than the 24px its own maths
+                    // assumes — so the box is sized here explicitly, and it bleeds
                     // across the dialog's horizontal padding.
                     //
                     // The leading spacer goes entirely. Both it and the content div
@@ -141,14 +140,23 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
                     // the full visible strip on its own and the spacer is never
                     // seen mid-scroll. At the bottom of the scroll everything
                     // returns to flow and the spacer becomes a visible empty band
-                    // between the last row and the buttons. Dropping it means the
-                    // box no longer needs the extra 24px it reserved for it: the
-                    // height and bottom offset collapse to the footer's own 84px,
-                    // which keeps the buttons on the container's bottom edge rather
-                    // than moving the gap below them.
+                    // between the last row and the buttons.
+                    //
+                    // The trailing shadow rule goes with it. It's a decorative
+                    // scroll affordance that reads as a hairline drawn straight
+                    // across the buttons here, and with the spacer gone there is
+                    // nothing left for it to shade.
+                    //
+                    // That leaves the content div as the only part still in flow,
+                    // so its negative margin has to go too or the 84px box would
+                    // reserve 24px of slack the `sticky bottom-0` content can never
+                    // drop into — the same empty band, just below the buttons
+                    // instead of above them. Content height, flow height and box
+                    // height all sit at 84px, which keeps the buttons on the
+                    // container's bottom edge.
                     <StickyFooter
-                        className='-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:h-[24px]'
-                        contentClassName='px-6 mb-[-24px] *:w-full'
+                        className='-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:hidden'
+                        contentClassName='px-6 mb-0 *:w-full'
                         height={84}
                         style={{bottom: 0, height: '84px'}}
                     >

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -1,169 +1,186 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import {
-    AlertDialog,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-    Button,
-    type ButtonProps,
-    LoadingIndicator,
-    StickyFooter
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  type ButtonProps,
+  LoadingIndicator,
+  StickyFooter,
 } from '@tryghost/shade/components';
-import {cn} from '@tryghost/shade/utils';
+import { cn } from '@tryghost/shade/utils';
 
 export interface ConfirmationModalProps {
-    title?: React.ReactNode;
-    prompt?: React.ReactNode;
-    cancelLabel?: string;
-    okLabel?: string;
-    okRunningLabel?: string;
-    okVariant?: ButtonProps['variant'];
-    onCancel?: () => void;
-    onOk?: (modal?: {
-        remove: () => void;
-    }) => void | Promise<void>;
-    customFooter?: React.ReactNode;
-    formSheet?: boolean;
-    stickyFooter?: boolean;
-    testId?: string;
+  title?: React.ReactNode;
+  prompt?: React.ReactNode;
+  cancelLabel?: string;
+  okLabel?: string;
+  okRunningLabel?: string;
+  okVariant?: ButtonProps['variant'];
+  onCancel?: () => void;
+  onOk?: (modal?: { remove: () => void }) => void | Promise<void>;
+  customFooter?: React.ReactNode;
+  formSheet?: boolean;
+  stickyFooter?: boolean;
+  testId?: string;
 }
 
 export type ConfirmationHostProps = {
-    visible?: boolean;
-    onRemove: () => void;
+  visible?: boolean;
+  onRemove: () => void;
 };
 
 export const ConfirmationModalContent: React.FC<ConfirmationModalProps & ConfirmationHostProps> = ({
-    visible = true,
-    onRemove,
-    title = 'Are you sure?',
-    prompt,
-    cancelLabel = 'Cancel',
-    okLabel = 'OK',
-    okRunningLabel,
-    okVariant = 'default',
-    onCancel,
-    onOk,
-    customFooter,
-    formSheet = true,
-    stickyFooter = false,
-    testId = 'confirmation-modal'
+  visible = true,
+  onRemove,
+  title = 'Are you sure?',
+  prompt,
+  cancelLabel = 'Cancel',
+  okLabel = 'OK',
+  okRunningLabel,
+  okVariant = 'default',
+  onCancel,
+  onOk,
+  customFooter,
+  formSheet = true,
+  stickyFooter = false,
+  testId = 'confirmation-modal',
 }) => {
-    const [taskState, setTaskState] = useState<'running' | ''>('');
-    const isRunning = taskState === 'running';
-    const runningLabel = okRunningLabel || okLabel;
+  const [taskState, setTaskState] = useState<'running' | ''>('');
+  const isRunning = taskState === 'running';
+  const runningLabel = okRunningLabel || okLabel;
 
-    const handleCancel = () => {
-        if (isRunning) {
-            return;
-        }
+  const handleCancel = () => {
+    if (isRunning) {
+      return;
+    }
 
-        if (onCancel) {
-            onCancel();
-        } else {
-            onRemove();
-        }
-    };
+    if (onCancel) {
+      onCancel();
+    } else {
+      onRemove();
+    }
+  };
 
-    const handleConfirm = async () => {
-        setTaskState('running');
+  const handleConfirm = async () => {
+    setTaskState('running');
 
-        try {
-            await onOk?.({remove: onRemove});
-        } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error('Unhandled Promise Rejection. Make sure you catch errors in your onOk handler.', error);
-        }
+    try {
+      await onOk?.({ remove: onRemove });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Unhandled Promise Rejection. Make sure you catch errors in your onOk handler.',
+        error,
+      );
+    }
 
-        setTaskState('');
-    };
+    setTaskState('');
+  };
 
-    const defaultFooter = (
-        // Inside the sticky footer the row is stretched to full width, so below
-        // `sm` its column-reverse buttons would otherwise touch.
-        <AlertDialogFooter className={cn(stickyFooter && 'gap-2')}>
-            {cancelLabel && (
-                <Button data-testid='cancel-modal' disabled={isRunning} type='button' variant='outline' onClick={handleCancel}>
-                    {cancelLabel}
-                </Button>
-            )}
-            {okLabel && (
-                <Button aria-busy={isRunning} data-testid='ok-modal' disabled={isRunning} type='button' variant={okVariant} onClick={() => void handleConfirm()}>
-                    {isRunning && <LoadingIndicator color='current' size='sm' />}
-                    {isRunning ? runningLabel : okLabel}
-                </Button>
-            )}
-        </AlertDialogFooter>
-    );
+  const defaultFooter = (
+    // Inside the sticky footer the row is stretched to full width, so below
+    // `sm` its column-reverse buttons would otherwise touch.
+    <AlertDialogFooter className={cn(stickyFooter && 'gap-2')}>
+      {cancelLabel && (
+        <Button
+          data-testid="cancel-modal"
+          disabled={isRunning}
+          type="button"
+          variant="outline"
+          onClick={handleCancel}
+        >
+          {cancelLabel}
+        </Button>
+      )}
+      {okLabel && (
+        <Button
+          aria-busy={isRunning}
+          data-testid="ok-modal"
+          disabled={isRunning}
+          type="button"
+          variant={okVariant}
+          onClick={() => void handleConfirm()}
+        >
+          {isRunning && <LoadingIndicator color="current" size="sm" />}
+          {isRunning ? runningLabel : okLabel}
+        </Button>
+      )}
+    </AlertDialogFooter>
+  );
 
-    const footer = customFooter === undefined ? defaultFooter : customFooter;
+  const footer = customFooter === undefined ? defaultFooter : customFooter;
 
-    return (
-        <AlertDialog open={visible} onOpenChange={open => !open && handleCancel()}>
-            <AlertDialogContent
-                className={cn(
-                    'z-[1100] max-h-[calc(100dvh-4rem)] w-[calc(100%-2rem)] overflow-y-auto bg-background',
-                    // A sticky grid item is boxed in by its own grid area and never
-                    // sticks, so the footer needs a flex column to stick within.
-                    // Sticky offsets resolve against the scroll container's content
-                    // box, so any bottom padding here becomes dead space the footer
-                    // can never reach — the footer supplies its own instead. The
-                    // row gap goes too: it lands between the issue list and the
-                    // footer and reads as an empty band above the buttons.
-                    stickyFooter && 'flex flex-col gap-0 pb-0'
-                )}
-                data-testid={testId}
-                overlayClassName={cn(
-                    'z-[1100] bg-foreground/20! backdrop-blur-[3px]',
-                    formSheet && 'bg-foreground/10!'
-                )}
-                onEscapeKeyDown={event => event.stopPropagation()}
+  return (
+    <AlertDialog open={visible} onOpenChange={(open) => !open && handleCancel()}>
+      <AlertDialogContent
+        className={cn(
+          'z-[1100] max-h-[calc(100dvh-4rem)] w-[calc(100%-2rem)] overflow-y-auto bg-background',
+          // A sticky grid item is boxed in by its own grid area and never
+          // sticks, so the footer needs a flex column to stick within.
+          // Sticky offsets resolve against the scroll container's content
+          // box, so any bottom padding here becomes dead space the footer
+          // can never reach — the footer supplies its own instead. The
+          // row gap goes too: it lands between the issue list and the
+          // footer and reads as an empty band above the buttons.
+          stickyFooter && 'flex flex-col gap-0 pb-0',
+        )}
+        data-testid={testId}
+        overlayClassName={cn(
+          'z-[1100] bg-foreground/20! backdrop-blur-[3px]',
+          formSheet && 'bg-foreground/10!',
+        )}
+        onEscapeKeyDown={(event) => event.stopPropagation()}
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="text-left text-foreground">{prompt}</div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {footer &&
+          (stickyFooter ? (
+            // StickyFooter sizes its own box in raw pixels but spaces its
+            // parts with `h-6`/`-mb-6`, which Shade's `--spacing: 0.4rem`
+            // scale renders as 38.4px rather than the 24px its own maths
+            // assumes — so the box is sized here explicitly, and it bleeds
+            // across the dialog's horizontal padding.
+            //
+            // The leading spacer goes entirely. Both it and the content div
+            // are `sticky bottom-0` with `bg-background`, but the content
+            // div is 84px tall and sits a layer above, so it already masks
+            // the full visible strip on its own and the spacer is never
+            // seen mid-scroll. At the bottom of the scroll everything
+            // returns to flow and the spacer becomes a visible empty band
+            // between the last row and the buttons.
+            //
+            // The trailing shadow rule goes with it. It's a decorative
+            // scroll affordance that reads as a hairline drawn straight
+            // across the buttons here, and with the spacer gone there is
+            // nothing left for it to shade.
+            //
+            // That leaves the content div as the only part still in flow,
+            // so its negative margin has to go too or the 84px box would
+            // reserve 24px of slack the `sticky bottom-0` content can never
+            // drop into — the same empty band, just below the buttons
+            // instead of above them. Content height, flow height and box
+            // height all sit at 84px, which keeps the buttons on the
+            // container's bottom edge.
+            <StickyFooter
+              className="-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:hidden"
+              contentClassName="px-6 mb-0 *:w-full"
+              height={84}
+              style={{ bottom: 0, height: '84px' }}
             >
-                <AlertDialogHeader>
-                    <AlertDialogTitle>{title}</AlertDialogTitle>
-                    <AlertDialogDescription asChild>
-                        <div className='text-left text-foreground'>{prompt}</div>
-                    </AlertDialogDescription>
-                </AlertDialogHeader>
-                {footer && (stickyFooter ? (
-                    // StickyFooter sizes its own box in raw pixels but spaces its
-                    // parts with `h-6`/`-mb-6`, which Shade's `--spacing: 0.4rem`
-                    // scale renders as 38.4px rather than the 24px its own maths
-                    // assumes — so the box is sized here explicitly, and it bleeds
-                    // across the dialog's horizontal padding.
-                    //
-                    // The leading spacer goes entirely. Both it and the content div
-                    // are `sticky bottom-0` with `bg-background`, but the content
-                    // div is 84px tall and sits a layer above, so it already masks
-                    // the full visible strip on its own and the spacer is never
-                    // seen mid-scroll. At the bottom of the scroll everything
-                    // returns to flow and the spacer becomes a visible empty band
-                    // between the last row and the buttons.
-                    //
-                    // The trailing shadow rule goes with it. It's a decorative
-                    // scroll affordance that reads as a hairline drawn straight
-                    // across the buttons here, and with the spacer gone there is
-                    // nothing left for it to shade.
-                    //
-                    // That leaves the content div as the only part still in flow,
-                    // so its negative margin has to go too or the 84px box would
-                    // reserve 24px of slack the `sticky bottom-0` content can never
-                    // drop into — the same empty band, just below the buttons
-                    // instead of above them. Content height, flow height and box
-                    // height all sit at 84px, which keeps the buttons on the
-                    // container's bottom edge.
-                    <StickyFooter
-                        className='-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:hidden'
-                        contentClassName='px-6 mb-0 *:w-full'
-                        height={84}
-                        style={{bottom: 0, height: '84px'}}
-                    >
-                        {footer}
-                    </StickyFooter>
-                ) : footer)}
-            </AlertDialogContent>
-        </AlertDialog>
-    );
+              {footer}
+            </StickyFooter>
+          ) : (
+            footer
+          ))}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 };

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -109,8 +109,10 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
                     // sticks, so the footer needs a flex column to stick within.
                     // Sticky offsets resolve against the scroll container's content
                     // box, so any bottom padding here becomes dead space the footer
-                    // can never reach — the footer supplies its own instead.
-                    stickyFooter && 'flex flex-col pb-0'
+                    // can never reach — the footer supplies its own instead. The
+                    // row gap goes too: StickyFooter already opens with a 24px
+                    // spacer, and stacking the two left a visible hole above it.
+                    stickyFooter && 'flex flex-col gap-0 pb-0'
                 )}
                 data-testid={testId}
                 overlayClassName={cn(

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -13,10 +13,6 @@ import {
 } from '@tryghost/shade/components';
 import { cn } from '@tryghost/shade/utils';
 
-/**
- * Names the sticky footer box so tests can address it without depending on the
- * z-index utilities Shade happens to draw it with.
- */
 export const STICKY_FOOTER_TESTID = 'modal-sticky-footer';
 
 export interface ConfirmationModalProps {
@@ -88,8 +84,6 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
   };
 
   const defaultFooter = (
-    // Inside the sticky footer the row is stretched to full width, so below
-    // `sm` its column-reverse buttons would otherwise touch.
     <AlertDialogFooter className={cn(stickyFooter && 'gap-2')}>
       {cancelLabel && (
         <Button
@@ -125,13 +119,8 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
       <AlertDialogContent
         className={cn(
           'z-[1100] max-h-[calc(100dvh-4rem)] w-[calc(100%-2rem)] overflow-y-auto bg-background',
-          // A sticky grid item is boxed in by its own grid area and never
-          // sticks, so the footer needs a flex column to stick within.
-          // Sticky offsets resolve against the scroll container's content
-          // box, so any bottom padding here becomes dead space the footer
-          // can never reach — the footer supplies its own instead. The
-          // row gap goes too: it lands between the issue list and the
-          // footer and reads as an empty band above the buttons.
+          // A sticky element never sticks inside a grid item, so the footer
+          // needs a flex column to stick within.
           stickyFooter && 'flex flex-col gap-0 pb-0',
         )}
         data-testid={testId}
@@ -149,32 +138,9 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
         </AlertDialogHeader>
         {footer &&
           (stickyFooter ? (
-            // StickyFooter sizes its own box in raw pixels but spaces its
-            // parts with `h-6`/`-mb-6`, which Shade's `--spacing: 0.4rem`
-            // scale renders as 38.4px rather than the 24px its own maths
-            // assumes — so the box is sized here explicitly, and it bleeds
-            // across the dialog's horizontal padding.
-            //
-            // The leading spacer goes entirely. Both it and the content div
-            // are `sticky bottom-0` with `bg-background`, but the content
-            // div is 84px tall and sits a layer above, so it already masks
-            // the full visible strip on its own and the spacer is never
-            // seen mid-scroll. At the bottom of the scroll everything
-            // returns to flow and the spacer becomes a visible empty band
-            // between the last row and the buttons.
-            //
-            // The trailing shadow rule goes with it. It's a decorative
-            // scroll affordance that reads as a hairline drawn straight
-            // across the buttons here, and with the spacer gone there is
-            // nothing left for it to shade.
-            //
-            // That leaves the content div as the only part still in flow,
-            // so its negative margin has to go too or the 84px box would
-            // reserve 24px of slack the `sticky bottom-0` content can never
-            // drop into — the same empty band, just below the buttons
-            // instead of above them. Content height, flow height and box
-            // height all sit at 84px, which keeps the buttons on the
-            // container's bottom edge.
+            // StickyFooter sizes its box in raw pixels but spaces its parts
+            // with `h-6`/`-mb-6`, which render at 38.4px on Shade's `0.4rem`
+            // scale — hence the explicit sizing overrides.
             <StickyFooter
               className="-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:hidden"
               contentClassName="px-6 mb-0 *:w-full"

--- a/apps/admin/src/settings/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/components/confirmation-modal.tsx
@@ -128,12 +128,30 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps & Confirm
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 {footer && (stickyFooter ? (
-                    // StickyFooter sizes its own box in raw pixels (`height + 24`)
-                    // but spaces its parts with `h-6`/`-mb-6`, which Shade's
-                    // `--spacing: 0.4rem` scale renders as 38.4px. Pin those three
-                    // offsets back to the 24px the component's own maths assumes,
-                    // and bleed it across the dialog's horizontal padding.
-                    <StickyFooter className='-mx-6 w-auto [&>div:first-child]:h-[24px] [&>div:last-child]:h-[24px]' contentClassName='px-6 mb-[-24px] *:w-full' height={84}>
+                    // StickyFooter sizes its own box in raw pixels but spaces its
+                    // parts with `h-6`/`-mb-6`, which Shade's `--spacing: 0.4rem`
+                    // scale renders as 38.4px — so the shadow rule and the content
+                    // div's negative margin are pinned back to the 24px the
+                    // component's own maths assumes, and the whole thing bleeds
+                    // across the dialog's horizontal padding.
+                    //
+                    // The leading spacer goes entirely. Both it and the content div
+                    // are `sticky bottom-0` with `bg-background`, but the content
+                    // div is 84px tall and sits a layer above, so it already masks
+                    // the full visible strip on its own and the spacer is never
+                    // seen mid-scroll. At the bottom of the scroll everything
+                    // returns to flow and the spacer becomes a visible empty band
+                    // between the last row and the buttons. Dropping it means the
+                    // box no longer needs the extra 24px it reserved for it: the
+                    // height and bottom offset collapse to the footer's own 84px,
+                    // which keeps the buttons on the container's bottom edge rather
+                    // than moving the gap below them.
+                    <StickyFooter
+                        className='-mx-6 w-auto [&>div:first-child]:hidden [&>div:last-child]:h-[24px]'
+                        contentClassName='px-6 mb-[-24px] *:w-full'
+                        height={84}
+                        style={{bottom: 0, height: '84px'}}
+                    >
                         {footer}
                     </StickyFooter>
                 ) : footer)}

--- a/apps/admin/src/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme-modal.tsx
@@ -3,7 +3,6 @@ import InvalidThemeModal, { type FatalErrors } from './theme/invalid-theme-modal
 import OfficialThemes from './theme/official-themes';
 import React, { useEffect, useState } from 'react';
 import ThemeInstalledModal, { type ThemeInstalledModalProps } from './theme/theme-installed-modal';
-import { describeThemeOutcome, getIssuesFromInstalledTheme } from './theme/theme-validation-issues';
 import ThemePreview from './theme/theme-preview';
 import {
   Button,
@@ -516,18 +515,10 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({ source, themeRef })
           return;
         }
 
-        const newlyInstalledTheme = data.themes[0];
-        const outcome = describeThemeOutcome(
-          'installed',
-          getIssuesFromInstalledTheme(newlyInstalledTheme),
-        );
-
-        statusMessage = (
-          <>
-            <strong>{newlyInstalledTheme.name}</strong> was {outcome}. Do you want to activate it?
-          </>
-        );
-        installedTheme = newlyInstalledTheme;
+        // No `statusMessage`: an install that reached the API is described by
+        // `action: 'installed'` alone, and restating that sentence here would
+        // give one line two sources to drift between.
+        installedTheme = data.themes[0];
       }
 
       setInstalledModal({

--- a/apps/admin/src/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme-modal.tsx
@@ -515,9 +515,6 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({ source, themeRef })
           return;
         }
 
-        // No `statusMessage`: an install that reached the API is described by
-        // `action: 'installed'` alone, and restating that sentence here would
-        // give one line two sources to drift between.
         installedTheme = data.themes[0];
       }
 

--- a/apps/admin/src/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme-modal.tsx
@@ -1,518 +1,601 @@
 import AdvancedThemeSettings from './theme/advanced-theme-settings';
-import InvalidThemeModal, {type FatalErrors} from './theme/invalid-theme-modal';
+import InvalidThemeModal, { type FatalErrors } from './theme/invalid-theme-modal';
 import OfficialThemes from './theme/official-themes';
-import React, {useEffect, useState} from 'react';
-import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme/theme-installed-modal';
-import {describeThemeOutcome, getIssuesFromInstalledTheme} from './theme/theme-validation-issues';
+import React, { useEffect, useState } from 'react';
+import ThemeInstalledModal, { type ThemeInstalledModalProps } from './theme/theme-installed-modal';
+import { describeThemeOutcome, getIssuesFromInstalledTheme } from './theme/theme-validation-issues';
 import ThemePreview from './theme/theme-preview';
-import {Button, Dropzone, LoadingIndicator, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
-import {type InstalledTheme, type Theme, type ThemesInstallResponseType, isDefaultOrLegacyTheme, useActivateTheme, useBrowseThemes, useInstallTheme, useUploadTheme} from '@tryghost/admin-x-framework/api/themes';
-import {JSONError} from '@tryghost/admin-x-framework/errors';
-import {type OfficialTheme} from '@/settings/providers/settings-app-context';
-import {PageHeader, SettingsModal} from '@tryghost/shade/patterns';
-import {toast} from 'sonner';
-import {useCheckThemeLimitError} from '@/settings/hooks/use-check-theme-limit-error';
-import {type ConfirmationHandle, useConfirmation} from '@/settings/providers/confirmation-context';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
-import {useUpgradeRoute} from '@/settings/hooks/use-upgrade-route';
+import {
+  Button,
+  Dropzone,
+  LoadingIndicator,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from '@tryghost/shade/components';
+import {
+  type InstalledTheme,
+  type Theme,
+  type ThemesInstallResponseType,
+  isDefaultOrLegacyTheme,
+  useActivateTheme,
+  useBrowseThemes,
+  useInstallTheme,
+  useUploadTheme,
+} from '@tryghost/admin-x-framework/api/themes';
+import { JSONError } from '@tryghost/admin-x-framework/errors';
+import { type OfficialTheme } from '@/settings/providers/settings-app-context';
+import { PageHeader, SettingsModal } from '@tryghost/shade/patterns';
+import { toast } from 'sonner';
+import { useCheckThemeLimitError } from '@/settings/hooks/use-check-theme-limit-error';
+import {
+  type ConfirmationHandle,
+  useConfirmation,
+} from '@/settings/providers/confirmation-context';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
+import { useUpgradeRoute } from '@/settings/hooks/use-upgrade-route';
 
 interface ThemeToolbarProps {
-    selectedTheme: OfficialTheme|null;
-    currentTab: string;
-    setCurrentTab: (tab: string) => void;
-    setSelectedTheme: (theme: OfficialTheme|null) => void;
-    themes: Theme[];
-    setPreviewMode: (mode: string) => void;
-    previewMode: string;
+  selectedTheme: OfficialTheme | null;
+  currentTab: string;
+  setCurrentTab: (tab: string) => void;
+  setSelectedTheme: (theme: OfficialTheme | null) => void;
+  themes: Theme[];
+  setPreviewMode: (mode: string) => void;
+  previewMode: string;
 }
 
 interface ThemeModalContentProps {
-    onSelectTheme: (theme: OfficialTheme|null) => void;
-    currentTab: string;
-    themes: Theme[];
+  onSelectTheme: (theme: OfficialTheme | null) => void;
+  currentTab: string;
+  themes: Theme[];
 }
 
-const UploadModalContent: React.FC<{onUpload: (file: File) => void}> = ({onUpload}) => {
-    return (
-        <Dropzone
-            accept={{'application/zip': ['.zip']}}
-            inputId="theme-upload"
-            onDropAccepted={([file]) => {
-                onUpload(file);
-            }}
-        >
-            Click to select or drag & drop zip file
-        </Dropzone>
-    );
+const UploadModalContent: React.FC<{ onUpload: (file: File) => void }> = ({ onUpload }) => {
+  return (
+    <Dropzone
+      accept={{ 'application/zip': ['.zip'] }}
+      inputId="theme-upload"
+      onDropAccepted={([file]) => {
+        onUpload(file);
+      }}
+    >
+      Click to select or drag & drop zip file
+    </Dropzone>
+  );
 };
 
-const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
-    currentTab,
-    setCurrentTab,
-    themes
-}) => {
-    const {updateRoute} = useSettingsNavigation();
-    const upgradeRoute = useUpgradeRoute();
-    const {mutateAsync: uploadTheme} = useUploadTheme();
-    const {checkThemeLimitError, isThemeLimited} = useCheckThemeLimitError();
-    const handleError = useHandleError();
-    const {confirm, showLimit} = useConfirmation();
+const ThemeToolbar: React.FC<ThemeToolbarProps> = ({ currentTab, setCurrentTab, themes }) => {
+  const { updateRoute } = useSettingsNavigation();
+  const upgradeRoute = useUpgradeRoute();
+  const { mutateAsync: uploadTheme } = useUploadTheme();
+  const { checkThemeLimitError, isThemeLimited } = useCheckThemeLimitError();
+  const handleError = useHandleError();
+  const { confirm, showLimit } = useConfirmation();
 
-    const [uploadConfig, setUploadConfig] = useState<{enabled: boolean; error?: string} | undefined>();
-    const [isUploading, setUploading] = useState(false);
-    const [uploadErrors, setUploadErrors] = useState<{themeName: string; fatalErrors: FatalErrors} | null>(null);
-    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
+  const [uploadConfig, setUploadConfig] = useState<
+    { enabled: boolean; error?: string } | undefined
+  >();
+  const [isUploading, setUploading] = useState(false);
+  const [uploadErrors, setUploadErrors] = useState<{
+    themeName: string;
+    fatalErrors: FatalErrors;
+  } | null>(null);
+  const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
 
-    useEffect(() => {
-        const checkUploadLimit = async () => {
-            // Theme upload is always a custom theme, so we check with '.'
-            // to force an error if ANY theme limit is applied
-            if (isThemeLimited) {
-                const error = await checkThemeLimitError('.');
-                setUploadConfig({enabled: false, error: error || 'Your current plan doesn\'t support uploading custom themes.'});
-            } else {
-                setUploadConfig({enabled: true});
-            }
-        };
-
-        void checkUploadLimit();
-    }, [checkThemeLimitError, isThemeLimited]);
-
-    const onClose = () => {
-        updateRoute('/');
-    };
-
-    const onThemeUpload = (file: File) => {
-        const themeFileName = file?.name.replace(/\.zip$/, '');
-        const existingThemeNames = themes.map(t => t.name);
-        if (isDefaultOrLegacyTheme({name: themeFileName})) {
-            confirm({
-                title: 'Upload failed',
-                cancelLabel: 'Cancel',
-                okLabel: '',
-                prompt: (
-                    <>
-                        <p>The default <strong>{themeFileName}</strong> theme cannot be overwritten.</p>
-                        <p>Rename your zip file and try again.</p>
-                    </>
-                ),
-                onOk: (confirmModal) => {
-                    confirmModal?.remove();
-                }
-            });
-        } else if (existingThemeNames.includes(themeFileName)) {
-            confirm({
-                title: 'Overwrite theme',
-                prompt: (
-                    <>
-                        The theme <strong>{themeFileName}</strong> already exists.
-                        Do you want to overwrite it?
-                    </>
-                ),
-                okLabel: 'Overwrite',
-                cancelLabel: 'Cancel',
-                okRunningLabel: 'Overwriting...',
-                okVariant: 'destructive',
-                onOk: async (confirmModal) => {
-                    setUploading(true);
-
-                    // this is to avoid the themes array from returning the overwritten theme.
-                    // find index of themeFileName in existingThemeNames and remove from the array
-                    const index = existingThemeNames.indexOf(themeFileName);
-                    themes.splice(index, 1);
-
-                    await handleThemeUpload({file, onActivate: onClose});
-                    setUploading(false);
-                    setCurrentTab('installed');
-                    confirmModal?.remove();
-                }
-            });
-        } else {
-            setCurrentTab('installed');
-            void handleThemeUpload({file, onActivate: onClose});
-        }
-    };
-
-    const handleThemeUpload = async ({
-        file,
-        onActivate
-    }: {
-        file: File;
-        onActivate?: () => void
-    }) => {
-        let data: ThemesInstallResponseType | undefined;
-        let fatalErrors: FatalErrors | null = null;
-
-        try {
-            setUploading(true);
-            data = await uploadTheme({file});
-            setUploading(false);
-        } catch (e) {
-            setUploading(false);
-
-            if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
-                fatalErrors = e.data.errors as FatalErrors;
-            } else {
-                handleError(e);
-            }
-        }
-
-        if (fatalErrors && !data) {
-            setUploadErrors({themeName: file.name.replace(/\.zip$/, ''), fatalErrors});
-        }
-
-        if (!data) {
-            return;
-        }
-
-        setInstalledModal({
-            title: 'Upload successful',
-            installedTheme: data.themes[0],
-            onActivate
+  useEffect(() => {
+    const checkUploadLimit = async () => {
+      // Theme upload is always a custom theme, so we check with '.'
+      // to force an error if ANY theme limit is applied
+      if (isThemeLimited) {
+        const error = await checkThemeLimitError('.');
+        setUploadConfig({
+          enabled: false,
+          error: error || "Your current plan doesn't support uploading custom themes.",
         });
+      } else {
+        setUploadConfig({ enabled: true });
+      }
     };
 
-    const left =
-    <div className='hidden md:!visible md:!block'>
-        <Tabs value={currentTab} variant='button' onValueChange={setCurrentTab}>
-            <TabsList>
-                <TabsTrigger value='official'>Official themes</TabsTrigger>
-                <TabsTrigger value='installed'>Installed</TabsTrigger>
-            </TabsList>
+    void checkUploadLimit();
+  }, [checkThemeLimitError, isThemeLimited]);
+
+  const onClose = () => {
+    updateRoute('/');
+  };
+
+  const onThemeUpload = (file: File) => {
+    const themeFileName = file?.name.replace(/\.zip$/, '');
+    const existingThemeNames = themes.map((t) => t.name);
+    if (isDefaultOrLegacyTheme({ name: themeFileName })) {
+      confirm({
+        title: 'Upload failed',
+        cancelLabel: 'Cancel',
+        okLabel: '',
+        prompt: (
+          <>
+            <p>
+              The default <strong>{themeFileName}</strong> theme cannot be overwritten.
+            </p>
+            <p>Rename your zip file and try again.</p>
+          </>
+        ),
+        onOk: (confirmModal) => {
+          confirmModal?.remove();
+        },
+      });
+    } else if (existingThemeNames.includes(themeFileName)) {
+      confirm({
+        title: 'Overwrite theme',
+        prompt: (
+          <>
+            The theme <strong>{themeFileName}</strong> already exists. Do you want to overwrite it?
+          </>
+        ),
+        okLabel: 'Overwrite',
+        cancelLabel: 'Cancel',
+        okRunningLabel: 'Overwriting...',
+        okVariant: 'destructive',
+        onOk: async (confirmModal) => {
+          setUploading(true);
+
+          // this is to avoid the themes array from returning the overwritten theme.
+          // find index of themeFileName in existingThemeNames and remove from the array
+          const index = existingThemeNames.indexOf(themeFileName);
+          themes.splice(index, 1);
+
+          await handleThemeUpload({ file, onActivate: onClose });
+          setUploading(false);
+          setCurrentTab('installed');
+          confirmModal?.remove();
+        },
+      });
+    } else {
+      setCurrentTab('installed');
+      void handleThemeUpload({ file, onActivate: onClose });
+    }
+  };
+
+  const handleThemeUpload = async ({
+    file,
+    onActivate,
+  }: {
+    file: File;
+    onActivate?: () => void;
+  }) => {
+    let data: ThemesInstallResponseType | undefined;
+    let fatalErrors: FatalErrors | null = null;
+
+    try {
+      setUploading(true);
+      data = await uploadTheme({ file });
+      setUploading(false);
+    } catch (e) {
+      setUploading(false);
+
+      if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
+        fatalErrors = e.data.errors as FatalErrors;
+      } else {
+        handleError(e);
+      }
+    }
+
+    if (fatalErrors && !data) {
+      setUploadErrors({ themeName: file.name.replace(/\.zip$/, ''), fatalErrors });
+    }
+
+    if (!data) {
+      return;
+    }
+
+    setInstalledModal({
+      title: 'Upload successful',
+      installedTheme: data.themes[0],
+      onActivate,
+    });
+  };
+
+  const left = (
+    <div className="hidden md:!visible md:!block">
+      <Tabs value={currentTab} variant="button" onValueChange={setCurrentTab}>
+        <TabsList>
+          <TabsTrigger value="official">Official themes</TabsTrigger>
+          <TabsTrigger value="installed">Installed</TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+
+  const handleUpload = () => {
+    // Don't do anything if still checking limits
+    if (!uploadConfig) {
+      return;
+    }
+
+    if (uploadConfig.enabled) {
+      const handleRef: { current: ConfirmationHandle | null } = { current: null };
+      handleRef.current = confirm({
+        title: 'Upload theme',
+        prompt: (
+          <UploadModalContent
+            onUpload={(file) => {
+              handleRef.current?.remove();
+              onThemeUpload(file);
+            }}
+          />
+        ),
+        okLabel: '',
+        formSheet: false,
+      });
+    } else {
+      showLimit({
+        title: 'Upgrade to enable custom themes',
+        prompt: uploadConfig.error || (
+          <>
+            Your current plan only supports official themes. You can install them from the{' '}
+            <a href="https://ghost.org/marketplace/">Ghost theme marketplace</a>.
+          </>
+        ),
+        onOk: () => updateRoute({ route: upgradeRoute, isExternal: true }),
+      });
+    }
+  };
+
+  const right = (
+    <div className="flex items-center gap-14">
+      <div className="flex items-center gap-3">
+        <Button type="button" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+        <Button disabled={isUploading} type="button" onClick={handleUpload}>
+          {isUploading && <LoadingIndicator size="sm" />}Upload theme
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <PageHeader
+        blurredBackground={false}
+        className="sticky -top-px z-50 h-22 min-h-[92px] bg-background p-8"
+        sticky={false}
+      >
+        <PageHeader.Left className="flex-auto">{left}</PageHeader.Left>
+        <PageHeader.Actions className="flex-auto justify-end">{right}</PageHeader.Actions>
+      </PageHeader>
+      <div className="px-[8vmin] md:hidden">
+        <Tabs value={currentTab} variant="button" onValueChange={setCurrentTab}>
+          <TabsList>
+            <TabsTrigger value="official">Official themes</TabsTrigger>
+            <TabsTrigger value="installed">Installed</TabsTrigger>
+          </TabsList>
         </Tabs>
-    </div>;
-
-    const handleUpload = () => {
-        // Don't do anything if still checking limits
-        if (!uploadConfig) {
-            return;
-        }
-
-        if (uploadConfig.enabled) {
-            const handleRef: {current: ConfirmationHandle | null} = {current: null};
-            handleRef.current = confirm({
-                title: 'Upload theme',
-                prompt: <UploadModalContent onUpload={(file) => {
-                    handleRef.current?.remove();
-                    onThemeUpload(file);
-                }} />,
-                okLabel: '',
-                formSheet: false
-            });
-        } else {
-            showLimit({
-                title: 'Upgrade to enable custom themes',
-                prompt: uploadConfig.error || <>Your current plan only supports official themes. You can install them from the <a href="https://ghost.org/marketplace/">Ghost theme marketplace</a>.</>,
-                onOk: () => updateRoute({route: upgradeRoute, isExternal: true})
-            });
-        }
-    };
-
-    const right =
-        <div className='flex items-center gap-14'>
-            <div className='flex items-center gap-3'>
-                <Button type='button' variant='outline' onClick={onClose}>Close</Button>
-                <Button disabled={isUploading} type='button' onClick={handleUpload}>{isUploading && <LoadingIndicator size='sm' />}Upload theme</Button>
-            </div>
-        </div>;
-
-    return (<>
-        <PageHeader blurredBackground={false} className='sticky -top-px z-50 h-22 min-h-[92px] bg-background p-8' sticky={false}>
-            <PageHeader.Left className='flex-auto'>
-                {left}
-            </PageHeader.Left>
-            <PageHeader.Actions className='flex-auto justify-end'>
-                {right}
-            </PageHeader.Actions>
-        </PageHeader>
-        <div className='px-[8vmin] md:hidden'>
-            <Tabs value={currentTab} variant='button' onValueChange={setCurrentTab}>
-                <TabsList>
-                    <TabsTrigger value='official'>Official themes</TabsTrigger>
-                    <TabsTrigger value='installed'>Installed</TabsTrigger>
-                </TabsList>
-            </Tabs>
-        </div>
-        {uploadErrors && (
-            <InvalidThemeModal
-                action='uploaded'
-                fatalErrors={uploadErrors.fatalErrors}
-                okLabel='Re-upload'
-                themeName={uploadErrors.themeName}
-                title='Theme not uploaded'
-                onClose={() => setUploadErrors(null)}
-                onRetry={() => {
-                    setUploadErrors(null);
-                    handleUpload();
-                }}
-            />
-        )}
-        {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
-    </>);
+      </div>
+      {uploadErrors && (
+        <InvalidThemeModal
+          action="uploaded"
+          fatalErrors={uploadErrors.fatalErrors}
+          okLabel="Re-upload"
+          themeName={uploadErrors.themeName}
+          title="Theme not uploaded"
+          onClose={() => setUploadErrors(null)}
+          onRetry={() => {
+            setUploadErrors(null);
+            handleUpload();
+          }}
+        />
+      )}
+      {installedModal && (
+        <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />
+      )}
+    </>
+  );
 };
 
 const ThemeModalContent: React.FC<ThemeModalContentProps> = ({
-    currentTab,
-    onSelectTheme,
-    themes
+  currentTab,
+  onSelectTheme,
+  themes,
 }) => {
-    switch (currentTab) {
+  switch (currentTab) {
     case 'official':
-        return (
-            <OfficialThemes onSelectTheme={onSelectTheme} />
-        );
+      return <OfficialThemes onSelectTheme={onSelectTheme} />;
     case 'installed':
-        return (
-            <AdvancedThemeSettings themes={themes} />
-        );
-    }
-    return null;
+      return <AdvancedThemeSettings themes={themes} />;
+  }
+  return null;
 };
 
 type ChangeThemeModalProps = {
-    source?: string | null;
-    themeRef?: string | null;
+  source?: string | null;
+  themeRef?: string | null;
 };
 
-const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) => {
-    const [currentTab, setCurrentTab] = useState('official');
-    const [selectedTheme, setSelectedTheme] = useState<OfficialTheme|null>(null);
-    const [previewMode, setPreviewMode] = useState('desktop');
-    const [isInstalling, setInstalling] = useState(false);
-    const [installedFromMarketplace, setInstalledFromMarketplace] = useState(false);
-    const [isMounted, setIsMounted] = useState(false);
-    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
-    const {updateRoute} = useSettingsNavigation();
-    const upgradeRoute = useUpgradeRoute();
+const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({ source, themeRef }) => {
+  const [currentTab, setCurrentTab] = useState('official');
+  const [selectedTheme, setSelectedTheme] = useState<OfficialTheme | null>(null);
+  const [previewMode, setPreviewMode] = useState('desktop');
+  const [isInstalling, setInstalling] = useState(false);
+  const [installedFromMarketplace, setInstalledFromMarketplace] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+  const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
+  const { updateRoute } = useSettingsNavigation();
+  const upgradeRoute = useUpgradeRoute();
 
-    const {data: {themes} = {}} = useBrowseThemes();
-    const {mutateAsync: installTheme} = useInstallTheme();
-    const {mutateAsync: activateTheme} = useActivateTheme();
-    const {checkThemeLimitError} = useCheckThemeLimitError();
-    const handleError = useHandleError();
-    const {confirm, showLimit} = useConfirmation();
+  const { data: { themes } = {} } = useBrowseThemes();
+  const { mutateAsync: installTheme } = useInstallTheme();
+  const { mutateAsync: activateTheme } = useActivateTheme();
+  const { checkThemeLimitError } = useCheckThemeLimitError();
+  const handleError = useHandleError();
+  const { confirm, showLimit } = useConfirmation();
 
-    const onSelectTheme = (theme: OfficialTheme|null) => {
-        setSelectedTheme(theme);
+  const onSelectTheme = (theme: OfficialTheme | null) => {
+    setSelectedTheme(theme);
+  };
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  // probably not the best place to handle the logic here, something for cleanup.
+  useEffect(() => {
+    const handleUrlInstallation = async () => {
+      // this grabs the theme ref from the url and installs it
+      // Only show confirmation if we have explicit source and themeRef props (not from URL params after redirect)
+      // Important: This should only run when ChangeThemeModal is explicitly given these props,
+      // not when it's rendered for the regular change-theme route
+      // Also wait for component to be mounted to avoid race conditions
+      if (source && themeRef && !installedFromMarketplace && isMounted) {
+        const themeName = themeRef.split('/')[1];
+
+        // Check theme limit before showing installation modal
+        const limitError = await checkThemeLimitError(themeName);
+        if (limitError) {
+          // Don't show installation modal if there's a limit error
+          // The parent component should handle this
+          // Also close the current modal to prevent any issues
+          updateRoute('theme');
+          return;
+        }
+
+        const titleText = 'Install Theme';
+        const existingThemeNames = themes?.map((t) => t.name) || [];
+        const willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
+        const index = existingThemeNames.indexOf(themeName.toLowerCase());
+        // get the theme that will be overwritten
+        const themeToOverwrite = themes?.[index];
+        const prompt = (
+          <>
+            By clicking below, <strong>{themeName}</strong> will automatically be activated as the
+            theme for your site.
+            {willOverwrite && (
+              <>
+                <br />
+                <br />
+                This will overwrite your existing version of <strong>{themeName}</strong>
+                {themeToOverwrite?.active ? ' which is your active theme' : ''}. All custom changes
+                will be lost.
+              </>
+            )}
+          </>
+        );
+        confirm({
+          title: titleText,
+          prompt,
+          okLabel: 'Install',
+          cancelLabel: 'Cancel',
+          okRunningLabel: 'Installing...',
+          okVariant: 'default',
+          onOk: async (confirmModal) => {
+            let data: ThemesInstallResponseType | undefined;
+            setInstalledFromMarketplace(true);
+            try {
+              if (willOverwrite) {
+                if (themes) {
+                  themes.splice(index, 1);
+                }
+              }
+              data = await installTheme(themeRef);
+              if (data?.themes[0]) {
+                await activateTheme(data.themes[0].name);
+                toast.success('Theme activated', {
+                  description: (
+                    <div>
+                      <span className="capitalize">{data.themes[0].name}</span> is now your active
+                      theme
+                    </div>
+                  ),
+                });
+              }
+              confirmModal?.remove();
+              updateRoute('');
+            } catch (e) {
+              handleError(e);
+            }
+            if (!data) {
+              return;
+            }
+          },
+        });
+      }
     };
 
-    useEffect(() => {
-        setIsMounted(true);
-    }, []);
+    void handleUrlInstallation();
+  }, [
+    themeRef,
+    source,
+    installTheme,
+    handleError,
+    activateTheme,
+    updateRoute,
+    themes,
+    installedFromMarketplace,
+    checkThemeLimitError,
+    confirm,
+    isMounted,
+  ]);
 
-    // probably not the best place to handle the logic here, something for cleanup.
-    useEffect(() => {
-        const handleUrlInstallation = async () => {
-            // this grabs the theme ref from the url and installs it
-            // Only show confirmation if we have explicit source and themeRef props (not from URL params after redirect)
-            // Important: This should only run when ChangeThemeModal is explicitly given these props,
-            // not when it's rendered for the regular change-theme route
-            // Also wait for component to be mounted to avoid race conditions
-            if (source && themeRef && !installedFromMarketplace && isMounted) {
-                const themeName = themeRef.split('/')[1];
+  if (!themes) {
+    return;
+  }
 
-                // Check theme limit before showing installation modal
-                const limitError = await checkThemeLimitError(themeName);
-                if (limitError) {
-                    // Don't show installation modal if there's a limit error
-                    // The parent component should handle this
-                    // Also close the current modal to prevent any issues
-                    updateRoute('theme');
-                    return;
-                }
-
-                const titleText = 'Install Theme';
-                const existingThemeNames = themes?.map(t => t.name) || [];
-                const willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
-                const index = existingThemeNames.indexOf(themeName.toLowerCase());
-                // get the theme that will be overwritten
-                const themeToOverwrite = themes?.[index];
-                const prompt = <>By clicking below, <strong>{themeName}</strong> will automatically be activated as the theme for your site.
-                    {willOverwrite &&
-                    <>
-                        <br/>
-                        <br/>
-                        This will overwrite your existing version of <strong>{themeName}</strong>{themeToOverwrite?.active ? ' which is your active theme' : ''}. All custom changes will be lost.
-                    </>
-                    }
-                </>;
-                confirm({
-                    title: titleText,
-                    prompt,
-                    okLabel: 'Install',
-                    cancelLabel: 'Cancel',
-                    okRunningLabel: 'Installing...',
-                    okVariant: 'default',
-                    onOk: async (confirmModal) => {
-                        let data: ThemesInstallResponseType | undefined;
-                        setInstalledFromMarketplace(true);
-                        try {
-                            if (willOverwrite) {
-                                if (themes) {
-                                    themes.splice(index, 1);
-                                }
-                            }
-                            data = await installTheme(themeRef);
-                            if (data?.themes[0]) {
-                                await activateTheme(data.themes[0].name);
-                                toast.success('Theme activated', {description: <div><span className='capitalize'>{data.themes[0].name}</span> is now your active theme</div>});
-                            }
-                            confirmModal?.remove();
-                            updateRoute('');
-                        } catch (e) {
-                            handleError(e);
-                        }
-                        if (!data) {
-                            return;
-                        }
-                    }
-                });
-            }
-        };
-
-        void handleUrlInstallation();
-    }, [themeRef, source, installTheme, handleError, activateTheme, updateRoute, themes, installedFromMarketplace, checkThemeLimitError, confirm, isMounted]);
-
-    if (!themes) {
-        return;
-    }
-
-    let installedTheme: Theme|InstalledTheme|undefined;
-    let onInstall;
-    if (selectedTheme) {
-        installedTheme = themes.find(theme => theme.name.toLowerCase() === selectedTheme.name.toLowerCase());
-        onInstall = async () => {
-            // Check theme limit FIRST, before any confirmation modals
-            const limitError = await checkThemeLimitError(selectedTheme.name);
-            if (limitError) {
-                showLimit({
-                    prompt: limitError,
-                    onOk: () => updateRoute({route: upgradeRoute, isExternal: true})
-                });
-                return;
-            }
-
-            // Handle the overwrite confirmation if needed
-            if (installedTheme && !isDefaultOrLegacyTheme(selectedTheme)) {
-                return new Promise<void>((resolve) => {
-                    confirm({
-                        title: 'Overwrite theme',
-                        prompt: (
-                            <>
-                                This will overwrite your existing version of {selectedTheme.name}{installedTheme?.active ? ', which is your active theme' : ''}. All custom changes will be lost.
-                            </>
-                        ),
-                        okLabel: 'Overwrite',
-                        okRunningLabel: 'Installing...',
-                        cancelLabel: 'Cancel',
-                        okVariant: 'destructive',
-                        onOk: async (confirmModal) => {
-                            confirmModal?.remove();
-                            await performInstallation();
-                            resolve();
-                        }
-                    });
-                });
-            } else {
-                return performInstallation();
-            }
-        };
-
-        const performInstallation = async () => {
-            let title = 'Installed successfully';
-            let statusMessage: React.ReactNode;
-
-            // default theme can't be installed, only activated
-            if (isDefaultOrLegacyTheme(selectedTheme)) {
-                title = 'Activate theme';
-                statusMessage = <>Do you want to activate <strong>{selectedTheme.name}</strong> as the theme for your site?</>;
-            } else {
-                setInstalling(true);
-                let data: ThemesInstallResponseType | undefined;
-                try {
-                    data = await installTheme(selectedTheme.ref);
-                } catch (e) {
-                    handleError(e);
-                } finally {
-                    setInstalling(false);
-                }
-
-                if (!data) {
-                    return;
-                }
-
-                const newlyInstalledTheme = data.themes[0];
-                const outcome = describeThemeOutcome('installed', getIssuesFromInstalledTheme(newlyInstalledTheme));
-
-                statusMessage = <><strong>{newlyInstalledTheme.name}</strong> was {outcome}. Do you want to activate it?</>;
-                installedTheme = newlyInstalledTheme;
-            }
-
-            setInstalledModal({
-                title,
-                statusMessage,
-                installedTheme: installedTheme!,
-                onActivate: () => {
-                    updateRoute('');
-                }
-            });
-        };
-    }
-
-    return (
-        <SettingsModal
-            animate={false}
-            cancelLabel=''
-            footer={false}
-            padding={false}
-            size='full'
-            testId='theme-modal'
-            title=''
-            scrolling
-            onCancel={() => {
-                updateRoute('');
-            }}
-            onClose={() => {
-                updateRoute('');
-            }}
-        >
-            <div className='flex h-full justify-between'>
-                <div className='grow'>
-                    {selectedTheme &&
-                        <ThemePreview
-                            installedTheme={installedTheme}
-                            isInstalling={isInstalling}
-                            selectedTheme={selectedTheme}
-                            onBack={() => {
-                                setSelectedTheme(null);
-                            }}
-                            onClose={() => {
-                                updateRoute('');
-                            }}
-                            onInstall={onInstall} />
-                    }
-                    <ThemeToolbar
-                        currentTab={currentTab}
-                        previewMode={previewMode}
-                        selectedTheme={selectedTheme}
-                        setCurrentTab={setCurrentTab}
-                        setPreviewMode={setPreviewMode}
-                        setSelectedTheme={setSelectedTheme}
-                        themes={themes}
-                    />
-                    {!selectedTheme &&
-                        <ThemeModalContent
-                            currentTab={currentTab}
-                            themes={themes}
-                            onSelectTheme={onSelectTheme}
-                        />
-                    }
-                </div>
-            </div>
-            {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
-        </SettingsModal>
+  let installedTheme: Theme | InstalledTheme | undefined;
+  let onInstall;
+  if (selectedTheme) {
+    installedTheme = themes.find(
+      (theme) => theme.name.toLowerCase() === selectedTheme.name.toLowerCase(),
     );
+    onInstall = async () => {
+      // Check theme limit FIRST, before any confirmation modals
+      const limitError = await checkThemeLimitError(selectedTheme.name);
+      if (limitError) {
+        showLimit({
+          prompt: limitError,
+          onOk: () => updateRoute({ route: upgradeRoute, isExternal: true }),
+        });
+        return;
+      }
+
+      // Handle the overwrite confirmation if needed
+      if (installedTheme && !isDefaultOrLegacyTheme(selectedTheme)) {
+        return new Promise<void>((resolve) => {
+          confirm({
+            title: 'Overwrite theme',
+            prompt: (
+              <>
+                This will overwrite your existing version of {selectedTheme.name}
+                {installedTheme?.active ? ', which is your active theme' : ''}. All custom changes
+                will be lost.
+              </>
+            ),
+            okLabel: 'Overwrite',
+            okRunningLabel: 'Installing...',
+            cancelLabel: 'Cancel',
+            okVariant: 'destructive',
+            onOk: async (confirmModal) => {
+              confirmModal?.remove();
+              await performInstallation();
+              resolve();
+            },
+          });
+        });
+      } else {
+        return performInstallation();
+      }
+    };
+
+    const performInstallation = async () => {
+      let title = 'Installed successfully';
+      let statusMessage: React.ReactNode;
+
+      // default theme can't be installed, only activated
+      if (isDefaultOrLegacyTheme(selectedTheme)) {
+        title = 'Activate theme';
+        statusMessage = (
+          <>
+            Do you want to activate <strong>{selectedTheme.name}</strong> as the theme for your
+            site?
+          </>
+        );
+      } else {
+        setInstalling(true);
+        let data: ThemesInstallResponseType | undefined;
+        try {
+          data = await installTheme(selectedTheme.ref);
+        } catch (e) {
+          handleError(e);
+        } finally {
+          setInstalling(false);
+        }
+
+        if (!data) {
+          return;
+        }
+
+        const newlyInstalledTheme = data.themes[0];
+        const outcome = describeThemeOutcome(
+          'installed',
+          getIssuesFromInstalledTheme(newlyInstalledTheme),
+        );
+
+        statusMessage = (
+          <>
+            <strong>{newlyInstalledTheme.name}</strong> was {outcome}. Do you want to activate it?
+          </>
+        );
+        installedTheme = newlyInstalledTheme;
+      }
+
+      setInstalledModal({
+        title,
+        statusMessage,
+        installedTheme: installedTheme!,
+        onActivate: () => {
+          updateRoute('');
+        },
+      });
+    };
+  }
+
+  return (
+    <SettingsModal
+      animate={false}
+      cancelLabel=""
+      footer={false}
+      padding={false}
+      size="full"
+      testId="theme-modal"
+      title=""
+      scrolling
+      onCancel={() => {
+        updateRoute('');
+      }}
+      onClose={() => {
+        updateRoute('');
+      }}
+    >
+      <div className="flex h-full justify-between">
+        <div className="grow">
+          {selectedTheme && (
+            <ThemePreview
+              installedTheme={installedTheme}
+              isInstalling={isInstalling}
+              selectedTheme={selectedTheme}
+              onBack={() => {
+                setSelectedTheme(null);
+              }}
+              onClose={() => {
+                updateRoute('');
+              }}
+              onInstall={onInstall}
+            />
+          )}
+          <ThemeToolbar
+            currentTab={currentTab}
+            previewMode={previewMode}
+            selectedTheme={selectedTheme}
+            setCurrentTab={setCurrentTab}
+            setPreviewMode={setPreviewMode}
+            setSelectedTheme={setSelectedTheme}
+            themes={themes}
+          />
+          {!selectedTheme && (
+            <ThemeModalContent
+              currentTab={currentTab}
+              themes={themes}
+              onSelectTheme={onSelectTheme}
+            />
+          )}
+        </div>
+      </div>
+      {installedModal && (
+        <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />
+      )}
+    </SettingsModal>
+  );
 };
 
 export default ChangeThemeModal;

--- a/apps/admin/src/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme-modal.tsx
@@ -1,653 +1,518 @@
 import AdvancedThemeSettings from './theme/advanced-theme-settings';
-import InvalidThemeModal, { type FatalErrors } from './theme/invalid-theme-modal';
+import InvalidThemeModal, {type FatalErrors} from './theme/invalid-theme-modal';
 import OfficialThemes from './theme/official-themes';
-import React, { useEffect, useState } from 'react';
-import ThemeInstalledModal, { type ThemeInstalledModalProps } from './theme/theme-installed-modal';
+import React, {useEffect, useState} from 'react';
+import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme/theme-installed-modal';
+import {describeThemeOutcome, getIssuesFromInstalledTheme} from './theme/theme-validation-issues';
 import ThemePreview from './theme/theme-preview';
-import {
-  Button,
-  Dropzone,
-  LoadingIndicator,
-  Tabs,
-  TabsList,
-  TabsTrigger,
-} from '@tryghost/shade/components';
-import {
-  type InstalledTheme,
-  type Theme,
-  type ThemesInstallResponseType,
-  isDefaultOrLegacyTheme,
-  useActivateTheme,
-  useBrowseThemes,
-  useInstallTheme,
-  useUploadTheme,
-} from '@tryghost/admin-x-framework/api/themes';
-import { JSONError } from '@tryghost/admin-x-framework/errors';
-import { type OfficialTheme } from '@/settings/providers/settings-app-context';
-import { PageHeader, SettingsModal } from '@tryghost/shade/patterns';
-import { toast } from 'sonner';
-import { useCheckThemeLimitError } from '@/settings/hooks/use-check-theme-limit-error';
-import {
-  type ConfirmationHandle,
-  useConfirmation,
-} from '@/settings/providers/confirmation-context';
-import { useHandleError } from '@tryghost/admin-x-framework/hooks';
-import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
-import { useUpgradeRoute } from '@/settings/hooks/use-upgrade-route';
+import {Button, Dropzone, LoadingIndicator, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
+import {type InstalledTheme, type Theme, type ThemesInstallResponseType, isDefaultOrLegacyTheme, useActivateTheme, useBrowseThemes, useInstallTheme, useUploadTheme} from '@tryghost/admin-x-framework/api/themes';
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {type OfficialTheme} from '@/settings/providers/settings-app-context';
+import {PageHeader, SettingsModal} from '@tryghost/shade/patterns';
+import {toast} from 'sonner';
+import {useCheckThemeLimitError} from '@/settings/hooks/use-check-theme-limit-error';
+import {type ConfirmationHandle, useConfirmation} from '@/settings/providers/confirmation-context';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
+import {useUpgradeRoute} from '@/settings/hooks/use-upgrade-route';
 
 interface ThemeToolbarProps {
-  selectedTheme: OfficialTheme | null;
-  currentTab: string;
-  setCurrentTab: (tab: string) => void;
-  setSelectedTheme: (theme: OfficialTheme | null) => void;
-  themes: Theme[];
-  setPreviewMode: (mode: string) => void;
-  previewMode: string;
+    selectedTheme: OfficialTheme|null;
+    currentTab: string;
+    setCurrentTab: (tab: string) => void;
+    setSelectedTheme: (theme: OfficialTheme|null) => void;
+    themes: Theme[];
+    setPreviewMode: (mode: string) => void;
+    previewMode: string;
 }
 
 interface ThemeModalContentProps {
-  onSelectTheme: (theme: OfficialTheme | null) => void;
-  currentTab: string;
-  themes: Theme[];
+    onSelectTheme: (theme: OfficialTheme|null) => void;
+    currentTab: string;
+    themes: Theme[];
 }
 
-const UploadModalContent: React.FC<{ onUpload: (file: File) => void }> = ({ onUpload }) => {
-  return (
-    <Dropzone
-      accept={{ 'application/zip': ['.zip'] }}
-      inputId="theme-upload"
-      onDropAccepted={([file]) => {
-        onUpload(file);
-      }}
-    >
-      Click to select or drag & drop zip file
-    </Dropzone>
-  );
+const UploadModalContent: React.FC<{onUpload: (file: File) => void}> = ({onUpload}) => {
+    return (
+        <Dropzone
+            accept={{'application/zip': ['.zip']}}
+            inputId="theme-upload"
+            onDropAccepted={([file]) => {
+                onUpload(file);
+            }}
+        >
+            Click to select or drag & drop zip file
+        </Dropzone>
+    );
 };
 
-const ThemeToolbar: React.FC<ThemeToolbarProps> = ({ currentTab, setCurrentTab, themes }) => {
-  const { updateRoute } = useSettingsNavigation();
-  const upgradeRoute = useUpgradeRoute();
-  const { mutateAsync: uploadTheme } = useUploadTheme();
-  const { checkThemeLimitError, isThemeLimited } = useCheckThemeLimitError();
-  const handleError = useHandleError();
-  const { confirm, showLimit } = useConfirmation();
+const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
+    currentTab,
+    setCurrentTab,
+    themes
+}) => {
+    const {updateRoute} = useSettingsNavigation();
+    const upgradeRoute = useUpgradeRoute();
+    const {mutateAsync: uploadTheme} = useUploadTheme();
+    const {checkThemeLimitError, isThemeLimited} = useCheckThemeLimitError();
+    const handleError = useHandleError();
+    const {confirm, showLimit} = useConfirmation();
 
-  const [uploadConfig, setUploadConfig] = useState<
-    { enabled: boolean; error?: string } | undefined
-  >();
-  const [isUploading, setUploading] = useState(false);
-  const [uploadErrors, setUploadErrors] = useState<FatalErrors | null>(null);
-  const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
+    const [uploadConfig, setUploadConfig] = useState<{enabled: boolean; error?: string} | undefined>();
+    const [isUploading, setUploading] = useState(false);
+    const [uploadErrors, setUploadErrors] = useState<{themeName: string; fatalErrors: FatalErrors} | null>(null);
+    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
 
-  useEffect(() => {
-    const checkUploadLimit = async () => {
-      // Theme upload is always a custom theme, so we check with '.'
-      // to force an error if ANY theme limit is applied
-      if (isThemeLimited) {
-        const error = await checkThemeLimitError('.');
-        setUploadConfig({
-          enabled: false,
-          error: error || "Your current plan doesn't support uploading custom themes.",
-        });
-      } else {
-        setUploadConfig({ enabled: true });
-      }
+    useEffect(() => {
+        const checkUploadLimit = async () => {
+            // Theme upload is always a custom theme, so we check with '.'
+            // to force an error if ANY theme limit is applied
+            if (isThemeLimited) {
+                const error = await checkThemeLimitError('.');
+                setUploadConfig({enabled: false, error: error || 'Your current plan doesn\'t support uploading custom themes.'});
+            } else {
+                setUploadConfig({enabled: true});
+            }
+        };
+
+        void checkUploadLimit();
+    }, [checkThemeLimitError, isThemeLimited]);
+
+    const onClose = () => {
+        updateRoute('/');
     };
 
-    void checkUploadLimit();
-  }, [checkThemeLimitError, isThemeLimited]);
+    const onThemeUpload = (file: File) => {
+        const themeFileName = file?.name.replace(/\.zip$/, '');
+        const existingThemeNames = themes.map(t => t.name);
+        if (isDefaultOrLegacyTheme({name: themeFileName})) {
+            confirm({
+                title: 'Upload failed',
+                cancelLabel: 'Cancel',
+                okLabel: '',
+                prompt: (
+                    <>
+                        <p>The default <strong>{themeFileName}</strong> theme cannot be overwritten.</p>
+                        <p>Rename your zip file and try again.</p>
+                    </>
+                ),
+                onOk: (confirmModal) => {
+                    confirmModal?.remove();
+                }
+            });
+        } else if (existingThemeNames.includes(themeFileName)) {
+            confirm({
+                title: 'Overwrite theme',
+                prompt: (
+                    <>
+                        The theme <strong>{themeFileName}</strong> already exists.
+                        Do you want to overwrite it?
+                    </>
+                ),
+                okLabel: 'Overwrite',
+                cancelLabel: 'Cancel',
+                okRunningLabel: 'Overwriting...',
+                okVariant: 'destructive',
+                onOk: async (confirmModal) => {
+                    setUploading(true);
 
-  const onClose = () => {
-    updateRoute('/');
-  };
+                    // this is to avoid the themes array from returning the overwritten theme.
+                    // find index of themeFileName in existingThemeNames and remove from the array
+                    const index = existingThemeNames.indexOf(themeFileName);
+                    themes.splice(index, 1);
 
-  const onThemeUpload = (file: File) => {
-    const themeFileName = file?.name.replace(/\.zip$/, '');
-    const existingThemeNames = themes.map((t) => t.name);
-    if (isDefaultOrLegacyTheme({ name: themeFileName })) {
-      confirm({
-        title: 'Upload failed',
-        cancelLabel: 'Cancel',
-        okLabel: '',
-        prompt: (
-          <>
-            <p>
-              The default <strong>{themeFileName}</strong> theme cannot be overwritten.
-            </p>
-            <p>Rename your zip file and try again.</p>
-          </>
-        ),
-        onOk: (confirmModal) => {
-          confirmModal?.remove();
-        },
-      });
-    } else if (existingThemeNames.includes(themeFileName)) {
-      confirm({
-        title: 'Overwrite theme',
-        prompt: (
-          <>
-            The theme <strong>{themeFileName}</strong> already exists. Do you want to overwrite it?
-          </>
-        ),
-        okLabel: 'Overwrite',
-        cancelLabel: 'Cancel',
-        okRunningLabel: 'Overwriting...',
-        okVariant: 'destructive',
-        onOk: async (confirmModal) => {
-          setUploading(true);
+                    await handleThemeUpload({file, onActivate: onClose});
+                    setUploading(false);
+                    setCurrentTab('installed');
+                    confirmModal?.remove();
+                }
+            });
+        } else {
+            setCurrentTab('installed');
+            void handleThemeUpload({file, onActivate: onClose});
+        }
+    };
 
-          // this is to avoid the themes array from returning the overwritten theme.
-          // find index of themeFileName in existingThemeNames and remove from the array
-          const index = existingThemeNames.indexOf(themeFileName);
-          themes.splice(index, 1);
+    const handleThemeUpload = async ({
+        file,
+        onActivate
+    }: {
+        file: File;
+        onActivate?: () => void
+    }) => {
+        let data: ThemesInstallResponseType | undefined;
+        let fatalErrors: FatalErrors | null = null;
 
-          await handleThemeUpload({ file, onActivate: onClose });
-          setUploading(false);
-          setCurrentTab('installed');
-          confirmModal?.remove();
-        },
-      });
-    } else {
-      setCurrentTab('installed');
-      void handleThemeUpload({ file, onActivate: onClose });
-    }
-  };
+        try {
+            setUploading(true);
+            data = await uploadTheme({file});
+            setUploading(false);
+        } catch (e) {
+            setUploading(false);
 
-  const handleThemeUpload = async ({
-    file,
-    onActivate,
-  }: {
-    file: File;
-    onActivate?: () => void;
-  }) => {
-    let data: ThemesInstallResponseType | undefined;
-    let fatalErrors: FatalErrors | null = null;
-
-    try {
-      setUploading(true);
-      data = await uploadTheme({ file });
-      setUploading(false);
-    } catch (e) {
-      setUploading(false);
-
-      if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
-        fatalErrors = e.data.errors as FatalErrors;
-      } else {
-        handleError(e);
-      }
-    }
-
-    if (fatalErrors && !data) {
-      setUploadErrors(fatalErrors);
-    }
-
-    if (!data) {
-      return;
-    }
-
-    const uploadedTheme = data.themes[0];
-
-    let title = 'Upload successful';
-    let prompt = (
-      <>
-        <strong>{uploadedTheme.name}</strong> uploaded
-      </>
-    );
-
-    if (!uploadedTheme.active) {
-      prompt = <>{prompt} Do you want to activate it now?</>;
-    }
-
-    if (uploadedTheme?.errors?.length || uploadedTheme.warnings?.length) {
-      title = 'Upload successful';
-      prompt = (
-        <>
-          The theme <strong>&quot;{uploadedTheme.name}&quot;</strong> was installed successfully.
-        </>
-      );
-
-      if (!uploadedTheme.active) {
-        prompt = (
-          <>
-            {prompt}
-            You can activate it when you&apos;re ready.
-          </>
-        );
-      }
-    }
-
-    setInstalledModal({
-      title,
-      prompt,
-      installedTheme: uploadedTheme,
-      onActivate,
-    });
-  };
-
-  const left = (
-    <div className="hidden md:!visible md:!block">
-      <Tabs value={currentTab} variant="button" onValueChange={setCurrentTab}>
-        <TabsList>
-          <TabsTrigger value="official">Official themes</TabsTrigger>
-          <TabsTrigger value="installed">Installed</TabsTrigger>
-        </TabsList>
-      </Tabs>
-    </div>
-  );
-
-  const handleUpload = () => {
-    // Don't do anything if still checking limits
-    if (!uploadConfig) {
-      return;
-    }
-
-    if (uploadConfig.enabled) {
-      const handleRef: { current: ConfirmationHandle | null } = { current: null };
-      handleRef.current = confirm({
-        title: 'Upload theme',
-        prompt: (
-          <UploadModalContent
-            onUpload={(file) => {
-              handleRef.current?.remove();
-              onThemeUpload(file);
-            }}
-          />
-        ),
-        okLabel: '',
-        formSheet: false,
-      });
-    } else {
-      showLimit({
-        title: 'Upgrade to enable custom themes',
-        prompt: uploadConfig.error || (
-          <>
-            Your current plan only supports official themes. You can install them from the{' '}
-            <a href="https://ghost.org/marketplace/">Ghost theme marketplace</a>.
-          </>
-        ),
-        onOk: () => updateRoute({ route: upgradeRoute, isExternal: true }),
-      });
-    }
-  };
-
-  const right = (
-    <div className="flex items-center gap-14">
-      <div className="flex items-center gap-3">
-        <Button type="button" variant="outline" onClick={onClose}>
-          Close
-        </Button>
-        <Button disabled={isUploading} type="button" onClick={handleUpload}>
-          {isUploading && <LoadingIndicator size="sm" />}Upload theme
-        </Button>
-      </div>
-    </div>
-  );
-
-  return (
-    <>
-      <PageHeader
-        blurredBackground={false}
-        className="sticky -top-px z-50 h-22 min-h-[92px] bg-background p-8"
-        sticky={false}
-      >
-        <PageHeader.Left className="flex-auto">{left}</PageHeader.Left>
-        <PageHeader.Actions className="flex-auto justify-end">{right}</PageHeader.Actions>
-      </PageHeader>
-      <div className="px-[8vmin] md:hidden">
-        <Tabs value={currentTab} variant="button" onValueChange={setCurrentTab}>
-          <TabsList>
-            <TabsTrigger value="official">Official themes</TabsTrigger>
-            <TabsTrigger value="installed">Installed</TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </div>
-      {uploadErrors && (
-        <InvalidThemeModal
-          fatalErrors={uploadErrors}
-          prompt={
-            <>
-              This theme couldn&apos;t be uploaded because Ghost found a blocking validation error.
-              Fix the issue below and upload the theme again.
-            </>
-          }
-          title="Theme not uploaded"
-          onClose={() => setUploadErrors(null)}
-          onRetry={() => {
-            setUploadErrors(null);
-            handleUpload();
-          }}
-        />
-      )}
-      {installedModal && (
-        <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />
-      )}
-    </>
-  );
-};
-
-const ThemeModalContent: React.FC<ThemeModalContentProps> = ({
-  currentTab,
-  onSelectTheme,
-  themes,
-}) => {
-  switch (currentTab) {
-    case 'official':
-      return <OfficialThemes onSelectTheme={onSelectTheme} />;
-    case 'installed':
-      return <AdvancedThemeSettings themes={themes} />;
-  }
-  return null;
-};
-
-type ChangeThemeModalProps = {
-  source?: string | null;
-  themeRef?: string | null;
-};
-
-const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({ source, themeRef }) => {
-  const [currentTab, setCurrentTab] = useState('official');
-  const [selectedTheme, setSelectedTheme] = useState<OfficialTheme | null>(null);
-  const [previewMode, setPreviewMode] = useState('desktop');
-  const [isInstalling, setInstalling] = useState(false);
-  const [installedFromMarketplace, setInstalledFromMarketplace] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-  const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
-  const { updateRoute } = useSettingsNavigation();
-  const upgradeRoute = useUpgradeRoute();
-
-  const { data: { themes } = {} } = useBrowseThemes();
-  const { mutateAsync: installTheme } = useInstallTheme();
-  const { mutateAsync: activateTheme } = useActivateTheme();
-  const { checkThemeLimitError } = useCheckThemeLimitError();
-  const handleError = useHandleError();
-  const { confirm, showLimit } = useConfirmation();
-
-  const onSelectTheme = (theme: OfficialTheme | null) => {
-    setSelectedTheme(theme);
-  };
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // probably not the best place to handle the logic here, something for cleanup.
-  useEffect(() => {
-    const handleUrlInstallation = async () => {
-      // this grabs the theme ref from the url and installs it
-      // Only show confirmation if we have explicit source and themeRef props (not from URL params after redirect)
-      // Important: This should only run when ChangeThemeModal is explicitly given these props,
-      // not when it's rendered for the regular change-theme route
-      // Also wait for component to be mounted to avoid race conditions
-      if (source && themeRef && !installedFromMarketplace && isMounted) {
-        const themeName = themeRef.split('/')[1];
-
-        // Check theme limit before showing installation modal
-        const limitError = await checkThemeLimitError(themeName);
-        if (limitError) {
-          // Don't show installation modal if there's a limit error
-          // The parent component should handle this
-          // Also close the current modal to prevent any issues
-          updateRoute('theme');
-          return;
+            if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
+                fatalErrors = e.data.errors as FatalErrors;
+            } else {
+                handleError(e);
+            }
         }
 
-        const titleText = 'Install Theme';
-        const existingThemeNames = themes?.map((t) => t.name) || [];
-        const willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
-        const index = existingThemeNames.indexOf(themeName.toLowerCase());
-        // get the theme that will be overwritten
-        const themeToOverwrite = themes?.[index];
-        const prompt = (
-          <>
-            By clicking below, <strong>{themeName}</strong> will automatically be activated as the
-            theme for your site.
-            {willOverwrite && (
-              <>
-                <br />
-                <br />
-                This will overwrite your existing version of <strong>{themeName}</strong>
-                {themeToOverwrite?.active ? ' which is your active theme' : ''}. All custom changes
-                will be lost.
-              </>
-            )}
-          </>
-        );
-        confirm({
-          title: titleText,
-          prompt,
-          okLabel: 'Install',
-          cancelLabel: 'Cancel',
-          okRunningLabel: 'Installing...',
-          okVariant: 'default',
-          onOk: async (confirmModal) => {
-            let data: ThemesInstallResponseType | undefined;
-            setInstalledFromMarketplace(true);
-            try {
-              if (willOverwrite) {
-                if (themes) {
-                  themes.splice(index, 1);
-                }
-              }
-              data = await installTheme(themeRef);
-              if (data?.themes[0]) {
-                await activateTheme(data.themes[0].name);
-                toast.success('Theme activated', {
-                  description: (
-                    <div>
-                      <span className="capitalize">{data.themes[0].name}</span> is now your active
-                      theme
-                    </div>
-                  ),
-                });
-              }
-              confirmModal?.remove();
-              updateRoute('');
-            } catch (e) {
-              handleError(e);
-            }
-            if (!data) {
-              return;
-            }
-          },
-        });
-      }
-    };
-
-    void handleUrlInstallation();
-  }, [
-    themeRef,
-    source,
-    installTheme,
-    handleError,
-    activateTheme,
-    updateRoute,
-    themes,
-    installedFromMarketplace,
-    checkThemeLimitError,
-    confirm,
-    isMounted,
-  ]);
-
-  if (!themes) {
-    return;
-  }
-
-  let installedTheme: Theme | InstalledTheme | undefined;
-  let onInstall;
-  if (selectedTheme) {
-    installedTheme = themes.find(
-      (theme) => theme.name.toLowerCase() === selectedTheme.name.toLowerCase(),
-    );
-    onInstall = async () => {
-      // Check theme limit FIRST, before any confirmation modals
-      const limitError = await checkThemeLimitError(selectedTheme.name);
-      if (limitError) {
-        showLimit({
-          prompt: limitError,
-          onOk: () => updateRoute({ route: upgradeRoute, isExternal: true }),
-        });
-        return;
-      }
-
-      // Handle the overwrite confirmation if needed
-      if (installedTheme && !isDefaultOrLegacyTheme(selectedTheme)) {
-        return new Promise<void>((resolve) => {
-          confirm({
-            title: 'Overwrite theme',
-            prompt: (
-              <>
-                This will overwrite your existing version of {selectedTheme.name}
-                {installedTheme?.active ? ', which is your active theme' : ''}. All custom changes
-                will be lost.
-              </>
-            ),
-            okLabel: 'Overwrite',
-            okRunningLabel: 'Installing...',
-            cancelLabel: 'Cancel',
-            okVariant: 'destructive',
-            onOk: async (confirmModal) => {
-              confirmModal?.remove();
-              await performInstallation();
-              resolve();
-            },
-          });
-        });
-      } else {
-        return performInstallation();
-      }
-    };
-
-    const performInstallation = async () => {
-      let title = 'Success';
-      let prompt = <></>;
-
-      // default theme can't be installed, only activated
-      if (isDefaultOrLegacyTheme(selectedTheme)) {
-        title = 'Activate theme';
-        prompt = (
-          <>
-            By clicking below, <strong>{selectedTheme.name}</strong> will automatically be activated
-            as the theme for your site.
-          </>
-        );
-      } else {
-        setInstalling(true);
-        let data: ThemesInstallResponseType | undefined;
-        try {
-          data = await installTheme(selectedTheme.ref);
-        } catch (e) {
-          handleError(e);
-        } finally {
-          setInstalling(false);
+        if (fatalErrors && !data) {
+            setUploadErrors({themeName: file.name.replace(/\.zip$/, ''), fatalErrors});
         }
 
         if (!data) {
-          return;
+            return;
         }
 
-        const newlyInstalledTheme = data.themes[0];
-
-        title = 'Success';
-        prompt = (
-          <>
-            <strong>{newlyInstalledTheme.name}</strong> has been successfully installed.
-          </>
-        );
-
-        if (!newlyInstalledTheme.active) {
-          prompt = <>{prompt} Do you want to activate it now?</>;
-        }
-
-        if (newlyInstalledTheme.errors?.length || newlyInstalledTheme.warnings?.length) {
-          title = 'Installed successfully';
-          prompt = (
-            <>
-              The theme <strong>&quot;{newlyInstalledTheme.name}&quot;</strong> was installed
-              successfully.
-            </>
-          );
-
-          if (!newlyInstalledTheme.active) {
-            prompt = (
-              <>
-                {prompt}
-                You can activate it when you&apos;re ready.
-              </>
-            );
-          }
-        }
-
-        installedTheme = newlyInstalledTheme;
-      }
-
-      setInstalledModal({
-        title,
-        prompt,
-        installedTheme: installedTheme!,
-        onActivate: () => {
-          updateRoute('');
-        },
-      });
+        setInstalledModal({
+            title: 'Upload successful',
+            installedTheme: data.themes[0],
+            onActivate
+        });
     };
-  }
 
-  return (
-    <SettingsModal
-      animate={false}
-      cancelLabel=""
-      footer={false}
-      padding={false}
-      size="full"
-      testId="theme-modal"
-      title=""
-      scrolling
-      onCancel={() => {
-        updateRoute('');
-      }}
-      onClose={() => {
-        updateRoute('');
-      }}
-    >
-      <div className="flex h-full justify-between">
-        <div className="grow">
-          {selectedTheme && (
-            <ThemePreview
-              installedTheme={installedTheme}
-              isInstalling={isInstalling}
-              selectedTheme={selectedTheme}
-              onBack={() => {
-                setSelectedTheme(null);
-              }}
-              onClose={() => {
-                updateRoute('');
-              }}
-              onInstall={onInstall}
-            />
-          )}
-          <ThemeToolbar
-            currentTab={currentTab}
-            previewMode={previewMode}
-            selectedTheme={selectedTheme}
-            setCurrentTab={setCurrentTab}
-            setPreviewMode={setPreviewMode}
-            setSelectedTheme={setSelectedTheme}
-            themes={themes}
-          />
-          {!selectedTheme && (
-            <ThemeModalContent
-              currentTab={currentTab}
-              themes={themes}
-              onSelectTheme={onSelectTheme}
-            />
-          )}
+    const left =
+    <div className='hidden md:!visible md:!block'>
+        <Tabs value={currentTab} variant='button' onValueChange={setCurrentTab}>
+            <TabsList>
+                <TabsTrigger value='official'>Official themes</TabsTrigger>
+                <TabsTrigger value='installed'>Installed</TabsTrigger>
+            </TabsList>
+        </Tabs>
+    </div>;
+
+    const handleUpload = () => {
+        // Don't do anything if still checking limits
+        if (!uploadConfig) {
+            return;
+        }
+
+        if (uploadConfig.enabled) {
+            const handleRef: {current: ConfirmationHandle | null} = {current: null};
+            handleRef.current = confirm({
+                title: 'Upload theme',
+                prompt: <UploadModalContent onUpload={(file) => {
+                    handleRef.current?.remove();
+                    onThemeUpload(file);
+                }} />,
+                okLabel: '',
+                formSheet: false
+            });
+        } else {
+            showLimit({
+                title: 'Upgrade to enable custom themes',
+                prompt: uploadConfig.error || <>Your current plan only supports official themes. You can install them from the <a href="https://ghost.org/marketplace/">Ghost theme marketplace</a>.</>,
+                onOk: () => updateRoute({route: upgradeRoute, isExternal: true})
+            });
+        }
+    };
+
+    const right =
+        <div className='flex items-center gap-14'>
+            <div className='flex items-center gap-3'>
+                <Button type='button' variant='outline' onClick={onClose}>Close</Button>
+                <Button disabled={isUploading} type='button' onClick={handleUpload}>{isUploading && <LoadingIndicator size='sm' />}Upload theme</Button>
+            </div>
+        </div>;
+
+    return (<>
+        <PageHeader blurredBackground={false} className='sticky -top-px z-50 h-22 min-h-[92px] bg-background p-8' sticky={false}>
+            <PageHeader.Left className='flex-auto'>
+                {left}
+            </PageHeader.Left>
+            <PageHeader.Actions className='flex-auto justify-end'>
+                {right}
+            </PageHeader.Actions>
+        </PageHeader>
+        <div className='px-[8vmin] md:hidden'>
+            <Tabs value={currentTab} variant='button' onValueChange={setCurrentTab}>
+                <TabsList>
+                    <TabsTrigger value='official'>Official themes</TabsTrigger>
+                    <TabsTrigger value='installed'>Installed</TabsTrigger>
+                </TabsList>
+            </Tabs>
         </div>
-      </div>
-      {installedModal && (
-        <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />
-      )}
-    </SettingsModal>
-  );
+        {uploadErrors && (
+            <InvalidThemeModal
+                action='uploaded'
+                fatalErrors={uploadErrors.fatalErrors}
+                okLabel='Re-upload'
+                themeName={uploadErrors.themeName}
+                title='Theme not uploaded'
+                onClose={() => setUploadErrors(null)}
+                onRetry={() => {
+                    setUploadErrors(null);
+                    handleUpload();
+                }}
+            />
+        )}
+        {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
+    </>);
+};
+
+const ThemeModalContent: React.FC<ThemeModalContentProps> = ({
+    currentTab,
+    onSelectTheme,
+    themes
+}) => {
+    switch (currentTab) {
+    case 'official':
+        return (
+            <OfficialThemes onSelectTheme={onSelectTheme} />
+        );
+    case 'installed':
+        return (
+            <AdvancedThemeSettings themes={themes} />
+        );
+    }
+    return null;
+};
+
+type ChangeThemeModalProps = {
+    source?: string | null;
+    themeRef?: string | null;
+};
+
+const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) => {
+    const [currentTab, setCurrentTab] = useState('official');
+    const [selectedTheme, setSelectedTheme] = useState<OfficialTheme|null>(null);
+    const [previewMode, setPreviewMode] = useState('desktop');
+    const [isInstalling, setInstalling] = useState(false);
+    const [installedFromMarketplace, setInstalledFromMarketplace] = useState(false);
+    const [isMounted, setIsMounted] = useState(false);
+    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
+    const {updateRoute} = useSettingsNavigation();
+    const upgradeRoute = useUpgradeRoute();
+
+    const {data: {themes} = {}} = useBrowseThemes();
+    const {mutateAsync: installTheme} = useInstallTheme();
+    const {mutateAsync: activateTheme} = useActivateTheme();
+    const {checkThemeLimitError} = useCheckThemeLimitError();
+    const handleError = useHandleError();
+    const {confirm, showLimit} = useConfirmation();
+
+    const onSelectTheme = (theme: OfficialTheme|null) => {
+        setSelectedTheme(theme);
+    };
+
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
+
+    // probably not the best place to handle the logic here, something for cleanup.
+    useEffect(() => {
+        const handleUrlInstallation = async () => {
+            // this grabs the theme ref from the url and installs it
+            // Only show confirmation if we have explicit source and themeRef props (not from URL params after redirect)
+            // Important: This should only run when ChangeThemeModal is explicitly given these props,
+            // not when it's rendered for the regular change-theme route
+            // Also wait for component to be mounted to avoid race conditions
+            if (source && themeRef && !installedFromMarketplace && isMounted) {
+                const themeName = themeRef.split('/')[1];
+
+                // Check theme limit before showing installation modal
+                const limitError = await checkThemeLimitError(themeName);
+                if (limitError) {
+                    // Don't show installation modal if there's a limit error
+                    // The parent component should handle this
+                    // Also close the current modal to prevent any issues
+                    updateRoute('theme');
+                    return;
+                }
+
+                const titleText = 'Install Theme';
+                const existingThemeNames = themes?.map(t => t.name) || [];
+                const willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
+                const index = existingThemeNames.indexOf(themeName.toLowerCase());
+                // get the theme that will be overwritten
+                const themeToOverwrite = themes?.[index];
+                const prompt = <>By clicking below, <strong>{themeName}</strong> will automatically be activated as the theme for your site.
+                    {willOverwrite &&
+                    <>
+                        <br/>
+                        <br/>
+                        This will overwrite your existing version of <strong>{themeName}</strong>{themeToOverwrite?.active ? ' which is your active theme' : ''}. All custom changes will be lost.
+                    </>
+                    }
+                </>;
+                confirm({
+                    title: titleText,
+                    prompt,
+                    okLabel: 'Install',
+                    cancelLabel: 'Cancel',
+                    okRunningLabel: 'Installing...',
+                    okVariant: 'default',
+                    onOk: async (confirmModal) => {
+                        let data: ThemesInstallResponseType | undefined;
+                        setInstalledFromMarketplace(true);
+                        try {
+                            if (willOverwrite) {
+                                if (themes) {
+                                    themes.splice(index, 1);
+                                }
+                            }
+                            data = await installTheme(themeRef);
+                            if (data?.themes[0]) {
+                                await activateTheme(data.themes[0].name);
+                                toast.success('Theme activated', {description: <div><span className='capitalize'>{data.themes[0].name}</span> is now your active theme</div>});
+                            }
+                            confirmModal?.remove();
+                            updateRoute('');
+                        } catch (e) {
+                            handleError(e);
+                        }
+                        if (!data) {
+                            return;
+                        }
+                    }
+                });
+            }
+        };
+
+        void handleUrlInstallation();
+    }, [themeRef, source, installTheme, handleError, activateTheme, updateRoute, themes, installedFromMarketplace, checkThemeLimitError, confirm, isMounted]);
+
+    if (!themes) {
+        return;
+    }
+
+    let installedTheme: Theme|InstalledTheme|undefined;
+    let onInstall;
+    if (selectedTheme) {
+        installedTheme = themes.find(theme => theme.name.toLowerCase() === selectedTheme.name.toLowerCase());
+        onInstall = async () => {
+            // Check theme limit FIRST, before any confirmation modals
+            const limitError = await checkThemeLimitError(selectedTheme.name);
+            if (limitError) {
+                showLimit({
+                    prompt: limitError,
+                    onOk: () => updateRoute({route: upgradeRoute, isExternal: true})
+                });
+                return;
+            }
+
+            // Handle the overwrite confirmation if needed
+            if (installedTheme && !isDefaultOrLegacyTheme(selectedTheme)) {
+                return new Promise<void>((resolve) => {
+                    confirm({
+                        title: 'Overwrite theme',
+                        prompt: (
+                            <>
+                                This will overwrite your existing version of {selectedTheme.name}{installedTheme?.active ? ', which is your active theme' : ''}. All custom changes will be lost.
+                            </>
+                        ),
+                        okLabel: 'Overwrite',
+                        okRunningLabel: 'Installing...',
+                        cancelLabel: 'Cancel',
+                        okVariant: 'destructive',
+                        onOk: async (confirmModal) => {
+                            confirmModal?.remove();
+                            await performInstallation();
+                            resolve();
+                        }
+                    });
+                });
+            } else {
+                return performInstallation();
+            }
+        };
+
+        const performInstallation = async () => {
+            let title = 'Installed successfully';
+            let statusMessage: React.ReactNode;
+
+            // default theme can't be installed, only activated
+            if (isDefaultOrLegacyTheme(selectedTheme)) {
+                title = 'Activate theme';
+                statusMessage = <>Do you want to activate <strong>{selectedTheme.name}</strong> as the theme for your site?</>;
+            } else {
+                setInstalling(true);
+                let data: ThemesInstallResponseType | undefined;
+                try {
+                    data = await installTheme(selectedTheme.ref);
+                } catch (e) {
+                    handleError(e);
+                } finally {
+                    setInstalling(false);
+                }
+
+                if (!data) {
+                    return;
+                }
+
+                const newlyInstalledTheme = data.themes[0];
+                const outcome = describeThemeOutcome('installed', getIssuesFromInstalledTheme(newlyInstalledTheme));
+
+                statusMessage = <><strong>{newlyInstalledTheme.name}</strong> was {outcome}. Do you want to activate it?</>;
+                installedTheme = newlyInstalledTheme;
+            }
+
+            setInstalledModal({
+                title,
+                statusMessage,
+                installedTheme: installedTheme!,
+                onActivate: () => {
+                    updateRoute('');
+                }
+            });
+        };
+    }
+
+    return (
+        <SettingsModal
+            animate={false}
+            cancelLabel=''
+            footer={false}
+            padding={false}
+            size='full'
+            testId='theme-modal'
+            title=''
+            scrolling
+            onCancel={() => {
+                updateRoute('');
+            }}
+            onClose={() => {
+                updateRoute('');
+            }}
+        >
+            <div className='flex h-full justify-between'>
+                <div className='grow'>
+                    {selectedTheme &&
+                        <ThemePreview
+                            installedTheme={installedTheme}
+                            isInstalling={isInstalling}
+                            selectedTheme={selectedTheme}
+                            onBack={() => {
+                                setSelectedTheme(null);
+                            }}
+                            onClose={() => {
+                                updateRoute('');
+                            }}
+                            onInstall={onInstall} />
+                    }
+                    <ThemeToolbar
+                        currentTab={currentTab}
+                        previewMode={previewMode}
+                        selectedTheme={selectedTheme}
+                        setCurrentTab={setCurrentTab}
+                        setPreviewMode={setPreviewMode}
+                        setSelectedTheme={setSelectedTheme}
+                        themes={themes}
+                    />
+                    {!selectedTheme &&
+                        <ThemeModalContent
+                            currentTab={currentTab}
+                            themes={themes}
+                            onSelectTheme={onSelectTheme}
+                        />
+                    }
+                </div>
+            </div>
+            {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
+        </SettingsModal>
+    );
 };
 
 export default ChangeThemeModal;

--- a/apps/admin/src/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme-modal.tsx
@@ -192,6 +192,7 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({ currentTab, setCurrentTab, 
 
     setInstalledModal({
       title: 'Upload successful',
+      action: 'uploaded',
       installedTheme: data.themes[0],
       onActivate,
     });
@@ -531,6 +532,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({ source, themeRef })
 
       setInstalledModal({
         title,
+        action: 'installed',
         statusMessage,
         installedTheme: installedTheme!,
         onActivate: () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -1,47 +1,49 @@
-import { describe, expect, it, onTestFinished, vi } from "vitest";
-import { page, userEvent } from "vitest/browser";
+import { describe, expect, it, onTestFinished, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 
 import {
-    configResponse,
-    currentRoute,
-    defaultThemesResponse,
-    fakeAdminEndpoint,
-    fakeEditSettings,
-    fakeSettingsScreens,
-    fakeThemes,
-    renderAdminApp,
-    theme,
-    type Theme,
-} from "@test-utils/acceptance";
-import * as sel from "@tryghost/test-data/selectors/settings";
-import { settingsScreen } from "@/settings/settings.screen";
+  configResponse,
+  currentRoute,
+  defaultThemesResponse,
+  fakeAdminEndpoint,
+  fakeEditSettings,
+  fakeSettingsScreens,
+  fakeThemes,
+  renderAdminApp,
+  theme,
+  type Theme,
+} from '@test-utils/acceptance';
+import * as sel from '@tryghost/test-data/selectors/settings';
+import { settingsScreen } from '@/settings/settings.screen';
 
 function themes(): Theme[] {
-    return defaultThemesResponse().themes;
+  return defaultThemesResponse().themes;
 }
 
 function fakeThemeWorld(): Theme[] {
-    fakeSettingsScreens();
-    const installed = themes();
-    fakeThemes(installed);
-    return installed;
+  fakeSettingsScreens();
+  const installed = themes();
+  fakeThemes(installed);
+  return installed;
 }
 
 function themeLimits(allowlist: string[], error: string) {
-    const config = configResponse();
-    config.config.hostSettings = {
-        limits: { customThemes: { allowlist, error } },
-    };
-    return { boot: { browseConfig: { response: config } } };
+  const config = configResponse();
+  config.config.hostSettings = {
+    limits: { customThemes: { allowlist, error } },
+  };
+  return { boot: { browseConfig: { response: config } } };
 }
 
 async function archiveBuffer(): Promise<ArrayBuffer> {
-    const fixture = new URL("../../../test-utils/acceptance/fixtures/theme.zip", import.meta.url);
-    return await fetch(fixture).then(response => response.arrayBuffer());
+  const fixture = new URL('../../../test-utils/acceptance/fixtures/theme.zip', import.meta.url);
+  return await fetch(fixture).then((response) => response.arrayBuffer());
 }
 
 async function fakeThemeDownload(name: string): Promise<void> {
-    fakeAdminEndpoint("GET", `/themes/${name}/download/`, await archiveBuffer(), { contentType: "application/zip" });
+  fakeAdminEndpoint('GET', `/themes/${name}/download/`, await archiveBuffer(), {
+    contentType: 'application/zip',
+  });
 }
 
 /**
@@ -51,10 +53,10 @@ async function fakeThemeDownload(name: string): Promise<void> {
  * anything `ghost.css` touches.
  */
 function stageLegacyGhostCss(css: string): void {
-    const style = document.createElement("style");
-    style.textContent = css;
-    document.head.appendChild(style);
-    onTestFinished(() => style.remove());
+  const style = document.createElement('style');
+  style.textContent = css;
+  document.head.appendChild(style);
+  onTestFinished(() => style.remove());
 }
 
 /**
@@ -75,742 +77,924 @@ const LEGACY_CODE_CSS = `code, tt {
 }`;
 
 /** Tachyons' `.rotate-180`, which Tailwind v4 expresses as `rotate` rather than `transform`. */
-const LEGACY_TACHYONS_CSS = ".rotate-180 { transform: rotate(180deg); }";
+const LEGACY_TACHYONS_CSS = '.rotate-180 { transform: rotate(180deg); }';
 
-function themeProblem(overrides: { code: string; level?: string; rule?: string; details?: string }) {
-    return {
-        level: "warning",
-        rule: "Replace {{@blog.url}} with {{@site.url}}",
-        details: "The helper {{@blog.url}} is deprecated and will be removed in a future version of Ghost.",
-        failures: [{ ref: "default.hbs", message: "line 12" }],
-        fatal: false,
-        ...overrides,
-    };
+function themeProblem(overrides: {
+  code: string;
+  level?: string;
+  rule?: string;
+  details?: string;
+}) {
+  return {
+    level: 'warning',
+    rule: 'Replace {{@blog.url}} with {{@site.url}}',
+    details:
+      'The helper {{@blog.url}} is deprecated and will be removed in a future version of Ghost.',
+    failures: [{ ref: 'default.hbs', message: 'line 12' }],
+    fatal: false,
+    ...overrides,
+  };
 }
 
 function installedTheme(name: string) {
-    return settingsScreen.themeModal().getByTestId(sel.themeListItem).filter({ hasText: new RegExp(name, "i") });
+  return settingsScreen
+    .themeModal()
+    .getByTestId(sel.themeListItem)
+    .filter({ hasText: new RegExp(name, 'i') });
 }
 
 async function uploadThemeFile(file: File): Promise<void> {
-    const prompt = page.getByText("Click to select or drag & drop zip file", { exact: true });
-    await expect.element(prompt).toBeVisible();
-    const input = prompt.element().parentElement?.querySelector("input[type=file]");
-    if (!(input instanceof HTMLInputElement)) {
-        throw new Error("Theme upload input was not rendered");
-    }
-    await page.elementLocator(input).upload(file);
+  const prompt = page.getByText('Click to select or drag & drop zip file', { exact: true });
+  await expect.element(prompt).toBeVisible();
+  const input = prompt.element().parentElement?.querySelector('input[type=file]');
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('Theme upload input was not rendered');
+  }
+  await page.elementLocator(input).upload(file);
 }
 
 /** Whole-pixel distance between two box edges; 0 means flush, either way round. */
 function edgeGap(a: number, b: number): number {
-    return Math.abs(Math.round(a - b));
+  return Math.abs(Math.round(a - b));
 }
 
 /** Line height as a multiple of font size, so sizes of different scale compare. */
 function lineRatio(style: CSSStyleDeclaration): number {
-    return parseFloat(style.lineHeight) / parseFloat(style.fontSize);
+  return parseFloat(style.lineHeight) / parseFloat(style.fontSize);
 }
 
 /** The one `<code>` in the open dialog reading exactly `text`. */
 function codeSpan(text: string): HTMLElement {
-    const dialog = settingsScreen.confirmationModal().element();
-    const match = [...dialog.querySelectorAll("code")].find(node => node.textContent === text);
-    if (!match) {
-        throw new Error(`No <code> reading ${text} was rendered`);
-    }
-    return match;
+  const dialog = settingsScreen.confirmationModal().element();
+  const match = [...dialog.querySelectorAll('code')].find((node) => node.textContent === text);
+  if (!match) {
+    throw new Error(`No <code> reading ${text} was rendered`);
+  }
+  return match;
 }
 
 async function editorTextbox() {
-    const editor = settingsScreen.themeCodeEditorModal().getByRole("textbox").first();
-    await expect.element(editor).toBeVisible();
-    return editor;
+  const editor = settingsScreen.themeCodeEditorModal().getByRole('textbox').first();
+  await expect.element(editor).toBeVisible();
+  return editor;
 }
 
-describe("Theme settings", () => {
-    it("activates an installed official theme and updates another", async () => {
-        const installed = fakeThemeWorld();
-        const casper = installed.find(item => item.name === "casper")!;
-        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", { themes: [{ ...casper, active: true }] });
-        const installApi = fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "edition" })] });
-        await renderAdminApp("/settings/design/change-theme", {
-            boot: { browseActiveTheme: { response: { themes: [installed.find(item => item.active)!] } } },
-        });
-
-        const modal = settingsScreen.themeModal();
-        await modal.getByRole("button", { name: /Casper/ }).click();
-        await modal.getByRole("button", { name: "Activate Casper" }).click();
-        await settingsScreen.confirmationModal().getByRole("button", { name: "Activate" }).click();
-        await expect.element(settingsScreen.successToast()).toHaveTextContent(/casper is now your active theme/i);
-        expect(activateApi.requests).toHaveLength(1);
-
-        await settingsScreen.theme().getByRole("button", { name: "Change theme" }).click();
-        const reopenedModal = settingsScreen.themeModal();
-        await reopenedModal.getByRole("button", { name: /Edition/ }).click();
-        await reopenedModal.getByRole("button", { name: "Update Edition" }).click();
-        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/overwrite/i);
-        await settingsScreen.confirmationModal().getByRole("button", { name: "Overwrite" }).click();
-        await expect.poll(() => installApi.lastRequest?.url).toContain("ref=TryGhost%2FEdition");
+describe('Theme settings', () => {
+  it('activates an installed official theme and updates another', async () => {
+    const installed = fakeThemeWorld();
+    const casper = installed.find((item) => item.name === 'casper')!;
+    const activateApi = fakeAdminEndpoint('PUT', '/themes/casper/activate/', {
+      themes: [{ ...casper, active: true }],
+    });
+    const installApi = fakeAdminEndpoint('POST', /^\/themes\/install\/\?/, {
+      themes: [theme({ name: 'edition' })],
+    });
+    await renderAdminApp('/settings/design/change-theme', {
+      boot: {
+        browseActiveTheme: { response: { themes: [installed.find((item) => item.active)!] } },
+      },
     });
 
-    it("manages installed themes", async () => {
-        const installed = fakeThemeWorld();
-        const casper = installed.find(item => item.name === "casper")!;
-        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", { themes: [{ ...casper, active: true }] });
-        const deleteApi = fakeAdminEndpoint("DELETE", "/themes/edition/", {});
-        await renderAdminApp("/settings/design/change-theme");
+    const modal = settingsScreen.themeModal();
+    await modal.getByRole('button', { name: /Casper/ }).click();
+    await modal.getByRole('button', { name: 'Activate Casper' }).click();
+    await settingsScreen.confirmationModal().getByRole('button', { name: 'Activate' }).click();
+    await expect
+      .element(settingsScreen.successToast())
+      .toHaveTextContent(/casper is now your active theme/i);
+    expect(activateApi.requests).toHaveLength(1);
 
-        const modal = settingsScreen.themeModal();
-        await modal.getByRole("tab", { name: "Installed" }).click();
-        await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(2);
-        await installedTheme("casper").getByRole("button", { name: "Activate" }).click();
-        await expect.element(installedTheme("casper")).toHaveTextContent(/Active/);
-        expect(activateApi.requests).toHaveLength(1);
+    await settingsScreen.theme().getByRole('button', { name: 'Change theme' }).click();
+    const reopenedModal = settingsScreen.themeModal();
+    await reopenedModal.getByRole('button', { name: /Edition/ }).click();
+    await reopenedModal.getByRole('button', { name: 'Update Edition' }).click();
+    await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/overwrite/i);
+    await settingsScreen.confirmationModal().getByRole('button', { name: 'Overwrite' }).click();
+    await expect.poll(() => installApi.lastRequest?.url).toContain('ref=TryGhost%2FEdition');
+  });
 
-        await installedTheme("casper").getByRole("button", { name: "Menu" }).click();
-        await settingsScreen.menuItem("Download").click();
-        await expect.poll(() => document.querySelector<HTMLIFrameElement>("iframe#iframeDownload")?.src).toMatch(/\/api\/admin\/themes\/casper\/download/);
-
-        await installedTheme("edition").getByRole("button", { name: "Menu" }).click();
-        await settingsScreen.menuItem("Delete").click();
-        await settingsScreen.confirmationModal().getByRole("button", { name: "Delete" }).click();
-        await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(1);
-        expect(deleteApi.requests).toHaveLength(1);
+  it('manages installed themes', async () => {
+    const installed = fakeThemeWorld();
+    const casper = installed.find((item) => item.name === 'casper')!;
+    const activateApi = fakeAdminEndpoint('PUT', '/themes/casper/activate/', {
+      themes: [{ ...casper, active: true }],
     });
+    const deleteApi = fakeAdminEndpoint('DELETE', '/themes/edition/', {});
+    await renderAdminApp('/settings/design/change-theme');
 
-    it("closes an installed-theme menu with Escape without closing the theme modal", async () => {
-        fakeThemeWorld();
-        await renderAdminApp("/settings/design/change-theme");
+    const modal = settingsScreen.themeModal();
+    await modal.getByRole('tab', { name: 'Installed' }).click();
+    await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(2);
+    await installedTheme('casper').getByRole('button', { name: 'Activate' }).click();
+    await expect.element(installedTheme('casper')).toHaveTextContent(/Active/);
+    expect(activateApi.requests).toHaveLength(1);
 
-        const modal = settingsScreen.themeModal();
-        await modal.getByRole("tab", { name: "Installed" }).click();
-        await installedTheme("casper").getByRole("button", { name: "Menu" }).click();
-        await expect.element(settingsScreen.menuItem("Download")).toBeVisible();
+    await installedTheme('casper').getByRole('button', { name: 'Menu' }).click();
+    await settingsScreen.menuItem('Download').click();
+    await expect
+      .poll(() => document.querySelector<HTMLIFrameElement>('iframe#iframeDownload')?.src)
+      .toMatch(/\/api\/admin\/themes\/casper\/download/);
 
-        await userEvent.keyboard("{Escape}");
+    await installedTheme('edition').getByRole('button', { name: 'Menu' }).click();
+    await settingsScreen.menuItem('Delete').click();
+    await settingsScreen.confirmationModal().getByRole('button', { name: 'Delete' }).click();
+    await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(1);
+    expect(deleteApi.requests).toHaveLength(1);
+  });
 
-        await expect(settingsScreen.menuItem("Download")).toHaveCount(0);
-        await expect.element(modal).toBeVisible();
-        await expect.poll(currentRoute).toBe("/settings/design/change-theme");
+  it('closes an installed-theme menu with Escape without closing the theme modal', async () => {
+    fakeThemeWorld();
+    await renderAdminApp('/settings/design/change-theme');
+
+    const modal = settingsScreen.themeModal();
+    await modal.getByRole('tab', { name: 'Installed' }).click();
+    await installedTheme('casper').getByRole('button', { name: 'Menu' }).click();
+    await expect.element(settingsScreen.menuItem('Download')).toBeVisible();
+
+    await userEvent.keyboard('{Escape}');
+
+    await expect(settingsScreen.menuItem('Download')).toHaveCount(0);
+    await expect.element(modal).toBeVisible();
+    await expect.poll(currentRoute).toBe('/settings/design/change-theme');
+  });
+
+  it('uploads a theme archive', async () => {
+    fakeThemeWorld();
+    const uploaded = theme({ name: 'mytheme' });
+    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', { themes: [uploaded] });
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
+
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'theme.zip', { type: 'application/zip' }));
+
+    await expect
+      .element(settingsScreen.confirmationModal())
+      .toHaveTextContent('mytheme was uploaded successfully. Do you want to activate it?');
+    expect(uploadApi.requests).toHaveLength(1);
+  });
+
+  it('summarises non-blocking issues on the installed-theme dialog', async () => {
+    fakeThemeWorld();
+    const uploaded = theme({
+      name: 'mytheme',
+      errors: [
+        themeProblem({
+          code: 'GS005-TPL-ERR',
+          level: 'error',
+          rule: 'Templates must contain valid Handlebars',
+        }),
+      ],
+      warnings: [
+        themeProblem({ code: 'GS001-DEPR-PURL', rule: 'Replace {{@blog.url}} with {{@site.url}}' }),
+        themeProblem({ code: 'GS002-DISQUS-ID', rule: 'Disqus id should be present' }),
+      ],
     });
+    fakeAdminEndpoint('POST', '/themes/upload/', { themes: [uploaded] });
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
 
-    it("uploads a theme archive", async () => {
-        fakeThemeWorld();
-        const uploaded = theme({ name: "mytheme" });
-        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "theme.zip", { type: "application/zip" }));
+    const installedModal = settingsScreen.confirmationModal();
+    // Errors and warnings are merged into one list, so the sentence says
+    // "issues" rather than contradicting the "1 error" in the heading.
+    await expect
+      .element(installedModal)
+      .toHaveTextContent(
+        'mytheme was uploaded, but it has some issues. Do you want to activate it?',
+      );
+    await expect.element(installedModal).toHaveTextContent('1 error, 2 warnings');
 
-        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent("mytheme was uploaded successfully. Do you want to activate it?");
-        expect(uploadApi.requests).toHaveLength(1);
+    // A summary that says "error" can't be headed by a warning-coloured
+    // icon: it takes the same red as the ERROR badge in the list below.
+    const heading = installedModal.element().querySelector('h3')!;
+    const badge = installedModal.getByText('Error', { exact: true }).element();
+    expect(getComputedStyle(heading.querySelector('svg')!).color).toBe(
+      getComputedStyle(badge).color,
+    );
+
+    // Every issue is listed up front; each one expands on its own.
+    await expect(installedModal.getByRole('button', { name: /GS001-DEPR-PURL/ })).toHaveCount(1);
+    await expect(installedModal.getByText(/deprecated/)).toHaveCount(0);
+    await installedModal.getByRole('button', { name: /GS001-DEPR-PURL/ }).click();
+    await expect.element(installedModal.getByText(/deprecated/)).toBeVisible();
+    await expect.element(installedModal).toHaveTextContent('Affected files');
+  });
+
+  it("flips an expanding issue row's chevron a single half turn", async () => {
+    fakeThemeWorld();
+    fakeAdminEndpoint('POST', '/themes/upload/', {
+      themes: [theme({ name: 'mytheme', warnings: [themeProblem({ code: 'GS001-DEPR-PURL' })] })],
     });
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
 
-    it("summarises non-blocking issues on the installed-theme dialog", async () => {
-        fakeThemeWorld();
-        const uploaded = theme({
-            name: "mytheme",
-            errors: [themeProblem({ code: "GS005-TPL-ERR", level: "error", rule: "Templates must contain valid Handlebars" })],
-            warnings: [
-                themeProblem({ code: "GS001-DEPR-PURL", rule: "Replace {{@blog.url}} with {{@site.url}}" }),
-                themeProblem({ code: "GS002-DISQUS-ID", rule: "Disqus id should be present" }),
-            ],
-        });
-        fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+    // Ghost's legacy Ember stylesheet ships Tachyons' `.rotate-180 {transform:
+    // rotate(180deg)}` unlayered alongside Tailwind v4's `.rotate-180 {rotate:
+    // 180deg}`. An icon carrying that literal class picks up both and turns a
+    // full circle, landing back where it started — the bug this dialog was
+    // rebuilt to fix. This tier serves no Ember CSS, so the collision is staged
+    // here; the chevron must rotate via a selector that rule cannot match.
+    stageLegacyGhostCss(LEGACY_TACHYONS_CSS);
 
-        const installedModal = settingsScreen.confirmationModal();
-        // Errors and warnings are merged into one list, so the sentence says
-        // "issues" rather than contradicting the "1 error" in the heading.
-        await expect.element(installedModal).toHaveTextContent("mytheme was uploaded, but it has some issues. Do you want to activate it?");
-        await expect.element(installedModal).toHaveTextContent("1 error, 2 warnings");
+    const row = settingsScreen.confirmationModal().getByRole('button', { name: /GS001-DEPR-PURL/ });
+    await expect.element(row).toBeVisible();
+    const chevron = () => (row.element() as HTMLElement).querySelector('svg')!;
+    expect(getComputedStyle(chevron()).rotate).toBe('none');
 
-        // A summary that says "error" can't be headed by a warning-coloured
-        // icon: it takes the same red as the ERROR badge in the list below.
-        const heading = installedModal.element().querySelector("h3")!;
-        const badge = installedModal.getByText("Error", { exact: true }).element();
-        expect(getComputedStyle(heading.querySelector("svg")!).color).toBe(getComputedStyle(badge).color);
+    await row.click();
 
-        // Every issue is listed up front; each one expands on its own.
-        await expect(installedModal.getByRole("button", { name: /GS001-DEPR-PURL/ })).toHaveCount(1);
-        await expect(installedModal.getByText(/deprecated/)).toHaveCount(0);
-        await installedModal.getByRole("button", { name: /GS001-DEPR-PURL/ }).click();
-        await expect.element(installedModal.getByText(/deprecated/)).toBeVisible();
-        await expect.element(installedModal).toHaveTextContent("Affected files");
+    // Polling rides out the expand transition without a fixed wait: an
+    // interpolated frame reads as an intermediate angle, never as 180deg.
+    await expect.poll(() => getComputedStyle(chevron()).rotate).toBe('180deg');
+    // ...and nothing may add a second rotation on top of that one.
+    expect(getComputedStyle(chevron()).transform).toBe('none');
+  });
+
+  it("renders gscan's inline code plainly under the legacy code rule", async () => {
+    fakeThemeWorld();
+    fakeAdminEndpoint('POST', '/themes/upload/', {
+      themes: [
+        theme({
+          name: 'mytheme',
+          warnings: [
+            themeProblem({
+              code: 'GS001-DEPR-PURL',
+              rule: 'Replace <code>{{@blog.url}}</code> with <code>{{@site.url}}</code>',
+              details: 'The <code>{{@blog.title}}</code> helper is deprecated.',
+            }),
+          ],
+        }),
+      ],
     });
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
 
-    it("flips an expanding issue row's chevron a single half turn", async () => {
-        fakeThemeWorld();
-        fakeAdminEndpoint("POST", "/themes/upload/", {
-            themes: [theme({ name: "mytheme", warnings: [themeProblem({ code: "GS001-DEPR-PURL" })] })],
-        });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
+    stageLegacyGhostCss(LEGACY_CODE_CSS);
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+    const row = settingsScreen.confirmationModal().getByRole('button', { name: /GS001-DEPR-PURL/ });
+    await expect.element(row).toBeVisible();
+    await row.click();
+    await expect.element(settingsScreen.confirmationModal().getByText(/deprecated/)).toBeVisible();
 
-        // Ghost's legacy Ember stylesheet ships Tachyons' `.rotate-180 {transform:
-        // rotate(180deg)}` unlayered alongside Tailwind v4's `.rotate-180 {rotate:
-        // 180deg}`. An icon carrying that literal class picks up both and turns a
-        // full circle, landing back where it started — the bug this dialog was
-        // rebuilt to fix. This tier serves no Ember CSS, so the collision is staged
-        // here; the chevron must rotate via a selector that rule cannot match.
-        stageLegacyGhostCss(LEGACY_TACHYONS_CSS);
+    // gscan's own markup: mono, inheriting the line it sits on, no chip.
+    for (const text of ['{{@blog.url}}', '{{@blog.title}}']) {
+      const code = codeSpan(text);
+      const surrounding = getComputedStyle(code.parentElement!);
+      const style = getComputedStyle(code);
+      expect(style.fontFamily).toContain('mono');
+      expect(style.color).toBe(surrounding.color);
+      // Nothing reads optically larger than the text it sits in.
+      expect(style.fontSize).toBe(surrounding.fontSize);
+      // The legacy `line-height: 1em` computes to exactly the font size;
+      // inheriting the surrounding ratio is what its absence would give.
+      expect(style.lineHeight).not.toBe(style.fontSize);
+      expect(lineRatio(style)).toBeCloseTo(lineRatio(surrounding), 2);
+      expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+      expect(style.borderTopWidth).toBe('0px');
+      expect(style.borderTopLeftRadius).toBe('0px');
+      expect(style.paddingLeft).toBe('0px');
+      expect(style.verticalAlign).toBe('baseline');
+    }
 
-        const row = settingsScreen.confirmationModal().getByRole("button", { name: /GS001-DEPR-PURL/ });
-        await expect.element(row).toBeVisible();
-        const chevron = () => (row.element() as HTMLElement).querySelector("svg")!;
-        expect(getComputedStyle(chevron()).rotate).toBe("none");
+    // An affected file is inline mono too: same size, family and weight as the
+    // code in the details above it, with no chip of its own left behind.
+    const filenameCode = codeSpan('default.hbs');
+    const filename = getComputedStyle(filenameCode);
+    const detailsCode = getComputedStyle(codeSpan('{{@blog.title}}'));
+    expect(filename.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(filename.borderTopWidth).toBe('0px');
+    expect(filename.borderTopLeftRadius).toBe('0px');
+    expect(filename.paddingLeft).toBe('0px');
+    expect(filename.verticalAlign).toBe('baseline');
+    expect(filename.fontSize).toBe(detailsCode.fontSize);
+    expect(filename.fontFamily).toBe(detailsCode.fontFamily);
+    expect(filename.fontWeight).toBe(detailsCode.fontWeight);
+    // Same foreground as the line it sits on — the affected-files list stays
+    // muted while the details read as body copy — i.e. not the legacy pink.
+    expect(filename.color).toBe(getComputedStyle(filenameCode.parentElement!).color);
+  });
 
-        await row.click();
+  it('keeps the installed-theme dialog open when activation fails', async () => {
+    fakeThemeWorld();
+    const uploaded = theme({ name: 'mytheme' });
+    fakeAdminEndpoint('POST', '/themes/upload/', { themes: [uploaded] });
+    const activateApi = fakeAdminEndpoint(
+      'PUT',
+      '/themes/mytheme/activate/',
+      {
+        errors: [{ message: 'Theme activation failed' }],
+      },
+      { status: 422 },
+    );
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
 
-        // Polling rides out the expand transition without a fixed wait: an
-        // interpolated frame reads as an intermediate angle, never as 180deg.
-        await expect.poll(() => getComputedStyle(chevron()).rotate).toBe("180deg");
-        // ...and nothing may add a second rotation on top of that one.
-        expect(getComputedStyle(chevron()).transform).toBe("none");
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
+
+    const installedModal = settingsScreen.confirmationModal();
+    await installedModal.getByRole('button', { name: 'Activate theme' }).click();
+
+    await expect.element(installedModal).toBeVisible();
+    await expect.element(settingsScreen.errorToast()).toHaveTextContent('Theme activation failed');
+    await expect.poll(currentRoute).toBe('/settings/design/change-theme');
+    expect(activateApi.requests).toHaveLength(1);
+  });
+
+  it('seats the sticky footer flush against the issue list, with no empty band and no shadow rule', async () => {
+    fakeThemeWorld();
+    fakeAdminEndpoint('POST', '/themes/upload/', {
+      themes: [
+        theme({
+          name: 'mytheme',
+          errors: [
+            themeProblem({
+              code: 'GS005-TPL-ERR',
+              level: 'error',
+              rule: 'Templates must contain valid Handlebars',
+            }),
+          ],
+          // Enough rows that the dialog scrolls, so the footer both
+          // floats mid-scroll and lands in flow at the bottom.
+          warnings: Array.from({ length: 8 }, (_, index) =>
+            themeProblem({ code: `GS10${index}-DEPR-PURL` }),
+          ),
+        }),
+      ],
     });
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
 
-    it("renders gscan's inline code plainly under the legacy code rule", async () => {
-        fakeThemeWorld();
-        fakeAdminEndpoint("POST", "/themes/upload/", {
-            themes: [
-                theme({
-                    name: "mytheme",
-                    warnings: [
-                        themeProblem({
-                            code: "GS001-DEPR-PURL",
-                            rule: "Replace <code>{{@blog.url}}</code> with <code>{{@site.url}}</code>",
-                            details: "The <code>{{@blog.title}}</code> helper is deprecated.",
-                        }),
-                    ],
-                }),
-            ],
-        });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
+    stageLegacyGhostCss(LEGACY_CODE_CSS);
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
-        stageLegacyGhostCss(LEGACY_CODE_CSS);
+    const dialog = settingsScreen.confirmationModal();
+    await expect.element(dialog).toHaveTextContent('1 error, 8 warnings');
 
-        const row = settingsScreen.confirmationModal().getByRole("button", { name: /GS001-DEPR-PURL/ });
-        await expect.element(row).toBeVisible();
-        await row.click();
-        await expect.element(settingsScreen.confirmationModal().getByText(/deprecated/)).toBeVisible();
+    const scroller = dialog.element() as HTMLElement;
+    const list = scroller.querySelector<HTMLElement>('div.overflow-hidden.rounded-lg.border')!;
+    const footer = scroller.querySelector<HTMLElement>('.z-\\[297\\]')!;
+    // The footer's own background: `sticky bottom-0`, 84px tall, and the
+    // only thing standing between scrolling rows and the buttons.
+    const mask = scroller.querySelector<HTMLElement>('.z-\\[299\\]')!;
+    expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+    expect(getComputedStyle(mask).backgroundColor).not.toMatch(/rgba\(.*, 0\)$/);
 
-        // gscan's own markup: mono, inheriting the line it sits on, no chip.
-        for (const text of ["{{@blog.url}}", "{{@blog.title}}"]) {
-            const code = codeSpan(text);
-            const surrounding = getComputedStyle(code.parentElement!);
-            const style = getComputedStyle(code);
-            expect(style.fontFamily).toContain("mono");
-            expect(style.color).toBe(surrounding.color);
-            // Nothing reads optically larger than the text it sits in.
-            expect(style.fontSize).toBe(surrounding.fontSize);
-            // The legacy `line-height: 1em` computes to exactly the font size;
-            // inheriting the surrounding ratio is what its absence would give.
-            expect(style.lineHeight).not.toBe(style.fontSize);
-            expect(lineRatio(style)).toBeCloseTo(lineRatio(surrounding), 2);
-            expect(style.backgroundColor).toBe("rgba(0, 0, 0, 0)");
-            expect(style.borderTopWidth).toBe("0px");
-            expect(style.borderTopLeftRadius).toBe("0px");
-            expect(style.paddingLeft).toBe("0px");
-            expect(style.verticalAlign).toBe("baseline");
-        }
+    // The component closes with a decorative scroll rule. Over a dialog
+    // whose footer already reads as a distinct block it lands as a hairline
+    // drawn across the buttons, so it must not render at all...
+    const rule = footer.lastElementChild as HTMLElement;
+    expect(rule).not.toBe(mask);
+    // ...and this is the element that would draw it.
+    expect(getComputedStyle(rule).boxShadow).not.toBe('none');
+    expect(getComputedStyle(rule).display).toBe('none');
+    expect(rule.getBoundingClientRect().height).toBe(0);
+    // Nothing else in the footer paints one in its place.
+    for (const part of [footer, ...footer.children]) {
+      if (part !== rule) {
+        expect(getComputedStyle(part).boxShadow).toBe('none');
+      }
+    }
 
-        // An affected file is inline mono too: same size, family and weight as the
-        // code in the details above it, with no chip of its own left behind.
-        const filenameCode = codeSpan("default.hbs");
-        const filename = getComputedStyle(filenameCode);
-        const detailsCode = getComputedStyle(codeSpan("{{@blog.title}}"));
-        expect(filename.backgroundColor).toBe("rgba(0, 0, 0, 0)");
-        expect(filename.borderTopWidth).toBe("0px");
-        expect(filename.borderTopLeftRadius).toBe("0px");
-        expect(filename.paddingLeft).toBe("0px");
-        expect(filename.verticalAlign).toBe("baseline");
-        expect(filename.fontSize).toBe(detailsCode.fontSize);
-        expect(filename.fontFamily).toBe(detailsCode.fontFamily);
-        expect(filename.fontWeight).toBe(detailsCode.fontWeight);
-        // Same foreground as the line it sits on — the affected-files list stays
-        // muted while the details read as body copy — i.e. not the legacy pink.
-        expect(filename.color).toBe(getComputedStyle(filenameCode.parentElement!).color);
+    // Mid-scroll the mask is pinned to the bottom of the scroll port and
+    // rows run underneath it rather than showing through.
+    scroller.scrollTop = Math.floor((scroller.scrollHeight - scroller.clientHeight) / 2);
+    await expect
+      .poll(() => Math.round(mask.getBoundingClientRect().bottom))
+      .toBe(Math.round(scroller.getBoundingClientRect().bottom));
+    await expect.poll(() => Math.round(mask.getBoundingClientRect().height)).toBe(84);
+    expect(list.getBoundingClientRect().bottom).toBeGreaterThan(mask.getBoundingClientRect().top);
+
+    // Scrolled to the end the footer returns to flow, and every part of it
+    // has to close up: the list ends exactly where the footer's background
+    // begins, and that background reaches the dialog's own bottom edge.
+    // Slack left anywhere in the footer's 84px box reads as an empty band —
+    // above the buttons if it sits before the background, below them if it
+    // sits after.
+    scroller.scrollTop = scroller.scrollHeight;
+    await expect
+      .poll(() => edgeGap(mask.getBoundingClientRect().top, list.getBoundingClientRect().bottom))
+      .toBe(0);
+    expect(
+      edgeGap(footer.getBoundingClientRect().bottom, scroller.getBoundingClientRect().bottom),
+    ).toBe(0);
+    expect(
+      edgeGap(mask.getBoundingClientRect().bottom, footer.getBoundingClientRect().bottom),
+    ).toBe(0);
+    expect(Math.round(mask.getBoundingClientRect().height)).toBe(84);
+  });
+
+  it('reports blocking upload errors and re-opens the upload dialog from the error dialog', async () => {
+    fakeThemeWorld();
+    const uploadApi = fakeAdminEndpoint(
+      'POST',
+      '/themes/upload/',
+      {
+        errors: [
+          { message: 'Theme is not compatible or contains errors.', details: 'Missing index.hbs' },
+        ],
+      },
+      { status: 422 },
+    );
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
+
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
+
+    const errorModal = settingsScreen.confirmationModal();
+    await expect.element(errorModal).toHaveTextContent('Theme not uploaded');
+    await expect
+      .element(errorModal)
+      .toHaveTextContent("mytheme couldn't be uploaded. Fix the errors below and try again.");
+    await expect.element(errorModal).toHaveTextContent('Missing index.hbs');
+    expect(uploadApi.requests).toHaveLength(1);
+
+    await errorModal.getByRole('button', { name: 'Re-upload' }).click();
+    await expect
+      .element(page.getByText('Click to select or drag & drop zip file', { exact: true }))
+      .toBeVisible();
+    await expect(page.getByText('Theme not uploaded')).toHaveCount(0);
+  });
+
+  it('reports blocking activation errors for an installed theme', async () => {
+    fakeThemeWorld();
+    const activateApi = fakeAdminEndpoint(
+      'PUT',
+      '/themes/casper/activate/',
+      {
+        errors: [
+          { message: 'Theme is not compatible or contains errors.', details: 'Missing post.hbs' },
+        ],
+      },
+      { status: 422 },
+    );
+    await renderAdminApp('/settings/design/change-theme');
+
+    const modal = settingsScreen.themeModal();
+    await modal.getByRole('tab', { name: 'Installed' }).click();
+    await installedTheme('casper').getByRole('button', { name: 'Activate' }).click();
+
+    const errorModal = settingsScreen.confirmationModal();
+    await expect.element(errorModal).toHaveTextContent('Theme not activated');
+    await expect.element(errorModal).toHaveTextContent('Missing post.hbs');
+    expect(activateApi.requests).toHaveLength(1);
+
+    await errorModal.getByRole('button', { name: 'Cancel' }).click();
+    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+    await expect.element(modal).toBeVisible();
+  });
+
+  it('prevents uploading an archive over a built-in theme', async () => {
+    fakeThemeWorld();
+    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', {
+      themes: [theme({ name: 'source' })],
     });
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
 
-    it("keeps the installed-theme dialog open when activation fails", async () => {
-        fakeThemeWorld();
-        const uploaded = theme({ name: "mytheme" });
-        fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
-        const activateApi = fakeAdminEndpoint("PUT", "/themes/mytheme/activate/", {
-            errors: [{ message: "Theme activation failed" }],
-        }, { status: 422 });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'source.zip', { type: 'application/zip' }));
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+    await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Upload failed/i);
+    await expect
+      .element(settingsScreen.confirmationModal())
+      .toHaveTextContent(/cannot be overwritten/i);
+    expect(uploadApi.requests).toHaveLength(0);
+  });
 
-        const installedModal = settingsScreen.confirmationModal();
-        await installedModal.getByRole("button", { name: "Activate theme" }).click();
-
-        await expect.element(installedModal).toBeVisible();
-        await expect.element(settingsScreen.errorToast()).toHaveTextContent("Theme activation failed");
-        await expect.poll(currentRoute).toBe("/settings/design/change-theme");
-        expect(activateApi.requests).toHaveLength(1);
+  it('loads the code editor and saves a changed theme', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', {
+      themes: [theme({ name: 'edition', active: true })],
     });
+    await renderAdminApp('/settings/theme/edit/edition');
 
-    it("seats the sticky footer flush against the issue list, with no empty band and no shadow rule", async () => {
-        fakeThemeWorld();
-        fakeAdminEndpoint("POST", "/themes/upload/", {
-            themes: [
-                theme({
-                    name: "mytheme",
-                    errors: [themeProblem({ code: "GS005-TPL-ERR", level: "error", rule: "Templates must contain valid Handlebars" })],
-                    // Enough rows that the dialog scrolls, so the footer both
-                    // floats mid-scroll and lands in flow at the bottom.
-                    warnings: Array.from({ length: 8 }, (_, index) => themeProblem({ code: `GS10${index}-DEPR-PURL` })),
-                }),
-            ],
-        });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    const modal = settingsScreen.themeCodeEditorModal();
+    await expect.element(modal).toHaveTextContent(/Edit theme/);
+    await expect.element(modal).toHaveTextContent(/json/i);
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    await expect.element(modal).toHaveTextContent(/1 file modified/);
+    await modal.getByRole('button', { name: 'Save' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Replace theme' })
+      .click();
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
-        stageLegacyGhostCss(LEGACY_CODE_CSS);
+    await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
+    expect(uploadApi.requests).toHaveLength(1);
+  });
 
-        const dialog = settingsScreen.confirmationModal();
-        await expect.element(dialog).toHaveTextContent("1 error, 8 warnings");
-
-        const scroller = dialog.element() as HTMLElement;
-        const list = scroller.querySelector<HTMLElement>("div.overflow-hidden.rounded-lg.border")!;
-        const footer = scroller.querySelector<HTMLElement>(".z-\\[297\\]")!;
-        // The footer's own background: `sticky bottom-0`, 84px tall, and the
-        // only thing standing between scrolling rows and the buttons.
-        const mask = scroller.querySelector<HTMLElement>(".z-\\[299\\]")!;
-        expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
-        expect(getComputedStyle(mask).backgroundColor).not.toMatch(/rgba\(.*, 0\)$/);
-
-        // The component closes with a decorative scroll rule. Over a dialog
-        // whose footer already reads as a distinct block it lands as a hairline
-        // drawn across the buttons, so it must not render at all...
-        const rule = footer.lastElementChild as HTMLElement;
-        expect(rule).not.toBe(mask);
-        // ...and this is the element that would draw it.
-        expect(getComputedStyle(rule).boxShadow).not.toBe("none");
-        expect(getComputedStyle(rule).display).toBe("none");
-        expect(rule.getBoundingClientRect().height).toBe(0);
-        // Nothing else in the footer paints one in its place.
-        for (const part of [footer, ...footer.children]) {
-            if (part !== rule) {
-                expect(getComputedStyle(part).boxShadow).toBe("none");
-            }
-        }
-
-        // Mid-scroll the mask is pinned to the bottom of the scroll port and
-        // rows run underneath it rather than showing through.
-        scroller.scrollTop = Math.floor((scroller.scrollHeight - scroller.clientHeight) / 2);
-        await expect.poll(() => Math.round(mask.getBoundingClientRect().bottom)).toBe(Math.round(scroller.getBoundingClientRect().bottom));
-        await expect.poll(() => Math.round(mask.getBoundingClientRect().height)).toBe(84);
-        expect(list.getBoundingClientRect().bottom).toBeGreaterThan(mask.getBoundingClientRect().top);
-
-        // Scrolled to the end the footer returns to flow, and every part of it
-        // has to close up: the list ends exactly where the footer's background
-        // begins, and that background reaches the dialog's own bottom edge.
-        // Slack left anywhere in the footer's 84px box reads as an empty band —
-        // above the buttons if it sits before the background, below them if it
-        // sits after.
-        scroller.scrollTop = scroller.scrollHeight;
-        await expect.poll(() => edgeGap(mask.getBoundingClientRect().top, list.getBoundingClientRect().bottom)).toBe(0);
-        expect(edgeGap(footer.getBoundingClientRect().bottom, scroller.getBoundingClientRect().bottom)).toBe(0);
-        expect(edgeGap(mask.getBoundingClientRect().bottom, footer.getBoundingClientRect().bottom)).toBe(0);
-        expect(Math.round(mask.getBoundingClientRect().height)).toBe(84);
+  it('runs the current save flow from the keyboard shortcut', async () => {
+    fakeThemeWorld();
+    // The editor shortcut currently propagates to the settings form too;
+    // keep that pre-existing request in the declared world (follow-up).
+    fakeEditSettings();
+    await fakeThemeDownload('edition');
+    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', {
+      themes: [theme({ name: 'edition', active: true })],
     });
+    await renderAdminApp('/settings/theme/edit/edition');
 
-    it("reports blocking upload errors and re-opens the upload dialog from the error dialog", async () => {
-        fakeThemeWorld();
-        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", {
-            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing index.hbs" }],
-        }, { status: 422 });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true }),
+    );
+    await expect.element(settingsScreen.themeEditorConfirmModal()).toBeVisible();
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true }),
+    );
+    await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(1);
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Replace theme' })
+      .click();
 
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+    await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
+    expect(uploadApi.requests).toHaveLength(1);
+  });
 
-        const errorModal = settingsScreen.confirmationModal();
-        await expect.element(errorModal).toHaveTextContent("Theme not uploaded");
-        await expect.element(errorModal).toHaveTextContent("mytheme couldn't be uploaded. Fix the errors below and try again.");
-        await expect.element(errorModal).toHaveTextContent("Missing index.hbs");
-        expect(uploadApi.requests).toHaveLength(1);
+  it('surfaces server-side archive limit details', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    fakeAdminEndpoint(
+      'POST',
+      '/themes/upload/',
+      {
+        errors: [
+          {
+            message: 'Zip entry exceeds maximum uncompressed size.',
+            errorType: 'UnsupportedMediaTypeError',
+            code: 'ENTRY_TOO_LARGE',
+            errorDetails: {
+              entryName: 'partials/huge.hbs',
+              observedBytes: 2_000_000,
+              limitBytes: 1_048_576,
+            },
+          },
+        ],
+      },
+      { status: 415 },
+    );
+    await renderAdminApp('/settings/theme/edit/edition');
 
-        await errorModal.getByRole("button", { name: "Re-upload" }).click();
-        await expect.element(page.getByText("Click to select or drag & drop zip file", { exact: true })).toBeVisible();
-        await expect(page.getByText("Theme not uploaded")).toHaveCount(0);
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Replace theme' })
+      .click();
+
+    await expect.element(settingsScreen.errorToast()).toHaveTextContent(/partials\/huge\.hbs/);
+    await expect.element(settingsScreen.errorToast()).toHaveTextContent(/1\.0 MB/);
+  });
+
+  it('falls back to the generic API error for malformed archive limit details', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    fakeAdminEndpoint(
+      'POST',
+      '/themes/upload/',
+      {
+        errors: [
+          {
+            message: 'Zip entry exceeds maximum uncompressed size.',
+            errorType: 'UnsupportedMediaTypeError',
+            code: 'ENTRY_TOO_LARGE',
+            errorDetails: { entryName: 'partials/huge.hbs', limitBytes: 'not-a-number' },
+          },
+        ],
+      },
+      { status: 415 },
+    );
+    await renderAdminApp('/settings/theme/edit/edition');
+
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Replace theme' })
+      .click();
+
+    await expect
+      .element(settingsScreen.errorToast())
+      .toHaveTextContent('Request contains an unknown or unsupported file type.');
+    await expect.element(settingsScreen.errorToast()).not.toHaveTextContent('NaN');
+  });
+
+  it('keeps the code editor open and reports blocking validation errors on save', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    fakeAdminEndpoint(
+      'POST',
+      '/themes/upload/',
+      {
+        errors: [
+          {
+            message: 'Theme is not compatible or contains errors.',
+            details: 'Missing default.hbs',
+          },
+        ],
+      },
+      { status: 422 },
+    );
+    await renderAdminApp('/settings/theme/edit/edition');
+
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Replace theme' })
+      .click();
+
+    const errorModal = settingsScreen.confirmationModal();
+    await expect.element(errorModal).toHaveTextContent('Theme not saved');
+    await expect.element(errorModal).toHaveTextContent('Missing default.hbs');
+    await expect(errorModal.getByRole('button', { name: 'Retry' })).toHaveCount(0);
+    await userEvent.keyboard('{Escape}');
+    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+  });
+
+  it('falls back to the generic API error for an empty validation payload', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    fakeAdminEndpoint('POST', '/themes/upload/', { errors: [] }, { status: 422 });
+    await renderAdminApp('/settings/theme/edit/edition');
+
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Replace theme' })
+      .click();
+
+    await expect.element(settingsScreen.errorToast()).toHaveTextContent(/Something went wrong/i);
+    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+  });
+
+  it('requires built-in themes to be saved under a valid new name', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('casper');
+    await renderAdminApp('/settings/theme/edit/casper');
+
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"casper","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    const inputModal = settingsScreen.themeEditorInputModal();
+    await inputModal.getByLabelText('Theme name').fill('Foo Bar!');
+    await inputModal.getByRole('button', { name: 'Continue' }).click();
+    await expect.element(page.getByText(/Invalid theme name/i)).toBeVisible();
+
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    await inputModal.getByLabelText('Theme name').fill('casper');
+    await inputModal.getByRole('button', { name: 'Continue' }).click();
+    await expect.element(page.getByText(/Built-in themes cannot be overwritten/i)).toBeVisible();
+  });
+
+  it('saves a built-in theme under a valid new name', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('casper');
+    await fakeThemeDownload('casper-edited');
+    // saving under a new name carries over the original theme's settings
+    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/?copy_settings_from=casper', {
+      themes: [theme({ name: 'casper-edited' })],
     });
+    await renderAdminApp('/settings/theme/edit/casper');
 
-    it("reports blocking activation errors for an installed theme", async () => {
-        fakeThemeWorld();
-        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", {
-            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing post.hbs" }],
-        }, { status: 422 });
-        await renderAdminApp("/settings/design/change-theme");
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"casper","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+    await settingsScreen.themeEditorInputModal().getByLabelText('Theme name').fill('casper-edited');
+    await settingsScreen.themeEditorInputModal().getByRole('button', { name: 'Continue' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Save theme' })
+      .click();
 
-        const modal = settingsScreen.themeModal();
-        await modal.getByRole("tab", { name: "Installed" }).click();
-        await installedTheme("casper").getByRole("button", { name: "Activate" }).click();
+    await expect.poll(() => uploadApi.requests.length).toBe(1);
+    await expect.poll(currentRoute).toBe('/settings/theme/edit/casper-edited');
+    await expect.element(settingsScreen.themeCodeEditorModal()).toHaveTextContent('casper-edited');
+  });
 
-        const errorModal = settingsScreen.confirmationModal();
-        await expect.element(errorModal).toHaveTextContent("Theme not activated");
-        await expect.element(errorModal).toHaveTextContent("Missing post.hbs");
-        expect(activateApi.requests).toHaveLength(1);
+  it.each([
+    { allowlist: ['casper'], opensThemes: false },
+    { allowlist: ['casper', 'edition'], opensThemes: true },
+  ])('enforces theme-change limits', async ({ allowlist, opensThemes }) => {
+    fakeThemeWorld();
+    await renderAdminApp('/settings/theme', themeLimits(allowlist, 'Upgrade to use custom themes'));
 
-        await errorModal.getByRole("button", { name: "Cancel" }).click();
-        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-        await expect.element(modal).toBeVisible();
+    await settingsScreen.theme().getByRole('button', { name: 'Change theme' }).click();
+    if (opensThemes) {
+      await expect.element(settingsScreen.themeModal()).toBeVisible();
+      await expect(settingsScreen.limitModal()).toHaveCount(0);
+    } else {
+      await expect
+        .element(settingsScreen.limitModal())
+        .toHaveTextContent(/Upgrade to use custom themes/);
+      await expect(settingsScreen.themeModal()).toHaveCount(0);
+    }
+  });
+
+  it('prevents direct access to the theme-change route when limited', async () => {
+    fakeThemeWorld();
+    await renderAdminApp(
+      '/settings/design/change-theme',
+      themeLimits(['casper'], 'Upgrade to use custom themes'),
+    );
+
+    await expect
+      .element(settingsScreen.limitModal())
+      .toHaveTextContent(/Upgrade to use custom themes/);
+    await expect(settingsScreen.themeModal()).toHaveCount(0);
+  });
+
+  it('prevents direct access to the theme editor when editing is limited', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    await renderAdminApp(
+      '/settings/theme/edit/edition',
+      themeLimits(['casper', 'edition'], 'Upgrade to use custom themes'),
+    );
+
+    await expect
+      .element(settingsScreen.limitModal())
+      .toHaveTextContent(/Upgrade to use custom themes/);
+    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+    await expect.poll(currentRoute).toBe('/settings/theme');
+  });
+
+  it('prevents theme uploads when custom themes are limited', async () => {
+    fakeThemeWorld();
+    await renderAdminApp(
+      '/settings/design/change-theme',
+      themeLimits(['casper', 'headline', 'edition'], 'Upgrade to use more themes'),
+    );
+
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await expect
+      .element(settingsScreen.limitModal())
+      .toHaveTextContent(/Upgrade to use more themes/);
+    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+  });
+
+  it.each([
+    { themeName: 'Headline', action: 'Install Headline', allowlist: ['casper', 'edition'] },
+    { themeName: 'Edition', action: 'Update Edition', allowlist: ['casper', 'headline'] },
+  ])(
+    'checks limits before installing or updating a theme card',
+    async ({ themeName, action, allowlist }) => {
+      fakeThemeWorld();
+      await renderAdminApp(
+        '/settings/design/change-theme',
+        themeLimits(allowlist, 'Upgrade to use more themes'),
+      );
+
+      const modal = settingsScreen.themeModal();
+      await modal.getByRole('button', { name: new RegExp(themeName) }).click();
+      await modal.getByRole('button', { name: action }).click();
+      await expect
+        .element(settingsScreen.limitModal())
+        .toHaveTextContent(/Upgrade to use more themes/);
+      await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+    },
+  );
+
+  it.each([
+    { allowlist: ['casper', 'headline', 'taste'], canInstall: true },
+    { allowlist: ['casper', 'headline', 'edition'], canInstall: false },
+  ])('enforces marketplace installation limits', async ({ allowlist, canInstall }) => {
+    fakeThemeWorld();
+    const installApi = fakeAdminEndpoint('POST', /^\/themes\/install\/\?/, {
+      themes: [theme({ name: 'taste' })],
     });
-
-    it("prevents uploading an archive over a built-in theme", async () => {
-        fakeThemeWorld();
-        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "source" })] });
-        const buffer = await archiveBuffer();
-        await renderAdminApp("/settings/design/change-theme");
-
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await uploadThemeFile(new File([buffer], "source.zip", { type: "application/zip" }));
-
-        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Upload failed/i);
-        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/cannot be overwritten/i);
-        expect(uploadApi.requests).toHaveLength(0);
+    fakeAdminEndpoint('PUT', '/themes/taste/activate/', {
+      themes: [theme({ name: 'taste', active: true })],
     });
+    await renderAdminApp(
+      '/settings/theme/install?source=github&ref=TryGhost/Taste',
+      themeLimits(allowlist, 'Upgrade to use more themes'),
+    );
 
-    it("loads the code editor and saves a changed theme", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "edition", active: true })] });
-        await renderAdminApp("/settings/theme/edit/edition");
+    if (canInstall) {
+      await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Install Theme/);
+      await settingsScreen.confirmationModal().getByRole('button', { name: 'Install' }).click();
+      await expect
+        .element(settingsScreen.successToast())
+        .toHaveTextContent(/taste is now your active theme/i);
+      expect(installApi.requests).toHaveLength(1);
+    } else {
+      await expect
+        .element(settingsScreen.limitModal())
+        .toHaveTextContent(/Upgrade to use more themes/);
+      expect(installApi.requests).toHaveLength(0);
+    }
+  });
 
-        const modal = settingsScreen.themeCodeEditorModal();
-        await expect.element(modal).toHaveTextContent(/Edit theme/);
-        await expect.element(modal).toHaveTextContent(/json/i);
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        await expect.element(modal).toHaveTextContent(/1 file modified/);
-        await modal.getByRole("button", { name: "Save" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+  it('replaces a blocked marketplace installation in history', async () => {
+    fakeThemeWorld();
+    fakeAdminEndpoint('POST', /^\/themes\/install\/\?/, { themes: [theme({ name: 'taste' })] });
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    await renderAdminApp(
+      '/settings/theme/install?source=github&ref=TryGhost/Taste',
+      themeLimits(['casper'], 'Upgrade to use custom themes'),
+    );
 
-        await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
-        expect(uploadApi.requests).toHaveLength(1);
-    });
+    await expect
+      .element(settingsScreen.limitModal())
+      .toHaveTextContent(/Upgrade to use custom themes/);
+    await expect.poll(currentRoute).toBe('/settings/theme');
 
-    it("runs the current save flow from the keyboard shortcut", async () => {
-        fakeThemeWorld();
-        // The editor shortcut currently propagates to the settings form too;
-        // keep that pre-existing request in the declared world (follow-up).
-        fakeEditSettings();
-        await fakeThemeDownload("edition");
-        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "edition", active: true })] });
-        await renderAdminApp("/settings/theme/edit/edition");
+    expect(
+      replaceState.mock.calls.some(([, , url]) => String(url).endsWith('#/settings/theme')),
+    ).toBe(true);
+    replaceState.mockRestore();
+  });
 
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true, bubbles: true, cancelable: true }));
-        await expect.element(settingsScreen.themeEditorConfirmModal()).toBeVisible();
-        window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true, bubbles: true, cancelable: true }));
-        await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(1);
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+  it('confirms before discarding editor changes', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    await renderAdminApp('/settings/theme/edit/edition');
 
-        await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
-        expect(uploadApi.requests).toHaveLength(1);
-    });
+    const editor = await editorTextbox();
+    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
+    await expect
+      .element(settingsScreen.themeEditorConfirmModal())
+      .toHaveTextContent(/unsaved theme changes/i);
+    await userEvent.keyboard('{Escape}');
+    await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(0);
+    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
+    await settingsScreen
+      .themeEditorConfirmModal()
+      .getByRole('button', { name: 'Discard changes' })
+      .click();
+    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+  });
 
-    it("surfaces server-side archive limit details", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        fakeAdminEndpoint("POST", "/themes/upload/", {
-            errors: [{
-                message: "Zip entry exceeds maximum uncompressed size.",
-                errorType: "UnsupportedMediaTypeError",
-                code: "ENTRY_TOO_LARGE",
-                errorDetails: { entryName: "partials/huge.hbs", observedBytes: 2_000_000, limitBytes: 1_048_576 },
-            }],
-        }, { status: 415 });
-        await renderAdminApp("/settings/theme/edit/edition");
+  it.each([
+    { from: 'theme', destination: '/settings/theme' },
+    { from: 'staff/owner-transfer', destination: '/settings/design/change-theme' },
+  ])('only honours allowlisted editor return routes', async ({ from, destination }) => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    await renderAdminApp(`/settings/theme/edit/edition?from=${from}`);
 
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
+    await expect.poll(currentRoute).toBe(destination);
+  });
 
-        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/partials\/huge\.hbs/);
-        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/1\.0 MB/);
-    });
+  it('opens the code editor from the active theme overflow menu and returns to settings on close', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    await renderAdminApp('/settings');
 
-    it("falls back to the generic API error for malformed archive limit details", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        fakeAdminEndpoint("POST", "/themes/upload/", {
-            errors: [{
-                message: "Zip entry exceeds maximum uncompressed size.",
-                errorType: "UnsupportedMediaTypeError",
-                code: "ENTRY_TOO_LARGE",
-                errorDetails: { entryName: "partials/huge.hbs", limitBytes: "not-a-number" },
-            }],
-        }, { status: 415 });
-        await renderAdminApp("/settings/theme/edit/edition");
+    await settingsScreen.theme().getByRole('button', { name: 'Menu' }).click();
+    await settingsScreen.menuItem('Edit code').click();
 
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+    await expect.poll(currentRoute).toContain('/settings/theme/edit/edition');
 
-        await expect.element(settingsScreen.errorToast()).toHaveTextContent("Request contains an unknown or unsupported file type.");
-        await expect.element(settingsScreen.errorToast()).not.toHaveTextContent("NaN");
-    });
+    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
+    await expect.poll(currentRoute).toBe('/settings');
+    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+    await expect.element(settingsScreen.theme()).toBeVisible();
+  });
 
-    it("keeps the code editor open and reports blocking validation errors on save", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        fakeAdminEndpoint("POST", "/themes/upload/", {
-            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing default.hbs" }],
-        }, { status: 422 });
-        await renderAdminApp("/settings/theme/edit/edition");
+  it('redirects invalid editor theme names', async () => {
+    fakeThemeWorld();
+    await renderAdminApp('/settings/theme/edit/%2Fedition');
 
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+    await expect.poll(currentRoute).toBe('/settings/theme');
+    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+  });
 
-        const errorModal = settingsScreen.confirmationModal();
-        await expect.element(errorModal).toHaveTextContent("Theme not saved");
-        await expect.element(errorModal).toHaveTextContent("Missing default.hbs");
-        await expect(errorModal.getByRole("button", { name: "Retry" })).toHaveCount(0);
-        await userEvent.keyboard("{Escape}");
-        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-    });
+  it('shows a controlled message for non-editable files', async () => {
+    fakeThemeWorld();
+    await fakeThemeDownload('edition');
+    await renderAdminApp('/settings/theme/edit/edition');
 
-    it("falls back to the generic API error for an empty validation payload", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        fakeAdminEndpoint("POST", "/themes/upload/", { errors: [] }, { status: 422 });
-        await renderAdminApp("/settings/theme/edit/edition");
-
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
-
-        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/Something went wrong/i);
-        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-    });
-
-    it("requires built-in themes to be saved under a valid new name", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("casper");
-        await renderAdminApp("/settings/theme/edit/casper");
-
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"casper","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        const inputModal = settingsScreen.themeEditorInputModal();
-        await inputModal.getByLabelText("Theme name").fill("Foo Bar!");
-        await inputModal.getByRole("button", { name: "Continue" }).click();
-        await expect.element(page.getByText(/Invalid theme name/i)).toBeVisible();
-
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        await inputModal.getByLabelText("Theme name").fill("casper");
-        await inputModal.getByRole("button", { name: "Continue" }).click();
-        await expect.element(page.getByText(/Built-in themes cannot be overwritten/i)).toBeVisible();
-    });
-
-    it("saves a built-in theme under a valid new name", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("casper");
-        await fakeThemeDownload("casper-edited");
-        // saving under a new name carries over the original theme's settings
-        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/?copy_settings_from=casper", {
-            themes: [theme({ name: "casper-edited" })],
-        });
-        await renderAdminApp("/settings/theme/edit/casper");
-
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"casper","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
-        await settingsScreen.themeEditorInputModal().getByLabelText("Theme name").fill("casper-edited");
-        await settingsScreen.themeEditorInputModal().getByRole("button", { name: "Continue" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Save theme" }).click();
-
-        await expect.poll(() => uploadApi.requests.length).toBe(1);
-        await expect.poll(currentRoute).toBe("/settings/theme/edit/casper-edited");
-        await expect.element(settingsScreen.themeCodeEditorModal()).toHaveTextContent("casper-edited");
-    });
-
-    it.each([
-        { allowlist: ["casper"], opensThemes: false },
-        { allowlist: ["casper", "edition"], opensThemes: true },
-    ])("enforces theme-change limits", async ({ allowlist, opensThemes }) => {
-        fakeThemeWorld();
-        await renderAdminApp("/settings/theme", themeLimits(allowlist, "Upgrade to use custom themes"));
-
-        await settingsScreen.theme().getByRole("button", { name: "Change theme" }).click();
-        if (opensThemes) {
-            await expect.element(settingsScreen.themeModal()).toBeVisible();
-            await expect(settingsScreen.limitModal()).toHaveCount(0);
-        } else {
-            await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
-            await expect(settingsScreen.themeModal()).toHaveCount(0);
-        }
-    });
-
-    it("prevents direct access to the theme-change route when limited", async () => {
-        fakeThemeWorld();
-        await renderAdminApp("/settings/design/change-theme", themeLimits(["casper"], "Upgrade to use custom themes"));
-
-        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
-        await expect(settingsScreen.themeModal()).toHaveCount(0);
-    });
-
-    it("prevents direct access to the theme editor when editing is limited", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        await renderAdminApp("/settings/theme/edit/edition", themeLimits(["casper", "edition"], "Upgrade to use custom themes"));
-
-        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
-        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-        await expect.poll(currentRoute).toBe("/settings/theme");
-    });
-
-    it("prevents theme uploads when custom themes are limited", async () => {
-        fakeThemeWorld();
-        await renderAdminApp("/settings/design/change-theme", themeLimits(["casper", "headline", "edition"], "Upgrade to use more themes"));
-
-        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
-        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
-        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-    });
-
-    it.each([
-        { themeName: "Headline", action: "Install Headline", allowlist: ["casper", "edition"] },
-        { themeName: "Edition", action: "Update Edition", allowlist: ["casper", "headline"] },
-    ])("checks limits before installing or updating a theme card", async ({ themeName, action, allowlist }) => {
-        fakeThemeWorld();
-        await renderAdminApp("/settings/design/change-theme", themeLimits(allowlist, "Upgrade to use more themes"));
-
-        const modal = settingsScreen.themeModal();
-        await modal.getByRole("button", { name: new RegExp(themeName) }).click();
-        await modal.getByRole("button", { name: action }).click();
-        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
-        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-    });
-
-    it.each([
-        { allowlist: ["casper", "headline", "taste"], canInstall: true },
-        { allowlist: ["casper", "headline", "edition"], canInstall: false },
-    ])("enforces marketplace installation limits", async ({ allowlist, canInstall }) => {
-        fakeThemeWorld();
-        const installApi = fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "taste" })] });
-        fakeAdminEndpoint("PUT", "/themes/taste/activate/", { themes: [theme({ name: "taste", active: true })] });
-        await renderAdminApp("/settings/theme/install?source=github&ref=TryGhost/Taste", themeLimits(allowlist, "Upgrade to use more themes"));
-
-        if (canInstall) {
-            await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Install Theme/);
-            await settingsScreen.confirmationModal().getByRole("button", { name: "Install" }).click();
-            await expect.element(settingsScreen.successToast()).toHaveTextContent(/taste is now your active theme/i);
-            expect(installApi.requests).toHaveLength(1);
-        } else {
-            await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
-            expect(installApi.requests).toHaveLength(0);
-        }
-    });
-
-    it("replaces a blocked marketplace installation in history", async () => {
-        fakeThemeWorld();
-        fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "taste" })] });
-        const replaceState = vi.spyOn(window.history, "replaceState");
-        await renderAdminApp(
-            "/settings/theme/install?source=github&ref=TryGhost/Taste",
-            themeLimits(["casper"], "Upgrade to use custom themes")
-        );
-
-        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
-        await expect.poll(currentRoute).toBe("/settings/theme");
-
-        expect(replaceState.mock.calls.some(([, , url]) => String(url).endsWith("#/settings/theme"))).toBe(true);
-        replaceState.mockRestore();
-    });
-
-    it("confirms before discarding editor changes", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        await renderAdminApp("/settings/theme/edit/edition");
-
-        const editor = await editorTextbox();
-        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
-        await expect.element(settingsScreen.themeEditorConfirmModal()).toHaveTextContent(/unsaved theme changes/i);
-        await userEvent.keyboard("{Escape}");
-        await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(0);
-        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
-        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Discard changes" }).click();
-        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-    });
-
-    it.each([
-        { from: "theme", destination: "/settings/theme" },
-        { from: "staff/owner-transfer", destination: "/settings/design/change-theme" },
-    ])("only honours allowlisted editor return routes", async ({ from, destination }) => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        await renderAdminApp(`/settings/theme/edit/edition?from=${from}`);
-
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
-        await expect.poll(currentRoute).toBe(destination);
-    });
-
-    it("opens the code editor from the active theme overflow menu and returns to settings on close", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        await renderAdminApp("/settings");
-
-        await settingsScreen.theme().getByRole("button", { name: "Menu" }).click();
-        await settingsScreen.menuItem("Edit code").click();
-
-        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-        await expect.poll(currentRoute).toContain("/settings/theme/edit/edition");
-
-        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
-        await expect.poll(currentRoute).toBe("/settings");
-        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-        await expect.element(settingsScreen.theme()).toBeVisible();
-    });
-
-    it("redirects invalid editor theme names", async () => {
-        fakeThemeWorld();
-        await renderAdminApp("/settings/theme/edit/%2Fedition");
-
-        await expect.poll(currentRoute).toBe("/settings/theme");
-        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-    });
-
-    it("shows a controlled message for non-editable files", async () => {
-        fakeThemeWorld();
-        await fakeThemeDownload("edition");
-        await renderAdminApp("/settings/theme/edit/edition");
-
-        const modal = settingsScreen.themeCodeEditorModal();
-        await modal.getByRole("button", { name: ".DS_Store" }).click();
-        await expect.element(modal).toHaveTextContent(/cannot be edited in the browser/i);
-        await expect(modal.getByRole("textbox")).toHaveCount(0);
-    });
+    const modal = settingsScreen.themeCodeEditorModal();
+    await modal.getByRole('button', { name: '.DS_Store' }).click();
+    await expect.element(modal).toHaveTextContent(/cannot be edited in the browser/i);
+    await expect(modal.getByRole('textbox')).toHaveCount(0);
+  });
 });

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -14,6 +14,8 @@ import {
   type Theme,
 } from '@test-utils/acceptance';
 import * as sel from '@tryghost/test-data/selectors/settings';
+import { STICKY_FOOTER_TESTID } from '@/settings/components/confirmation-modal';
+import { THEME_PROBLEM_LIST_TESTID } from '@/settings/site/theme/theme-validation-details';
 import { settingsScreen } from '@/settings/settings.screen';
 
 function themes(): Theme[] {
@@ -132,6 +134,12 @@ function codeSpan(text: string): HTMLElement {
     throw new Error(`No <code> reading ${text} was rendered`);
   }
   return match;
+}
+
+/** Every bordered problem list in the open dialog, in document order. */
+function problemLists(): HTMLElement[] {
+  const dialog = settingsScreen.confirmationModal().element();
+  return [...dialog.querySelectorAll<HTMLElement>(`[data-testid="${THEME_PROBLEM_LIST_TESTID}"]`)];
 }
 
 async function editorTextbox() {
@@ -455,11 +463,13 @@ describe('Theme settings', () => {
     await expect.element(dialog).toHaveTextContent('1 error, 8 warnings');
 
     const scroller = dialog.element() as HTMLElement;
-    const list = scroller.querySelector<HTMLElement>('div.overflow-hidden.rounded-lg.border')!;
-    const footer = scroller.querySelector<HTMLElement>('.z-\\[297\\]')!;
-    // The footer's own background: `sticky bottom-0`, 84px tall, and the
-    // only thing standing between scrolling rows and the buttons.
-    const mask = scroller.querySelector<HTMLElement>('.z-\\[299\\]')!;
+    const [list] = problemLists();
+    const footer = scroller.querySelector<HTMLElement>(`[data-testid="${STICKY_FOOTER_TESTID}"]`)!;
+    // The footer's own background: `sticky bottom-0`, 84px tall, and the only
+    // thing standing between scrolling rows and the buttons. It's the part of
+    // the footer the buttons sit in — the other parts are decoration.
+    const okButton = dialog.getByTestId('ok-modal').element();
+    const mask = [...footer.children].find((part) => part.contains(okButton)) as HTMLElement;
     expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
     expect(getComputedStyle(mask).backgroundColor).not.toMatch(/rgba\(.*, 0\)$/);
 
@@ -581,9 +591,7 @@ describe('Theme settings', () => {
 
     // Both groups are errors; only one of them stopped the upload. Labelling
     // them identically leaves the dialog unable to say which.
-    const lists = errorModal
-      .element()
-      .querySelectorAll<HTMLElement>('div.overflow-hidden.rounded-lg.border');
+    const lists = problemLists();
     expect(lists).toHaveLength(2);
     expect(lists[0].textContent).toContain('GS010-PJ-REQ');
     expect(lists[0].textContent).toContain('Blocking');
@@ -672,6 +680,59 @@ describe('Theme settings', () => {
     await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
     expect(uploadApi.requests).toHaveLength(1);
   });
+
+  it.each([
+    {
+      severity: 'warnings',
+      problems: { warnings: [themeProblem({ code: 'GS001-DEPR-PURL' })] },
+      sentence: 'edition is now visible to your readers, but it has some warnings.',
+      summary: '1 warning',
+    },
+    {
+      severity: 'issues',
+      problems: {
+        errors: [
+          themeProblem({
+            code: 'GS005-TPL-ERR',
+            level: 'error',
+            rule: 'Templates must contain valid Handlebars',
+          }),
+        ],
+        warnings: [themeProblem({ code: 'GS001-DEPR-PURL' })],
+      },
+      sentence: 'edition is now visible to your readers, but it has some issues.',
+      summary: '1 error, 1 warning',
+    },
+  ])(
+    'says the live theme carries $severity after saving it',
+    async ({ problems, sentence, summary }) => {
+      fakeThemeWorld();
+      await fakeThemeDownload('edition');
+      fakeAdminEndpoint('POST', '/themes/upload/', {
+        themes: [theme({ name: 'edition', active: true, ...problems })],
+      });
+      await renderAdminApp('/settings/theme/edit/edition');
+
+      const editor = await editorTextbox();
+      await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+      await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
+      await settingsScreen
+        .themeEditorConfirmModal()
+        .getByRole('button', { name: 'Replace theme' })
+        .click();
+
+      // The saved theme is the live one, so the dialog reports it as live —
+      // but a set of problems is listed directly underneath, and calling that
+      // a clean success contradicts the list saying otherwise.
+      const installedModal = settingsScreen.confirmationModal();
+      await expect.element(installedModal).toHaveTextContent(sentence);
+      await expect.element(installedModal).not.toHaveTextContent('successfully');
+      await expect.element(installedModal).toHaveTextContent(summary);
+      await expect.element(installedModal.getByRole('link', { name: /Take a look/ })).toBeVisible();
+      // Nothing left to activate, so the dialog only acknowledges.
+      await expect.element(installedModal.getByTestId('ok-modal')).toHaveTextContent('OK');
+    },
+  );
 
   it('runs the current save flow from the keyboard shortcut', async () => {
     fakeThemeWorld();

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -102,6 +102,11 @@ async function uploadThemeFile(file: File): Promise<void> {
     await page.elementLocator(input).upload(file);
 }
 
+/** Whole-pixel distance between two box edges; 0 means flush, either way round. */
+function edgeGap(a: number, b: number): number {
+    return Math.abs(Math.round(a - b));
+}
+
 /** Line height as a multiple of font size, so sizes of different scale compare. */
 function lineRatio(style: CSSStyleDeclaration): number {
     return parseFloat(style.lineHeight) / parseFloat(style.fontSize);
@@ -362,7 +367,7 @@ describe("Theme settings", () => {
         expect(activateApi.requests).toHaveLength(1);
     });
 
-    it("seats the sticky footer against the issue list without an empty band", async () => {
+    it("seats the sticky footer flush against the issue list, with no empty band and no shadow rule", async () => {
         fakeThemeWorld();
         fakeAdminEndpoint("POST", "/themes/upload/", {
             themes: [
@@ -387,11 +392,28 @@ describe("Theme settings", () => {
 
         const scroller = dialog.element() as HTMLElement;
         const list = scroller.querySelector<HTMLElement>("div.overflow-hidden.rounded-lg.border")!;
+        const footer = scroller.querySelector<HTMLElement>(".z-\\[297\\]")!;
         // The footer's own background: `sticky bottom-0`, 84px tall, and the
         // only thing standing between scrolling rows and the buttons.
         const mask = scroller.querySelector<HTMLElement>(".z-\\[299\\]")!;
         expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
         expect(getComputedStyle(mask).backgroundColor).not.toMatch(/rgba\(.*, 0\)$/);
+
+        // The component closes with a decorative scroll rule. Over a dialog
+        // whose footer already reads as a distinct block it lands as a hairline
+        // drawn across the buttons, so it must not render at all...
+        const rule = footer.lastElementChild as HTMLElement;
+        expect(rule).not.toBe(mask);
+        // ...and this is the element that would draw it.
+        expect(getComputedStyle(rule).boxShadow).not.toBe("none");
+        expect(getComputedStyle(rule).display).toBe("none");
+        expect(rule.getBoundingClientRect().height).toBe(0);
+        // Nothing else in the footer paints one in its place.
+        for (const part of [footer, ...footer.children]) {
+            if (part !== rule) {
+                expect(getComputedStyle(part).boxShadow).toBe("none");
+            }
+        }
 
         // Mid-scroll the mask is pinned to the bottom of the scroll port and
         // rows run underneath it rather than showing through.
@@ -400,12 +422,17 @@ describe("Theme settings", () => {
         await expect.poll(() => Math.round(mask.getBoundingClientRect().height)).toBe(84);
         expect(list.getBoundingClientRect().bottom).toBeGreaterThan(mask.getBoundingClientRect().top);
 
-        // Scrolled to the end the footer returns to flow, and the list has to
-        // end exactly where the footer's background begins — the 24px spacer
-        // the component opens with would read as an empty band here.
+        // Scrolled to the end the footer returns to flow, and every part of it
+        // has to close up: the list ends exactly where the footer's background
+        // begins, and that background reaches the dialog's own bottom edge.
+        // Slack left anywhere in the footer's 84px box reads as an empty band —
+        // above the buttons if it sits before the background, below them if it
+        // sits after.
         scroller.scrollTop = scroller.scrollHeight;
-        await expect.poll(() => Math.round(mask.getBoundingClientRect().bottom)).toBe(Math.round(scroller.getBoundingClientRect().bottom));
-        await expect.poll(() => Math.round(mask.getBoundingClientRect().top - list.getBoundingClientRect().bottom)).toBe(0);
+        await expect.poll(() => edgeGap(mask.getBoundingClientRect().top, list.getBoundingClientRect().bottom)).toBe(0);
+        expect(edgeGap(footer.getBoundingClientRect().bottom, scroller.getBoundingClientRect().bottom)).toBe(0);
+        expect(edgeGap(mask.getBoundingClientRect().bottom, footer.getBoundingClientRect().bottom)).toBe(0);
+        expect(Math.round(mask.getBoundingClientRect().height)).toBe(84);
     });
 
     it("reports blocking upload errors and re-opens the upload dialog from the error dialog", async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -275,6 +275,11 @@ describe('Theme settings', () => {
       getComputedStyle(badge).color,
     );
 
+    // The gscan code sits on the same row as the badge, so the two read as
+    // one line rather than the code out-sizing the label beside it.
+    const problemCode = installedModal.getByText('GS005-TPL-ERR', { exact: true }).element();
+    expect(getComputedStyle(problemCode).fontSize).toBe(getComputedStyle(badge).fontSize);
+
     // Every issue is listed up front; each one expands on its own.
     await expect(installedModal.getByRole('button', { name: /GS001-DEPR-PURL/ })).toHaveCount(1);
     await expect(installedModal.getByText(/deprecated/)).toHaveCount(0);

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
 
 import {
@@ -185,6 +185,42 @@ describe("Theme settings", () => {
         await installedModal.getByRole("button", { name: /GS001-DEPR-PURL/ }).click();
         await expect.element(installedModal.getByText(/deprecated/)).toBeVisible();
         await expect.element(installedModal).toHaveTextContent("Affected files");
+    });
+
+    it("flips an expanding issue row's chevron a single half turn", async () => {
+        fakeThemeWorld();
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            themes: [theme({ name: "mytheme", warnings: [themeProblem({ code: "GS001-DEPR-PURL" })] })],
+        });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
+
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+
+        // Ghost's legacy Ember stylesheet ships Tachyons' `.rotate-180 {transform:
+        // rotate(180deg)}` unlayered alongside Tailwind v4's `.rotate-180 {rotate:
+        // 180deg}`. An icon carrying that literal class picks up both and turns a
+        // full circle, landing back where it started — the bug this dialog was
+        // rebuilt to fix. This tier serves no Ember CSS, so the collision is staged
+        // here; the chevron must rotate via a selector that rule cannot match.
+        const legacyTachyons = document.createElement("style");
+        legacyTachyons.textContent = ".rotate-180 { transform: rotate(180deg); }";
+        document.head.appendChild(legacyTachyons);
+        onTestFinished(() => legacyTachyons.remove());
+
+        const row = settingsScreen.confirmationModal().getByRole("button", { name: /GS001-DEPR-PURL/ });
+        await expect.element(row).toBeVisible();
+        const chevron = () => (row.element() as HTMLElement).querySelector("svg")!;
+        expect(getComputedStyle(chevron()).rotate).toBe("none");
+
+        await row.click();
+
+        // Polling rides out the expand transition without a fixed wait: an
+        // interpolated frame reads as an intermediate angle, never as 180deg.
+        await expect.poll(() => getComputedStyle(chevron()).rotate).toBe("180deg");
+        // ...and nothing may add a second rotation on top of that one.
+        expect(getComputedStyle(chevron()).transform).toBe("none");
     });
 
     it("keeps the installed-theme dialog open when activation fails", async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -1,693 +1,590 @@
-import { describe, expect, it, vi } from 'vitest';
-import { page, userEvent } from 'vitest/browser';
+import { describe, expect, it, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
 
 import {
-  configResponse,
-  currentRoute,
-  defaultThemesResponse,
-  fakeAdminEndpoint,
-  fakeEditSettings,
-  fakeSettingsScreens,
-  fakeThemes,
-  renderAdminApp,
-  theme,
-  type Theme,
-} from '@test-utils/acceptance';
-import * as sel from '@tryghost/test-data/selectors/settings';
-import { settingsScreen } from '@/settings/settings.screen';
+    configResponse,
+    currentRoute,
+    defaultThemesResponse,
+    fakeAdminEndpoint,
+    fakeEditSettings,
+    fakeSettingsScreens,
+    fakeThemes,
+    renderAdminApp,
+    theme,
+    type Theme,
+} from "@test-utils/acceptance";
+import * as sel from "@tryghost/test-data/selectors/settings";
+import { settingsScreen } from "@/settings/settings.screen";
 
 function themes(): Theme[] {
-  return defaultThemesResponse().themes;
+    return defaultThemesResponse().themes;
 }
 
 function fakeThemeWorld(): Theme[] {
-  fakeSettingsScreens();
-  const installed = themes();
-  fakeThemes(installed);
-  return installed;
+    fakeSettingsScreens();
+    const installed = themes();
+    fakeThemes(installed);
+    return installed;
 }
 
 function themeLimits(allowlist: string[], error: string) {
-  const config = configResponse();
-  config.config.hostSettings = {
-    limits: { customThemes: { allowlist, error } },
-  };
-  return { boot: { browseConfig: { response: config } } };
+    const config = configResponse();
+    config.config.hostSettings = {
+        limits: { customThemes: { allowlist, error } },
+    };
+    return { boot: { browseConfig: { response: config } } };
 }
 
 async function archiveBuffer(): Promise<ArrayBuffer> {
-  const fixture = new URL('../../../test-utils/acceptance/fixtures/theme.zip', import.meta.url);
-  return await fetch(fixture).then((response) => response.arrayBuffer());
+    const fixture = new URL("../../../test-utils/acceptance/fixtures/theme.zip", import.meta.url);
+    return await fetch(fixture).then(response => response.arrayBuffer());
 }
 
 async function fakeThemeDownload(name: string): Promise<void> {
-  fakeAdminEndpoint('GET', `/themes/${name}/download/`, await archiveBuffer(), {
-    contentType: 'application/zip',
-  });
+    fakeAdminEndpoint("GET", `/themes/${name}/download/`, await archiveBuffer(), { contentType: "application/zip" });
+}
+
+function themeProblem(overrides: { code: string; level?: string; rule?: string }) {
+    return {
+        level: "warning",
+        rule: "Replace {{@blog.url}} with {{@site.url}}",
+        details: "The helper {{@blog.url}} is deprecated and will be removed in a future version of Ghost.",
+        failures: [{ ref: "default.hbs", message: "line 12" }],
+        fatal: false,
+        ...overrides,
+    };
 }
 
 function installedTheme(name: string) {
-  return settingsScreen
-    .themeModal()
-    .getByTestId(sel.themeListItem)
-    .filter({ hasText: new RegExp(name, 'i') });
+    return settingsScreen.themeModal().getByTestId(sel.themeListItem).filter({ hasText: new RegExp(name, "i") });
 }
 
 async function uploadThemeFile(file: File): Promise<void> {
-  const prompt = page.getByText('Click to select or drag & drop zip file', { exact: true });
-  await expect.element(prompt).toBeVisible();
-  const input = prompt.element().parentElement?.querySelector('input[type=file]');
-  if (!(input instanceof HTMLInputElement)) {
-    throw new Error('Theme upload input was not rendered');
-  }
-  await page.elementLocator(input).upload(file);
+    const prompt = page.getByText("Click to select or drag & drop zip file", { exact: true });
+    await expect.element(prompt).toBeVisible();
+    const input = prompt.element().parentElement?.querySelector("input[type=file]");
+    if (!(input instanceof HTMLInputElement)) {
+        throw new Error("Theme upload input was not rendered");
+    }
+    await page.elementLocator(input).upload(file);
 }
 
 async function editorTextbox() {
-  const editor = settingsScreen.themeCodeEditorModal().getByRole('textbox').first();
-  await expect.element(editor).toBeVisible();
-  return editor;
+    const editor = settingsScreen.themeCodeEditorModal().getByRole("textbox").first();
+    await expect.element(editor).toBeVisible();
+    return editor;
 }
 
-describe('Theme settings', () => {
-  it('activates an installed official theme and updates another', async () => {
-    const installed = fakeThemeWorld();
-    const casper = installed.find((item) => item.name === 'casper')!;
-    const activateApi = fakeAdminEndpoint('PUT', '/themes/casper/activate/', {
-      themes: [{ ...casper, active: true }],
+describe("Theme settings", () => {
+    it("activates an installed official theme and updates another", async () => {
+        const installed = fakeThemeWorld();
+        const casper = installed.find(item => item.name === "casper")!;
+        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", { themes: [{ ...casper, active: true }] });
+        const installApi = fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "edition" })] });
+        await renderAdminApp("/settings/design/change-theme", {
+            boot: { browseActiveTheme: { response: { themes: [installed.find(item => item.active)!] } } },
+        });
+
+        const modal = settingsScreen.themeModal();
+        await modal.getByRole("button", { name: /Casper/ }).click();
+        await modal.getByRole("button", { name: "Activate Casper" }).click();
+        await settingsScreen.confirmationModal().getByRole("button", { name: "Activate" }).click();
+        await expect.element(settingsScreen.successToast()).toHaveTextContent(/casper is now your active theme/i);
+        expect(activateApi.requests).toHaveLength(1);
+
+        await settingsScreen.theme().getByRole("button", { name: "Change theme" }).click();
+        const reopenedModal = settingsScreen.themeModal();
+        await reopenedModal.getByRole("button", { name: /Edition/ }).click();
+        await reopenedModal.getByRole("button", { name: "Update Edition" }).click();
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/overwrite/i);
+        await settingsScreen.confirmationModal().getByRole("button", { name: "Overwrite" }).click();
+        await expect.poll(() => installApi.lastRequest?.url).toContain("ref=TryGhost%2FEdition");
     });
-    const installApi = fakeAdminEndpoint('POST', /^\/themes\/install\/\?/, {
-      themes: [theme({ name: 'edition' })],
+
+    it("manages installed themes", async () => {
+        const installed = fakeThemeWorld();
+        const casper = installed.find(item => item.name === "casper")!;
+        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", { themes: [{ ...casper, active: true }] });
+        const deleteApi = fakeAdminEndpoint("DELETE", "/themes/edition/", {});
+        await renderAdminApp("/settings/design/change-theme");
+
+        const modal = settingsScreen.themeModal();
+        await modal.getByRole("tab", { name: "Installed" }).click();
+        await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(2);
+        await installedTheme("casper").getByRole("button", { name: "Activate" }).click();
+        await expect.element(installedTheme("casper")).toHaveTextContent(/Active/);
+        expect(activateApi.requests).toHaveLength(1);
+
+        await installedTheme("casper").getByRole("button", { name: "Menu" }).click();
+        await settingsScreen.menuItem("Download").click();
+        await expect.poll(() => document.querySelector<HTMLIFrameElement>("iframe#iframeDownload")?.src).toMatch(/\/api\/admin\/themes\/casper\/download/);
+
+        await installedTheme("edition").getByRole("button", { name: "Menu" }).click();
+        await settingsScreen.menuItem("Delete").click();
+        await settingsScreen.confirmationModal().getByRole("button", { name: "Delete" }).click();
+        await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(1);
+        expect(deleteApi.requests).toHaveLength(1);
     });
-    await renderAdminApp('/settings/design/change-theme', {
-      boot: {
-        browseActiveTheme: { response: { themes: [installed.find((item) => item.active)!] } },
-      },
+
+    it("closes an installed-theme menu with Escape without closing the theme modal", async () => {
+        fakeThemeWorld();
+        await renderAdminApp("/settings/design/change-theme");
+
+        const modal = settingsScreen.themeModal();
+        await modal.getByRole("tab", { name: "Installed" }).click();
+        await installedTheme("casper").getByRole("button", { name: "Menu" }).click();
+        await expect.element(settingsScreen.menuItem("Download")).toBeVisible();
+
+        await userEvent.keyboard("{Escape}");
+
+        await expect(settingsScreen.menuItem("Download")).toHaveCount(0);
+        await expect.element(modal).toBeVisible();
+        await expect.poll(currentRoute).toBe("/settings/design/change-theme");
     });
 
-    const modal = settingsScreen.themeModal();
-    await modal.getByRole('button', { name: /Casper/ }).click();
-    await modal.getByRole('button', { name: 'Activate Casper' }).click();
-    await settingsScreen.confirmationModal().getByRole('button', { name: 'Activate' }).click();
-    await expect
-      .element(settingsScreen.successToast())
-      .toHaveTextContent(/casper is now your active theme/i);
-    expect(activateApi.requests).toHaveLength(1);
+    it("uploads a theme archive", async () => {
+        fakeThemeWorld();
+        const uploaded = theme({ name: "mytheme" });
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
 
-    await settingsScreen.theme().getByRole('button', { name: 'Change theme' }).click();
-    const reopenedModal = settingsScreen.themeModal();
-    await reopenedModal.getByRole('button', { name: /Edition/ }).click();
-    await reopenedModal.getByRole('button', { name: 'Update Edition' }).click();
-    await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/overwrite/i);
-    await settingsScreen.confirmationModal().getByRole('button', { name: 'Overwrite' }).click();
-    await expect.poll(() => installApi.lastRequest?.url).toContain('ref=TryGhost%2FEdition');
-  });
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "theme.zip", { type: "application/zip" }));
 
-  it('manages installed themes', async () => {
-    const installed = fakeThemeWorld();
-    const casper = installed.find((item) => item.name === 'casper')!;
-    const activateApi = fakeAdminEndpoint('PUT', '/themes/casper/activate/', {
-      themes: [{ ...casper, active: true }],
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent("mytheme was uploaded successfully. Do you want to activate it?");
+        expect(uploadApi.requests).toHaveLength(1);
     });
-    const deleteApi = fakeAdminEndpoint('DELETE', '/themes/edition/', {});
-    await renderAdminApp('/settings/design/change-theme');
 
-    const modal = settingsScreen.themeModal();
-    await modal.getByRole('tab', { name: 'Installed' }).click();
-    await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(2);
-    await installedTheme('casper').getByRole('button', { name: 'Activate' }).click();
-    await expect.element(installedTheme('casper')).toHaveTextContent(/Active/);
-    expect(activateApi.requests).toHaveLength(1);
+    it("summarises non-blocking issues on the installed-theme dialog", async () => {
+        fakeThemeWorld();
+        const uploaded = theme({
+            name: "mytheme",
+            errors: [themeProblem({ code: "GS005-TPL-ERR", level: "error", rule: "Templates must contain valid Handlebars" })],
+            warnings: [
+                themeProblem({ code: "GS001-DEPR-PURL", rule: "Replace {{@blog.url}} with {{@site.url}}" }),
+                themeProblem({ code: "GS002-DISQUS-ID", rule: "Disqus id should be present" }),
+            ],
+        });
+        fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
 
-    await installedTheme('casper').getByRole('button', { name: 'Menu' }).click();
-    await settingsScreen.menuItem('Download').click();
-    await expect
-      .poll(() => document.querySelector<HTMLIFrameElement>('iframe#iframeDownload')?.src)
-      .toMatch(/\/api\/admin\/themes\/casper\/download/);
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
 
-    await installedTheme('edition').getByRole('button', { name: 'Menu' }).click();
-    await settingsScreen.menuItem('Delete').click();
-    await settingsScreen.confirmationModal().getByRole('button', { name: 'Delete' }).click();
-    await expect(modal.getByTestId(sel.themeListItem)).toHaveCount(1);
-    expect(deleteApi.requests).toHaveLength(1);
-  });
+        const installedModal = settingsScreen.confirmationModal();
+        // Errors and warnings are merged into one list, so the sentence says
+        // "issues" rather than contradicting the "1 error" in the heading.
+        await expect.element(installedModal).toHaveTextContent("mytheme was uploaded, but it has some issues. Do you want to activate it?");
+        await expect.element(installedModal).toHaveTextContent("1 error, 2 warnings");
 
-  it('closes an installed-theme menu with Escape without closing the theme modal', async () => {
-    fakeThemeWorld();
-    await renderAdminApp('/settings/design/change-theme');
-
-    const modal = settingsScreen.themeModal();
-    await modal.getByRole('tab', { name: 'Installed' }).click();
-    await installedTheme('casper').getByRole('button', { name: 'Menu' }).click();
-    await expect.element(settingsScreen.menuItem('Download')).toBeVisible();
-
-    await userEvent.keyboard('{Escape}');
-
-    await expect(settingsScreen.menuItem('Download')).toHaveCount(0);
-    await expect.element(modal).toBeVisible();
-    await expect.poll(currentRoute).toBe('/settings/design/change-theme');
-  });
-
-  it('uploads a theme archive', async () => {
-    fakeThemeWorld();
-    const uploaded = theme({ name: 'mytheme' });
-    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', { themes: [uploaded] });
-    const buffer = await archiveBuffer();
-    await renderAdminApp('/settings/design/change-theme');
-
-    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
-    await uploadThemeFile(new File([buffer], 'theme.zip', { type: 'application/zip' }));
-
-    await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/successful/i);
-    expect(uploadApi.requests).toHaveLength(1);
-  });
-
-  it('keeps the installed-theme dialog open when activation fails', async () => {
-    fakeThemeWorld();
-    const uploaded = theme({ name: 'mytheme' });
-    fakeAdminEndpoint('POST', '/themes/upload/', { themes: [uploaded] });
-    const activateApi = fakeAdminEndpoint(
-      'PUT',
-      '/themes/mytheme/activate/',
-      {
-        errors: [{ message: 'Theme activation failed' }],
-      },
-      { status: 422 },
-    );
-    const buffer = await archiveBuffer();
-    await renderAdminApp('/settings/design/change-theme');
-
-    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
-    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
-
-    const installedModal = settingsScreen.confirmationModal();
-    await installedModal.getByRole('button', { name: 'Activate theme' }).click();
-
-    await expect.element(installedModal).toBeVisible();
-    await expect.element(settingsScreen.errorToast()).toHaveTextContent('Theme activation failed');
-    await expect.poll(currentRoute).toBe('/settings/design/change-theme');
-    expect(activateApi.requests).toHaveLength(1);
-  });
-
-  it('reports blocking upload errors and retries the upload from the error dialog', async () => {
-    fakeThemeWorld();
-    const uploadApi = fakeAdminEndpoint(
-      'POST',
-      '/themes/upload/',
-      {
-        errors: [
-          { message: 'Theme is not compatible or contains errors.', details: 'Missing index.hbs' },
-        ],
-      },
-      { status: 422 },
-    );
-    const buffer = await archiveBuffer();
-    await renderAdminApp('/settings/design/change-theme');
-
-    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
-    await uploadThemeFile(new File([buffer], 'theme.zip', { type: 'application/zip' }));
-
-    const errorModal = settingsScreen.confirmationModal();
-    await expect.element(errorModal).toHaveTextContent('Theme not uploaded');
-    await expect.element(errorModal).toHaveTextContent('Missing index.hbs');
-    expect(uploadApi.requests).toHaveLength(1);
-
-    await errorModal.getByRole('button', { name: 'Retry' }).click();
-    await expect
-      .element(page.getByText('Click to select or drag & drop zip file', { exact: true }))
-      .toBeVisible();
-    await expect(page.getByText('Theme not uploaded')).toHaveCount(0);
-  });
-
-  it('reports blocking activation errors for an installed theme', async () => {
-    fakeThemeWorld();
-    const activateApi = fakeAdminEndpoint(
-      'PUT',
-      '/themes/casper/activate/',
-      {
-        errors: [
-          { message: 'Theme is not compatible or contains errors.', details: 'Missing post.hbs' },
-        ],
-      },
-      { status: 422 },
-    );
-    await renderAdminApp('/settings/design/change-theme');
-
-    const modal = settingsScreen.themeModal();
-    await modal.getByRole('tab', { name: 'Installed' }).click();
-    await installedTheme('casper').getByRole('button', { name: 'Activate' }).click();
-
-    const errorModal = settingsScreen.confirmationModal();
-    await expect.element(errorModal).toHaveTextContent('Theme not activated');
-    await expect.element(errorModal).toHaveTextContent('Missing post.hbs');
-    expect(activateApi.requests).toHaveLength(1);
-
-    await errorModal.getByRole('button', { name: 'Close' }).click();
-    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-    await expect.element(modal).toBeVisible();
-  });
-
-  it('prevents uploading an archive over a built-in theme', async () => {
-    fakeThemeWorld();
-    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', {
-      themes: [theme({ name: 'source' })],
+        // Every issue is listed up front; each one expands on its own.
+        await expect(installedModal.getByRole("button", { name: /GS001-DEPR-PURL/ })).toHaveCount(1);
+        await expect(installedModal.getByText(/deprecated/)).toHaveCount(0);
+        await installedModal.getByRole("button", { name: /GS001-DEPR-PURL/ }).click();
+        await expect.element(installedModal.getByText(/deprecated/)).toBeVisible();
+        await expect.element(installedModal).toHaveTextContent("Affected files");
     });
-    const buffer = await archiveBuffer();
-    await renderAdminApp('/settings/design/change-theme');
 
-    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
-    await uploadThemeFile(new File([buffer], 'source.zip', { type: 'application/zip' }));
+    it("keeps the installed-theme dialog open when activation fails", async () => {
+        fakeThemeWorld();
+        const uploaded = theme({ name: "mytheme" });
+        fakeAdminEndpoint("POST", "/themes/upload/", { themes: [uploaded] });
+        const activateApi = fakeAdminEndpoint("PUT", "/themes/mytheme/activate/", {
+            errors: [{ message: "Theme activation failed" }],
+        }, { status: 422 });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
 
-    await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Upload failed/i);
-    await expect
-      .element(settingsScreen.confirmationModal())
-      .toHaveTextContent(/cannot be overwritten/i);
-    expect(uploadApi.requests).toHaveLength(0);
-  });
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
 
-  it('loads the code editor and saves a changed theme', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', {
-      themes: [theme({ name: 'edition', active: true })],
+        const installedModal = settingsScreen.confirmationModal();
+        await installedModal.getByRole("button", { name: "Activate theme" }).click();
+
+        await expect.element(installedModal).toBeVisible();
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent("Theme activation failed");
+        await expect.poll(currentRoute).toBe("/settings/design/change-theme");
+        expect(activateApi.requests).toHaveLength(1);
     });
-    await renderAdminApp('/settings/theme/edit/edition');
 
-    const modal = settingsScreen.themeCodeEditorModal();
-    await expect.element(modal).toHaveTextContent(/Edit theme/);
-    await expect.element(modal).toHaveTextContent(/json/i);
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    await expect.element(modal).toHaveTextContent(/1 file modified/);
-    await modal.getByRole('button', { name: 'Save' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Replace theme' })
-      .click();
+    it("reports blocking upload errors and re-opens the upload dialog from the error dialog", async () => {
+        fakeThemeWorld();
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing index.hbs" }],
+        }, { status: 422 });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
 
-    await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
-    expect(uploadApi.requests).toHaveLength(1);
-  });
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
 
-  it('runs the current save flow from the keyboard shortcut', async () => {
-    fakeThemeWorld();
-    // The editor shortcut currently propagates to the settings form too;
-    // keep that pre-existing request in the declared world (follow-up).
-    fakeEditSettings();
-    await fakeThemeDownload('edition');
-    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/', {
-      themes: [theme({ name: 'edition', active: true })],
+        const errorModal = settingsScreen.confirmationModal();
+        await expect.element(errorModal).toHaveTextContent("Theme not uploaded");
+        await expect.element(errorModal).toHaveTextContent("mytheme couldn't be uploaded. Fix the errors below and try again.");
+        await expect.element(errorModal).toHaveTextContent("Missing index.hbs");
+        expect(uploadApi.requests).toHaveLength(1);
+
+        await errorModal.getByRole("button", { name: "Re-upload" }).click();
+        await expect.element(page.getByText("Click to select or drag & drop zip file", { exact: true })).toBeVisible();
+        await expect(page.getByText("Theme not uploaded")).toHaveCount(0);
     });
-    await renderAdminApp('/settings/theme/edit/edition');
 
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    window.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true }),
-    );
-    await expect.element(settingsScreen.themeEditorConfirmModal()).toBeVisible();
-    window.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true }),
-    );
-    await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(1);
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Replace theme' })
-      .click();
+    it("reports blocking activation errors for an installed theme", async () => {
+        fakeThemeWorld();
+        const activateApi = fakeAdminEndpoint("PUT", "/themes/casper/activate/", {
+            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing post.hbs" }],
+        }, { status: 422 });
+        await renderAdminApp("/settings/design/change-theme");
 
-    await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
-    expect(uploadApi.requests).toHaveLength(1);
-  });
+        const modal = settingsScreen.themeModal();
+        await modal.getByRole("tab", { name: "Installed" }).click();
+        await installedTheme("casper").getByRole("button", { name: "Activate" }).click();
 
-  it('surfaces server-side archive limit details', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    fakeAdminEndpoint(
-      'POST',
-      '/themes/upload/',
-      {
-        errors: [
-          {
-            message: 'Zip entry exceeds maximum uncompressed size.',
-            errorType: 'UnsupportedMediaTypeError',
-            code: 'ENTRY_TOO_LARGE',
-            errorDetails: {
-              entryName: 'partials/huge.hbs',
-              observedBytes: 2_000_000,
-              limitBytes: 1_048_576,
-            },
-          },
-        ],
-      },
-      { status: 415 },
-    );
-    await renderAdminApp('/settings/theme/edit/edition');
+        const errorModal = settingsScreen.confirmationModal();
+        await expect.element(errorModal).toHaveTextContent("Theme not activated");
+        await expect.element(errorModal).toHaveTextContent("Missing post.hbs");
+        expect(activateApi.requests).toHaveLength(1);
 
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Replace theme' })
-      .click();
-
-    await expect.element(settingsScreen.errorToast()).toHaveTextContent(/partials\/huge\.hbs/);
-    await expect.element(settingsScreen.errorToast()).toHaveTextContent(/1\.0 MB/);
-  });
-
-  it('falls back to the generic API error for malformed archive limit details', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    fakeAdminEndpoint(
-      'POST',
-      '/themes/upload/',
-      {
-        errors: [
-          {
-            message: 'Zip entry exceeds maximum uncompressed size.',
-            errorType: 'UnsupportedMediaTypeError',
-            code: 'ENTRY_TOO_LARGE',
-            errorDetails: { entryName: 'partials/huge.hbs', limitBytes: 'not-a-number' },
-          },
-        ],
-      },
-      { status: 415 },
-    );
-    await renderAdminApp('/settings/theme/edit/edition');
-
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Replace theme' })
-      .click();
-
-    await expect
-      .element(settingsScreen.errorToast())
-      .toHaveTextContent('Request contains an unknown or unsupported file type.');
-    await expect.element(settingsScreen.errorToast()).not.toHaveTextContent('NaN');
-  });
-
-  it('keeps the code editor open and reports blocking validation errors on save', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    fakeAdminEndpoint(
-      'POST',
-      '/themes/upload/',
-      {
-        errors: [
-          {
-            message: 'Theme is not compatible or contains errors.',
-            details: 'Missing default.hbs',
-          },
-        ],
-      },
-      { status: 422 },
-    );
-    await renderAdminApp('/settings/theme/edit/edition');
-
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Replace theme' })
-      .click();
-
-    const errorModal = settingsScreen.confirmationModal();
-    await expect.element(errorModal).toHaveTextContent('Theme not saved');
-    await expect.element(errorModal).toHaveTextContent('Missing default.hbs');
-    await expect(errorModal.getByRole('button', { name: 'Retry' })).toHaveCount(0);
-    await userEvent.keyboard('{Escape}');
-    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-  });
-
-  it('falls back to the generic API error for an empty validation payload', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    fakeAdminEndpoint('POST', '/themes/upload/', { errors: [] }, { status: 422 });
-    await renderAdminApp('/settings/theme/edit/edition');
-
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Replace theme' })
-      .click();
-
-    await expect.element(settingsScreen.errorToast()).toHaveTextContent(/Something went wrong/i);
-    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-  });
-
-  it('requires built-in themes to be saved under a valid new name', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('casper');
-    await renderAdminApp('/settings/theme/edit/casper');
-
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"casper","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    const inputModal = settingsScreen.themeEditorInputModal();
-    await inputModal.getByLabelText('Theme name').fill('Foo Bar!');
-    await inputModal.getByRole('button', { name: 'Continue' }).click();
-    await expect.element(page.getByText(/Invalid theme name/i)).toBeVisible();
-
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    await inputModal.getByLabelText('Theme name').fill('casper');
-    await inputModal.getByRole('button', { name: 'Continue' }).click();
-    await expect.element(page.getByText(/Built-in themes cannot be overwritten/i)).toBeVisible();
-  });
-
-  it('saves a built-in theme under a valid new name', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('casper');
-    await fakeThemeDownload('casper-edited');
-    // saving under a new name carries over the original theme's settings
-    const uploadApi = fakeAdminEndpoint('POST', '/themes/upload/?copy_settings_from=casper', {
-      themes: [theme({ name: 'casper-edited' })],
+        await errorModal.getByRole("button", { name: "Cancel" }).click();
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(modal).toBeVisible();
     });
-    await renderAdminApp('/settings/theme/edit/casper');
 
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"casper","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-    await settingsScreen.themeEditorInputModal().getByLabelText('Theme name').fill('casper-edited');
-    await settingsScreen.themeEditorInputModal().getByRole('button', { name: 'Continue' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Save theme' })
-      .click();
+    it("prevents uploading an archive over a built-in theme", async () => {
+        fakeThemeWorld();
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "source" })] });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
 
-    await expect.poll(() => uploadApi.requests.length).toBe(1);
-    await expect.poll(currentRoute).toBe('/settings/theme/edit/casper-edited');
-    await expect.element(settingsScreen.themeCodeEditorModal()).toHaveTextContent('casper-edited');
-  });
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "source.zip", { type: "application/zip" }));
 
-  it.each([
-    { allowlist: ['casper'], opensThemes: false },
-    { allowlist: ['casper', 'edition'], opensThemes: true },
-  ])('enforces theme-change limits', async ({ allowlist, opensThemes }) => {
-    fakeThemeWorld();
-    await renderAdminApp('/settings/theme', themeLimits(allowlist, 'Upgrade to use custom themes'));
-
-    await settingsScreen.theme().getByRole('button', { name: 'Change theme' }).click();
-    if (opensThemes) {
-      await expect.element(settingsScreen.themeModal()).toBeVisible();
-      await expect(settingsScreen.limitModal()).toHaveCount(0);
-    } else {
-      await expect
-        .element(settingsScreen.limitModal())
-        .toHaveTextContent(/Upgrade to use custom themes/);
-      await expect(settingsScreen.themeModal()).toHaveCount(0);
-    }
-  });
-
-  it('prevents direct access to the theme-change route when limited', async () => {
-    fakeThemeWorld();
-    await renderAdminApp(
-      '/settings/design/change-theme',
-      themeLimits(['casper'], 'Upgrade to use custom themes'),
-    );
-
-    await expect
-      .element(settingsScreen.limitModal())
-      .toHaveTextContent(/Upgrade to use custom themes/);
-    await expect(settingsScreen.themeModal()).toHaveCount(0);
-  });
-
-  it('prevents direct access to the theme editor when editing is limited', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    await renderAdminApp(
-      '/settings/theme/edit/edition',
-      themeLimits(['casper', 'edition'], 'Upgrade to use custom themes'),
-    );
-
-    await expect
-      .element(settingsScreen.limitModal())
-      .toHaveTextContent(/Upgrade to use custom themes/);
-    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-    await expect.poll(currentRoute).toBe('/settings/theme');
-  });
-
-  it('prevents theme uploads when custom themes are limited', async () => {
-    fakeThemeWorld();
-    await renderAdminApp(
-      '/settings/design/change-theme',
-      themeLimits(['casper', 'headline', 'edition'], 'Upgrade to use more themes'),
-    );
-
-    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
-    await expect
-      .element(settingsScreen.limitModal())
-      .toHaveTextContent(/Upgrade to use more themes/);
-    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-  });
-
-  it.each([
-    { themeName: 'Headline', action: 'Install Headline', allowlist: ['casper', 'edition'] },
-    { themeName: 'Edition', action: 'Update Edition', allowlist: ['casper', 'headline'] },
-  ])(
-    'checks limits before installing or updating a theme card',
-    async ({ themeName, action, allowlist }) => {
-      fakeThemeWorld();
-      await renderAdminApp(
-        '/settings/design/change-theme',
-        themeLimits(allowlist, 'Upgrade to use more themes'),
-      );
-
-      const modal = settingsScreen.themeModal();
-      await modal.getByRole('button', { name: new RegExp(themeName) }).click();
-      await modal.getByRole('button', { name: action }).click();
-      await expect
-        .element(settingsScreen.limitModal())
-        .toHaveTextContent(/Upgrade to use more themes/);
-      await expect(settingsScreen.confirmationModal()).toHaveCount(0);
-    },
-  );
-
-  it.each([
-    { allowlist: ['casper', 'headline', 'taste'], canInstall: true },
-    { allowlist: ['casper', 'headline', 'edition'], canInstall: false },
-  ])('enforces marketplace installation limits', async ({ allowlist, canInstall }) => {
-    fakeThemeWorld();
-    const installApi = fakeAdminEndpoint('POST', /^\/themes\/install\/\?/, {
-      themes: [theme({ name: 'taste' })],
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Upload failed/i);
+        await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/cannot be overwritten/i);
+        expect(uploadApi.requests).toHaveLength(0);
     });
-    fakeAdminEndpoint('PUT', '/themes/taste/activate/', {
-      themes: [theme({ name: 'taste', active: true })],
+
+    it("loads the code editor and saves a changed theme", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "edition", active: true })] });
+        await renderAdminApp("/settings/theme/edit/edition");
+
+        const modal = settingsScreen.themeCodeEditorModal();
+        await expect.element(modal).toHaveTextContent(/Edit theme/);
+        await expect.element(modal).toHaveTextContent(/json/i);
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await expect.element(modal).toHaveTextContent(/1 file modified/);
+        await modal.getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
+
+        await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
+        expect(uploadApi.requests).toHaveLength(1);
     });
-    await renderAdminApp(
-      '/settings/theme/install?source=github&ref=TryGhost/Taste',
-      themeLimits(allowlist, 'Upgrade to use more themes'),
-    );
 
-    if (canInstall) {
-      await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Install Theme/);
-      await settingsScreen.confirmationModal().getByRole('button', { name: 'Install' }).click();
-      await expect
-        .element(settingsScreen.successToast())
-        .toHaveTextContent(/taste is now your active theme/i);
-      expect(installApi.requests).toHaveLength(1);
-    } else {
-      await expect
-        .element(settingsScreen.limitModal())
-        .toHaveTextContent(/Upgrade to use more themes/);
-      expect(installApi.requests).toHaveLength(0);
-    }
-  });
+    it("runs the current save flow from the keyboard shortcut", async () => {
+        fakeThemeWorld();
+        // The editor shortcut currently propagates to the settings form too;
+        // keep that pre-existing request in the declared world (follow-up).
+        fakeEditSettings();
+        await fakeThemeDownload("edition");
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/", { themes: [theme({ name: "edition", active: true })] });
+        await renderAdminApp("/settings/theme/edit/edition");
 
-  it('replaces a blocked marketplace installation in history', async () => {
-    fakeThemeWorld();
-    fakeAdminEndpoint('POST', /^\/themes\/install\/\?/, { themes: [theme({ name: 'taste' })] });
-    const replaceState = vi.spyOn(window.history, 'replaceState');
-    await renderAdminApp(
-      '/settings/theme/install?source=github&ref=TryGhost/Taste',
-      themeLimits(['casper'], 'Upgrade to use custom themes'),
-    );
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true, bubbles: true, cancelable: true }));
+        await expect.element(settingsScreen.themeEditorConfirmModal()).toBeVisible();
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true, bubbles: true, cancelable: true }));
+        await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(1);
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
 
-    await expect
-      .element(settingsScreen.limitModal())
-      .toHaveTextContent(/Upgrade to use custom themes/);
-    await expect.poll(currentRoute).toBe('/settings/theme');
+        await expect.element(settingsScreen.successToast()).toHaveTextContent(/Theme saved/i);
+        expect(uploadApi.requests).toHaveLength(1);
+    });
 
-    expect(
-      replaceState.mock.calls.some(([, , url]) => String(url).endsWith('#/settings/theme')),
-    ).toBe(true);
-    replaceState.mockRestore();
-  });
+    it("surfaces server-side archive limit details", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{
+                message: "Zip entry exceeds maximum uncompressed size.",
+                errorType: "UnsupportedMediaTypeError",
+                code: "ENTRY_TOO_LARGE",
+                errorDetails: { entryName: "partials/huge.hbs", observedBytes: 2_000_000, limitBytes: 1_048_576 },
+            }],
+        }, { status: 415 });
+        await renderAdminApp("/settings/theme/edit/edition");
 
-  it('confirms before discarding editor changes', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    await renderAdminApp('/settings/theme/edit/edition');
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
 
-    const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
-    await expect
-      .element(settingsScreen.themeEditorConfirmModal())
-      .toHaveTextContent(/unsaved theme changes/i);
-    await userEvent.keyboard('{Escape}');
-    await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(0);
-    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
-    await settingsScreen
-      .themeEditorConfirmModal()
-      .getByRole('button', { name: 'Discard changes' })
-      .click();
-    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-  });
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/partials\/huge\.hbs/);
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/1\.0 MB/);
+    });
 
-  it.each([
-    { from: 'theme', destination: '/settings/theme' },
-    { from: 'staff/owner-transfer', destination: '/settings/design/change-theme' },
-  ])('only honours allowlisted editor return routes', async ({ from, destination }) => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    await renderAdminApp(`/settings/theme/edit/edition?from=${from}`);
+    it("falls back to the generic API error for malformed archive limit details", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{
+                message: "Zip entry exceeds maximum uncompressed size.",
+                errorType: "UnsupportedMediaTypeError",
+                code: "ENTRY_TOO_LARGE",
+                errorDetails: { entryName: "partials/huge.hbs", limitBytes: "not-a-number" },
+            }],
+        }, { status: 415 });
+        await renderAdminApp("/settings/theme/edit/edition");
 
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
-    await expect.poll(currentRoute).toBe(destination);
-  });
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
 
-  it('opens the code editor from the active theme overflow menu and returns to settings on close', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    await renderAdminApp('/settings');
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent("Request contains an unknown or unsupported file type.");
+        await expect.element(settingsScreen.errorToast()).not.toHaveTextContent("NaN");
+    });
 
-    await settingsScreen.theme().getByRole('button', { name: 'Menu' }).click();
-    await settingsScreen.menuItem('Edit code').click();
+    it("keeps the code editor open and reports blocking validation errors on save", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            errors: [{ message: "Theme is not compatible or contains errors.", details: "Missing default.hbs" }],
+        }, { status: 422 });
+        await renderAdminApp("/settings/theme/edit/edition");
 
-    await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
-    await expect.poll(currentRoute).toContain('/settings/theme/edit/edition');
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
 
-    await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
-    await expect.poll(currentRoute).toBe('/settings');
-    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-    await expect.element(settingsScreen.theme()).toBeVisible();
-  });
+        const errorModal = settingsScreen.confirmationModal();
+        await expect.element(errorModal).toHaveTextContent("Theme not saved");
+        await expect.element(errorModal).toHaveTextContent("Missing default.hbs");
+        await expect(errorModal.getByRole("button", { name: "Retry" })).toHaveCount(0);
+        await userEvent.keyboard("{Escape}");
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+    });
 
-  it('redirects invalid editor theme names', async () => {
-    fakeThemeWorld();
-    await renderAdminApp('/settings/theme/edit/%2Fedition');
+    it("falls back to the generic API error for an empty validation payload", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        fakeAdminEndpoint("POST", "/themes/upload/", { errors: [] }, { status: 422 });
+        await renderAdminApp("/settings/theme/edit/edition");
 
-    await expect.poll(currentRoute).toBe('/settings/theme');
-    await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
-  });
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Replace theme" }).click();
 
-  it('shows a controlled message for non-editable files', async () => {
-    fakeThemeWorld();
-    await fakeThemeDownload('edition');
-    await renderAdminApp('/settings/theme/edit/edition');
+        await expect.element(settingsScreen.errorToast()).toHaveTextContent(/Something went wrong/i);
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+    });
 
-    const modal = settingsScreen.themeCodeEditorModal();
-    await modal.getByRole('button', { name: '.DS_Store' }).click();
-    await expect.element(modal).toHaveTextContent(/cannot be edited in the browser/i);
-    await expect(modal.getByRole('textbox')).toHaveCount(0);
-  });
+    it("requires built-in themes to be saved under a valid new name", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("casper");
+        await renderAdminApp("/settings/theme/edit/casper");
+
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"casper","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        const inputModal = settingsScreen.themeEditorInputModal();
+        await inputModal.getByLabelText("Theme name").fill("Foo Bar!");
+        await inputModal.getByRole("button", { name: "Continue" }).click();
+        await expect.element(page.getByText(/Invalid theme name/i)).toBeVisible();
+
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await inputModal.getByLabelText("Theme name").fill("casper");
+        await inputModal.getByRole("button", { name: "Continue" }).click();
+        await expect.element(page.getByText(/Built-in themes cannot be overwritten/i)).toBeVisible();
+    });
+
+    it("saves a built-in theme under a valid new name", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("casper");
+        await fakeThemeDownload("casper-edited");
+        // saving under a new name carries over the original theme's settings
+        const uploadApi = fakeAdminEndpoint("POST", "/themes/upload/?copy_settings_from=casper", {
+            themes: [theme({ name: "casper-edited" })],
+        });
+        await renderAdminApp("/settings/theme/edit/casper");
+
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"casper","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Save" }).click();
+        await settingsScreen.themeEditorInputModal().getByLabelText("Theme name").fill("casper-edited");
+        await settingsScreen.themeEditorInputModal().getByRole("button", { name: "Continue" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Save theme" }).click();
+
+        await expect.poll(() => uploadApi.requests.length).toBe(1);
+        await expect.poll(currentRoute).toBe("/settings/theme/edit/casper-edited");
+        await expect.element(settingsScreen.themeCodeEditorModal()).toHaveTextContent("casper-edited");
+    });
+
+    it.each([
+        { allowlist: ["casper"], opensThemes: false },
+        { allowlist: ["casper", "edition"], opensThemes: true },
+    ])("enforces theme-change limits", async ({ allowlist, opensThemes }) => {
+        fakeThemeWorld();
+        await renderAdminApp("/settings/theme", themeLimits(allowlist, "Upgrade to use custom themes"));
+
+        await settingsScreen.theme().getByRole("button", { name: "Change theme" }).click();
+        if (opensThemes) {
+            await expect.element(settingsScreen.themeModal()).toBeVisible();
+            await expect(settingsScreen.limitModal()).toHaveCount(0);
+        } else {
+            await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
+            await expect(settingsScreen.themeModal()).toHaveCount(0);
+        }
+    });
+
+    it("prevents direct access to the theme-change route when limited", async () => {
+        fakeThemeWorld();
+        await renderAdminApp("/settings/design/change-theme", themeLimits(["casper"], "Upgrade to use custom themes"));
+
+        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
+        await expect(settingsScreen.themeModal()).toHaveCount(0);
+    });
+
+    it("prevents direct access to the theme editor when editing is limited", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        await renderAdminApp("/settings/theme/edit/edition", themeLimits(["casper", "edition"], "Upgrade to use custom themes"));
+
+        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
+        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+        await expect.poll(currentRoute).toBe("/settings/theme");
+    });
+
+    it("prevents theme uploads when custom themes are limited", async () => {
+        fakeThemeWorld();
+        await renderAdminApp("/settings/design/change-theme", themeLimits(["casper", "headline", "edition"], "Upgrade to use more themes"));
+
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+    });
+
+    it.each([
+        { themeName: "Headline", action: "Install Headline", allowlist: ["casper", "edition"] },
+        { themeName: "Edition", action: "Update Edition", allowlist: ["casper", "headline"] },
+    ])("checks limits before installing or updating a theme card", async ({ themeName, action, allowlist }) => {
+        fakeThemeWorld();
+        await renderAdminApp("/settings/design/change-theme", themeLimits(allowlist, "Upgrade to use more themes"));
+
+        const modal = settingsScreen.themeModal();
+        await modal.getByRole("button", { name: new RegExp(themeName) }).click();
+        await modal.getByRole("button", { name: action }).click();
+        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
+        await expect(settingsScreen.confirmationModal()).toHaveCount(0);
+    });
+
+    it.each([
+        { allowlist: ["casper", "headline", "taste"], canInstall: true },
+        { allowlist: ["casper", "headline", "edition"], canInstall: false },
+    ])("enforces marketplace installation limits", async ({ allowlist, canInstall }) => {
+        fakeThemeWorld();
+        const installApi = fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "taste" })] });
+        fakeAdminEndpoint("PUT", "/themes/taste/activate/", { themes: [theme({ name: "taste", active: true })] });
+        await renderAdminApp("/settings/theme/install?source=github&ref=TryGhost/Taste", themeLimits(allowlist, "Upgrade to use more themes"));
+
+        if (canInstall) {
+            await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/Install Theme/);
+            await settingsScreen.confirmationModal().getByRole("button", { name: "Install" }).click();
+            await expect.element(settingsScreen.successToast()).toHaveTextContent(/taste is now your active theme/i);
+            expect(installApi.requests).toHaveLength(1);
+        } else {
+            await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use more themes/);
+            expect(installApi.requests).toHaveLength(0);
+        }
+    });
+
+    it("replaces a blocked marketplace installation in history", async () => {
+        fakeThemeWorld();
+        fakeAdminEndpoint("POST", /^\/themes\/install\/\?/, { themes: [theme({ name: "taste" })] });
+        const replaceState = vi.spyOn(window.history, "replaceState");
+        await renderAdminApp(
+            "/settings/theme/install?source=github&ref=TryGhost/Taste",
+            themeLimits(["casper"], "Upgrade to use custom themes")
+        );
+
+        await expect.element(settingsScreen.limitModal()).toHaveTextContent(/Upgrade to use custom themes/);
+        await expect.poll(currentRoute).toBe("/settings/theme");
+
+        expect(replaceState.mock.calls.some(([, , url]) => String(url).endsWith("#/settings/theme"))).toBe(true);
+        replaceState.mockRestore();
+    });
+
+    it("confirms before discarding editor changes", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        await renderAdminApp("/settings/theme/edit/edition");
+
+        const editor = await editorTextbox();
+        await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
+        await expect.element(settingsScreen.themeEditorConfirmModal()).toHaveTextContent(/unsaved theme changes/i);
+        await userEvent.keyboard("{Escape}");
+        await expect(settingsScreen.themeEditorConfirmModal()).toHaveCount(0);
+        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
+        await settingsScreen.themeEditorConfirmModal().getByRole("button", { name: "Discard changes" }).click();
+        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+    });
+
+    it.each([
+        { from: "theme", destination: "/settings/theme" },
+        { from: "staff/owner-transfer", destination: "/settings/design/change-theme" },
+    ])("only honours allowlisted editor return routes", async ({ from, destination }) => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        await renderAdminApp(`/settings/theme/edit/edition?from=${from}`);
+
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
+        await expect.poll(currentRoute).toBe(destination);
+    });
+
+    it("opens the code editor from the active theme overflow menu and returns to settings on close", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        await renderAdminApp("/settings");
+
+        await settingsScreen.theme().getByRole("button", { name: "Menu" }).click();
+        await settingsScreen.menuItem("Edit code").click();
+
+        await expect.element(settingsScreen.themeCodeEditorModal()).toBeVisible();
+        await expect.poll(currentRoute).toContain("/settings/theme/edit/edition");
+
+        await settingsScreen.themeCodeEditorModal().getByRole("button", { name: "Close" }).click();
+        await expect.poll(currentRoute).toBe("/settings");
+        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+        await expect.element(settingsScreen.theme()).toBeVisible();
+    });
+
+    it("redirects invalid editor theme names", async () => {
+        fakeThemeWorld();
+        await renderAdminApp("/settings/theme/edit/%2Fedition");
+
+        await expect.poll(currentRoute).toBe("/settings/theme");
+        await expect(settingsScreen.themeCodeEditorModal()).toHaveCount(0);
+    });
+
+    it("shows a controlled message for non-editable files", async () => {
+        fakeThemeWorld();
+        await fakeThemeDownload("edition");
+        await renderAdminApp("/settings/theme/edit/edition");
+
+        const modal = settingsScreen.themeCodeEditorModal();
+        await modal.getByRole("button", { name: ".DS_Store" }).click();
+        await expect.element(modal).toHaveTextContent(/cannot be edited in the browser/i);
+        await expect(modal.getByRole("textbox")).toHaveCount(0);
+    });
 });

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -327,7 +327,7 @@ describe('Theme settings', () => {
     expect(getComputedStyle(chevron()).transform).toBe('none');
   });
 
-  it("renders gscan's inline code plainly under the legacy code rule", async () => {
+  it("chips gscan's inline code without letting the legacy code rule through", async () => {
     fakeThemeWorld();
     fakeAdminEndpoint('POST', '/themes/upload/', {
       themes: [
@@ -355,32 +355,36 @@ describe('Theme settings', () => {
     await row.click();
     await expect.element(settingsScreen.confirmationModal().getByText(/deprecated/)).toBeVisible();
 
-    // gscan's own markup: mono, inheriting the line it sits on, no chip.
+    // gscan's own markup: a grey chip, sized and coloured by the line it sits
+    // on rather than by the legacy rule, and never broken across two lines.
     for (const text of ['{{@blog.url}}', '{{@blog.title}}']) {
       const code = codeSpan(text);
       const surrounding = getComputedStyle(code.parentElement!);
       const style = getComputedStyle(code);
       expect(style.fontFamily).toContain('mono');
       expect(style.color).toBe(surrounding.color);
-      expect(style.fontSize).toBe(surrounding.fontSize);
+      // A step down, since mono reads larger than the text it sits in.
+      expect(parseFloat(style.fontSize)).toBeLessThan(parseFloat(surrounding.fontSize));
       // The legacy `line-height: 1em` computes to exactly the font size.
       expect(style.lineHeight).not.toBe(style.fontSize);
       expect(lineRatio(style)).toBeCloseTo(lineRatio(surrounding), 2);
-      expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+      expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+      expect(parseFloat(style.borderTopLeftRadius)).toBeGreaterThan(0);
+      expect(parseFloat(style.paddingLeft)).toBeGreaterThan(0);
+      expect(style.whiteSpace).toBe('nowrap');
+      // The legacy rule's border and pink must still lose.
       expect(style.borderTopWidth).toBe('0px');
-      expect(style.borderTopLeftRadius).toBe('0px');
-      expect(style.paddingLeft).toBe('0px');
       expect(style.verticalAlign).toBe('baseline');
     }
 
-    // An affected file is inline mono too, with no chip left behind.
+    // An affected file gets the same chip as the mono in the details above it.
     const filenameCode = codeSpan('default.hbs');
     const filename = getComputedStyle(filenameCode);
     const detailsCode = getComputedStyle(codeSpan('{{@blog.title}}'));
-    expect(filename.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(filename.backgroundColor).toBe(detailsCode.backgroundColor);
+    expect(filename.borderTopLeftRadius).toBe(detailsCode.borderTopLeftRadius);
+    expect(filename.paddingLeft).toBe(detailsCode.paddingLeft);
     expect(filename.borderTopWidth).toBe('0px');
-    expect(filename.borderTopLeftRadius).toBe('0px');
-    expect(filename.paddingLeft).toBe('0px');
     expect(filename.verticalAlign).toBe('baseline');
     expect(filename.fontSize).toBe(detailsCode.fontSize);
     expect(filename.fontFamily).toBe(detailsCode.fontFamily);

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -303,6 +303,8 @@ describe("Theme settings", () => {
             const style = getComputedStyle(code);
             expect(style.fontFamily).toContain("mono");
             expect(style.color).toBe(surrounding.color);
+            // Nothing reads optically larger than the text it sits in.
+            expect(style.fontSize).toBe(surrounding.fontSize);
             // The legacy `line-height: 1em` computes to exactly the font size;
             // inheriting the surrounding ratio is what its absence would give.
             expect(style.lineHeight).not.toBe(style.fontSize);
@@ -314,14 +316,22 @@ describe("Theme settings", () => {
             expect(style.verticalAlign).toBe("baseline");
         }
 
-        // The affected-files chip is deliberately chipped, so it keeps its
-        // background — but the legacy border and mid-line alignment still go.
-        const chip = codeSpan("default.hbs");
-        expect(getComputedStyle(chip).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
-        expect(getComputedStyle(chip).borderTopWidth).toBe("0px");
-        expect(getComputedStyle(chip).verticalAlign).toBe("baseline");
-        // Same foreground as the rule line's code, i.e. not the legacy pink.
-        expect(getComputedStyle(chip).color).toBe(getComputedStyle(codeSpan("{{@blog.url}}")).color);
+        // An affected file is inline mono too: same size, family and weight as the
+        // code in the details above it, with no chip of its own left behind.
+        const filenameCode = codeSpan("default.hbs");
+        const filename = getComputedStyle(filenameCode);
+        const detailsCode = getComputedStyle(codeSpan("{{@blog.title}}"));
+        expect(filename.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+        expect(filename.borderTopWidth).toBe("0px");
+        expect(filename.borderTopLeftRadius).toBe("0px");
+        expect(filename.paddingLeft).toBe("0px");
+        expect(filename.verticalAlign).toBe("baseline");
+        expect(filename.fontSize).toBe(detailsCode.fontSize);
+        expect(filename.fontFamily).toBe(detailsCode.fontFamily);
+        expect(filename.fontWeight).toBe(detailsCode.fontWeight);
+        // Same foreground as the line it sits on — the affected-files list stays
+        // muted while the details read as body copy — i.e. not the legacy pink.
+        expect(filename.color).toBe(getComputedStyle(filenameCode.parentElement!).color);
     });
 
     it("keeps the installed-theme dialog open when activation fails", async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -681,59 +681,6 @@ describe('Theme settings', () => {
     expect(uploadApi.requests).toHaveLength(1);
   });
 
-  it.each([
-    {
-      severity: 'warnings',
-      problems: { warnings: [themeProblem({ code: 'GS001-DEPR-PURL' })] },
-      sentence: 'edition is now visible to your readers, but it has some warnings.',
-      summary: '1 warning',
-    },
-    {
-      severity: 'issues',
-      problems: {
-        errors: [
-          themeProblem({
-            code: 'GS005-TPL-ERR',
-            level: 'error',
-            rule: 'Templates must contain valid Handlebars',
-          }),
-        ],
-        warnings: [themeProblem({ code: 'GS001-DEPR-PURL' })],
-      },
-      sentence: 'edition is now visible to your readers, but it has some issues.',
-      summary: '1 error, 1 warning',
-    },
-  ])(
-    'says the live theme carries $severity after saving it',
-    async ({ problems, sentence, summary }) => {
-      fakeThemeWorld();
-      await fakeThemeDownload('edition');
-      fakeAdminEndpoint('POST', '/themes/upload/', {
-        themes: [theme({ name: 'edition', active: true, ...problems })],
-      });
-      await renderAdminApp('/settings/theme/edit/edition');
-
-      const editor = await editorTextbox();
-      await editor.fill('{"name":"edition","version":"1.0.0"}\n');
-      await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
-      await settingsScreen
-        .themeEditorConfirmModal()
-        .getByRole('button', { name: 'Replace theme' })
-        .click();
-
-      // The saved theme is the live one, so the dialog reports it as live —
-      // but a set of problems is listed directly underneath, and calling that
-      // a clean success contradicts the list saying otherwise.
-      const installedModal = settingsScreen.confirmationModal();
-      await expect.element(installedModal).toHaveTextContent(sentence);
-      await expect.element(installedModal).not.toHaveTextContent('successfully');
-      await expect.element(installedModal).toHaveTextContent(summary);
-      await expect.element(installedModal.getByRole('link', { name: /Take a look/ })).toBeVisible();
-      // Nothing left to activate, so the dialog only acknowledges.
-      await expect.element(installedModal.getByTestId('ok-modal')).toHaveTextContent('OK');
-    },
-  );
-
   it('runs the current save flow from the keyboard shortcut', async () => {
     fakeThemeWorld();
     // The editor shortcut currently propagates to the settings form too;

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -84,6 +84,7 @@ function themeProblem(overrides: {
   level?: string;
   rule?: string;
   details?: string;
+  fatal?: boolean;
 }) {
   return {
     level: 'warning',
@@ -266,6 +267,14 @@ describe('Theme settings', () => {
         'mytheme was uploaded, but it has some issues. Do you want to activate it?',
       );
     await expect.element(installedModal).toHaveTextContent('1 error, 2 warnings');
+    // Errors are the only severity that restricts anything, so only they are
+    // explained — and the button says what activating now would accept.
+    await expect
+      .element(installedModal)
+      .toHaveTextContent('Highly recommended to fix, functionality could be restricted');
+    await expect
+      .element(installedModal.getByRole('button', { name: 'Activate with errors' }))
+      .toBeVisible();
 
     // A summary that says "error" can't be headed by a warning-coloured
     // icon: it takes the same red as the ERROR badge in the list below.
@@ -529,6 +538,69 @@ describe('Theme settings', () => {
       .element(page.getByText('Click to select or drag & drop zip file', { exact: true }))
       .toBeVisible();
     await expect(page.getByText('Theme not uploaded')).toHaveCount(0);
+  });
+
+  it('tells a blocking problem apart from the errors reported alongside it', async () => {
+    fakeThemeWorld();
+    fakeAdminEndpoint(
+      'POST',
+      '/themes/upload/',
+      {
+        errors: [
+          {
+            message: 'Theme is not compatible or contains errors.',
+            details: {
+              errors: [
+                themeProblem({
+                  code: 'GS010-PJ-REQ',
+                  level: 'error',
+                  rule: 'package.json must be present',
+                  fatal: true,
+                }),
+                themeProblem({
+                  code: 'GS005-TPL-ERR',
+                  level: 'error',
+                  rule: 'Templates must contain valid Handlebars',
+                }),
+              ],
+            },
+          },
+        ],
+      },
+      { status: 422 },
+    );
+    const buffer = await archiveBuffer();
+    await renderAdminApp('/settings/design/change-theme');
+
+    await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
+    await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
+    stageLegacyGhostCss(LEGACY_CODE_CSS);
+
+    const errorModal = settingsScreen.confirmationModal();
+    await expect.element(errorModal).toHaveTextContent('Theme not uploaded');
+
+    // Both groups are errors; only one of them stopped the upload. Labelling
+    // them identically leaves the dialog unable to say which.
+    const lists = errorModal
+      .element()
+      .querySelectorAll<HTMLElement>('div.overflow-hidden.rounded-lg.border');
+    expect(lists).toHaveLength(2);
+    expect(lists[0].textContent).toContain('GS010-PJ-REQ');
+    expect(lists[0].textContent).toContain('Blocking');
+    expect(lists[0].textContent).not.toContain('Error');
+    expect(lists[1].textContent).toContain('GS005-TPL-ERR');
+    expect(lists[1].textContent).toContain('Error');
+    expect(lists[1].textContent).not.toContain('Blocking');
+
+    // Both read as shouted labels — the difference is the word, not the style.
+    const blocking = errorModal.getByText('Blocking', { exact: true }).element();
+    const error = errorModal.getByText('Error', { exact: true }).element();
+    expect(getComputedStyle(blocking).textTransform).toBe('uppercase');
+    expect(getComputedStyle(blocking).backgroundColor).toBe(
+      getComputedStyle(error).backgroundColor,
+    );
+    // The blocking group is stated first.
+    expect(blocking.getBoundingClientRect().top).toBeLessThan(error.getBoundingClientRect().top);
   });
 
   it('reports blocking activation errors for an installed theme', async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -44,7 +44,40 @@ async function fakeThemeDownload(name: string): Promise<void> {
     fakeAdminEndpoint("GET", `/themes/${name}/download/`, await archiveBuffer(), { contentType: "application/zip" });
 }
 
-function themeProblem(overrides: { code: string; level?: string; rule?: string }) {
+/**
+ * This tier serves no Ember CSS, so nothing here collides with Ghost's legacy
+ * unlayered stylesheet unless the collision is staged. Without staging, both
+ * assertions AND screenshots taken from this harness flatter the UI for
+ * anything `ghost.css` touches.
+ */
+function stageLegacyGhostCss(css: string): void {
+    const style = document.createElement("style");
+    style.textContent = css;
+    document.head.appendChild(style);
+    onTestFinished(() => style.remove());
+}
+
+/**
+ * Verbatim from `ghost/core/core/built/admin/assets/ghost.css` — a bare element
+ * selector that turns every `<code>` in Admin into a bordered grey chip with
+ * pink text.
+ */
+const LEGACY_CODE_CSS = `code, tt {
+    padding: 0.2rem 0.3rem;
+    border: 1px solid hsl(203, 12.29%, 91.14%);
+    background: hsl(205, 12.29%, 95.14%);
+    border-radius: 2px;
+    color: hsl(332.04, 96.26%, 43.04%);
+    vertical-align: middle;
+    white-space: pre-wrap;
+    font-size: 0.85em;
+    line-height: 1em;
+}`;
+
+/** Tachyons' `.rotate-180`, which Tailwind v4 expresses as `rotate` rather than `transform`. */
+const LEGACY_TACHYONS_CSS = ".rotate-180 { transform: rotate(180deg); }";
+
+function themeProblem(overrides: { code: string; level?: string; rule?: string; details?: string }) {
     return {
         level: "warning",
         rule: "Replace {{@blog.url}} with {{@site.url}}",
@@ -67,6 +100,21 @@ async function uploadThemeFile(file: File): Promise<void> {
         throw new Error("Theme upload input was not rendered");
     }
     await page.elementLocator(input).upload(file);
+}
+
+/** Line height as a multiple of font size, so sizes of different scale compare. */
+function lineRatio(style: CSSStyleDeclaration): number {
+    return parseFloat(style.lineHeight) / parseFloat(style.fontSize);
+}
+
+/** The one `<code>` in the open dialog reading exactly `text`. */
+function codeSpan(text: string): HTMLElement {
+    const dialog = settingsScreen.confirmationModal().element();
+    const match = [...dialog.querySelectorAll("code")].find(node => node.textContent === text);
+    if (!match) {
+        throw new Error(`No <code> reading ${text} was rendered`);
+    }
+    return match;
 }
 
 async function editorTextbox() {
@@ -204,10 +252,7 @@ describe("Theme settings", () => {
         // full circle, landing back where it started — the bug this dialog was
         // rebuilt to fix. This tier serves no Ember CSS, so the collision is staged
         // here; the chevron must rotate via a selector that rule cannot match.
-        const legacyTachyons = document.createElement("style");
-        legacyTachyons.textContent = ".rotate-180 { transform: rotate(180deg); }";
-        document.head.appendChild(legacyTachyons);
-        onTestFinished(() => legacyTachyons.remove());
+        stageLegacyGhostCss(LEGACY_TACHYONS_CSS);
 
         const row = settingsScreen.confirmationModal().getByRole("button", { name: /GS001-DEPR-PURL/ });
         await expect.element(row).toBeVisible();
@@ -221,6 +266,62 @@ describe("Theme settings", () => {
         await expect.poll(() => getComputedStyle(chevron()).rotate).toBe("180deg");
         // ...and nothing may add a second rotation on top of that one.
         expect(getComputedStyle(chevron()).transform).toBe("none");
+    });
+
+    it("renders gscan's inline code plainly under the legacy code rule", async () => {
+        fakeThemeWorld();
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            themes: [
+                theme({
+                    name: "mytheme",
+                    warnings: [
+                        themeProblem({
+                            code: "GS001-DEPR-PURL",
+                            rule: "Replace <code>{{@blog.url}}</code> with <code>{{@site.url}}</code>",
+                            details: "The <code>{{@blog.title}}</code> helper is deprecated.",
+                        }),
+                    ],
+                }),
+            ],
+        });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
+
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+        stageLegacyGhostCss(LEGACY_CODE_CSS);
+
+        const row = settingsScreen.confirmationModal().getByRole("button", { name: /GS001-DEPR-PURL/ });
+        await expect.element(row).toBeVisible();
+        await row.click();
+        await expect.element(settingsScreen.confirmationModal().getByText(/deprecated/)).toBeVisible();
+
+        // gscan's own markup: mono, inheriting the line it sits on, no chip.
+        for (const text of ["{{@blog.url}}", "{{@blog.title}}"]) {
+            const code = codeSpan(text);
+            const surrounding = getComputedStyle(code.parentElement!);
+            const style = getComputedStyle(code);
+            expect(style.fontFamily).toContain("mono");
+            expect(style.color).toBe(surrounding.color);
+            // The legacy `line-height: 1em` computes to exactly the font size;
+            // inheriting the surrounding ratio is what its absence would give.
+            expect(style.lineHeight).not.toBe(style.fontSize);
+            expect(lineRatio(style)).toBeCloseTo(lineRatio(surrounding), 2);
+            expect(style.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+            expect(style.borderTopWidth).toBe("0px");
+            expect(style.borderTopLeftRadius).toBe("0px");
+            expect(style.paddingLeft).toBe("0px");
+            expect(style.verticalAlign).toBe("baseline");
+        }
+
+        // The affected-files chip is deliberately chipped, so it keeps its
+        // background — but the legacy border and mid-line alignment still go.
+        const chip = codeSpan("default.hbs");
+        expect(getComputedStyle(chip).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+        expect(getComputedStyle(chip).borderTopWidth).toBe("0px");
+        expect(getComputedStyle(chip).verticalAlign).toBe("baseline");
+        // Same foreground as the rule line's code, i.e. not the legacy pink.
+        expect(getComputedStyle(chip).color).toBe(getComputedStyle(codeSpan("{{@blog.url}}")).color);
     });
 
     it("keeps the installed-theme dialog open when activation fails", async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -227,6 +227,12 @@ describe("Theme settings", () => {
         await expect.element(installedModal).toHaveTextContent("mytheme was uploaded, but it has some issues. Do you want to activate it?");
         await expect.element(installedModal).toHaveTextContent("1 error, 2 warnings");
 
+        // A summary that says "error" can't be headed by a warning-coloured
+        // icon: it takes the same red as the ERROR badge in the list below.
+        const heading = installedModal.element().querySelector("h3")!;
+        const badge = installedModal.getByText("Error", { exact: true }).element();
+        expect(getComputedStyle(heading.querySelector("svg")!).color).toBe(getComputedStyle(badge).color);
+
         // Every issue is listed up front; each one expands on its own.
         await expect(installedModal.getByRole("button", { name: /GS001-DEPR-PURL/ })).toHaveCount(1);
         await expect(installedModal.getByText(/deprecated/)).toHaveCount(0);
@@ -354,6 +360,52 @@ describe("Theme settings", () => {
         await expect.element(settingsScreen.errorToast()).toHaveTextContent("Theme activation failed");
         await expect.poll(currentRoute).toBe("/settings/design/change-theme");
         expect(activateApi.requests).toHaveLength(1);
+    });
+
+    it("seats the sticky footer against the issue list without an empty band", async () => {
+        fakeThemeWorld();
+        fakeAdminEndpoint("POST", "/themes/upload/", {
+            themes: [
+                theme({
+                    name: "mytheme",
+                    errors: [themeProblem({ code: "GS005-TPL-ERR", level: "error", rule: "Templates must contain valid Handlebars" })],
+                    // Enough rows that the dialog scrolls, so the footer both
+                    // floats mid-scroll and lands in flow at the bottom.
+                    warnings: Array.from({ length: 8 }, (_, index) => themeProblem({ code: `GS10${index}-DEPR-PURL` })),
+                }),
+            ],
+        });
+        const buffer = await archiveBuffer();
+        await renderAdminApp("/settings/design/change-theme");
+
+        await settingsScreen.themeModal().getByRole("button", { name: "Upload theme" }).click();
+        await uploadThemeFile(new File([buffer], "mytheme.zip", { type: "application/zip" }));
+        stageLegacyGhostCss(LEGACY_CODE_CSS);
+
+        const dialog = settingsScreen.confirmationModal();
+        await expect.element(dialog).toHaveTextContent("1 error, 8 warnings");
+
+        const scroller = dialog.element() as HTMLElement;
+        const list = scroller.querySelector<HTMLElement>("div.overflow-hidden.rounded-lg.border")!;
+        // The footer's own background: `sticky bottom-0`, 84px tall, and the
+        // only thing standing between scrolling rows and the buttons.
+        const mask = scroller.querySelector<HTMLElement>(".z-\\[299\\]")!;
+        expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+        expect(getComputedStyle(mask).backgroundColor).not.toMatch(/rgba\(.*, 0\)$/);
+
+        // Mid-scroll the mask is pinned to the bottom of the scroll port and
+        // rows run underneath it rather than showing through.
+        scroller.scrollTop = Math.floor((scroller.scrollHeight - scroller.clientHeight) / 2);
+        await expect.poll(() => Math.round(mask.getBoundingClientRect().bottom)).toBe(Math.round(scroller.getBoundingClientRect().bottom));
+        await expect.poll(() => Math.round(mask.getBoundingClientRect().height)).toBe(84);
+        expect(list.getBoundingClientRect().bottom).toBeGreaterThan(mask.getBoundingClientRect().top);
+
+        // Scrolled to the end the footer returns to flow, and the list has to
+        // end exactly where the footer's background begins — the 24px spacer
+        // the component opens with would read as an empty band here.
+        scroller.scrollTop = scroller.scrollHeight;
+        await expect.poll(() => Math.round(mask.getBoundingClientRect().bottom)).toBe(Math.round(scroller.getBoundingClientRect().bottom));
+        await expect.poll(() => Math.round(mask.getBoundingClientRect().top - list.getBoundingClientRect().bottom)).toBe(0);
     });
 
     it("reports blocking upload errors and re-opens the upload dialog from the error dialog", async () => {

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -49,10 +49,8 @@ async function fakeThemeDownload(name: string): Promise<void> {
 }
 
 /**
- * This tier serves no Ember CSS, so nothing here collides with Ghost's legacy
- * unlayered stylesheet unless the collision is staged. Without staging, both
- * assertions AND screenshots taken from this harness flatter the UI for
- * anything `ghost.css` touches.
+ * This tier serves no Ember CSS, so a collision with Ghost's legacy unlayered
+ * stylesheet only shows up here if it is staged deliberately.
  */
 function stageLegacyGhostCss(css: string): void {
   const style = document.createElement('style');
@@ -61,11 +59,7 @@ function stageLegacyGhostCss(css: string): void {
   onTestFinished(() => style.remove());
 }
 
-/**
- * Verbatim from `ghost/core/core/built/admin/assets/ghost.css` — a bare element
- * selector that turns every `<code>` in Admin into a bordered grey chip with
- * pink text.
- */
+/** Verbatim from `ghost/core/core/built/admin/assets/ghost.css`. */
 const LEGACY_CODE_CSS = `code, tt {
     padding: 0.2rem 0.3rem;
     border: 1px solid hsl(203, 12.29%, 91.14%);
@@ -316,12 +310,9 @@ describe('Theme settings', () => {
     await settingsScreen.themeModal().getByRole('button', { name: 'Upload theme' }).click();
     await uploadThemeFile(new File([buffer], 'mytheme.zip', { type: 'application/zip' }));
 
-    // Ghost's legacy Ember stylesheet ships Tachyons' `.rotate-180 {transform:
-    // rotate(180deg)}` unlayered alongside Tailwind v4's `.rotate-180 {rotate:
-    // 180deg}`. An icon carrying that literal class picks up both and turns a
-    // full circle, landing back where it started — the bug this dialog was
-    // rebuilt to fix. This tier serves no Ember CSS, so the collision is staged
-    // here; the chevron must rotate via a selector that rule cannot match.
+    // Legacy Tachyons `.rotate-180` (transform) and Tailwind v4's (rotate)
+    // both apply to that literal class, turning the icon a full circle. The
+    // chevron must rotate via a selector the legacy rule cannot match.
     stageLegacyGhostCss(LEGACY_TACHYONS_CSS);
 
     const row = settingsScreen.confirmationModal().getByRole('button', { name: /GS001-DEPR-PURL/ });
@@ -331,10 +322,8 @@ describe('Theme settings', () => {
 
     await row.click();
 
-    // Polling rides out the expand transition without a fixed wait: an
-    // interpolated frame reads as an intermediate angle, never as 180deg.
     await expect.poll(() => getComputedStyle(chevron()).rotate).toBe('180deg');
-    // ...and nothing may add a second rotation on top of that one.
+    // Nothing may add a second rotation on top of that one.
     expect(getComputedStyle(chevron()).transform).toBe('none');
   });
 
@@ -373,10 +362,8 @@ describe('Theme settings', () => {
       const style = getComputedStyle(code);
       expect(style.fontFamily).toContain('mono');
       expect(style.color).toBe(surrounding.color);
-      // Nothing reads optically larger than the text it sits in.
       expect(style.fontSize).toBe(surrounding.fontSize);
-      // The legacy `line-height: 1em` computes to exactly the font size;
-      // inheriting the surrounding ratio is what its absence would give.
+      // The legacy `line-height: 1em` computes to exactly the font size.
       expect(style.lineHeight).not.toBe(style.fontSize);
       expect(lineRatio(style)).toBeCloseTo(lineRatio(surrounding), 2);
       expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
@@ -386,8 +373,7 @@ describe('Theme settings', () => {
       expect(style.verticalAlign).toBe('baseline');
     }
 
-    // An affected file is inline mono too: same size, family and weight as the
-    // code in the details above it, with no chip of its own left behind.
+    // An affected file is inline mono too, with no chip left behind.
     const filenameCode = codeSpan('default.hbs');
     const filename = getComputedStyle(filenameCode);
     const detailsCode = getComputedStyle(codeSpan('{{@blog.title}}'));
@@ -399,8 +385,7 @@ describe('Theme settings', () => {
     expect(filename.fontSize).toBe(detailsCode.fontSize);
     expect(filename.fontFamily).toBe(detailsCode.fontFamily);
     expect(filename.fontWeight).toBe(detailsCode.fontWeight);
-    // Same foreground as the line it sits on — the affected-files list stays
-    // muted while the details read as body copy — i.e. not the legacy pink.
+    // Same foreground as the line it sits on, i.e. not the legacy pink.
     expect(filename.color).toBe(getComputedStyle(filenameCode.parentElement!).color);
   });
 
@@ -465,32 +450,26 @@ describe('Theme settings', () => {
     const scroller = dialog.element() as HTMLElement;
     const [list] = problemLists();
     const footer = scroller.querySelector<HTMLElement>(`[data-testid="${STICKY_FOOTER_TESTID}"]`)!;
-    // The footer's own background: `sticky bottom-0`, 84px tall, and the only
-    // thing standing between scrolling rows and the buttons. It's the part of
-    // the footer the buttons sit in — the other parts are decoration.
+    // The part of the footer the buttons sit in; the rest is decoration.
     const okButton = dialog.getByTestId('ok-modal').element();
     const mask = [...footer.children].find((part) => part.contains(okButton)) as HTMLElement;
     expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
     expect(getComputedStyle(mask).backgroundColor).not.toMatch(/rgba\(.*, 0\)$/);
 
-    // The component closes with a decorative scroll rule. Over a dialog
-    // whose footer already reads as a distinct block it lands as a hairline
-    // drawn across the buttons, so it must not render at all...
+    // StickyFooter's decorative scroll rule lands as a hairline across the
+    // buttons here, so it must not render — and nothing may replace it.
     const rule = footer.lastElementChild as HTMLElement;
     expect(rule).not.toBe(mask);
-    // ...and this is the element that would draw it.
     expect(getComputedStyle(rule).boxShadow).not.toBe('none');
     expect(getComputedStyle(rule).display).toBe('none');
     expect(rule.getBoundingClientRect().height).toBe(0);
-    // Nothing else in the footer paints one in its place.
     for (const part of [footer, ...footer.children]) {
       if (part !== rule) {
         expect(getComputedStyle(part).boxShadow).toBe('none');
       }
     }
 
-    // Mid-scroll the mask is pinned to the bottom of the scroll port and
-    // rows run underneath it rather than showing through.
+    // Mid-scroll: pinned to the scroll port, rows running underneath.
     scroller.scrollTop = Math.floor((scroller.scrollHeight - scroller.clientHeight) / 2);
     await expect
       .poll(() => Math.round(mask.getBoundingClientRect().bottom))
@@ -498,12 +477,8 @@ describe('Theme settings', () => {
     await expect.poll(() => Math.round(mask.getBoundingClientRect().height)).toBe(84);
     expect(list.getBoundingClientRect().bottom).toBeGreaterThan(mask.getBoundingClientRect().top);
 
-    // Scrolled to the end the footer returns to flow, and every part of it
-    // has to close up: the list ends exactly where the footer's background
-    // begins, and that background reaches the dialog's own bottom edge.
-    // Slack left anywhere in the footer's 84px box reads as an empty band —
-    // above the buttons if it sits before the background, below them if it
-    // sits after.
+    // Scrolled to the end the footer returns to flow and must close up:
+    // slack anywhere in its 84px box reads as an empty band.
     scroller.scrollTop = scroller.scrollHeight;
     await expect
       .poll(() => edgeGap(mask.getBoundingClientRect().top, list.getBoundingClientRect().bottom))
@@ -589,8 +564,7 @@ describe('Theme settings', () => {
     const errorModal = settingsScreen.confirmationModal();
     await expect.element(errorModal).toHaveTextContent('Theme not uploaded');
 
-    // Both groups are errors; only one of them stopped the upload. Labelling
-    // them identically leaves the dialog unable to say which.
+    // Both groups are errors; only one stopped the upload.
     const lists = problemLists();
     expect(lists).toHaveLength(2);
     expect(lists[0].textContent).toContain('GS010-PJ-REQ');

--- a/apps/admin/src/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin/src/settings/site/theme/advanced-theme-settings.tsx
@@ -1,260 +1,230 @@
-import InvalidThemeModal, { type FatalErrors } from './invalid-theme-modal';
-import React, { useState } from 'react';
+import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
+import React, {useState} from 'react';
 import useCustomFonts from '@/settings/hooks/use-custom-fonts';
-import {
-  ActionList,
-  ActionListItem,
-  ActionListItemActions,
-  ActionListItemContent,
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@tryghost/shade/components';
-import { JSONError } from '@tryghost/admin-x-framework/errors';
-import { LucideIcon } from '@tryghost/shade/utils';
-import { ModalPage } from '@tryghost/shade/page-templates';
-import {
-  type Theme,
-  isActiveTheme,
-  isDefaultTheme,
-  isDeletableTheme,
-  isLegacyTheme,
-  useActivateTheme,
-  useDeleteTheme,
-} from '@tryghost/admin-x-framework/api/themes';
-import { downloadFromEndpoint } from '@tryghost/admin-x-framework/helpers';
-import { toast } from 'sonner';
-import { useCheckThemeLimitError } from '@/settings/hooks/use-check-theme-limit-error';
-import { useConfirmation } from '@/settings/providers/confirmation-context';
-import { useHandleError } from '@tryghost/admin-x-framework/hooks';
-import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
-import { useUpgradeRoute } from '@/settings/hooks/use-upgrade-route';
+import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {ModalPage} from '@tryghost/shade/page-templates';
+import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
+import {downloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
+import {toast} from 'sonner';
+import {useCheckThemeLimitError} from '@/settings/hooks/use-check-theme-limit-error';
+import {useConfirmation} from '@/settings/providers/confirmation-context';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
+import {useUpgradeRoute} from '@/settings/hooks/use-upgrade-route';
 
 interface ThemeActionProps {
-  theme: Theme;
+    theme: Theme;
 }
 
 interface ThemeSettingProps {
-  themes: Theme[];
+    themes: Theme[];
 }
 
 function getThemeLabel(theme: Theme): React.ReactNode {
-  const name = theme.package?.name || theme.name;
-  let label: React.ReactNode = name;
+    const name = theme.package?.name || theme.name;
+    let label: React.ReactNode = name;
 
-  if (isDefaultTheme(theme)) {
-    label = `${name} (default)`;
-  } else if (isLegacyTheme(theme)) {
-    label = `${name} (legacy)`;
-  } else if (theme.package?.name !== theme.name) {
-    label = (
-      <span className="md:text-base">
-        {label} <span className="text-grey-600">({theme.name})</span>
-      </span>
-    );
-  }
+    if (isDefaultTheme(theme)) {
+        label = `${name} (default)`;
+    } else if (isLegacyTheme(theme)) {
+        label = `${name} (legacy)`;
+    } else if (theme.package?.name !== theme.name) {
+        label =
+            <span className='md:text-base'>
+                {label} <span className='text-grey-600'>({theme.name})</span>
+            </span>;
+    }
 
-  if (isActiveTheme(theme)) {
-    label = (
-      <span className="font-bold md:text-base">
-        {label} &mdash; <span className="text-green"> Active</span>
-      </span>
-    );
-  }
+    if (isActiveTheme(theme)) {
+        label =
+            <span className="font-bold md:text-base">
+                {label} &mdash; <span className='text-green'> Active</span>
+            </span>;
+    }
 
-  return label;
+    return label;
 }
 
 function getThemeVersion(theme: Theme): string {
-  return theme.package?.version || '1.0';
+    return theme.package?.version || '1.0';
 }
 
-const ThemeActions: React.FC<ThemeActionProps> = ({ theme }) => {
-  const { mutateAsync: activateTheme } = useActivateTheme();
-  const { mutateAsync: deleteTheme } = useDeleteTheme();
-  const { refreshActiveThemeData } = useCustomFonts();
-  const handleError = useHandleError();
-  const { route, updateRoute } = useSettingsNavigation();
-  const upgradeRoute = useUpgradeRoute();
-  const { checkThemeLimitError } = useCheckThemeLimitError();
-  const { confirm, showLimit } = useConfirmation();
-  const [activationErrors, setActivationErrors] = useState<FatalErrors | null>(null);
+const ThemeActions: React.FC<ThemeActionProps> = ({
+    theme
+}) => {
+    const {mutateAsync: activateTheme} = useActivateTheme();
+    const {mutateAsync: deleteTheme} = useDeleteTheme();
+    const {refreshActiveThemeData} = useCustomFonts();
+    const handleError = useHandleError();
+    const {route, updateRoute} = useSettingsNavigation();
+    const upgradeRoute = useUpgradeRoute();
+    const {checkThemeLimitError} = useCheckThemeLimitError();
+    const {confirm, showLimit} = useConfirmation();
+    const [activationErrors, setActivationErrors] = useState<FatalErrors | null>(null);
 
-  const handleActivate = async () => {
-    try {
-      await activateTheme(theme.name);
-      refreshActiveThemeData();
-      toast.success('Theme activated', {
-        description: (
-          <div>
-            <span className="capitalize">{theme.name}</span> is now your active theme
-          </div>
-        ),
-      });
-    } catch (e) {
-      let fatalErrors: FatalErrors | null = null;
-      if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
-        fatalErrors = e.data.errors as unknown as FatalErrors;
-      } else {
-        handleError(e);
-      }
-      if (fatalErrors) {
-        setActivationErrors(fatalErrors);
-      }
-    }
-  };
-
-  const handleDownload = () => {
-    downloadFromEndpoint(`/themes/${theme.name}/download`);
-  };
-
-  const handleDelete = () => {
-    confirm({
-      title: 'Are you sure you want to delete this?',
-      prompt: (
-        <>
-          You are about to delete <strong>&quot;{theme.name}&quot;.</strong> This is permanent! We
-          warned you, k? Maybe download{' '}
-          <span className="cursor-pointer text-green-500" onClick={handleDownload}>
-            your theme before continuing
-          </span>
-        </>
-      ),
-      okLabel: 'Delete',
-      okRunningLabel: 'Deleting',
-      okVariant: 'destructive',
-      onOk: async (modal) => {
+    const handleActivate = async () => {
         try {
-          await deleteTheme(theme.name);
-          modal?.remove();
+            await activateTheme(theme.name);
+            refreshActiveThemeData();
+            toast.success('Theme activated', {description: <div><span className='capitalize'>{theme.name}</span> is now your active theme</div>});
         } catch (e) {
-          handleError(e);
+            let fatalErrors: FatalErrors | null = null;
+            if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
+                fatalErrors = e.data.errors as unknown as FatalErrors;
+            } else {
+                handleError(e);
+            }
+            if (fatalErrors) {
+                setActivationErrors(fatalErrors);
+            }
         }
-      },
+    };
+
+    const handleDownload = () => {
+        downloadFromEndpoint(`/themes/${theme.name}/download`);
+    };
+
+    const handleDelete = () => {
+        confirm({
+            title: 'Are you sure you want to delete this?',
+            prompt: (
+                <>
+                    You are about to delete <strong>&quot;{theme.name}&quot;.</strong> This is permanent! We warned you, k?
+                    Maybe download
+                    {' '}
+                    <span
+                        className='cursor-pointer text-green-500'
+                        onClick={handleDownload}
+                    >
+                        your theme before continuing
+                    </span>
+                </>
+            ),
+            okLabel: 'Delete',
+            okRunningLabel: 'Deleting',
+            okVariant: 'destructive',
+            onOk: async (modal) => {
+                try {
+                    await deleteTheme(theme.name);
+                    modal?.remove();
+                } catch (e) {
+                    handleError(e);
+                }
+            }
+        });
+    };
+
+    const handleEditCode = async () => {
+        const limitError = await checkThemeLimitError('.');
+
+        if (limitError) {
+            showLimit({
+                prompt: limitError,
+                onOk: () => updateRoute({route: upgradeRoute, isExternal: true})
+            });
+            return;
+        }
+
+        updateRoute(`theme/edit/${encodeURIComponent(theme.name)}?from=${encodeURIComponent(route ?? '')}`);
+    };
+
+    const actions = [];
+
+    if (!isActiveTheme(theme)) {
+        actions.push(
+            <Button
+                key='activate'
+                className='ml-2'
+                size='sm'
+                type='button'
+                variant='ghost'
+                onClick={() => void handleActivate()}
+            >Activate</Button>
+        );
+    }
+
+    return (
+        <div className='-mr-3 flex items-center gap-4'>
+            {actions}
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button aria-label='Menu' size='icon' type='button' variant='ghost'><LucideIcon.Ellipsis /></Button>
+                </DropdownMenuTrigger>
+                {/* legacy Modal overlay is z-[1000]; keep the portalled menu above it */}
+                <DropdownMenuContent align='end' className='z-[9999]'>
+                    <DropdownMenuItem onSelect={() => void handleEditCode()}>Edit code</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={handleDownload}>Download</DropdownMenuItem>
+                    {isDeletableTheme(theme) && (
+                        <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+            {activationErrors && (
+                <InvalidThemeModal
+                    action='activated'
+                    fatalErrors={activationErrors}
+                    themeName={theme.package?.name || theme.name}
+                    title='Theme not activated'
+                    onClose={() => setActivationErrors(null)}
+                    onRetry={() => {
+                        setActivationErrors(null);
+                        void handleActivate();
+                    }}
+                />
+            )}
+        </div>
+    );
+};
+
+const ThemeList:React.FC<ThemeSettingProps> = ({
+    themes
+}) => {
+    themes.sort((a, b) => {
+        if (a.active && !b.active) {
+            return -1; // a comes before b
+        } else if (!a.active && b.active) {
+            return 1; // b comes before a
+        } else {
+            // Both have the same active status, sort alphabetically
+            if (a.package?.name && b.package?.name) {
+                return a.package.name.localeCompare(b.package.name);
+            } else {
+                return a.name.localeCompare(b.name);
+            }
+        }
     });
-  };
 
-  const handleEditCode = async () => {
-    const limitError = await checkThemeLimitError('.');
+    return (
+        <>
+            <h1 className='mb-5 text-2xl font-bold'>Installed themes</h1>
+            <ActionList className='border-t border-border'>
+                {themes.map((theme) => {
+                const label = getThemeLabel(theme);
+                const detail = getThemeVersion(theme);
 
-    if (limitError) {
-      showLimit({
-        prompt: limitError,
-        onOk: () => updateRoute({ route: upgradeRoute, isExternal: true }),
-      });
-      return;
-    }
-
-    updateRoute(
-      `theme/edit/${encodeURIComponent(theme.name)}?from=${encodeURIComponent(route ?? '')}`,
+                return (
+                    <ActionListItem key={theme.name} data-testid='theme-list-item'>
+                        <ActionListItemContent className='py-3 pr-6' id={`theme-${theme.name}`}>
+                            <div>{label}</div>
+                            {detail && <div className='text-sm text-muted-foreground'>{detail}</div>}
+                        </ActionListItemContent>
+                        <ActionListItemActions><ThemeActions theme={theme} /></ActionListItemActions>
+                    </ActionListItem>
+                );
+                })}
+            </ActionList>
+        </>
     );
-  };
-
-  const actions = [];
-
-  if (!isActiveTheme(theme)) {
-    actions.push(
-      <Button
-        key="activate"
-        className="ml-2"
-        size="sm"
-        type="button"
-        variant="ghost"
-        onClick={() => void handleActivate()}
-      >
-        Activate
-      </Button>,
-    );
-  }
-
-  return (
-    <div className="-mr-3 flex items-center gap-4">
-      {actions}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button aria-label="Menu" size="icon" type="button" variant="ghost">
-            <LucideIcon.Ellipsis />
-          </Button>
-        </DropdownMenuTrigger>
-        {/* legacy Modal overlay is z-[1000]; keep the portalled menu above it */}
-        <DropdownMenuContent align="end" className="z-[9999]">
-          <DropdownMenuItem onSelect={() => void handleEditCode()}>Edit code</DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleDownload}>Download</DropdownMenuItem>
-          {isDeletableTheme(theme) && (
-            <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-      {activationErrors && (
-        <InvalidThemeModal
-          fatalErrors={activationErrors}
-          prompt={
-            <>
-              This theme couldn&apos;t be activated because Ghost found a blocking validation error.
-              Fix the issue below and try again.
-            </>
-          }
-          title="Theme not activated"
-          onClose={() => setActivationErrors(null)}
-          onRetry={() => {
-            setActivationErrors(null);
-            void handleActivate();
-          }}
-        />
-      )}
-    </div>
-  );
 };
 
-const ThemeList: React.FC<ThemeSettingProps> = ({ themes }) => {
-  themes.sort((a, b) => {
-    if (a.active && !b.active) {
-      return -1; // a comes before b
-    } else if (!a.active && b.active) {
-      return 1; // b comes before a
-    } else {
-      // Both have the same active status, sort alphabetically
-      if (a.package?.name && b.package?.name) {
-        return a.package.name.localeCompare(b.package.name);
-      } else {
-        return a.name.localeCompare(b.name);
-      }
-    }
-  });
-
-  return (
-    <>
-      <h1 className="mb-5 text-2xl font-bold">Installed themes</h1>
-      <ActionList className="border-t border-border">
-        {themes.map((theme) => {
-          const label = getThemeLabel(theme);
-          const detail = getThemeVersion(theme);
-
-          return (
-            <ActionListItem key={theme.name} data-testid="theme-list-item">
-              <ActionListItemContent className="py-3 pr-6" id={`theme-${theme.name}`}>
-                <div>{label}</div>
-                {detail && <div className="text-sm text-muted-foreground">{detail}</div>}
-              </ActionListItemContent>
-              <ActionListItemActions>
-                <ThemeActions theme={theme} />
-              </ActionListItemActions>
-            </ActionListItem>
-          );
-        })}
-      </ActionList>
-    </>
-  );
-};
-
-const AdvancedThemeSettings: React.FC<ThemeSettingProps> = ({ themes }) => {
-  return (
-    <ModalPage>
-      <ThemeList themes={themes} />
-    </ModalPage>
-  );
+const AdvancedThemeSettings: React.FC<ThemeSettingProps> = ({themes}) => {
+    return (
+        <ModalPage>
+            <ThemeList themes={themes} />
+        </ModalPage>
+    );
 };
 
 export default AdvancedThemeSettings;

--- a/apps/admin/src/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin/src/settings/site/theme/advanced-theme-settings.tsx
@@ -1,230 +1,256 @@
-import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
-import React, {useState} from 'react';
+import InvalidThemeModal, { type FatalErrors } from './invalid-theme-modal';
+import React, { useState } from 'react';
 import useCustomFonts from '@/settings/hooks/use-custom-fonts';
-import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
-import {JSONError} from '@tryghost/admin-x-framework/errors';
-import {LucideIcon} from '@tryghost/shade/utils';
-import {ModalPage} from '@tryghost/shade/page-templates';
-import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
-import {downloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
-import {toast} from 'sonner';
-import {useCheckThemeLimitError} from '@/settings/hooks/use-check-theme-limit-error';
-import {useConfirmation} from '@/settings/providers/confirmation-context';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
-import {useUpgradeRoute} from '@/settings/hooks/use-upgrade-route';
+import {
+  ActionList,
+  ActionListItem,
+  ActionListItemActions,
+  ActionListItemContent,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@tryghost/shade/components';
+import { JSONError } from '@tryghost/admin-x-framework/errors';
+import { LucideIcon } from '@tryghost/shade/utils';
+import { ModalPage } from '@tryghost/shade/page-templates';
+import {
+  type Theme,
+  isActiveTheme,
+  isDefaultTheme,
+  isDeletableTheme,
+  isLegacyTheme,
+  useActivateTheme,
+  useDeleteTheme,
+} from '@tryghost/admin-x-framework/api/themes';
+import { downloadFromEndpoint } from '@tryghost/admin-x-framework/helpers';
+import { toast } from 'sonner';
+import { useCheckThemeLimitError } from '@/settings/hooks/use-check-theme-limit-error';
+import { useConfirmation } from '@/settings/providers/confirmation-context';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
+import { useUpgradeRoute } from '@/settings/hooks/use-upgrade-route';
 
 interface ThemeActionProps {
-    theme: Theme;
+  theme: Theme;
 }
 
 interface ThemeSettingProps {
-    themes: Theme[];
+  themes: Theme[];
 }
 
 function getThemeLabel(theme: Theme): React.ReactNode {
-    const name = theme.package?.name || theme.name;
-    let label: React.ReactNode = name;
+  const name = theme.package?.name || theme.name;
+  let label: React.ReactNode = name;
 
-    if (isDefaultTheme(theme)) {
-        label = `${name} (default)`;
-    } else if (isLegacyTheme(theme)) {
-        label = `${name} (legacy)`;
-    } else if (theme.package?.name !== theme.name) {
-        label =
-            <span className='md:text-base'>
-                {label} <span className='text-grey-600'>({theme.name})</span>
-            </span>;
-    }
+  if (isDefaultTheme(theme)) {
+    label = `${name} (default)`;
+  } else if (isLegacyTheme(theme)) {
+    label = `${name} (legacy)`;
+  } else if (theme.package?.name !== theme.name) {
+    label = (
+      <span className="md:text-base">
+        {label} <span className="text-grey-600">({theme.name})</span>
+      </span>
+    );
+  }
 
-    if (isActiveTheme(theme)) {
-        label =
-            <span className="font-bold md:text-base">
-                {label} &mdash; <span className='text-green'> Active</span>
-            </span>;
-    }
+  if (isActiveTheme(theme)) {
+    label = (
+      <span className="font-bold md:text-base">
+        {label} &mdash; <span className="text-green"> Active</span>
+      </span>
+    );
+  }
 
-    return label;
+  return label;
 }
 
 function getThemeVersion(theme: Theme): string {
-    return theme.package?.version || '1.0';
+  return theme.package?.version || '1.0';
 }
 
-const ThemeActions: React.FC<ThemeActionProps> = ({
-    theme
-}) => {
-    const {mutateAsync: activateTheme} = useActivateTheme();
-    const {mutateAsync: deleteTheme} = useDeleteTheme();
-    const {refreshActiveThemeData} = useCustomFonts();
-    const handleError = useHandleError();
-    const {route, updateRoute} = useSettingsNavigation();
-    const upgradeRoute = useUpgradeRoute();
-    const {checkThemeLimitError} = useCheckThemeLimitError();
-    const {confirm, showLimit} = useConfirmation();
-    const [activationErrors, setActivationErrors] = useState<FatalErrors | null>(null);
+const ThemeActions: React.FC<ThemeActionProps> = ({ theme }) => {
+  const { mutateAsync: activateTheme } = useActivateTheme();
+  const { mutateAsync: deleteTheme } = useDeleteTheme();
+  const { refreshActiveThemeData } = useCustomFonts();
+  const handleError = useHandleError();
+  const { route, updateRoute } = useSettingsNavigation();
+  const upgradeRoute = useUpgradeRoute();
+  const { checkThemeLimitError } = useCheckThemeLimitError();
+  const { confirm, showLimit } = useConfirmation();
+  const [activationErrors, setActivationErrors] = useState<FatalErrors | null>(null);
 
-    const handleActivate = async () => {
+  const handleActivate = async () => {
+    try {
+      await activateTheme(theme.name);
+      refreshActiveThemeData();
+      toast.success('Theme activated', {
+        description: (
+          <div>
+            <span className="capitalize">{theme.name}</span> is now your active theme
+          </div>
+        ),
+      });
+    } catch (e) {
+      let fatalErrors: FatalErrors | null = null;
+      if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
+        fatalErrors = e.data.errors as unknown as FatalErrors;
+      } else {
+        handleError(e);
+      }
+      if (fatalErrors) {
+        setActivationErrors(fatalErrors);
+      }
+    }
+  };
+
+  const handleDownload = () => {
+    downloadFromEndpoint(`/themes/${theme.name}/download`);
+  };
+
+  const handleDelete = () => {
+    confirm({
+      title: 'Are you sure you want to delete this?',
+      prompt: (
+        <>
+          You are about to delete <strong>&quot;{theme.name}&quot;.</strong> This is permanent! We
+          warned you, k? Maybe download{' '}
+          <span className="cursor-pointer text-green-500" onClick={handleDownload}>
+            your theme before continuing
+          </span>
+        </>
+      ),
+      okLabel: 'Delete',
+      okRunningLabel: 'Deleting',
+      okVariant: 'destructive',
+      onOk: async (modal) => {
         try {
-            await activateTheme(theme.name);
-            refreshActiveThemeData();
-            toast.success('Theme activated', {description: <div><span className='capitalize'>{theme.name}</span> is now your active theme</div>});
+          await deleteTheme(theme.name);
+          modal?.remove();
         } catch (e) {
-            let fatalErrors: FatalErrors | null = null;
-            if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
-                fatalErrors = e.data.errors as unknown as FatalErrors;
-            } else {
-                handleError(e);
-            }
-            if (fatalErrors) {
-                setActivationErrors(fatalErrors);
-            }
+          handleError(e);
         }
-    };
+      },
+    });
+  };
 
-    const handleDownload = () => {
-        downloadFromEndpoint(`/themes/${theme.name}/download`);
-    };
+  const handleEditCode = async () => {
+    const limitError = await checkThemeLimitError('.');
 
-    const handleDelete = () => {
-        confirm({
-            title: 'Are you sure you want to delete this?',
-            prompt: (
-                <>
-                    You are about to delete <strong>&quot;{theme.name}&quot;.</strong> This is permanent! We warned you, k?
-                    Maybe download
-                    {' '}
-                    <span
-                        className='cursor-pointer text-green-500'
-                        onClick={handleDownload}
-                    >
-                        your theme before continuing
-                    </span>
-                </>
-            ),
-            okLabel: 'Delete',
-            okRunningLabel: 'Deleting',
-            okVariant: 'destructive',
-            onOk: async (modal) => {
-                try {
-                    await deleteTheme(theme.name);
-                    modal?.remove();
-                } catch (e) {
-                    handleError(e);
-                }
-            }
-        });
-    };
-
-    const handleEditCode = async () => {
-        const limitError = await checkThemeLimitError('.');
-
-        if (limitError) {
-            showLimit({
-                prompt: limitError,
-                onOk: () => updateRoute({route: upgradeRoute, isExternal: true})
-            });
-            return;
-        }
-
-        updateRoute(`theme/edit/${encodeURIComponent(theme.name)}?from=${encodeURIComponent(route ?? '')}`);
-    };
-
-    const actions = [];
-
-    if (!isActiveTheme(theme)) {
-        actions.push(
-            <Button
-                key='activate'
-                className='ml-2'
-                size='sm'
-                type='button'
-                variant='ghost'
-                onClick={() => void handleActivate()}
-            >Activate</Button>
-        );
+    if (limitError) {
+      showLimit({
+        prompt: limitError,
+        onOk: () => updateRoute({ route: upgradeRoute, isExternal: true }),
+      });
+      return;
     }
 
-    return (
-        <div className='-mr-3 flex items-center gap-4'>
-            {actions}
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <Button aria-label='Menu' size='icon' type='button' variant='ghost'><LucideIcon.Ellipsis /></Button>
-                </DropdownMenuTrigger>
-                {/* legacy Modal overlay is z-[1000]; keep the portalled menu above it */}
-                <DropdownMenuContent align='end' className='z-[9999]'>
-                    <DropdownMenuItem onSelect={() => void handleEditCode()}>Edit code</DropdownMenuItem>
-                    <DropdownMenuItem onSelect={handleDownload}>Download</DropdownMenuItem>
-                    {isDeletableTheme(theme) && (
-                        <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
-                    )}
-                </DropdownMenuContent>
-            </DropdownMenu>
-            {activationErrors && (
-                <InvalidThemeModal
-                    action='activated'
-                    fatalErrors={activationErrors}
-                    themeName={theme.package?.name || theme.name}
-                    title='Theme not activated'
-                    onClose={() => setActivationErrors(null)}
-                    onRetry={() => {
-                        setActivationErrors(null);
-                        void handleActivate();
-                    }}
-                />
-            )}
-        </div>
+    updateRoute(
+      `theme/edit/${encodeURIComponent(theme.name)}?from=${encodeURIComponent(route ?? '')}`,
     );
+  };
+
+  const actions = [];
+
+  if (!isActiveTheme(theme)) {
+    actions.push(
+      <Button
+        key="activate"
+        className="ml-2"
+        size="sm"
+        type="button"
+        variant="ghost"
+        onClick={() => void handleActivate()}
+      >
+        Activate
+      </Button>,
+    );
+  }
+
+  return (
+    <div className="-mr-3 flex items-center gap-4">
+      {actions}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button aria-label="Menu" size="icon" type="button" variant="ghost">
+            <LucideIcon.Ellipsis />
+          </Button>
+        </DropdownMenuTrigger>
+        {/* legacy Modal overlay is z-[1000]; keep the portalled menu above it */}
+        <DropdownMenuContent align="end" className="z-[9999]">
+          <DropdownMenuItem onSelect={() => void handleEditCode()}>Edit code</DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleDownload}>Download</DropdownMenuItem>
+          {isDeletableTheme(theme) && (
+            <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {activationErrors && (
+        <InvalidThemeModal
+          action="activated"
+          fatalErrors={activationErrors}
+          themeName={theme.package?.name || theme.name}
+          title="Theme not activated"
+          onClose={() => setActivationErrors(null)}
+          onRetry={() => {
+            setActivationErrors(null);
+            void handleActivate();
+          }}
+        />
+      )}
+    </div>
+  );
 };
 
-const ThemeList:React.FC<ThemeSettingProps> = ({
-    themes
-}) => {
-    themes.sort((a, b) => {
-        if (a.active && !b.active) {
-            return -1; // a comes before b
-        } else if (!a.active && b.active) {
-            return 1; // b comes before a
-        } else {
-            // Both have the same active status, sort alphabetically
-            if (a.package?.name && b.package?.name) {
-                return a.package.name.localeCompare(b.package.name);
-            } else {
-                return a.name.localeCompare(b.name);
-            }
-        }
-    });
+const ThemeList: React.FC<ThemeSettingProps> = ({ themes }) => {
+  themes.sort((a, b) => {
+    if (a.active && !b.active) {
+      return -1; // a comes before b
+    } else if (!a.active && b.active) {
+      return 1; // b comes before a
+    } else {
+      // Both have the same active status, sort alphabetically
+      if (a.package?.name && b.package?.name) {
+        return a.package.name.localeCompare(b.package.name);
+      } else {
+        return a.name.localeCompare(b.name);
+      }
+    }
+  });
 
-    return (
-        <>
-            <h1 className='mb-5 text-2xl font-bold'>Installed themes</h1>
-            <ActionList className='border-t border-border'>
-                {themes.map((theme) => {
-                const label = getThemeLabel(theme);
-                const detail = getThemeVersion(theme);
+  return (
+    <>
+      <h1 className="mb-5 text-2xl font-bold">Installed themes</h1>
+      <ActionList className="border-t border-border">
+        {themes.map((theme) => {
+          const label = getThemeLabel(theme);
+          const detail = getThemeVersion(theme);
 
-                return (
-                    <ActionListItem key={theme.name} data-testid='theme-list-item'>
-                        <ActionListItemContent className='py-3 pr-6' id={`theme-${theme.name}`}>
-                            <div>{label}</div>
-                            {detail && <div className='text-sm text-muted-foreground'>{detail}</div>}
-                        </ActionListItemContent>
-                        <ActionListItemActions><ThemeActions theme={theme} /></ActionListItemActions>
-                    </ActionListItem>
-                );
-                })}
-            </ActionList>
-        </>
-    );
+          return (
+            <ActionListItem key={theme.name} data-testid="theme-list-item">
+              <ActionListItemContent className="py-3 pr-6" id={`theme-${theme.name}`}>
+                <div>{label}</div>
+                {detail && <div className="text-sm text-muted-foreground">{detail}</div>}
+              </ActionListItemContent>
+              <ActionListItemActions>
+                <ThemeActions theme={theme} />
+              </ActionListItemActions>
+            </ActionListItem>
+          );
+        })}
+      </ActionList>
+    </>
+  );
 };
 
-const AdvancedThemeSettings: React.FC<ThemeSettingProps> = ({themes}) => {
-    return (
-        <ModalPage>
-            <ThemeList themes={themes} />
-        </ModalPage>
-    );
+const AdvancedThemeSettings: React.FC<ThemeSettingProps> = ({ themes }) => {
+  return (
+    <ModalPage>
+      <ThemeList themes={themes} />
+    </ModalPage>
+  );
 };
 
 export default AdvancedThemeSettings;

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -1,83 +1,59 @@
-import React, { type ReactNode } from 'react';
-import { ConfirmationModalContent } from '@/settings/components/confirmation-modal';
-import {
-  ErrorTextCard,
-  ThemeValidationDetailsDisclosure,
-  ValidationProblemCard,
-} from './theme-validation-details';
-import { type FatalErrors, getIssuesFromFatalErrors } from './theme-validation-issues';
-import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
-import { formatNumber } from '@tryghost/shade/utils';
+import React from 'react';
+import {ConfirmationModalContent} from '@/settings/components/confirmation-modal';
+import {ThemeValidationIssueList, ValidationProblemList} from './theme-validation-details';
+import {type FatalErrors, getIssuesFromFatalErrors} from './theme-validation-issues';
 
-export type { FatalErrors } from './theme-validation-issues';
+export type {FatalErrors} from './theme-validation-issues';
+
+/** Past tense of the action that Ghost refused to complete. */
+export type InvalidThemeAction = 'uploaded' | 'activated' | 'saved';
 
 export type InvalidThemeModalProps = {
-  title: string;
-  prompt?: ReactNode;
-  fatalErrors?: FatalErrors;
-  validationDetailsDefaultOpen?: boolean;
-  onRetry?: (modal?: { remove: () => void }) => void | Promise<void>;
+    title: string;
+    /** Theme the failed action applied to, named in the status sentence. */
+    themeName?: string;
+    action?: InvalidThemeAction;
+    cancelLabel?: string;
+    /** Defaults to `Try again` when the caller can retry, and to no button when it can't. */
+    okLabel?: string;
+    fatalErrors?: FatalErrors;
+    onRetry?: (modal?: {
+        remove: () => void;
+    }) => void | Promise<void>;
 };
 
-const InvalidThemeModal: React.FC<InvalidThemeModalProps & { onClose: () => void }> = ({
-  title,
-  prompt,
-  fatalErrors,
-  validationDetailsDefaultOpen,
-  onRetry,
-  onClose,
+const InvalidThemeModal: React.FC<InvalidThemeModalProps & {onClose: () => void}> = ({
+    title,
+    themeName,
+    action = 'uploaded',
+    cancelLabel = 'Cancel',
+    okLabel,
+    fatalErrors,
+    onRetry,
+    onClose
 }) => {
-  const { data: configData } = useBrowseConfig();
-  const defaultOpen =
-    validationDetailsDefaultOpen ?? configData?.config?.environment === 'development';
-  const { blockingProblems, secondaryProblems, stringErrors } =
-    getIssuesFromFatalErrors(fatalErrors);
-  const blockingIssueCount = blockingProblems.length + stringErrors.length;
-  const promptText = prompt ?? (
-    <>
-      Ghost found{' '}
-      {blockingIssueCount === 1
-        ? 'a blocking validation error'
-        : `${formatNumber(blockingIssueCount)} blocking validation errors`}{' '}
-      and did not save your theme. Fix {blockingIssueCount === 1 ? 'the issue' : 'the issues'} below
-      and try again.
-    </>
-  );
+    const {blockingProblems, secondaryProblems, stringErrors} = getIssuesFromFatalErrors(fatalErrors);
 
-  return (
-    <ConfirmationModalContent
-      cancelLabel="Close"
-      okLabel={onRetry ? 'Retry' : ''}
-      okVariant="default"
-      prompt={
-        <>
-          <div className="space-y-5">
-            <div className="text-sm text-foreground">{promptText}</div>
+    return <ConfirmationModalContent
+        cancelLabel={cancelLabel}
+        okLabel={okLabel ?? (onRetry ? 'Try again' : '')}
+        okVariant='default'
+        prompt={
+            <div className='space-y-5'>
+                <p className='text-sm text-foreground'>
+                    {themeName ? <strong>{themeName}</strong> : 'This theme'} couldn&apos;t be {action}. Fix the errors below and try again.
+                </p>
 
-            {(blockingProblems.length > 0 || stringErrors.length > 0) && (
-              <div className="space-y-3">
-                {blockingProblems.map((problem) => (
-                  <ValidationProblemCard key={problem.code} problem={problem} prominent />
-                ))}
-                {stringErrors.map((error) => (
-                  <ErrorTextCard key={error} message={error} />
-                ))}
-              </div>
-            )}
+                <ValidationProblemList messages={stringErrors} problems={blockingProblems} expandedByDefault />
 
-            <ThemeValidationDetailsDisclosure
-              defaultOpen={defaultOpen}
-              problems={secondaryProblems}
-            />
-          </div>
-        </>
-      }
-      stickyFooter={true}
-      title={title}
-      onOk={onRetry}
-      onRemove={onClose}
-    />
-  );
+                <ThemeValidationIssueList problems={secondaryProblems} />
+            </div>
+        }
+        stickyFooter={true}
+        title={title}
+        onOk={onRetry}
+        onRemove={onClose}
+    />;
 };
 
 export default InvalidThemeModal;

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -1,59 +1,65 @@
 import React from 'react';
-import {ConfirmationModalContent} from '@/settings/components/confirmation-modal';
-import {ThemeValidationIssueList, ValidationProblemList} from './theme-validation-details';
-import {type FatalErrors, getIssuesFromFatalErrors} from './theme-validation-issues';
+import { ConfirmationModalContent } from '@/settings/components/confirmation-modal';
+import { ThemeValidationIssueList, ValidationProblemList } from './theme-validation-details';
+import { type FatalErrors, getIssuesFromFatalErrors } from './theme-validation-issues';
 
-export type {FatalErrors} from './theme-validation-issues';
+export type { FatalErrors } from './theme-validation-issues';
 
 /** Past tense of the action that Ghost refused to complete. */
 export type InvalidThemeAction = 'uploaded' | 'activated' | 'saved';
 
 export type InvalidThemeModalProps = {
-    title: string;
-    /** Theme the failed action applied to, named in the status sentence. */
-    themeName?: string;
-    action?: InvalidThemeAction;
-    cancelLabel?: string;
-    /** Defaults to `Try again` when the caller can retry, and to no button when it can't. */
-    okLabel?: string;
-    fatalErrors?: FatalErrors;
-    onRetry?: (modal?: {
-        remove: () => void;
-    }) => void | Promise<void>;
+  title: string;
+  /** Theme the failed action applied to, named in the status sentence. */
+  themeName?: string;
+  action?: InvalidThemeAction;
+  cancelLabel?: string;
+  /** Defaults to `Try again` when the caller can retry, and to no button when it can't. */
+  okLabel?: string;
+  fatalErrors?: FatalErrors;
+  onRetry?: (modal?: { remove: () => void }) => void | Promise<void>;
 };
 
-const InvalidThemeModal: React.FC<InvalidThemeModalProps & {onClose: () => void}> = ({
-    title,
-    themeName,
-    action = 'uploaded',
-    cancelLabel = 'Cancel',
-    okLabel,
-    fatalErrors,
-    onRetry,
-    onClose
+const InvalidThemeModal: React.FC<InvalidThemeModalProps & { onClose: () => void }> = ({
+  title,
+  themeName,
+  action = 'uploaded',
+  cancelLabel = 'Cancel',
+  okLabel,
+  fatalErrors,
+  onRetry,
+  onClose,
 }) => {
-    const {blockingProblems, secondaryProblems, stringErrors} = getIssuesFromFatalErrors(fatalErrors);
+  const { blockingProblems, secondaryProblems, stringErrors } =
+    getIssuesFromFatalErrors(fatalErrors);
 
-    return <ConfirmationModalContent
-        cancelLabel={cancelLabel}
-        okLabel={okLabel ?? (onRetry ? 'Try again' : '')}
-        okVariant='default'
-        prompt={
-            <div className='flex flex-col gap-4'>
-                <p className='text-base text-foreground'>
-                    {themeName ? <strong>{themeName}</strong> : 'This theme'} couldn&apos;t be {action}. Fix the errors below and try again.
-                </p>
+  return (
+    <ConfirmationModalContent
+      cancelLabel={cancelLabel}
+      okLabel={okLabel ?? (onRetry ? 'Try again' : '')}
+      okVariant="default"
+      prompt={
+        <div className="flex flex-col gap-4">
+          <p className="text-base text-foreground">
+            {themeName ? <strong>{themeName}</strong> : 'This theme'} couldn&apos;t be {action}. Fix
+            the errors below and try again.
+          </p>
 
-                <ValidationProblemList messages={stringErrors} problems={blockingProblems} expandedByDefault />
+          <ValidationProblemList
+            messages={stringErrors}
+            problems={blockingProblems}
+            expandedByDefault
+          />
 
-                <ThemeValidationIssueList problems={secondaryProblems} />
-            </div>
-        }
-        stickyFooter={true}
-        title={title}
-        onOk={onRetry}
-        onRemove={onClose}
-    />;
+          <ThemeValidationIssueList problems={secondaryProblems} />
+        </div>
+      }
+      stickyFooter={true}
+      title={title}
+      onOk={onRetry}
+      onRemove={onClose}
+    />
+  );
 };
 
 export default InvalidThemeModal;

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -39,7 +39,7 @@ const InvalidThemeModal: React.FC<InvalidThemeModalProps & {onClose: () => void}
         okLabel={okLabel ?? (onRetry ? 'Try again' : '')}
         okVariant='default'
         prompt={
-            <div className='space-y-5'>
+            <div className='flex flex-col gap-4'>
                 <p className='text-base text-foreground'>
                     {themeName ? <strong>{themeName}</strong> : 'This theme'} couldn&apos;t be {action}. Fix the errors below and try again.
                 </p>

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -45,7 +45,10 @@ const InvalidThemeModal: React.FC<InvalidThemeModalProps & { onClose: () => void
             the errors below and try again.
           </p>
 
+          {/* What actually stopped the action, told apart from the errors
+                        merely reported underneath it. */}
           <ValidationProblemList
+            errorLabel="Blocking"
             messages={stringErrors}
             problems={blockingProblems}
             expandedByDefault

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -40,7 +40,7 @@ const InvalidThemeModal: React.FC<InvalidThemeModalProps & {onClose: () => void}
         okVariant='default'
         prompt={
             <div className='space-y-5'>
-                <p className='text-sm text-foreground'>
+                <p className='text-base text-foreground'>
                     {themeName ? <strong>{themeName}</strong> : 'This theme'} couldn&apos;t be {action}. Fix the errors below and try again.
                 </p>
 

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -38,6 +38,11 @@ const InvalidThemeModal: React.FC<InvalidThemeModalProps & { onClose: () => void
   return (
     <ConfirmationModalContent
       cancelLabel={cancelLabel}
+      contentClassName={
+        blockingProblems.length + stringErrors.length + secondaryProblems.length > 0
+          ? 'max-w-[600px]'
+          : undefined
+      }
       okLabel={okLabel ?? (onRetry ? 'Try again' : '')}
       okVariant="default"
       prompt={

--- a/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/site/theme/invalid-theme-modal.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { ConfirmationModalContent } from '@/settings/components/confirmation-modal';
 import { ThemeValidationIssueList, ValidationProblemList } from './theme-validation-details';
-import { type FatalErrors, getIssuesFromFatalErrors } from './theme-validation-issues';
+import {
+  type FatalErrors,
+  type ThemeAction,
+  getIssuesFromFatalErrors,
+} from './theme-validation-issues';
 
 export type { FatalErrors } from './theme-validation-issues';
-
-/** Past tense of the action that Ghost refused to complete. */
-export type InvalidThemeAction = 'uploaded' | 'activated' | 'saved';
 
 export type InvalidThemeModalProps = {
   title: string;
   /** Theme the failed action applied to, named in the status sentence. */
   themeName?: string;
-  action?: InvalidThemeAction;
+  /** Past tense of the action that Ghost refused to complete. */
+  action?: ThemeAction;
   cancelLabel?: string;
   /** Defaults to `Try again` when the caller can retry, and to no button when it can't. */
   okLabel?: string;

--- a/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
@@ -1,161 +1,169 @@
-import CodeMirror, {EditorView} from '@uiw/react-codemirror';
-import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import CodeMirror, { EditorView } from '@uiw/react-codemirror';
+import InvalidThemeModal, { type FatalErrors } from './invalid-theme-modal';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ThemeEditorConfirmModal from './theme-editor-confirm-modal';
 import ThemeEditorInputModal from './theme-editor-input-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
 import ThemeFileTree from './theme-file-tree';
-import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme-installed-modal';
-import {describeThemeOutcome, getIssuesFromInstalledTheme, parseFatalErrors} from './theme-validation-issues';
-import {TextWrap, Undo2} from 'lucide-react';
+import ThemeInstalledModal, { type ThemeInstalledModalProps } from './theme-installed-modal';
 import {
-    cloneThemeFiles,
-    createFolderRenameMap,
-    extractThemeArchive,
-    getExtension,
-    getThemeChanges,
-    isDefaultThemeName,
-    isEditablePath,
-    normaliseRelativePath,
-    packThemeArchive
+  describeThemeOutcome,
+  getIssuesFromInstalledTheme,
+  parseFatalErrors,
+} from './theme-validation-issues';
+import { TextWrap, Undo2 } from 'lucide-react';
+import {
+  cloneThemeFiles,
+  createFolderRenameMap,
+  extractThemeArchive,
+  getExtension,
+  getThemeChanges,
+  isDefaultThemeName,
+  isEditablePath,
+  normaliseRelativePath,
+  packThemeArchive,
 } from './theme-editor-utils';
-import {APIError, JSONError, UnsupportedMediaTypeError} from '@tryghost/admin-x-framework/errors';
-import {apiUrl} from '@tryghost/admin-x-framework/helpers';
-import {oneDark} from '@codemirror/theme-one-dark';
-import {search} from '@codemirror/search';
+import { APIError, JSONError, UnsupportedMediaTypeError } from '@tryghost/admin-x-framework/errors';
+import { apiUrl } from '@tryghost/admin-x-framework/helpers';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { search } from '@codemirror/search';
 
-import {toast} from 'sonner';
-import {useBrowseThemes, useUploadTheme} from '@tryghost/admin-x-framework/api/themes';
-import {useFetchApi, useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {formatNumber} from '@tryghost/shade/utils';
-import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
-import {z} from 'zod';
-import type {SelectedNode} from './theme-file-tree';
-import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
-import type {ThemeEditorFile} from './theme-editor-utils';
-import type {ThemeEditorInputModalProps} from './theme-editor-input-modal';
+import { toast } from 'sonner';
+import { useBrowseThemes, useUploadTheme } from '@tryghost/admin-x-framework/api/themes';
+import { useFetchApi, useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { formatNumber } from '@tryghost/shade/utils';
+import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
+import { z } from 'zod';
+import type { SelectedNode } from './theme-file-tree';
+import type { ThemeEditorConfirmModalProps } from './theme-editor-confirm-modal';
+import type { ThemeEditorFile } from './theme-editor-utils';
+import type { ThemeEditorInputModalProps } from './theme-editor-input-modal';
 
 const getLanguageExtension = (path: string) => {
-    const extension = getExtension(path);
+  const extension = getExtension(path);
 
-    switch (extension) {
+  switch (extension) {
     case 'css':
     case 'scss':
     case 'sass':
     case 'less':
-        return import('@codemirror/lang-css').then(module => module.css());
+      return import('@codemirror/lang-css').then((module) => module.css());
     case 'js':
     case 'cjs':
     case 'mjs':
-        return import('@codemirror/lang-javascript').then(module => module.javascript());
+      return import('@codemirror/lang-javascript').then((module) => module.javascript());
     case 'json':
-        return import('@codemirror/lang-json').then(module => module.json());
+      return import('@codemirror/lang-json').then((module) => module.json());
     case 'md':
     case 'markdown':
-        return import('@codemirror/lang-markdown').then(module => module.markdown());
+      return import('@codemirror/lang-markdown').then((module) => module.markdown());
     case 'yaml':
     case 'yml':
-        return import('@codemirror/lang-yaml').then(module => module.yaml());
+      return import('@codemirror/lang-yaml').then((module) => module.yaml());
     case 'hbs':
     case 'handlebars':
     case 'html':
     case 'htm':
     case 'svg':
     case 'xml':
-        return import('@codemirror/lang-html').then(module => module.html());
+      return import('@codemirror/lang-html').then((module) => module.html());
     default:
-        return import('@codemirror/lang-html').then(module => module.html());
-    }
+      return import('@codemirror/lang-html').then((module) => module.html());
+  }
 };
 
 const getLanguageLabel = (path: string) => {
-    const extension = getExtension(path);
+  const extension = getExtension(path);
 
-    if (!extension) {
-        return 'text';
-    }
+  if (!extension) {
+    return 'text';
+  }
 
-    switch (extension) {
+  switch (extension) {
     case 'hbs':
-        return 'handlebars';
+      return 'handlebars';
     case 'htm':
-        return 'html';
+      return 'html';
     case 'yml':
-        return 'yaml';
+      return 'yaml';
     default:
-        return extension;
-    }
+      return extension;
+  }
 };
 
 const getDefaultSelection = (files: Record<string, ThemeEditorFile>): SelectedNode => {
-    if (files['package.json']?.editable) {
-        return {type: 'file', path: 'package.json'};
-    }
+  if (files['package.json']?.editable) {
+    return { type: 'file', path: 'package.json' };
+  }
 
-    const nextEditable = Object.keys(files).sort().find(path => files[path].editable);
+  const nextEditable = Object.keys(files)
+    .sort()
+    .find((path) => files[path].editable);
 
-    if (nextEditable) {
-        return {type: 'file', path: nextEditable};
-    }
+  if (nextEditable) {
+    return { type: 'file', path: nextEditable };
+  }
 
-    const firstPath = Object.keys(files).sort()[0];
+  const firstPath = Object.keys(files).sort()[0];
 
-    return firstPath ? {type: 'file', path: firstPath} : null;
+  return firstPath ? { type: 'file', path: firstPath } : null;
 };
 
 const getParentDirectories = (path: string) => {
-    const segments = path.split('/');
-    const directories: string[] = [''];
+  const segments = path.split('/');
+  const directories: string[] = [''];
 
-    for (let index = 0; index < segments.length - 1; index += 1) {
-        directories.push(`${segments.slice(0, index + 1).join('/')}/`);
-    }
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    directories.push(`${segments.slice(0, index + 1).join('/')}/`);
+  }
 
-    return directories;
+  return directories;
 };
 
 const ALLOWED_RETURN_ROUTE_PREFIXES = ['theme', 'design'];
 
 const isAllowedReturnRoute = (route: string): boolean => {
-    return ALLOWED_RETURN_ROUTE_PREFIXES.some(prefix => route === prefix || route.startsWith(`${prefix}/`));
+  return ALLOWED_RETURN_ROUTE_PREFIXES.some(
+    (prefix) => route === prefix || route.startsWith(`${prefix}/`),
+  );
 };
 
 const getReturnRouteFromHash = () => {
-    const hash = window.location.hash.substring(1);
-    const domain = `${window.location.protocol}//${window.location.hostname}`;
+  const hash = window.location.hash.substring(1);
+  const domain = `${window.location.protocol}//${window.location.hostname}`;
 
-    let url: URL;
-    try {
-        url = new URL(hash || '/', domain);
-    } catch {
-        return null;
-    }
-
-    const from = url.searchParams.get('from');
-
-    if (from === null) {
-        return null;
-    }
-
-    if (from === '' || isAllowedReturnRoute(from)) {
-        return from;
-    }
-
+  let url: URL;
+  try {
+    url = new URL(hash || '/', domain);
+  } catch {
     return null;
+  }
+
+  const from = url.searchParams.get('from');
+
+  if (from === null) {
+    return null;
+  }
+
+  if (from === '' || isAllowedReturnRoute(from)) {
+    return from;
+  }
+
+  return null;
 };
 
 const buildThemeEditorRoute = (themeName: string, fromRoute: string | null) => {
-    const nextRoute = `theme/edit/${encodeURIComponent(themeName)}`;
+  const nextRoute = `theme/edit/${encodeURIComponent(themeName)}`;
 
-    if (fromRoute === null) {
-        return nextRoute;
-    }
+  if (fromRoute === null) {
+    return nextRoute;
+  }
 
-    return `${nextRoute}?from=${encodeURIComponent(fromRoute)}`;
+  return `${nextRoute}?from=${encodeURIComponent(fromRoute)}`;
 };
 
 const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string) => {
-    return !file.editable && isEditablePath(nextPath);
+  return !file.editable && isEditablePath(nextPath);
 };
 
 // Positive allowlist for theme names typed into the "Save as" flow.
@@ -176,872 +184,957 @@ const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string
 // stripping on Windows when the archive is later unzipped.
 const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
 
-type ThemeEditorDialogRequest = {
-    type: 'confirmation';
-    props: ThemeEditorConfirmModalProps;
-    resolve: (result: boolean) => void;
-} | {
-    type: 'input';
-    props: ThemeEditorInputModalProps;
-    resolve: (result: string | null) => void;
-};
+type ThemeEditorDialogRequest =
+  | {
+      type: 'confirmation';
+      props: ThemeEditorConfirmModalProps;
+      resolve: (result: boolean) => void;
+    }
+  | {
+      type: 'input';
+      props: ThemeEditorInputModalProps;
+      resolve: (result: string | null) => void;
+    };
 
-const UPLOAD_SIZE_LIMIT_CODES = ['COMPRESSED_TOO_LARGE', 'ENTRY_TOO_LARGE', 'TOTAL_TOO_LARGE'] as const;
+const UPLOAD_SIZE_LIMIT_CODES = [
+  'COMPRESSED_TOO_LARGE',
+  'ENTRY_TOO_LARGE',
+  'TOTAL_TOO_LARGE',
+] as const;
 
-const UPLOAD_SIZE_LIMIT_TITLES: Record<typeof UPLOAD_SIZE_LIMIT_CODES[number], string> = {
-    COMPRESSED_TOO_LARGE: 'Theme too large to upload',
-    ENTRY_TOO_LARGE: 'File too large',
-    TOTAL_TOO_LARGE: 'Theme contents too large'
+const UPLOAD_SIZE_LIMIT_TITLES: Record<(typeof UPLOAD_SIZE_LIMIT_CODES)[number], string> = {
+  COMPRESSED_TOO_LARGE: 'Theme too large to upload',
+  ENTRY_TOO_LARGE: 'File too large',
+  TOTAL_TOO_LARGE: 'Theme contents too large',
 };
 
 const uploadSizeLimitErrorSchema = z.object({
-    message: z.string().optional(),
-    code: z.enum(UPLOAD_SIZE_LIMIT_CODES),
-    errorDetails: z.object({
-        entryName: z.string().optional(),
-        limitBytes: z.number().positive().finite().optional()
-    }).optional()
+  message: z.string().optional(),
+  code: z.enum(UPLOAD_SIZE_LIMIT_CODES),
+  errorDetails: z
+    .object({
+      entryName: z.string().optional(),
+      limitBytes: z.number().positive().finite().optional(),
+    })
+    .optional(),
 });
 
 const uploadSizeLimitResponseSchema = z.object({
-    errors: z.array(uploadSizeLimitErrorSchema).min(1)
+  errors: z.array(uploadSizeLimitErrorSchema).min(1),
 });
 
 type UploadSizeLimitError = z.infer<typeof uploadSizeLimitErrorSchema>;
 
 const formatLimitBytes = (bytes: number | undefined) => {
-    if (!bytes || bytes <= 0) {
-        return 'the allowed size';
-    }
-    const mb = bytes / (1024 * 1024);
-    if (mb >= 1) {
-        return `${mb.toFixed(1)} MB`;
-    }
-    return `${Math.round(bytes / 1024)} KB`;
+  if (!bytes || bytes <= 0) {
+    return 'the allowed size';
+  }
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) {
+    return `${mb.toFixed(1)} MB`;
+  }
+  return `${Math.round(bytes / 1024)} KB`;
 };
 
 // Size-limit failures are 415s, which the fetch layer surfaces as an
 // UnsupportedMediaTypeError carrying the raw response text
 const getUploadSizeLimitError = (error: unknown): UploadSizeLimitError | null => {
-    if (!(error instanceof UnsupportedMediaTypeError)) {
-        return null;
-    }
-
-    let data: unknown = error.data;
-
-    if (typeof data === 'string') {
-        try {
-            data = JSON.parse(data);
-        } catch {
-            return null;
-        }
-    }
-
-    const parsed = uploadSizeLimitResponseSchema.safeParse(data);
-
-    if (parsed.success) {
-        return parsed.data.errors[0] ?? null;
-    }
-
+  if (!(error instanceof UnsupportedMediaTypeError)) {
     return null;
+  }
+
+  let data: unknown = error.data;
+
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+
+  const parsed = uploadSizeLimitResponseSchema.safeParse(data);
+
+  if (parsed.success) {
+    return parsed.data.errors[0] ?? null;
+  }
+
+  return null;
 };
 
 const buildUploadSizeLimitMessage = (err: UploadSizeLimitError) => {
-    const {entryName, limitBytes} = err.errorDetails ?? {};
-    const limit = formatLimitBytes(limitBytes);
+  const { entryName, limitBytes } = err.errorDetails ?? {};
+  const limit = formatLimitBytes(limitBytes);
 
-    switch (err.code) {
+  switch (err.code) {
     case 'COMPRESSED_TOO_LARGE':
-        return `The theme archive is too large to upload (max ${limit}).`;
+      return `The theme archive is too large to upload (max ${limit}).`;
     case 'ENTRY_TOO_LARGE':
-        return entryName
-            ? `The file "${entryName}" is too large (max ${limit} per file).`
-            : `One of the files is too large (max ${limit} per file).`;
+      return entryName
+        ? `The file "${entryName}" is too large (max ${limit} per file).`
+        : `One of the files is too large (max ${limit} per file).`;
     case 'TOTAL_TOO_LARGE':
-        return `The theme contents exceed the maximum allowed size of ${limit}.`;
+      return `The theme contents exceed the maximum allowed size of ${limit}.`;
     default:
-        return err.message || 'Theme upload failed.';
-    }
+      return err.message || 'Theme upload failed.';
+  }
 };
 
-const wrapToggleClass = (active: boolean) => `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
+const wrapToggleClass = (active: boolean) =>
+  `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
 
-const editorPaneEmptyStateClass = 'flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
+const editorPaneEmptyStateClass =
+  'flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
 
-const editorSelectionTheme = EditorView.theme({
-    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
-        backgroundColor: '#355070'
-    },
+const editorSelectionTheme = EditorView.theme(
+  {
+    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection':
+      {
+        backgroundColor: '#355070',
+      },
     '.cm-content ::selection': {
-        color: '#ffffff'
-    }
-}, {dark: true});
+      color: '#ffffff',
+    },
+  },
+  { dark: true },
+);
 
-const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
-    const {updateRoute} = useSettingsNavigation();
-    const fetchApi = useFetchApi();
-    const handleError = useHandleError();
-    const {data: themesData} = useBrowseThemes();
-    const {mutateAsync: uploadTheme} = useUploadTheme();
+const ThemeCodeEditorModal: React.FC<{ themeName: string }> = ({ themeName }) => {
+  const { updateRoute } = useSettingsNavigation();
+  const fetchApi = useFetchApi();
+  const handleError = useHandleError();
+  const { data: themesData } = useBrowseThemes();
+  const { mutateAsync: uploadTheme } = useUploadTheme();
 
-    const [currentThemeName, setCurrentThemeName] = useState(themeName);
-    const [baseFiles, setBaseFiles] = useState<Record<string, ThemeEditorFile>>({});
-    const [currentFiles, setCurrentFiles] = useState<Record<string, ThemeEditorFile>>({});
-    const [rootPrefix, setRootPrefix] = useState('');
-    const [selectedNode, setSelectedNode] = useState<SelectedNode>(null);
-    const [expandedDirectories, setExpandedDirectories] = useState<Set<string>>(new Set(['']));
-    const [isLoading, setIsLoading] = useState(true);
-    const [isSaving, setIsSaving] = useState(false);
-    const [loadError, setLoadError] = useState<string | null>(null);
-    const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
-    const [dialogRequest, setDialogRequest] = useState<ThemeEditorDialogRequest | null>(null);
-    const dialogRequestRef = useRef<ThemeEditorDialogRequest | null>(null);
-    const [saveErrors, setSaveErrors] = useState<FatalErrors | null>(null);
-    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
-    const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
+  const [currentThemeName, setCurrentThemeName] = useState(themeName);
+  const [baseFiles, setBaseFiles] = useState<Record<string, ThemeEditorFile>>({});
+  const [currentFiles, setCurrentFiles] = useState<Record<string, ThemeEditorFile>>({});
+  const [rootPrefix, setRootPrefix] = useState('');
+  const [selectedNode, setSelectedNode] = useState<SelectedNode>(null);
+  const [expandedDirectories, setExpandedDirectories] = useState<Set<string>>(new Set(['']));
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
+  const [dialogRequest, setDialogRequest] = useState<ThemeEditorDialogRequest | null>(null);
+  const dialogRequestRef = useRef<ThemeEditorDialogRequest | null>(null);
+  const [saveErrors, setSaveErrors] = useState<FatalErrors | null>(null);
+  const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
+  const [editorExtensions, setEditorExtensions] = useState<
+    Array<ReturnType<typeof search> | Awaited<ReturnType<typeof getLanguageExtension>>>
+  >([]);
 
-    useEffect(() => {
-        let isMounted = true;
+  useEffect(() => {
+    let isMounted = true;
 
-        const resetLoadedTheme = () => {
-            setCurrentThemeName(themeName);
-            setBaseFiles({});
-            setCurrentFiles({});
-            setRootPrefix('');
-            setSelectedNode(null);
-            setExpandedDirectories(new Set(['']));
-        };
+    const resetLoadedTheme = () => {
+      setCurrentThemeName(themeName);
+      setBaseFiles({});
+      setCurrentFiles({});
+      setRootPrefix('');
+      setSelectedNode(null);
+      setExpandedDirectories(new Set(['']));
+    };
 
-        const loadTheme = async () => {
-            setIsLoading(true);
-            setLoadError(null);
-            resetLoadedTheme();
+    const loadTheme = async () => {
+      setIsLoading(true);
+      setLoadError(null);
+      resetLoadedTheme();
 
-            try {
-                const archive = await fetchApi<ArrayBuffer>(apiUrl(`/themes/${encodeURIComponent(themeName)}/download/`), {
-                    responseType: 'arraybuffer'
-                });
-                const snapshot = await extractThemeArchive(archive);
-                const nextFiles = cloneThemeFiles(snapshot.files);
-                const nextSelection = getDefaultSelection(nextFiles);
+      try {
+        const archive = await fetchApi<ArrayBuffer>(
+          apiUrl(`/themes/${encodeURIComponent(themeName)}/download/`),
+          {
+            responseType: 'arraybuffer',
+          },
+        );
+        const snapshot = await extractThemeArchive(archive);
+        const nextFiles = cloneThemeFiles(snapshot.files);
+        const nextSelection = getDefaultSelection(nextFiles);
 
-                if (!isMounted) {
-                    return;
-                }
-
-                setCurrentThemeName(themeName);
-                setBaseFiles(cloneThemeFiles(snapshot.files));
-                setCurrentFiles(nextFiles);
-                setRootPrefix(snapshot.rootPrefix);
-                setSelectedNode(nextSelection);
-                setExpandedDirectories(new Set(nextSelection?.type === 'file' ? getParentDirectories(nextSelection.path) : ['']));
-            } catch (error) {
-                if (!isMounted) {
-                    return;
-                }
-
-                if (error instanceof APIError && error.response) {
-                    setLoadError(`Failed to load theme "${themeName}" (${error.response.status})`);
-                } else {
-                    setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
-                }
-            } finally {
-                if (isMounted) {
-                    setIsLoading(false);
-                }
-            }
-        };
-
-        void loadTheme();
-
-        return () => {
-            isMounted = false;
-        };
-    }, [themeName, fetchApi]);
-
-    useEffect(() => {
-        const previousOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-
-        return () => {
-            document.body.style.overflow = previousOverflow;
-        };
-    }, []);
-
-    const changes = useMemo(() => getThemeChanges({baseFiles, currentFiles}), [baseFiles, currentFiles]);
-    const changesMap = useMemo(() => new Map(changes.map(change => [change.path, change.status])), [changes]);
-    const selectedFile = selectedNode?.type === 'file' ? currentFiles[selectedNode.path] : null;
-
-    useEffect(() => {
-        let isMounted = true;
-
-        if (!selectedFile?.editable) {
-            setEditorExtensions([]);
-            return () => {
-                isMounted = false;
-            };
+        if (!isMounted) {
+          return;
         }
 
-        // Only the language extension is async (dynamic import); oneDark and
-        // the other extensions are static. Awaiting just the language load
-        // keeps the Promise types honest and makes the fallback branch read
-        // more clearly.
-        getLanguageExtension(selectedFile.path).then((languageExtension) => {
-            if (isMounted) {
-                setEditorExtensions([
-                    search({top: true}),
-                    oneDark,
-                    languageExtension,
-                    ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
-                    editorSelectionTheme
-                ]);
-            }
-        }).catch(() => {
-            if (isMounted) {
-                setEditorExtensions([
-                    search({top: true}),
-                    oneDark,
-                    ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
-                    editorSelectionTheme
-                ]);
-            }
-        });
-
-        return () => {
-            isMounted = false;
-        };
-    }, [isTextWrapEnabled, selectedFile]);
-
-    const cancelPendingDialogRequest = useCallback(() => {
-        const request = dialogRequestRef.current;
-
-        if (!request) {
-            return;
+        setCurrentThemeName(themeName);
+        setBaseFiles(cloneThemeFiles(snapshot.files));
+        setCurrentFiles(nextFiles);
+        setRootPrefix(snapshot.rootPrefix);
+        setSelectedNode(nextSelection);
+        setExpandedDirectories(
+          new Set(nextSelection?.type === 'file' ? getParentDirectories(nextSelection.path) : ['']),
+        );
+      } catch (error) {
+        if (!isMounted) {
+          return;
         }
 
-        dialogRequestRef.current = null;
-
-        if (request.type === 'confirmation') {
-            request.resolve(false);
+        if (error instanceof APIError && error.response) {
+          setLoadError(`Failed to load theme "${themeName}" (${error.response.status})`);
         } else {
-            request.resolve(null);
+          setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
         }
-    }, []);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
 
-    const requestConfirmation = (props: ThemeEditorConfirmModalProps) => {
-        cancelPendingDialogRequest();
+    void loadTheme();
 
-        return new Promise<boolean>((resolve) => {
-            const request: ThemeEditorDialogRequest = {type: 'confirmation', props, resolve};
-            dialogRequestRef.current = request;
-            setDialogRequest(request);
+    return () => {
+      isMounted = false;
+    };
+  }, [themeName, fetchApi]);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  const changes = useMemo(
+    () => getThemeChanges({ baseFiles, currentFiles }),
+    [baseFiles, currentFiles],
+  );
+  const changesMap = useMemo(
+    () => new Map(changes.map((change) => [change.path, change.status])),
+    [changes],
+  );
+  const selectedFile = selectedNode?.type === 'file' ? currentFiles[selectedNode.path] : null;
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!selectedFile?.editable) {
+      setEditorExtensions([]);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    // Only the language extension is async (dynamic import); oneDark and
+    // the other extensions are static. Awaiting just the language load
+    // keeps the Promise types honest and makes the fallback branch read
+    // more clearly.
+    getLanguageExtension(selectedFile.path)
+      .then((languageExtension) => {
+        if (isMounted) {
+          setEditorExtensions([
+            search({ top: true }),
+            oneDark,
+            languageExtension,
+            ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
+            editorSelectionTheme,
+          ]);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setEditorExtensions([
+            search({ top: true }),
+            oneDark,
+            ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
+            editorSelectionTheme,
+          ]);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isTextWrapEnabled, selectedFile]);
+
+  const cancelPendingDialogRequest = useCallback(() => {
+    const request = dialogRequestRef.current;
+
+    if (!request) {
+      return;
+    }
+
+    dialogRequestRef.current = null;
+
+    if (request.type === 'confirmation') {
+      request.resolve(false);
+    } else {
+      request.resolve(null);
+    }
+  }, []);
+
+  const requestConfirmation = (props: ThemeEditorConfirmModalProps) => {
+    cancelPendingDialogRequest();
+
+    return new Promise<boolean>((resolve) => {
+      const request: ThemeEditorDialogRequest = { type: 'confirmation', props, resolve };
+      dialogRequestRef.current = request;
+      setDialogRequest(request);
+    });
+  };
+
+  const requestInput = (props: ThemeEditorInputModalProps) => {
+    cancelPendingDialogRequest();
+
+    return new Promise<string | null>((resolve) => {
+      const request: ThemeEditorDialogRequest = { type: 'input', props, resolve };
+      dialogRequestRef.current = request;
+      setDialogRequest(request);
+    });
+  };
+
+  useEffect(() => {
+    return () => cancelPendingDialogRequest();
+  }, [cancelPendingDialogRequest]);
+
+  const closeEditor = async () => {
+    if (changes.length > 0) {
+      const shouldDiscard = await requestConfirmation({
+        title: 'Discard changes?',
+        prompt: 'You have unsaved theme changes. Close the editor and discard them?',
+        okLabel: 'Discard changes',
+        okVariant: 'destructive',
+      });
+
+      if (!shouldDiscard) {
+        return;
+      }
+    }
+
+    updateRoute(getReturnRouteFromHash() ?? 'design/change-theme');
+  };
+
+  // Keep a ref to the latest handleSave so the keydown listener can call
+  // the freshest version without re-registering on every render. handleSave
+  // captures state (currentFiles, changes, isSaving, ...) and is recreated
+  // each render — using a ref decouples that churn from the global listener.
+  const handleSaveRef = useRef<() => Promise<void>>(async () => {});
+
+  const hasOpenDialog = Boolean(dialogRequest || saveErrors || installedModal);
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+
+        if (hasOpenDialog) {
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+          return;
+        }
+
+        void handleSaveRef.current();
+        return;
+      }
+
+      if (event.key !== 'Escape') {
+        return;
+      }
+
+      if (hasOpenDialog) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+
+    window.addEventListener('keydown', handleKeydown, true);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown, true);
+    };
+  }, [hasOpenDialog]);
+
+  const ensurePathExpanded = (path: string) => {
+    setExpandedDirectories((current) => {
+      const next = new Set(current);
+
+      for (const dir of getParentDirectories(path)) {
+        next.add(dir);
+      }
+
+      return next;
+    });
+  };
+
+  const setFilesAndSelection = (
+    files: Record<string, ThemeEditorFile>,
+    nextSelection?: SelectedNode,
+  ) => {
+    setCurrentFiles(files);
+
+    if (nextSelection) {
+      setSelectedNode(nextSelection);
+      if (nextSelection.type === 'file') {
+        ensurePathExpanded(nextSelection.path);
+      }
+      return;
+    }
+
+    if (selectedNode?.type === 'file' && files[selectedNode.path]) {
+      return;
+    }
+
+    setSelectedNode(getDefaultSelection(files));
+  };
+
+  const handleCreateFile = async () => {
+    const requestedPath = await requestInput({
+      title: 'Create file',
+      fieldTitle: 'File path',
+      initialValue: 'partials/new-file.hbs',
+      okLabel: 'Create file',
+      prompt: 'Add a new editable file to this theme.',
+    });
+    const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
+
+    if (!nextPath) {
+      return;
+    }
+
+    if (!isEditablePath(nextPath)) {
+      toast.error('Only text files can be created here', {
+        description: 'Use a text-based theme file extension such as .hbs, .css, .js, or .json.',
+      });
+      return;
+    }
+
+    if (currentFiles[nextPath]) {
+      toast.error('File already exists');
+      return;
+    }
+
+    const nextFiles = {
+      ...currentFiles,
+      [nextPath]: {
+        path: nextPath,
+        editable: true,
+        content: '',
+        binary: null,
+        date: new Date(),
+        unixPermissions: null,
+        dosPermissions: null,
+      },
+    };
+
+    setFilesAndSelection(nextFiles, { type: 'file', path: nextPath });
+  };
+
+  const handleRenameSelected = async () => {
+    if (!selectedNode) {
+      return;
+    }
+
+    const defaultValue =
+      selectedNode.type === 'dir' ? selectedNode.path.replace(/\/$/, '') : selectedNode.path;
+    const promptLabel = selectedNode.type === 'dir' ? 'Rename folder to' : 'Rename file to';
+    const requestedPath = await requestInput({
+      title: selectedNode.type === 'dir' ? 'Rename folder' : 'Rename file',
+      fieldTitle: 'Path',
+      initialValue: defaultValue,
+      okLabel: 'Rename',
+      prompt: promptLabel,
+    });
+    const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
+
+    if (!nextPath || nextPath === defaultValue) {
+      return;
+    }
+
+    if (selectedNode.type === 'file') {
+      const fileToRename = currentFiles[selectedNode.path];
+
+      if (!isEditablePath(nextPath) && fileToRename.editable) {
+        toast.error('Text files must keep a text file extension');
+        return;
+      }
+
+      if (wouldRenameBinaryFileToEditable(fileToRename, nextPath)) {
+        toast.error('Binary files cannot be renamed to a text file', {
+          description: 'Rename this file with a non-text extension to keep its contents intact.',
         });
-    };
-
-    const requestInput = (props: ThemeEditorInputModalProps) => {
-        cancelPendingDialogRequest();
-
-        return new Promise<string | null>((resolve) => {
-            const request: ThemeEditorDialogRequest = {type: 'input', props, resolve};
-            dialogRequestRef.current = request;
-            setDialogRequest(request);
-        });
-    };
-
-    useEffect(() => {
-        return () => cancelPendingDialogRequest();
-    }, [cancelPendingDialogRequest]);
-
-    const closeEditor = async () => {
-        if (changes.length > 0) {
-            const shouldDiscard = await requestConfirmation({
-                title: 'Discard changes?',
-                prompt: 'You have unsaved theme changes. Close the editor and discard them?',
-                okLabel: 'Discard changes',
-                okVariant: 'destructive'
-            });
-
-            if (!shouldDiscard) {
-                return;
-            }
-        }
-
-        updateRoute(getReturnRouteFromHash() ?? 'design/change-theme');
-    };
-
-    // Keep a ref to the latest handleSave so the keydown listener can call
-    // the freshest version without re-registering on every render. handleSave
-    // captures state (currentFiles, changes, isSaving, ...) and is recreated
-    // each render — using a ref decouples that churn from the global listener.
-    const handleSaveRef = useRef<() => Promise<void>>(async () => {});
-
-    const hasOpenDialog = Boolean(dialogRequest || saveErrors || installedModal);
-
-    useEffect(() => {
-        const handleKeydown = (event: KeyboardEvent) => {
-            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
-                event.preventDefault();
-
-                if (hasOpenDialog) {
-                    event.stopPropagation();
-                    event.stopImmediatePropagation();
-                    return;
-                }
-
-                void handleSaveRef.current();
-                return;
-            }
-
-            if (event.key !== 'Escape') {
-                return;
-            }
-
-            if (hasOpenDialog) {
-                return;
-            }
-
-            event.preventDefault();
-            event.stopPropagation();
-            event.stopImmediatePropagation();
-        };
-
-        window.addEventListener('keydown', handleKeydown, true);
-
-        return () => {
-            window.removeEventListener('keydown', handleKeydown, true);
-        };
-    }, [hasOpenDialog]);
-
-    const ensurePathExpanded = (path: string) => {
-        setExpandedDirectories((current) => {
-            const next = new Set(current);
-
-            for (const dir of getParentDirectories(path)) {
-                next.add(dir);
-            }
-
-            return next;
-        });
-    };
-
-    const setFilesAndSelection = (files: Record<string, ThemeEditorFile>, nextSelection?: SelectedNode) => {
-        setCurrentFiles(files);
-
-        if (nextSelection) {
-            setSelectedNode(nextSelection);
-            if (nextSelection.type === 'file') {
-                ensurePathExpanded(nextSelection.path);
-            }
-            return;
-        }
-
-        if (selectedNode?.type === 'file' && files[selectedNode.path]) {
-            return;
-        }
-
-        setSelectedNode(getDefaultSelection(files));
-    };
-
-    const handleCreateFile = async () => {
-        const requestedPath = await requestInput({
-            title: 'Create file',
-            fieldTitle: 'File path',
-            initialValue: 'partials/new-file.hbs',
-            okLabel: 'Create file',
-            prompt: 'Add a new editable file to this theme.'
-        });
-        const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
-
-        if (!nextPath) {
-            return;
-        }
-
-        if (!isEditablePath(nextPath)) {
-            toast.error('Only text files can be created here', {description: 'Use a text-based theme file extension such as .hbs, .css, .js, or .json.'});
-            return;
-        }
-
-        if (currentFiles[nextPath]) {
-            toast.error('File already exists');
-            return;
-        }
-
-        const nextFiles = {
-            ...currentFiles,
-            [nextPath]: {
-                path: nextPath,
-                editable: true,
-                content: '',
-                binary: null,
-                date: new Date(),
-                unixPermissions: null,
-                dosPermissions: null
-            }
-        };
-
-        setFilesAndSelection(nextFiles, {type: 'file', path: nextPath});
-    };
-
-    const handleRenameSelected = async () => {
-        if (!selectedNode) {
-            return;
-        }
-
-        const defaultValue = selectedNode.type === 'dir'
-            ? selectedNode.path.replace(/\/$/, '')
-            : selectedNode.path;
-        const promptLabel = selectedNode.type === 'dir' ? 'Rename folder to' : 'Rename file to';
-        const requestedPath = await requestInput({
-            title: selectedNode.type === 'dir' ? 'Rename folder' : 'Rename file',
-            fieldTitle: 'Path',
-            initialValue: defaultValue,
-            okLabel: 'Rename',
-            prompt: promptLabel
-        });
-        const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
-
-        if (!nextPath || nextPath === defaultValue) {
-            return;
-        }
-
-        if (selectedNode.type === 'file') {
-            const fileToRename = currentFiles[selectedNode.path];
-
-            if (!isEditablePath(nextPath) && fileToRename.editable) {
-                toast.error('Text files must keep a text file extension');
-                return;
-            }
-
-            if (wouldRenameBinaryFileToEditable(fileToRename, nextPath)) {
-                toast.error('Binary files cannot be renamed to a text file', {description: 'Rename this file with a non-text extension to keep its contents intact.'});
-                return;
-            }
-
-            if (currentFiles[nextPath]) {
-                toast.error('A file with that name already exists');
-                return;
-            }
-
-            const nextFiles = {...currentFiles};
-            const file = nextFiles[selectedNode.path];
-            delete nextFiles[selectedNode.path];
-            nextFiles[nextPath] = {
-                ...file,
-                path: nextPath,
-                editable: isEditablePath(nextPath)
-            };
-
-            setFilesAndSelection(nextFiles, {type: 'file', path: nextPath});
-            return;
-        }
-
-        const nextDirectoryPath = `${nextPath}/`;
-
-        if (nextDirectoryPath.startsWith(selectedNode.path)) {
-            toast.error('A folder cannot be renamed inside itself');
-            return;
-        }
-
-        const conflictingPath = Object.keys(currentFiles).find(path => path.startsWith(nextDirectoryPath));
-
-        if (conflictingPath) {
-            toast.error('A folder with that path already exists');
-            return;
-        }
-
-        const nextFiles = createFolderRenameMap({
-            files: currentFiles,
-            oldPrefix: selectedNode.path,
-            newPrefix: nextDirectoryPath
-        });
-
-        setFilesAndSelection(nextFiles, {type: 'dir', path: nextDirectoryPath});
-        setExpandedDirectories((current) => {
-            const next = new Set<string>();
-
-            for (const directory of current) {
-                if (!directory.startsWith(selectedNode.path)) {
-                    next.add(directory);
-                    continue;
-                }
-
-                next.add(`${nextDirectoryPath}${directory.slice(selectedNode.path.length)}`);
-            }
-
-            return next;
-        });
-    };
-
-    const handleDeleteSelected = async () => {
-        if (!selectedNode) {
-            return;
-        }
-
-        if (selectedNode.type === 'file') {
-            const confirmed = await requestConfirmation({
-                title: 'Delete file',
-                prompt: <>Delete <strong>{selectedNode.path}</strong> from this theme?</>,
-                okLabel: 'Delete',
-                okVariant: 'destructive'
-            });
-
-            if (!confirmed) {
-                return;
-            }
-
-            const nextFiles = {...currentFiles};
-            delete nextFiles[selectedNode.path];
-            setFilesAndSelection(nextFiles);
-            return;
-        }
-
-        const matchingPaths = Object.keys(currentFiles).filter(path => path.startsWith(selectedNode.path));
-
-        if (!matchingPaths.length) {
-            return;
-        }
-
-        const confirmed = await requestConfirmation({
-            title: 'Delete folder',
-            prompt: <>Delete {formatNumber(matchingPaths.length)} file{matchingPaths.length === 1 ? '' : 's'} from <strong>{selectedNode.path}</strong>?</>,
-            okLabel: 'Delete',
-            okVariant: 'destructive'
-        });
-
-        if (!confirmed) {
-            return;
-        }
-
-        const nextFiles = {...currentFiles};
-
-        for (const path of matchingPaths) {
-            delete nextFiles[path];
-        }
-
-        setFilesAndSelection(nextFiles);
-    };
-
-    const handleRevertPath = (path: string) => {
-        const baseFile = baseFiles[path];
-        const currentFile = currentFiles[path];
-        const nextFiles = {...currentFiles};
-
-        if (!baseFile && currentFile) {
-            delete nextFiles[path];
-        } else if (baseFile) {
-            nextFiles[path] = {
-                ...baseFile,
-                binary: baseFile.binary ? new Uint8Array(baseFile.binary) : null
-            };
-        }
-
-        setFilesAndSelection(nextFiles);
-    };
-
-    const requestSaveAsThemeName = async () => {
-        const requestedName = await requestInput({
-            title: 'Save as new theme',
-            fieldTitle: 'Theme name',
-            initialValue: `${currentThemeName}-edited`,
-            okLabel: 'Continue',
-            prompt: 'Default themes cannot be overwritten. Save your edits as a new theme instead.'
-        });
-        const nextName = requestedName?.trim().toLowerCase();
-
-        if (!nextName) {
-            return null;
-        }
-
-        if (!THEME_NAME_PATTERN.test(nextName)) {
-            toast.error('Invalid theme name', {description: 'Use 1-64 characters, starting with a letter or number. Allowed: letters, numbers, dashes, and underscores.'});
-            return null;
-        }
-
-        if (isDefaultThemeName(nextName)) {
-            toast.error('Built-in themes cannot be overwritten');
-            return null;
-        }
-
-        return nextName;
-    };
-
-    const handleSave = async () => {
-        if (isSaving) {
-            return;
-        }
-
-        if (changes.length === 0) {
-            toast.info('No changes to save');
-            return;
-        }
-
-        const previousThemeName = currentThemeName;
-        const nextThemeName = isDefaultThemeName(previousThemeName) ? await requestSaveAsThemeName() : previousThemeName;
-
-        if (!nextThemeName) {
-            return;
-        }
-
-        const isSaveAs = nextThemeName !== previousThemeName;
-        const themeExists = themesData?.themes.some(theme => theme.name === nextThemeName) || false;
-        const confirmMessage = isSaveAs
-            ? `Save your edits as "${nextThemeName}"?`
-            : `Upload ${formatNumber(changes.length)} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
-
-        const confirmedSave = await requestConfirmation({
-            title: isSaveAs ? 'Save theme as new copy' : 'Update theme',
-            prompt: confirmMessage,
-            okLabel: isSaveAs ? 'Save theme' : 'Replace theme'
-        });
-
-        if (!confirmedSave) {
-            return;
-        }
-
-        if (isSaveAs && themeExists) {
-            const confirmedOverwrite = await requestConfirmation({
-                title: 'Overwrite theme',
-                prompt: <><strong>{nextThemeName}</strong> already exists. Do you want to overwrite it?</>,
-                okLabel: 'Overwrite',
-                okVariant: 'destructive'
-            });
-
-            if (!confirmedOverwrite) {
-                return;
-            }
-        }
-
-        setIsSaving(true);
-
-        try {
-            const blob = await packThemeArchive({
-                files: currentFiles,
-                rootPrefix
-            });
-
-            const data = await uploadTheme({
-                file: new File([blob], `${nextThemeName}.zip`, {type: 'application/zip'}),
-                // when saving under a new name, carry over the original theme's
-                // settings so activating the copy keeps the site's design
-                copySettingsFrom: isSaveAs ? previousThemeName : undefined
-            });
-
-            const uploadedTheme = data.themes[0];
-            const returnRoute = getReturnRouteFromHash();
-
-            setBaseFiles(cloneThemeFiles(currentFiles));
-
-            if (isSaveAs) {
-                setCurrentThemeName(nextThemeName);
-                setRootPrefix(rootPrefix ? `${nextThemeName}/` : '');
-                updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
-            }
-
-            const problems = getIssuesFromInstalledTheme(uploadedTheme);
-
-            if (isSaveAs || problems.length) {
-                setInstalledModal({
-                    title: isSaveAs ? 'Theme saved' : 'Theme updated',
-                    statusMessage: <><strong>{uploadedTheme.name}</strong> was {describeThemeOutcome('saved', problems)}. Do you want to activate it?</>,
-                    installedTheme: uploadedTheme
-                });
-            } else {
-                toast.success('Theme saved', {description: <div><span className='capitalize'>{uploadedTheme.name}</span> has been updated.</div>});
-            }
-        } catch (error) {
-            if (error instanceof JSONError && error.response?.status === 422) {
-                const fatalErrors = parseFatalErrors(error.data?.errors);
-
-                if (fatalErrors) {
-                    setSaveErrors(fatalErrors);
-                    return;
-                }
-            }
-
-            const sizeLimitError = getUploadSizeLimitError(error);
-
-            if (sizeLimitError) {
-                toast.error(UPLOAD_SIZE_LIMIT_TITLES[sizeLimitError.code], {description: buildUploadSizeLimitMessage(sizeLimitError)});
-                return;
-            }
-
-            handleError(error);
-        } finally {
-            setIsSaving(false);
-        }
-    };
-
-    useEffect(() => {
-        handleSaveRef.current = handleSave;
+        return;
+      }
+
+      if (currentFiles[nextPath]) {
+        toast.error('A file with that name already exists');
+        return;
+      }
+
+      const nextFiles = { ...currentFiles };
+      const file = nextFiles[selectedNode.path];
+      delete nextFiles[selectedNode.path];
+      nextFiles[nextPath] = {
+        ...file,
+        path: nextPath,
+        editable: isEditablePath(nextPath),
+      };
+
+      setFilesAndSelection(nextFiles, { type: 'file', path: nextPath });
+      return;
+    }
+
+    const nextDirectoryPath = `${nextPath}/`;
+
+    if (nextDirectoryPath.startsWith(selectedNode.path)) {
+      toast.error('A folder cannot be renamed inside itself');
+      return;
+    }
+
+    const conflictingPath = Object.keys(currentFiles).find((path) =>
+      path.startsWith(nextDirectoryPath),
+    );
+
+    if (conflictingPath) {
+      toast.error('A folder with that path already exists');
+      return;
+    }
+
+    const nextFiles = createFolderRenameMap({
+      files: currentFiles,
+      oldPrefix: selectedNode.path,
+      newPrefix: nextDirectoryPath,
     });
 
-    const openFile = (path: string) => {
-        setSelectedNode({type: 'file', path});
-        ensurePathExpanded(path);
-    };
+    setFilesAndSelection(nextFiles, { type: 'dir', path: nextDirectoryPath });
+    setExpandedDirectories((current) => {
+      const next = new Set<string>();
 
-    const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
+      for (const directory of current) {
+        if (!directory.startsWith(selectedNode.path)) {
+          next.add(directory);
+          continue;
+        }
 
-    return (<>
-        <div
-            aria-label={`Edit theme ${themeName}`}
-            aria-modal='true'
-            className='dark fixed inset-0 z-[140] bg-[rgba(10,11,13,0.72)] text-[#e6e7ea] backdrop-blur-[4px]'
-            data-testid='theme-code-editor-modal'
-            role='dialog'
-            onClick={(event) => {
-                if (event.target === event.currentTarget) {
-                    void closeEditor();
-                }
-            }}
-        >
-            <div className='relative flex size-full flex-col overflow-hidden bg-[#15171a]'>
-                <ThemeEditorToolbar
-                    changes={changes}
-                    currentThemeName={currentThemeName}
-                    isSaving={isSaving}
-                    onClose={() => void closeEditor()}
-                    onSave={() => void handleSave()}
-                />
+        next.add(`${nextDirectoryPath}${directory.slice(selectedNode.path.length)}`);
+      }
 
-                {loadError && (
-                    <div className='border-b border-[#512828] bg-[#3a1d1d] px-4 py-2 text-[12px] text-[#ffbdbd]'>
-                        {loadError}
-                    </div>
+      return next;
+    });
+  };
+
+  const handleDeleteSelected = async () => {
+    if (!selectedNode) {
+      return;
+    }
+
+    if (selectedNode.type === 'file') {
+      const confirmed = await requestConfirmation({
+        title: 'Delete file',
+        prompt: (
+          <>
+            Delete <strong>{selectedNode.path}</strong> from this theme?
+          </>
+        ),
+        okLabel: 'Delete',
+        okVariant: 'destructive',
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      const nextFiles = { ...currentFiles };
+      delete nextFiles[selectedNode.path];
+      setFilesAndSelection(nextFiles);
+      return;
+    }
+
+    const matchingPaths = Object.keys(currentFiles).filter((path) =>
+      path.startsWith(selectedNode.path),
+    );
+
+    if (!matchingPaths.length) {
+      return;
+    }
+
+    const confirmed = await requestConfirmation({
+      title: 'Delete folder',
+      prompt: (
+        <>
+          Delete {formatNumber(matchingPaths.length)} file{matchingPaths.length === 1 ? '' : 's'}{' '}
+          from <strong>{selectedNode.path}</strong>?
+        </>
+      ),
+      okLabel: 'Delete',
+      okVariant: 'destructive',
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    const nextFiles = { ...currentFiles };
+
+    for (const path of matchingPaths) {
+      delete nextFiles[path];
+    }
+
+    setFilesAndSelection(nextFiles);
+  };
+
+  const handleRevertPath = (path: string) => {
+    const baseFile = baseFiles[path];
+    const currentFile = currentFiles[path];
+    const nextFiles = { ...currentFiles };
+
+    if (!baseFile && currentFile) {
+      delete nextFiles[path];
+    } else if (baseFile) {
+      nextFiles[path] = {
+        ...baseFile,
+        binary: baseFile.binary ? new Uint8Array(baseFile.binary) : null,
+      };
+    }
+
+    setFilesAndSelection(nextFiles);
+  };
+
+  const requestSaveAsThemeName = async () => {
+    const requestedName = await requestInput({
+      title: 'Save as new theme',
+      fieldTitle: 'Theme name',
+      initialValue: `${currentThemeName}-edited`,
+      okLabel: 'Continue',
+      prompt: 'Default themes cannot be overwritten. Save your edits as a new theme instead.',
+    });
+    const nextName = requestedName?.trim().toLowerCase();
+
+    if (!nextName) {
+      return null;
+    }
+
+    if (!THEME_NAME_PATTERN.test(nextName)) {
+      toast.error('Invalid theme name', {
+        description:
+          'Use 1-64 characters, starting with a letter or number. Allowed: letters, numbers, dashes, and underscores.',
+      });
+      return null;
+    }
+
+    if (isDefaultThemeName(nextName)) {
+      toast.error('Built-in themes cannot be overwritten');
+      return null;
+    }
+
+    return nextName;
+  };
+
+  const handleSave = async () => {
+    if (isSaving) {
+      return;
+    }
+
+    if (changes.length === 0) {
+      toast.info('No changes to save');
+      return;
+    }
+
+    const previousThemeName = currentThemeName;
+    const nextThemeName = isDefaultThemeName(previousThemeName)
+      ? await requestSaveAsThemeName()
+      : previousThemeName;
+
+    if (!nextThemeName) {
+      return;
+    }
+
+    const isSaveAs = nextThemeName !== previousThemeName;
+    const themeExists = themesData?.themes.some((theme) => theme.name === nextThemeName) || false;
+    const confirmMessage = isSaveAs
+      ? `Save your edits as "${nextThemeName}"?`
+      : `Upload ${formatNumber(changes.length)} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
+
+    const confirmedSave = await requestConfirmation({
+      title: isSaveAs ? 'Save theme as new copy' : 'Update theme',
+      prompt: confirmMessage,
+      okLabel: isSaveAs ? 'Save theme' : 'Replace theme',
+    });
+
+    if (!confirmedSave) {
+      return;
+    }
+
+    if (isSaveAs && themeExists) {
+      const confirmedOverwrite = await requestConfirmation({
+        title: 'Overwrite theme',
+        prompt: (
+          <>
+            <strong>{nextThemeName}</strong> already exists. Do you want to overwrite it?
+          </>
+        ),
+        okLabel: 'Overwrite',
+        okVariant: 'destructive',
+      });
+
+      if (!confirmedOverwrite) {
+        return;
+      }
+    }
+
+    setIsSaving(true);
+
+    try {
+      const blob = await packThemeArchive({
+        files: currentFiles,
+        rootPrefix,
+      });
+
+      const data = await uploadTheme({
+        file: new File([blob], `${nextThemeName}.zip`, { type: 'application/zip' }),
+        // when saving under a new name, carry over the original theme's
+        // settings so activating the copy keeps the site's design
+        copySettingsFrom: isSaveAs ? previousThemeName : undefined,
+      });
+
+      const uploadedTheme = data.themes[0];
+      const returnRoute = getReturnRouteFromHash();
+
+      setBaseFiles(cloneThemeFiles(currentFiles));
+
+      if (isSaveAs) {
+        setCurrentThemeName(nextThemeName);
+        setRootPrefix(rootPrefix ? `${nextThemeName}/` : '');
+        updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
+      }
+
+      const problems = getIssuesFromInstalledTheme(uploadedTheme);
+
+      if (isSaveAs || problems.length) {
+        setInstalledModal({
+          title: isSaveAs ? 'Theme saved' : 'Theme updated',
+          statusMessage: (
+            <>
+              <strong>{uploadedTheme.name}</strong> was {describeThemeOutcome('saved', problems)}.
+              Do you want to activate it?
+            </>
+          ),
+          installedTheme: uploadedTheme,
+        });
+      } else {
+        toast.success('Theme saved', {
+          description: (
+            <div>
+              <span className="capitalize">{uploadedTheme.name}</span> has been updated.
+            </div>
+          ),
+        });
+      }
+    } catch (error) {
+      if (error instanceof JSONError && error.response?.status === 422) {
+        const fatalErrors = parseFatalErrors(error.data?.errors);
+
+        if (fatalErrors) {
+          setSaveErrors(fatalErrors);
+          return;
+        }
+      }
+
+      const sizeLimitError = getUploadSizeLimitError(error);
+
+      if (sizeLimitError) {
+        toast.error(UPLOAD_SIZE_LIMIT_TITLES[sizeLimitError.code], {
+          description: buildUploadSizeLimitMessage(sizeLimitError),
+        });
+        return;
+      }
+
+      handleError(error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  useEffect(() => {
+    handleSaveRef.current = handleSave;
+  });
+
+  const openFile = (path: string) => {
+    setSelectedNode({ type: 'file', path });
+    ensurePathExpanded(path);
+  };
+
+  const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
+
+  return (
+    <>
+      <div
+        aria-label={`Edit theme ${themeName}`}
+        aria-modal="true"
+        className="dark fixed inset-0 z-[140] bg-[rgba(10,11,13,0.72)] text-[#e6e7ea] backdrop-blur-[4px]"
+        data-testid="theme-code-editor-modal"
+        role="dialog"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) {
+            void closeEditor();
+          }
+        }}
+      >
+        <div className="relative flex size-full flex-col overflow-hidden bg-[#15171a]">
+          <ThemeEditorToolbar
+            changes={changes}
+            currentThemeName={currentThemeName}
+            isSaving={isSaving}
+            onClose={() => void closeEditor()}
+            onSave={() => void handleSave()}
+          />
+
+          {loadError && (
+            <div className="border-b border-[#512828] bg-[#3a1d1d] px-4 py-2 text-[12px] text-[#ffbdbd]">
+              {loadError}
+            </div>
+          )}
+
+          <div className="flex min-h-0 flex-1">
+            <ThemeFileTree
+              changesMap={changesMap}
+              currentFiles={currentFiles}
+              expandedDirectories={expandedDirectories}
+              isLoading={isLoading}
+              selectedNode={selectedNode}
+              setExpandedDirectories={setExpandedDirectories}
+              setSelectedNode={setSelectedNode}
+              onCreateFile={() => void handleCreateFile()}
+              onDeleteSelected={() => void handleDeleteSelected()}
+              onOpenFile={openFile}
+              onRenameSelected={() => void handleRenameSelected()}
+            />
+
+            <section className="flex min-w-0 flex-1 flex-col bg-[#16181c]">
+              <div className="flex items-center gap-2 border-b border-[#23262c] bg-[#17191d] px-4 py-2 text-[12px] text-[#8a8f98]">
+                {selectedFile ? (
+                  <>
+                    <span className="min-w-0 truncate font-medium text-[#e6e7ea]">
+                      {selectedFile.path}
+                    </span>
+                    <span className="rounded bg-[#2a2d33] px-2 py-0.5 text-[10px] tracking-[0.04em] text-[#c8ccd3] uppercase">
+                      {getLanguageLabel(selectedFile.path)}
+                    </span>
+                    {selectedFileStatus && (
+                      <button
+                        className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] tracking-[0.04em] uppercase ${selectedFileStatus === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : selectedFileStatus === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}
+                        type="button"
+                        onClick={() => handleRevertPath(selectedFile.path)}
+                      >
+                        <Undo2 size={11} />
+                        Revert
+                      </button>
+                    )}
+                    <div className="grow" />
+                    {selectedFile.editable && (
+                      <button
+                        aria-label={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
+                        aria-pressed={isTextWrapEnabled}
+                        className={wrapToggleClass(isTextWrapEnabled)}
+                        title={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
+                        type="button"
+                        onClick={() => setIsTextWrapEnabled((value) => !value)}
+                      >
+                        <TextWrap className="shrink-0" size={14} strokeWidth={2} />
+                      </button>
+                    )}
+                  </>
+                ) : (
+                  <span>No file selected</span>
+                )}
+              </div>
+
+              <div className="min-h-0 flex-1">
+                {!selectedNode && !isLoading && (
+                  <div className={editorPaneEmptyStateClass}>
+                    Select a file from the tree to start editing.
+                  </div>
                 )}
 
-                <div className='flex min-h-0 flex-1'>
-                    <ThemeFileTree
-                        changesMap={changesMap}
-                        currentFiles={currentFiles}
-                        expandedDirectories={expandedDirectories}
-                        isLoading={isLoading}
-                        selectedNode={selectedNode}
-                        setExpandedDirectories={setExpandedDirectories}
-                        setSelectedNode={setSelectedNode}
-                        onCreateFile={() => void handleCreateFile()}
-                        onDeleteSelected={() => void handleDeleteSelected()}
-                        onOpenFile={openFile}
-                        onRenameSelected={() => void handleRenameSelected()}
-                    />
+                {selectedNode?.type === 'dir' && (
+                  <div className={editorPaneEmptyStateClass}>
+                    Folder selected. Choose a file to edit, or rename or delete the folder from the
+                    file pane.
+                  </div>
+                )}
 
-                    <section className='flex min-w-0 flex-1 flex-col bg-[#16181c]'>
-                        <div className='flex items-center gap-2 border-b border-[#23262c] bg-[#17191d] px-4 py-2 text-[12px] text-[#8a8f98]'>
-                            {selectedFile ? (
-                                <>
-                                    <span className='min-w-0 truncate font-medium text-[#e6e7ea]'>{selectedFile.path}</span>
-                                    <span className='rounded bg-[#2a2d33] px-2 py-0.5 text-[10px] tracking-[0.04em] text-[#c8ccd3] uppercase'>
-                                        {getLanguageLabel(selectedFile.path)}
-                                    </span>
-                                    {selectedFileStatus && (
-                                        <button
-                                            className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] tracking-[0.04em] uppercase ${selectedFileStatus === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : selectedFileStatus === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}
-                                            type='button'
-                                            onClick={() => handleRevertPath(selectedFile.path)}
-                                        >
-                                            <Undo2 size={11} />
-                                            Revert
-                                        </button>
-                                    )}
-                                    <div className='grow' />
-                                    {selectedFile.editable && (
-                                        <button
-                                            aria-label={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
-                                            aria-pressed={isTextWrapEnabled}
-                                            className={wrapToggleClass(isTextWrapEnabled)}
-                                            title={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
-                                            type='button'
-                                            onClick={() => setIsTextWrapEnabled(value => !value)}
-                                        >
-                                            <TextWrap className='shrink-0' size={14} strokeWidth={2} />
-                                        </button>
-                                    )}
-                                </>
-                            ) : (
-                                <span>No file selected</span>
-                            )}
-                        </div>
+                {selectedFile && !selectedFile.editable && (
+                  <div className={editorPaneEmptyStateClass}>
+                    This file cannot be edited in the browser.
+                  </div>
+                )}
 
-                        <div className='min-h-0 flex-1'>
-                            {!selectedNode && !isLoading && (
-                                <div className={editorPaneEmptyStateClass}>
-                                    Select a file from the tree to start editing.
-                                </div>
-                            )}
-
-                            {selectedNode?.type === 'dir' && (
-                                <div className={editorPaneEmptyStateClass}>
-                                    Folder selected. Choose a file to edit, or rename or delete the folder from the file pane.
-                                </div>
-                            )}
-
-                            {selectedFile && !selectedFile.editable && (
-                                <div className={editorPaneEmptyStateClass}>
-                                    This file cannot be edited in the browser.
-                                </div>
-                            )}
-
-                            {selectedFile?.editable && (
-                                <CodeMirror
-                                    key={`${selectedFile.path}:${editorExtensions.length}`}
-                                    basicSetup={{
-                                        highlightActiveLine: false,
-                                        highlightActiveLineGutter: false
-                                    }}
-                                    className='h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:size-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]'
-                                    extensions={editorExtensions}
-                                    height='full'
-                                    theme={oneDark}
-                                    value={selectedFile.content || ''}
-                                    autoFocus
-                                    onChange={(value) => {
-                                        setCurrentFiles(files => ({
-                                            ...files,
-                                            [selectedFile.path]: {
-                                                ...files[selectedFile.path],
-                                                content: value
-                                            }
-                                        }));
-                                    }}
-                                />
-                            )}
-                        </div>
-                    </section>
-                </div>
-
-            </div>
+                {selectedFile?.editable && (
+                  <CodeMirror
+                    key={`${selectedFile.path}:${editorExtensions.length}`}
+                    basicSetup={{
+                      highlightActiveLine: false,
+                      highlightActiveLineGutter: false,
+                    }}
+                    className="h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:size-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]"
+                    extensions={editorExtensions}
+                    height="full"
+                    theme={oneDark}
+                    value={selectedFile.content || ''}
+                    autoFocus
+                    onChange={(value) => {
+                      setCurrentFiles((files) => ({
+                        ...files,
+                        [selectedFile.path]: {
+                          ...files[selectedFile.path],
+                          content: value,
+                        },
+                      }));
+                    }}
+                  />
+                )}
+              </div>
+            </section>
+          </div>
         </div>
-        {dialogRequest?.type === 'confirmation' && (
-            <ThemeEditorConfirmModal
-                {...dialogRequest.props}
-                onResolve={(result) => {
-                    if (dialogRequestRef.current !== dialogRequest) {
-                        return;
-                    }
+      </div>
+      {dialogRequest?.type === 'confirmation' && (
+        <ThemeEditorConfirmModal
+          {...dialogRequest.props}
+          onResolve={(result) => {
+            if (dialogRequestRef.current !== dialogRequest) {
+              return;
+            }
 
-                    dialogRequestRef.current = null;
-                    setDialogRequest(null);
-                    dialogRequest.resolve(result);
-                }}
-            />
-        )}
-        {dialogRequest?.type === 'input' && (
-            <ThemeEditorInputModal
-                {...dialogRequest.props}
-                onResolve={(result) => {
-                    if (dialogRequestRef.current !== dialogRequest) {
-                        return;
-                    }
+            dialogRequestRef.current = null;
+            setDialogRequest(null);
+            dialogRequest.resolve(result);
+          }}
+        />
+      )}
+      {dialogRequest?.type === 'input' && (
+        <ThemeEditorInputModal
+          {...dialogRequest.props}
+          onResolve={(result) => {
+            if (dialogRequestRef.current !== dialogRequest) {
+              return;
+            }
 
-                    dialogRequestRef.current = null;
-                    setDialogRequest(null);
-                    dialogRequest.resolve(result);
-                }}
-            />
-        )}
-        {saveErrors && <InvalidThemeModal action='saved' cancelLabel='Close' fatalErrors={saveErrors} themeName={currentThemeName} title='Theme not saved' onClose={() => setSaveErrors(null)} />}
-        {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
-    </>);
+            dialogRequestRef.current = null;
+            setDialogRequest(null);
+            dialogRequest.resolve(result);
+          }}
+        />
+      )}
+      {saveErrors && (
+        <InvalidThemeModal
+          action="saved"
+          cancelLabel="Close"
+          fatalErrors={saveErrors}
+          themeName={currentThemeName}
+          title="Theme not saved"
+          onClose={() => setSaveErrors(null)}
+        />
+      )}
+      {installedModal && (
+        <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />
+      )}
+    </>
+  );
 };
 
 export default ThemeCodeEditorModal;

--- a/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
@@ -6,11 +6,7 @@ import ThemeEditorInputModal from './theme-editor-input-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
 import ThemeFileTree from './theme-file-tree';
 import ThemeInstalledModal, { type ThemeInstalledModalProps } from './theme-installed-modal';
-import {
-  describeThemeOutcome,
-  getIssuesFromInstalledTheme,
-  parseFatalErrors,
-} from './theme-validation-issues';
+import { getIssuesFromInstalledTheme, parseFatalErrors } from './theme-validation-issues';
 import { TextWrap, Undo2 } from 'lucide-react';
 import {
   cloneThemeFiles,
@@ -908,12 +904,6 @@ const ThemeCodeEditorModal: React.FC<{ themeName: string }> = ({ themeName }) =>
         setInstalledModal({
           title: isSaveAs ? 'Theme saved' : 'Theme updated',
           action: 'saved',
-          statusMessage: (
-            <>
-              <strong>{uploadedTheme.name}</strong> was {describeThemeOutcome('saved', problems)}.
-              Do you want to activate it?
-            </>
-          ),
           installedTheme: uploadedTheme,
         });
       } else {

--- a/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
@@ -1,165 +1,161 @@
-import CodeMirror, { EditorView } from '@uiw/react-codemirror';
-import InvalidThemeModal, { type FatalErrors } from './invalid-theme-modal';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import CodeMirror, {EditorView} from '@uiw/react-codemirror';
+import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import ThemeEditorConfirmModal from './theme-editor-confirm-modal';
 import ThemeEditorInputModal from './theme-editor-input-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
 import ThemeFileTree from './theme-file-tree';
-import ThemeInstalledModal, { type ThemeInstalledModalProps } from './theme-installed-modal';
-import { parseFatalErrors } from './theme-validation-issues';
-import { TextWrap, Undo2 } from 'lucide-react';
+import ThemeInstalledModal, {type ThemeInstalledModalProps} from './theme-installed-modal';
+import {describeThemeOutcome, getIssuesFromInstalledTheme, parseFatalErrors} from './theme-validation-issues';
+import {TextWrap, Undo2} from 'lucide-react';
 import {
-  cloneThemeFiles,
-  createFolderRenameMap,
-  extractThemeArchive,
-  getExtension,
-  getThemeChanges,
-  isDefaultThemeName,
-  isEditablePath,
-  normaliseRelativePath,
-  packThemeArchive,
+    cloneThemeFiles,
+    createFolderRenameMap,
+    extractThemeArchive,
+    getExtension,
+    getThemeChanges,
+    isDefaultThemeName,
+    isEditablePath,
+    normaliseRelativePath,
+    packThemeArchive
 } from './theme-editor-utils';
-import { APIError, JSONError, UnsupportedMediaTypeError } from '@tryghost/admin-x-framework/errors';
-import { apiUrl } from '@tryghost/admin-x-framework/helpers';
-import { oneDark } from '@codemirror/theme-one-dark';
-import { search } from '@codemirror/search';
+import {APIError, JSONError, UnsupportedMediaTypeError} from '@tryghost/admin-x-framework/errors';
+import {apiUrl} from '@tryghost/admin-x-framework/helpers';
+import {oneDark} from '@codemirror/theme-one-dark';
+import {search} from '@codemirror/search';
 
-import { toast } from 'sonner';
-import { useBrowseThemes, useUploadTheme } from '@tryghost/admin-x-framework/api/themes';
-import { useFetchApi, useHandleError } from '@tryghost/admin-x-framework/hooks';
-import { formatNumber } from '@tryghost/shade/utils';
-import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
-import { z } from 'zod';
-import type { SelectedNode } from './theme-file-tree';
-import type { ThemeEditorConfirmModalProps } from './theme-editor-confirm-modal';
-import type { ThemeEditorFile } from './theme-editor-utils';
-import type { ThemeEditorInputModalProps } from './theme-editor-input-modal';
+import {toast} from 'sonner';
+import {useBrowseThemes, useUploadTheme} from '@tryghost/admin-x-framework/api/themes';
+import {useFetchApi, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {formatNumber} from '@tryghost/shade/utils';
+import {useSettingsNavigation} from '@/settings/hooks/use-settings-navigation';
+import {z} from 'zod';
+import type {SelectedNode} from './theme-file-tree';
+import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
+import type {ThemeEditorFile} from './theme-editor-utils';
+import type {ThemeEditorInputModalProps} from './theme-editor-input-modal';
 
 const getLanguageExtension = (path: string) => {
-  const extension = getExtension(path);
+    const extension = getExtension(path);
 
-  switch (extension) {
+    switch (extension) {
     case 'css':
     case 'scss':
     case 'sass':
     case 'less':
-      return import('@codemirror/lang-css').then((module) => module.css());
+        return import('@codemirror/lang-css').then(module => module.css());
     case 'js':
     case 'cjs':
     case 'mjs':
-      return import('@codemirror/lang-javascript').then((module) => module.javascript());
+        return import('@codemirror/lang-javascript').then(module => module.javascript());
     case 'json':
-      return import('@codemirror/lang-json').then((module) => module.json());
+        return import('@codemirror/lang-json').then(module => module.json());
     case 'md':
     case 'markdown':
-      return import('@codemirror/lang-markdown').then((module) => module.markdown());
+        return import('@codemirror/lang-markdown').then(module => module.markdown());
     case 'yaml':
     case 'yml':
-      return import('@codemirror/lang-yaml').then((module) => module.yaml());
+        return import('@codemirror/lang-yaml').then(module => module.yaml());
     case 'hbs':
     case 'handlebars':
     case 'html':
     case 'htm':
     case 'svg':
     case 'xml':
-      return import('@codemirror/lang-html').then((module) => module.html());
+        return import('@codemirror/lang-html').then(module => module.html());
     default:
-      return import('@codemirror/lang-html').then((module) => module.html());
-  }
+        return import('@codemirror/lang-html').then(module => module.html());
+    }
 };
 
 const getLanguageLabel = (path: string) => {
-  const extension = getExtension(path);
+    const extension = getExtension(path);
 
-  if (!extension) {
-    return 'text';
-  }
+    if (!extension) {
+        return 'text';
+    }
 
-  switch (extension) {
+    switch (extension) {
     case 'hbs':
-      return 'handlebars';
+        return 'handlebars';
     case 'htm':
-      return 'html';
+        return 'html';
     case 'yml':
-      return 'yaml';
+        return 'yaml';
     default:
-      return extension;
-  }
+        return extension;
+    }
 };
 
 const getDefaultSelection = (files: Record<string, ThemeEditorFile>): SelectedNode => {
-  if (files['package.json']?.editable) {
-    return { type: 'file', path: 'package.json' };
-  }
+    if (files['package.json']?.editable) {
+        return {type: 'file', path: 'package.json'};
+    }
 
-  const nextEditable = Object.keys(files)
-    .sort()
-    .find((path) => files[path].editable);
+    const nextEditable = Object.keys(files).sort().find(path => files[path].editable);
 
-  if (nextEditable) {
-    return { type: 'file', path: nextEditable };
-  }
+    if (nextEditable) {
+        return {type: 'file', path: nextEditable};
+    }
 
-  const firstPath = Object.keys(files).sort()[0];
+    const firstPath = Object.keys(files).sort()[0];
 
-  return firstPath ? { type: 'file', path: firstPath } : null;
+    return firstPath ? {type: 'file', path: firstPath} : null;
 };
 
 const getParentDirectories = (path: string) => {
-  const segments = path.split('/');
-  const directories: string[] = [''];
+    const segments = path.split('/');
+    const directories: string[] = [''];
 
-  for (let index = 0; index < segments.length - 1; index += 1) {
-    directories.push(`${segments.slice(0, index + 1).join('/')}/`);
-  }
+    for (let index = 0; index < segments.length - 1; index += 1) {
+        directories.push(`${segments.slice(0, index + 1).join('/')}/`);
+    }
 
-  return directories;
+    return directories;
 };
 
 const ALLOWED_RETURN_ROUTE_PREFIXES = ['theme', 'design'];
 
 const isAllowedReturnRoute = (route: string): boolean => {
-  return ALLOWED_RETURN_ROUTE_PREFIXES.some(
-    (prefix) => route === prefix || route.startsWith(`${prefix}/`),
-  );
+    return ALLOWED_RETURN_ROUTE_PREFIXES.some(prefix => route === prefix || route.startsWith(`${prefix}/`));
 };
 
 const getReturnRouteFromHash = () => {
-  const hash = window.location.hash.substring(1);
-  const domain = `${window.location.protocol}//${window.location.hostname}`;
+    const hash = window.location.hash.substring(1);
+    const domain = `${window.location.protocol}//${window.location.hostname}`;
 
-  let url: URL;
-  try {
-    url = new URL(hash || '/', domain);
-  } catch {
+    let url: URL;
+    try {
+        url = new URL(hash || '/', domain);
+    } catch {
+        return null;
+    }
+
+    const from = url.searchParams.get('from');
+
+    if (from === null) {
+        return null;
+    }
+
+    if (from === '' || isAllowedReturnRoute(from)) {
+        return from;
+    }
+
     return null;
-  }
-
-  const from = url.searchParams.get('from');
-
-  if (from === null) {
-    return null;
-  }
-
-  if (from === '' || isAllowedReturnRoute(from)) {
-    return from;
-  }
-
-  return null;
 };
 
 const buildThemeEditorRoute = (themeName: string, fromRoute: string | null) => {
-  const nextRoute = `theme/edit/${encodeURIComponent(themeName)}`;
+    const nextRoute = `theme/edit/${encodeURIComponent(themeName)}`;
 
-  if (fromRoute === null) {
-    return nextRoute;
-  }
+    if (fromRoute === null) {
+        return nextRoute;
+    }
 
-  return `${nextRoute}?from=${encodeURIComponent(fromRoute)}`;
+    return `${nextRoute}?from=${encodeURIComponent(fromRoute)}`;
 };
 
 const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string) => {
-  return !file.editable && isEditablePath(nextPath);
+    return !file.editable && isEditablePath(nextPath);
 };
 
 // Positive allowlist for theme names typed into the "Save as" flow.
@@ -180,951 +176,872 @@ const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string
 // stripping on Windows when the archive is later unzipped.
 const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
 
-type ThemeEditorDialogRequest =
-  | {
-      type: 'confirmation';
-      props: ThemeEditorConfirmModalProps;
-      resolve: (result: boolean) => void;
-    }
-  | {
-      type: 'input';
-      props: ThemeEditorInputModalProps;
-      resolve: (result: string | null) => void;
-    };
+type ThemeEditorDialogRequest = {
+    type: 'confirmation';
+    props: ThemeEditorConfirmModalProps;
+    resolve: (result: boolean) => void;
+} | {
+    type: 'input';
+    props: ThemeEditorInputModalProps;
+    resolve: (result: string | null) => void;
+};
 
-const UPLOAD_SIZE_LIMIT_CODES = [
-  'COMPRESSED_TOO_LARGE',
-  'ENTRY_TOO_LARGE',
-  'TOTAL_TOO_LARGE',
-] as const;
+const UPLOAD_SIZE_LIMIT_CODES = ['COMPRESSED_TOO_LARGE', 'ENTRY_TOO_LARGE', 'TOTAL_TOO_LARGE'] as const;
 
-const UPLOAD_SIZE_LIMIT_TITLES: Record<(typeof UPLOAD_SIZE_LIMIT_CODES)[number], string> = {
-  COMPRESSED_TOO_LARGE: 'Theme too large to upload',
-  ENTRY_TOO_LARGE: 'File too large',
-  TOTAL_TOO_LARGE: 'Theme contents too large',
+const UPLOAD_SIZE_LIMIT_TITLES: Record<typeof UPLOAD_SIZE_LIMIT_CODES[number], string> = {
+    COMPRESSED_TOO_LARGE: 'Theme too large to upload',
+    ENTRY_TOO_LARGE: 'File too large',
+    TOTAL_TOO_LARGE: 'Theme contents too large'
 };
 
 const uploadSizeLimitErrorSchema = z.object({
-  message: z.string().optional(),
-  code: z.enum(UPLOAD_SIZE_LIMIT_CODES),
-  errorDetails: z
-    .object({
-      entryName: z.string().optional(),
-      limitBytes: z.number().positive().finite().optional(),
-    })
-    .optional(),
+    message: z.string().optional(),
+    code: z.enum(UPLOAD_SIZE_LIMIT_CODES),
+    errorDetails: z.object({
+        entryName: z.string().optional(),
+        limitBytes: z.number().positive().finite().optional()
+    }).optional()
 });
 
 const uploadSizeLimitResponseSchema = z.object({
-  errors: z.array(uploadSizeLimitErrorSchema).min(1),
+    errors: z.array(uploadSizeLimitErrorSchema).min(1)
 });
 
 type UploadSizeLimitError = z.infer<typeof uploadSizeLimitErrorSchema>;
 
 const formatLimitBytes = (bytes: number | undefined) => {
-  if (!bytes || bytes <= 0) {
-    return 'the allowed size';
-  }
-  const mb = bytes / (1024 * 1024);
-  if (mb >= 1) {
-    return `${mb.toFixed(1)} MB`;
-  }
-  return `${Math.round(bytes / 1024)} KB`;
+    if (!bytes || bytes <= 0) {
+        return 'the allowed size';
+    }
+    const mb = bytes / (1024 * 1024);
+    if (mb >= 1) {
+        return `${mb.toFixed(1)} MB`;
+    }
+    return `${Math.round(bytes / 1024)} KB`;
 };
 
 // Size-limit failures are 415s, which the fetch layer surfaces as an
 // UnsupportedMediaTypeError carrying the raw response text
 const getUploadSizeLimitError = (error: unknown): UploadSizeLimitError | null => {
-  if (!(error instanceof UnsupportedMediaTypeError)) {
-    return null;
-  }
-
-  let data: unknown = error.data;
-
-  if (typeof data === 'string') {
-    try {
-      data = JSON.parse(data);
-    } catch {
-      return null;
+    if (!(error instanceof UnsupportedMediaTypeError)) {
+        return null;
     }
-  }
 
-  const parsed = uploadSizeLimitResponseSchema.safeParse(data);
+    let data: unknown = error.data;
 
-  if (parsed.success) {
-    return parsed.data.errors[0] ?? null;
-  }
+    if (typeof data === 'string') {
+        try {
+            data = JSON.parse(data);
+        } catch {
+            return null;
+        }
+    }
 
-  return null;
+    const parsed = uploadSizeLimitResponseSchema.safeParse(data);
+
+    if (parsed.success) {
+        return parsed.data.errors[0] ?? null;
+    }
+
+    return null;
 };
 
 const buildUploadSizeLimitMessage = (err: UploadSizeLimitError) => {
-  const { entryName, limitBytes } = err.errorDetails ?? {};
-  const limit = formatLimitBytes(limitBytes);
+    const {entryName, limitBytes} = err.errorDetails ?? {};
+    const limit = formatLimitBytes(limitBytes);
 
-  switch (err.code) {
+    switch (err.code) {
     case 'COMPRESSED_TOO_LARGE':
-      return `The theme archive is too large to upload (max ${limit}).`;
+        return `The theme archive is too large to upload (max ${limit}).`;
     case 'ENTRY_TOO_LARGE':
-      return entryName
-        ? `The file "${entryName}" is too large (max ${limit} per file).`
-        : `One of the files is too large (max ${limit} per file).`;
+        return entryName
+            ? `The file "${entryName}" is too large (max ${limit} per file).`
+            : `One of the files is too large (max ${limit} per file).`;
     case 'TOTAL_TOO_LARGE':
-      return `The theme contents exceed the maximum allowed size of ${limit}.`;
+        return `The theme contents exceed the maximum allowed size of ${limit}.`;
     default:
-      return err.message || 'Theme upload failed.';
-  }
+        return err.message || 'Theme upload failed.';
+    }
 };
 
-const wrapToggleClass = (active: boolean) =>
-  `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
+const wrapToggleClass = (active: boolean) => `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
 
-const editorPaneEmptyStateClass =
-  'flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
+const editorPaneEmptyStateClass = 'flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
 
-const editorSelectionTheme = EditorView.theme(
-  {
-    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection':
-      {
-        backgroundColor: '#355070',
-      },
-    '.cm-content ::selection': {
-      color: '#ffffff',
+const editorSelectionTheme = EditorView.theme({
+    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
+        backgroundColor: '#355070'
     },
-  },
-  { dark: true },
-);
+    '.cm-content ::selection': {
+        color: '#ffffff'
+    }
+}, {dark: true});
 
-const ThemeCodeEditorModal: React.FC<{ themeName: string }> = ({ themeName }) => {
-  const { updateRoute } = useSettingsNavigation();
-  const fetchApi = useFetchApi();
-  const handleError = useHandleError();
-  const { data: themesData } = useBrowseThemes();
-  const { mutateAsync: uploadTheme } = useUploadTheme();
+const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
+    const {updateRoute} = useSettingsNavigation();
+    const fetchApi = useFetchApi();
+    const handleError = useHandleError();
+    const {data: themesData} = useBrowseThemes();
+    const {mutateAsync: uploadTheme} = useUploadTheme();
 
-  const [currentThemeName, setCurrentThemeName] = useState(themeName);
-  const [baseFiles, setBaseFiles] = useState<Record<string, ThemeEditorFile>>({});
-  const [currentFiles, setCurrentFiles] = useState<Record<string, ThemeEditorFile>>({});
-  const [rootPrefix, setRootPrefix] = useState('');
-  const [selectedNode, setSelectedNode] = useState<SelectedNode>(null);
-  const [expandedDirectories, setExpandedDirectories] = useState<Set<string>>(new Set(['']));
-  const [isLoading, setIsLoading] = useState(true);
-  const [isSaving, setIsSaving] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
-  const [dialogRequest, setDialogRequest] = useState<ThemeEditorDialogRequest | null>(null);
-  const dialogRequestRef = useRef<ThemeEditorDialogRequest | null>(null);
-  const [saveErrors, setSaveErrors] = useState<FatalErrors | null>(null);
-  const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
-  const [editorExtensions, setEditorExtensions] = useState<
-    Array<ReturnType<typeof search> | Awaited<ReturnType<typeof getLanguageExtension>>>
-  >([]);
+    const [currentThemeName, setCurrentThemeName] = useState(themeName);
+    const [baseFiles, setBaseFiles] = useState<Record<string, ThemeEditorFile>>({});
+    const [currentFiles, setCurrentFiles] = useState<Record<string, ThemeEditorFile>>({});
+    const [rootPrefix, setRootPrefix] = useState('');
+    const [selectedNode, setSelectedNode] = useState<SelectedNode>(null);
+    const [expandedDirectories, setExpandedDirectories] = useState<Set<string>>(new Set(['']));
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
+    const [dialogRequest, setDialogRequest] = useState<ThemeEditorDialogRequest | null>(null);
+    const dialogRequestRef = useRef<ThemeEditorDialogRequest | null>(null);
+    const [saveErrors, setSaveErrors] = useState<FatalErrors | null>(null);
+    const [installedModal, setInstalledModal] = useState<ThemeInstalledModalProps | null>(null);
+    const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
 
-  useEffect(() => {
-    let isMounted = true;
+    useEffect(() => {
+        let isMounted = true;
 
-    const resetLoadedTheme = () => {
-      setCurrentThemeName(themeName);
-      setBaseFiles({});
-      setCurrentFiles({});
-      setRootPrefix('');
-      setSelectedNode(null);
-      setExpandedDirectories(new Set(['']));
-    };
+        const resetLoadedTheme = () => {
+            setCurrentThemeName(themeName);
+            setBaseFiles({});
+            setCurrentFiles({});
+            setRootPrefix('');
+            setSelectedNode(null);
+            setExpandedDirectories(new Set(['']));
+        };
 
-    const loadTheme = async () => {
-      setIsLoading(true);
-      setLoadError(null);
-      resetLoadedTheme();
+        const loadTheme = async () => {
+            setIsLoading(true);
+            setLoadError(null);
+            resetLoadedTheme();
 
-      try {
-        const archive = await fetchApi<ArrayBuffer>(
-          apiUrl(`/themes/${encodeURIComponent(themeName)}/download/`),
-          {
-            responseType: 'arraybuffer',
-          },
-        );
-        const snapshot = await extractThemeArchive(archive);
-        const nextFiles = cloneThemeFiles(snapshot.files);
-        const nextSelection = getDefaultSelection(nextFiles);
+            try {
+                const archive = await fetchApi<ArrayBuffer>(apiUrl(`/themes/${encodeURIComponent(themeName)}/download/`), {
+                    responseType: 'arraybuffer'
+                });
+                const snapshot = await extractThemeArchive(archive);
+                const nextFiles = cloneThemeFiles(snapshot.files);
+                const nextSelection = getDefaultSelection(nextFiles);
 
-        if (!isMounted) {
-          return;
+                if (!isMounted) {
+                    return;
+                }
+
+                setCurrentThemeName(themeName);
+                setBaseFiles(cloneThemeFiles(snapshot.files));
+                setCurrentFiles(nextFiles);
+                setRootPrefix(snapshot.rootPrefix);
+                setSelectedNode(nextSelection);
+                setExpandedDirectories(new Set(nextSelection?.type === 'file' ? getParentDirectories(nextSelection.path) : ['']));
+            } catch (error) {
+                if (!isMounted) {
+                    return;
+                }
+
+                if (error instanceof APIError && error.response) {
+                    setLoadError(`Failed to load theme "${themeName}" (${error.response.status})`);
+                } else {
+                    setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
+                }
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        void loadTheme();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [themeName, fetchApi]);
+
+    useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, []);
+
+    const changes = useMemo(() => getThemeChanges({baseFiles, currentFiles}), [baseFiles, currentFiles]);
+    const changesMap = useMemo(() => new Map(changes.map(change => [change.path, change.status])), [changes]);
+    const selectedFile = selectedNode?.type === 'file' ? currentFiles[selectedNode.path] : null;
+
+    useEffect(() => {
+        let isMounted = true;
+
+        if (!selectedFile?.editable) {
+            setEditorExtensions([]);
+            return () => {
+                isMounted = false;
+            };
         }
 
-        setCurrentThemeName(themeName);
-        setBaseFiles(cloneThemeFiles(snapshot.files));
-        setCurrentFiles(nextFiles);
-        setRootPrefix(snapshot.rootPrefix);
-        setSelectedNode(nextSelection);
-        setExpandedDirectories(
-          new Set(nextSelection?.type === 'file' ? getParentDirectories(nextSelection.path) : ['']),
-        );
-      } catch (error) {
-        if (!isMounted) {
-          return;
+        // Only the language extension is async (dynamic import); oneDark and
+        // the other extensions are static. Awaiting just the language load
+        // keeps the Promise types honest and makes the fallback branch read
+        // more clearly.
+        getLanguageExtension(selectedFile.path).then((languageExtension) => {
+            if (isMounted) {
+                setEditorExtensions([
+                    search({top: true}),
+                    oneDark,
+                    languageExtension,
+                    ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
+                    editorSelectionTheme
+                ]);
+            }
+        }).catch(() => {
+            if (isMounted) {
+                setEditorExtensions([
+                    search({top: true}),
+                    oneDark,
+                    ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
+                    editorSelectionTheme
+                ]);
+            }
+        });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [isTextWrapEnabled, selectedFile]);
+
+    const cancelPendingDialogRequest = useCallback(() => {
+        const request = dialogRequestRef.current;
+
+        if (!request) {
+            return;
         }
 
-        if (error instanceof APIError && error.response) {
-          setLoadError(`Failed to load theme "${themeName}" (${error.response.status})`);
+        dialogRequestRef.current = null;
+
+        if (request.type === 'confirmation') {
+            request.resolve(false);
         } else {
-          setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
+            request.resolve(null);
         }
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      }
-    };
+    }, []);
 
-    void loadTheme();
+    const requestConfirmation = (props: ThemeEditorConfirmModalProps) => {
+        cancelPendingDialogRequest();
 
-    return () => {
-      isMounted = false;
-    };
-  }, [themeName, fetchApi]);
-
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, []);
-
-  const changes = useMemo(
-    () => getThemeChanges({ baseFiles, currentFiles }),
-    [baseFiles, currentFiles],
-  );
-  const changesMap = useMemo(
-    () => new Map(changes.map((change) => [change.path, change.status])),
-    [changes],
-  );
-  const selectedFile = selectedNode?.type === 'file' ? currentFiles[selectedNode.path] : null;
-
-  useEffect(() => {
-    let isMounted = true;
-
-    if (!selectedFile?.editable) {
-      setEditorExtensions([]);
-      return () => {
-        isMounted = false;
-      };
-    }
-
-    // Only the language extension is async (dynamic import); oneDark and
-    // the other extensions are static. Awaiting just the language load
-    // keeps the Promise types honest and makes the fallback branch read
-    // more clearly.
-    getLanguageExtension(selectedFile.path)
-      .then((languageExtension) => {
-        if (isMounted) {
-          setEditorExtensions([
-            search({ top: true }),
-            oneDark,
-            languageExtension,
-            ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
-            editorSelectionTheme,
-          ]);
-        }
-      })
-      .catch(() => {
-        if (isMounted) {
-          setEditorExtensions([
-            search({ top: true }),
-            oneDark,
-            ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
-            editorSelectionTheme,
-          ]);
-        }
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [isTextWrapEnabled, selectedFile]);
-
-  const cancelPendingDialogRequest = useCallback(() => {
-    const request = dialogRequestRef.current;
-
-    if (!request) {
-      return;
-    }
-
-    dialogRequestRef.current = null;
-
-    if (request.type === 'confirmation') {
-      request.resolve(false);
-    } else {
-      request.resolve(null);
-    }
-  }, []);
-
-  const requestConfirmation = (props: ThemeEditorConfirmModalProps) => {
-    cancelPendingDialogRequest();
-
-    return new Promise<boolean>((resolve) => {
-      const request: ThemeEditorDialogRequest = { type: 'confirmation', props, resolve };
-      dialogRequestRef.current = request;
-      setDialogRequest(request);
-    });
-  };
-
-  const requestInput = (props: ThemeEditorInputModalProps) => {
-    cancelPendingDialogRequest();
-
-    return new Promise<string | null>((resolve) => {
-      const request: ThemeEditorDialogRequest = { type: 'input', props, resolve };
-      dialogRequestRef.current = request;
-      setDialogRequest(request);
-    });
-  };
-
-  useEffect(() => {
-    return () => cancelPendingDialogRequest();
-  }, [cancelPendingDialogRequest]);
-
-  const closeEditor = async () => {
-    if (changes.length > 0) {
-      const shouldDiscard = await requestConfirmation({
-        title: 'Discard changes?',
-        prompt: 'You have unsaved theme changes. Close the editor and discard them?',
-        okLabel: 'Discard changes',
-        okVariant: 'destructive',
-      });
-
-      if (!shouldDiscard) {
-        return;
-      }
-    }
-
-    updateRoute(getReturnRouteFromHash() ?? 'design/change-theme');
-  };
-
-  // Keep a ref to the latest handleSave so the keydown listener can call
-  // the freshest version without re-registering on every render. handleSave
-  // captures state (currentFiles, changes, isSaving, ...) and is recreated
-  // each render — using a ref decouples that churn from the global listener.
-  const handleSaveRef = useRef<() => Promise<void>>(async () => {});
-
-  const hasOpenDialog = Boolean(dialogRequest || saveErrors || installedModal);
-
-  useEffect(() => {
-    const handleKeydown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
-        event.preventDefault();
-
-        if (hasOpenDialog) {
-          event.stopPropagation();
-          event.stopImmediatePropagation();
-          return;
-        }
-
-        void handleSaveRef.current();
-        return;
-      }
-
-      if (event.key !== 'Escape') {
-        return;
-      }
-
-      if (hasOpenDialog) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-    };
-
-    window.addEventListener('keydown', handleKeydown, true);
-
-    return () => {
-      window.removeEventListener('keydown', handleKeydown, true);
-    };
-  }, [hasOpenDialog]);
-
-  const ensurePathExpanded = (path: string) => {
-    setExpandedDirectories((current) => {
-      const next = new Set(current);
-
-      for (const dir of getParentDirectories(path)) {
-        next.add(dir);
-      }
-
-      return next;
-    });
-  };
-
-  const setFilesAndSelection = (
-    files: Record<string, ThemeEditorFile>,
-    nextSelection?: SelectedNode,
-  ) => {
-    setCurrentFiles(files);
-
-    if (nextSelection) {
-      setSelectedNode(nextSelection);
-      if (nextSelection.type === 'file') {
-        ensurePathExpanded(nextSelection.path);
-      }
-      return;
-    }
-
-    if (selectedNode?.type === 'file' && files[selectedNode.path]) {
-      return;
-    }
-
-    setSelectedNode(getDefaultSelection(files));
-  };
-
-  const handleCreateFile = async () => {
-    const requestedPath = await requestInput({
-      title: 'Create file',
-      fieldTitle: 'File path',
-      initialValue: 'partials/new-file.hbs',
-      okLabel: 'Create file',
-      prompt: 'Add a new editable file to this theme.',
-    });
-    const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
-
-    if (!nextPath) {
-      return;
-    }
-
-    if (!isEditablePath(nextPath)) {
-      toast.error('Only text files can be created here', {
-        description: 'Use a text-based theme file extension such as .hbs, .css, .js, or .json.',
-      });
-      return;
-    }
-
-    if (currentFiles[nextPath]) {
-      toast.error('File already exists');
-      return;
-    }
-
-    const nextFiles = {
-      ...currentFiles,
-      [nextPath]: {
-        path: nextPath,
-        editable: true,
-        content: '',
-        binary: null,
-        date: new Date(),
-        unixPermissions: null,
-        dosPermissions: null,
-      },
-    };
-
-    setFilesAndSelection(nextFiles, { type: 'file', path: nextPath });
-  };
-
-  const handleRenameSelected = async () => {
-    if (!selectedNode) {
-      return;
-    }
-
-    const defaultValue =
-      selectedNode.type === 'dir' ? selectedNode.path.replace(/\/$/, '') : selectedNode.path;
-    const promptLabel = selectedNode.type === 'dir' ? 'Rename folder to' : 'Rename file to';
-    const requestedPath = await requestInput({
-      title: selectedNode.type === 'dir' ? 'Rename folder' : 'Rename file',
-      fieldTitle: 'Path',
-      initialValue: defaultValue,
-      okLabel: 'Rename',
-      prompt: promptLabel,
-    });
-    const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
-
-    if (!nextPath || nextPath === defaultValue) {
-      return;
-    }
-
-    if (selectedNode.type === 'file') {
-      const fileToRename = currentFiles[selectedNode.path];
-
-      if (!isEditablePath(nextPath) && fileToRename.editable) {
-        toast.error('Text files must keep a text file extension');
-        return;
-      }
-
-      if (wouldRenameBinaryFileToEditable(fileToRename, nextPath)) {
-        toast.error('Binary files cannot be renamed to a text file', {
-          description: 'Rename this file with a non-text extension to keep its contents intact.',
+        return new Promise<boolean>((resolve) => {
+            const request: ThemeEditorDialogRequest = {type: 'confirmation', props, resolve};
+            dialogRequestRef.current = request;
+            setDialogRequest(request);
         });
-        return;
-      }
+    };
 
-      if (currentFiles[nextPath]) {
-        toast.error('A file with that name already exists');
-        return;
-      }
+    const requestInput = (props: ThemeEditorInputModalProps) => {
+        cancelPendingDialogRequest();
 
-      const nextFiles = { ...currentFiles };
-      const file = nextFiles[selectedNode.path];
-      delete nextFiles[selectedNode.path];
-      nextFiles[nextPath] = {
-        ...file,
-        path: nextPath,
-        editable: isEditablePath(nextPath),
-      };
+        return new Promise<string | null>((resolve) => {
+            const request: ThemeEditorDialogRequest = {type: 'input', props, resolve};
+            dialogRequestRef.current = request;
+            setDialogRequest(request);
+        });
+    };
 
-      setFilesAndSelection(nextFiles, { type: 'file', path: nextPath });
-      return;
-    }
+    useEffect(() => {
+        return () => cancelPendingDialogRequest();
+    }, [cancelPendingDialogRequest]);
 
-    const nextDirectoryPath = `${nextPath}/`;
+    const closeEditor = async () => {
+        if (changes.length > 0) {
+            const shouldDiscard = await requestConfirmation({
+                title: 'Discard changes?',
+                prompt: 'You have unsaved theme changes. Close the editor and discard them?',
+                okLabel: 'Discard changes',
+                okVariant: 'destructive'
+            });
 
-    if (nextDirectoryPath.startsWith(selectedNode.path)) {
-      toast.error('A folder cannot be renamed inside itself');
-      return;
-    }
-
-    const conflictingPath = Object.keys(currentFiles).find((path) =>
-      path.startsWith(nextDirectoryPath),
-    );
-
-    if (conflictingPath) {
-      toast.error('A folder with that path already exists');
-      return;
-    }
-
-    const nextFiles = createFolderRenameMap({
-      files: currentFiles,
-      oldPrefix: selectedNode.path,
-      newPrefix: nextDirectoryPath,
-    });
-
-    setFilesAndSelection(nextFiles, { type: 'dir', path: nextDirectoryPath });
-    setExpandedDirectories((current) => {
-      const next = new Set<string>();
-
-      for (const directory of current) {
-        if (!directory.startsWith(selectedNode.path)) {
-          next.add(directory);
-          continue;
+            if (!shouldDiscard) {
+                return;
+            }
         }
 
-        next.add(`${nextDirectoryPath}${directory.slice(selectedNode.path.length)}`);
-      }
+        updateRoute(getReturnRouteFromHash() ?? 'design/change-theme');
+    };
 
-      return next;
-    });
-  };
+    // Keep a ref to the latest handleSave so the keydown listener can call
+    // the freshest version without re-registering on every render. handleSave
+    // captures state (currentFiles, changes, isSaving, ...) and is recreated
+    // each render — using a ref decouples that churn from the global listener.
+    const handleSaveRef = useRef<() => Promise<void>>(async () => {});
 
-  const handleDeleteSelected = async () => {
-    if (!selectedNode) {
-      return;
-    }
+    const hasOpenDialog = Boolean(dialogRequest || saveErrors || installedModal);
 
-    if (selectedNode.type === 'file') {
-      const confirmed = await requestConfirmation({
-        title: 'Delete file',
-        prompt: (
-          <>
-            Delete <strong>{selectedNode.path}</strong> from this theme?
-          </>
-        ),
-        okLabel: 'Delete',
-        okVariant: 'destructive',
-      });
+    useEffect(() => {
+        const handleKeydown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+                event.preventDefault();
 
-      if (!confirmed) {
-        return;
-      }
+                if (hasOpenDialog) {
+                    event.stopPropagation();
+                    event.stopImmediatePropagation();
+                    return;
+                }
 
-      const nextFiles = { ...currentFiles };
-      delete nextFiles[selectedNode.path];
-      setFilesAndSelection(nextFiles);
-      return;
-    }
+                void handleSaveRef.current();
+                return;
+            }
 
-    const matchingPaths = Object.keys(currentFiles).filter((path) =>
-      path.startsWith(selectedNode.path),
-    );
+            if (event.key !== 'Escape') {
+                return;
+            }
 
-    if (!matchingPaths.length) {
-      return;
-    }
+            if (hasOpenDialog) {
+                return;
+            }
 
-    const confirmed = await requestConfirmation({
-      title: 'Delete folder',
-      prompt: (
-        <>
-          Delete {formatNumber(matchingPaths.length)} file{matchingPaths.length === 1 ? '' : 's'}{' '}
-          from <strong>{selectedNode.path}</strong>?
-        </>
-      ),
-      okLabel: 'Delete',
-      okVariant: 'destructive',
-    });
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+        };
 
-    if (!confirmed) {
-      return;
-    }
+        window.addEventListener('keydown', handleKeydown, true);
 
-    const nextFiles = { ...currentFiles };
+        return () => {
+            window.removeEventListener('keydown', handleKeydown, true);
+        };
+    }, [hasOpenDialog]);
 
-    for (const path of matchingPaths) {
-      delete nextFiles[path];
-    }
+    const ensurePathExpanded = (path: string) => {
+        setExpandedDirectories((current) => {
+            const next = new Set(current);
 
-    setFilesAndSelection(nextFiles);
-  };
+            for (const dir of getParentDirectories(path)) {
+                next.add(dir);
+            }
 
-  const handleRevertPath = (path: string) => {
-    const baseFile = baseFiles[path];
-    const currentFile = currentFiles[path];
-    const nextFiles = { ...currentFiles };
-
-    if (!baseFile && currentFile) {
-      delete nextFiles[path];
-    } else if (baseFile) {
-      nextFiles[path] = {
-        ...baseFile,
-        binary: baseFile.binary ? new Uint8Array(baseFile.binary) : null,
-      };
-    }
-
-    setFilesAndSelection(nextFiles);
-  };
-
-  const requestSaveAsThemeName = async () => {
-    const requestedName = await requestInput({
-      title: 'Save as new theme',
-      fieldTitle: 'Theme name',
-      initialValue: `${currentThemeName}-edited`,
-      okLabel: 'Continue',
-      prompt: 'Default themes cannot be overwritten. Save your edits as a new theme instead.',
-    });
-    const nextName = requestedName?.trim().toLowerCase();
-
-    if (!nextName) {
-      return null;
-    }
-
-    if (!THEME_NAME_PATTERN.test(nextName)) {
-      toast.error('Invalid theme name', {
-        description:
-          'Use 1-64 characters, starting with a letter or number. Allowed: letters, numbers, dashes, and underscores.',
-      });
-      return null;
-    }
-
-    if (isDefaultThemeName(nextName)) {
-      toast.error('Built-in themes cannot be overwritten');
-      return null;
-    }
-
-    return nextName;
-  };
-
-  const handleSave = async () => {
-    if (isSaving) {
-      return;
-    }
-
-    if (changes.length === 0) {
-      toast.info('No changes to save');
-      return;
-    }
-
-    const previousThemeName = currentThemeName;
-    const nextThemeName = isDefaultThemeName(previousThemeName)
-      ? await requestSaveAsThemeName()
-      : previousThemeName;
-
-    if (!nextThemeName) {
-      return;
-    }
-
-    const isSaveAs = nextThemeName !== previousThemeName;
-    const themeExists = themesData?.themes.some((theme) => theme.name === nextThemeName) || false;
-    const confirmMessage = isSaveAs
-      ? `Save your edits as "${nextThemeName}"?`
-      : `Upload ${formatNumber(changes.length)} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
-
-    const confirmedSave = await requestConfirmation({
-      title: isSaveAs ? 'Save theme as new copy' : 'Update theme',
-      prompt: confirmMessage,
-      okLabel: isSaveAs ? 'Save theme' : 'Replace theme',
-    });
-
-    if (!confirmedSave) {
-      return;
-    }
-
-    if (isSaveAs && themeExists) {
-      const confirmedOverwrite = await requestConfirmation({
-        title: 'Overwrite theme',
-        prompt: (
-          <>
-            <strong>{nextThemeName}</strong> already exists. Do you want to overwrite it?
-          </>
-        ),
-        okLabel: 'Overwrite',
-        okVariant: 'destructive',
-      });
-
-      if (!confirmedOverwrite) {
-        return;
-      }
-    }
-
-    setIsSaving(true);
-
-    try {
-      const blob = await packThemeArchive({
-        files: currentFiles,
-        rootPrefix,
-      });
-
-      const data = await uploadTheme({
-        file: new File([blob], `${nextThemeName}.zip`, { type: 'application/zip' }),
-        // when saving under a new name, carry over the original theme's
-        // settings so activating the copy keeps the site's design
-        copySettingsFrom: isSaveAs ? previousThemeName : undefined,
-      });
-
-      const uploadedTheme = data.themes[0];
-      const returnRoute = getReturnRouteFromHash();
-
-      setBaseFiles(cloneThemeFiles(currentFiles));
-
-      if (isSaveAs) {
-        setCurrentThemeName(nextThemeName);
-        setRootPrefix(rootPrefix ? `${nextThemeName}/` : '');
-        updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
-      }
-
-      if (isSaveAs || uploadedTheme.errors?.length || uploadedTheme.warnings?.length) {
-        setInstalledModal({
-          title: isSaveAs ? 'Theme saved' : 'Theme updated',
-          prompt: (
-            <>
-              <strong>{uploadedTheme.name}</strong> saved successfully.
-            </>
-          ),
-          installedTheme: uploadedTheme,
+            return next;
         });
-      } else {
-        toast.success('Theme saved', {
-          description: (
-            <div>
-              <span className="capitalize">{uploadedTheme.name}</span> has been updated.
+    };
+
+    const setFilesAndSelection = (files: Record<string, ThemeEditorFile>, nextSelection?: SelectedNode) => {
+        setCurrentFiles(files);
+
+        if (nextSelection) {
+            setSelectedNode(nextSelection);
+            if (nextSelection.type === 'file') {
+                ensurePathExpanded(nextSelection.path);
+            }
+            return;
+        }
+
+        if (selectedNode?.type === 'file' && files[selectedNode.path]) {
+            return;
+        }
+
+        setSelectedNode(getDefaultSelection(files));
+    };
+
+    const handleCreateFile = async () => {
+        const requestedPath = await requestInput({
+            title: 'Create file',
+            fieldTitle: 'File path',
+            initialValue: 'partials/new-file.hbs',
+            okLabel: 'Create file',
+            prompt: 'Add a new editable file to this theme.'
+        });
+        const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
+
+        if (!nextPath) {
+            return;
+        }
+
+        if (!isEditablePath(nextPath)) {
+            toast.error('Only text files can be created here', {description: 'Use a text-based theme file extension such as .hbs, .css, .js, or .json.'});
+            return;
+        }
+
+        if (currentFiles[nextPath]) {
+            toast.error('File already exists');
+            return;
+        }
+
+        const nextFiles = {
+            ...currentFiles,
+            [nextPath]: {
+                path: nextPath,
+                editable: true,
+                content: '',
+                binary: null,
+                date: new Date(),
+                unixPermissions: null,
+                dosPermissions: null
+            }
+        };
+
+        setFilesAndSelection(nextFiles, {type: 'file', path: nextPath});
+    };
+
+    const handleRenameSelected = async () => {
+        if (!selectedNode) {
+            return;
+        }
+
+        const defaultValue = selectedNode.type === 'dir'
+            ? selectedNode.path.replace(/\/$/, '')
+            : selectedNode.path;
+        const promptLabel = selectedNode.type === 'dir' ? 'Rename folder to' : 'Rename file to';
+        const requestedPath = await requestInput({
+            title: selectedNode.type === 'dir' ? 'Rename folder' : 'Rename file',
+            fieldTitle: 'Path',
+            initialValue: defaultValue,
+            okLabel: 'Rename',
+            prompt: promptLabel
+        });
+        const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
+
+        if (!nextPath || nextPath === defaultValue) {
+            return;
+        }
+
+        if (selectedNode.type === 'file') {
+            const fileToRename = currentFiles[selectedNode.path];
+
+            if (!isEditablePath(nextPath) && fileToRename.editable) {
+                toast.error('Text files must keep a text file extension');
+                return;
+            }
+
+            if (wouldRenameBinaryFileToEditable(fileToRename, nextPath)) {
+                toast.error('Binary files cannot be renamed to a text file', {description: 'Rename this file with a non-text extension to keep its contents intact.'});
+                return;
+            }
+
+            if (currentFiles[nextPath]) {
+                toast.error('A file with that name already exists');
+                return;
+            }
+
+            const nextFiles = {...currentFiles};
+            const file = nextFiles[selectedNode.path];
+            delete nextFiles[selectedNode.path];
+            nextFiles[nextPath] = {
+                ...file,
+                path: nextPath,
+                editable: isEditablePath(nextPath)
+            };
+
+            setFilesAndSelection(nextFiles, {type: 'file', path: nextPath});
+            return;
+        }
+
+        const nextDirectoryPath = `${nextPath}/`;
+
+        if (nextDirectoryPath.startsWith(selectedNode.path)) {
+            toast.error('A folder cannot be renamed inside itself');
+            return;
+        }
+
+        const conflictingPath = Object.keys(currentFiles).find(path => path.startsWith(nextDirectoryPath));
+
+        if (conflictingPath) {
+            toast.error('A folder with that path already exists');
+            return;
+        }
+
+        const nextFiles = createFolderRenameMap({
+            files: currentFiles,
+            oldPrefix: selectedNode.path,
+            newPrefix: nextDirectoryPath
+        });
+
+        setFilesAndSelection(nextFiles, {type: 'dir', path: nextDirectoryPath});
+        setExpandedDirectories((current) => {
+            const next = new Set<string>();
+
+            for (const directory of current) {
+                if (!directory.startsWith(selectedNode.path)) {
+                    next.add(directory);
+                    continue;
+                }
+
+                next.add(`${nextDirectoryPath}${directory.slice(selectedNode.path.length)}`);
+            }
+
+            return next;
+        });
+    };
+
+    const handleDeleteSelected = async () => {
+        if (!selectedNode) {
+            return;
+        }
+
+        if (selectedNode.type === 'file') {
+            const confirmed = await requestConfirmation({
+                title: 'Delete file',
+                prompt: <>Delete <strong>{selectedNode.path}</strong> from this theme?</>,
+                okLabel: 'Delete',
+                okVariant: 'destructive'
+            });
+
+            if (!confirmed) {
+                return;
+            }
+
+            const nextFiles = {...currentFiles};
+            delete nextFiles[selectedNode.path];
+            setFilesAndSelection(nextFiles);
+            return;
+        }
+
+        const matchingPaths = Object.keys(currentFiles).filter(path => path.startsWith(selectedNode.path));
+
+        if (!matchingPaths.length) {
+            return;
+        }
+
+        const confirmed = await requestConfirmation({
+            title: 'Delete folder',
+            prompt: <>Delete {formatNumber(matchingPaths.length)} file{matchingPaths.length === 1 ? '' : 's'} from <strong>{selectedNode.path}</strong>?</>,
+            okLabel: 'Delete',
+            okVariant: 'destructive'
+        });
+
+        if (!confirmed) {
+            return;
+        }
+
+        const nextFiles = {...currentFiles};
+
+        for (const path of matchingPaths) {
+            delete nextFiles[path];
+        }
+
+        setFilesAndSelection(nextFiles);
+    };
+
+    const handleRevertPath = (path: string) => {
+        const baseFile = baseFiles[path];
+        const currentFile = currentFiles[path];
+        const nextFiles = {...currentFiles};
+
+        if (!baseFile && currentFile) {
+            delete nextFiles[path];
+        } else if (baseFile) {
+            nextFiles[path] = {
+                ...baseFile,
+                binary: baseFile.binary ? new Uint8Array(baseFile.binary) : null
+            };
+        }
+
+        setFilesAndSelection(nextFiles);
+    };
+
+    const requestSaveAsThemeName = async () => {
+        const requestedName = await requestInput({
+            title: 'Save as new theme',
+            fieldTitle: 'Theme name',
+            initialValue: `${currentThemeName}-edited`,
+            okLabel: 'Continue',
+            prompt: 'Default themes cannot be overwritten. Save your edits as a new theme instead.'
+        });
+        const nextName = requestedName?.trim().toLowerCase();
+
+        if (!nextName) {
+            return null;
+        }
+
+        if (!THEME_NAME_PATTERN.test(nextName)) {
+            toast.error('Invalid theme name', {description: 'Use 1-64 characters, starting with a letter or number. Allowed: letters, numbers, dashes, and underscores.'});
+            return null;
+        }
+
+        if (isDefaultThemeName(nextName)) {
+            toast.error('Built-in themes cannot be overwritten');
+            return null;
+        }
+
+        return nextName;
+    };
+
+    const handleSave = async () => {
+        if (isSaving) {
+            return;
+        }
+
+        if (changes.length === 0) {
+            toast.info('No changes to save');
+            return;
+        }
+
+        const previousThemeName = currentThemeName;
+        const nextThemeName = isDefaultThemeName(previousThemeName) ? await requestSaveAsThemeName() : previousThemeName;
+
+        if (!nextThemeName) {
+            return;
+        }
+
+        const isSaveAs = nextThemeName !== previousThemeName;
+        const themeExists = themesData?.themes.some(theme => theme.name === nextThemeName) || false;
+        const confirmMessage = isSaveAs
+            ? `Save your edits as "${nextThemeName}"?`
+            : `Upload ${formatNumber(changes.length)} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
+
+        const confirmedSave = await requestConfirmation({
+            title: isSaveAs ? 'Save theme as new copy' : 'Update theme',
+            prompt: confirmMessage,
+            okLabel: isSaveAs ? 'Save theme' : 'Replace theme'
+        });
+
+        if (!confirmedSave) {
+            return;
+        }
+
+        if (isSaveAs && themeExists) {
+            const confirmedOverwrite = await requestConfirmation({
+                title: 'Overwrite theme',
+                prompt: <><strong>{nextThemeName}</strong> already exists. Do you want to overwrite it?</>,
+                okLabel: 'Overwrite',
+                okVariant: 'destructive'
+            });
+
+            if (!confirmedOverwrite) {
+                return;
+            }
+        }
+
+        setIsSaving(true);
+
+        try {
+            const blob = await packThemeArchive({
+                files: currentFiles,
+                rootPrefix
+            });
+
+            const data = await uploadTheme({
+                file: new File([blob], `${nextThemeName}.zip`, {type: 'application/zip'}),
+                // when saving under a new name, carry over the original theme's
+                // settings so activating the copy keeps the site's design
+                copySettingsFrom: isSaveAs ? previousThemeName : undefined
+            });
+
+            const uploadedTheme = data.themes[0];
+            const returnRoute = getReturnRouteFromHash();
+
+            setBaseFiles(cloneThemeFiles(currentFiles));
+
+            if (isSaveAs) {
+                setCurrentThemeName(nextThemeName);
+                setRootPrefix(rootPrefix ? `${nextThemeName}/` : '');
+                updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
+            }
+
+            const problems = getIssuesFromInstalledTheme(uploadedTheme);
+
+            if (isSaveAs || problems.length) {
+                setInstalledModal({
+                    title: isSaveAs ? 'Theme saved' : 'Theme updated',
+                    statusMessage: <><strong>{uploadedTheme.name}</strong> was {describeThemeOutcome('saved', problems)}. Do you want to activate it?</>,
+                    installedTheme: uploadedTheme
+                });
+            } else {
+                toast.success('Theme saved', {description: <div><span className='capitalize'>{uploadedTheme.name}</span> has been updated.</div>});
+            }
+        } catch (error) {
+            if (error instanceof JSONError && error.response?.status === 422) {
+                const fatalErrors = parseFatalErrors(error.data?.errors);
+
+                if (fatalErrors) {
+                    setSaveErrors(fatalErrors);
+                    return;
+                }
+            }
+
+            const sizeLimitError = getUploadSizeLimitError(error);
+
+            if (sizeLimitError) {
+                toast.error(UPLOAD_SIZE_LIMIT_TITLES[sizeLimitError.code], {description: buildUploadSizeLimitMessage(sizeLimitError)});
+                return;
+            }
+
+            handleError(error);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    useEffect(() => {
+        handleSaveRef.current = handleSave;
+    });
+
+    const openFile = (path: string) => {
+        setSelectedNode({type: 'file', path});
+        ensurePathExpanded(path);
+    };
+
+    const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
+
+    return (<>
+        <div
+            aria-label={`Edit theme ${themeName}`}
+            aria-modal='true'
+            className='dark fixed inset-0 z-[140] bg-[rgba(10,11,13,0.72)] text-[#e6e7ea] backdrop-blur-[4px]'
+            data-testid='theme-code-editor-modal'
+            role='dialog'
+            onClick={(event) => {
+                if (event.target === event.currentTarget) {
+                    void closeEditor();
+                }
+            }}
+        >
+            <div className='relative flex size-full flex-col overflow-hidden bg-[#15171a]'>
+                <ThemeEditorToolbar
+                    changes={changes}
+                    currentThemeName={currentThemeName}
+                    isSaving={isSaving}
+                    onClose={() => void closeEditor()}
+                    onSave={() => void handleSave()}
+                />
+
+                {loadError && (
+                    <div className='border-b border-[#512828] bg-[#3a1d1d] px-4 py-2 text-[12px] text-[#ffbdbd]'>
+                        {loadError}
+                    </div>
+                )}
+
+                <div className='flex min-h-0 flex-1'>
+                    <ThemeFileTree
+                        changesMap={changesMap}
+                        currentFiles={currentFiles}
+                        expandedDirectories={expandedDirectories}
+                        isLoading={isLoading}
+                        selectedNode={selectedNode}
+                        setExpandedDirectories={setExpandedDirectories}
+                        setSelectedNode={setSelectedNode}
+                        onCreateFile={() => void handleCreateFile()}
+                        onDeleteSelected={() => void handleDeleteSelected()}
+                        onOpenFile={openFile}
+                        onRenameSelected={() => void handleRenameSelected()}
+                    />
+
+                    <section className='flex min-w-0 flex-1 flex-col bg-[#16181c]'>
+                        <div className='flex items-center gap-2 border-b border-[#23262c] bg-[#17191d] px-4 py-2 text-[12px] text-[#8a8f98]'>
+                            {selectedFile ? (
+                                <>
+                                    <span className='min-w-0 truncate font-medium text-[#e6e7ea]'>{selectedFile.path}</span>
+                                    <span className='rounded bg-[#2a2d33] px-2 py-0.5 text-[10px] tracking-[0.04em] text-[#c8ccd3] uppercase'>
+                                        {getLanguageLabel(selectedFile.path)}
+                                    </span>
+                                    {selectedFileStatus && (
+                                        <button
+                                            className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] tracking-[0.04em] uppercase ${selectedFileStatus === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : selectedFileStatus === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}
+                                            type='button'
+                                            onClick={() => handleRevertPath(selectedFile.path)}
+                                        >
+                                            <Undo2 size={11} />
+                                            Revert
+                                        </button>
+                                    )}
+                                    <div className='grow' />
+                                    {selectedFile.editable && (
+                                        <button
+                                            aria-label={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
+                                            aria-pressed={isTextWrapEnabled}
+                                            className={wrapToggleClass(isTextWrapEnabled)}
+                                            title={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
+                                            type='button'
+                                            onClick={() => setIsTextWrapEnabled(value => !value)}
+                                        >
+                                            <TextWrap className='shrink-0' size={14} strokeWidth={2} />
+                                        </button>
+                                    )}
+                                </>
+                            ) : (
+                                <span>No file selected</span>
+                            )}
+                        </div>
+
+                        <div className='min-h-0 flex-1'>
+                            {!selectedNode && !isLoading && (
+                                <div className={editorPaneEmptyStateClass}>
+                                    Select a file from the tree to start editing.
+                                </div>
+                            )}
+
+                            {selectedNode?.type === 'dir' && (
+                                <div className={editorPaneEmptyStateClass}>
+                                    Folder selected. Choose a file to edit, or rename or delete the folder from the file pane.
+                                </div>
+                            )}
+
+                            {selectedFile && !selectedFile.editable && (
+                                <div className={editorPaneEmptyStateClass}>
+                                    This file cannot be edited in the browser.
+                                </div>
+                            )}
+
+                            {selectedFile?.editable && (
+                                <CodeMirror
+                                    key={`${selectedFile.path}:${editorExtensions.length}`}
+                                    basicSetup={{
+                                        highlightActiveLine: false,
+                                        highlightActiveLineGutter: false
+                                    }}
+                                    className='h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:size-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]'
+                                    extensions={editorExtensions}
+                                    height='full'
+                                    theme={oneDark}
+                                    value={selectedFile.content || ''}
+                                    autoFocus
+                                    onChange={(value) => {
+                                        setCurrentFiles(files => ({
+                                            ...files,
+                                            [selectedFile.path]: {
+                                                ...files[selectedFile.path],
+                                                content: value
+                                            }
+                                        }));
+                                    }}
+                                />
+                            )}
+                        </div>
+                    </section>
+                </div>
+
             </div>
-          ),
-        });
-      }
-    } catch (error) {
-      if (error instanceof JSONError && error.response?.status === 422) {
-        const fatalErrors = parseFatalErrors(error.data?.errors);
-
-        if (fatalErrors) {
-          setSaveErrors(fatalErrors);
-          return;
-        }
-      }
-
-      const sizeLimitError = getUploadSizeLimitError(error);
-
-      if (sizeLimitError) {
-        toast.error(UPLOAD_SIZE_LIMIT_TITLES[sizeLimitError.code], {
-          description: buildUploadSizeLimitMessage(sizeLimitError),
-        });
-        return;
-      }
-
-      handleError(error);
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  useEffect(() => {
-    handleSaveRef.current = handleSave;
-  });
-
-  const openFile = (path: string) => {
-    setSelectedNode({ type: 'file', path });
-    ensurePathExpanded(path);
-  };
-
-  const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
-
-  return (
-    <>
-      <div
-        aria-label={`Edit theme ${themeName}`}
-        aria-modal="true"
-        className="dark fixed inset-0 z-[140] bg-[rgba(10,11,13,0.72)] text-[#e6e7ea] backdrop-blur-[4px]"
-        data-testid="theme-code-editor-modal"
-        role="dialog"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) {
-            void closeEditor();
-          }
-        }}
-      >
-        <div className="relative flex size-full flex-col overflow-hidden bg-[#15171a]">
-          <ThemeEditorToolbar
-            changes={changes}
-            currentThemeName={currentThemeName}
-            isSaving={isSaving}
-            onClose={() => void closeEditor()}
-            onSave={() => void handleSave()}
-          />
-
-          {loadError && (
-            <div className="border-b border-[#512828] bg-[#3a1d1d] px-4 py-2 text-[12px] text-[#ffbdbd]">
-              {loadError}
-            </div>
-          )}
-
-          <div className="flex min-h-0 flex-1">
-            <ThemeFileTree
-              changesMap={changesMap}
-              currentFiles={currentFiles}
-              expandedDirectories={expandedDirectories}
-              isLoading={isLoading}
-              selectedNode={selectedNode}
-              setExpandedDirectories={setExpandedDirectories}
-              setSelectedNode={setSelectedNode}
-              onCreateFile={() => void handleCreateFile()}
-              onDeleteSelected={() => void handleDeleteSelected()}
-              onOpenFile={openFile}
-              onRenameSelected={() => void handleRenameSelected()}
-            />
-
-            <section className="flex min-w-0 flex-1 flex-col bg-[#16181c]">
-              <div className="flex items-center gap-2 border-b border-[#23262c] bg-[#17191d] px-4 py-2 text-[12px] text-[#8a8f98]">
-                {selectedFile ? (
-                  <>
-                    <span className="min-w-0 truncate font-medium text-[#e6e7ea]">
-                      {selectedFile.path}
-                    </span>
-                    <span className="rounded bg-[#2a2d33] px-2 py-0.5 text-[10px] tracking-[0.04em] text-[#c8ccd3] uppercase">
-                      {getLanguageLabel(selectedFile.path)}
-                    </span>
-                    {selectedFileStatus && (
-                      <button
-                        className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] tracking-[0.04em] uppercase ${selectedFileStatus === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : selectedFileStatus === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}
-                        type="button"
-                        onClick={() => handleRevertPath(selectedFile.path)}
-                      >
-                        <Undo2 size={11} />
-                        Revert
-                      </button>
-                    )}
-                    <div className="grow" />
-                    {selectedFile.editable && (
-                      <button
-                        aria-label={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
-                        aria-pressed={isTextWrapEnabled}
-                        className={wrapToggleClass(isTextWrapEnabled)}
-                        title={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
-                        type="button"
-                        onClick={() => setIsTextWrapEnabled((value) => !value)}
-                      >
-                        <TextWrap className="shrink-0" size={14} strokeWidth={2} />
-                      </button>
-                    )}
-                  </>
-                ) : (
-                  <span>No file selected</span>
-                )}
-              </div>
-
-              <div className="min-h-0 flex-1">
-                {!selectedNode && !isLoading && (
-                  <div className={editorPaneEmptyStateClass}>
-                    Select a file from the tree to start editing.
-                  </div>
-                )}
-
-                {selectedNode?.type === 'dir' && (
-                  <div className={editorPaneEmptyStateClass}>
-                    Folder selected. Choose a file to edit, or rename or delete the folder from the
-                    file pane.
-                  </div>
-                )}
-
-                {selectedFile && !selectedFile.editable && (
-                  <div className={editorPaneEmptyStateClass}>
-                    This file cannot be edited in the browser.
-                  </div>
-                )}
-
-                {selectedFile?.editable && (
-                  <CodeMirror
-                    key={`${selectedFile.path}:${editorExtensions.length}`}
-                    basicSetup={{
-                      highlightActiveLine: false,
-                      highlightActiveLineGutter: false,
-                    }}
-                    className="h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:size-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]"
-                    extensions={editorExtensions}
-                    height="full"
-                    theme={oneDark}
-                    value={selectedFile.content || ''}
-                    autoFocus
-                    onChange={(value) => {
-                      setCurrentFiles((files) => ({
-                        ...files,
-                        [selectedFile.path]: {
-                          ...files[selectedFile.path],
-                          content: value,
-                        },
-                      }));
-                    }}
-                  />
-                )}
-              </div>
-            </section>
-          </div>
         </div>
-      </div>
-      {dialogRequest?.type === 'confirmation' && (
-        <ThemeEditorConfirmModal
-          {...dialogRequest.props}
-          onResolve={(result) => {
-            if (dialogRequestRef.current !== dialogRequest) {
-              return;
-            }
+        {dialogRequest?.type === 'confirmation' && (
+            <ThemeEditorConfirmModal
+                {...dialogRequest.props}
+                onResolve={(result) => {
+                    if (dialogRequestRef.current !== dialogRequest) {
+                        return;
+                    }
 
-            dialogRequestRef.current = null;
-            setDialogRequest(null);
-            dialogRequest.resolve(result);
-          }}
-        />
-      )}
-      {dialogRequest?.type === 'input' && (
-        <ThemeEditorInputModal
-          {...dialogRequest.props}
-          onResolve={(result) => {
-            if (dialogRequestRef.current !== dialogRequest) {
-              return;
-            }
+                    dialogRequestRef.current = null;
+                    setDialogRequest(null);
+                    dialogRequest.resolve(result);
+                }}
+            />
+        )}
+        {dialogRequest?.type === 'input' && (
+            <ThemeEditorInputModal
+                {...dialogRequest.props}
+                onResolve={(result) => {
+                    if (dialogRequestRef.current !== dialogRequest) {
+                        return;
+                    }
 
-            dialogRequestRef.current = null;
-            setDialogRequest(null);
-            dialogRequest.resolve(result);
-          }}
-        />
-      )}
-      {saveErrors && (
-        <InvalidThemeModal
-          fatalErrors={saveErrors}
-          title="Theme not saved"
-          onClose={() => setSaveErrors(null)}
-        />
-      )}
-      {installedModal && (
-        <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />
-      )}
-    </>
-  );
+                    dialogRequestRef.current = null;
+                    setDialogRequest(null);
+                    dialogRequest.resolve(result);
+                }}
+            />
+        )}
+        {saveErrors && <InvalidThemeModal action='saved' cancelLabel='Close' fatalErrors={saveErrors} themeName={currentThemeName} title='Theme not saved' onClose={() => setSaveErrors(null)} />}
+        {installedModal && <ThemeInstalledModal {...installedModal} onClose={() => setInstalledModal(null)} />}
+    </>);
 };
 
 export default ThemeCodeEditorModal;

--- a/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-code-editor-modal.tsx
@@ -907,6 +907,7 @@ const ThemeCodeEditorModal: React.FC<{ themeName: string }> = ({ themeName }) =>
       if (isSaveAs || problems.length) {
         setInstalledModal({
           title: isSaveAs ? 'Theme saved' : 'Theme updated',
+          action: 'saved',
           statusMessage: (
             <>
               <strong>{uploadedTheme.name}</strong> was {describeThemeOutcome('saved', problems)}.

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -53,7 +53,7 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & {onClose: () => v
         okVariant='default'
         prompt={
             <div className='space-y-5'>
-                <p className='text-sm text-foreground'>{status}</p>
+                <p className='text-base text-foreground'>{status}</p>
                 <ThemeValidationIssueList problems={problems} />
             </div>
         }

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -5,7 +5,6 @@ import { type InstalledTheme, useActivateTheme } from '@tryghost/admin-x-framewo
 import { ThemeValidationIssueList } from './theme-validation-details';
 import {
   type ThemeAction,
-  describeProblemSet,
   describeThemeOutcome,
   getIssuesFromInstalledTheme,
   hasErrorProblem,
@@ -61,24 +60,10 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   let status: ReactNode;
 
   if (installedTheme.active) {
-    // Saving the active theme, or re-uploading over it, lands here with
-    // problems in hand. "Successfully" directly above a list of them is a
-    // clean-success sentence the dialog immediately contradicts, so a set
-    // that has anything in it is named instead — by the same rule the list
-    // and the badges use.
     status = (
       <>
-        {problems.length > 0 ? (
-          <>
-            Your theme <strong>{installedTheme.name}</strong> is now visible to your readers, but it
-            has some {describeProblemSet(problems)}.
-          </>
-        ) : (
-          <>
-            Your theme <strong>{installedTheme.name}</strong> was {action} successfully and is now
-            visible to your readers.
-          </>
-        )}
+        Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible
+        to your readers.
         {homepageUrl ? (
           <>
             {' '}

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -52,7 +52,7 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & {onClose: () => v
         okRunningLabel='Activating...'
         okVariant='default'
         prompt={
-            <div className='space-y-5'>
+            <div className='flex flex-col gap-4'>
                 <p className='text-base text-foreground'>{status}</p>
                 <ThemeValidationIssueList problems={problems} />
             </div>

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -88,6 +88,7 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   return (
     <ConfirmationModalContent
       cancelLabel="Close"
+      contentClassName={problems.length > 0 ? 'max-w-[600px]' : undefined}
       okLabel={okLabel}
       okRunningLabel="Activating..."
       okVariant="default"

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -1,82 +1,118 @@
-import React, {type ReactNode} from 'react';
+import React, { type ReactNode } from 'react';
 import useCustomFonts from '@/settings/hooks/use-custom-fonts';
-import {ConfirmationModalContent} from '@/settings/components/confirmation-modal';
-import {type InstalledTheme, useActivateTheme} from '@tryghost/admin-x-framework/api/themes';
-import {ThemeValidationIssueList} from './theme-validation-details';
-import {describeThemeOutcome, getIssuesFromInstalledTheme} from './theme-validation-issues';
-import {getHomepageUrl, useBrowseSite} from '@tryghost/admin-x-framework/api/site';
-import {toast} from 'sonner';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import { ConfirmationModalContent } from '@/settings/components/confirmation-modal';
+import { type InstalledTheme, useActivateTheme } from '@tryghost/admin-x-framework/api/themes';
+import { ThemeValidationIssueList } from './theme-validation-details';
+import { describeThemeOutcome, getIssuesFromInstalledTheme } from './theme-validation-issues';
+import { getHomepageUrl, useBrowseSite } from '@tryghost/admin-x-framework/api/site';
+import { toast } from 'sonner';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 
 export type ThemeInstalledModalProps = {
-    title: string;
-    /**
-     * Replaces the derived "was uploaded" sentence for flows that didn't upload
-     * an archive (marketplace installs, code editor saves). Ignored when the
-     * theme is already active, which has its own copy.
-     */
-    statusMessage?: ReactNode;
-    installedTheme: InstalledTheme;
-    onActivate?: () => void;
+  title: string;
+  /**
+   * Replaces the derived "was uploaded" sentence for flows that didn't upload
+   * an archive (marketplace installs, code editor saves). Ignored when the
+   * theme is already active, which has its own copy.
+   */
+  statusMessage?: ReactNode;
+  installedTheme: InstalledTheme;
+  onActivate?: () => void;
 };
 
-const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & {onClose: () => void}> = ({title, statusMessage, installedTheme, onActivate, onClose}) => {
-    const {mutateAsync: activateTheme} = useActivateTheme();
-    const {refreshActiveThemeData} = useCustomFonts();
-    const handleError = useHandleError();
-    const {data: siteData} = useBrowseSite();
-    const problems = getIssuesFromInstalledTheme(installedTheme);
-    const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
+const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => void }> = ({
+  title,
+  statusMessage,
+  installedTheme,
+  onActivate,
+  onClose,
+}) => {
+  const { mutateAsync: activateTheme } = useActivateTheme();
+  const { refreshActiveThemeData } = useCustomFonts();
+  const handleError = useHandleError();
+  const { data: siteData } = useBrowseSite();
+  const problems = getIssuesFromInstalledTheme(installedTheme);
+  const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
 
-    const okLabel = installedTheme.active ? 'OK' : 'Activate theme';
-    const modalTitle = installedTheme.active ? <span className='text-green'>It&apos;s live!</span> : title;
+  const okLabel = installedTheme.active ? 'OK' : 'Activate theme';
+  const modalTitle = installedTheme.active ? (
+    <span className="text-green">It&apos;s live!</span>
+  ) : (
+    title
+  );
 
-    let status: ReactNode;
+  let status: ReactNode;
 
-    if (installedTheme.active) {
-        status = <>
-            Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible to your readers.
-            {homepageUrl ? <>
-                {' '}<a className='font-semibold text-foreground hover:underline' href={homepageUrl} rel='noreferrer' target='_blank'>Take a look →</a>
-            </> : null}
-        </>;
-    } else if (statusMessage) {
-        status = statusMessage;
-    } else {
-        status = <><strong>{installedTheme.name}</strong> was {describeThemeOutcome('uploaded', problems)}. Do you want to activate it?</>;
-    }
+  if (installedTheme.active) {
+    status = (
+      <>
+        Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible
+        to your readers.
+        {homepageUrl ? (
+          <>
+            {' '}
+            <a
+              className="font-semibold text-foreground hover:underline"
+              href={homepageUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Take a look →
+            </a>
+          </>
+        ) : null}
+      </>
+    );
+  } else if (statusMessage) {
+    status = statusMessage;
+  } else {
+    status = (
+      <>
+        <strong>{installedTheme.name}</strong> was {describeThemeOutcome('uploaded', problems)}. Do
+        you want to activate it?
+      </>
+    );
+  }
 
-    return <ConfirmationModalContent
-        cancelLabel='Close'
-        okLabel={okLabel}
-        okRunningLabel='Activating...'
-        okVariant='default'
-        prompt={
-            <div className='flex flex-col gap-4'>
-                <p className='text-base text-foreground'>{status}</p>
-                <ThemeValidationIssueList problems={problems} />
-            </div>
+  return (
+    <ConfirmationModalContent
+      cancelLabel="Close"
+      okLabel={okLabel}
+      okRunningLabel="Activating..."
+      okVariant="default"
+      prompt={
+        <div className="flex flex-col gap-4">
+          <p className="text-base text-foreground">{status}</p>
+          <ThemeValidationIssueList problems={problems} />
+        </div>
+      }
+      stickyFooter={true}
+      title={modalTitle}
+      onOk={async (activateModal) => {
+        if (!installedTheme.active) {
+          try {
+            const resData = await activateTheme(installedTheme.name);
+            const updatedTheme = resData.themes[0];
+            refreshActiveThemeData();
+
+            toast.success('Theme activated', {
+              description: (
+                <div>
+                  <span className="capitalize">{updatedTheme.name}</span> is now your active theme.
+                </div>
+              ),
+            });
+          } catch (e) {
+            handleError(e);
+            return;
+          }
         }
-        stickyFooter={true}
-        title={modalTitle}
-        onOk={async (activateModal) => {
-            if (!installedTheme.active) {
-                try {
-                    const resData = await activateTheme(installedTheme.name);
-                    const updatedTheme = resData.themes[0];
-                    refreshActiveThemeData();
-
-                    toast.success('Theme activated', {description: <div><span className='capitalize'>{updatedTheme.name}</span> is now your active theme.</div>});
-                } catch (e) {
-                    handleError(e);
-                    return;
-                }
-            }
-            onActivate?.();
-            activateModal?.remove();
-        }}
-        onRemove={onClose}
-    />;
+        onActivate?.();
+        activateModal?.remove();
+      }}
+      onRemove={onClose}
+    />
+  );
 };
 
 export default ThemeInstalledModal;

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -18,11 +18,8 @@ export type ThemeInstalledModalProps = {
   /** Past tense of how the theme arrived, named in the status sentence. */
   action?: ThemeAction;
   /**
-   * Replaces the derived "was uploaded" sentence for a flow whose outcome
-   * `action` cannot describe — activating a default or legacy theme, which was
-   * never installed at all. A flow that only restates the derived sentence
-   * should leave this unset rather than give one line two sources to drift
-   * between. Ignored when the theme is already active, which has its own copy.
+   * Replaces the derived "was uploaded" sentence for a flow `action` cannot
+   * describe. Ignored when the theme is already active.
    */
   statusMessage?: ReactNode;
   installedTheme: InstalledTheme;
@@ -44,8 +41,6 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   const problems = getIssuesFromInstalledTheme(installedTheme);
   const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
 
-  // Activating a theme Ghost has already flagged is a decision, not a default:
-  // the button says what the user is about to accept.
   const okLabel = installedTheme.active
     ? 'OK'
     : hasErrorProblem(problems)

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -4,6 +4,8 @@ import { ConfirmationModalContent } from '@/settings/components/confirmation-mod
 import { type InstalledTheme, useActivateTheme } from '@tryghost/admin-x-framework/api/themes';
 import { ThemeValidationIssueList } from './theme-validation-details';
 import {
+  type ThemeAction,
+  describeProblemSet,
   describeThemeOutcome,
   getIssuesFromInstalledTheme,
   hasErrorProblem,
@@ -12,16 +14,16 @@ import { getHomepageUrl, useBrowseSite } from '@tryghost/admin-x-framework/api/s
 import { toast } from 'sonner';
 import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 
-/** Past tense of how the theme arrived, named in the status sentence. */
-export type ThemeInstalledAction = 'uploaded' | 'installed' | 'saved';
-
 export type ThemeInstalledModalProps = {
   title: string;
-  action?: ThemeInstalledAction;
+  /** Past tense of how the theme arrived, named in the status sentence. */
+  action?: ThemeAction;
   /**
-   * Replaces the derived "was uploaded" sentence for flows that didn't upload
-   * an archive (marketplace installs, code editor saves). Ignored when the
-   * theme is already active, which has its own copy.
+   * Replaces the derived "was uploaded" sentence for a flow whose outcome
+   * `action` cannot describe — activating a default or legacy theme, which was
+   * never installed at all. A flow that only restates the derived sentence
+   * should leave this unset rather than give one line two sources to drift
+   * between. Ignored when the theme is already active, which has its own copy.
    */
   statusMessage?: ReactNode;
   installedTheme: InstalledTheme;
@@ -59,10 +61,24 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   let status: ReactNode;
 
   if (installedTheme.active) {
+    // Saving the active theme, or re-uploading over it, lands here with
+    // problems in hand. "Successfully" directly above a list of them is a
+    // clean-success sentence the dialog immediately contradicts, so a set
+    // that has anything in it is named instead — by the same rule the list
+    // and the badges use.
     status = (
       <>
-        Your theme <strong>{installedTheme.name}</strong> was {action} successfully and is now
-        visible to your readers.
+        {problems.length > 0 ? (
+          <>
+            Your theme <strong>{installedTheme.name}</strong> is now visible to your readers, but it
+            has some {describeProblemSet(problems)}.
+          </>
+        ) : (
+          <>
+            Your theme <strong>{installedTheme.name}</strong> was {action} successfully and is now
+            visible to your readers.
+          </>
+        )}
         {homepageUrl ? (
           <>
             {' '}

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -3,13 +3,21 @@ import useCustomFonts from '@/settings/hooks/use-custom-fonts';
 import { ConfirmationModalContent } from '@/settings/components/confirmation-modal';
 import { type InstalledTheme, useActivateTheme } from '@tryghost/admin-x-framework/api/themes';
 import { ThemeValidationIssueList } from './theme-validation-details';
-import { describeThemeOutcome, getIssuesFromInstalledTheme } from './theme-validation-issues';
+import {
+  describeThemeOutcome,
+  getIssuesFromInstalledTheme,
+  hasErrorProblem,
+} from './theme-validation-issues';
 import { getHomepageUrl, useBrowseSite } from '@tryghost/admin-x-framework/api/site';
 import { toast } from 'sonner';
 import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 
+/** Past tense of how the theme arrived, named in the status sentence. */
+export type ThemeInstalledAction = 'uploaded' | 'installed' | 'saved';
+
 export type ThemeInstalledModalProps = {
   title: string;
+  action?: ThemeInstalledAction;
   /**
    * Replaces the derived "was uploaded" sentence for flows that didn't upload
    * an archive (marketplace installs, code editor saves). Ignored when the
@@ -22,6 +30,7 @@ export type ThemeInstalledModalProps = {
 
 const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => void }> = ({
   title,
+  action = 'uploaded',
   statusMessage,
   installedTheme,
   onActivate,
@@ -34,7 +43,13 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   const problems = getIssuesFromInstalledTheme(installedTheme);
   const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
 
-  const okLabel = installedTheme.active ? 'OK' : 'Activate theme';
+  // Activating a theme Ghost has already flagged is a decision, not a default:
+  // the button says what the user is about to accept.
+  const okLabel = installedTheme.active
+    ? 'OK'
+    : hasErrorProblem(problems)
+      ? 'Activate with errors'
+      : 'Activate theme';
   const modalTitle = installedTheme.active ? (
     <span className="text-green">It&apos;s live!</span>
   ) : (
@@ -46,8 +61,8 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   if (installedTheme.active) {
     status = (
       <>
-        Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible
-        to your readers.
+        Your theme <strong>{installedTheme.name}</strong> was {action} successfully and is now
+        visible to your readers.
         {homepageUrl ? (
           <>
             {' '}
@@ -68,8 +83,8 @@ const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => 
   } else {
     status = (
       <>
-        <strong>{installedTheme.name}</strong> was {describeThemeOutcome('uploaded', problems)}. Do
-        you want to activate it?
+        <strong>{installedTheme.name}</strong> was {describeThemeOutcome(action, problems)}. Do you
+        want to activate it?
       </>
     );
   }

--- a/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/site/theme/theme-installed-modal.tsx
@@ -1,130 +1,82 @@
-import React, { type ReactNode } from 'react';
+import React, {type ReactNode} from 'react';
 import useCustomFonts from '@/settings/hooks/use-custom-fonts';
-import { ConfirmationModalContent } from '@/settings/components/confirmation-modal';
-import { type InstalledTheme, useActivateTheme } from '@tryghost/admin-x-framework/api/themes';
-import { OutcomeBanner, ThemeValidationDetailsDisclosure } from './theme-validation-details';
-import { getIssuesFromInstalledTheme } from './theme-validation-issues';
-import { getHomepageUrl, useBrowseSite } from '@tryghost/admin-x-framework/api/site';
-import { toast } from 'sonner';
-import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
-import { useHandleError } from '@tryghost/admin-x-framework/hooks';
+import {ConfirmationModalContent} from '@/settings/components/confirmation-modal';
+import {type InstalledTheme, useActivateTheme} from '@tryghost/admin-x-framework/api/themes';
+import {ThemeValidationIssueList} from './theme-validation-details';
+import {describeThemeOutcome, getIssuesFromInstalledTheme} from './theme-validation-issues';
+import {getHomepageUrl, useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+import {toast} from 'sonner';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 export type ThemeInstalledModalProps = {
-  title: string;
-  prompt: ReactNode;
-  installedTheme: InstalledTheme;
-  validationDetailsDefaultOpen?: boolean;
-  onActivate?: () => void;
+    title: string;
+    /**
+     * Replaces the derived "was uploaded" sentence for flows that didn't upload
+     * an archive (marketplace installs, code editor saves). Ignored when the
+     * theme is already active, which has its own copy.
+     */
+    statusMessage?: ReactNode;
+    installedTheme: InstalledTheme;
+    onActivate?: () => void;
 };
 
-const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & { onClose: () => void }> = ({
-  title,
-  installedTheme,
-  validationDetailsDefaultOpen,
-  onActivate,
-  onClose,
-}) => {
-  const { mutateAsync: activateTheme } = useActivateTheme();
-  const { refreshActiveThemeData } = useCustomFonts();
-  const handleError = useHandleError();
-  const { data: configData } = useBrowseConfig();
-  const { data: siteData } = useBrowseSite();
-  const defaultOpen =
-    validationDetailsDefaultOpen ?? configData?.config?.environment === 'development';
-  const secondaryProblems = getIssuesFromInstalledTheme(installedTheme);
-  const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
+const ThemeInstalledModal: React.FC<ThemeInstalledModalProps & {onClose: () => void}> = ({title, statusMessage, installedTheme, onActivate, onClose}) => {
+    const {mutateAsync: activateTheme} = useActivateTheme();
+    const {refreshActiveThemeData} = useCustomFonts();
+    const handleError = useHandleError();
+    const {data: siteData} = useBrowseSite();
+    const problems = getIssuesFromInstalledTheme(installedTheme);
+    const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
 
-  let okLabel = 'Activate theme';
+    const okLabel = installedTheme.active ? 'OK' : 'Activate theme';
+    const modalTitle = installedTheme.active ? <span className='text-green'>It&apos;s live!</span> : title;
 
-  if (installedTheme.active) {
-    okLabel = 'OK';
-  }
+    let status: ReactNode;
 
-  const modalTitle = installedTheme.active ? (
-    <span className="text-green">It&apos;s live!</span>
-  ) : (
-    title
-  );
-  const outcomeTitle = 'Uploaded successfully';
-  const outcomeCopy = installedTheme.active ? (
-    <>
-      Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible to
-      your readers.
-      {homepageUrl ? (
-        <>
-          {' '}
-          <a
-            className="font-semibold text-black hover:underline dark:text-white"
-            href={homepageUrl}
-            rel="noreferrer"
-            target="_blank"
-          >
-            Take a look →
-          </a>
-        </>
-      ) : null}
-    </>
-  ) : (
-    <>
-      <strong>{installedTheme.name}</strong> has been uploaded. Activate it to make it live.
-    </>
-  );
+    if (installedTheme.active) {
+        status = <>
+            Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible to your readers.
+            {homepageUrl ? <>
+                {' '}<a className='font-semibold text-foreground hover:underline' href={homepageUrl} rel='noreferrer' target='_blank'>Take a look →</a>
+            </> : null}
+        </>;
+    } else if (statusMessage) {
+        status = statusMessage;
+    } else {
+        status = <><strong>{installedTheme.name}</strong> was {describeThemeOutcome('uploaded', problems)}. Do you want to activate it?</>;
+    }
 
-  return (
-    <ConfirmationModalContent
-      cancelLabel="Close"
-      okLabel={okLabel}
-      okRunningLabel="Activating..."
-      okVariant="default"
-      prompt={
-        <>
-          <div className="space-y-5">
-            {installedTheme.active ? (
-              <div className="space-y-2 text-sm text-foreground">
-                <p>{outcomeCopy}</p>
-              </div>
-            ) : (
-              <OutcomeBanner title={outcomeTitle} variant="success">
-                <div className="space-y-2">
-                  <p>{outcomeCopy}</p>
-                </div>
-              </OutcomeBanner>
-            )}
-
-            <ThemeValidationDetailsDisclosure
-              defaultOpen={defaultOpen}
-              problems={secondaryProblems}
-            />
-          </div>
-        </>
-      }
-      stickyFooter={true}
-      title={modalTitle}
-      onOk={async (activateModal) => {
-        if (!installedTheme.active) {
-          try {
-            const resData = await activateTheme(installedTheme.name);
-            const updatedTheme = resData.themes[0];
-            refreshActiveThemeData();
-
-            toast.success('Theme activated', {
-              description: (
-                <div>
-                  <span className="capitalize">{updatedTheme.name}</span> is now your active theme.
-                </div>
-              ),
-            });
-          } catch (e) {
-            handleError(e);
-            return;
-          }
+    return <ConfirmationModalContent
+        cancelLabel='Close'
+        okLabel={okLabel}
+        okRunningLabel='Activating...'
+        okVariant='default'
+        prompt={
+            <div className='space-y-5'>
+                <p className='text-sm text-foreground'>{status}</p>
+                <ThemeValidationIssueList problems={problems} />
+            </div>
         }
-        onActivate?.();
-        activateModal?.remove();
-      }}
-      onRemove={onClose}
-    />
-  );
+        stickyFooter={true}
+        title={modalTitle}
+        onOk={async (activateModal) => {
+            if (!installedTheme.active) {
+                try {
+                    const resData = await activateTheme(installedTheme.name);
+                    const updatedTheme = resData.themes[0];
+                    refreshActiveThemeData();
+
+                    toast.success('Theme activated', {description: <div><span className='capitalize'>{updatedTheme.name}</span> is now your active theme.</div>});
+                } catch (e) {
+                    handleError(e);
+                    return;
+                }
+            }
+            onActivate?.();
+            activateModal?.remove();
+        }}
+        onRemove={onClose}
+    />;
 };
 
 export default ThemeInstalledModal;

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -1,8 +1,14 @@
-import {useMemo} from 'react';
-import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge} from '@tryghost/shade/components';
-import {SEVERITY_ORDER, getDisplaySeverity, sortBySeverity} from './theme-validation-issues';
-import {type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
-import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+import { useMemo } from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Badge,
+} from '@tryghost/shade/components';
+import { SEVERITY_ORDER, getDisplaySeverity, sortBySeverity } from './theme-validation-issues';
+import { type ThemeProblem } from '@tryghost/admin-x-framework/api/themes';
+import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
 
 /**
  * Ghost's legacy Ember stylesheet ships an unlayered `code, tt` rule that gives
@@ -11,7 +17,8 @@ import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
  * explicitly — including `border-radius`, `vertical-align` and `line-height`,
  * whose absence reads as baseline drift rather than an obvious box.
  */
-const LEGACY_CODE_RESET = '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:text-inherit [&_code]:leading-[inherit]';
+const LEGACY_CODE_RESET =
+  '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:text-inherit [&_code]:leading-[inherit]';
 
 /**
  * The same reset applied straight to a `<code>` element we render ourselves,
@@ -19,7 +26,8 @@ const LEGACY_CODE_RESET = '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-t
  * Size is left to the line it sits on: nothing should read larger than its
  * surrounding text.
  */
-const INLINE_CODE = 'rounded-none border-0 bg-transparent p-0 align-baseline font-mono text-inherit leading-[inherit]';
+const INLINE_CODE =
+  'rounded-none border-0 bg-transparent p-0 align-baseline font-mono text-inherit leading-[inherit]';
 
 /**
  * gscan writes `rule` and `details` as HTML containing `<code>`, `<br>` and
@@ -32,15 +40,15 @@ const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground [&_cod
 const DETAILS_HTML = `text-sm leading-[1.45] text-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-sm ${LEGACY_CODE_RESET}`;
 
 function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
-    if (problem.level === 'warning') {
-        return 'warning';
-    }
+  if (problem.level === 'warning') {
+    return 'warning';
+  }
 
-    if (problem.level === 'recommendation') {
-        return 'secondary';
-    }
+  if (problem.level === 'recommendation') {
+    return 'secondary';
+  }
 
-    return 'destructive';
+  return 'destructive';
 }
 
 /**
@@ -49,12 +57,10 @@ function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | '
  * set contains, so its wording and its icon can never disagree.
  */
 function countBySeverity(problems: ThemeProblem[]) {
-    return SEVERITY_ORDER
-        .map(severity => ({
-            severity,
-            count: problems.filter(problem => getDisplaySeverity(problem) === severity).length
-        }))
-        .filter(({count}) => count > 0);
+  return SEVERITY_ORDER.map((severity) => ({
+    severity,
+    count: problems.filter((problem) => getDisplaySeverity(problem) === severity).length,
+  })).filter(({ count }) => count > 0);
 }
 
 /**
@@ -62,74 +68,93 @@ function countBySeverity(problems: ThemeProblem[]) {
  * `2 errors, 3 warnings`. Empty severities are omitted entirely.
  */
 function formatIssueSummary(counts: ReturnType<typeof countBySeverity>): string {
-    return counts
-        .map(({severity, count}) => `${formatNumber(count)} ${severity.toLowerCase()}${count === 1 ? '' : 's'}`)
-        .join(', ');
+  return counts
+    .map(
+      ({ severity, count }) =>
+        `${formatNumber(count)} ${severity.toLowerCase()}${count === 1 ? '' : 's'}`,
+    )
+    .join(', ');
 }
 
 /** Problem codes repeat across gscan results, so the index keeps accordion values unique. */
 function problemValue(problem: ThemeProblem, index: number): string {
-    return `${problem.code || 'issue'}-${index}`;
+  return `${problem.code || 'issue'}-${index}`;
 }
 
-function SeverityBadge({children, variant}: {children: string; variant: 'destructive' | 'warning' | 'secondary'}) {
-    return <Badge className='py-1 font-mono text-sm leading-none uppercase' variant={variant}>{children}</Badge>;
+function SeverityBadge({
+  children,
+  variant,
+}: {
+  children: string;
+  variant: 'destructive' | 'warning' | 'secondary';
+}) {
+  return (
+    <Badge className="py-1 font-mono text-sm leading-none uppercase" variant={variant}>
+      {children}
+    </Badge>
+  );
 }
 
-function ProblemDetails({problem}: {problem: ThemeProblem}) {
-    return (
-        <div className='space-y-3'>
-            <div dangerouslySetInnerHTML={{__html: problem.details}} className={DETAILS_HTML} />
-            {problem.failures?.length > 0 && (
-                <div>
-                    <h6 className='mb-1 text-base font-semibold text-muted-foreground'>Affected files</h6>
-                    <ul className='space-y-1 text-sm text-muted-foreground'>
-                        {problem.failures.map(failure => (
-                            <li key={`${failure.ref}-${failure.message || ''}`}>
-                                {/* A filename is inline mono like any other, so it carries no chip:
+function ProblemDetails({ problem }: { problem: ThemeProblem }) {
+  return (
+    <div className="space-y-3">
+      <div dangerouslySetInnerHTML={{ __html: problem.details }} className={DETAILS_HTML} />
+      {problem.failures?.length > 0 && (
+        <div>
+          <h6 className="mb-1 text-base font-semibold text-muted-foreground">Affected files</h6>
+          <ul className="space-y-1 text-sm text-muted-foreground">
+            {problem.failures.map((failure) => (
+              <li key={`${failure.ref}-${failure.message || ''}`}>
+                {/* A filename is inline mono like any other, so it carries no chip:
                                     same size, colour and family as the code in the details above. */}
-                                <code className={`${INLINE_CODE} text-sm`}>{failure.ref}</code>
-                                {failure.message ? <span>: {failure.message}</span> : null}
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            )}
+                <code className={`${INLINE_CODE} text-sm`}>{failure.ref}</code>
+                {failure.message ? <span>: {failure.message}</span> : null}
+              </li>
+            ))}
+          </ul>
         </div>
-    );
+      )}
+    </div>
+  );
 }
 
-function ValidationProblemItem({problem, value}: {problem: ThemeProblem; value: string}) {
-    return (
-        <AccordionItem className='last:border-b-0' value={value}>
-            {/* Expanding closes the trigger's own bottom padding so the details
+function ValidationProblemItem({ problem, value }: { problem: ThemeProblem; value: string }) {
+  return (
+    <AccordionItem className="last:border-b-0" value={value}>
+      {/* Expanding closes the trigger's own bottom padding so the details
                 sit under the rule line rather than a row's worth of space. */}
-            <AccordionTrigger className='items-start gap-3 p-5 hover:no-underline data-[state=open]:pb-1 [&>svg]:mt-1'>
-                <div className='flex min-w-0 flex-1 flex-col gap-2'>
-                    <div className='flex items-center gap-3'>
-                        <SeverityBadge variant={getDisplayVariant(problem)}>{getDisplaySeverity(problem)}</SeverityBadge>
-                        {problem.code && <span className='font-mono text-md font-normal text-muted-foreground'>{problem.code}</span>}
-                    </div>
-                    <div dangerouslySetInnerHTML={{__html: problem.rule}} className={RULE_HTML} />
-                </div>
-            </AccordionTrigger>
-            <AccordionContent className='px-5 pb-5'>
-                <ProblemDetails problem={problem} />
-            </AccordionContent>
-        </AccordionItem>
-    );
+      <AccordionTrigger className="items-start gap-3 p-5 hover:no-underline data-[state=open]:pb-1 [&>svg]:mt-1">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <SeverityBadge variant={getDisplayVariant(problem)}>
+              {getDisplaySeverity(problem)}
+            </SeverityBadge>
+            {problem.code && (
+              <span className="font-mono text-md font-normal text-muted-foreground">
+                {problem.code}
+              </span>
+            )}
+          </div>
+          <div dangerouslySetInnerHTML={{ __html: problem.rule }} className={RULE_HTML} />
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="px-5 pb-5">
+        <ProblemDetails problem={problem} />
+      </AccordionContent>
+    </AccordionItem>
+  );
 }
 
 /** A bare error string from the API: same row as a problem, minus anything to expand. */
-function ValidationMessageRow({message}: {message: string}) {
-    return (
-        <div className='flex flex-col gap-2 border-b border-border p-5 last:border-b-0'>
-            <div className='flex items-center gap-3'>
-                <SeverityBadge variant='destructive'>Error</SeverityBadge>
-            </div>
-            <p className='text-base font-semibold text-foreground'>{message}</p>
-        </div>
-    );
+function ValidationMessageRow({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col gap-2 border-b border-border p-5 last:border-b-0">
+      <div className="flex items-center gap-3">
+        <SeverityBadge variant="destructive">Error</SeverityBadge>
+      </div>
+      <p className="text-base font-semibold text-foreground">{message}</p>
+    </div>
+  );
 }
 
 /**
@@ -139,59 +164,63 @@ function ValidationMessageRow({message}: {message: string}) {
  * the same kind of content.
  */
 export function ValidationProblemList({
-    className,
-    expandedByDefault = false,
-    messages = [],
-    problems
+  className,
+  expandedByDefault = false,
+  messages = [],
+  problems,
 }: {
-    className?: string;
-    expandedByDefault?: boolean;
-    messages?: string[];
-    problems: ThemeProblem[];
+  className?: string;
+  expandedByDefault?: boolean;
+  messages?: string[];
+  problems: ThemeProblem[];
 }) {
-    const sortedProblems = useMemo(() => sortBySeverity(problems), [problems]);
-    const values = useMemo(() => sortedProblems.map(problemValue), [sortedProblems]);
+  const sortedProblems = useMemo(() => sortBySeverity(problems), [problems]);
+  const values = useMemo(() => sortedProblems.map(problemValue), [sortedProblems]);
 
-    if (!sortedProblems.length && !messages.length) {
-        return null;
-    }
+  if (!sortedProblems.length && !messages.length) {
+    return null;
+  }
 
-    return (
-        <div className={cn('overflow-hidden rounded-lg border border-border', className)}>
-            {messages.map(message => <ValidationMessageRow key={message} message={message} />)}
-            {sortedProblems.length > 0 && (
-                <Accordion defaultValue={expandedByDefault ? values : []} type='multiple'>
-                    {sortedProblems.map((problem, index) => (
-                        <ValidationProblemItem key={values[index]} problem={problem} value={values[index]} />
-                    ))}
-                </Accordion>
-            )}
-        </div>
-    );
+  return (
+    <div className={cn('overflow-hidden rounded-lg border border-border', className)}>
+      {messages.map((message) => (
+        <ValidationMessageRow key={message} message={message} />
+      ))}
+      {sortedProblems.length > 0 && (
+        <Accordion defaultValue={expandedByDefault ? values : []} type="multiple">
+          {sortedProblems.map((problem, index) => (
+            <ValidationProblemItem key={values[index]} problem={problem} value={values[index]} />
+          ))}
+        </Accordion>
+      )}
+    </div>
+  );
 }
 
 /**
  * Non-blocking validation problems, headed by a static count of what was
  * found. Renders nothing when the theme validated cleanly.
  */
-export function ThemeValidationIssueList({problems}: {problems: ThemeProblem[]}) {
-    if (!problems.length) {
-        return null;
-    }
+export function ThemeValidationIssueList({ problems }: { problems: ThemeProblem[] }) {
+  if (!problems.length) {
+    return null;
+  }
 
-    const counts = countBySeverity(problems);
-    // A set that contains errors is headed "1 error, 2 warnings", so the icon
-    // beside it has to read as an error too — amber is only right when the set
-    // is warnings and recommendations alone.
-    const hasError = counts.some(({severity}) => severity === 'Error');
+  const counts = countBySeverity(problems);
+  // A set that contains errors is headed "1 error, 2 warnings", so the icon
+  // beside it has to read as an error too — amber is only right when the set
+  // is warnings and recommendations alone.
+  const hasError = counts.some(({ severity }) => severity === 'Error');
 
-    return (
-        <div className='flex flex-col gap-4'>
-            <h3 className='flex items-center gap-2 text-base font-semibold text-foreground'>
-                <LucideIcon.TriangleAlert className={cn('size-4 shrink-0', hasError ? 'text-destructive' : 'text-state-warning')} />
-                {formatIssueSummary(counts)}
-            </h3>
-            <ValidationProblemList problems={problems} />
-        </div>
-    );
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="flex items-center gap-2 text-base font-semibold text-foreground">
+        <LucideIcon.TriangleAlert
+          className={cn('size-4 shrink-0', hasError ? 'text-destructive' : 'text-state-warning')}
+        />
+        {formatIssueSummary(counts)}
+      </h3>
+      <ValidationProblemList problems={problems} />
+    </div>
+  );
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -6,7 +6,12 @@ import {
   AccordionTrigger,
   Badge,
 } from '@tryghost/shade/components';
-import { SEVERITY_ORDER, getDisplaySeverity, sortBySeverity } from './theme-validation-issues';
+import {
+  SEVERITY_ORDER,
+  getDisplaySeverity,
+  hasErrorProblem,
+  sortBySeverity,
+} from './theme-validation-issues';
 import { type ThemeProblem } from '@tryghost/admin-x-framework/api/themes';
 import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
 
@@ -118,7 +123,17 @@ function ProblemDetails({ problem }: { problem: ThemeProblem }) {
   );
 }
 
-function ValidationProblemItem({ problem, value }: { problem: ThemeProblem; value: string }) {
+function ValidationProblemItem({
+  errorLabel,
+  problem,
+  value,
+}: {
+  errorLabel: string;
+  problem: ThemeProblem;
+  value: string;
+}) {
+  const severity = getDisplaySeverity(problem);
+
   return (
     <AccordionItem className="last:border-b-0" value={value}>
       {/* Expanding closes the trigger's own bottom padding so the details
@@ -127,7 +142,7 @@ function ValidationProblemItem({ problem, value }: { problem: ThemeProblem; valu
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex items-center gap-3">
             <SeverityBadge variant={getDisplayVariant(problem)}>
-              {getDisplaySeverity(problem)}
+              {severity === 'Error' ? errorLabel : severity}
             </SeverityBadge>
             {problem.code && (
               <span className="font-mono text-sm font-normal text-muted-foreground">
@@ -146,11 +161,11 @@ function ValidationProblemItem({ problem, value }: { problem: ThemeProblem; valu
 }
 
 /** A bare error string from the API: same row as a problem, minus anything to expand. */
-function ValidationMessageRow({ message }: { message: string }) {
+function ValidationMessageRow({ errorLabel, message }: { errorLabel: string; message: string }) {
   return (
     <div className="flex flex-col gap-2 border-b border-border p-5 last:border-b-0">
       <div className="flex items-center gap-3">
-        <SeverityBadge variant="destructive">Error</SeverityBadge>
+        <SeverityBadge variant="destructive">{errorLabel}</SeverityBadge>
       </div>
       <p className="text-base font-semibold text-foreground">{message}</p>
     </div>
@@ -162,14 +177,20 @@ function ValidationMessageRow({ message }: { message: string }) {
  * separated by a hairline, each independently expandable. Bare `messages`
  * render as rows in the same list so a dialog never stacks two treatments for
  * the same kind of content.
+ *
+ * `errorLabel` names what an error-severity row is, so a dialog that shows two
+ * lists can say which one stopped it: the problems that blocked the action are
+ * `Blocking`, the ones merely reported alongside them stay `Error`.
  */
 export function ValidationProblemList({
   className,
+  errorLabel = 'Error',
   expandedByDefault = false,
   messages = [],
   problems,
 }: {
   className?: string;
+  errorLabel?: string;
   expandedByDefault?: boolean;
   messages?: string[];
   problems: ThemeProblem[];
@@ -184,12 +205,17 @@ export function ValidationProblemList({
   return (
     <div className={cn('overflow-hidden rounded-lg border border-border', className)}>
       {messages.map((message) => (
-        <ValidationMessageRow key={message} message={message} />
+        <ValidationMessageRow key={message} errorLabel={errorLabel} message={message} />
       ))}
       {sortedProblems.length > 0 && (
         <Accordion defaultValue={expandedByDefault ? values : []} type="multiple">
           {sortedProblems.map((problem, index) => (
-            <ValidationProblemItem key={values[index]} problem={problem} value={values[index]} />
+            <ValidationProblemItem
+              key={values[index]}
+              errorLabel={errorLabel}
+              problem={problem}
+              value={values[index]}
+            />
           ))}
         </Accordion>
       )}
@@ -210,16 +236,25 @@ export function ThemeValidationIssueList({ problems }: { problems: ThemeProblem[
   // A set that contains errors is headed "1 error, 2 warnings", so the icon
   // beside it has to read as an error too — amber is only right when the set
   // is warnings and recommendations alone.
-  const hasError = counts.some(({ severity }) => severity === 'Error');
+  const hasError = hasErrorProblem(problems);
 
   return (
     <div className="flex flex-col gap-4">
-      <h3 className="flex items-center gap-2 text-base font-semibold text-foreground">
-        <LucideIcon.TriangleAlert
-          className={cn('size-4 shrink-0', hasError ? 'text-destructive' : 'text-state-warning')}
-        />
-        {formatIssueSummary(counts)}
-      </h3>
+      <div className="flex flex-col gap-1">
+        <h3 className="flex items-center gap-2 text-base font-semibold text-foreground">
+          <LucideIcon.TriangleAlert
+            className={cn('size-4 shrink-0', hasError ? 'text-destructive' : 'text-state-warning')}
+          />
+          {formatIssueSummary(counts)}
+        </h3>
+        {/* Only errors get explained: warnings and recommendations restrict
+                    nothing, so the same line under them would overstate them. */}
+        {hasError && (
+          <p className="text-sm text-muted-foreground">
+            Highly recommended to fix, functionality could be restricted
+          </p>
+        )}
+      </div>
       <ValidationProblemList problems={problems} />
     </div>
   );

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -150,12 +150,12 @@ export function ThemeValidationIssueList({problems}: {problems: ThemeProblem[]})
     }
 
     return (
-        <div>
+        <div className='flex flex-col gap-4'>
             <h3 className='flex items-center gap-2 text-base font-semibold text-foreground'>
                 <LucideIcon.TriangleAlert className='size-4 shrink-0 text-state-warning' />
                 {formatIssueSummary(problems)}
             </h3>
-            <ValidationProblemList className='mt-4' problems={problems} />
+            <ValidationProblemList problems={problems} />
         </div>
     );
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -23,11 +23,11 @@ import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
  * only generates utilities it finds literally in the source.
  */
 const CODE_CHIP =
-  '[&_code]:rounded-xs [&_code]:border-0 [&_code]:bg-secondary [&_code]:px-1 [&_code]:py-0.5 [&_code]:align-baseline [&_code]:font-mono [&_code]:text-sm [&_code]:text-inherit [&_code]:leading-[inherit] [&_code]:whitespace-nowrap';
+  '[&_code]:rounded-md [&_code]:border-0 [&_code]:bg-secondary [&_code]:px-1 [&_code]:py-0.5 [&_code]:align-baseline [&_code]:font-mono [&_code]:text-sm [&_code]:text-inherit [&_code]:leading-[inherit] [&_code]:whitespace-nowrap';
 
 /** gscan writes `rule` and `details` as HTML, rendered verbatim. */
-const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground ${CODE_CHIP}`;
-const DETAILS_HTML = `text-base leading-[1.45] text-foreground [&_a]:underline ${CODE_CHIP}`;
+const RULE_HTML = `text-base leading-[1.55] font-semibold text-foreground ${CODE_CHIP}`;
+const DETAILS_HTML = `text-base leading-[1.55] text-foreground [&_a]:underline ${CODE_CHIP}`;
 
 const FAILURE_LIST = `space-y-1 text-base text-muted-foreground ${CODE_CHIP}`;
 

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -18,53 +18,29 @@ import { type ThemeProblem } from '@tryghost/admin-x-framework/api/themes';
 import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
 
 /**
- * Ghost's legacy Ember stylesheet ships an unlayered `code, tt` rule that gives
- * every `<code>` in Admin a bordered grey chip with pink text. A bare element
- * selector loses to any class, so each property it sets has to be answered
- * explicitly — including `border-radius`, `vertical-align` and `line-height`,
- * whose absence reads as baseline drift rather than an obvious box.
- *
- * Written once and applied to `<code>` descendants, so inline mono looks the
- * same whether the markup came from gscan or from us. Class names are spelled
- * out in full rather than assembled, because Tailwind only generates the
- * utilities it can find literally in the source.
+ * Answers every property of Ghost's legacy unlayered `code, tt` rule, which
+ * would otherwise chip each `<code>` in Admin. Tokens are spelled out in full
+ * because Tailwind only generates utilities it finds literally in the source.
  */
 const CODE_RESET =
   '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:font-mono [&_code]:text-inherit [&_code]:leading-[inherit]';
 
-/**
- * A bare `font-family: monospace` drops to the browser's mono default, which
- * reads a size smaller, so the size of the surrounding text is restated.
- */
+/** `font-mono` alone drops to the browser default, a size smaller. */
 const CODE_SIZE = {
   base: '[&_code]:text-base',
   sm: '[&_code]:text-sm',
 } as const;
 
-/** The reset, at the size of the text the code sits in. */
 function codeStyles(size: keyof typeof CODE_SIZE): string {
   return `${CODE_RESET} ${CODE_SIZE[size]}`;
 }
 
-/**
- * gscan writes `rule` and `details` as HTML containing `<code>`, `<br>` and
- * `<a>`. We render it verbatim, so inline code is styled through those
- * descendants rather than by touching the markup.
- */
+/** gscan writes `rule` and `details` as HTML, rendered verbatim. */
 const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground ${codeStyles('base')}`;
 const DETAILS_HTML = `text-sm leading-[1.45] text-foreground [&_a]:underline ${codeStyles('sm')}`;
 
-/**
- * A filename is inline mono like any other, so it carries no chip: the same
- * reset the details above it get, at the same size.
- */
 const FAILURE_LIST = `space-y-1 text-sm text-muted-foreground ${codeStyles('sm')}`;
 
-/**
- * Counts a set of problems by display severity, most severe first, dropping
- * severities that aren't present. The single place the heading looks at what a
- * set contains, so its wording and its icon can never disagree.
- */
 function countBySeverity(problems: ThemeProblem[]) {
   return SEVERITY_ORDER.map((severity) => ({
     severity,
@@ -72,10 +48,7 @@ function countBySeverity(problems: ThemeProblem[]) {
   })).filter(({ count }) => count > 0);
 }
 
-/**
- * Summarises a set of problems by the severities actually present, e.g.
- * `2 errors, 3 warnings`. Empty severities are omitted entirely.
- */
+/** e.g. `2 errors, 3 warnings`, omitting severities that aren't present. */
 function formatIssueSummary(counts: ReturnType<typeof countBySeverity>): string {
   return counts
     .map(
@@ -130,14 +103,10 @@ function ValidationProblemItem({
 }) {
   const severity = getDisplaySeverity(problem);
 
-  // Shade's own `border-b` leaves the colour to the cascade. A row divider
-  // inside an opaque card takes the opaque token, not the translucent one
-  // floating surfaces composite with — which reads as a missing line in dark
-  // mode.
+  // An explicit colour: the cascade would give this row the translucent
+  // border token, which disappears against an opaque card in dark mode.
   return (
     <AccordionItem className="border-border-default last:border-b-0" value={value}>
-      {/* Expanding closes the trigger's own bottom padding so the details
-                sit under the rule line rather than a row's worth of space. */}
       <AccordionTrigger className="items-start gap-3 p-5 hover:no-underline data-[state=open]:pb-1 [&>svg]:mt-1">
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex items-center gap-3">
@@ -172,21 +141,11 @@ function ValidationMessageRow({ errorLabel, message }: { errorLabel: string; mes
   );
 }
 
-/**
- * Names the bordered container so tests can address a whole list — and tell
- * two of them apart — without reaching for the utility classes that draw it.
- */
 export const THEME_PROBLEM_LIST_TESTID = 'theme-problem-list';
 
 /**
- * The problems themselves: one bordered container, one row per problem,
- * separated by a hairline, each independently expandable. Bare `messages`
- * render as rows in the same list so a dialog never stacks two treatments for
- * the same kind of content.
- *
- * `errorLabel` names what an error-severity row is, so a dialog that shows two
- * lists can say which one stopped it: the problems that blocked the action are
- * `Blocking`, the ones merely reported alongside them stay `Error`.
+ * `errorLabel` names an error-severity row, so a dialog showing two lists can
+ * say which one blocked it: `Blocking` vs. plain `Error`.
  */
 export function ValidationProblemList({
   errorLabel = 'Error',
@@ -230,19 +189,14 @@ export function ValidationProblemList({
   );
 }
 
-/**
- * Non-blocking validation problems, headed by a static count of what was
- * found. Renders nothing when the theme validated cleanly.
- */
 export function ThemeValidationIssueList({ problems }: { problems: ThemeProblem[] }) {
   if (!problems.length) {
     return null;
   }
 
   const counts = countBySeverity(problems);
-  // A set that contains errors is headed "1 error, 2 warnings", so the icon
-  // beside it has to read as an error too — amber is only right when the set
-  // is warnings and recommendations alone.
+  // The heading reads severity, not count, so the icon has to match it: amber
+  // is only right when the set is warnings and recommendations alone.
   const hasError = hasErrorProblem(problems);
 
   return (
@@ -254,8 +208,6 @@ export function ThemeValidationIssueList({ problems }: { problems: ThemeProblem[
           />
           {formatIssueSummary(counts)}
         </h3>
-        {/* Only errors get explained: warnings and recommendations restrict
-                    nothing, so the same line under them would overstate them. */}
         {hasError && (
           <p className="text-sm text-muted-foreground">
             Highly recommended to fix, functionality could be restricted

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -2,7 +2,15 @@ import {useMemo} from 'react';
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge} from '@tryghost/shade/components';
 import {SEVERITY_ORDER, getDisplaySeverity, sortBySeverity} from './theme-validation-issues';
 import {type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
-import {formatNumber} from '@tryghost/shade/utils';
+import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+
+/**
+ * gscan writes `rule` and `details` as HTML containing `<code>`, `<br>` and
+ * `<a>`. We render it verbatim, so the mono treatment for inline code is
+ * applied by styling those descendants rather than touching the markup.
+ */
+const RULE_HTML = 'text-base font-semibold text-foreground [&_code]:font-mono [&_code]:text-md';
+const DETAILS_HTML = 'text-sm text-muted-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-base';
 
 function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
     if (problem.level === 'warning') {
@@ -36,17 +44,21 @@ function problemValue(problem: ThemeProblem, index: number): string {
     return `${problem.code || 'issue'}-${index}`;
 }
 
+function SeverityBadge({children, variant}: {children: string; variant: 'destructive' | 'warning' | 'secondary'}) {
+    return <Badge className='py-1 font-mono text-md leading-none uppercase' variant={variant}>{children}</Badge>;
+}
+
 function ProblemDetails({problem}: {problem: ThemeProblem}) {
     return (
         <div className='space-y-3'>
-            <div dangerouslySetInnerHTML={{__html: problem.details}} className='text-sm text-muted-foreground' />
+            <div dangerouslySetInnerHTML={{__html: problem.details}} className={DETAILS_HTML} />
             {problem.failures?.length > 0 && (
                 <div>
                     <h6 className='mb-1 text-xs font-semibold text-muted-foreground uppercase'>Affected files</h6>
                     <ul className='space-y-1 text-sm text-muted-foreground'>
                         {problem.failures.map(failure => (
                             <li key={`${failure.ref}-${failure.message || ''}`}>
-                                <code className='rounded bg-muted px-1 py-0.5 text-xs text-foreground'>{failure.ref}</code>
+                                <code className='rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground'>{failure.ref}</code>
                                 {failure.message ? <span>: {failure.message}</span> : null}
                             </li>
                         ))}
@@ -60,16 +72,18 @@ function ProblemDetails({problem}: {problem: ThemeProblem}) {
 function ValidationProblemItem({problem, value}: {problem: ThemeProblem; value: string}) {
     return (
         <AccordionItem className='last:border-b-0' value={value}>
-            <AccordionTrigger className='items-start gap-3 hover:no-underline'>
-                <div className='min-w-0 flex-1'>
-                    <div className='mb-2 flex items-center gap-2'>
-                        <Badge variant={getDisplayVariant(problem)}>{getDisplaySeverity(problem)}</Badge>
-                        {problem.code && <span className='text-xs font-normal text-muted-foreground'>{problem.code}</span>}
+            {/* Expanding closes the trigger's own bottom padding so the details
+                sit under the rule line rather than a row's worth of space. */}
+            <AccordionTrigger className='items-start gap-3 p-5 hover:no-underline data-[state=open]:pb-1 [&>svg]:mt-1'>
+                <div className='flex min-w-0 flex-1 flex-col gap-2'>
+                    <div className='flex items-center gap-3'>
+                        <SeverityBadge variant={getDisplayVariant(problem)}>{getDisplaySeverity(problem)}</SeverityBadge>
+                        {problem.code && <span className='font-mono text-md font-normal text-muted-foreground'>{problem.code}</span>}
                     </div>
-                    <div dangerouslySetInnerHTML={{__html: problem.rule}} className='text-sm font-medium text-foreground' />
+                    <div dangerouslySetInnerHTML={{__html: problem.rule}} className={RULE_HTML} />
                 </div>
             </AccordionTrigger>
-            <AccordionContent>
+            <AccordionContent className='px-5 pb-5'>
                 <ProblemDetails problem={problem} />
             </AccordionContent>
         </AccordionItem>
@@ -79,19 +93,20 @@ function ValidationProblemItem({problem, value}: {problem: ThemeProblem; value: 
 /** A bare error string from the API: same row as a problem, minus anything to expand. */
 function ValidationMessageRow({message}: {message: string}) {
     return (
-        <div className='border-b border-border py-4 last:border-b-0'>
-            <div className='mb-2 flex items-center gap-2'>
-                <Badge variant='destructive'>Error</Badge>
+        <div className='flex flex-col gap-2 border-b border-border p-5 last:border-b-0'>
+            <div className='flex items-center gap-3'>
+                <SeverityBadge variant='destructive'>Error</SeverityBadge>
             </div>
-            <p className='text-sm font-medium text-foreground'>{message}</p>
+            <p className='text-base font-semibold text-foreground'>{message}</p>
         </div>
     );
 }
 
 /**
- * The problems themselves: one row per problem, separated by a hairline, each
- * independently expandable. Bare `messages` render as rows in the same list so
- * a dialog never stacks two treatments for the same kind of content.
+ * The problems themselves: one bordered container, one row per problem,
+ * separated by a hairline, each independently expandable. Bare `messages`
+ * render as rows in the same list so a dialog never stacks two treatments for
+ * the same kind of content.
  */
 export function ValidationProblemList({
     className,
@@ -112,7 +127,7 @@ export function ValidationProblemList({
     }
 
     return (
-        <div className={className}>
+        <div className={cn('overflow-hidden rounded-lg border border-border', className)}>
             {messages.map(message => <ValidationMessageRow key={message} message={message} />)}
             {sortedProblems.length > 0 && (
                 <Accordion defaultValue={expandedByDefault ? values : []} type='multiple'>
@@ -135,9 +150,12 @@ export function ThemeValidationIssueList({problems}: {problems: ThemeProblem[]})
     }
 
     return (
-        <div className='border-t border-border pt-5'>
-            <h3 className='border-b border-border pb-3 text-md font-semibold text-foreground'>{formatIssueSummary(problems)}</h3>
-            <ValidationProblemList problems={problems} />
+        <div>
+            <h3 className='flex items-center gap-2 text-base font-semibold text-foreground'>
+                <LucideIcon.TriangleAlert className='size-4 shrink-0 text-state-warning' />
+                {formatIssueSummary(problems)}
+            </h3>
+            <ValidationProblemList className='mt-4' problems={problems} />
         </div>
     );
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -14,12 +14,22 @@ import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 const LEGACY_CODE_RESET = '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:text-inherit [&_code]:leading-[inherit]';
 
 /**
+ * The same reset applied straight to a `<code>` element we render ourselves,
+ * so inline mono looks identical whether it came from gscan's HTML or from us.
+ * Size is left to the line it sits on: nothing should read larger than its
+ * surrounding text.
+ */
+const INLINE_CODE = 'rounded-none border-0 bg-transparent p-0 align-baseline font-mono text-inherit leading-[inherit]';
+
+/**
  * gscan writes `rule` and `details` as HTML containing `<code>`, `<br>` and
  * `<a>`. We render it verbatim, so the mono treatment for inline code is
- * applied by styling those descendants rather than touching the markup.
+ * applied by styling those descendants rather than touching the markup. The
+ * explicit `[&_code]:text-*` matches the block's own size, because a bare
+ * `font-family: monospace` otherwise drops to the browser's mono default.
  */
-const RULE_HTML = `text-base font-semibold text-foreground [&_code]:font-mono [&_code]:text-md ${LEGACY_CODE_RESET}`;
-const DETAILS_HTML = `text-sm text-muted-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-base ${LEGACY_CODE_RESET}`;
+const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground [&_code]:font-mono [&_code]:text-base ${LEGACY_CODE_RESET}`;
+const DETAILS_HTML = `text-sm leading-[1.45] text-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-sm ${LEGACY_CODE_RESET}`;
 
 function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
     if (problem.level === 'warning') {
@@ -63,13 +73,13 @@ function ProblemDetails({problem}: {problem: ThemeProblem}) {
             <div dangerouslySetInnerHTML={{__html: problem.details}} className={DETAILS_HTML} />
             {problem.failures?.length > 0 && (
                 <div>
-                    <h6 className='mb-1 text-xs font-semibold text-muted-foreground uppercase'>Affected files</h6>
+                    <h6 className='mb-1 text-base font-semibold text-muted-foreground'>Affected files</h6>
                     <ul className='space-y-1 text-sm text-muted-foreground'>
                         {problem.failures.map(failure => (
                             <li key={`${failure.ref}-${failure.message || ''}`}>
-                                {/* This chip keeps a deliberate `bg-muted` treatment; it still has to
-                                    turn off the legacy rule's border and mid-line alignment. */}
-                                <code className='rounded border-0 bg-muted px-1 py-0.5 align-baseline font-mono text-xs leading-[inherit] text-foreground'>{failure.ref}</code>
+                                {/* A filename is inline mono like any other, so it carries no chip:
+                                    same size, colour and family as the code in the details above. */}
+                                <code className={`${INLINE_CODE} text-sm`}>{failure.ref}</code>
                                 {failure.message ? <span>: {failure.message}</span> : null}
                             </li>
                         ))}

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -5,12 +5,21 @@ import {type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 
 /**
+ * Ghost's legacy Ember stylesheet ships an unlayered `code, tt` rule that gives
+ * every `<code>` in Admin a bordered grey chip with pink text. A bare element
+ * selector loses to any class, so each property it sets has to be answered
+ * explicitly — including `border-radius`, `vertical-align` and `line-height`,
+ * whose absence reads as baseline drift rather than an obvious box.
+ */
+const LEGACY_CODE_RESET = '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:text-inherit [&_code]:leading-[inherit]';
+
+/**
  * gscan writes `rule` and `details` as HTML containing `<code>`, `<br>` and
  * `<a>`. We render it verbatim, so the mono treatment for inline code is
  * applied by styling those descendants rather than touching the markup.
  */
-const RULE_HTML = 'text-base font-semibold text-foreground [&_code]:font-mono [&_code]:text-md';
-const DETAILS_HTML = 'text-sm text-muted-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-base';
+const RULE_HTML = `text-base font-semibold text-foreground [&_code]:font-mono [&_code]:text-md ${LEGACY_CODE_RESET}`;
+const DETAILS_HTML = `text-sm text-muted-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-base ${LEGACY_CODE_RESET}`;
 
 function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
     if (problem.level === 'warning') {
@@ -58,7 +67,9 @@ function ProblemDetails({problem}: {problem: ThemeProblem}) {
                     <ul className='space-y-1 text-sm text-muted-foreground'>
                         {problem.failures.map(failure => (
                             <li key={`${failure.ref}-${failure.message || ''}`}>
-                                <code className='rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground'>{failure.ref}</code>
+                                {/* This chip keeps a deliberate `bg-muted` treatment; it still has to
+                                    turn off the legacy rule's border and mid-line alignment. */}
+                                <code className='rounded border-0 bg-muted px-1 py-0.5 align-baseline font-mono text-xs leading-[inherit] text-foreground'>{failure.ref}</code>
                                 {failure.message ? <span>: {failure.message}</span> : null}
                             </li>
                         ))}

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -130,7 +130,7 @@ function ValidationProblemItem({ problem, value }: { problem: ThemeProblem; valu
               {getDisplaySeverity(problem)}
             </SeverityBadge>
             {problem.code && (
-              <span className="font-mono text-md font-normal text-muted-foreground">
+              <span className="font-mono text-sm font-normal text-muted-foreground">
                 {problem.code}
               </span>
             )}

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -18,28 +18,18 @@ import { type ThemeProblem } from '@tryghost/admin-x-framework/api/themes';
 import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
 
 /**
- * Answers every property of Ghost's legacy unlayered `code, tt` rule, which
- * would otherwise chip each `<code>` in Admin. Tokens are spelled out in full
- * because Tailwind only generates utilities it finds literally in the source.
+ * A grey inline-code chip that also answers every property of Ghost's legacy
+ * unlayered `code, tt` rule. Tokens are spelled out in full because Tailwind
+ * only generates utilities it finds literally in the source.
  */
-const CODE_RESET =
-  '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:font-mono [&_code]:text-inherit [&_code]:leading-[inherit]';
-
-/** `font-mono` alone drops to the browser default, a size smaller. */
-const CODE_SIZE = {
-  base: '[&_code]:text-base',
-  sm: '[&_code]:text-sm',
-} as const;
-
-function codeStyles(size: keyof typeof CODE_SIZE): string {
-  return `${CODE_RESET} ${CODE_SIZE[size]}`;
-}
+const CODE_CHIP =
+  '[&_code]:rounded-xs [&_code]:border-0 [&_code]:bg-secondary [&_code]:px-1 [&_code]:py-0.5 [&_code]:align-baseline [&_code]:font-mono [&_code]:text-sm [&_code]:text-inherit [&_code]:leading-[inherit] [&_code]:whitespace-nowrap';
 
 /** gscan writes `rule` and `details` as HTML, rendered verbatim. */
-const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground ${codeStyles('base')}`;
-const DETAILS_HTML = `text-sm leading-[1.45] text-foreground [&_a]:underline ${codeStyles('sm')}`;
+const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground ${CODE_CHIP}`;
+const DETAILS_HTML = `text-base leading-[1.45] text-foreground [&_a]:underline ${CODE_CHIP}`;
 
-const FAILURE_LIST = `space-y-1 text-sm text-muted-foreground ${codeStyles('sm')}`;
+const FAILURE_LIST = `space-y-1 text-base text-muted-foreground ${CODE_CHIP}`;
 
 function countBySeverity(problems: ThemeProblem[]) {
   return SEVERITY_ORDER.map((severity) => ({

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -63,7 +63,7 @@ function SeverityBadge({ children, variant }: { children: string; variant: Displ
 
 function ProblemDetails({ problem }: { problem: ThemeProblem }) {
   return (
-    <div className="space-y-3">
+    <div className="mt-3 space-y-3">
       <div dangerouslySetInnerHTML={{ __html: problem.details }} className={DETAILS_HTML} />
       {problem.failures?.length > 0 && (
         <div>

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -7,8 +7,10 @@ import {
   Badge,
 } from '@tryghost/shade/components';
 import {
+  type DisplayVariant,
   SEVERITY_ORDER,
   getDisplaySeverity,
+  getDisplayVariant,
   hasErrorProblem,
   sortBySeverity,
 } from './theme-validation-issues';
@@ -21,40 +23,42 @@ import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
  * selector loses to any class, so each property it sets has to be answered
  * explicitly — including `border-radius`, `vertical-align` and `line-height`,
  * whose absence reads as baseline drift rather than an obvious box.
+ *
+ * Written once and applied to `<code>` descendants, so inline mono looks the
+ * same whether the markup came from gscan or from us. Class names are spelled
+ * out in full rather than assembled, because Tailwind only generates the
+ * utilities it can find literally in the source.
  */
-const LEGACY_CODE_RESET =
-  '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:text-inherit [&_code]:leading-[inherit]';
+const CODE_RESET =
+  '[&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:align-baseline [&_code]:font-mono [&_code]:text-inherit [&_code]:leading-[inherit]';
 
 /**
- * The same reset applied straight to a `<code>` element we render ourselves,
- * so inline mono looks identical whether it came from gscan's HTML or from us.
- * Size is left to the line it sits on: nothing should read larger than its
- * surrounding text.
+ * A bare `font-family: monospace` drops to the browser's mono default, which
+ * reads a size smaller, so the size of the surrounding text is restated.
  */
-const INLINE_CODE =
-  'rounded-none border-0 bg-transparent p-0 align-baseline font-mono text-inherit leading-[inherit]';
+const CODE_SIZE = {
+  base: '[&_code]:text-base',
+  sm: '[&_code]:text-sm',
+} as const;
+
+/** The reset, at the size of the text the code sits in. */
+function codeStyles(size: keyof typeof CODE_SIZE): string {
+  return `${CODE_RESET} ${CODE_SIZE[size]}`;
+}
 
 /**
  * gscan writes `rule` and `details` as HTML containing `<code>`, `<br>` and
- * `<a>`. We render it verbatim, so the mono treatment for inline code is
- * applied by styling those descendants rather than touching the markup. The
- * explicit `[&_code]:text-*` matches the block's own size, because a bare
- * `font-family: monospace` otherwise drops to the browser's mono default.
+ * `<a>`. We render it verbatim, so inline code is styled through those
+ * descendants rather than by touching the markup.
  */
-const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground [&_code]:font-mono [&_code]:text-base ${LEGACY_CODE_RESET}`;
-const DETAILS_HTML = `text-sm leading-[1.45] text-foreground [&_a]:underline [&_code]:font-mono [&_code]:text-sm ${LEGACY_CODE_RESET}`;
+const RULE_HTML = `text-base leading-[1.45] font-semibold text-foreground ${codeStyles('base')}`;
+const DETAILS_HTML = `text-sm leading-[1.45] text-foreground [&_a]:underline ${codeStyles('sm')}`;
 
-function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
-  if (problem.level === 'warning') {
-    return 'warning';
-  }
-
-  if (problem.level === 'recommendation') {
-    return 'secondary';
-  }
-
-  return 'destructive';
-}
+/**
+ * A filename is inline mono like any other, so it carries no chip: the same
+ * reset the details above it get, at the same size.
+ */
+const FAILURE_LIST = `space-y-1 text-sm text-muted-foreground ${codeStyles('sm')}`;
 
 /**
  * Counts a set of problems by display severity, most severe first, dropping
@@ -86,13 +90,7 @@ function problemValue(problem: ThemeProblem, index: number): string {
   return `${problem.code || 'issue'}-${index}`;
 }
 
-function SeverityBadge({
-  children,
-  variant,
-}: {
-  children: string;
-  variant: 'destructive' | 'warning' | 'secondary';
-}) {
+function SeverityBadge({ children, variant }: { children: string; variant: DisplayVariant }) {
   return (
     <Badge className="py-1 font-mono text-sm leading-none uppercase" variant={variant}>
       {children}
@@ -107,12 +105,10 @@ function ProblemDetails({ problem }: { problem: ThemeProblem }) {
       {problem.failures?.length > 0 && (
         <div>
           <h6 className="mb-1 text-base font-semibold text-muted-foreground">Affected files</h6>
-          <ul className="space-y-1 text-sm text-muted-foreground">
+          <ul className={FAILURE_LIST}>
             {problem.failures.map((failure) => (
               <li key={`${failure.ref}-${failure.message || ''}`}>
-                {/* A filename is inline mono like any other, so it carries no chip:
-                                    same size, colour and family as the code in the details above. */}
-                <code className={`${INLINE_CODE} text-sm`}>{failure.ref}</code>
+                <code>{failure.ref}</code>
                 {failure.message ? <span>: {failure.message}</span> : null}
               </li>
             ))}
@@ -134,8 +130,12 @@ function ValidationProblemItem({
 }) {
   const severity = getDisplaySeverity(problem);
 
+  // Shade's own `border-b` leaves the colour to the cascade. A row divider
+  // inside an opaque card takes the opaque token, not the translucent one
+  // floating surfaces composite with — which reads as a missing line in dark
+  // mode.
   return (
-    <AccordionItem className="last:border-b-0" value={value}>
+    <AccordionItem className="border-border-default last:border-b-0" value={value}>
       {/* Expanding closes the trigger's own bottom padding so the details
                 sit under the rule line rather than a row's worth of space. */}
       <AccordionTrigger className="items-start gap-3 p-5 hover:no-underline data-[state=open]:pb-1 [&>svg]:mt-1">
@@ -163,7 +163,7 @@ function ValidationProblemItem({
 /** A bare error string from the API: same row as a problem, minus anything to expand. */
 function ValidationMessageRow({ errorLabel, message }: { errorLabel: string; message: string }) {
   return (
-    <div className="flex flex-col gap-2 border-b border-border p-5 last:border-b-0">
+    <div className="flex flex-col gap-2 border-b border-border-default p-5 last:border-b-0">
       <div className="flex items-center gap-3">
         <SeverityBadge variant="destructive">{errorLabel}</SeverityBadge>
       </div>
@@ -171,6 +171,12 @@ function ValidationMessageRow({ errorLabel, message }: { errorLabel: string; mes
     </div>
   );
 }
+
+/**
+ * Names the bordered container so tests can address a whole list — and tell
+ * two of them apart — without reaching for the utility classes that draw it.
+ */
+export const THEME_PROBLEM_LIST_TESTID = 'theme-problem-list';
 
 /**
  * The problems themselves: one bordered container, one row per problem,
@@ -183,13 +189,11 @@ function ValidationMessageRow({ errorLabel, message }: { errorLabel: string; mes
  * `Blocking`, the ones merely reported alongside them stay `Error`.
  */
 export function ValidationProblemList({
-  className,
   errorLabel = 'Error',
   expandedByDefault = false,
   messages = [],
   problems,
 }: {
-  className?: string;
   errorLabel?: string;
   expandedByDefault?: boolean;
   messages?: string[];
@@ -203,7 +207,10 @@ export function ValidationProblemList({
   }
 
   return (
-    <div className={cn('overflow-hidden rounded-lg border border-border', className)}>
+    <div
+      className="overflow-hidden rounded-lg border border-border-default"
+      data-testid={THEME_PROBLEM_LIST_TESTID}
+    >
       {messages.map((message) => (
         <ValidationMessageRow key={message} errorLabel={errorLabel} message={message} />
       ))}

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -44,16 +44,25 @@ function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | '
 }
 
 /**
- * Summarises a set of problems by the severities actually present, e.g.
- * `2 errors, 3 warnings`. Empty severities are omitted entirely.
+ * Counts a set of problems by display severity, most severe first, dropping
+ * severities that aren't present. The single place the heading looks at what a
+ * set contains, so its wording and its icon can never disagree.
  */
-function formatIssueSummary(problems: ThemeProblem[]): string {
+function countBySeverity(problems: ThemeProblem[]) {
     return SEVERITY_ORDER
         .map(severity => ({
             severity,
             count: problems.filter(problem => getDisplaySeverity(problem) === severity).length
         }))
-        .filter(({count}) => count > 0)
+        .filter(({count}) => count > 0);
+}
+
+/**
+ * Summarises a set of problems by the severities actually present, e.g.
+ * `2 errors, 3 warnings`. Empty severities are omitted entirely.
+ */
+function formatIssueSummary(counts: ReturnType<typeof countBySeverity>): string {
+    return counts
         .map(({severity, count}) => `${formatNumber(count)} ${severity.toLowerCase()}${count === 1 ? '' : 's'}`)
         .join(', ');
 }
@@ -170,11 +179,17 @@ export function ThemeValidationIssueList({problems}: {problems: ThemeProblem[]})
         return null;
     }
 
+    const counts = countBySeverity(problems);
+    // A set that contains errors is headed "1 error, 2 warnings", so the icon
+    // beside it has to read as an error too — amber is only right when the set
+    // is warnings and recommendations alone.
+    const hasError = counts.some(({severity}) => severity === 'Error');
+
     return (
         <div className='flex flex-col gap-4'>
             <h3 className='flex items-center gap-2 text-base font-semibold text-foreground'>
-                <LucideIcon.TriangleAlert className='size-4 shrink-0 text-state-warning' />
-                {formatIssueSummary(problems)}
+                <LucideIcon.TriangleAlert className={cn('size-4 shrink-0', hasError ? 'text-destructive' : 'text-state-warning')} />
+                {formatIssueSummary(counts)}
             </h3>
             <ValidationProblemList problems={problems} />
         </div>

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -45,7 +45,7 @@ function problemValue(problem: ThemeProblem, index: number): string {
 }
 
 function SeverityBadge({children, variant}: {children: string; variant: 'destructive' | 'warning' | 'secondary'}) {
-    return <Badge className='py-1 font-mono text-md leading-none uppercase' variant={variant}>{children}</Badge>;
+    return <Badge className='py-1 font-mono text-sm leading-none uppercase' variant={variant}>{children}</Badge>;
 }
 
 function ProblemDetails({problem}: {problem: ThemeProblem}) {

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge} from '@tryghost/shade/components';
 import {SEVERITY_ORDER, getDisplaySeverity, sortBySeverity} from './theme-validation-issues';
 import {type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
-import {cn, formatNumber} from '@tryghost/shade/utils';
+import {formatNumber} from '@tryghost/shade/utils';
 
 function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
     if (problem.level === 'warning') {
@@ -59,7 +59,7 @@ function ProblemDetails({problem}: {problem: ThemeProblem}) {
 
 function ValidationProblemItem({problem, value}: {problem: ThemeProblem; value: string}) {
     return (
-        <AccordionItem className='border-b-0' value={value}>
+        <AccordionItem className='last:border-b-0' value={value}>
             <AccordionTrigger className='items-start gap-3 hover:no-underline'>
                 <div className='min-w-0 flex-1'>
                     <div className='mb-2 flex items-center gap-2'>
@@ -79,7 +79,7 @@ function ValidationProblemItem({problem, value}: {problem: ThemeProblem; value: 
 /** A bare error string from the API: same row as a problem, minus anything to expand. */
 function ValidationMessageRow({message}: {message: string}) {
     return (
-        <div className='py-4'>
+        <div className='border-b border-border py-4 last:border-b-0'>
             <div className='mb-2 flex items-center gap-2'>
                 <Badge variant='destructive'>Error</Badge>
             </div>
@@ -112,10 +112,10 @@ export function ValidationProblemList({
     }
 
     return (
-        <div className={cn('divide-y divide-border', className)}>
+        <div className={className}>
             {messages.map(message => <ValidationMessageRow key={message} message={message} />)}
             {sortedProblems.length > 0 && (
-                <Accordion className='divide-y divide-border' defaultValue={expandedByDefault ? values : []} type='multiple'>
+                <Accordion defaultValue={expandedByDefault ? values : []} type='multiple'>
                     {sortedProblems.map((problem, index) => (
                         <ValidationProblemItem key={values[index]} problem={problem} value={values[index]} />
                     ))}
@@ -136,8 +136,8 @@ export function ThemeValidationIssueList({problems}: {problems: ThemeProblem[]})
 
     return (
         <div className='border-t border-border pt-5'>
-            <h3 className='text-sm font-semibold text-foreground'>{formatIssueSummary(problems)}</h3>
-            <ValidationProblemList className='mt-1' problems={problems} />
+            <h3 className='border-b border-border pb-3 text-md font-semibold text-foreground'>{formatIssueSummary(problems)}</h3>
+            <ValidationProblemList problems={problems} />
         </div>
     );
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin/src/settings/site/theme/theme-validation-details.tsx
@@ -1,211 +1,143 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Badge, Banner } from '@tryghost/shade/components';
-import { type ThemeProblem } from '@tryghost/admin-x-framework/api/themes';
-import { LucideIcon } from '@tryghost/shade/utils';
-
-type DisplaySeverity = 'Error' | 'Warning' | 'Recommendation';
-
-function getDisplaySeverity(problem: ThemeProblem): DisplaySeverity {
-  if (problem.level === 'warning') {
-    return 'Warning';
-  }
-
-  if (problem.level === 'recommendation') {
-    return 'Recommendation';
-  }
-
-  return 'Error';
-}
+import {useMemo} from 'react';
+import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge} from '@tryghost/shade/components';
+import {SEVERITY_ORDER, getDisplaySeverity, sortBySeverity} from './theme-validation-issues';
+import {type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+import {cn, formatNumber} from '@tryghost/shade/utils';
 
 function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
-  if (problem.level === 'warning') {
-    return 'warning';
-  }
+    if (problem.level === 'warning') {
+        return 'warning';
+    }
 
-  if (problem.level === 'recommendation') {
-    return 'secondary';
-  }
+    if (problem.level === 'recommendation') {
+        return 'secondary';
+    }
 
-  return 'destructive';
+    return 'destructive';
 }
 
-function formatNonBlockingIssueCount(count: number) {
-  return `${count} non-blocking ${count === 1 ? 'issue' : 'issues'}`;
+/**
+ * Summarises a set of problems by the severities actually present, e.g.
+ * `2 errors, 3 warnings`. Empty severities are omitted entirely.
+ */
+function formatIssueSummary(problems: ThemeProblem[]): string {
+    return SEVERITY_ORDER
+        .map(severity => ({
+            severity,
+            count: problems.filter(problem => getDisplaySeverity(problem) === severity).length
+        }))
+        .filter(({count}) => count > 0)
+        .map(({severity, count}) => `${formatNumber(count)} ${severity.toLowerCase()}${count === 1 ? '' : 's'}`)
+        .join(', ');
 }
 
-function ProblemDetails({ problem }: { problem: ThemeProblem }) {
-  return (
-    <div className="space-y-3">
-      <div
-        dangerouslySetInnerHTML={{ __html: problem.details }}
-        className="text-sm text-muted-foreground"
-      />
-      {problem.failures?.length > 0 && (
-        <div>
-          <h6 className="mb-1 text-xs font-semibold text-muted-foreground uppercase">
-            Affected files
-          </h6>
-          <ul className="space-y-1 text-sm text-muted-foreground">
-            {problem.failures.map((failure) => (
-              <li key={`${failure.ref}-${failure.message || ''}`}>
-                <code className="rounded bg-muted px-1 py-0.5 text-xs text-foreground">
-                  {failure.ref}
-                </code>
-                {failure.message ? <span>: {failure.message}</span> : null}
-              </li>
-            ))}
-          </ul>
+/** Problem codes repeat across gscan results, so the index keeps accordion values unique. */
+function problemValue(problem: ThemeProblem, index: number): string {
+    return `${problem.code || 'issue'}-${index}`;
+}
+
+function ProblemDetails({problem}: {problem: ThemeProblem}) {
+    return (
+        <div className='space-y-3'>
+            <div dangerouslySetInnerHTML={{__html: problem.details}} className='text-sm text-muted-foreground' />
+            {problem.failures?.length > 0 && (
+                <div>
+                    <h6 className='mb-1 text-xs font-semibold text-muted-foreground uppercase'>Affected files</h6>
+                    <ul className='space-y-1 text-sm text-muted-foreground'>
+                        {problem.failures.map(failure => (
+                            <li key={`${failure.ref}-${failure.message || ''}`}>
+                                <code className='rounded bg-muted px-1 py-0.5 text-xs text-foreground'>{failure.ref}</code>
+                                {failure.message ? <span>: {failure.message}</span> : null}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 }
 
-export function ValidationProblemCard({
-  problem,
-  prominent = false,
+function ValidationProblemItem({problem, value}: {problem: ThemeProblem; value: string}) {
+    return (
+        <AccordionItem className='border-b-0' value={value}>
+            <AccordionTrigger className='items-start gap-3 hover:no-underline'>
+                <div className='min-w-0 flex-1'>
+                    <div className='mb-2 flex items-center gap-2'>
+                        <Badge variant={getDisplayVariant(problem)}>{getDisplaySeverity(problem)}</Badge>
+                        {problem.code && <span className='text-xs font-normal text-muted-foreground'>{problem.code}</span>}
+                    </div>
+                    <div dangerouslySetInnerHTML={{__html: problem.rule}} className='text-sm font-medium text-foreground' />
+                </div>
+            </AccordionTrigger>
+            <AccordionContent>
+                <ProblemDetails problem={problem} />
+            </AccordionContent>
+        </AccordionItem>
+    );
+}
+
+/** A bare error string from the API: same row as a problem, minus anything to expand. */
+function ValidationMessageRow({message}: {message: string}) {
+    return (
+        <div className='py-4'>
+            <div className='mb-2 flex items-center gap-2'>
+                <Badge variant='destructive'>Error</Badge>
+            </div>
+            <p className='text-sm font-medium text-foreground'>{message}</p>
+        </div>
+    );
+}
+
+/**
+ * The problems themselves: one row per problem, separated by a hairline, each
+ * independently expandable. Bare `messages` render as rows in the same list so
+ * a dialog never stacks two treatments for the same kind of content.
+ */
+export function ValidationProblemList({
+    className,
+    expandedByDefault = false,
+    messages = [],
+    problems
 }: {
-  problem: ThemeProblem;
-  prominent?: boolean;
+    className?: string;
+    expandedByDefault?: boolean;
+    messages?: string[];
+    problems: ThemeProblem[];
 }) {
-  const [expanded, setExpanded] = useState(prominent);
-  const displaySeverity = getDisplaySeverity(problem);
+    const sortedProblems = useMemo(() => sortBySeverity(problems), [problems]);
+    const values = useMemo(() => sortedProblems.map(problemValue), [sortedProblems]);
 
-  return (
-    <div
-      className={`rounded-lg border ${prominent ? 'border-destructive/30 bg-background' : 'border-border bg-background'} p-4`}
-    >
-      <button
-        className="flex w-full items-start justify-between gap-3 text-left"
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <div className="min-w-0 flex-1">
-          <div className="mb-2 flex items-center gap-2">
-            <Badge variant={getDisplayVariant(problem)}>{displaySeverity}</Badge>
-            {problem.code && <span className="text-xs text-muted-foreground">{problem.code}</span>}
-          </div>
-          <div
-            dangerouslySetInnerHTML={{ __html: problem.rule }}
-            className="text-sm font-medium text-foreground"
-          />
+    if (!sortedProblems.length && !messages.length) {
+        return null;
+    }
+
+    return (
+        <div className={cn('divide-y divide-border', className)}>
+            {messages.map(message => <ValidationMessageRow key={message} message={message} />)}
+            {sortedProblems.length > 0 && (
+                <Accordion className='divide-y divide-border' defaultValue={expandedByDefault ? values : []} type='multiple'>
+                    {sortedProblems.map((problem, index) => (
+                        <ValidationProblemItem key={values[index]} problem={problem} value={values[index]} />
+                    ))}
+                </Accordion>
+            )}
         </div>
-        <LucideIcon.ChevronDown
-          className={`mt-1 size-4 shrink-0 text-muted-foreground transition-transform ${expanded ? 'rotate-180' : ''}`}
-        />
-      </button>
-      {expanded && (
-        <div className="mt-4 border-t border-border pt-4">
-          <ProblemDetails problem={problem} />
-        </div>
-      )}
-    </div>
-  );
+    );
 }
 
-export function ThemeValidationDetailsDisclosure({
-  defaultOpen,
-  problems,
-}: {
-  defaultOpen: boolean;
-  problems: ThemeProblem[];
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  const count = problems.length;
+/**
+ * Non-blocking validation problems, headed by a static count of what was
+ * found. Renders nothing when the theme validated cleanly.
+ */
+export function ThemeValidationIssueList({problems}: {problems: ThemeProblem[]}) {
+    if (!problems.length) {
+        return null;
+    }
 
-  useEffect(() => {
-    setOpen(defaultOpen);
-  }, [defaultOpen]);
-
-  const sortedProblems = useMemo(() => {
-    return [...problems].sort((a, b) => {
-      const severityOrder: Record<DisplaySeverity, number> = {
-        Error: 0,
-        Warning: 1,
-        Recommendation: 2,
-      };
-      return severityOrder[getDisplaySeverity(a)] - severityOrder[getDisplaySeverity(b)];
-    });
-  }, [problems]);
-
-  if (!count) {
-    return null;
-  }
-
-  return (
-    <div className="mt-6 border-t border-border pt-5">
-      <button
-        className="flex w-full items-center justify-between gap-3 rounded-lg border border-border bg-background p-4 text-left transition-colors hover:bg-muted/40"
-        type="button"
-        onClick={() => setOpen(!open)}
-      >
-        <div>
-          <div className="text-sm font-semibold text-foreground">
-            Review {formatNonBlockingIssueCount(count)}
-          </div>
-          <div className="mt-1 text-sm text-muted-foreground">
-            {open ? 'Hide details' : 'Show details'}
-          </div>
+    return (
+        <div className='border-t border-border pt-5'>
+            <h3 className='text-sm font-semibold text-foreground'>{formatIssueSummary(problems)}</h3>
+            <ValidationProblemList className='mt-1' problems={problems} />
         </div>
-        <LucideIcon.ChevronDown
-          className={`size-4 shrink-0 text-muted-foreground transition-transform ${open ? 'rotate-180' : ''}`}
-        />
-      </button>
-      {open && (
-        <div className="mt-4 space-y-3">
-          {sortedProblems.map((problem) => (
-            <ValidationProblemCard key={problem.code} problem={problem} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-export function ErrorTextCard({ message }: { message: string }) {
-  return (
-    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-      <div className="flex items-start gap-2">
-        <LucideIcon.AlertTriangle className="mt-0.5 size-4 shrink-0" />
-        <p>{message}</p>
-      </div>
-    </div>
-  );
-}
-
-export function OutcomeBanner({
-  children,
-  title,
-  variant,
-}: {
-  children: React.ReactNode;
-  title: string;
-  variant: 'success' | 'destructive';
-}) {
-  const Icon = variant === 'success' ? LucideIcon.CheckCircle2 : LucideIcon.AlertTriangle;
-  const iconClassName = variant === 'success' ? 'text-state-success' : 'text-destructive';
-
-  return (
-    <Banner
-      role={variant === 'destructive' ? 'alert' : 'status'}
-      size="lg"
-      variant={variant === 'success' ? 'success' : 'destructive'}
-    >
-      <div className="flex items-start gap-3">
-        <div
-          className={`mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full ${variant === 'success' ? 'bg-state-success/10' : 'bg-destructive/10'}`}
-        >
-          <Icon className={`size-5 ${iconClassName}`} />
-        </div>
-        <div>
-          <h3
-            className={`text-xl font-semibold tracking-tight ${variant === 'success' ? 'text-state-success' : 'text-destructive'}`}
-          >
-            {title}
-          </h3>
-          <div className="mt-1 text-sm text-foreground">{children}</div>
-        </div>
-      </div>
-    </Banner>
-  );
+    );
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.test.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.test.ts
@@ -1,98 +1,121 @@
-import {describeThemeOutcome, fatalErrorsSchema, getIssuesFromFatalErrors, getIssuesFromInstalledTheme, parseFatalErrors, sortBySeverity} from './theme-validation-issues';
-import {type InstalledTheme, type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+import {
+  describeThemeOutcome,
+  fatalErrorsSchema,
+  getIssuesFromFatalErrors,
+  getIssuesFromInstalledTheme,
+  parseFatalErrors,
+  sortBySeverity,
+} from './theme-validation-issues';
+import { type InstalledTheme, type ThemeProblem } from '@tryghost/admin-x-framework/api/themes';
 
 const problem = {
-    code: 'GS030-NO-DEFAULT-TEMPLATE',
-    details: 'The theme must have a default.hbs template.',
-    failures: [{ref: 'default.hbs'}],
-    fatal: true,
-    level: 'error' as const,
-    rule: 'A default template is required.'
+  code: 'GS030-NO-DEFAULT-TEMPLATE',
+  details: 'The theme must have a default.hbs template.',
+  failures: [{ ref: 'default.hbs' }],
+  fatal: true,
+  level: 'error' as const,
+  rule: 'A default template is required.',
 };
 
 /** A problem at an arbitrary severity, for the display-level helpers. */
 function themeProblem(level: string, code = 'GS000'): ThemeProblem {
-    return {code, level, rule: 'rule', details: 'details', failures: [], fatal: false} as unknown as ThemeProblem;
+  return {
+    code,
+    level,
+    rule: 'rule',
+    details: 'details',
+    failures: [],
+    fatal: false,
+  } as unknown as ThemeProblem;
 }
 
 describe('fatalErrorsSchema', () => {
-    it('parses string and structured validation details', () => {
-        const result = fatalErrorsSchema.safeParse([
-            {details: 'Missing default.hbs'},
-            {details: {errors: [problem]}}
-        ]);
+  it('parses string and structured validation details', () => {
+    const result = fatalErrorsSchema.safeParse([
+      { details: 'Missing default.hbs' },
+      { details: { errors: [problem] } },
+    ]);
 
-        expect(result.success).toBe(true);
+    expect(result.success).toBe(true);
 
-        if (result.success) {
-            expect(getIssuesFromFatalErrors(result.data)).toEqual({
-                blockingProblems: [problem],
-                secondaryProblems: [],
-                stringErrors: ['Missing default.hbs']
-            });
-        }
-    });
+    if (result.success) {
+      expect(getIssuesFromFatalErrors(result.data)).toEqual({
+        blockingProblems: [problem],
+        secondaryProblems: [],
+        stringErrors: ['Missing default.hbs'],
+      });
+    }
+  });
 
-    it('rejects malformed theme problems', () => {
-        const result = fatalErrorsSchema.safeParse([
-            {details: {errors: [{...problem, fatal: 'yes'}]}}
-        ]);
+  it('rejects malformed theme problems', () => {
+    const result = fatalErrorsSchema.safeParse([
+      { details: { errors: [{ ...problem, fatal: 'yes' }] } },
+    ]);
 
-        expect(result.success).toBe(false);
-    });
+    expect(result.success).toBe(false);
+  });
 
-    it('does not treat empty or non-blocking payloads as fatal errors', () => {
-        expect(parseFatalErrors([])).toBeNull();
-        expect(parseFatalErrors([{details: {}}])).toBeNull();
-        expect(parseFatalErrors([{
-            details: {
-                warnings: [{...problem, fatal: false, level: 'warning'}]
-            }
-        }])).toBeNull();
-        expect(parseFatalErrors([{details: '   '}])).toBeNull();
-    });
+  it('does not treat empty or non-blocking payloads as fatal errors', () => {
+    expect(parseFatalErrors([])).toBeNull();
+    expect(parseFatalErrors([{ details: {} }])).toBeNull();
+    expect(
+      parseFatalErrors([
+        {
+          details: {
+            warnings: [{ ...problem, fatal: false, level: 'warning' }],
+          },
+        },
+      ]),
+    ).toBeNull();
+    expect(parseFatalErrors([{ details: '   ' }])).toBeNull();
+  });
 });
 
 describe('describeThemeOutcome', () => {
-    it('reports a clean install', () => {
-        expect(describeThemeOutcome('uploaded', [])).toBe('uploaded successfully');
-    });
+  it('reports a clean install', () => {
+    expect(describeThemeOutcome('uploaded', [])).toBe('uploaded successfully');
+  });
 
-    it('calls a warnings-only set warnings', () => {
-        expect(describeThemeOutcome('uploaded', [themeProblem('warning'), themeProblem('recommendation')]))
-            .toBe('uploaded, but it has some warnings');
-    });
+  it('calls a warnings-only set warnings', () => {
+    expect(
+      describeThemeOutcome('uploaded', [themeProblem('warning'), themeProblem('recommendation')]),
+    ).toBe('uploaded, but it has some warnings');
+  });
 
-    it('calls a set containing an error issues, so it cannot contradict the issue list', () => {
-        expect(describeThemeOutcome('uploaded', [themeProblem('error'), themeProblem('warning')]))
-            .toBe('uploaded, but it has some issues');
-    });
+  it('calls a set containing an error issues, so it cannot contradict the issue list', () => {
+    expect(describeThemeOutcome('uploaded', [themeProblem('error'), themeProblem('warning')])).toBe(
+      'uploaded, but it has some issues',
+    );
+  });
 
-    it('carries the caller\'s verb', () => {
-        expect(describeThemeOutcome('saved', [])).toBe('saved successfully');
-        expect(describeThemeOutcome('installed', [themeProblem('warning')])).toBe('installed, but it has some warnings');
-    });
+  it("carries the caller's verb", () => {
+    expect(describeThemeOutcome('saved', [])).toBe('saved successfully');
+    expect(describeThemeOutcome('installed', [themeProblem('warning')])).toBe(
+      'installed, but it has some warnings',
+    );
+  });
 
-    it('treats a theme\'s merged errors and warnings as one set', () => {
-        const theme = {
-            name: 'mytheme',
-            errors: [themeProblem('error')],
-            warnings: [themeProblem('warning')]
-        } as unknown as InstalledTheme;
+  it("treats a theme's merged errors and warnings as one set", () => {
+    const theme = {
+      name: 'mytheme',
+      errors: [themeProblem('error')],
+      warnings: [themeProblem('warning')],
+    } as unknown as InstalledTheme;
 
-        expect(describeThemeOutcome('uploaded', getIssuesFromInstalledTheme(theme)))
-            .toBe('uploaded, but it has some issues');
-    });
+    expect(describeThemeOutcome('uploaded', getIssuesFromInstalledTheme(theme))).toBe(
+      'uploaded, but it has some issues',
+    );
+  });
 });
 
 describe('sortBySeverity', () => {
-    it('orders errors before warnings before recommendations', () => {
-        const sorted = sortBySeverity([
-            themeProblem('recommendation', 'REC'),
-            themeProblem('warning', 'WARN'),
-            themeProblem('error', 'ERR')
-        ]);
+  it('orders errors before warnings before recommendations', () => {
+    const sorted = sortBySeverity([
+      themeProblem('recommendation', 'REC'),
+      themeProblem('warning', 'WARN'),
+      themeProblem('error', 'ERR'),
+    ]);
 
-        expect(sorted.map(item => item.code)).toEqual(['ERR', 'WARN', 'REC']);
-    });
+    expect(sorted.map((item) => item.code)).toEqual(['ERR', 'WARN', 'REC']);
+  });
 });

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.test.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.test.ts
@@ -1,56 +1,98 @@
-import {
-  fatalErrorsSchema,
-  getIssuesFromFatalErrors,
-  parseFatalErrors,
-} from './theme-validation-issues';
+import {describeThemeOutcome, fatalErrorsSchema, getIssuesFromFatalErrors, getIssuesFromInstalledTheme, parseFatalErrors, sortBySeverity} from './theme-validation-issues';
+import {type InstalledTheme, type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
 
 const problem = {
-  code: 'GS030-NO-DEFAULT-TEMPLATE',
-  details: 'The theme must have a default.hbs template.',
-  failures: [{ ref: 'default.hbs' }],
-  fatal: true,
-  level: 'error' as const,
-  rule: 'A default template is required.',
+    code: 'GS030-NO-DEFAULT-TEMPLATE',
+    details: 'The theme must have a default.hbs template.',
+    failures: [{ref: 'default.hbs'}],
+    fatal: true,
+    level: 'error' as const,
+    rule: 'A default template is required.'
 };
 
+/** A problem at an arbitrary severity, for the display-level helpers. */
+function themeProblem(level: string, code = 'GS000'): ThemeProblem {
+    return {code, level, rule: 'rule', details: 'details', failures: [], fatal: false} as unknown as ThemeProblem;
+}
+
 describe('fatalErrorsSchema', () => {
-  it('parses string and structured validation details', () => {
-    const result = fatalErrorsSchema.safeParse([
-      { details: 'Missing default.hbs' },
-      { details: { errors: [problem] } },
-    ]);
+    it('parses string and structured validation details', () => {
+        const result = fatalErrorsSchema.safeParse([
+            {details: 'Missing default.hbs'},
+            {details: {errors: [problem]}}
+        ]);
 
-    expect(result.success).toBe(true);
+        expect(result.success).toBe(true);
 
-    if (result.success) {
-      expect(getIssuesFromFatalErrors(result.data)).toEqual({
-        blockingProblems: [problem],
-        secondaryProblems: [],
-        stringErrors: ['Missing default.hbs'],
-      });
-    }
-  });
+        if (result.success) {
+            expect(getIssuesFromFatalErrors(result.data)).toEqual({
+                blockingProblems: [problem],
+                secondaryProblems: [],
+                stringErrors: ['Missing default.hbs']
+            });
+        }
+    });
 
-  it('rejects malformed theme problems', () => {
-    const result = fatalErrorsSchema.safeParse([
-      { details: { errors: [{ ...problem, fatal: 'yes' }] } },
-    ]);
+    it('rejects malformed theme problems', () => {
+        const result = fatalErrorsSchema.safeParse([
+            {details: {errors: [{...problem, fatal: 'yes'}]}}
+        ]);
 
-    expect(result.success).toBe(false);
-  });
+        expect(result.success).toBe(false);
+    });
 
-  it('does not treat empty or non-blocking payloads as fatal errors', () => {
-    expect(parseFatalErrors([])).toBeNull();
-    expect(parseFatalErrors([{ details: {} }])).toBeNull();
-    expect(
-      parseFatalErrors([
-        {
-          details: {
-            warnings: [{ ...problem, fatal: false, level: 'warning' }],
-          },
-        },
-      ]),
-    ).toBeNull();
-    expect(parseFatalErrors([{ details: '   ' }])).toBeNull();
-  });
+    it('does not treat empty or non-blocking payloads as fatal errors', () => {
+        expect(parseFatalErrors([])).toBeNull();
+        expect(parseFatalErrors([{details: {}}])).toBeNull();
+        expect(parseFatalErrors([{
+            details: {
+                warnings: [{...problem, fatal: false, level: 'warning'}]
+            }
+        }])).toBeNull();
+        expect(parseFatalErrors([{details: '   '}])).toBeNull();
+    });
+});
+
+describe('describeThemeOutcome', () => {
+    it('reports a clean install', () => {
+        expect(describeThemeOutcome('uploaded', [])).toBe('uploaded successfully');
+    });
+
+    it('calls a warnings-only set warnings', () => {
+        expect(describeThemeOutcome('uploaded', [themeProblem('warning'), themeProblem('recommendation')]))
+            .toBe('uploaded, but it has some warnings');
+    });
+
+    it('calls a set containing an error issues, so it cannot contradict the issue list', () => {
+        expect(describeThemeOutcome('uploaded', [themeProblem('error'), themeProblem('warning')]))
+            .toBe('uploaded, but it has some issues');
+    });
+
+    it('carries the caller\'s verb', () => {
+        expect(describeThemeOutcome('saved', [])).toBe('saved successfully');
+        expect(describeThemeOutcome('installed', [themeProblem('warning')])).toBe('installed, but it has some warnings');
+    });
+
+    it('treats a theme\'s merged errors and warnings as one set', () => {
+        const theme = {
+            name: 'mytheme',
+            errors: [themeProblem('error')],
+            warnings: [themeProblem('warning')]
+        } as unknown as InstalledTheme;
+
+        expect(describeThemeOutcome('uploaded', getIssuesFromInstalledTheme(theme)))
+            .toBe('uploaded, but it has some issues');
+    });
+});
+
+describe('sortBySeverity', () => {
+    it('orders errors before warnings before recommendations', () => {
+        const sorted = sortBySeverity([
+            themeProblem('recommendation', 'REC'),
+            themeProblem('warning', 'WARN'),
+            themeProblem('error', 'ERR')
+        ]);
+
+        expect(sorted.map(item => item.code)).toEqual(['ERR', 'WARN', 'REC']);
+    });
 });

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -97,19 +97,22 @@ export type DisplaySeverity = 'Error' | 'Warning' | 'Recommendation';
 export const SEVERITY_ORDER: DisplaySeverity[] = ['Error', 'Warning', 'Recommendation'];
 
 export function getDisplaySeverity(problem: ThemeProblem): DisplaySeverity {
-    if (problem.level === 'warning') {
-        return 'Warning';
-    }
+  if (problem.level === 'warning') {
+    return 'Warning';
+  }
 
-    if (problem.level === 'recommendation') {
-        return 'Recommendation';
-    }
+  if (problem.level === 'recommendation') {
+    return 'Recommendation';
+  }
 
-    return 'Error';
+  return 'Error';
 }
 
 export function sortBySeverity(problems: ThemeProblem[]): ThemeProblem[] {
-    return [...problems].sort((a, b) => SEVERITY_ORDER.indexOf(getDisplaySeverity(a)) - SEVERITY_ORDER.indexOf(getDisplaySeverity(b)));
+  return [...problems].sort(
+    (a, b) =>
+      SEVERITY_ORDER.indexOf(getDisplaySeverity(a)) - SEVERITY_ORDER.indexOf(getDisplaySeverity(b)),
+  );
 }
 
 /**
@@ -120,11 +123,11 @@ export function sortBySeverity(problems: ThemeProblem[]): ThemeProblem[] {
  * contradicts the issue list rendered directly beneath it.
  */
 export function describeThemeOutcome(action: string, problems: ThemeProblem[]): string {
-    if (!problems.length) {
-        return `${action} successfully`;
-    }
+  if (!problems.length) {
+    return `${action} successfully`;
+  }
 
-    const hasError = problems.some(problem => getDisplaySeverity(problem) === 'Error');
+  const hasError = problems.some((problem) => getDisplaySeverity(problem) === 'Error');
 
-    return `${action}, but it has some ${hasError ? 'issues' : 'warnings'}`;
+  return `${action}, but it has some ${hasError ? 'issues' : 'warnings'}`;
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -84,3 +84,47 @@ export function parseFatalErrors(data: unknown): FatalErrors | null {
 export function getIssuesFromInstalledTheme(installedTheme: InstalledTheme): ThemeProblem[] {
   return [...(installedTheme.errors || []), ...(installedTheme.warnings || [])];
 }
+
+/*
+ * Display layer. Everything above turns an API payload into buckets of
+ * `ThemeProblem`; everything below classifies those problems for the UI that
+ * renders them.
+ */
+
+export type DisplaySeverity = 'Error' | 'Warning' | 'Recommendation';
+
+/** Most to least severe — drives both the list order and the summary order. */
+export const SEVERITY_ORDER: DisplaySeverity[] = ['Error', 'Warning', 'Recommendation'];
+
+export function getDisplaySeverity(problem: ThemeProblem): DisplaySeverity {
+    if (problem.level === 'warning') {
+        return 'Warning';
+    }
+
+    if (problem.level === 'recommendation') {
+        return 'Recommendation';
+    }
+
+    return 'Error';
+}
+
+export function sortBySeverity(problems: ThemeProblem[]): ThemeProblem[] {
+    return [...problems].sort((a, b) => SEVERITY_ORDER.indexOf(getDisplaySeverity(a)) - SEVERITY_ORDER.indexOf(getDisplaySeverity(b)));
+}
+
+/**
+ * Completes "<theme> was ..." for a theme that installed successfully but may
+ * carry non-blocking problems. `errors` and `warnings` are merged by
+ * `getIssuesFromInstalledTheme`, so the phrase has to look at the levels
+ * rather than the count: calling a set that contains errors "warnings"
+ * contradicts the issue list rendered directly beneath it.
+ */
+export function describeThemeOutcome(action: string, problems: ThemeProblem[]): string {
+    if (!problems.length) {
+        return `${action} successfully`;
+    }
+
+    const hasError = problems.some(problem => getDisplaySeverity(problem) === 'Error');
+
+    return `${action}, but it has some ${hasError ? 'issues' : 'warnings'}`;
+}

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -116,6 +116,15 @@ export function sortBySeverity(problems: ThemeProblem[]): ThemeProblem[] {
 }
 
 /**
+ * Whether a set of problems contains anything Ghost displays as an error. The
+ * single answer to that question: copy, badges and button labels all read it,
+ * so none of them can classify a set differently from the list beside them.
+ */
+export function hasErrorProblem(problems: ThemeProblem[]): boolean {
+  return problems.some((problem) => getDisplaySeverity(problem) === 'Error');
+}
+
+/**
  * Completes "<theme> was ..." for a theme that installed successfully but may
  * carry non-blocking problems. `errors` and `warnings` are merged by
  * `getIssuesFromInstalledTheme`, so the phrase has to look at the levels
@@ -127,7 +136,5 @@ export function describeThemeOutcome(action: string, problems: ThemeProblem[]): 
     return `${action} successfully`;
   }
 
-  const hasError = problems.some((problem) => getDisplaySeverity(problem) === 'Error');
-
-  return `${action}, but it has some ${hasError ? 'issues' : 'warnings'}`;
+  return `${action}, but it has some ${hasErrorProblem(problems) ? 'issues' : 'warnings'}`;
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -85,12 +85,6 @@ export function getIssuesFromInstalledTheme(installedTheme: InstalledTheme): The
   return [...(installedTheme.errors || []), ...(installedTheme.warnings || [])];
 }
 
-/*
- * Display layer. Everything above turns an API payload into buckets of
- * `ThemeProblem`; everything below classifies those problems for the UI that
- * renders them.
- */
-
 export type DisplaySeverity = 'Error' | 'Warning' | 'Recommendation';
 
 /** The Shade `Badge` variants a severity is allowed to take. */
@@ -99,12 +93,7 @@ export type DisplayVariant = 'destructive' | 'warning' | 'secondary';
 /** Most to least severe — drives both the list order and the summary order. */
 export const SEVERITY_ORDER: DisplaySeverity[] = ['Error', 'Warning', 'Recommendation'];
 
-/**
- * What each gscan level is called and how it is coloured, in one row per
- * level. Name and colour are read from the same place, so a badge can never
- * say "Warning" in the red that means error. Anything unrecognised is treated
- * as an error rather than silently rendering as the mildest severity.
- */
+/** Name and colour in one row per level, so a badge can never mix the two. */
 const SEVERITY_DISPLAY: Record<
   ThemeProblem['level'],
   { severity: DisplaySeverity; variant: DisplayVariant }
@@ -133,11 +122,6 @@ export function sortBySeverity(problems: ThemeProblem[]): ThemeProblem[] {
   );
 }
 
-/**
- * Whether a set of problems contains anything Ghost displays as an error. The
- * single answer to that question: copy, badges and button labels all read it,
- * so none of them can classify a set differently from the list beside them.
- */
 export function hasErrorProblem(problems: ThemeProblem[]): boolean {
   return problems.some((problem) => getDisplaySeverity(problem) === 'Error');
 }
@@ -146,11 +130,9 @@ export function hasErrorProblem(problems: ThemeProblem[]): boolean {
 export type ThemeAction = 'uploaded' | 'installed' | 'activated' | 'saved';
 
 /**
- * Completes "<theme> was ..." for a theme that installed successfully but may
- * carry non-blocking problems. `errors` and `warnings` are merged by
- * `getIssuesFromInstalledTheme`, so the noun naming the set has to look at the
- * levels rather than the count: calling a set that contains errors "warnings"
- * contradicts the issue list rendered beside it.
+ * Completes "<theme> was ...". `errors` and `warnings` arrive merged, so the
+ * noun reads the severities present rather than the count — a set containing
+ * errors called "warnings" contradicts the list rendered beside it.
  */
 export function describeThemeOutcome(action: ThemeAction, problems: ThemeProblem[]): string {
   if (!problems.length) {

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -93,19 +93,37 @@ export function getIssuesFromInstalledTheme(installedTheme: InstalledTheme): The
 
 export type DisplaySeverity = 'Error' | 'Warning' | 'Recommendation';
 
+/** The Shade `Badge` variants a severity is allowed to take. */
+export type DisplayVariant = 'destructive' | 'warning' | 'secondary';
+
 /** Most to least severe — drives both the list order and the summary order. */
 export const SEVERITY_ORDER: DisplaySeverity[] = ['Error', 'Warning', 'Recommendation'];
 
+/**
+ * What each gscan level is called and how it is coloured, in one row per
+ * level. Name and colour are read from the same place, so a badge can never
+ * say "Warning" in the red that means error. Anything unrecognised is treated
+ * as an error rather than silently rendering as the mildest severity.
+ */
+const SEVERITY_DISPLAY: Record<
+  ThemeProblem['level'],
+  { severity: DisplaySeverity; variant: DisplayVariant }
+> = {
+  error: { severity: 'Error', variant: 'destructive' },
+  warning: { severity: 'Warning', variant: 'warning' },
+  recommendation: { severity: 'Recommendation', variant: 'secondary' },
+};
+
+function displayFor(problem: ThemeProblem) {
+  return SEVERITY_DISPLAY[problem.level] ?? SEVERITY_DISPLAY.error;
+}
+
 export function getDisplaySeverity(problem: ThemeProblem): DisplaySeverity {
-  if (problem.level === 'warning') {
-    return 'Warning';
-  }
+  return displayFor(problem).severity;
+}
 
-  if (problem.level === 'recommendation') {
-    return 'Recommendation';
-  }
-
-  return 'Error';
+export function getDisplayVariant(problem: ThemeProblem): DisplayVariant {
+  return displayFor(problem).variant;
 }
 
 export function sortBySeverity(problems: ThemeProblem[]): ThemeProblem[] {
@@ -124,17 +142,28 @@ export function hasErrorProblem(problems: ThemeProblem[]): boolean {
   return problems.some((problem) => getDisplaySeverity(problem) === 'Error');
 }
 
+/** Past tense of what Ghost did, or refused to do, with a theme. */
+export type ThemeAction = 'uploaded' | 'installed' | 'activated' | 'saved';
+
+/**
+ * What to call a non-empty set of problems. `errors` and `warnings` are merged
+ * by `getIssuesFromInstalledTheme`, so the noun has to look at the levels
+ * rather than the count: calling a set that contains errors "warnings"
+ * contradicts the issue list rendered beside it. Every sentence that names a
+ * set reads it from here, so no two of them can disagree.
+ */
+export function describeProblemSet(problems: ThemeProblem[]): string {
+  return hasErrorProblem(problems) ? 'issues' : 'warnings';
+}
+
 /**
  * Completes "<theme> was ..." for a theme that installed successfully but may
- * carry non-blocking problems. `errors` and `warnings` are merged by
- * `getIssuesFromInstalledTheme`, so the phrase has to look at the levels
- * rather than the count: calling a set that contains errors "warnings"
- * contradicts the issue list rendered directly beneath it.
+ * carry non-blocking problems.
  */
-export function describeThemeOutcome(action: string, problems: ThemeProblem[]): string {
+export function describeThemeOutcome(action: ThemeAction, problems: ThemeProblem[]): string {
   if (!problems.length) {
     return `${action} successfully`;
   }
 
-  return `${action}, but it has some ${hasErrorProblem(problems) ? 'issues' : 'warnings'}`;
+  return `${action}, but it has some ${describeProblemSet(problems)}`;
 }

--- a/apps/admin/src/settings/site/theme/theme-validation-issues.ts
+++ b/apps/admin/src/settings/site/theme/theme-validation-issues.ts
@@ -146,24 +146,16 @@ export function hasErrorProblem(problems: ThemeProblem[]): boolean {
 export type ThemeAction = 'uploaded' | 'installed' | 'activated' | 'saved';
 
 /**
- * What to call a non-empty set of problems. `errors` and `warnings` are merged
- * by `getIssuesFromInstalledTheme`, so the noun has to look at the levels
- * rather than the count: calling a set that contains errors "warnings"
- * contradicts the issue list rendered beside it. Every sentence that names a
- * set reads it from here, so no two of them can disagree.
- */
-export function describeProblemSet(problems: ThemeProblem[]): string {
-  return hasErrorProblem(problems) ? 'issues' : 'warnings';
-}
-
-/**
  * Completes "<theme> was ..." for a theme that installed successfully but may
- * carry non-blocking problems.
+ * carry non-blocking problems. `errors` and `warnings` are merged by
+ * `getIssuesFromInstalledTheme`, so the noun naming the set has to look at the
+ * levels rather than the count: calling a set that contains errors "warnings"
+ * contradicts the issue list rendered beside it.
  */
 export function describeThemeOutcome(action: ThemeAction, problems: ThemeProblem[]): string {
   if (!problems.length) {
     return `${action} successfully`;
   }
 
-  return `${action}, but it has some ${describeProblemSet(problems)}`;
+  return `${action}, but it has some ${hasErrorProblem(problems) ? 'issues' : 'warnings'}`;
 }


### PR DESCRIPTION
ref [DES-1421](https://linear.app/ghost/issue/DES-1421/improve-theme-installationactivation-modal-layout-and-copy)

The upload dialog led with a large green banner that repeated what the title already said, then stacked three different treatments underneath it: a show/hide toggle, bordered cards per issue, and a red card for bare error strings. The result buried the one decision the dialog exists to ask — activate this theme, or not.

## What changed

- **Status summary replaces the green banner.** One sentence naming the theme and the outcome, in three states: uploaded successfully / uploaded but has issues / couldn't be uploaded.
- **Error state gets `[Cancel] [Re-upload]`**, and Re-upload reopens the upload dialog. Labels are per-caller, so the activation and editor-save failures still read accurately.
- **Issue list is always visible** under a plain `2 errors, 3 warnings` heading, contextual to the severities actually present. The show/hide toggle is gone, and the section stays hidden when the theme validates cleanly.
- **One hairline-separated list** instead of per-issue cards, each row expanding in place. Bare error strings now render as rows in the same list rather than as a separate red card.
- **Sticky footer** no longer leaves dead space below it, and its buttons sit right-aligned to match Shade's dialog default.
- **Chevron rotates 180°** instead of a full turn back to where it started.

## Notes for review

The outcome sentence keys off the problems' *severity*, not their count. `getIssuesFromInstalledTheme` merges `errors` and `warnings`, so counting alone would have printed "some warnings" directly above a heading reading "1 error, 2 warnings". `describeThemeOutcome` in `theme-validation-issues.ts` owns that, with unit coverage.

The chevron bug was a genuine collision, worth knowing about beyond this PR: Ghost's legacy Ember stylesheet ships Tachyons' `.rotate-180`, which sets `transform`, while Tailwind v4 compiles the same class name to the `rotate` property. Both sheets are unlayered in Admin, so any element carrying the literal class gets both declarations and turns 360°. Moving to Shade's `Accordion` sidesteps it — Radix rotates via a parent arbitrary variant that compiles to a class name the legacy rule can't match. **`apps/admin/src/members/detail/member-subscriptions-section.tsx:101` still has the same bug** and is not fixed here.

Both layout fixes live in the shared `ConfirmationModalContent` but are gated on the `stickyFooter` branch, so no other dialog is affected. A sticky grid item is boxed in by its own grid area and never sticks, hence the flex column; and Shade's `StickyFooter` sizes its box in raw pixels while spacing its parts with `h-6`/`-mb-6`, which the 0.4rem spacing scale renders as 38.4px. The call site pins those offsets back to 24px. **The underlying defect is in `StickyFooter` itself** — left alone deliberately to keep Shade out of this PR, and worth a follow-up.

One inconsistency left untouched: the upload and activation paths still cast raw API data to `FatalErrors` while the editor validates through `parseFatalErrors`. That's pre-existing and out of scope here.

## Testing

- `lint`, `typecheck` clean
- Unit: 1628 passing, including new coverage for the outcome copy and severity sort
- Acceptance: 510 passing, with a new spec covering the counted heading, per-item expansion, and the Re-upload flow
- All four visual fixes confirmed against rendered screenshots at desktop and 420px, including the error dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)