### PR TITLE
Added the Oxfmt reformat commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to make local
+# git blame skip the commits listed here. The GitHub blame view uses this
+# file automatically.
+
+# Formatted the repository with oxfmt (#30184)
+5ad154310fa5b325c2201ff3caeaa4daee8172d3

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -66,10 +66,11 @@ pnpm format path/to/file.ts
 configuration; the root config is the only one.
 
 The one-time repository reformat is listed in `.git-blame-ignore-revs`. GitHub's
-blame view skips it automatically; for local `git blame`, run once:
+blame view skips it automatically, and `pnpm setup` configures local Git to use
+the file. For an existing checkout, rerun `pnpm setup` or run once:
 
 ```bash
-git config blame.ignoreRevsFile .git-blame-ignore-revs
+git config --local blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 
 ## Record package release intent

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -65,6 +65,13 @@ pnpm format path/to/file.ts
 `pnpm format:check` reports without writing. Do not add per-package formatter
 configuration; the root config is the only one.
 
+The one-time repository reformat is listed in `.git-blame-ignore-revs`. GitHub's
+blame view skips it automatically; for local `git blame`, run once:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## Record package release intent
 
 Changes that affect a publishable `@tryghost/*` package under `koenig/` or

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fix": "pnpm store prune && rimraf -g '**/node_modules' && pnpm install && pnpm nx reset",
     "create-package": "node ./scripts/create-package.js",
     "knex-migrator": "pnpm --filter ghost run knex-migrator",
-    "setup": "pnpm install && git submodule update --init --recursive",
+    "setup": "pnpm install && git submodule update --init --recursive && git config --local blame.ignoreRevsFile .git-blame-ignore-revs",
     "migrate:db": "docker exec --workdir /home/ghost/ghost/core ghost-dev pnpm knex-migrator migrate",
     "rollback:db": "docker exec --workdir /home/ghost/ghost/core ghost-dev pnpm knex-migrator rollback",
     "reset:db": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && pnpm knex-migrator reset && pnpm knex-migrator init'",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-137

Follow-up to #30184: lists the reformat squash commit (`5ad154310f`) in `.git-blame-ignore-revs` so blame can attribute reformatted lines to their earlier authors. GitHub's blame view uses the file automatically; `pnpm setup` now configures the repository-local `blame.ignoreRevsFile` setting for local `git blame`. Existing checkouts can rerun `pnpm setup` or use the documented one-time `git config --local blame.ignoreRevsFile .git-blame-ignore-revs` command.

Verified locally: with the config set, `git blame` on sampled reformatted files attributes zero lines to the reformat commit.