### PR TITLE
Replaced promise package usage with simple `await`s and loops

### DIFF
--- a/ghost/core/core/server/data/exporter/exporter.js
+++ b/ghost/core/core/server/data/exporter/exporter.js
@@ -4,7 +4,6 @@ const commands = require('../schema').commands;
 const ghostVersion = require('@tryghost/version');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
-const { sequence } = require('@tryghost/promise');
 
 const messages = {
   errorExportingData: 'Error exporting data',
@@ -38,11 +37,10 @@ const doExport = async function doExport(options) {
   try {
     const tables = await commands.getTables(options.transacting);
 
-    const tableData = await sequence(
-      tables.map((tableName) => async () => {
-        return exportTable(tableName, options);
-      }),
-    );
+    const tableData = [];
+    for (const tableName of tables) {
+      tableData.push(await exportTable(tableName, options));
+    }
 
     const exportData = {
       meta: {

--- a/ghost/core/core/server/data/importer/importers/data/base.js
+++ b/ghost/core/core/server/data/importer/importers/data/base.js
@@ -2,7 +2,6 @@ const debug = require('@tryghost/debug')('importer:base');
 const _ = require('lodash');
 const ObjectId = require('bson-objectid').default;
 const errors = require('@tryghost/errors');
-const { sequence } = require('@tryghost/promise');
 const models = require('../../../../models');
 
 class Base {
@@ -346,7 +345,9 @@ class Base {
       });
     });
 
-    await sequence(ops);
+    for (const op of ops) {
+      await op();
+    }
   }
 }
 

--- a/ghost/core/core/server/data/importer/importers/data/custom-theme-settings-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/custom-theme-settings-importer.js
@@ -3,7 +3,6 @@ const debug = require('@tryghost/debug')('importer:roles');
 const BaseImporter = require('./base');
 const models = require('../../../../models');
 const { activate } = require('../../../../services/themes/activate');
-const { sequence } = require('@tryghost/promise');
 
 class CustomThemeSettingsImporter extends BaseImporter {
   constructor(allDataFromFile) {
@@ -55,7 +54,9 @@ class CustomThemeSettingsImporter extends BaseImporter {
       });
     });
 
-    await sequence(ops);
+    for (const op of ops) {
+      await op();
+    }
 
     const theme = await models.Settings.findOne({ key: 'active_theme' }, options);
     const currentTheme = theme && theme.get('value');

--- a/ghost/core/core/server/data/importer/importers/data/data-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/data-importer.js
@@ -3,7 +3,6 @@ const ObjectId = require('bson-objectid').default;
 const semver = require('semver');
 const { IncorrectUsageError, DataImportError } = require('@tryghost/errors');
 const debug = require('@tryghost/debug')('importer:data');
-const { sequence } = require('@tryghost/promise');
 const models = require('../../../../models');
 const PostsImporter = require('./posts-importer');
 const TagsImporter = require('./tags-importer');
@@ -168,7 +167,7 @@ DataImporter = {
        *   - already exist in the db
        * so we only need to map imported products
        */
-      ops.push(() => {
+      ops.push(async () => {
         const importedStripePrices = importers.stripe_prices.importedData;
         const importedProducts = importers.products.importedData;
         const productOps = [];
@@ -189,10 +188,14 @@ DataImporter = {
           });
         });
 
-        return sequence(productOps);
+        for (const productOp of productOps) {
+          await productOp();
+        }
       });
 
-      await sequence(ops);
+      for (const op of ops) {
+        await op();
+      }
 
       // Errors preventing import:
       if (errors.length > 0) {

--- a/ghost/core/core/server/data/importer/importers/data/settings-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/settings-importer.js
@@ -7,7 +7,6 @@ const defaultSettings = require('../../../schema').defaultSettings;
 const keyGroupMapper = require('../../../../api/endpoints/utils/serializers/input/utils/settings-key-group-mapper');
 const keyTypeMapper = require('../../../../api/endpoints/utils/serializers/input/utils/settings-key-type-mapper');
 const { WRITABLE_KEYS_ALLOWLIST } = require('../../../../../shared/labs');
-const { sequence } = require('@tryghost/promise');
 
 const labsDefaults = JSON.parse(defaultSettings.labs.labs.defaultValue);
 const ignoredSettings = [
@@ -281,7 +280,9 @@ class SettingsImporter extends BaseImporter {
       });
     });
 
-    await sequence(ops);
+    for (const op of ops) {
+      await op();
+    }
   }
 }
 

--- a/ghost/core/core/server/data/importer/importers/data/tags-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/tags-importer.js
@@ -2,7 +2,6 @@ const debug = require('@tryghost/debug')('importer:tags');
 const _ = require('lodash');
 const BaseImporter = require('./base');
 const models = require('../../../../models');
-const { sequence } = require('@tryghost/promise');
 
 class TagsImporter extends BaseImporter {
   constructor(allDataFromFile) {
@@ -71,7 +70,9 @@ class TagsImporter extends BaseImporter {
       });
     });
 
-    await sequence(ops);
+    for (const op of ops) {
+      await op();
+    }
   }
 }
 

--- a/ghost/core/core/server/data/migrations/init/1-create-tables.js
+++ b/ghost/core/core/server/data/migrations/init/1-create-tables.js
@@ -3,7 +3,6 @@ const schema = require('../../schema').tables;
 const views = require('../../schema').views;
 const logging = require('@tryghost/logging');
 const schemaTables = Object.keys(schema);
-const { sequence } = require('@tryghost/promise');
 
 module.exports.up = async (options) => {
   const connection = options.connection;
@@ -11,12 +10,10 @@ module.exports.up = async (options) => {
   const existingTables = await commands.getTables(connection);
   const missingTables = schemaTables.filter((t) => !existingTables.includes(t));
 
-  await sequence(
-    missingTables.map((table) => async () => {
-      logging.info('Creating table: ' + table);
-      await commands.createTable(table, connection);
-    }),
-  );
+  for (const table of missingTables) {
+    logging.info('Creating table: ' + table);
+    await commands.createTable(table, connection);
+  }
 
   // Create views after tables exist. View creation is idempotent
   // (createViewOrReplace) so adding a new view to views.js does not require
@@ -38,9 +35,9 @@ module.exports.up = async (options) => {
 
         // Reference between tables!
         schemaTables.reverse();
-        await sequence(schemaTables.map(table => async () => {
+        for (const table of schemaTables) {
             logging.info('Drop table: ' + table);
             await commands.deleteTable(table, connection);
-        }));
+        }
     };
  */

--- a/ghost/core/core/server/data/schema/fixtures/fixture-manager.js
+++ b/ghost/core/core/server/data/schema/fixtures/fixture-manager.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const logging = require('@tryghost/logging');
-const { sequence } = require('@tryghost/promise');
 
 const models = require('../../../models');
 const baseUtils = require('../../../models/base/utils');
@@ -125,23 +124,15 @@ class FixtureManager {
     const userRolesRelation = this.fixtures.relations.find((r) => r.from.relation === 'roles');
     await this.addFixturesForRelation(userRolesRelation, localOptions);
 
-    await sequence(
-      this.fixtures.models
-        .filter((m) => !['User', 'Role'].includes(m.name))
-        .map((model) => () => {
-          logging.info('Model: ' + model.name);
-          return this.addFixturesForModel(model, localOptions);
-        }),
-    );
+    for (const model of this.fixtures.models.filter((m) => !['User', 'Role'].includes(m.name))) {
+      logging.info('Model: ' + model.name);
+      await this.addFixturesForModel(model, localOptions);
+    }
 
-    await sequence(
-      this.fixtures.relations
-        .filter((r) => r.from.relation !== 'roles')
-        .map((relation) => () => {
-          logging.info('Relation: ' + relation.from.model + ' to ' + relation.to.model);
-          return this.addFixturesForRelation(relation, localOptions);
-        }),
-    );
+    for (const relation of this.fixtures.relations.filter((r) => r.from.relation !== 'roles')) {
+      logging.info('Relation: ' + relation.from.model + ' to ' + relation.to.model);
+      await this.addFixturesForRelation(relation, localOptions);
+    }
   }
 
   /*
@@ -358,29 +349,28 @@ class FixtureManager {
       });
     }
 
-    const results = await sequence(
-      modelFixture.entries.map((entry) => async () => {
-        let data = {};
+    const results = [];
+    for (const entry of modelFixture.entries) {
+      let data = {};
 
-        // CASE: if id is specified, only query by id
-        if (entry.id) {
-          data.id = entry.id;
-        } else if (entry.slug) {
-          data.slug = entry.slug;
-        } else {
-          data = _.cloneDeep(entry);
-        }
+      // CASE: if id is specified, only query by id
+      if (entry.id) {
+        data.id = entry.id;
+      } else if (entry.slug) {
+        data.slug = entry.slug;
+      } else {
+        data = _.cloneDeep(entry);
+      }
 
-        if (modelFixture.name === 'Post') {
-          data.status = 'all';
-        }
+      if (modelFixture.name === 'Post') {
+        data.status = 'all';
+      }
 
-        const found = await models[modelFixture.name].findOne(data, options);
-        if (!found) {
-          return models[modelFixture.name].add(entry, options);
-        }
-      }),
-    );
+      const found = await models[modelFixture.name].findOne(data, options);
+      if (!found) {
+        results.push(await models[modelFixture.name].add(entry, options));
+      }
+    }
 
     return { expected: modelFixture.entries.length, done: _.compact(results).length };
   }
@@ -440,22 +430,25 @@ class FixtureManager {
       });
     });
 
-    const result = await sequence(ops);
+    const result = [];
+    for (const op of ops) {
+      result.push(await op());
+    }
     return { expected: max, done: _(result).map('length').sum() };
   }
 
   async removeFixturesForModel(modelFixture, options) {
-    const results = await sequence(
-      modelFixture.entries.map((entry) => async () => {
-        const found = models[modelFixture.name].findOne(
-          entry.id ? { id: entry.id } : entry,
-          options,
-        );
-        if (found) {
-          return models[modelFixture.name].destroy(_.extend(options, { id: found.id }));
-        }
-      }),
-    );
+    const results = [];
+    for (const entry of modelFixture.entries) {
+      const found = await models[modelFixture.name].findOne(
+        entry.id ? { id: entry.id } : entry,
+        options,
+      );
+      const result = found
+        ? await models[modelFixture.name].destroy(_.extend(options, { id: found.id }))
+        : undefined;
+      results.push(result);
+    }
 
     return { expected: modelFixture.entries.length, done: results.length };
   }
@@ -486,7 +479,11 @@ class FixtureManager {
       });
     });
 
-    return await sequence(ops);
+    const results = [];
+    for (const op of ops) {
+      results.push(await op());
+    }
+    return results;
   }
 }
 

--- a/ghost/core/core/server/models/base/listeners.js
+++ b/ghost/core/core/server/models/base/listeners.js
@@ -3,7 +3,6 @@ const _ = require('lodash');
 const models = require('../../models');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-const { sequence } = require('@tryghost/promise');
 
 // Listen to settings.timezone.edited and settings.notifications.edited to bind extra logic to settings, similar to the bridge and member service
 const events = require('../../lib/common/events');
@@ -42,41 +41,39 @@ const onTimezoneEdited = function (settingModel, options) {
         return;
       }
 
-      await sequence(
-        results.map((post) => async () => {
-          const newPublishedAtMoment = moment(post.get('published_at')).add(
-            timezoneOffsetDiff,
-            'minutes',
+      for (const post of results) {
+        const newPublishedAtMoment = moment(post.get('published_at')).add(
+          timezoneOffsetDiff,
+          'minutes',
+        );
+
+        /**
+         * CASE:
+         *   - your configured TZ is GMT+01:00
+         *   - now is 10AM +01:00 (9AM UTC)
+         *   - your post should be published 8PM +01:00 (7PM UTC)
+         *   - you reconfigure your blog TZ to GMT+08:00
+         *   - now is 5PM +08:00 (9AM UTC)
+         *   - if we don't change the published_at, 7PM + 8 hours === next day 5AM
+         *   - so we update published_at to 7PM - 480minutes === 11AM UTC
+         *   - 11AM UTC === 7PM +08:00
+         */
+        if (newPublishedAtMoment.isBefore(moment().add(5, 'minutes'))) {
+          post.set('status', 'draft');
+        } else {
+          post.set('published_at', newPublishedAtMoment.toDate());
+        }
+
+        try {
+          await models.Post.edit(post.toJSON(), _.merge({ id: post.id }, options));
+        } catch (err) {
+          logging.error(
+            new errors.InternalServerError({
+              err,
+            }),
           );
-
-          /**
-           * CASE:
-           *   - your configured TZ is GMT+01:00
-           *   - now is 10AM +01:00 (9AM UTC)
-           *   - your post should be published 8PM +01:00 (7PM UTC)
-           *   - you reconfigure your blog TZ to GMT+08:00
-           *   - now is 5PM +08:00 (9AM UTC)
-           *   - if we don't change the published_at, 7PM + 8 hours === next day 5AM
-           *   - so we update published_at to 7PM - 480minutes === 11AM UTC
-           *   - 11AM UTC === 7PM +08:00
-           */
-          if (newPublishedAtMoment.isBefore(moment().add(5, 'minutes'))) {
-            post.set('status', 'draft');
-          } else {
-            post.set('published_at', newPublishedAtMoment.toDate());
-          }
-
-          try {
-            await models.Post.edit(post.toJSON(), _.merge({ id: post.id }, options));
-          } catch (err) {
-            logging.error(
-              new errors.InternalServerError({
-                err,
-              }),
-            );
-          }
-        }),
-      );
+        }
+      }
     } catch (err) {
       logging.error(
         new errors.InternalServerError({

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -2,7 +2,6 @@
 const _ = require('lodash');
 const crypto = require('crypto');
 const moment = require('moment');
-const { sequence } = require('@tryghost/promise');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const nql = require('@tryghost/nql');
@@ -1052,7 +1051,11 @@ Post = ghostBookshelf.Model.extend(
         }
       }
 
-      return sequence(ops);
+      const results = [];
+      for (const op of ops) {
+        results.push(await op());
+      }
+      return results;
     },
 
     published_by: function publishedBy() {

--- a/ghost/core/core/server/models/relations/authors.js
+++ b/ghost/core/core/server/models/relations/authors.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
-const { sequence } = require('@tryghost/promise');
 const { setIsRoles } = require('../role-utils');
 
 const messages = {
@@ -130,7 +129,13 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
           return proto.onSaving.call(this, model, attrs, options);
         });
 
-        return sequence(ops);
+        return (async () => {
+          const results = [];
+          for (const op of ops) {
+            results.push(await op());
+          }
+          return results;
+        })();
       },
 
       serialize: function serialize(options) {
@@ -224,7 +229,13 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
           });
         });
 
-        return sequence(ops);
+        return (async () => {
+          const results = [];
+          for (const op of ops) {
+            results.push(await op());
+          }
+          return results;
+        })();
       },
     },
     {


### PR DESCRIPTION
no ref

This should have no user impact.

The `sequence` export from `@tryghost/promise` can be replaced with simple `await`s and loops. This brings us closer to removing the package.
