### PR TITLE
TypeScriptify labs flags

### DIFF
--- a/.agents/skills/add-private-feature-flag/SKILL.md
+++ b/.agents/skills/add-private-feature-flag/SKILL.md
@@ -11,11 +11,11 @@ Adds a new private feature flag to Ghost. Private flags appear in Labs settings 
 
 ## Steps
 
-1. **Add the flag to `ghost/core/core/shared/labs.js`**
+1. **Add the flag to `ghost/core/core/shared/labs.ts`**
    - Add the flag name (camelCase string) to the `PRIVATE_FEATURES` array.
 
 2. **Add a UI toggle in `apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx`**
-   - Add a new entry to the `features` array with `title`, `description`, and `flag` (must match the string in `labs.js`).
+   - Add a new entry to the `features` array with `title`, `description`, and `flag` (must match the string in `labs.ts`).
 
 3. **Run tests and update the config API snapshot**
    - Unit: `cd ghost/core && pnpm test:single test/unit/shared/labs.test.js`
@@ -25,6 +25,6 @@ Adds a new private feature flag to Ghost. Private flags appear in Labs settings 
 ## Notes
 
 - No database migration is needed. Labs flags are stored in a single JSON `labs` setting.
-- The flag name must be identical in `labs.js`, `private-features.tsx`, and the snapshot.
+- The flag name must be identical in `labs.ts`, `private-features.tsx`, and the snapshot.
 - Flags are camelCase strings (e.g. `welcomeEmailDesignCustomization`).
-- For public beta flags (visible to all users), add to `PUBLIC_BETA_FEATURES` in `labs.js` instead and add the toggle to `apps/admin/src/settings/app/components/settings/advanced/labs/beta-features.tsx`.
+- For public beta flags (visible to all users), add to `PUBLIC_BETA_FEATURES` in `labs.ts` instead and add the toggle to `apps/admin/src/settings/app/components/settings/advanced/labs/beta-features.tsx`.

--- a/ghost/core/core/shared/labs.ts
+++ b/ghost/core/core/shared/labs.ts
@@ -10,14 +10,14 @@
 // For more details, see the E2E testing documentation:
 // https://www.notion.so/ghost/End-to-end-Testing-6a2ef073b1754b18aff42e24a632a007
 
-const _ = require('lodash');
-const errors = require('@tryghost/errors');
-const logging = require('@tryghost/logging');
-const tpl = require('@tryghost/tpl');
-
-const settingsCache = require('./settings-cache');
-const config = require('./config');
-const flagOverrides = require('./labs-flag-overrides');
+import errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
+import tpl from '@tryghost/tpl';
+import _ from 'lodash';
+import config from './config';
+import * as flagOverrides from './labs-flag-overrides';
+// @ts-expect-error This module lacks type definitions.
+import settingsCache from './settings-cache';
 
 const messages = {
   errorMessage: 'The \\{\\{{helperName}\\}\\} helper is not available.',
@@ -55,10 +55,10 @@ const PRIVATE_FEATURES = [
   'machinePayments',
 ];
 
-module.exports.GA_KEYS = [...GA_FEATURES];
-module.exports.WRITABLE_KEYS_ALLOWLIST = [...PUBLIC_BETA_FEATURES, ...PRIVATE_FEATURES];
+export const GA_KEYS = [...GA_FEATURES];
+export const WRITABLE_KEYS_ALLOWLIST = [...PUBLIC_BETA_FEATURES, ...PRIVATE_FEATURES];
 
-module.exports.getAll = () => {
+export const getAll = () => {
   const labs = _.cloneDeep(settingsCache.get('labs')) || {};
 
   GA_FEATURES.forEach((gaKey) => {
@@ -83,52 +83,45 @@ module.exports.getAll = () => {
   return labs;
 };
 
-module.exports.getAllFlags = function () {
+export const getAllFlags = function () {
   return [...GA_FEATURES, ...PUBLIC_BETA_FEATURES, ...PRIVATE_FEATURES];
 };
 
-/**
- * @param {string} flag
- * @returns {boolean}
- */
-module.exports.isSet = function isSet(flag) {
-  const labsConfig = module.exports.getAll();
+export const isSet = function isSet(flag: string): boolean {
+  const labsConfig = getAll();
 
   return !!(labsConfig && labsConfig[flag] && labsConfig[flag] === true);
 };
 
-/**
- *
- * @param {object} options
- * @param {string} options.flagKey the internal lookup key of the flag e.g. labs.isSet(matchHelper)
- * @param {string} options.flagName the user-facing name of the flag e.g. Match helper
- * @param {string} options.helperName Name of the helper to be enabled/disabled
- * @param {string} [options.errorMessage] Optional replacement error message
- * @param {string} [options.errorContext] Optional replacement context message
- * @param {string} [options.errorHelp] Optional replacement help message
- * @param {string} [options.helpUrl] Url to show in the help message
- * @param {string} [options.async] is the helper async?
- * @param {function} callback
- * @returns {Promise<Handlebars.SafeString>|Handlebars.SafeString}
- */
-module.exports.enabledHelper = function enabledHelper(options, callback) {
-  const errDetails = {};
-  let errString;
-
-  if (module.exports.isSet(options.flagKey) === true) {
+export function enabledHelper(
+  options: {
+    /** The internal lookup key of the flag e.g. labs.isSet(matchHelper) */
+    flagKey: string;
+    /** the user-facing name of the flag e.g. Match helper */
+    flagName: string;
+    /** Name of the helper to be enabled/disabled */
+    helperName: string;
+    /** Url to show in the help message */
+    helpUrl: string;
+  },
+  callback: () => Handlebars.SafeString,
+): Handlebars.SafeString {
+  if (isSet(options.flagKey) === true) {
     // helper is active, use the callback
     return callback();
   }
 
   // Else, the helper is not active and we need to handle this as an error
-  errDetails.message = tpl(options.errorMessage || messages.errorMessage, {
-    helperName: options.helperName,
-  });
-  errDetails.context = tpl(options.errorContext || messages.errorContext, {
-    helperName: options.helperName,
-    flagName: options.flagName,
-  });
-  errDetails.help = tpl(options.errorHelp || messages.errorHelp, { url: options.helpUrl });
+  const errDetails = {
+    message: tpl(messages.errorMessage, {
+      helperName: options.helperName,
+    }),
+    context: tpl(messages.errorContext, {
+      helperName: options.helperName,
+      flagName: options.flagName,
+    }),
+    help: tpl(messages.errorHelp, { url: options.helpUrl }),
+  };
 
   logging.error(
     new errors.DisabledFeatureError({
@@ -139,20 +132,16 @@ module.exports.enabledHelper = function enabledHelper(options, callback) {
   );
 
   const { SafeString } = require('express-hbs');
-  errString = new SafeString(
+  const errString = new SafeString(
     `<script>console.error("${_.values(errDetails).join(' ')}");</script>`,
   );
 
-  if (options.async) {
-    return Promise.resolve(errString);
-  }
-
   return errString;
-};
+}
 
-module.exports.enabledMiddleware = (flag) =>
-  function labsEnabledMw(req, res, next) {
-    if (module.exports.isSet(flag) === true) {
+export const enabledMiddleware = (flag: string) =>
+  function labsEnabledMw(_req: unknown, _res: unknown, next: (err?: unknown) => void) {
+    if (isSet(flag) === true) {
       return next();
     } else {
       return next(new errors.NotFoundError());

--- a/ghost/core/test/unit/shared/labs.test.ts
+++ b/ghost/core/test/unit/shared/labs.test.ts
@@ -1,10 +1,12 @@
-const assert = require('node:assert/strict');
-const sinon = require('sinon');
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
 
-const configUtils = require('../../utils/config-utils');
-const labs = require('../../../core/shared/labs');
-const flagOverrides = require('../../../core/shared/labs-flag-overrides');
-const settingsCache = require('../../../core/shared/settings-cache');
+// @ts-expect-error This module lacks type definitions.
+import configUtils from '../../utils/config-utils';
+import * as labs from '../../../core/shared/labs';
+import * as flagOverrides from '../../../core/shared/labs-flag-overrides';
+// @ts-expect-error This module lacks type definitions.
+import settingsCache from '../../../core/shared/settings-cache';
 
 // The labs allowlists (`WRITABLE_KEYS_ALLOWLIST`, `GA_KEYS`) drain to empty
 // once every flag in them graduates. Tests that pick the first allowlist
@@ -15,10 +17,10 @@ const itIfHasBothFlags = it.skipIf(
   labs.WRITABLE_KEYS_ALLOWLIST.length === 0 || labs.GA_KEYS.length === 0,
 );
 
-function expectedLabsObject(obj) {
-  let enabledFlags = {};
+function expectedLabsObject(obj: Record<string, boolean>): Record<string, boolean> {
+  let enabledFlags: Record<string, boolean> = {};
 
-  labs.GA_KEYS.forEach((key) => {
+  labs.GA_KEYS.forEach((key: string) => {
     enabledFlags[key] = true;
   });
 


### PR DESCRIPTION
no ref

Notably, a few options from `enabledHelper` were never used, so we can remove them.
