### PR TITLE
Added Casper Network as an x402 machine-payments rail

### DIFF
--- a/ghost/core/core/server/services/machine-payments/README.md
+++ b/ghost/core/core/server/services/machine-payments/README.md
@@ -58,6 +58,52 @@ To use a different mainnet facilitator:
 
 If x402 challenges are missing from 402 responses while MPP works, check Ghost logs for x402 warnings (network/facilitator mismatch is the usual cause).
 
+## Casper configuration
+
+Casper is an optional third rail, **off by default**. It speaks the same x402 `exact` scheme over the [Casper Network](https://casper.network), settling in **wCSPR** — a CEP-18 token — through `transfer_with_authorization` calls authorized by EIP-712 typed-data signatures and relayed by the [cspr.cloud facilitator](https://x402-facilitator.cspr.cloud).
+
+Unlike the Base rail, the recipient address cannot be minted by Stripe (Stripe issues no Casper deposit addresses), so the publisher must configure `payTo` explicitly. The settlement asset is a CEP-18 **contract package hash** (64 hex characters), not an `0x` EVM contract address, so `asset` is required too.
+
+Supported values are validated at boot:
+
+- `enabled`: `false` by default; the rail is only registered when this is `true`
+- `network`: `casper:casper` (mainnet) or `casper:casper-test` (testnet)
+- `facilitatorUrl`: HTTPS URL, defaults to `https://x402-facilitator.cspr.cloud`
+- `payTo`: the publisher's Casper account address that receives wCSPR
+- `asset`: the 64-character wCSPR CEP-18 contract package hash for the chosen network
+
+Invalid or incomplete Casper config disables the rail at boot with a warning; the x402 (Base) and MPP rails continue to work untouched.
+
+```json
+{
+  "machinePayments": {
+    "casper": {
+      "enabled": true,
+      "network": "casper:casper",
+      "payTo": "<your-casper-account-address>",
+      "asset": "<wcspr-cep18-contract-package-hash>"
+    }
+  }
+}
+```
+
+For local development against Casper testnet:
+
+```json
+{
+  "machinePayments": {
+    "casper": {
+      "enabled": true,
+      "network": "casper:casper-test",
+      "payTo": "<your-testnet-casper-account-address>",
+      "asset": "<testnet-wcspr-cep18-contract-package-hash>"
+    }
+  }
+}
+```
+
+Agents that don't speak Casper simply ignore the extra `accepts` entry and pay over an existing rail.
+
 ## Architecture boundary
 
 Membership and content gating stay frozen. Adapters only implement `canHandle` / `challenge` / `fulfill`. The orchestrator loads full post HTML and writes `machine_payment_events` only after a successful `fulfill`.

--- a/ghost/core/core/server/services/machine-payments/adapters/casper-x402-adapter.ts
+++ b/ghost/core/core/server/services/machine-payments/adapters/casper-x402-adapter.ts
@@ -1,0 +1,418 @@
+import errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
+import { z } from 'zod';
+import config from '../../../../shared/config';
+import type { Fulfillment, PaymentAdapter, PaymentTerms } from '../types';
+import { BoundedRouteCache, formatPrice, settlementReference } from './x402-adapter';
+
+/**
+ * Casper x402 adapter. A third rail behind the same canHandle/challenge/fulfill
+ * boundary, speaking the x402 `exact` scheme on the Casper Network.
+ *
+ * It is a sibling of the EVM/Base rail in `x402-adapter.ts` rather than an
+ * extension of it, because Casper settlement differs in three ways that cannot
+ * be expressed as configuration of the EVM rail:
+ *
+ * 1. `payTo` cannot come from the Stripe `DepositAddressStore` — Stripe mints no
+ *    Casper deposit addresses. The Casper rail therefore takes an explicit,
+ *    publisher-configured `payTo` Casper address and takes no deposit address
+ *    store dependency at all.
+ * 2. The scheme server is `ExactCasperScheme` from
+ *    `@make-software/casper-x402/exact/server`, and settlement happens in wCSPR,
+ *    a CEP-18 token, via `transfer_with_authorization` authorized by EIP-712
+ *    typed-data signatures. The asset identifier is a CEP-18 contract package
+ *    hash (64 hex chars), not an `0x` EVM contract address, so `accepts` carries
+ *    an explicit `asset` alongside scheme/price/network/payTo.
+ * 3. `Fulfillment.method` is `casper`, because Casper is not a Stripe crypto
+ *    network. The `protocol` stays `x402`.
+ *
+ * The rail is off by default and disables itself (init resolves false, warning
+ * logged) on any invalid config or missing runtime module — the EVM x402 and MPP
+ * rails are unaffected either way.
+ */
+
+const CASPER_ROUTE_CACHE_LIMIT = 128;
+const CASPER_MAINNET = 'casper:casper';
+const CASPER_TESTNET = 'casper:casper-test';
+const DEFAULT_CASPER_FACILITATOR_URL = 'https://x402-facilitator.cspr.cloud';
+
+const casperConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    network: z.string().regex(/^casper:[a-z0-9-]+$/, {
+      message: 'machinePayments.casper.network must be a CAIP-2 Casper network (casper:<chainName>)',
+    }),
+    facilitatorUrl: z.string().url({
+      message: 'machinePayments.casper.facilitatorUrl must be a valid URL',
+    }),
+    payTo: z.string().min(1, {
+      message: 'machinePayments.casper.payTo must be a Casper address',
+    }),
+    asset: z.string().regex(/^[0-9a-fA-F]{64}$/, {
+      message:
+        'machinePayments.casper.asset must be a 64-character CEP-18 contract package hash (wCSPR)',
+    }),
+  })
+  .superRefine((value, ctx) => {
+    if (![CASPER_MAINNET, CASPER_TESTNET].includes(value.network)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `machinePayments.casper.network must be ${CASPER_MAINNET} or ${CASPER_TESTNET}`,
+      });
+    }
+
+    let parsedFacilitatorUrl: URL;
+    try {
+      parsedFacilitatorUrl = new URL(value.facilitatorUrl);
+    } catch {
+      return;
+    }
+
+    if (parsedFacilitatorUrl.protocol !== 'https:') {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'machinePayments.casper.facilitatorUrl must use HTTPS',
+      });
+    }
+  });
+
+export type CasperX402Config = z.infer<typeof casperConfigSchema>;
+
+type FacilitatorClientLike = {
+  // @x402/core HTTPFacilitatorClient — kept loose for test doubles.
+  [key: string]: unknown;
+};
+
+type DispatchOptions = {
+  body: string;
+};
+
+type CachedApp = {
+  fetch: (request: Request) => Promise<Response>;
+};
+
+type HonoLike = {
+  use: (middleware: unknown) => void;
+  get: (path: string, handler: () => Response) => void;
+  on: (method: string, path: string, handler: () => Response) => void;
+  fetch: (request: Request) => Promise<Response>;
+};
+
+type CasperRuntimeModules = {
+  paymentMiddlewareFromConfig: (...args: unknown[]) => unknown;
+  HTTPFacilitatorClient: new (options?: { url?: string }) => FacilitatorClientLike;
+  ExactCasperScheme: new () => unknown;
+  Hono: new () => HonoLike;
+};
+
+type CasperX402AdapterDeps = {
+  facilitatorClient?: FacilitatorClientLike;
+  maxCachedApps?: number;
+  runtimeFactory?: () => CasperRuntimeModules;
+  configProvider?: () => {
+    enabled?: unknown;
+    network?: unknown;
+    facilitatorUrl?: unknown;
+    payTo?: unknown;
+    asset?: unknown;
+  };
+};
+
+export function parseCasperX402Config(raw: {
+  enabled?: unknown;
+  network?: unknown;
+  facilitatorUrl?: unknown;
+  payTo?: unknown;
+  asset?: unknown;
+}): CasperX402Config | null {
+  const parsed = casperConfigSchema.safeParse({
+    enabled: raw.enabled ?? false,
+    network: raw.network ?? CASPER_MAINNET,
+    facilitatorUrl: raw.facilitatorUrl ?? DEFAULT_CASPER_FACILITATOR_URL,
+    payTo: raw.payTo ?? '',
+    asset: raw.asset ?? '',
+  });
+
+  if (!parsed.success) {
+    logging.warn(
+      `Invalid machinePayments.casper config: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
+    );
+    return null;
+  }
+
+  if (!parsed.data.enabled) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
+export class CasperX402Adapter implements PaymentAdapter {
+  facilitatorClient?: FacilitatorClientLike;
+  name: string;
+
+  #config: CasperX402Config | null = null;
+  #facilitator: FacilitatorClientLike | null = null;
+  #scheme: unknown = null;
+  #runtime: CasperRuntimeModules | null = null;
+  #apps: BoundedRouteCache<CachedApp>;
+  #runtimeFactory?: () => CasperRuntimeModules;
+  #configProvider?: CasperX402AdapterDeps['configProvider'];
+  #ready = false;
+  #initAttempted = false;
+
+  constructor({
+    facilitatorClient,
+    maxCachedApps = CASPER_ROUTE_CACHE_LIMIT,
+    runtimeFactory,
+    configProvider,
+  }: CasperX402AdapterDeps = {}) {
+    this.facilitatorClient = facilitatorClient;
+    this.#apps = new BoundedRouteCache(maxCachedApps);
+    this.#runtimeFactory = runtimeFactory;
+    this.#configProvider = configProvider;
+    this.name = 'x402-casper';
+  }
+
+  get isReady(): boolean {
+    return this.#ready;
+  }
+
+  /**
+   * Boot-owned initialization. Never throws: an unconfigured, misconfigured or
+   * uninstallable Casper rail simply stays out of the adapter list.
+   */
+  async init(): Promise<boolean> {
+    if (this.#initAttempted) {
+      return this.#ready;
+    }
+
+    this.#initAttempted = true;
+
+    const rawConfig = this.#configProvider
+      ? this.#configProvider()
+      : {
+          enabled: config.get('machinePayments:casper:enabled'),
+          network: config.get('machinePayments:casper:network'),
+          facilitatorUrl: config.get('machinePayments:casper:facilitatorUrl'),
+          payTo: config.get('machinePayments:casper:payTo'),
+          asset: config.get('machinePayments:casper:asset'),
+        };
+
+    const parsedConfig = parseCasperX402Config(rawConfig);
+    if (!parsedConfig) {
+      return false;
+    }
+
+    try {
+      const runtime = this.#loadRuntimeModules();
+      const { HTTPFacilitatorClient, ExactCasperScheme } = runtime;
+
+      this.#config = parsedConfig;
+      this.#runtime = runtime;
+      this.#facilitator =
+        this.facilitatorClient || new HTTPFacilitatorClient({ url: parsedConfig.facilitatorUrl });
+      this.#scheme = new ExactCasperScheme();
+      this.#ready = true;
+      return true;
+    } catch (err) {
+      logging.warn(err);
+      this.#config = null;
+      this.#runtime = null;
+      this.#facilitator = null;
+      this.#scheme = null;
+      this.#ready = false;
+      return false;
+    }
+  }
+
+  canHandle(request: Request): boolean {
+    return Boolean(request.headers.get('x-payment') || request.headers.get('payment-signature'));
+  }
+
+  async challenge(request: Request, terms: PaymentTerms): Promise<Response | null> {
+    if (!this.#ready) {
+      return null;
+    }
+
+    try {
+      const response = await this.#dispatch(request, terms, { body: '' });
+      if (response.status === 402) {
+        return response;
+      }
+
+      logging.warn(`Casper x402 challenge unavailable for ${terms.url}: HTTP ${response.status}`);
+      return null;
+    } catch (err) {
+      logging.warn(err);
+      return null;
+    }
+  }
+
+  async fulfill(request: Request, terms: PaymentTerms): Promise<Fulfillment> {
+    if (!this.#ready || !this.#config) {
+      throw new errors.NoPermissionError({
+        message: 'Casper x402 payment credential rejected',
+      });
+    }
+
+    const response = await this.#dispatch(request, terms, { body: 'ok' });
+    if (response.status === 402) {
+      throw new errors.NoPermissionError({
+        message: 'Payment required',
+      });
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new errors.NoPermissionError({
+        message: 'Casper x402 payment credential rejected',
+      });
+    }
+
+    const paymentResponse =
+      response.headers.get('payment-response') || response.headers.get('X-PAYMENT-RESPONSE');
+    if (!paymentResponse) {
+      throw new errors.InternalServerError({
+        message: 'Casper x402 payment succeeded without a stable settlement reference',
+      });
+    }
+
+    return {
+      protocol: 'x402',
+      method: 'casper',
+      reference: settlementReference(paymentResponse),
+      amount: terms.amount,
+      currency: terms.currency,
+      stripePaymentIntentId: null,
+      receiptHeaders: { 'payment-response': paymentResponse },
+    };
+  }
+
+  async #dispatch(
+    request: Request,
+    terms: PaymentTerms,
+    responseData: DispatchOptions,
+  ): Promise<Response> {
+    if (!this.#config || !this.#runtime || !this.#facilitator || !this.#scheme) {
+      throw new errors.InternalServerError({
+        message: 'Casper x402 adapter used before boot initialization',
+      });
+    }
+
+    const { network, payTo, asset } = this.#config;
+    const method = (terms.method || 'GET').toUpperCase();
+    const route = `${method} ${new URL(terms.url).pathname}`;
+    const price = formatPrice(terms);
+    const cacheKey = `${route}:${payTo}:${price}:${network}:${asset}:${responseData.body ? 'fulfill' : 'challenge'}`;
+
+    let cached = this.#apps.get(cacheKey);
+    if (!cached) {
+      cached = this.#createApp({
+        route,
+        method,
+        network,
+        payTo,
+        asset,
+        price,
+        terms,
+        responseData,
+      });
+      this.#apps.set(cacheKey, cached);
+    }
+
+    return await cached.fetch(request);
+  }
+
+  #loadRuntimeModules(): CasperRuntimeModules {
+    if (this.#runtimeFactory) {
+      return this.#runtimeFactory();
+    }
+
+    const { paymentMiddlewareFromConfig } = require('@x402/hono') as {
+      paymentMiddlewareFromConfig: CasperRuntimeModules['paymentMiddlewareFromConfig'];
+    };
+    const { HTTPFacilitatorClient } = require('@x402/core/server') as {
+      HTTPFacilitatorClient: CasperRuntimeModules['HTTPFacilitatorClient'];
+    };
+    const { ExactCasperScheme } = require('@make-software/casper-x402/exact/server') as {
+      ExactCasperScheme: CasperRuntimeModules['ExactCasperScheme'];
+    };
+    const { Hono } = require('hono') as {
+      Hono: CasperRuntimeModules['Hono'];
+    };
+
+    return { paymentMiddlewareFromConfig, HTTPFacilitatorClient, ExactCasperScheme, Hono };
+  }
+
+  #createApp({
+    route,
+    method,
+    network,
+    payTo,
+    asset,
+    price,
+    terms,
+    responseData,
+  }: {
+    route: string;
+    method: string;
+    network: string;
+    payTo: string;
+    asset: string;
+    price: string;
+    terms: PaymentTerms;
+    responseData: DispatchOptions;
+  }): CachedApp {
+    if (!this.#runtime || !this.#facilitator || !this.#scheme) {
+      throw new errors.InternalServerError({
+        message: 'Casper x402 adapter used before boot initialization',
+      });
+    }
+
+    const { paymentMiddlewareFromConfig, Hono } = this.#runtime;
+
+    const app = new Hono();
+    app.use(
+      paymentMiddlewareFromConfig(
+        {
+          [route]: {
+            accepts: [
+              {
+                scheme: 'exact',
+                price,
+                network,
+                payTo,
+                asset,
+              },
+            ],
+            description: terms.description,
+            mimeType: terms.mimeType,
+          },
+        },
+        this.#facilitator,
+        [
+          {
+            network,
+            server: this.#scheme,
+          },
+        ],
+      ),
+    );
+
+    const handler = () =>
+      new Response(responseData.body, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+      });
+
+    if (method === 'GET') {
+      app.get('*', handler);
+    } else if (method === 'HEAD') {
+      app.on('HEAD', '*', handler);
+    } else {
+      app.on(method, '*', handler);
+    }
+
+    return { fetch: (request) => app.fetch(request) };
+  }
+}

--- a/ghost/core/core/server/services/machine-payments/index.js
+++ b/ghost/core/core/server/services/machine-payments/index.js
@@ -10,6 +10,7 @@ const { DepositAddressStore } = require('./stripe/deposit-address-store');
 const { PaymentRecorder } = require('./stripe/payment-recorder');
 const { MppAdapter } = require('./adapters/mpp-adapter');
 const { X402Adapter } = require('./adapters/x402-adapter');
+const { CasperX402Adapter } = require('./adapters/casper-x402-adapter');
 const { MachinePaymentEventRepository } = require('./events/machine-payment-event-repository');
 const { ContentLoader } = require('./content-loader');
 const { Pricing } = require('./pricing');
@@ -56,6 +57,11 @@ class MachinePaymentsServiceWrapper {
     const x402Adapter = new X402Adapter({ depositAddressStore });
     if (await x402Adapter.init()) {
       adapters.push(x402Adapter);
+    }
+
+    const casperX402Adapter = new CasperX402Adapter();
+    if (await casperX402Adapter.init()) {
+      adapters.push(casperX402Adapter);
     }
 
     this.service = new MachinePaymentsService({

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -283,6 +283,13 @@
       "stripeNetwork": "base",
       "facilitatorUrl": "https://facilitator.xpay.sh"
     },
+    "casper": {
+      "enabled": false,
+      "network": "casper:casper",
+      "facilitatorUrl": "https://x402-facilitator.cspr.cloud",
+      "payTo": null,
+      "asset": null
+    },
     "mpp": {
       "secretKey": null,
       "stripeNetwork": "tempo",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -81,6 +81,7 @@
     "@extractus/oembed-extractor": "3.2.1",
     "@faker-js/faker": "catalog:",
     "@isaacs/ttlcache": "1.4.1",
+    "@make-software/casper-x402": "catalog:",
     "@sentry/node": "7.120.4",
     "@slack/webhook": "7.1.0",
     "@tryghost/adapter-base-cache": "workspace:*",

--- a/ghost/core/test/unit/server/services/machine-payments/casper-adapter.test.js
+++ b/ghost/core/test/unit/server/services/machine-payments/casper-adapter.test.js
@@ -1,0 +1,364 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+const {
+  CasperX402Adapter,
+  parseCasperX402Config,
+} = require('../../../../../core/server/services/machine-payments/adapters/casper-x402-adapter');
+
+const WCSPR_PACKAGE_HASH = 'a'.repeat(64);
+
+function validConfig(overrides = {}) {
+  return {
+    enabled: true,
+    network: 'casper:casper',
+    facilitatorUrl: 'https://x402-facilitator.cspr.cloud',
+    payTo: '0203f1c4b9b1a1f4a2b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f6071829',
+    asset: WCSPR_PACKAGE_HASH,
+    ...overrides,
+  };
+}
+
+function createCasperRuntimeFactory({ response } = {}) {
+  let honoCreateCount = 0;
+
+  return {
+    get honoCreateCount() {
+      return honoCreateCount;
+    },
+    factory: () => ({
+      paymentMiddlewareFromConfig: () => () => {},
+      HTTPFacilitatorClient: class {},
+      ExactCasperScheme: class {},
+      Hono: class {
+        constructor() {
+          honoCreateCount += 1;
+        }
+
+        use() {}
+
+        get() {}
+
+        on() {}
+
+        fetch() {
+          return Promise.resolve(
+            response ? response() : new Response('', { status: 402 }),
+          );
+        }
+      },
+    }),
+  };
+}
+
+function createCasperAdapter(overrides = {}) {
+  return new CasperX402Adapter({
+    facilitatorClient: {},
+    configProvider: () => validConfig(),
+    runtimeFactory: createCasperRuntimeFactory().factory,
+    ...overrides,
+  });
+}
+
+async function initCasperAdapter(overrides = {}) {
+  const adapter = createCasperAdapter(overrides);
+  await adapter.init();
+  return adapter;
+}
+
+describe('Unit: server/services/machine-payments/adapters/casper-x402-adapter', function () {
+  const terms = {
+    amount: 100,
+    currency: 'USD',
+    description: 'Paid post',
+    method: 'GET',
+    mimeType: 'text/markdown',
+    url: 'http://example.com/paid-post.md',
+  };
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('parseCasperX402Config', function () {
+    it('accepts a valid mainnet config', function () {
+      const parsed = parseCasperX402Config(validConfig());
+
+      assert.equal(parsed.network, 'casper:casper');
+      assert.equal(parsed.asset, WCSPR_PACKAGE_HASH);
+      assert.equal(parsed.facilitatorUrl, 'https://x402-facilitator.cspr.cloud');
+    });
+
+    it('accepts a valid testnet config', function () {
+      const parsed = parseCasperX402Config(validConfig({ network: 'casper:casper-test' }));
+
+      assert.equal(parsed.network, 'casper:casper-test');
+    });
+
+    it('returns null when the rail is disabled', function () {
+      assert.equal(parseCasperX402Config(validConfig({ enabled: false })), null);
+    });
+
+    it('rejects a non-HTTPS facilitator', function () {
+      sinon.stub(logging, 'warn');
+
+      assert.equal(
+        parseCasperX402Config(validConfig({ facilitatorUrl: 'http://facilitator.example' })),
+        null,
+      );
+      assert.match(String(logging.warn.firstCall.args[0]), /must use HTTPS/);
+    });
+
+    it('rejects a non-Casper CAIP-2 network', function () {
+      sinon.stub(logging, 'warn');
+
+      assert.equal(parseCasperX402Config(validConfig({ network: 'eip155:8453' })), null);
+      assert.match(String(logging.warn.firstCall.args[0]), /CAIP-2 Casper network/);
+    });
+
+    it('rejects an unknown Casper chain name', function () {
+      sinon.stub(logging, 'warn');
+
+      assert.equal(parseCasperX402Config(validConfig({ network: 'casper:integration' })), null);
+      assert.match(String(logging.warn.firstCall.args[0]), /casper:casper-test/);
+    });
+
+    it('rejects a missing payTo address', function () {
+      sinon.stub(logging, 'warn');
+
+      assert.equal(parseCasperX402Config(validConfig({ payTo: null })), null);
+      assert.match(String(logging.warn.firstCall.args[0]), /payTo must be a Casper address/);
+    });
+
+    it('rejects an asset that is not a CEP-18 contract package hash', function () {
+      sinon.stub(logging, 'warn');
+
+      assert.equal(
+        parseCasperX402Config(validConfig({ asset: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174' })),
+        null,
+      );
+      assert.match(String(logging.warn.firstCall.args[0]), /CEP-18 contract package hash/);
+    });
+  });
+
+  describe('CasperX402Adapter', function () {
+    it('is named x402-casper and takes no deposit address store', function () {
+      const adapter = new CasperX402Adapter();
+
+      assert.equal(adapter.name, 'x402-casper');
+      assert.equal(adapter.depositAddressStore, undefined);
+    });
+
+    it('is disabled by default', async function () {
+      const adapter = new CasperX402Adapter({
+        configProvider: () => ({}),
+        runtimeFactory: createCasperRuntimeFactory().factory,
+      });
+
+      assert.equal(await adapter.init(), false);
+      assert.equal(adapter.isReady, false);
+      assert.equal(await adapter.challenge(new Request('http://example.com/paid.md'), terms), null);
+    });
+
+    it('stays disabled when payTo is not configured', async function () {
+      sinon.stub(logging, 'warn');
+      const adapter = new CasperX402Adapter({
+        configProvider: () => validConfig({ payTo: '' }),
+        runtimeFactory: createCasperRuntimeFactory().factory,
+      });
+
+      assert.equal(await adapter.init(), false);
+      assert.equal(adapter.isReady, false);
+    });
+
+    it('stays disabled and warns when the Casper runtime cannot be loaded', async function () {
+      sinon.stub(logging, 'warn');
+      const adapter = createCasperAdapter({
+        runtimeFactory: () => {
+          throw new Error('Cannot find module @make-software/casper-x402/exact/server');
+        },
+      });
+
+      assert.equal(await adapter.init(), false);
+      assert.equal(adapter.isReady, false);
+      assert.match(String(logging.warn.firstCall.args[0]), /casper-x402/);
+    });
+
+    it('initializes runtime modules and facilitator once at boot', async function () {
+      let runtimeLoads = 0;
+      const adapter = createCasperAdapter({
+        runtimeFactory: () => {
+          runtimeLoads += 1;
+          return createCasperRuntimeFactory().factory();
+        },
+      });
+
+      assert.equal(await adapter.init(), true);
+      assert.equal(adapter.isReady, true);
+      assert.equal(runtimeLoads, 1);
+
+      await adapter.challenge(new Request('http://example.com/a.md'), terms);
+      assert.equal(runtimeLoads, 1);
+      assert.equal(await adapter.init(), true);
+      assert.equal(runtimeLoads, 1);
+    });
+
+    it('detects x-payment and payment-signature credentials', function () {
+      const adapter = new CasperX402Adapter();
+
+      assert.equal(adapter.canHandle(new Request('http://example.com/paid.md')), false);
+      assert.equal(
+        adapter.canHandle(
+          new Request('http://example.com/paid.md', { headers: { 'x-payment': 'abc' } }),
+        ),
+        true,
+      );
+      assert.equal(
+        adapter.canHandle(
+          new Request('http://example.com/paid.md', { headers: { 'payment-signature': 'abc' } }),
+        ),
+        true,
+      );
+    });
+
+    it('returns the 402 challenge response', async function () {
+      const adapter = await initCasperAdapter();
+
+      const challenge = await adapter.challenge(new Request('http://example.com/paid.md'), terms);
+
+      assert.ok(challenge);
+      assert.equal(challenge.status, 402);
+    });
+
+    it('logs and returns null when the middleware does not produce a 402', async function () {
+      sinon.stub(logging, 'warn');
+      const adapter = await initCasperAdapter({
+        runtimeFactory: createCasperRuntimeFactory({
+          response: () => new Response('', { status: 500 }),
+        }).factory,
+      });
+
+      const challenge = await adapter.challenge(new Request('http://example.com/paid.md'), terms);
+
+      assert.equal(challenge, null);
+      assert.match(String(logging.warn.firstCall.args[0]), /Casper x402 challenge unavailable/);
+    });
+
+    it('reuses the cached route app for identical terms', async function () {
+      const runtime = createCasperRuntimeFactory();
+      const adapter = await initCasperAdapter({ runtimeFactory: runtime.factory });
+
+      await adapter.challenge(new Request('http://example.com/a.md'), terms);
+      await adapter.challenge(new Request('http://example.com/a.md'), terms);
+      await adapter.challenge(new Request('http://example.com/a.md'), terms);
+
+      assert.equal(runtime.honoCreateCount, 1);
+
+      await adapter.challenge(new Request('http://example.com/b.md'), {
+        ...terms,
+        url: 'http://example.com/b.md',
+      });
+
+      assert.equal(runtime.honoCreateCount, 2);
+    });
+
+    it('fulfills with protocol x402, method casper and the settlement reference', async function () {
+      const paymentResponse = Buffer.from(
+        JSON.stringify({ transaction: 'casper-deploy-hash' }),
+      ).toString('base64');
+
+      const adapter = await initCasperAdapter({
+        runtimeFactory: createCasperRuntimeFactory({
+          response: () =>
+            new Response('ok', {
+              status: 200,
+              headers: { 'payment-response': paymentResponse },
+            }),
+        }).factory,
+      });
+
+      const fulfillment = await adapter.fulfill(
+        new Request('http://example.com/paid.md', { headers: { 'x-payment': 'abc' } }),
+        terms,
+      );
+
+      assert.equal(fulfillment.protocol, 'x402');
+      assert.equal(fulfillment.method, 'casper');
+      assert.equal(fulfillment.reference, 'casper-deploy-hash');
+      assert.equal(fulfillment.amount, 100);
+      assert.equal(fulfillment.currency, 'USD');
+      assert.equal(fulfillment.stripePaymentIntentId, null);
+      assert.equal(fulfillment.receiptHeaders['payment-response'], paymentResponse);
+    });
+
+    it('rejects fulfill when the rail is not ready', async function () {
+      const adapter = new CasperX402Adapter({ configProvider: () => ({}) });
+      await adapter.init();
+
+      await assert.rejects(
+        () =>
+          adapter.fulfill(
+            new Request('http://example.com/paid.md', { headers: { 'x-payment': 'abc' } }),
+            terms,
+          ),
+        /Casper x402 payment credential rejected/,
+      );
+    });
+
+    it('rejects fulfill on a 402 response', async function () {
+      const adapter = await initCasperAdapter();
+
+      await assert.rejects(
+        () =>
+          adapter.fulfill(
+            new Request('http://example.com/paid.md', { headers: { 'x-payment': 'abc' } }),
+            terms,
+          ),
+        /Payment required/,
+      );
+    });
+
+    it('rejects fulfill on a non-2xx response', async function () {
+      const adapter = await initCasperAdapter({
+        runtimeFactory: createCasperRuntimeFactory({
+          response: () => new Response('', { status: 500 }),
+        }).factory,
+      });
+
+      await assert.rejects(
+        () =>
+          adapter.fulfill(
+            new Request('http://example.com/paid.md', { headers: { 'x-payment': 'abc' } }),
+            terms,
+          ),
+        /Casper x402 payment credential rejected/,
+      );
+    });
+
+    it('rejects fulfill when the payment-response header is missing', async function () {
+      const adapter = await initCasperAdapter({
+        runtimeFactory: createCasperRuntimeFactory({
+          response: () => new Response('ok', { status: 200 }),
+        }).factory,
+      });
+
+      await assert.rejects(
+        () =>
+          adapter.fulfill(
+            new Request('http://example.com/paid.md', { headers: { 'x-payment': 'abc' } }),
+            terms,
+          ),
+        /stable settlement reference/,
+      );
+    });
+
+    it('rejects non-USD terms', async function () {
+      const adapter = await initCasperAdapter();
+
+      await assert.rejects(
+        () => adapter.fulfill(new Request('http://example.com/paid.md'), { ...terms, currency: 'EUR' }),
+        /USD only/,
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ catalogs:
     '@faker-js/faker':
       specifier: 10.5.0
       version: 10.5.0
+    '@make-software/casper-x402':
+      specifier: 1.0.0
+      version: 1.0.0
     '@octokit/core':
       specifier: 7.0.7
       version: 7.0.7
@@ -2215,6 +2218,9 @@ importers:
       '@isaacs/ttlcache':
         specifier: 1.4.1
         version: 1.4.1
+      '@make-software/casper-x402':
+        specifier: 'catalog:'
+        version: 1.0.0(debug@4.4.3(supports-color@10.2.2))(encoding@0.1.13)(supports-color@10.2.2)
       '@sentry/node':
         specifier: 7.120.4
         version: 7.120.4
@@ -5054,6 +5060,12 @@ packages:
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
+  '@casper-ecosystem/casper-eip-712@1.2.1':
+    resolution: {integrity: sha512-qhrpaISByIoOnbELH7hhLMVBinIP1vOc4Z+6ZI5aItcc1O3SrDXNu0fdKm5qRSLLb5p94JxaS+jGegiIAwiKDA==}
+
+  '@casperlabs/ts-results@3.3.5':
+    resolution: {integrity: sha512-ymSQqqb4mOSet592li02u1Gd28LoOFJUm6R3jkdNQ+nqsnbHvN+izBigtP4aYmNwh6gFyCwDgjYporEJgDT4eA==}
+
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
@@ -5880,6 +5892,18 @@ packages:
     peerDependencies:
       storybook: ^10.0.0
 
+  '@ethersproject/bignumber@5.8.0':
+    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
+
+  '@ethersproject/bytes@5.8.0':
+    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
+
+  '@ethersproject/constants@5.8.0':
+    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
+
+  '@ethersproject/logger@5.8.0':
+    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
+
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -6595,6 +6619,9 @@ packages:
     resolution: {integrity: sha512-F5z53uvRIF4dYfFfJP3a2Cqg+4P1dgJchJsFnsZE0eZp0LK8X7g2J0CsJHRgns+skpXOlM7n5vFGwkWCWj8qJg==}
     engines: {node: 12.* || >= 14}
 
+  '@make-software/casper-x402@1.0.0':
+    resolution: {integrity: sha512-Etn6CCzHpA5dxhJcBhoFvZNDxc271Gg2TU+HoVmAsuKE5/SZYqbePC4OvHT9ZzpqzBEcLlenTQSn255NpFEdjg==}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -6652,9 +6679,15 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ed25519@1.7.5':
+    resolution: {integrity: sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/secp256k1@1.7.2':
+    resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -10405,6 +10438,9 @@ packages:
   '@x402/core@2.12.0':
     resolution: {integrity: sha512-dLae9AbZRN/W7GsKe9ngqGsflnP+esE72s0GjmqDZbPihM/tlHCA6UnDdgM0qfOiDOf9iL+mmCs1OyLWpwnGLQ==}
 
+  '@x402/core@2.15.0':
+    resolution: {integrity: sha512-Hwop1cu80sf3H4dpNdiMJt7ay30Jf7JUjgx7dXHxQm/nYqOjTcm71FC/ZhpnIpeg6RSAUt7EI/rFTXx/lafHhw==}
+
   '@x402/evm@2.12.0':
     resolution: {integrity: sha512-kZUoHPVdBS8wlTg5K1eoh/1V0+5n9ABGRPC5DOQwRlkAwIrAFOEi2pQE+jgvOx0iM5ib2xj9gJjpldRbasX12w==}
 
@@ -11892,6 +11928,10 @@ packages:
   cardinal@1.0.0:
     resolution: {integrity: sha512-INsuF4GyiFLk8C91FPokbKTc/rwHqV4JnfatVZ6GPhguP1qmkRWX2dp5tepYboYdPpGWisLVLI+KsXoXFPRSMg==}
     hasBin: true
+
+  casper-js-sdk@5.0.12:
+    resolution: {integrity: sha512-2jzJ2joQRESSeQ1I7Za5w2fBfBSncTRl24roLtgX4zK1kzJj7YYJZEpVugtZaNa5ZgV3sJOp2qSSl6WYTkwniQ==}
+    engines: {node: '>=18'}
 
   ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -14290,6 +14330,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -15434,6 +15478,9 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  humanize-duration@3.34.0:
+    resolution: {integrity: sha512-NDxhYxiiRzsST6xULIHuYWRvsCtviJXRdjarhyWyh78S4Ou+MWhM2k4HQ+y7iegdrzreXe11isd0au1N2PB/pQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -17919,6 +17966,15 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
+  node-fetch@2.6.13:
+    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -20059,6 +20115,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  reflect-metadata@0.1.14:
+    resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -21702,6 +21761,9 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typedjson@1.8.0:
+    resolution: {integrity: sha512-taVJVGebQDagEmVc3Cu6vVVLkWLnxqPcTrkVgbpAsI02ZDDrnHy5zvt1JVqXv4/yztBgZAX1oR07+bkiusGJLQ==}
 
   typescript-eslint@8.67.0:
     resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
@@ -23966,6 +24028,15 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
+  '@casper-ecosystem/casper-eip-712@1.2.1':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+
+  '@casperlabs/ts-results@3.3.5':
+    dependencies:
+      tslib: 2.8.1
+
   '@cfworker/json-schema@4.1.1': {}
 
   '@cnakazawa/watch@1.0.4':
@@ -24962,6 +25033,22 @@ snapshots:
       lodash: 4.18.1
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  '@ethersproject/bignumber@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      bn.js: 5.2.3
+
+  '@ethersproject/bytes@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/constants@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+
+  '@ethersproject/logger@5.8.0': {}
+
   '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
@@ -25882,6 +25969,16 @@ snapshots:
       tslib: 2.8.1
       upath: 2.0.1
 
+  '@make-software/casper-x402@1.0.0(debug@4.4.3(supports-color@10.2.2))(encoding@0.1.13)(supports-color@10.2.2)':
+    dependencies:
+      '@casper-ecosystem/casper-eip-712': 1.2.1
+      '@x402/core': 2.15.0
+      casper-js-sdk: 5.0.12(debug@4.4.3(supports-color@10.2.2))(encoding@0.1.13)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1(supports-color@10.2.2)':
@@ -26018,7 +26115,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/ed25519@1.7.5': {}
+
   '@noble/hashes@1.8.0': {}
+
+  '@noble/secp256k1@1.7.2': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -30496,6 +30597,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@x402/core@2.15.0':
+    dependencies:
+      zod: 3.25.76
+
   '@x402/evm@2.12.0':
     dependencies:
       '@x402/core': 2.12.0
@@ -32757,6 +32862,32 @@ snapshots:
     dependencies:
       ansicolors: 0.2.1
       redeyed: 1.0.1
+
+  casper-js-sdk@5.0.12(debug@4.4.3(supports-color@10.2.2))(encoding@0.1.13)(supports-color@10.2.2):
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@noble/curves': 1.9.7
+      '@noble/ed25519': 1.7.5
+      '@noble/hashes': 1.8.0
+      '@noble/secp256k1': 1.7.2
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      asn1.js: 5.4.1
+      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      bn.js: 5.2.3
+      eventsource: 2.0.2
+      glob: 7.2.3
+      humanize-duration: 3.34.0
+      node-fetch: 2.6.13(encoding@0.1.13)
+      reflect-metadata: 0.1.14
+      ts-results: '@casperlabs/ts-results@3.3.5'
+      typedjson: 1.8.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
 
   ccount@1.1.0: {}
 
@@ -36539,6 +36670,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource@2.0.2: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -38157,6 +38290,8 @@ snapshots:
     optional: true
 
   human-signals@8.0.1: {}
+
+  humanize-duration@3.34.0: {}
 
   husky@9.1.7: {}
 
@@ -41381,6 +41516,12 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-fetch@2.6.13(encoding@0.1.13):
+    dependencies:
+      whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
+
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -43822,6 +43963,8 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  reflect-metadata@0.1.14: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -45956,6 +46099,10 @@ snapshots:
       is-typedarray: 1.0.0
 
   typedarray@0.0.6: {}
+
+  typedjson@1.8.0:
+    dependencies:
+      tslib: 2.8.1
 
   typescript-eslint@8.67.0(@typescript/typescript6@6.0.2)(eslint@9.39.4(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -197,6 +197,7 @@ catalog:
   shell-quote: 1.10.0
   unidecode: 1.1.0
   mppx: 0.6.20
+  '@make-software/casper-x402': 1.0.0
   '@x402/core': 2.12.0
   '@x402/evm': 2.12.0
   '@x402/hono': 2.12.0


### PR DESCRIPTION
Adds the Casper Network as an additional x402 machine-payments rail, alongside the existing Base/EVM x402 rail and MPP.

**Why are you making it?**

The machine-payments orchestrator is explicitly multi-adapter-ready — adapters only implement `canHandle` / `challenge` / `fulfill` — so adding a settlement rail is purely additive. Casper is a WASM L1 with a live x402 implementation: its `exact` scheme settles wCSPR (a CEP-18 token) via `transfer_with_authorization` calls authorized by EIP-712 typed-data signatures, relayed by the cspr.cloud facilitator. Publishers who want to accept payments there can now do so without any change to how existing agents pay; agents that don't speak Casper just ignore the extra `accepts` entry.

**What does it do?**

- New `CasperX402Adapter` (`name: 'x402-casper'`) built as a close sibling of the existing `X402Adapter`, reusing its `BoundedRouteCache`, `formatPrice` and `settlementReference` helpers rather than duplicating them.
- New `machinePayments.casper` config block: `enabled` (default `false`), `network` (`casper:casper` or `casper:casper-test`), `facilitatorUrl` (HTTPS, defaults to the cspr.cloud facilitator), `payTo` and `asset`. Config is zod-validated at boot; anything invalid logs a warning and leaves the rail unregistered — it never throws.
- Wired into the service exactly like the Base rail: constructed, then pushed only if `await adapter.init()` resolves true.
- README section documenting the config, the two supported CAIP-2 networks and the wCSPR/CEP-18 settlement model.

Two things differ from the Base rail and are the reason this is a separate adapter rather than configuration of the existing one:

1. `payTo` cannot come from the Stripe `DepositAddressStore` — Stripe mints no Casper deposit addresses — so the Casper rail takes an explicit publisher-configured address and no deposit-address-store dependency.
2. The settlement asset is a CEP-18 contract package hash (64 hex chars), not an `0x` EVM contract address, so `accepts` carries an explicit `asset`. `Fulfillment.method` is `casper` (not a Stripe network); `protocol` stays `x402`.

**Why is this something Ghost users or developers need?**

It widens the set of agents that can pay for gated content without touching membership or content gating, and it does so behind an off-by-default flag: with no configuration, default install behaviour is byte-identical to today and the Base and MPP rails are untouched.

**Testing**

`ghost/core/test/unit/server/services/machine-payments/casper-adapter.test.js` covers config parsing (valid mainnet/testnet, non-HTTPS facilitator, bad CAIP-2 network, missing `payTo`, non-CEP-18 asset), disabled-by-default, graceful degradation when the runtime module is unavailable, header detection, the 402 challenge path, route-app caching, and the fulfill success/402/non-2xx/missing-header paths.

```
Test Files  7 passed (7)
     Tests  73 passed (73)
```

(73 = the 26 pre-existing adapter tests plus the rest of the machine-payments unit suite, all still green.)

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
