### PR TITLE
Fixed the Admin import error CSV to use the members export format

### DIFF
--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
@@ -38,6 +38,7 @@ describe('csv helpers', () => {
         name: 'Alice',
         email: 'bad@example.com',
         subscribed: true,
+        complimentary_plan: false,
         labels: [{ name: 'vip' }, { name: 'gold' }],
         error: 'Invalid email, "quote"',
       },
@@ -50,6 +51,20 @@ describe('csv helpers', () => {
     expect(output.split('\n')[1]).toContain('"true"');
     expect(output).not.toContain('[object Object]');
     expect(output).toContain('"Invalid email, ""quote"""');
+  });
+
+  it('does not invent subscription columns when the source omitted them', () => {
+    const output = unparseErrorCSV([
+      {
+        email: 'a@example.com',
+        labels: [],
+        error: 'nope',
+      },
+    ]);
+
+    const [header] = output.split('\r\n');
+    expect(header).not.toContain('subscribed_to_emails');
+    expect(header).not.toContain('complimentary_plan');
   });
 
   it('drops malformed label entries instead of crashing the download', () => {

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
@@ -65,6 +65,18 @@ describe('csv helpers', () => {
     expect(output).not.toContain('[object Object]');
   });
 
+  it('escapes formula-like values before writing the downloadable CSV', () => {
+    const output = unparseErrorCSV([
+      {
+        name: '=1+2',
+        email: 'a@example.com',
+        error: 'nope',
+      },
+    ]);
+
+    expect(output).toContain(`"'=1+2"`);
+  });
+
   it('keeps a column carried only by a later row, with the error column last', () => {
     const output = unparseErrorCSV([
       { email: 'a@example.com', labels: [], error: 'nope' },

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
@@ -32,16 +32,38 @@ describe('csv helpers', () => {
     ]);
   });
 
-  it('serializes error rows to a downloadable CSV string', () => {
+  it('serializes error rows into the members export format', () => {
     const output = unparseErrorCSV([
       {
         name: 'Alice',
         email: 'bad@example.com',
+        subscribed: true,
+        labels: [{ name: 'vip' }, { name: 'gold' }],
         error: 'Invalid email, "quote"',
       },
     ]);
 
-    expect(output).toContain('"name","email","error"');
-    expect(output).toContain('"Alice","bad@example.com","Invalid email, ""quote"""');
+    expect(output).toContain(
+      '"email","name","note","subscribed_to_emails","complimentary_plan","stripe_customer_id","created_at","labels","gift_id","error"',
+    );
+    expect(output).toContain('"vip,gold"');
+    expect(output).not.toContain('[object Object]');
+    expect(output).toContain('"Invalid email, ""quote"""');
+  });
+
+  it('carries the newsletters column only when the submitted file did', () => {
+    const withColumn = unparseErrorCSV([
+      {
+        email: 'a@example.com',
+        labels: [],
+        newsletters: [{ name: 'Daily News' }],
+        error: 'nope',
+      },
+    ]);
+    expect(withColumn).toContain('"newsletters"');
+    expect(withColumn).toContain('"Daily News"');
+
+    const withoutColumn = unparseErrorCSV([{ email: 'a@example.com', labels: [], error: 'nope' }]);
+    expect(withoutColumn.split('\n')[0]).not.toContain('newsletters');
   });
 });

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
@@ -47,8 +47,22 @@ describe('csv helpers', () => {
       '"email","name","note","subscribed_to_emails","complimentary_plan","stripe_customer_id","created_at","labels","gift_id","error"',
     );
     expect(output).toContain('"vip,gold"');
+    expect(output.split('\n')[1]).toContain('"true"');
     expect(output).not.toContain('[object Object]');
     expect(output).toContain('"Invalid email, ""quote"""');
+  });
+
+  it('drops malformed label entries instead of crashing the download', () => {
+    const output = unparseErrorCSV([
+      {
+        email: 'a@example.com',
+        labels: [null, { name: 'vip' }, 42, { name: 'gold' }],
+        error: 'nope',
+      },
+    ]);
+
+    expect(output).toContain('"vip,gold"');
+    expect(output).not.toContain('[object Object]');
   });
 
   it('keeps a column carried only by a later row, with the error column last', () => {

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.test.ts
@@ -51,6 +51,24 @@ describe('csv helpers', () => {
     expect(output).toContain('"Invalid email, ""quote"""');
   });
 
+  it('keeps a column carried only by a later row, with the error column last', () => {
+    const output = unparseErrorCSV([
+      { email: 'a@example.com', labels: [], error: 'nope' },
+      {
+        email: 'b@example.com',
+        labels: [],
+        newsletters: [{ name: 'Daily News' }],
+        'custom_fields.topic': 'ghosts',
+        error: 'nope',
+      },
+    ]);
+
+    const header = output.split('\n')[0].trimEnd();
+    expect(header).toContain('"newsletters"');
+    expect(header).toContain('"custom_fields.topic"');
+    expect(header.endsWith('"error"')).toBe(true);
+  });
+
   it('carries the newsletters column only when the submitted file did', () => {
     const withColumn = unparseErrorCSV([
       {

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
@@ -24,12 +24,71 @@ export function parseCSV(text: string): Record<string, string>[] {
   });
 }
 
-export function unparseErrorCSV(rows: Array<Record<string, string> & { error: string }>): string {
+// The API hands back the raw import rows, where labels and newsletters are arrays of
+// {name} objects and field names are internal (subscribed, not subscribed_to_emails).
+// Downloaded as-is they render as [object Object] and cannot be fixed and re-uploaded,
+// so rows are shaped into the members export vocabulary first, matching the emailed
+// error report. The newsletters column only appears when the submitted file carried
+// one: an empty cell in that column reads back as an explicit "no newsletters".
+type RawErrorRow = Record<string, unknown> & { error: string };
+
+function joinNames(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === 'string' ? item : ((item as { name?: string }).name ?? '')))
+      .filter(Boolean)
+      .join(',');
+  }
+  return '';
+}
+
+function cell(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return '';
+}
+
+function toExportErrorRow(row: RawErrorRow): Record<string, string> {
+  const shaped: Record<string, string> = {
+    email: cell(row.email),
+    name: cell(row.name),
+    note: cell(row.note),
+    subscribed_to_emails: cell(row.subscribed),
+    complimentary_plan: cell(row.complimentary_plan),
+    stripe_customer_id: cell(row.stripe_customer_id),
+    created_at: cell(row.created_at),
+    labels: joinNames(row.labels),
+  };
+
+  if (row.newsletters !== undefined) {
+    shaped.newsletters = joinNames(row.newsletters);
+  }
+
+  for (const [key, value] of Object.entries(row)) {
+    if (key.startsWith('custom_fields.')) {
+      shaped[key] = cell(value);
+    }
+  }
+
+  shaped.gift_id = cell(row.gift_id);
+  shaped.error = cell(row.error);
+
+  return shaped;
+}
+
+export function unparseErrorCSV(rows: RawErrorRow[]): string {
   if (rows.length === 0) {
     return '';
   }
 
-  return Papa.unparse(rows, {
+  return Papa.unparse(rows.map(toExportErrorRow), {
     quotes: true,
   });
 }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
@@ -71,13 +71,18 @@ function toExportErrorRow(row: RawErrorRow): Record<string, string> {
     email: cell(row.email),
     name: cell(row.name),
     note: cell(row.note),
-    subscribed_to_emails: cell(row.subscribed),
-    complimentary_plan: cell(row.complimentary_plan),
+    ...(row.subscribed !== undefined ? { subscribed_to_emails: cell(row.subscribed) } : {}),
+    ...(row.complimentary_plan !== undefined
+      ? { complimentary_plan: cell(row.complimentary_plan) }
+      : {}),
     stripe_customer_id: cell(row.stripe_customer_id),
     created_at: cell(row.created_at),
     labels: joinNames(row.labels),
   };
 
+  // An absent subscription column must stay absent. The importer treats a present
+  // blank subscribed_to_emails cell as true, so inventing this column would change
+  // subscription state when the error report is re-uploaded.
   if (row.newsletters !== undefined) {
     shaped.newsletters = joinNames(row.newsletters);
   }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
@@ -88,7 +88,23 @@ export function unparseErrorCSV(rows: RawErrorRow[]): string {
     return '';
   }
 
-  return Papa.unparse(rows.map(toExportErrorRow), {
+  const shaped = rows.map(toExportErrorRow);
+
+  // Columns come from every row, not just the first: Papa.unparse otherwise takes the
+  // header from the first row's keys, dropping an optional column (newsletters, a
+  // custom field) that only a later row carries. The error column stays last.
+  const columns: string[] = [];
+  for (const row of shaped) {
+    for (const key of Object.keys(row)) {
+      if (key !== 'error' && !columns.includes(key)) {
+        columns.push(key);
+      }
+    }
+  }
+  columns.push('error');
+
+  return Papa.unparse(shaped, {
     quotes: true,
+    columns,
   });
 }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
@@ -1,4 +1,5 @@
 import Papa from 'papaparse';
+import { z } from 'zod';
 
 export function parseCSV(text: string): Record<string, string>[] {
   const parsed = Papa.parse(text, {
@@ -30,19 +31,29 @@ export function parseCSV(text: string): Record<string, string>[] {
 // so rows are shaped into the members export vocabulary first, matching the emailed
 // error report. The newsletters column only appears when the submitted file carried
 // one: an empty cell in that column reads back as an explicit "no newsletters".
-type RawErrorRow = Record<string, unknown> & { error: string };
+const nameEntrySchema = z.union([z.string(), z.object({ name: z.string() })]);
+
+const rawErrorRowSchema = z.object({ error: z.string().catch('') }).catchall(z.unknown());
+
+type RawErrorRow = z.infer<typeof rawErrorRowSchema>;
 
 function joinNames(value: unknown): string {
   if (typeof value === 'string') {
     return value;
   }
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => (typeof item === 'string' ? item : ((item as { name?: string }).name ?? '')))
-      .filter(Boolean)
-      .join(',');
+  if (!Array.isArray(value)) {
+    return '';
   }
-  return '';
+  return value
+    .map((item) => {
+      const parsed = nameEntrySchema.safeParse(item);
+      if (!parsed.success) {
+        return '';
+      }
+      return typeof parsed.data === 'string' ? parsed.data : parsed.data.name;
+    })
+    .filter(Boolean)
+    .join(',');
 }
 
 function cell(value: unknown): string {
@@ -83,12 +94,12 @@ function toExportErrorRow(row: RawErrorRow): Record<string, string> {
   return shaped;
 }
 
-export function unparseErrorCSV(rows: RawErrorRow[]): string {
+export function unparseErrorCSV(rows: unknown[]): string {
   if (rows.length === 0) {
     return '';
   }
 
-  const shaped = rows.map(toExportErrorRow);
+  const shaped = rows.map((row) => toExportErrorRow(rawErrorRowSchema.parse(row)));
 
   // Columns come from every row, not just the first: Papa.unparse otherwise takes the
   // header from the first row's keys, dropping an optional column (newsletters, a

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/csv.ts
@@ -116,6 +116,7 @@ export function unparseErrorCSV(rows: unknown[]): string {
 
   return Papa.unparse(shaped, {
     quotes: true,
+    escapeFormulae: true,
     columns,
   });
 }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/upload.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/upload.test.ts
@@ -215,6 +215,29 @@ describe('buildImportResponse', () => {
     expect(result.errorList).toEqual([]);
   });
 
+  it('handles malformed invalid rows without crashing the error download', async () => {
+    const result = buildImportResponse({
+      meta: {
+        stats: {
+          imported: 0,
+          invalid: [
+            null as never,
+            {
+              email: 'bad@example.com',
+              errors: 'not-an-array' as never,
+              error: 'bad row',
+            },
+          ],
+        },
+      },
+    });
+
+    const csv = await (mockCreateObjectURL.mock.calls[0][0] as Blob).text();
+    expect(result.errorCount).toBe(2);
+    expect(result.errorList).toEqual([]);
+    expect(csv).toContain('"error"');
+  });
+
   it('creates a downloadable blob URL for the error CSV', () => {
     buildImportResponse({
       meta: {
@@ -237,8 +260,9 @@ describe('buildImportResponse', () => {
     expect(blob.type).toBe('text/csv');
   });
 
-  it('writes the error file with the submitted columns and no others', async () => {
-    // The file echoes the row back, so every key on it becomes a column.
+  it('writes the error file with export columns and submitted custom fields', async () => {
+    // The file uses the members export vocabulary, then carries through custom fields
+    // from the submitted row so the failed data can be fixed and re-uploaded.
     buildImportResponse({
       meta: {
         stats: {
@@ -264,7 +288,10 @@ describe('buildImportResponse', () => {
     // CRLF between rows; a reason may itself contain a bare newline.
     const [header] = csv.split('\r\n');
 
-    expect(header).toBe('"email","custom_fields.home_address.country","error"');
+    expect(header).toBe(
+      '"email","name","note","stripe_customer_id","created_at","labels","custom_fields.home_address.country","gift_id","error"',
+    );
+    expect(csv).toContain('"IRL"');
     expect(csv).toContain(
       '"Missing email address\ncustom_fields.home_address.country: Enter a 2-letter country code, like US."',
     );

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/upload.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/upload.ts
@@ -1,16 +1,27 @@
 import moment from 'moment-timezone';
+import { z } from 'zod';
 import { type ImportMembersCompleteResponseType } from '@tryghost/admin-x-framework/api/members';
 import { type ImportResponse } from './state';
 import { formatImportError } from './mapping';
 import { unparseErrorCSV } from './csv';
 
+const invalidImportRowSchema = z
+  .object({
+    errors: z.array(z.string()).catch([]),
+  })
+  .catchall(z.unknown());
+
 export function buildImportResponse(importData: ImportMembersCompleteResponseType): ImportResponse {
   const importedCount = importData.meta.stats.imported;
-  const erroredMembers = importData.meta.stats.invalid || [];
+  const erroredMembers = Array.isArray(importData.meta.stats.invalid)
+    ? importData.meta.stats.invalid
+    : [];
   const errorCount = erroredMembers.length;
   const errorListMap: Record<string, { message: string; count: number }> = {};
 
-  const errorsWithFormattedMessages = erroredMembers.map((row) => {
+  const errorsWithFormattedMessages = erroredMembers.map((rawRow) => {
+    const parsedRow = invalidImportRowSchema.safeParse(rawRow);
+    const row = parsedRow.success ? parsedRow.data : { errors: [] };
     const { errors, ...columns } = row;
     const formatted = errors.map((reason) => formatImportError(reason).trim()).filter(Boolean);
     for (const reason of formatted) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/30204

### Why
When a members CSV import has failed rows, the error file downloaded from the Admin import modal is built from the raw API rows. Array fields like labels render as `[object Object]` and the columns use internal field names (`subscribed`) instead of the export headers (`subscribed_to_emails`). Re-uploading the downloaded report then creates a label literally named `[object Object]` on the member, since labels are created on import, and drops subscription state because that header isn't in the import mapping.

### What it does
Rows are now shaped into the members export vocabulary before serialization, matching the emailed error report: labels joined by name, `subscribed_to_emails` instead of `subscribed`, custom field columns passed through, and a newsletters column carried only when the submitted file had one, so re-uploading a report can't change subscription state the original file never mentioned.

I verified this against a running instance: imported a CSV with failing rows carrying labels, took the actual rows the API returned, and ran them through the current serializer and this one. The current output contains `[object Object],[object Object]` where the fixed output reads `vip,gold`.

### Why Ghost users/developers need it
The fix-and-re-upload workflow is the whole point of the error report. Today it silently corrupts member data instead; with this change the downloaded file matches the members export format and round-trips cleanly.

### Tests
The serialization test now asserts the export-format header, and two new cases pin the regression: label arrays render as joined names rather than `[object Object]`, and the newsletters column appears only when present in the source rows.