### PR TITLE
Extracted a shared signed flush scheduler from the gifts service

### DIFF
--- a/ghost/core/core/server/adapters/scheduling/README.md
+++ b/ghost/core/core/server/adapters/scheduling/README.md
@@ -1,8 +1,7 @@
 # Scheduling
 
-The scheduling adapter arms HTTP callbacks that hit the Admin API at a future
-time, so scheduled work fires even if no request wakes the process. The
-contract lives in `@tryghost/adapter-base-scheduling`
+Scheduling adapters queue future Admin API callbacks, allowing scheduled work
+to wake the process. The contract lives in `@tryghost/adapter-base-scheduling`
 (`packages/adapters/scheduling-base`): adapters implement `run`, `schedule`,
 and `unschedule`, and inherit a registry of reschedulers from
 `SchedulingBase`.
@@ -27,14 +26,15 @@ and `unschedule`, and inherit a registry of reschedulers from
 
 ## Queue rebuilds
 
-Consumers `register()` themselves with the adapter. The adapter calls
-`rescheduleAll({previousKey})` on every registered consumer when the queue
-must be rebuilt — today from `services/auth/reset-authentication.ts` after the
-internal scheduler key rotates, and (without a `previousKey`) from boot when
-the adapter sets `rescheduleOnBoot`. During rotation, consumers unschedule the
-job signed under the previous key and schedule a replacement under the current
-one; on boot there is no distinct stale URL, so unschedules are flagged
-`bootstrap` and the adapter skips writing a tombstone.
+Consumers `register()` themselves so the adapter can rebuild every queue after
+the internal scheduler key rotates. `services/auth/reset-authentication.ts`
+starts this rebuild with the previous key. Post scheduling and
+`SignedFlushScheduler` replace jobs signed under that key; automations starts a
+fresh poll chain and lets the old callback fail authentication.
+
+Boot rebuilds are consumer-specific and only run when the adapter sets
+`rescheduleOnBoot`. Same-key replacements use `bootstrap` unscheduling so the
+default adapter does not tombstone the replacement job.
 
 ## Consumers
 

--- a/ghost/core/core/server/adapters/scheduling/README.md
+++ b/ghost/core/core/server/adapters/scheduling/README.md
@@ -1,7 +1,7 @@
 # Scheduling
 
-Scheduling adapters queue future Admin API callbacks, allowing scheduled work
-to wake the process. The contract lives in `@tryghost/adapter-base-scheduling`
+Scheduling adapters queue and trigger future Admin API callbacks. The contract
+lives in `@tryghost/adapter-base-scheduling`
 (`packages/adapters/scheduling-base`): adapters implement `run`, `schedule`,
 and `unschedule`, and inherit a registry of reschedulers from
 `SchedulingBase`.

--- a/ghost/core/core/server/adapters/scheduling/README.md
+++ b/ghost/core/core/server/adapters/scheduling/README.md
@@ -1,0 +1,45 @@
+# Scheduling
+
+The scheduling adapter arms HTTP callbacks that hit the Admin API at a future
+time, so scheduled work fires even if no request wakes the process. The
+contract lives in `@tryghost/adapter-base-scheduling`
+(`packages/adapters/scheduling-base`): adapters implement `run`, `schedule`,
+and `unschedule`, and inherit a registry of reschedulers from
+`SchedulingBase`.
+
+## Modules
+
+- `scheduling-default.ts` — the in-process default adapter. Its queue dies
+  with the process, so it sets `rescheduleOnBoot = true` and consumers rebuild
+  their jobs at boot. External adapters with a persistent queue opt out.
+- `error-capture.ts` — `withErrorCapture(adapter)` decorates the resolved
+  adapter so `schedule`/`unschedule` failures are reported (Sentry and logs)
+  instead of propagated; no caller awaits these calls. Boot and post
+  scheduling both wrap the adapter from `adapter-manager` with it.
+- `utils.ts` — `getSignedAdminToken`, which signs a short-lived admin JWT for
+  a job's fire time.
+- `build-signed-job.ts` — builds an adapter job whose callback URL carries
+  that signed token, from an Admin API path and fire time.
+- `signed-flush-scheduler.ts` — `SignedFlushScheduler`, a flush-queue
+  primitive on top of the two above: arms one job per fire time (deduplicated
+  in memory), skips already-due times in favour of the caller's own recovery
+  pass, and rebuilds its queue at boot and on key rotation.
+
+## Queue rebuilds
+
+Consumers `register()` themselves with the adapter. The adapter calls
+`rescheduleAll({previousKey})` on every registered consumer when the queue
+must be rebuilt — today from `services/auth/reset-authentication.ts` after the
+internal scheduler key rotates, and (without a `previousKey`) from boot when
+the adapter sets `rescheduleOnBoot`. During rotation, consumers unschedule the
+job signed under the previous key and schedule a replacement under the current
+one; on boot there is no distinct stale URL, so unschedules are flagged
+`bootstrap` and the adapter skips writing a tombstone.
+
+## Consumers
+
+- `services/post-scheduling` — one job per scheduled post or page.
+- `services/automations` — a chain-head poll callback; each poll arms the
+  next.
+- `services/gifts` — two `SignedFlushScheduler` configurations, for delivery
+  and reminder flushes.

--- a/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
+++ b/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
@@ -17,10 +17,6 @@ interface BuildSignedJobOptions {
   getIdempotencyKey?(url: URL): string;
 }
 
-/**
- * Builds a scheduling-adapter job whose callback URL carries an admin token
- * signed for the fire time.
- */
 export function buildSignedJob({
   apiUrl,
   path,

--- a/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
+++ b/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
@@ -12,6 +12,7 @@ interface BuildSignedJobOptions {
   // Fire time (ms since epoch); the admin token is signed for this time.
   time: number;
   key: InternalApiKey;
+  extra?: Omit<SchedulerJob['extra'], 'httpMethod' | 'idempotencyKey'>;
   // Derives an idempotency key from the final callback URL, which carries
   // the signed token and so can't be known before the job is built.
   getIdempotencyKey?(url: URL): string;
@@ -22,6 +23,7 @@ export function buildSignedJob({
   path,
   time,
   key,
+  extra,
   getIdempotencyKey,
 }: BuildSignedJobOptions): SchedulerJob {
   const signedAdminToken = getSignedAdminToken({
@@ -32,10 +34,10 @@ export function buildSignedJob({
   const url = new URL(urlUtils.urlJoin(apiUrl, ...path));
   url.searchParams.set('token', signedAdminToken);
 
-  const extra: SchedulerJob['extra'] = { httpMethod: 'PUT' };
+  const jobExtra: SchedulerJob['extra'] = { httpMethod: 'PUT', ...extra };
   if (getIdempotencyKey) {
-    extra.idempotencyKey = getIdempotencyKey(url);
+    jobExtra.idempotencyKey = getIdempotencyKey(url);
   }
 
-  return { time, url: url.toString(), extra };
+  return { time, url: url.toString(), extra: jobExtra };
 }

--- a/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
+++ b/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
@@ -1,0 +1,45 @@
+import type { SchedulerJob } from '@tryghost/adapter-base-scheduling';
+import type { InternalApiKey } from '../../services/internal-keys';
+
+const urlUtils = require('../../../shared/url-utils').default;
+const { getSignedAdminToken } = require('./utils');
+
+interface BuildSignedJobOptions {
+  apiUrl: string;
+  // Admin API path segments of the endpoint the callback hits
+  // (e.g. ['automations', 'poll']).
+  path: string[];
+  // Fire time (ms since epoch); the admin token is signed for this time.
+  time: number;
+  key: InternalApiKey;
+  // Derives an idempotency key from the final callback URL, which carries
+  // the signed token and so can't be known before the job is built.
+  getIdempotencyKey?(url: URL): string;
+}
+
+/**
+ * Builds a scheduling-adapter job whose callback URL carries an admin token
+ * signed for the fire time.
+ */
+export function buildSignedJob({
+  apiUrl,
+  path,
+  time,
+  key,
+  getIdempotencyKey,
+}: BuildSignedJobOptions): SchedulerJob {
+  const signedAdminToken = getSignedAdminToken({
+    publishedAt: new Date(time).toISOString(),
+    apiUrl,
+    key,
+  });
+  const url = new URL(urlUtils.urlJoin(apiUrl, ...path));
+  url.searchParams.set('token', signedAdminToken);
+
+  const extra: SchedulerJob['extra'] = { httpMethod: 'PUT' };
+  if (getIdempotencyKey) {
+    extra.idempotencyKey = getIdempotencyKey(url);
+  }
+
+  return { time, url: url.toString(), extra };
+}

--- a/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
+++ b/ghost/core/core/server/adapters/scheduling/build-signed-job.ts
@@ -1,8 +1,7 @@
 import type { SchedulerJob } from '@tryghost/adapter-base-scheduling';
 import type { InternalApiKey } from '../../services/internal-keys';
-
-const urlUtils = require('../../../shared/url-utils').default;
-const { getSignedAdminToken } = require('./utils');
+import urlUtils from '../../../shared/url-utils';
+import { getSignedAdminToken } from './utils';
 
 interface BuildSignedJobOptions {
   apiUrl: string;
@@ -15,7 +14,7 @@ interface BuildSignedJobOptions {
   extra?: Omit<SchedulerJob['extra'], 'httpMethod' | 'idempotencyKey'>;
   // Derives an idempotency key from the final callback URL, which carries
   // the signed token and so can't be known before the job is built.
-  getIdempotencyKey?(url: URL): string;
+  getIdempotencyKey?(url: Readonly<URL>): string;
 }
 
 export function buildSignedJob({

--- a/ghost/core/core/server/adapters/scheduling/signed-flush-scheduler.ts
+++ b/ghost/core/core/server/adapters/scheduling/signed-flush-scheduler.ts
@@ -1,9 +1,9 @@
 import logging from '@tryghost/logging';
 import type { SchedulerAdapter, SchedulerJob } from '@tryghost/adapter-base-scheduling';
-import type { InternalApiKey, InternalKeys } from '../internal-keys';
+import type { InternalApiKey, InternalKeys } from '../../services/internal-keys';
 
 const urlUtils = require('../../../shared/url-utils').default;
-const { getSignedAdminToken } = require('../../adapters/scheduling/utils');
+const { getSignedAdminToken } = require('./utils');
 
 // The default scheduling adapter can ping up to 50ms before the scheduled
 // time, and the flush queries truncate "now" to whole seconds — an exactly
@@ -15,29 +15,35 @@ function normalizeTime(time: number): number {
   return Math.floor(time / 1000) * 1000;
 }
 
-interface GiftFlushSchedulerOptions {
+interface SignedFlushSchedulerOptions {
   apiUrl: string;
   adapter: SchedulerAdapter;
   internalKeys: InternalKeys;
-  endpoint: 'flush_reminders' | 'flush_deliveries';
+  // Admin API path segments of the flush endpoint the armed callback hits
+  // (e.g. ['gifts', 'flush_deliveries']).
+  endpoint: string[];
   // snake_case identifier used to derive log event names and messages.
   name: string;
   // Times (ms since epoch) still needing a flush job, used to rebuild the
   // adapter queue at boot and on key rotation.
   findScheduledTimes(): Promise<number[]>;
+  // Delays used by older versions of this callback. During key rotation,
+  // those stale URL+time pairs are unscheduled alongside the current job.
+  legacyDelaysMs?: number[];
 }
 
 /**
  * Arms one-shot Admin API flush callbacks through the scheduling adapter,
  * deduplicated by fire time.
  */
-export class GiftFlushScheduler {
+export class SignedFlushScheduler {
   readonly #apiUrl: string;
   readonly #adapter: SchedulerAdapter;
   readonly #internalKeys: InternalKeys;
-  readonly #endpoint: GiftFlushSchedulerOptions['endpoint'];
+  readonly #endpoint: SignedFlushSchedulerOptions['endpoint'];
   readonly #name: string;
-  readonly #findScheduledTimes: GiftFlushSchedulerOptions['findScheduledTimes'];
+  readonly #findScheduledTimes: SignedFlushSchedulerOptions['findScheduledTimes'];
+  readonly #legacyDelaysMs: number[];
   readonly #scheduledTimes = new Set<number>();
 
   constructor({
@@ -47,19 +53,21 @@ export class GiftFlushScheduler {
     endpoint,
     name,
     findScheduledTimes,
-  }: GiftFlushSchedulerOptions) {
+    legacyDelaysMs = [],
+  }: SignedFlushSchedulerOptions) {
     this.#apiUrl = apiUrl;
     this.#adapter = adapter;
     this.#internalKeys = internalKeys;
     this.#endpoint = endpoint;
     this.#name = name;
     this.#findScheduledTimes = findScheduledTimes;
+    this.#legacyDelaysMs = legacyDelaysMs;
     this.#adapter.register(this);
   }
 
   /**
    * Arm a flush for the given fire time. Already-due work is left to the
-   * daily recovery jobs.
+   * caller's recovery pass.
    */
   async scheduleAt(time: number, logContext: Record<string, unknown> = {}): Promise<void> {
     time = normalizeTime(time);
@@ -97,8 +105,8 @@ export class GiftFlushScheduler {
       this.#adapter.schedule(job);
     } catch (err) {
       // A synchronous key, job-construction, or adapter failure must not escape
-      // into the completed gift flow. Remove any marker so a later call can
-      // retry; daily recovery handles the work if it does not.
+      // into the caller. Remove any marker so a later call can retry; the
+      // caller's recovery pass handles the work if it does not.
       this.#scheduledTimes.delete(time);
       logging.error(
         {
@@ -137,11 +145,10 @@ export class GiftFlushScheduler {
       const staleJob = previousKey ? this.#buildJob(time, previousKey) : job;
       this.#adapter.unschedule(staleJob, { bootstrap });
 
-      // Before GiftFlushScheduler, reminder jobs were armed without the
-      // one-second flush delay. During the first scheduler-key rotation after
-      // an upgrade, tombstone that legacy URL+time as well.
-      if (previousKey && this.#endpoint === 'flush_reminders') {
-        this.#adapter.unschedule(this.#buildJob(time, previousKey, 0), { bootstrap });
+      if (previousKey) {
+        for (const delayMs of this.#legacyDelaysMs) {
+          this.#adapter.unschedule(this.#buildJob(time, previousKey, delayMs), { bootstrap });
+        }
       }
 
       this.#adapter.schedule(job);
@@ -156,7 +163,7 @@ export class GiftFlushScheduler {
       apiUrl: this.#apiUrl,
       key,
     });
-    const url = new URL(urlUtils.urlJoin(this.#apiUrl, 'gifts', this.#endpoint));
+    const url = new URL(urlUtils.urlJoin(this.#apiUrl, ...this.#endpoint));
     url.searchParams.set('token', signedAdminToken);
     return { time: jobTime, url: url.toString(), extra: { httpMethod: 'PUT' } };
   }

--- a/ghost/core/core/server/adapters/scheduling/signed-flush-scheduler.ts
+++ b/ghost/core/core/server/adapters/scheduling/signed-flush-scheduler.ts
@@ -1,9 +1,7 @@
 import logging from '@tryghost/logging';
 import type { SchedulerAdapter, SchedulerJob } from '@tryghost/adapter-base-scheduling';
 import type { InternalApiKey, InternalKeys } from '../../services/internal-keys';
-
-const urlUtils = require('../../../shared/url-utils').default;
-const { getSignedAdminToken } = require('./utils');
+import { buildSignedJob } from './build-signed-job';
 
 // The default scheduling adapter can ping up to 50ms before the scheduled
 // time, and the flush queries truncate "now" to whole seconds — an exactly
@@ -157,14 +155,11 @@ export class SignedFlushScheduler {
   }
 
   #buildJob(time: number, key: InternalApiKey, delayMs = FLUSH_DELAY_MS): SchedulerJob {
-    const jobTime = time + delayMs;
-    const signedAdminToken = getSignedAdminToken({
-      publishedAt: new Date(jobTime).toISOString(),
+    return buildSignedJob({
       apiUrl: this.#apiUrl,
+      path: this.#endpoint,
+      time: time + delayMs,
       key,
     });
-    const url = new URL(urlUtils.urlJoin(this.#apiUrl, ...this.#endpoint));
-    url.searchParams.set('token', signedAdminToken);
-    return { time: jobTime, url: url.toString(), extra: { httpMethod: 'PUT' } };
   }
 }

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -7,6 +7,7 @@ import { oneAtATime } from '../../../shared/one-at-a-time';
 import { poll } from './poll';
 import * as automationsApi from './automations-api';
 import { getSchedulerIdempotencyKey } from './get-scheduler-idempotency-key';
+import { buildSignedJob } from '../../adapters/scheduling/build-signed-job';
 import { setImmediate as flushEventLoop } from 'node:timers/promises';
 import { SoonestTimer } from '../../lib/soonest-timer';
 import { getSchedulerPollTime } from './scheduler-poll-time';
@@ -14,9 +15,7 @@ import { getSchedulerPollTime } from './scheduler-poll-time';
 import emailAnalyticsJobs from '../email-analytics/jobs';
 import { StartAutomationsPollEvent } from './events/start-automations-poll-event';
 
-const urlUtils = require('../../../shared/url-utils').default;
 const logging = require('@tryghost/logging');
-const { getSignedAdminToken } = require('../../adapters/scheduling/utils');
 const { welcomeEmailAutomationPoll } = require('./welcome-email-automation-poll');
 const memberWelcomeEmailService = require('../member-welcome-emails/service');
 
@@ -81,21 +80,15 @@ export class AutomationsService {
       try {
         const schedulerPollTime = getSchedulerPollTime(date, siteIdentifier);
         const key = await internalKeys.get('ghost-scheduler');
-        const signedAdminToken = getSignedAdminToken({
-          publishedAt: schedulerPollTime.toISOString(),
-          apiUrl,
-          key,
-        });
-        const url = new URL(urlUtils.urlJoin(apiUrl, 'automations', 'poll'));
-        url.searchParams.set('token', signedAdminToken);
-        schedulerAdapter.schedule({
-          time: schedulerPollTime.getTime(),
-          url: url.toString(),
-          extra: {
-            httpMethod: 'PUT',
-            idempotencyKey: getSchedulerIdempotencyKey(date, url),
-          },
-        });
+        schedulerAdapter.schedule(
+          buildSignedJob({
+            apiUrl,
+            path: ['automations', 'poll'],
+            time: schedulerPollTime.getTime(),
+            key,
+            getIdempotencyKey: (url) => getSchedulerIdempotencyKey(date, url),
+          }),
+        );
       } catch (err) {
         logging.error(
           { event: { name: 'automations.enqueue-poll.error' }, err, at: date.toISOString() },

--- a/ghost/core/core/server/services/gifts/gift-delivery-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-delivery-service.ts
@@ -7,8 +7,8 @@ import type {
 } from './gift-delivery-bookshelf-repository';
 import type { GiftDeliveryData } from './gift-delivery-schema';
 import type { GiftCadence } from './gift-schema';
-import type { GiftFlushScheduler } from './gift-flush-scheduler';
 import type { Gift } from './gift';
+import type { SignedFlushScheduler } from '../../adapters/scheduling/signed-flush-scheduler';
 import { SendGiftDeliveryEvent } from './events/send-gift-delivery-event';
 import { GIFT_DELIVERY_STALE_AFTER_MS } from './constants';
 
@@ -77,7 +77,7 @@ interface GiftDeliveryServiceDeps {
   giftEmailAnalytics: {
     schedule(): Promise<void>;
   };
-  giftDeliveryScheduler: Pick<GiftFlushScheduler, 'scheduleAt' | 'rescheduleAll'>;
+  giftDeliveryScheduler: Pick<SignedFlushScheduler, 'scheduleAt' | 'rescheduleAll'>;
 }
 
 export interface GiftDeliveryRecoveryResult {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -11,7 +11,7 @@ import type {
   GiftRepository,
 } from './gift-bookshelf-repository';
 import type { GiftDeliveryDispatchResult, GiftDeliveryService } from './gift-delivery-service';
-import type { GiftFlushScheduler } from './gift-flush-scheduler';
+import type { SignedFlushScheduler } from '../../adapters/scheduling/signed-flush-scheduler';
 import { GiftCadenceSchema, type GiftCadence } from './gift-schema';
 import tpl from '@tryghost/tpl';
 import {
@@ -181,7 +181,7 @@ interface GiftServiceDeps {
   tiersService: TiersService;
   giftEmailService: GiftEmailService;
   staffServiceEmails: StaffServiceEmails;
-  giftReminderScheduler: Pick<GiftFlushScheduler, 'scheduleAt'>;
+  giftReminderScheduler: Pick<SignedFlushScheduler, 'scheduleAt'>;
   checkoutAdapter: {
     getCustomerId(buyer: GiftCheckoutBuyer): Promise<string | null>;
     createSession(data: GiftCheckoutSession): Promise<{ id: string; url: string }>;

--- a/ghost/core/core/server/services/gifts/index.ts
+++ b/ghost/core/core/server/services/gifts/index.ts
@@ -4,7 +4,7 @@ import { GiftBookshelfRepository } from './gift-bookshelf-repository';
 import { GiftDeliveryBookshelfRepository } from './gift-delivery-bookshelf-repository';
 import { GiftDeliveryService } from './gift-delivery-service';
 import { GiftService } from './gift-service';
-import { GiftFlushScheduler } from './gift-flush-scheduler';
+import { SignedFlushScheduler } from '../../adapters/scheduling/signed-flush-scheduler';
 import { GiftEmailService } from './gift-email-service';
 import { GiftController } from './gift-controller';
 import { SendGiftDeliveryEvent } from './events/send-gift-delivery-event';
@@ -85,11 +85,11 @@ export async function init(options: GiftServiceInitOptions): Promise<void> {
     blogIcon,
     t,
   });
-  const giftDeliveryScheduler = new GiftFlushScheduler({
+  const giftDeliveryScheduler = new SignedFlushScheduler({
     apiUrl: options.apiUrl,
     adapter: options.schedulerAdapter,
     internalKeys: options.internalKeys,
-    endpoint: 'flush_deliveries',
+    endpoint: ['gifts', 'flush_deliveries'],
     name: 'gift_delivery',
     findScheduledTimes: async () => {
       const scheduled = await deliveryRepository.findScheduledTimesForPurchasedGifts(new Date());
@@ -107,12 +107,13 @@ export async function init(options: GiftServiceInitOptions): Promise<void> {
     giftDeliveryScheduler,
   });
 
-  const giftReminderScheduler = new GiftFlushScheduler({
+  const giftReminderScheduler = new SignedFlushScheduler({
     apiUrl: options.apiUrl,
     adapter: options.schedulerAdapter,
     internalKeys: options.internalKeys,
-    endpoint: 'flush_reminders',
+    endpoint: ['gifts', 'flush_reminders'],
     name: 'gift_reminder',
+    legacyDelaysMs: [0],
     findScheduledTimes: async () => {
       const pending = await repository.findUnsentReminders();
       return pending

--- a/ghost/core/core/server/services/post-scheduling/post-scheduling.ts
+++ b/ghost/core/core/server/services/post-scheduling/post-scheduling.ts
@@ -2,12 +2,11 @@ import moment from 'moment';
 import logging from '@tryghost/logging';
 import type { SchedulerAdapter, SchedulerJob } from '@tryghost/adapter-base-scheduling';
 import type { InternalApiKey, InternalKeys } from '../internal-keys';
+import { buildSignedJob } from '../../adapters/scheduling/build-signed-job';
 
 // CJS-only modules — typed loosely below. models is the Bookshelf registry
 // without TS declarations; the rest are JS modules without types.
 const models = require('../../models');
-const urlUtils = require('../../../shared/url-utils').default;
-const { getSignedAdminToken } = require('../../adapters/scheduling/utils');
 const events = require('../../lib/common/events');
 
 interface PostSchedulingDeps {
@@ -152,19 +151,16 @@ export default class PostScheduling {
     const resource = `${resourceType}s`;
     const publishedAt =
       event === 'unscheduled' ? model.previous('published_at') : model.get('published_at');
-    const signedAdminToken = getSignedAdminToken({ publishedAt, apiUrl: this.#apiUrl, key });
-    const url = `${urlUtils.urlJoin(this.#apiUrl, 'schedules', resource, model.get('id'))}/?token=${signedAdminToken}`;
+    const previousPublishedAt = model.previous('published_at');
 
-    return {
-      // NOTE: The scheduler expects a unix timestamp.
+    return buildSignedJob({
+      apiUrl: this.#apiUrl,
+      path: ['schedules', resource, `${model.get('id')}/`],
       time: moment(publishedAt).valueOf(),
-      url,
+      key,
       extra: {
-        httpMethod: 'PUT',
-        oldTime: model.previous('published_at')
-          ? moment(model.previous('published_at')).valueOf()
-          : null,
+        oldTime: previousPublishedAt ? moment(previousPublishedAt).valueOf() : null,
       },
-    };
+    });
   }
 }

--- a/ghost/core/test/unit/server/adapters/scheduling/signed-flush-scheduler.test.ts
+++ b/ghost/core/test/unit/server/adapters/scheduling/signed-flush-scheduler.test.ts
@@ -8,9 +8,7 @@ import type {
   InternalIntegrationSlug,
 } from '../../../../../core/server/services/internal-keys';
 
-// Use real signing and URL helpers; stub only cross-domain collaborators.
-// Test secrets are 64-char hex so getSignedAdminToken (which decodes via
-// Buffer.from(secret, 'hex')) treats them as distinct signing keys.
+// Use distinct 64-character hex secrets because token signing decodes them as hex.
 const HEX_CURRENT = 'aa'.repeat(32);
 const HEX_OLD = '55'.repeat(32);
 

--- a/ghost/core/test/unit/server/adapters/scheduling/signed-flush-scheduler.test.ts
+++ b/ghost/core/test/unit/server/adapters/scheduling/signed-flush-scheduler.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import logging from '@tryghost/logging';
 import sinon from 'sinon';
-import { GiftFlushScheduler } from '../../../../../core/server/services/gifts/gift-flush-scheduler';
+import { SignedFlushScheduler } from '../../../../../core/server/adapters/scheduling/signed-flush-scheduler';
 import { AutoFillingMap } from '../../../../../core/server/lib/auto-filling-map';
 import type {
   InternalApiKey,
@@ -36,20 +36,20 @@ function buildDeps(
       run: sinon.stub(),
     },
     internalKeys,
-    endpoint: 'flush_deliveries' as const,
+    endpoint: ['gifts', 'flush_deliveries'],
     name: 'gift_delivery',
     findScheduledTimes: sinon.stub<[], Promise<number[]>>().resolves(overrides.pending ?? []),
   };
 }
 
-describe('GiftFlushScheduler', function () {
+describe('SignedFlushScheduler', function () {
   afterEach(function () {
     sinon.restore();
   });
 
   it('registers itself with the adapter on construction', function () {
     const deps = buildDeps();
-    new GiftFlushScheduler(deps);
+    new SignedFlushScheduler(deps);
 
     sinon.assert.calledOnce(deps.adapter.register);
     assert.equal(typeof deps.adapter.register.firstCall.firstArg.rescheduleAll, 'function');
@@ -58,7 +58,7 @@ describe('GiftFlushScheduler', function () {
   describe('scheduleAt', function () {
     it('arms a flush callback just past the given time, signed with the current key', async function () {
       const deps = buildDeps();
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
       const time = Date.now() + 60_000;
 
       await scheduler.scheduleAt(time);
@@ -74,8 +74,8 @@ describe('GiftFlushScheduler', function () {
     });
 
     it('targets the configured endpoint', async function () {
-      const deps = { ...buildDeps(), endpoint: 'flush_reminders' as const };
-      const scheduler = new GiftFlushScheduler(deps);
+      const deps = { ...buildDeps(), endpoint: ['gifts', 'flush_reminders'] };
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.scheduleAt(Date.now() + 60_000);
 
@@ -85,7 +85,7 @@ describe('GiftFlushScheduler', function () {
 
     it('does not arm an already-due time', async function () {
       const deps = buildDeps();
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.scheduleAt(Date.now() - 1);
 
@@ -94,7 +94,7 @@ describe('GiftFlushScheduler', function () {
 
     it('arms one batch flush for repeat schedules of the same time', async function () {
       const deps = buildDeps();
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
       const time = Date.now() + 60_000;
 
       await scheduler.scheduleAt(time, { deliveryId: 'delivery_1' });
@@ -105,7 +105,7 @@ describe('GiftFlushScheduler', function () {
 
     it('deduplicates times within the same persisted database second', async function () {
       const deps = buildDeps();
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
       const second = Math.floor((Date.now() + 60_000) / 1000) * 1000;
 
       await scheduler.scheduleAt(second + 123);
@@ -117,7 +117,7 @@ describe('GiftFlushScheduler', function () {
 
     it('does not let synchronous job construction failures escape', async function () {
       const deps = { ...buildDeps(), apiUrl: 'not a url' };
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
       const logError = sinon.stub(logging, 'error');
 
       await scheduler.scheduleAt(Date.now() + 60_000);
@@ -129,7 +129,7 @@ describe('GiftFlushScheduler', function () {
     it('retries after a synchronous adapter failure', async function () {
       const deps = buildDeps();
       deps.adapter.schedule.onFirstCall().throws(new Error('adapter failed'));
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
       sinon.stub(logging, 'error');
       const time = Date.now() + 60_000;
 
@@ -147,7 +147,7 @@ describe('GiftFlushScheduler', function () {
       const rejection = Promise.reject(new Error('Transient key failure'));
       rejection.catch(() => {});
       failingKeys.set('ghost-scheduler', rejection);
-      const scheduler = new GiftFlushScheduler({ ...deps, internalKeys: failingKeys });
+      const scheduler = new SignedFlushScheduler({ ...deps, internalKeys: failingKeys });
       const time = Date.now() + 60_000;
 
       await scheduler.scheduleAt(time);
@@ -164,7 +164,7 @@ describe('GiftFlushScheduler', function () {
     it('re-signs every pending time under the current key', async function () {
       const pending = [Date.now() + 30_000, Date.now() + 60_000];
       const deps = buildDeps({ pending, currentKey: { id: 'k', secret: HEX_CURRENT } });
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll({ previousKey: { id: 'k', secret: HEX_OLD } });
 
@@ -186,7 +186,7 @@ describe('GiftFlushScheduler', function () {
     it('unschedules stale old-key jobs during rotation', async function () {
       // Non-bootstrap unscheduling tombstones the stale callback.
       const deps = buildDeps({ pending: [Date.now() + 30_000] });
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll({ previousKey: { id: 'k', secret: HEX_OLD } });
 
@@ -198,9 +198,10 @@ describe('GiftFlushScheduler', function () {
       const time = Math.floor((Date.now() + 30_000) / 1000) * 1000;
       const deps = {
         ...buildDeps({ pending: [time] }),
-        endpoint: 'flush_reminders' as const,
+        endpoint: ['gifts', 'flush_reminders'],
+        legacyDelaysMs: [0],
       };
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll({ previousKey: { id: 'k', secret: HEX_OLD } });
 
@@ -213,7 +214,7 @@ describe('GiftFlushScheduler', function () {
     it('does not tombstone the replacement during boot rebuilds', async function () {
       // Boot reuses the current-key URL, so unscheduling must use bootstrap mode.
       const deps = buildDeps({ pending: [Date.now() + 30_000] });
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll();
 
@@ -230,7 +231,7 @@ describe('GiftFlushScheduler', function () {
     it('rebuilds duplicate pending times as one job', async function () {
       const time = Date.now() + 30_000;
       const deps = buildDeps({ pending: [time, time] });
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll({ previousKey: { id: 'k', secret: HEX_OLD } });
 
@@ -239,7 +240,7 @@ describe('GiftFlushScheduler', function () {
 
     it('skips times that have already passed', async function () {
       const deps = buildDeps({ pending: [Date.now() - 1] });
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll({ previousKey: { id: 'k', secret: HEX_OLD } });
 
@@ -249,7 +250,7 @@ describe('GiftFlushScheduler', function () {
 
     it('is a no-op when nothing is pending', async function () {
       const deps = buildDeps({ pending: [] });
-      const scheduler = new GiftFlushScheduler(deps);
+      const scheduler = new SignedFlushScheduler(deps);
 
       await scheduler.rescheduleAll({ previousKey: { id: 'k', secret: HEX_OLD } });
 

--- a/ghost/core/test/unit/server/services/post-scheduling/post-scheduling.test.js
+++ b/ghost/core/test/unit/server/services/post-scheduling/post-scheduling.test.js
@@ -7,6 +7,7 @@ const events = require('../../../../../core/server/lib/common/events');
 const SchedulingDefault =
   require('../../../../../core/server/adapters/scheduling/scheduling-default').default;
 const urlUtils = require('../../../../../core/shared/url-utils').default;
+const { getSignedAdminToken } = require('../../../../../core/server/adapters/scheduling/utils');
 const PostScheduling =
   require('../../../../../core/server/services/post-scheduling/post-scheduling').default;
 const nock = require('nock');
@@ -71,20 +72,23 @@ describe('PostScheduling', function () {
       });
 
       sinon.assert.calledOnce(adapter.schedule);
-      assert.equal(adapter.schedule.args[0][0].time, moment(post.get('published_at')).valueOf());
-      assert(
-        adapter.schedule.args[0][0].url.startsWith(
-          urlUtils.urlJoin(
-            'http://scheduler.local:1111/',
-            'schedules',
-            'posts',
-            post.get('id'),
-            '?token=',
-          ),
-        ),
-      );
-      assert.equal(adapter.schedule.args[0][0].extra.httpMethod, 'PUT');
-      assert.equal(adapter.schedule.args[0][0].extra.oldTime, null);
+      const job = adapter.schedule.args[0][0];
+      const signedAdminToken = getSignedAdminToken({
+        publishedAt: post.get('published_at'),
+        apiUrl: 'http://scheduler.local:1111/',
+        key: { id: 'integrationUniqueId', secret: 'aaaa' },
+      });
+      const callbackUrl = `${urlUtils.urlJoin(
+        'http://scheduler.local:1111/',
+        'schedules',
+        'posts',
+        post.get('id'),
+      )}/?token=${signedAdminToken}`;
+
+      assert.equal(job.time, moment(post.get('published_at')).valueOf());
+      assert.equal(job.url, callbackUrl);
+      assert.equal(job.extra.httpMethod, 'PUT');
+      assert.equal(job.extra.oldTime, null);
     });
   });
 


### PR DESCRIPTION
no ref

Moves the gift flush scheduler into the scheduling adapter layer as `SignedFlushScheduler`. It keeps time deduplication, delayed flush timing, and queue rebuilds at boot and after scheduler-key rotation in one place, while gift delivery and reminder scheduling provide their endpoint and pending times.

Extracts `buildSignedJob` for constructing signed Admin API callbacks and reuses it in automations without changing its polling, jitter, or idempotency behaviour. Adds a nearby README documenting the scheduling contract and queue rebuild behaviour.
