### PR TITLE
Added formatting check to pnpm check

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,9 +121,9 @@ For more detail, see the [contribution workflow](contributing/workflow.md).
 
 ### Testing
 
-Use `pnpm check` as the default one-stop command for linting and testing. Add
-tests at the closest layer to the behavior you changed. Browser end-to-end tests
-and Ember Admin tests run separately from `pnpm check`.
+Use `pnpm check` as the default one-stop command for formatting checks, linting,
+and testing. Add tests at the closest layer to the behavior you changed. Browser
+end-to-end tests and Ember Admin tests run separately from `pnpm check`.
 
 For more detail, see the [testing guide](contributing/testing.md) including how
 to choose a test suite, run focused tests, and use the separate browser and

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -12,8 +12,9 @@ From the repository root, run:
 pnpm check
 ```
 
-This is the default one-stop command for linting and testing. It runs
-`pnpm lint` followed by `pnpm test` across the monorepo.
+This is the default one-stop command for formatting checks, linting, and
+testing. It runs `pnpm format:check`, `pnpm lint`, and then `pnpm test` across
+the monorepo.
 
 `pnpm check` does not run the Playwright browser end-to-end suite or Ember
 Admin's test suite. Run those separately when your change affects those areas.

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -37,17 +37,18 @@ first; ordinary pull requests target `main`.
 
 Add or update automated tests when behavior changes. Run the most focused checks
 for the code you touched, following the README beside that workspace. Before
-handing off a change, use the repository's one-stop lint and test command:
+handing off a change, use the repository's one-stop formatting, lint, and test
+command:
 
 ```bash
 pnpm check
 ```
 
-`pnpm check` runs `pnpm lint` followed by `pnpm test`. It does not include the
-browser E2E suite or Ember Admin tests, so run those separately when the affected
-area requires them. CI uses the Nx affected graph and path filters to select the
-relevant lint, unit, integration, acceptance, build, and browser-test jobs for a
-pull request.
+`pnpm check` runs `pnpm format:check`, `pnpm lint`, and then `pnpm test`. It does
+not include the browser E2E suite or Ember Admin tests, so run those separately
+when the affected area requires them. CI uses the Nx affected graph and path
+filters to select the relevant lint, unit, integration, acceptance, build, and
+browser-test jobs for a pull request.
 
 ## Formatting
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint:docs": "pnpm lint:agent-skills && pnpm lint:agent-guidance && pnpm lint:markdown && pnpm lint:doc-links",
     "format": "node scripts/format.js",
     "format:check": "oxfmt --check",
-    "check": "pnpm lint && pnpm test",
+    "check": "pnpm format:check && pnpm lint && pnpm test",
     "test": "pnpm nx run-many -t test --exclude @tryghost/e2e --exclude ghost-admin",
     "test:unit": "pnpm nx run-many -t test:unit",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

- run the existing Oxfmt check before lint and tests in pnpm check
- update contributor documentation to reflect the expanded validation pipeline

## Validation

- pnpm format:check passed on 5,316 files
- formatting, lint, and documentation stages of pnpm check passed
- the test stage reported unrelated failures in admin-x-framework type tests and a Koenig Lexical Playwright timeout