### PR TITLE
Added HTML & Markdown processing and field mapping to CSV imports

### DIFF
--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -86,13 +86,21 @@ export const useDeletePost = createMutation<unknown, string>({
   path: (id) => `/posts/${id}/`,
 });
 
-export const useImportContentCSV = createMutation<unknown, File>({
+export interface ImportContentCSVPayload {
+  file: File;
+  mapping: Record<string, string>;
+}
+
+export const useImportContentCSV = createMutation<unknown, ImportContentCSVPayload>({
   method: 'POST',
   retry: false,
   path: () => '/posts/upload/',
-  body: (file) => {
+  body: ({ file, mapping }) => {
     const formData = new FormData();
     formData.append('postsfile', file);
+    for (const [header, field] of Object.entries(mapping)) {
+      formData.append(`mapping[${header}]`, field);
+    }
     return formData;
   },
 });

--- a/apps/admin-x-framework/test/unit/api/posts.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/posts.test.tsx
@@ -12,13 +12,19 @@ describe('posts api', () => {
       const { result } = renderHookWithProviders(() => useImportContentCSV());
 
       await act(async () => {
-        await result.current.mutateAsync(file);
+        await result.current.mutateAsync({
+          file,
+          mapping: { Headline: 'title', Body: '', Published: 'published_at' },
+        });
       });
 
       expect(mock.calls[0][0]).toBe('http://localhost:3000/ghost/api/admin/posts/upload/');
       expect(mock.calls[0][1].method).toBe('POST');
       expect(mock.calls[0][1].body).toBeInstanceOf(FormData);
       expect(mock.calls[0][1].body.get('postsfile')).toBe(file);
+      expect(mock.calls[0][1].body.get('mapping[Headline]')).toBe('title');
+      expect(mock.calls[0][1].body.get('mapping[Body]')).toBe('');
+      expect(mock.calls[0][1].body.get('mapping[Published]')).toBe('published_at');
       expect(mock.calls[0][1].headers).not.toHaveProperty('content-type');
     });
   });
@@ -36,7 +42,9 @@ describe('posts api', () => {
 
     try {
       const { result } = renderHookWithProviders(() => useImportContentCSV(), { queryClient });
-      const importPromise = result.current.mutateAsync(file).catch((error) => error);
+      const importPromise = result.current
+        .mutateAsync({ file, mapping: { title: 'title' } })
+        .catch((error) => error);
 
       await vi.advanceTimersByTimeAsync(600);
 

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/csv.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/csv.test.ts
@@ -1,0 +1,20 @@
+import { columnsOf, parseCSV } from './csv';
+
+describe('content import CSV', () => {
+  it('parses CSV values and preserves columns missing from the first row', () => {
+    const rows = parseCSV('Title,Body,Date\nFirst,,\nSecond,<p>Body</p>,2025-01-01\n');
+
+    expect(rows).toEqual([
+      { Title: 'First', Body: '', Date: '' },
+      { Title: 'Second', Body: '<p>Body</p>', Date: '2025-01-01' },
+    ]);
+    expect(columnsOf(rows)).toEqual(['Title', 'Body', 'Date']);
+  });
+
+  it('drops Papa Parse overflow cells from the mapping columns', () => {
+    const rows = parseCSV('Title\nFirst,overflow\n');
+
+    expect(rows).toEqual([{ Title: 'First' }]);
+    expect(columnsOf(rows)).toEqual(['Title']);
+  });
+});

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/csv.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/csv.ts
@@ -1,0 +1,50 @@
+import Papa from 'papaparse';
+
+export function parseCSV(text: string): Record<string, string>[] {
+  const parsed = Papa.parse<Record<string, unknown>>(text.replace(/^\ufeff/, ''), {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  return parsed.data
+    .map((row) => {
+      const normalized: Record<string, string> = {};
+      for (const [key, value] of Object.entries(row)) {
+        if (key === '__parsed_extra') {
+          continue;
+        }
+        normalized[key] = typeof value === 'string' ? value : '';
+      }
+      return normalized;
+    })
+    .filter((row) => Object.keys(row).length > 0);
+}
+
+export function columnsOf(rows: Record<string, string>[]): string[] {
+  const columns = new Set<string>();
+  for (const row of rows) {
+    for (const column of Object.keys(row)) {
+      columns.add(column);
+    }
+  }
+  return [...columns];
+}
+
+export function readCSV(file: File): Promise<Record<string, string>[]> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        if (typeof reader.result !== 'string') {
+          throw new Error('Failed to read CSV file as text');
+        }
+        resolve(parseCSV(reader.result));
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error('Failed to parse CSV file'));
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read CSV file'));
+    reader.onabort = () => reject(new Error('Reading the CSV file was interrupted'));
+    reader.readAsText(file);
+  });
+}

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/field-picker.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/field-picker.tsx
@@ -1,0 +1,94 @@
+import {
+  Button,
+  Command,
+  CommandCheck,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@tryghost/shade/components';
+import { LucideIcon, cn } from '@tryghost/shade/utils';
+import { useState } from 'react';
+import { CONTENT_FIELD_GROUPS, CONTENT_FIELD_MAPPINGS } from './mapping';
+
+interface FieldPickerProps {
+  column: string;
+  value: string | null;
+  disabled: boolean;
+  onValueChange: (value: string | null) => void;
+}
+
+export function FieldPicker({ column, value, disabled, onValueChange }: FieldPickerProps) {
+  const [open, setOpen] = useState(false);
+  const selected = CONTENT_FIELD_MAPPINGS.find((field) => field.value === value);
+
+  const choose = (target: string | null) => {
+    onValueChange(target);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} modal onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label={`Field for ${column}, ${selected?.label ?? 'not imported'}`}
+          className={cn(
+            'h-8 w-full justify-start gap-2 px-2 font-normal',
+            !selected && 'text-muted-foreground',
+          )}
+          disabled={disabled}
+          role="combobox"
+          variant="outline"
+        >
+          <span className="min-w-0 flex-1 truncate text-left text-sm">
+            {selected
+              ? `${selected.label}${selected.required ? ' (required)' : ''}`
+              : 'Not imported'}
+          </span>
+          <LucideIcon.ChevronDown className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-(--radix-popover-trigger-width) min-w-64 p-0"
+        collisionPadding={16}
+      >
+        <Command>
+          <CommandInput placeholder="Search post fields..." />
+          <CommandList>
+            <CommandEmpty>No post fields found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem value="Not imported" onSelect={() => choose(null)}>
+                <LucideIcon.Ban />
+                <span>Not imported</span>
+                {!value && <CommandCheck />}
+              </CommandItem>
+            </CommandGroup>
+            {CONTENT_FIELD_GROUPS.map((group) => (
+              <CommandGroup key={group.label} heading={group.label}>
+                {group.fields.map((field) => (
+                  <CommandItem
+                    key={field.value}
+                    keywords={[field.label]}
+                    value={field.value}
+                    onSelect={() => choose(field.value)}
+                  >
+                    <span>
+                      {field.label}
+                      {field.required ? ' (required)' : ''}
+                    </span>
+                    {value === field.value && <CommandCheck />}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping-step.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping-step.tsx
@@ -1,10 +1,5 @@
 import {
   Banner,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Table,
   TableBody,
   TableCell,
@@ -14,7 +9,8 @@ import {
 } from '@tryghost/shade/components';
 import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
-import { CONTENT_FIELD_MAPPINGS, ContentFieldMapping } from './mapping';
+import { FieldPicker } from './field-picker';
+import { ContentFieldMapping } from './mapping';
 
 interface MappingStepProps {
   rows: Record<string, string>[];
@@ -105,32 +101,12 @@ export function MappingStep({
                     {row[column] || '\u00a0'}
                   </TableCell>
                   <TableCell>
-                    <Select
+                    <FieldPicker
+                      column={column}
                       disabled={disabled}
-                      value={mapping.get(column) ?? '__not_imported__'}
-                      onValueChange={(value) =>
-                        onMappingChange(column, value === '__not_imported__' ? null : value)
-                      }
-                    >
-                      <SelectTrigger
-                        aria-label={`Field for ${column}`}
-                        className={cn(
-                          'h-8 text-sm',
-                          !mapping.get(column) && 'text-muted-foreground',
-                        )}
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="__not_imported__">Not imported</SelectItem>
-                        {CONTENT_FIELD_MAPPINGS.map((field) => (
-                          <SelectItem key={field.value} value={field.value}>
-                            {field.label}
-                            {field.required ? ' (required)' : ''}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      value={mapping.get(column)}
+                      onValueChange={(value) => onMappingChange(column, value)}
+                    />
                   </TableCell>
                 </TableRow>
               ))}

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping-step.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping-step.tsx
@@ -1,4 +1,5 @@
 import {
+  Banner,
   Select,
   SelectContent,
   SelectItem,
@@ -20,6 +21,7 @@ interface MappingStepProps {
   mapping: ContentFieldMapping;
   sampleIndex: number;
   disabled: boolean;
+  missingTitle: boolean;
   onMappingChange: (column: string, target: string | null) => void;
   onSampleIndexChange: (index: number) => void;
 }
@@ -29,6 +31,7 @@ export function MappingStep({
   mapping,
   sampleIndex,
   disabled,
+  missingTitle,
   onMappingChange,
   onSampleIndexChange,
 }: MappingStepProps) {
@@ -42,6 +45,16 @@ export function MappingStep({
       <Text tone="secondary">
         Choose which Ghost field each column in your CSV should import as.
       </Text>
+      {missingTitle && (
+        <Banner role="alert" size="sm" variant="warning">
+          <Inline align="center" gap="sm">
+            <LucideIcon.TriangleAlert className="size-4 shrink-0 text-state-warning" />
+            <Text size="sm" weight="semibold">
+              Required field missing: Title
+            </Text>
+          </Inline>
+        </Banner>
+      )}
       <div className="overflow-hidden rounded-md border border-border-default">
         <div className="max-h-[50vh] overflow-auto">
           <Table className="table-fixed">
@@ -113,6 +126,7 @@ export function MappingStep({
                         {CONTENT_FIELD_MAPPINGS.map((field) => (
                           <SelectItem key={field.value} value={field.value}>
                             {field.label}
+                            {field.required ? ' (required)' : ''}
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping-step.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping-step.tsx
@@ -1,0 +1,129 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tryghost/shade/components';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
+import { CONTENT_FIELD_MAPPINGS, ContentFieldMapping } from './mapping';
+
+interface MappingStepProps {
+  rows: Record<string, string>[];
+  mapping: ContentFieldMapping;
+  sampleIndex: number;
+  disabled: boolean;
+  onMappingChange: (column: string, target: string | null) => void;
+  onSampleIndexChange: (index: number) => void;
+}
+
+export function MappingStep({
+  rows,
+  mapping,
+  sampleIndex,
+  disabled,
+  onMappingChange,
+  onSampleIndexChange,
+}: MappingStepProps) {
+  const row = rows[sampleIndex] ?? {};
+  const columns = Object.keys(mapping.toJSON());
+  const hasPrevious = sampleIndex > 0;
+  const hasNext = sampleIndex < rows.length - 1;
+
+  return (
+    <Stack gap="lg">
+      <Text tone="secondary">
+        Choose which Ghost field each column in your CSV should import as.
+      </Text>
+      <div className="overflow-hidden rounded-md border border-border-default">
+        <div className="max-h-[50vh] overflow-auto">
+          <Table className="table-fixed">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-1/3">CSV column</TableHead>
+                <TableHead className="w-1/3">
+                  <Inline align="center" justify="between">
+                    <span>Sample #{formatNumber(sampleIndex + 1)}</span>
+                    <Inline align="center" gap="xs">
+                      <button
+                        aria-label="Show previous sample row"
+                        className={cn(
+                          'rounded p-0.5 hover:bg-interactive-hover',
+                          !hasPrevious && 'cursor-default opacity-30',
+                        )}
+                        disabled={disabled || !hasPrevious}
+                        type="button"
+                        onClick={() => onSampleIndexChange(sampleIndex - 1)}
+                      >
+                        <LucideIcon.ChevronLeft className="size-4" />
+                      </button>
+                      <button
+                        aria-label="Show next sample row"
+                        className={cn(
+                          'rounded p-0.5 hover:bg-interactive-hover',
+                          !hasNext && 'cursor-default opacity-30',
+                        )}
+                        disabled={disabled || !hasNext}
+                        type="button"
+                        onClick={() => onSampleIndexChange(sampleIndex + 1)}
+                      >
+                        <LucideIcon.ChevronRight className="size-4" />
+                      </button>
+                    </Inline>
+                  </Inline>
+                </TableHead>
+                <TableHead className="w-1/3">Import as</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {columns.map((column) => (
+                <TableRow key={column}>
+                  <TableCell className="text-sm font-medium break-all">{column}</TableCell>
+                  <TableCell
+                    className={cn('text-sm break-all', !row[column] && 'text-muted-foreground')}
+                  >
+                    {row[column] || '\u00a0'}
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      disabled={disabled}
+                      value={mapping.get(column) ?? '__not_imported__'}
+                      onValueChange={(value) =>
+                        onMappingChange(column, value === '__not_imported__' ? null : value)
+                      }
+                    >
+                      <SelectTrigger
+                        aria-label={`Field for ${column}`}
+                        className={cn(
+                          'h-8 text-sm',
+                          !mapping.get(column) && 'text-muted-foreground',
+                        )}
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__not_imported__">Not imported</SelectItem>
+                        {CONTENT_FIELD_MAPPINGS.map((field) => (
+                          <SelectItem key={field.value} value={field.value}>
+                            {field.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </Stack>
+  );
+}

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
@@ -1,0 +1,17 @@
+import { ContentFieldMapping } from './mapping';
+
+describe('ContentFieldMapping', () => {
+  it('keeps every CSV column in the upload contract', () => {
+    const mapping = ContentFieldMapping.empty(['Headline', 'Body']).update('Headline', 'title');
+
+    expect(mapping.toJSON()).toEqual({ Headline: 'title', Body: '' });
+  });
+
+  it('allows only one CSV column to claim a Ghost field', () => {
+    const mapping = ContentFieldMapping.empty(['First title', 'Second title'])
+      .update('First title', 'title')
+      .update('Second title', 'title');
+
+    expect(mapping.toJSON()).toEqual({ 'First title': '', 'Second title': 'title' });
+  });
+});

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
@@ -31,4 +31,12 @@ describe('ContentFieldMapping', () => {
 
     expect(mapping.toJSON()).toEqual({ Title: '', 'Post HTML': '', 'Published At': '' });
   });
+
+  it('reports whether the required title target is mapped', () => {
+    const missing = ContentFieldMapping.detect(['Headline']);
+    const complete = missing.update('Headline', 'title');
+
+    expect(missing.hasTarget('title')).toBe(false);
+    expect(complete.hasTarget('title')).toBe(true);
+  });
 });

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
@@ -16,11 +16,18 @@ describe('ContentFieldMapping', () => {
   });
 
   it('detects exact field-name headers', () => {
-    const mapping = ContentFieldMapping.detect(['title', 'html', 'published_at', 'Something else']);
+    const mapping = ContentFieldMapping.detect([
+      'title',
+      'html',
+      'markdown',
+      'published_at',
+      'Something else',
+    ]);
 
     expect(mapping.toJSON()).toEqual({
       title: 'title',
       html: 'html',
+      markdown: 'markdown',
       published_at: 'published_at',
       'Something else': '',
     });
@@ -52,6 +59,7 @@ describe('ContentFieldMapping', () => {
     expect(CONTENT_FIELD_MAPPINGS.map((field) => field.value)).toEqual([
       'title',
       'html',
+      'markdown',
       'slug',
       'custom_excerpt',
       'type',

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
@@ -1,4 +1,4 @@
-import { ContentFieldMapping } from './mapping';
+import { CONTENT_FIELD_GROUPS, CONTENT_FIELD_MAPPINGS, ContentFieldMapping } from './mapping';
 
 describe('ContentFieldMapping', () => {
   it('keeps every CSV column in the upload contract', () => {
@@ -38,5 +38,58 @@ describe('ContentFieldMapping', () => {
 
     expect(missing.hasTarget('title')).toBe(false);
     expect(complete.hasTarget('title')).toBe(true);
+  });
+
+  it('offers the full editorial field set grouped for search', () => {
+    expect(CONTENT_FIELD_GROUPS.map((group) => group.label)).toEqual([
+      'Content',
+      'Publishing',
+      'Images',
+      'SEO',
+      'Social',
+      'Advanced',
+    ]);
+    expect(CONTENT_FIELD_MAPPINGS.map((field) => field.value)).toEqual([
+      'title',
+      'html',
+      'slug',
+      'custom_excerpt',
+      'type',
+      'status',
+      'visibility',
+      'featured',
+      'created_at',
+      'updated_at',
+      'published_at',
+      'feature_image',
+      'feature_image_alt',
+      'feature_image_caption',
+      'show_title_and_feature_image',
+      'meta_title',
+      'meta_description',
+      'canonical_url',
+      'og_image',
+      'og_title',
+      'og_description',
+      'twitter_image',
+      'twitter_title',
+      'twitter_description',
+      'custom_template',
+      'codeinjection_head',
+      'codeinjection_foot',
+      'frontmatter',
+    ]);
+    expect(CONTENT_FIELD_MAPPINGS.map((field) => field.value)).not.toEqual(
+      expect.arrayContaining([
+        'authors',
+        'tags',
+        'comment_id',
+        'newsletter_id',
+        'email',
+        'tiers',
+        'id',
+        'lexical',
+      ]),
+    );
   });
 });

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
@@ -14,4 +14,21 @@ describe('ContentFieldMapping', () => {
 
     expect(mapping.toJSON()).toEqual({ 'First title': '', 'Second title': 'title' });
   });
+
+  it('detects exact field-name headers', () => {
+    const mapping = ContentFieldMapping.detect(['title', 'html', 'published_at', 'Something else']);
+
+    expect(mapping.toJSON()).toEqual({
+      title: 'title',
+      html: 'html',
+      published_at: 'published_at',
+      'Something else': '',
+    });
+  });
+
+  it('does not case-fold or guess header mappings', () => {
+    const mapping = ContentFieldMapping.detect(['Title', 'Post HTML', 'Published At']);
+
+    expect(mapping.toJSON()).toEqual({ Title: '', 'Post HTML': '', 'Published At': '' });
+  });
 });

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
@@ -1,0 +1,40 @@
+export const CONTENT_FIELD_MAPPINGS = [
+  { label: 'Title', value: 'title' },
+  { label: 'HTML', value: 'html' },
+  { label: 'Published at', value: 'published_at' },
+] as const;
+
+export class ContentFieldMapping {
+  private readonly mapping: Record<string, string | null>;
+
+  constructor(mapping: Record<string, string | null>) {
+    this.mapping = { ...mapping };
+  }
+
+  static empty(columns: string[]): ContentFieldMapping {
+    return new ContentFieldMapping(Object.fromEntries(columns.map((column) => [column, null])));
+  }
+
+  get(column: string): string | null {
+    return this.mapping[column] ?? null;
+  }
+
+  update(column: string, target: string | null): ContentFieldMapping {
+    const next = { ...this.mapping };
+    if (target) {
+      for (const mappedColumn of Object.keys(next)) {
+        if (next[mappedColumn] === target) {
+          next[mappedColumn] = null;
+        }
+      }
+    }
+    next[column] = target;
+    return new ContentFieldMapping(next);
+  }
+
+  toJSON(): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(this.mapping).map(([column, target]) => [column, target ?? '']),
+    );
+  }
+}

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
@@ -15,6 +15,13 @@ export class ContentFieldMapping {
     return new ContentFieldMapping(Object.fromEntries(columns.map((column) => [column, null])));
   }
 
+  static detect(columns: string[]): ContentFieldMapping {
+    const targets = new Set<string>(CONTENT_FIELD_MAPPINGS.map((field) => field.value));
+    return new ContentFieldMapping(
+      Object.fromEntries(columns.map((column) => [column, targets.has(column) ? column : null])),
+    );
+  }
+
   get(column: string): string | null {
     return this.mapping[column] ?? null;
   }

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
@@ -1,8 +1,80 @@
-export const CONTENT_FIELD_MAPPINGS = [
-  { label: 'Title', value: 'title', required: true },
-  { label: 'HTML', value: 'html', required: false },
-  { label: 'Published at', value: 'published_at', required: false },
+export interface ContentField {
+  label: string;
+  value: string;
+  required: boolean;
+}
+
+interface ContentFieldGroup {
+  label: string;
+  fields: readonly ContentField[];
+}
+
+export const CONTENT_FIELD_GROUPS: readonly ContentFieldGroup[] = [
+  {
+    label: 'Content',
+    fields: [
+      { label: 'Title', value: 'title', required: true },
+      { label: 'HTML', value: 'html', required: false },
+      { label: 'Slug', value: 'slug', required: false },
+      { label: 'Custom excerpt', value: 'custom_excerpt', required: false },
+    ],
+  },
+  {
+    label: 'Publishing',
+    fields: [
+      { label: 'Type', value: 'type', required: false },
+      { label: 'Status', value: 'status', required: false },
+      { label: 'Visibility', value: 'visibility', required: false },
+      { label: 'Featured', value: 'featured', required: false },
+      { label: 'Created at', value: 'created_at', required: false },
+      { label: 'Updated at', value: 'updated_at', required: false },
+      { label: 'Published at', value: 'published_at', required: false },
+    ],
+  },
+  {
+    label: 'Images',
+    fields: [
+      { label: 'Feature image', value: 'feature_image', required: false },
+      { label: 'Feature image alt', value: 'feature_image_alt', required: false },
+      { label: 'Feature image caption', value: 'feature_image_caption', required: false },
+      {
+        label: 'Show title and feature image',
+        value: 'show_title_and_feature_image',
+        required: false,
+      },
+    ],
+  },
+  {
+    label: 'SEO',
+    fields: [
+      { label: 'Meta title', value: 'meta_title', required: false },
+      { label: 'Meta description', value: 'meta_description', required: false },
+      { label: 'Canonical URL', value: 'canonical_url', required: false },
+    ],
+  },
+  {
+    label: 'Social',
+    fields: [
+      { label: 'Open Graph image', value: 'og_image', required: false },
+      { label: 'Open Graph title', value: 'og_title', required: false },
+      { label: 'Open Graph description', value: 'og_description', required: false },
+      { label: 'Twitter image', value: 'twitter_image', required: false },
+      { label: 'Twitter title', value: 'twitter_title', required: false },
+      { label: 'Twitter description', value: 'twitter_description', required: false },
+    ],
+  },
+  {
+    label: 'Advanced',
+    fields: [
+      { label: 'Custom template', value: 'custom_template', required: false },
+      { label: 'Code injection head', value: 'codeinjection_head', required: false },
+      { label: 'Code injection foot', value: 'codeinjection_foot', required: false },
+      { label: 'Frontmatter', value: 'frontmatter', required: false },
+    ],
+  },
 ] as const;
+
+export const CONTENT_FIELD_MAPPINGS = CONTENT_FIELD_GROUPS.flatMap((group) => group.fields);
 
 export class ContentFieldMapping {
   private readonly mapping: Record<string, string | null>;

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
@@ -15,6 +15,7 @@ export const CONTENT_FIELD_GROUPS: readonly ContentFieldGroup[] = [
     fields: [
       { label: 'Title', value: 'title', required: true },
       { label: 'HTML', value: 'html', required: false },
+      { label: 'Markdown', value: 'markdown', required: false },
       { label: 'Slug', value: 'slug', required: false },
       { label: 'Custom excerpt', value: 'custom_excerpt', required: false },
     ],

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
@@ -1,7 +1,7 @@
 export const CONTENT_FIELD_MAPPINGS = [
-  { label: 'Title', value: 'title' },
-  { label: 'HTML', value: 'html' },
-  { label: 'Published at', value: 'published_at' },
+  { label: 'Title', value: 'title', required: true },
+  { label: 'HTML', value: 'html', required: false },
+  { label: 'Published at', value: 'published_at', required: false },
 ] as const;
 
 export class ContentFieldMapping {
@@ -24,6 +24,10 @@ export class ContentFieldMapping {
 
   get(column: string): string | null {
     return this.mapping[column] ?? null;
+  }
+
+  hasTarget(target: string): boolean {
+    return Object.values(this.mapping).includes(target);
   }
 
   update(column: string, target: string | null): ContentFieldMapping {

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
@@ -131,7 +131,7 @@ describe('UniversalImportModal', () => {
     await waitFor(() =>
       expect(mockImportContentCSV).toHaveBeenCalledWith({
         file,
-        mapping: { title: '' },
+        mapping: { title: 'title' },
       }),
     );
     expect(mockImportContent).not.toHaveBeenCalled();

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
@@ -151,6 +151,17 @@ describe('UniversalImportModal', () => {
     expect(mockImportContentCSV).not.toHaveBeenCalled();
   });
 
+  it('blocks importing while the required title field is unmapped', async () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    showModal();
+
+    await dropFile(new File(['Headline\nHello'], 'posts.csv', { type: 'text/csv' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Required field missing: Title');
+    expect(screen.getByRole('button', { name: 'Import' })).toBeDisabled();
+    expect(mockImportContentCSV).not.toHaveBeenCalled();
+  });
+
   it('still sends JSON files to the db import when csvContentImporter is enabled', async () => {
     mockUseFeatureFlag.mockReturnValue(true);
     showModal();

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
@@ -109,7 +109,7 @@ describe('UniversalImportModal', () => {
     expect(screen.getByTestId('universal-import-modal')).toBeInTheDocument();
   });
 
-  it('sends CSV files to the posts upload endpoint when csvContentImporter is enabled', async () => {
+  it('maps CSV files before sending them to the posts upload endpoint', async () => {
     mockUseFeatureFlag.mockReturnValue(true);
     showModal();
 
@@ -121,9 +121,34 @@ describe('UniversalImportModal', () => {
     const file = new File(['title\nHello'], 'posts.csv', { type: 'text/csv' });
     await dropFile(file);
 
-    await waitFor(() => expect(mockImportContentCSV).toHaveBeenCalledWith(file));
+    expect(await screen.findByText('Map CSV fields')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(mockImportContentCSV).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() =>
+      expect(mockImportContentCSV).toHaveBeenCalledWith({
+        file,
+        mapping: { title: '' },
+      }),
+    );
     expect(mockImportContent).not.toHaveBeenCalled();
     expect(await screen.findByTestId('confirmation-modal')).toHaveTextContent('Import in progress');
+  });
+
+  it('can start over after selecting a CSV file', async () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    showModal();
+
+    await dropFile(new File(['title\nHello'], 'posts.csv', { type: 'text/csv' }));
+    expect(await screen.findByText('Map CSV fields')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start over' }));
+
+    expect(await fileInput()).toBeInTheDocument();
+    expect(mockImportContentCSV).not.toHaveBeenCalled();
   });
 
   it('still sends JSON files to the db import when csvContentImporter is enabled', async () => {
@@ -144,6 +169,8 @@ describe('UniversalImportModal', () => {
     showModal();
 
     await dropFile(new File(['title\nHello'], 'posts.csv', { type: 'text/csv' }));
+    await screen.findByText('Map CSV fields');
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => expect(mockHandleError).toHaveBeenCalledWith(error));
     expect(screen.getByTestId('universal-import-modal')).toBeInTheDocument();

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.test.tsx
@@ -38,6 +38,10 @@ vi.mock('@tryghost/admin-x-framework/hooks', async () => {
 });
 
 describe('UniversalImportModal', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockImportContent.mockResolvedValue({});
@@ -160,6 +164,33 @@ describe('UniversalImportModal', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('Required field missing: Title');
     expect(screen.getByRole('button', { name: 'Import' })).toBeDisabled();
     expect(mockImportContentCSV).not.toHaveBeenCalled();
+  });
+
+  it('searches grouped editorial targets and submits the chosen field', async () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    showModal();
+
+    const file = new File(['title,Social summary\nHello,Shared copy'], 'posts.csv', {
+      type: 'text/csv',
+    });
+    await dropFile(file);
+
+    fireEvent.click(await screen.findByRole('combobox', { name: /Field for Social summary/ }));
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByText('Social')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search post fields...'), {
+      target: { value: 'Twitter description' },
+    });
+    fireEvent.click(screen.getByText('Twitter description'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() =>
+      expect(mockImportContentCSV).toHaveBeenCalledWith({
+        file,
+        mapping: { title: 'title', 'Social summary': 'twitter_description' },
+      }),
+    );
   });
 
   it('still sends JSON files to the db import when csvContentImporter is enabled', async () => {

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -59,7 +59,7 @@ const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) =>
         setCSVImport({
           file,
           rows,
-          mapping: ContentFieldMapping.empty(columnsOf(rows)),
+          mapping: ContentFieldMapping.detect(columnsOf(rows)),
           sampleIndex: 0,
         });
       } catch (error) {

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -1,18 +1,30 @@
 import React, { useState } from 'react';
 import { Button, Dropzone } from '@tryghost/shade/components';
 import { ExternalLink } from 'lucide-react';
-import { Inline } from '@tryghost/shade/primitives';
+import { Inline, Stack } from '@tryghost/shade/primitives';
 import { SettingsModal } from '@tryghost/shade/patterns';
 import { useConfirmation } from '@/settings/providers/confirmation-context';
 import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { useImportContent } from '@tryghost/admin-x-framework/api/db';
 import { useImportContentCSV } from '@tryghost/admin-x-framework/api/posts';
+import { ContentFieldMapping } from './content-import/mapping';
+import { MappingStep } from './content-import/mapping-step';
+import { columnsOf, readCSV } from './content-import/csv';
+
+interface CSVImportState {
+  file: File;
+  rows: Record<string, string>[];
+  mapping: ContentFieldMapping;
+  sampleIndex: number;
+}
 
 const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { mutateAsync: importContent } = useImportContent();
   const { mutateAsync: importContentCSV } = useImportContentCSV();
   const csvContentImporter = useFeatureFlag('csvContentImporter');
   const [uploading, setUploading] = useState(false);
+  const [reading, setReading] = useState(false);
+  const [csvImport, setCSVImport] = useState<CSVImportState | null>(null);
   const handleError = useHandleError();
   const { confirm } = useConfirmation();
 
@@ -20,27 +32,48 @@ const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) =>
     ? { 'application/json': ['.json'], 'application/zip': ['.zip'], 'text/csv': ['.csv'] }
     : { 'application/json': ['.json'], 'application/zip': ['.zip'] };
 
+  const finishImport = (isCSV: boolean) => {
+    onClose();
+    confirm({
+      title: 'Import in progress',
+      // CSV imports don't send a completion email yet, so don't promise one
+      prompt: isCSV
+        ? `Your import is being processed, and imported posts will appear on your site as soon as it’s complete. Usually this only takes a few minutes, but larger imports may take longer.`
+        : `Your import is being processed, and you'll receive a confirmation email as soon as it’s complete. Usually this only takes a few minutes, but larger imports may take longer.`,
+      cancelLabel: '',
+      okLabel: 'Got it',
+      onOk: (confirmModal) => confirmModal?.remove(),
+      formSheet: false,
+    });
+  };
+
   const importFile = async (file: File) => {
+    const isCSV = csvContentImporter && file.name.toLowerCase().endsWith('.csv');
+    if (isCSV) {
+      setReading(true);
+      try {
+        const rows = await readCSV(file);
+        if (rows.length === 0) {
+          throw new Error('File is empty, nothing to import. Please select a different file.');
+        }
+        setCSVImport({
+          file,
+          rows,
+          mapping: ContentFieldMapping.empty(columnsOf(rows)),
+          sampleIndex: 0,
+        });
+      } catch (error) {
+        handleError(error);
+      } finally {
+        setReading(false);
+      }
+      return;
+    }
+
     setUploading(true);
     try {
-      const isCSV = csvContentImporter && file.name.toLowerCase().endsWith('.csv');
-      if (isCSV) {
-        await importContentCSV(file);
-      } else {
-        await importContent(file);
-      }
-      onClose();
-      confirm({
-        title: 'Import in progress',
-        // CSV imports don't send a completion email yet, so don't promise one
-        prompt: isCSV
-          ? `Your import is being processed, and imported posts will appear on your site as soon as it’s complete. Usually this only takes a few minutes, but larger imports may take longer.`
-          : `Your import is being processed, and you'll receive a confirmation email as soon as it’s complete. Usually this only takes a few minutes, but larger imports may take longer.`,
-        cancelLabel: '',
-        okLabel: 'Got it',
-        onOk: (confirmModal) => confirmModal?.remove(),
-        formSheet: false,
-      });
+      await importContent(file);
+      finishImport(false);
     } catch (e) {
       handleError(e);
     } finally {
@@ -48,51 +81,108 @@ const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) =>
     }
   };
 
+  const importCSV = async () => {
+    if (!csvImport) {
+      return;
+    }
+    setUploading(true);
+    try {
+      await importContentCSV({ file: csvImport.file, mapping: csvImport.mapping.toJSON() });
+      finishImport(true);
+    } catch (error) {
+      handleError(error);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const updateMapping = (column: string, target: string | null) => {
+    setCSVImport((current) =>
+      current ? { ...current, mapping: current.mapping.update(column, target) } : current,
+    );
+  };
+
+  const footer = csvImport ? (
+    <Inline align="center" className="w-full p-8" justify="between">
+      <Button
+        disabled={uploading}
+        type="button"
+        variant="outline"
+        onClick={() => setCSVImport(null)}
+      >
+        Start over
+      </Button>
+      <Inline gap="sm">
+        <Button disabled={uploading} type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button disabled={uploading} type="button" onClick={() => void importCSV()}>
+          {uploading ? 'Uploading...' : 'Import'}
+        </Button>
+      </Inline>
+    </Inline>
+  ) : (
+    <Inline align="center" className="w-full p-8" justify="between">
+      <a
+        className="inline-flex items-center gap-1 text-green transition-colors hover:text-green-400"
+        href="https://docs.ghost.org/migration/ghost"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Learn more
+        <ExternalLink aria-hidden="true" className="size-3" />
+      </a>
+      <Button disabled={uploading || reading} type="button" variant="outline" onClick={onClose}>
+        Cancel
+      </Button>
+    </Inline>
+  );
+
   return (
     <SettingsModal
       backDropClick={false}
-      footer={
-        <Inline align="center" className="w-full p-8" justify="between">
-          <a
-            className="inline-flex items-center gap-1 text-green transition-colors hover:text-green-400"
-            href="https://docs.ghost.org/migration/ghost"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Learn more
-            <ExternalLink aria-hidden="true" className="size-3" />
-          </a>
-          <Button disabled={uploading} type="button" variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-        </Inline>
-      }
+      footer={footer}
       okLabel=""
-      size="sm"
+      size={csvImport ? 'lg' : 'sm'}
       testId="universal-import-modal"
-      title="Universal import"
+      title={csvImport ? 'Map CSV fields' : 'Universal import'}
       onClose={onClose}
     >
-      <div className="py-4">
-        <Dropzone
-          accept={acceptedTypes}
-          inputId="import-file"
-          inputTestId="import-file"
-          onDropAccepted={([file]) => void importFile(file)}
-        >
-          <div className="text-center" data-testid="import-file-description">
-            {uploading ? (
-              'Uploading...'
-            ) : (
-              <>
-                Select any {csvContentImporter ? 'JSON, zip or CSV' : 'JSON or zip'} file that
-                contains <br />
-                posts and settings
-              </>
-            )}
-          </div>
-        </Dropzone>
-      </div>
+      <Stack className="py-4">
+        {csvImport ? (
+          <MappingStep
+            disabled={uploading}
+            mapping={csvImport.mapping}
+            rows={csvImport.rows}
+            sampleIndex={csvImport.sampleIndex}
+            onMappingChange={updateMapping}
+            onSampleIndexChange={(sampleIndex) =>
+              setCSVImport((current) => (current ? { ...current, sampleIndex } : current))
+            }
+          />
+        ) : (
+          <Dropzone
+            accept={acceptedTypes}
+            inputId="import-file"
+            inputTestId="import-file"
+            onDropAccepted={([file]) => void importFile(file)}
+          >
+            <div className="text-center" data-testid="import-file-description">
+              {uploading ? (
+                'Uploading...'
+              ) : reading ? (
+                'Reading CSV...'
+              ) : (
+                <>
+                  Select any {csvContentImporter ? 'JSON, zip or CSV' : 'JSON or zip'} file that
+                  contains <br />
+                  posts and settings
+                </>
+              )}
+            </div>
+          </Dropzone>
+        )}
+      </Stack>
     </SettingsModal>
   );
 };

--- a/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -102,6 +102,8 @@ const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) =>
     );
   };
 
+  const missingTitle = csvImport !== null && !csvImport.mapping.hasTarget('title');
+
   const footer = csvImport ? (
     <Inline align="center" className="w-full p-8" justify="between">
       <Button
@@ -116,7 +118,7 @@ const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) =>
         <Button disabled={uploading} type="button" variant="outline" onClick={onClose}>
           Cancel
         </Button>
-        <Button disabled={uploading} type="button" onClick={() => void importCSV()}>
+        <Button disabled={uploading || missingTitle} type="button" onClick={() => void importCSV()}>
           {uploading ? 'Uploading...' : 'Import'}
         </Button>
       </Inline>
@@ -153,6 +155,7 @@ const UniversalImportModal: React.FC<{ onClose: () => void }> = ({ onClose }) =>
           <MappingStep
             disabled={uploading}
             mapping={csvImport.mapping}
+            missingTitle={missingTitle}
             rows={csvImport.rows}
             sampleIndex={csvImport.sampleIndex}
             onMappingChange={updateMapping}

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -134,6 +134,7 @@ const controller = {
       // the 202.
       const { importId, total } = await contentImportService.importCSV({
         filePath: frame.file.path,
+        mapping: frame.data.mapping,
       });
       return { meta: { import_id: importId, total } };
     },

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -13,6 +13,7 @@ const tpl = require('@tryghost/tpl');
 
 export interface ImportRequest {
   filePath: string;
+  mapping?: Record<string, string>;
 }
 
 // The id is what a completion report will be looked up by.
@@ -33,7 +34,7 @@ export interface PostsRepository {
 // Must not throw: it is called from catch blocks that exist to stop an error escaping.
 export type FailureReporter = (error: unknown) => void;
 
-type ReadRows = (path: string) => Promise<PostImportRow[]>;
+type ReadRows = (path: string, mapping?: Record<string, string>) => Promise<PostImportRow[]>;
 
 const messages = {
   unreadableFile: 'The file could not be parsed as a CSV file.',
@@ -113,7 +114,7 @@ class ContentCSVImporter {
   async importCSV(request: ImportRequest): Promise<ImportAccepted> {
     let rows: PostImportRow[];
     try {
-      rows = await this._readRows(request.filePath);
+      rows = await this._readRows(request.filePath, request.mapping);
     } catch (error) {
       throw new errors.ValidationError({
         message: tpl(messages.unreadableFile),

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -1,6 +1,7 @@
 import moment from 'moment-timezone';
 import buildPostData, {
   RowSkipped,
+  type CleanHTML,
   type HtmlToLexical,
   type MarkdownToHtml,
   type PostData,
@@ -65,6 +66,7 @@ interface ImporterDeps {
   // A getter so the heavy html->lexical require resolves once per run
   getHtmlToLexical: () => HtmlToLexical;
   getMarkdownToHtml: () => MarkdownToHtml;
+  getCleanHTML: () => CleanHTML;
   addJob: (job: { job: () => Promise<void>; offloaded: boolean; name: string }) => void;
   report: FailureReporter;
   store: ImportRunStore;
@@ -86,6 +88,7 @@ class ContentCSVImporter {
   private _posts: PostsRepository;
   private _getHtmlToLexical: () => HtmlToLexical;
   private _getMarkdownToHtml: () => MarkdownToHtml;
+  private _getCleanHTML: () => CleanHTML;
   private _addJob: ImporterDeps['addJob'];
   private _report: FailureReporter;
   private _store: ImportRunStore;
@@ -99,6 +102,7 @@ class ContentCSVImporter {
     posts,
     getHtmlToLexical,
     getMarkdownToHtml,
+    getCleanHTML,
     addJob,
     report,
     store,
@@ -111,6 +115,7 @@ class ContentCSVImporter {
     this._posts = posts;
     this._getHtmlToLexical = getHtmlToLexical;
     this._getMarkdownToHtml = getMarkdownToHtml;
+    this._getCleanHTML = getCleanHTML;
     this._addJob = addJob;
     this._report = report;
     this._store = store;
@@ -169,6 +174,7 @@ class ContentCSVImporter {
     try {
       const htmlToLexical = this._getHtmlToLexical();
       const markdownToHtml = this._getMarkdownToHtml();
+      const cleanHTML = this._getCleanHTML();
       let attemptedWrites = 0;
       let successfulWrites = 0;
       let failedWrites = 0;
@@ -179,7 +185,7 @@ class ContentCSVImporter {
         let data: PostData;
 
         try {
-          data = buildPostData(row, htmlToLexical, importTagNames, markdownToHtml);
+          data = buildPostData(row, htmlToLexical, importTagNames, markdownToHtml, cleanHTML);
         } catch (error) {
           if (error instanceof RowSkipped) {
             this._store.record(runId, {

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -1,5 +1,10 @@
 import moment from 'moment-timezone';
-import buildPostData, { RowSkipped, type HtmlToLexical, type PostData } from './post-data';
+import buildPostData, {
+  RowSkipped,
+  type HtmlToLexical,
+  type MarkdownToHtml,
+  type PostData,
+} from './post-data';
 import type { PostImportRow } from './row';
 import type { Clock, ImportRunStore, RowOutcome } from './store';
 
@@ -59,6 +64,7 @@ interface ImporterDeps {
   posts: PostsRepository;
   // A getter so the heavy html->lexical require resolves once per run
   getHtmlToLexical: () => HtmlToLexical;
+  getMarkdownToHtml: () => MarkdownToHtml;
   addJob: (job: { job: () => Promise<void>; offloaded: boolean; name: string }) => void;
   report: FailureReporter;
   store: ImportRunStore;
@@ -79,6 +85,7 @@ class ContentCSVImporter {
   private _readRows: ReadRows;
   private _posts: PostsRepository;
   private _getHtmlToLexical: () => HtmlToLexical;
+  private _getMarkdownToHtml: () => MarkdownToHtml;
   private _addJob: ImporterDeps['addJob'];
   private _report: FailureReporter;
   private _store: ImportRunStore;
@@ -91,6 +98,7 @@ class ContentCSVImporter {
     readRows,
     posts,
     getHtmlToLexical,
+    getMarkdownToHtml,
     addJob,
     report,
     store,
@@ -102,6 +110,7 @@ class ContentCSVImporter {
     this._readRows = readRows;
     this._posts = posts;
     this._getHtmlToLexical = getHtmlToLexical;
+    this._getMarkdownToHtml = getMarkdownToHtml;
     this._addJob = addJob;
     this._report = report;
     this._store = store;
@@ -159,6 +168,7 @@ class ContentCSVImporter {
 
     try {
       const htmlToLexical = this._getHtmlToLexical();
+      const markdownToHtml = this._getMarkdownToHtml();
       let attemptedWrites = 0;
       let successfulWrites = 0;
       let failedWrites = 0;
@@ -169,7 +179,7 @@ class ContentCSVImporter {
         let data: PostData;
 
         try {
-          data = buildPostData(row, htmlToLexical, importTagNames);
+          data = buildPostData(row, htmlToLexical, importTagNames, markdownToHtml);
         } catch (error) {
           if (error instanceof RowSkipped) {
             this._store.record(runId, {

--- a/ghost/core/core/server/services/content-import/import/post-data.ts
+++ b/ghost/core/core/server/services/content-import/import/post-data.ts
@@ -4,6 +4,7 @@ const { slugify } = require('@tryghost/string');
 
 export type HtmlToLexical = (html: string) => unknown;
 export type MarkdownToHtml = (markdown: string) => string;
+export type CleanHTML = (args: { html: string; opinionated: boolean }) => string;
 
 // A malformed row, refused before any write was attempted; distinct from a write
 // that failed, which the importer records separately.
@@ -82,6 +83,7 @@ export default function buildPostData(
   htmlToLexical: HtmlToLexical,
   importTagNames: string[],
   markdownToHtml?: MarkdownToHtml,
+  cleanHTML?: CleanHTML,
 ): PostData {
   const check = importableRowSchema.safeParse(row);
   if (!check.success) {
@@ -108,20 +110,34 @@ export default function buildPostData(
     throw new RowSkipped('html and markdown cannot both be provided');
   }
 
+  let sourceHTML = row.html;
+  let sourceKind: 'html' | 'markdown' = 'html';
   if (row.markdown) {
     if (!markdownToHtml) {
       throw new RowSkipped('markdown could not be converted');
     }
     try {
-      data.lexical = JSON.stringify(htmlToLexical(markdownToHtml(row.markdown)));
+      sourceHTML = markdownToHtml(row.markdown);
+      sourceKind = 'markdown';
     } catch {
       throw new RowSkipped('markdown could not be converted');
     }
-  } else if (row.html) {
+  }
+
+  if (sourceHTML) {
+    let cleanedHTML = sourceHTML;
+    if (cleanHTML) {
+      try {
+        cleanedHTML = cleanHTML({ html: sourceHTML, opinionated: true });
+      } catch {
+        throw new RowSkipped('html could not be cleaned');
+      }
+    }
+
     try {
-      data.lexical = JSON.stringify(htmlToLexical(row.html));
+      data.lexical = JSON.stringify(htmlToLexical(cleanedHTML));
     } catch {
-      throw new RowSkipped('html could not be converted');
+      throw new RowSkipped(`${sourceKind} could not be converted`);
     }
   }
 

--- a/ghost/core/core/server/services/content-import/import/post-data.ts
+++ b/ghost/core/core/server/services/content-import/import/post-data.ts
@@ -13,6 +13,20 @@ export class RowSkipped extends Error {
   }
 }
 
+export interface PostsMetaData {
+  feature_image_alt?: string;
+  feature_image_caption?: string;
+  meta_title?: string;
+  meta_description?: string;
+  og_image?: string;
+  og_title?: string;
+  og_description?: string;
+  twitter_image?: string;
+  twitter_title?: string;
+  twitter_description?: string;
+  frontmatter?: string;
+}
+
 // The values handed to models.Post.add. Content is lexical only: under
 // options.importing the model strips client-supplied html and regenerates it from
 // lexical on save, so the CSV's html must be converted, never passed through.
@@ -21,14 +35,46 @@ export interface PostData {
   title: string;
   slug: string;
   lexical?: string;
+  custom_excerpt?: string;
+  feature_image?: string;
+  canonical_url?: string;
+  custom_template?: string;
+  codeinjection_head?: string;
+  codeinjection_foot?: string;
+  featured?: boolean;
+  show_title_and_feature_image?: boolean;
   published_at?: string;
   created_at?: string;
   updated_at?: string;
-  status: 'published';
-  type: 'post';
-  visibility: 'public';
+  status: 'draft' | 'published';
+  type: 'post' | 'page';
+  visibility: 'public' | 'members' | 'paid';
   tags: Array<{ name: string }>;
+  posts_meta?: PostsMetaData;
 }
+
+const DIRECT_OPTIONAL_FIELDS = [
+  'custom_excerpt',
+  'feature_image',
+  'canonical_url',
+  'custom_template',
+  'codeinjection_head',
+  'codeinjection_foot',
+] as const;
+
+const META_FIELDS = [
+  'feature_image_alt',
+  'feature_image_caption',
+  'meta_title',
+  'meta_description',
+  'og_image',
+  'og_title',
+  'og_description',
+  'twitter_image',
+  'twitter_title',
+  'twitter_description',
+  'frontmatter',
+] as const;
 
 export default function buildPostData(
   row: PostImportRow,
@@ -45,13 +91,13 @@ export default function buildPostData(
     // Slugified here with the standard rules: left to the model, the
     // importing-context slug pass keeps every punctuation dash
     // (slugify requiredChangesOnly).
-    slug: slugify(row.title),
-    // Explicit rather than left to the model, which would default status to draft and
-    // visibility to the default_content_visibility setting. Never 'scheduled': the
-    // post scheduler has no importing check.
-    status: 'published',
-    type: 'post',
-    visibility: 'public',
+    slug: slugify(row.slug ?? row.title),
+    // Explicit rather than left to the model, which would default visibility
+    // from the site setting. Never 'scheduled': the post scheduler has no
+    // importing check.
+    status: (row.status as PostData['status'] | undefined) ?? 'published',
+    type: (row.type as PostData['type'] | undefined) ?? 'post',
+    visibility: (row.visibility as PostData['visibility'] | undefined) ?? 'public',
     // The # prefix gives the batch tags internal visibility.
     tags: importTagNames.map((name) => ({ name })),
   };
@@ -64,13 +110,44 @@ export default function buildPostData(
     }
   }
 
-  // The one date column dates the whole post; preserved only because the write runs
-  // under options.importing, which stops the model stamping its own timestamps.
+  for (const field of DIRECT_OPTIONAL_FIELDS) {
+    if (row[field] !== undefined) {
+      data[field] = row[field];
+    }
+  }
+
+  if (row.featured !== undefined) {
+    data.featured = toBoolean(row.featured);
+  }
+  if (row.show_title_and_feature_image !== undefined) {
+    data.show_title_and_feature_image = toBoolean(row.show_title_and_feature_image);
+  }
+
+  // published_at remains the fallback timestamp for the whole post, while an
+  // explicit created_at or updated_at wins for that individual field.
   if (row.published_at) {
     data.published_at = row.published_at;
-    data.created_at = row.published_at;
-    data.updated_at = row.published_at;
+  }
+  if (row.created_at ?? row.published_at) {
+    data.created_at = row.created_at ?? row.published_at;
+  }
+  if (row.updated_at ?? row.published_at) {
+    data.updated_at = row.updated_at ?? row.published_at;
+  }
+
+  const postsMeta: PostsMetaData = {};
+  for (const field of META_FIELDS) {
+    if (row[field] !== undefined) {
+      postsMeta[field] = row[field];
+    }
+  }
+  if (Object.keys(postsMeta).length > 0) {
+    data.posts_meta = postsMeta;
   }
 
   return data;
+}
+
+function toBoolean(value: string): boolean {
+  return value === '1' || value.toLowerCase() === 'true';
 }

--- a/ghost/core/core/server/services/content-import/import/post-data.ts
+++ b/ghost/core/core/server/services/content-import/import/post-data.ts
@@ -3,6 +3,7 @@ import { importableRowSchema, type PostImportRow } from './row';
 const { slugify } = require('@tryghost/string');
 
 export type HtmlToLexical = (html: string) => unknown;
+export type MarkdownToHtml = (markdown: string) => string;
 
 // A malformed row, refused before any write was attempted; distinct from a write
 // that failed, which the importer records separately.
@@ -80,6 +81,7 @@ export default function buildPostData(
   row: PostImportRow,
   htmlToLexical: HtmlToLexical,
   importTagNames: string[],
+  markdownToHtml?: MarkdownToHtml,
 ): PostData {
   const check = importableRowSchema.safeParse(row);
   if (!check.success) {
@@ -102,7 +104,20 @@ export default function buildPostData(
     tags: importTagNames.map((name) => ({ name })),
   };
 
-  if (row.html) {
+  if (row.html && row.markdown) {
+    throw new RowSkipped('html and markdown cannot both be provided');
+  }
+
+  if (row.markdown) {
+    if (!markdownToHtml) {
+      throw new RowSkipped('markdown could not be converted');
+    }
+    try {
+      data.lexical = JSON.stringify(htmlToLexical(markdownToHtml(row.markdown)));
+    } catch {
+      throw new RowSkipped('markdown could not be converted');
+    }
+  } else if (row.html) {
     try {
       data.lexical = JSON.stringify(htmlToLexical(row.html));
     } catch {

--- a/ghost/core/core/server/services/content-import/import/reader.ts
+++ b/ghost/core/core/server/services/content-import/import/reader.ts
@@ -8,7 +8,10 @@ const FIELD_BY_HEADER: Record<string, string> = {
   published_at: 'published_at',
 };
 
-export default async function readPostRows(path: string): Promise<PostImportRow[]> {
-  const rows = await parseCSV(path, FIELD_BY_HEADER);
+export default async function readPostRows(
+  path: string,
+  mapping?: Record<string, string>,
+): Promise<PostImportRow[]> {
+  const rows = await parseCSV(path, mapping ?? FIELD_BY_HEADER);
   return rows.map((row) => postImportRowSchema.parse(row));
 }

--- a/ghost/core/core/server/services/content-import/import/reader.ts
+++ b/ghost/core/core/server/services/content-import/import/reader.ts
@@ -1,12 +1,9 @@
 import { parse as parseCSV } from '../csv';
-import { postImportRowSchema, type PostImportRow } from './row';
+import { EDITORIAL_POST_FIELDS, postImportRowSchema, type PostImportRow } from './row';
 
-// Identity map until the field-mapping milestone adds caller-supplied mappings.
-const FIELD_BY_HEADER: Record<string, string> = {
-  title: 'title',
-  html: 'html',
-  published_at: 'published_at',
-};
+const FIELD_BY_HEADER: Record<string, string> = Object.fromEntries(
+  EDITORIAL_POST_FIELDS.map((field) => [field, field]),
+);
 
 export default async function readPostRows(
   path: string,

--- a/ghost/core/core/server/services/content-import/import/row.ts
+++ b/ghost/core/core/server/services/content-import/import/row.ts
@@ -4,6 +4,7 @@ import { Temporal } from 'temporal-polyfill';
 export const EDITORIAL_POST_FIELDS = [
   'title',
   'html',
+  'markdown',
   'slug',
   'custom_excerpt',
   'type',
@@ -47,6 +48,7 @@ export const postImportRowSchema = z
       .default('')
       .transform((cell) => cell.trim()),
     html: z.string().default(''),
+    markdown: z.string().default(''),
     slug: optionalCell,
     custom_excerpt: optionalCell,
     type: optionalCell,

--- a/ghost/core/core/server/services/content-import/import/row.ts
+++ b/ghost/core/core/server/services/content-import/import/row.ts
@@ -1,6 +1,37 @@
 import { z } from 'zod';
 import { Temporal } from 'temporal-polyfill';
 
+export const EDITORIAL_POST_FIELDS = [
+  'title',
+  'html',
+  'slug',
+  'custom_excerpt',
+  'type',
+  'status',
+  'visibility',
+  'featured',
+  'created_at',
+  'updated_at',
+  'published_at',
+  'feature_image',
+  'feature_image_alt',
+  'feature_image_caption',
+  'show_title_and_feature_image',
+  'meta_title',
+  'meta_description',
+  'canonical_url',
+  'og_image',
+  'og_title',
+  'og_description',
+  'twitter_image',
+  'twitter_title',
+  'twitter_description',
+  'custom_template',
+  'codeinjection_head',
+  'codeinjection_foot',
+  'frontmatter',
+] as const;
+
 // An empty cell (or the literal 'undefined') reads as absent, not as a value.
 const optionalCell = z
   .string()
@@ -16,31 +47,77 @@ export const postImportRowSchema = z
       .default('')
       .transform((cell) => cell.trim()),
     html: z.string().default(''),
+    slug: optionalCell,
+    custom_excerpt: optionalCell,
+    type: optionalCell,
+    status: optionalCell,
+    visibility: optionalCell,
+    featured: optionalCell,
+    created_at: optionalCell,
+    updated_at: optionalCell,
     published_at: optionalCell,
+    feature_image: optionalCell,
+    feature_image_alt: optionalCell,
+    feature_image_caption: optionalCell,
+    show_title_and_feature_image: optionalCell,
+    meta_title: optionalCell,
+    meta_description: optionalCell,
+    canonical_url: optionalCell,
+    og_image: optionalCell,
+    og_title: optionalCell,
+    og_description: optionalCell,
+    twitter_image: optionalCell,
+    twitter_title: optionalCell,
+    twitter_description: optionalCell,
+    custom_template: optionalCell,
+    codeinjection_head: optionalCell,
+    codeinjection_foot: optionalCell,
+    frontmatter: optionalCell,
   })
   .loose();
 
 export type PostImportRow = z.infer<typeof postImportRowSchema>;
 
+const ENUM_FIELDS = {
+  type: ['post', 'page'],
+  status: ['draft', 'published'],
+  visibility: ['public', 'members', 'paid'],
+} as const;
+const BOOLEAN_FIELDS = ['featured', 'show_title_and_feature_image'] as const;
+const DATE_FIELDS = ['created_at', 'updated_at', 'published_at'] as const;
+
 // Validation for coerced rows; buildPostData turns the first issue into a row
 // skip. A blank title is refused because the model's (Untitled) fallback is
-// skipped under options.importing; an invalid date is refused rather than
-// silently replaced with the import time (what the JSON importer does). The
-// title cap matches the posts schema's isLength validation.
-export const importableRowSchema = z
-  .object({
-    title: z.string().min(1, 'title is required').max(255, 'title must be 255 characters or fewer'),
-  })
-  .loose()
-  .superRefine((row, ctx) => {
-    const publishedAt = row.published_at;
-    if (typeof publishedAt === 'string' && !isValidDate(publishedAt)) {
-      ctx.addIssue({
-        code: 'custom',
-        message: `published_at is not a valid date: "${publishedAt}"`,
-      });
+// skipped under options.importing. Invalid source values are refused per row
+// rather than silently replaced with defaults.
+export const importableRowSchema = postImportRowSchema.superRefine((row, ctx) => {
+  if (!row.title) {
+    ctx.addIssue({ code: 'custom', message: 'title is required' });
+  } else if (row.title.length > 255) {
+    ctx.addIssue({ code: 'custom', message: 'title must be 255 characters or fewer' });
+  }
+
+  for (const field of DATE_FIELDS) {
+    const value = row[field];
+    if (value && !isValidDate(value)) {
+      ctx.addIssue({ code: 'custom', message: `${field} is not a valid date: "${value}"` });
     }
-  });
+  }
+
+  for (const [field, allowed] of Object.entries(ENUM_FIELDS)) {
+    const value = row[field];
+    if (typeof value === 'string' && !allowed.includes(value as never)) {
+      ctx.addIssue({ code: 'custom', message: `${field} must be one of: ${allowed.join(', ')}` });
+    }
+  }
+
+  for (const field of BOOLEAN_FIELDS) {
+    const value = row[field];
+    if (value && !['true', 'false', '1', '0'].includes(value.toLowerCase())) {
+      ctx.addIssue({ code: 'custom', message: `${field} must be true, false, 1, or 0` });
+    }
+  }
+});
 
 // new Date() alone is not enough: it normalizes rolled-over calendar dates, so
 // 2025-02-30 silently becomes March 2. For ISO-shaped values the calendar components

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -73,6 +73,7 @@ function makeImporter(): ContentCSVImporter {
     },
     getHtmlToLexical: () => lexicalLib.htmlToLexicalConverter,
     getMarkdownToHtml: () => require('@tryghost/kg-markdown-html-renderer').render,
+    getCleanHTML: () => require('@tryghost/mg-clean-html').cleanHTML,
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -9,7 +9,26 @@ import { ImportRunStore } from './import/store';
 
 // The request is built from HTTP upload metadata, so it is validated at the
 // service boundary rather than trusted.
-const importRequestSchema = z.object({ filePath: z.string().min(1) });
+const importableFields = new Set(['title', 'html', 'published_at']);
+const mappingSchema = z.record(z.string(), z.string()).superRefine((mapping, ctx) => {
+  const targets = new Set<string>();
+  for (const [header, target] of Object.entries(mapping)) {
+    if (!header || header in Object.prototype) {
+      ctx.addIssue({ code: 'custom', message: `Invalid CSV header mapping: "${header}"` });
+    }
+    if (target && !importableFields.has(target)) {
+      ctx.addIssue({ code: 'custom', message: `Unknown post field mapping: "${target}"` });
+    }
+    if (target && targets.has(target)) {
+      ctx.addIssue({ code: 'custom', message: `Post field is mapped more than once: "${target}"` });
+    }
+    targets.add(target);
+  }
+});
+const importRequestSchema = z.object({
+  filePath: z.string().min(1),
+  mapping: mappingSchema.optional(),
+});
 // A junk timezone setting falls back to UTC rather than mis-stamping the batch tag.
 const timezoneSchema = z.string().min(1).catch('Etc/UTC');
 

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -24,6 +24,9 @@ const mappingSchema = z.record(z.string(), z.string()).superRefine((mapping, ctx
     }
     targets.add(target);
   }
+  if (!targets.has('title')) {
+    ctx.addIssue({ code: 'custom', message: 'Post field mapping must include "title"' });
+  }
 });
 const importRequestSchema = z.object({
   filePath: z.string().min(1),
@@ -90,5 +93,15 @@ export function importCSV(request: ImportRequest): Promise<ImportAccepted> {
   if (!importer) {
     throw new errors.InternalServerError({ message: 'Content import service used before init' });
   }
-  return importer.importCSV(importRequestSchema.parse(request));
+
+  const parsedRequest = importRequestSchema.safeParse(request);
+
+  if (!parsedRequest.success) {
+    throw new errors.ValidationError({
+      message: parsedRequest.error.issues[0]?.message ?? 'Invalid content import request',
+      err: parsedRequest.error,
+    });
+  }
+
+  return importer.importCSV(parsedRequest.data);
 }

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -72,6 +72,7 @@ function makeImporter(): ContentCSVImporter {
       create: (data, options) => models.Post.add(data, options),
     },
     getHtmlToLexical: () => lexicalLib.htmlToLexicalConverter,
+    getMarkdownToHtml: () => require('@tryghost/kg-markdown-html-renderer').render,
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -5,11 +5,12 @@ import ContentCSVImporter, {
   type FailureReporter,
 } from './import/importer';
 import readPostRows from './import/reader';
+import { EDITORIAL_POST_FIELDS } from './import/row';
 import { ImportRunStore } from './import/store';
 
 // The request is built from HTTP upload metadata, so it is validated at the
 // service boundary rather than trusted.
-const importableFields = new Set(['title', 'html', 'published_at']);
+const importableFields = new Set<string>(EDITORIAL_POST_FIELDS);
 const mappingSchema = z.record(z.string(), z.string()).superRefine((mapping, ctx) => {
   const targets = new Set<string>();
   for (const [header, target] of Object.entries(mapping)) {

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -113,6 +113,7 @@
     "@tryghost/kg-default-nodes": "workspace:*",
     "@tryghost/kg-html-to-lexical": "workspace:*",
     "@tryghost/kg-lexical-html-renderer": "workspace:*",
+    "@tryghost/kg-markdown-html-renderer": "workspace:*",
     "@tryghost/limit-service": "catalog:",
     "@tryghost/logging": "catalog:",
     "@tryghost/metrics": "catalog:",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -117,6 +117,7 @@
     "@tryghost/limit-service": "catalog:",
     "@tryghost/logging": "catalog:",
     "@tryghost/metrics": "catalog:",
+    "@tryghost/mg-clean-html": "catalog:",
     "@tryghost/mongo-knex": "catalog:",
     "@tryghost/mongo-utils": "0.6.5",
     "@tryghost/mw-error-handler": "1.0.13",

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -340,10 +340,25 @@ describe('Posts Importer API', function () {
 
     const post = await models.Post.findOne({ title: 'Markdown field post', status: 'all' });
     assert.ok(post);
-    assert.match(
-      post.get('html'),
-      /<h2[^>]*>Imported heading with <strong>strong text<\/strong><\/h2>/,
+    assert.match(post.get('html'), /<h2[^>]*>Imported heading with strong text<\/h2>/);
+  });
+
+  it('Cleans supplied HTML before converting it to post content', async function () {
+    await agent.loginAsOwner();
+
+    const cleanupCsvPath = await csvFile(
+      'posts-import-clean-html.csv',
+      'title,html\n' +
+        'Clean HTML post,"<p style=""text-align: center; color: red; background: blue""><span style=""font-weight: bold"">Clean me</span></p>"\n',
     );
+
+    await agent.post('posts/upload/').attach('postsfile', cleanupCsvPath).expectStatus(202);
+    await jobsService.allSettled();
+
+    const post = await models.Post.findOne({ title: 'Clean HTML post', status: 'all' });
+    assert.ok(post);
+    assert.match(post.get('html'), /<p><strong>Clean me<\/strong><\/p>/);
+    assert.doesNotMatch(post.get('html'), /style=/);
   });
 
   it('Skips a malformed row on its own and imports the rest', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -320,6 +320,32 @@ describe('Posts Importer API', function () {
     assert.match(post.get('html'), /Mapped body/);
   });
 
+  it('Renders a mapped Markdown column through the post content converter', async function () {
+    await agent.loginAsOwner();
+
+    const markdownCsvPath = await csvFile(
+      'posts-import-markdown.csv',
+      'Headline,Source\n' + 'Markdown field post,"## Imported heading with **strong text**"\n',
+    );
+    const form = new FormData();
+    form.append('mapping[Headline]', 'title');
+    form.append('mapping[Source]', 'markdown');
+    form.append('postsfile', await fs.readFile(markdownCsvPath), {
+      filename: path.basename(markdownCsvPath),
+      contentType: 'text/csv',
+    });
+
+    await agent.post('posts/upload/').body(form).expectStatus(202);
+    await jobsService.allSettled();
+
+    const post = await models.Post.findOne({ title: 'Markdown field post', status: 'all' });
+    assert.ok(post);
+    assert.match(
+      post.get('html'),
+      /<h2[^>]*>Imported heading with <strong>strong text<\/strong><\/h2>/,
+    );
+  });
+
   it('Skips a malformed row on its own and imports the rest', async function () {
     await agent.loginAsOwner();
 
@@ -333,6 +359,7 @@ describe('Posts Importer API', function () {
         `${'x'.repeat(256)},<p>This title is too long</p>,,2024-03-02T00:00:00.000Z,published,false\n` +
         'Bad rows check status,<p>This row has a bad status</p>,,2024-03-02T00:00:00.000Z,scheduled,false\n' +
         'Bad rows check featured,<p>This row has a bad featured value</p>,,2024-03-02T00:00:00.000Z,published,yes\n' +
+        'Bad rows check content,<p>This row has HTML</p>,This row also has Markdown,2024-03-02T00:00:00.000Z,published,false\n' +
         'Bad rows check two,<p>After the bad rows</p>,,2024-03-04T00:00:00.000Z,published,false\n' +
         'Bad rows check three,<p>A loose date format</p>,,01 May 2024 00:00:00 GMT,published,false\n',
     );

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -262,16 +262,79 @@ describe('Posts Importer API', function () {
     assert.equal(post.get('visibility'), 'public');
   });
 
+  it('Imports arbitrarily headed CSV fields across every editorial category', async function () {
+    await agent.loginAsOwner();
+
+    const fullCsvPath = await csvFile(
+      'posts-import-full-fields.csv',
+      'Headline,Body,Address,Kind,State,Audience,Hero,Show title,Search title,Social copy,Template,Created,Published\n' +
+        'Mapped field post,"<p>Mapped body</p>",Custom Address,page,draft,members,1,0,Mapped SEO title,Mapped social description,wide,2024-01-02T00:00:00.000Z,2024-02-03T00:00:00.000Z\n',
+    );
+
+    const form = new FormData();
+    for (const [header, field] of Object.entries({
+      Headline: 'title',
+      Body: 'html',
+      Address: 'slug',
+      Kind: 'type',
+      State: 'status',
+      Audience: 'visibility',
+      Hero: 'featured',
+      'Show title': 'show_title_and_feature_image',
+      'Search title': 'meta_title',
+      'Social copy': 'twitter_description',
+      Template: 'custom_template',
+      Created: 'created_at',
+      Published: 'published_at',
+    })) {
+      form.append(`mapping[${header}]`, field);
+    }
+    form.append('postsfile', await fs.readFile(fullCsvPath), {
+      filename: path.basename(fullCsvPath),
+      contentType: 'text/csv',
+    });
+
+    await agent.post('posts/upload/').body(form).expectStatus(202);
+    await jobsService.allSettled();
+
+    const post = await models.Post.findOne(
+      { title: 'Mapped field post', status: 'all' },
+      { withRelated: ['posts_meta'] },
+    );
+    assert.ok(post);
+    assert.equal(post.get('slug'), 'custom-address');
+    assert.equal(post.get('type'), 'page');
+    assert.equal(post.get('status'), 'draft');
+    assert.equal(post.get('visibility'), 'members');
+    assert.equal(post.get('featured'), true);
+    assert.equal(post.get('show_title_and_feature_image'), false);
+    assert.equal(post.get('custom_template'), 'wide');
+    assert.equal(post.get('created_at').toISOString(), '2024-01-02T00:00:00.000Z');
+    assert.equal(post.get('published_at').toISOString(), '2024-02-03T00:00:00.000Z');
+    assert.equal(post.get('updated_at').toISOString(), '2024-02-03T00:00:00.000Z');
+    assert.equal(post.related('posts_meta').get('meta_title'), 'Mapped SEO title');
+    assert.equal(
+      post.related('posts_meta').get('twitter_description'),
+      'Mapped social description',
+    );
+    assert.match(post.get('html'), /Mapped body/);
+  });
+
   it('Skips a malformed row on its own and imports the rest', async function () {
     await agent.loginAsOwner();
 
     const badRowsCsvPath = await csvFile(
       'posts-import-with-bad-rows.csv',
-      'title,html,published_at\n' +
-        'Bad rows check one,<p>Before the bad row</p>,2024-03-01T00:00:00.000Z\n' +
-        ',<p>This row has no title</p>,2024-03-02T00:00:00.000Z\n' +
-        'Bad rows check date,<p>This row has a bad date</p>,not-a-date\n' +
-        'Bad rows check two,<p>After the bad rows</p>,2024-03-04T00:00:00.000Z\n',
+      'title,html,markdown,published_at,status,featured\n' +
+        'Bad rows check one,<p>Before the bad row</p>,,2024-03-01T00:00:00.000Z,published,false\n' +
+        ',<p>This row has no title</p>,,2024-03-02T00:00:00.000Z,published,false\n' +
+        'Bad rows check date,<p>This row has a bad date</p>,,not-a-date,published,false\n' +
+        'Bad rows check calendar,<p>This row has a rolled-over date</p>,,2025-02-30T00:00:00.000Z,published,false\n' +
+        `${'x'.repeat(256)},<p>This title is too long</p>,,2024-03-02T00:00:00.000Z,published,false\n` +
+        'Bad rows check status,<p>This row has a bad status</p>,,2024-03-02T00:00:00.000Z,scheduled,false\n' +
+        'Bad rows check featured,<p>This row has a bad featured value</p>,,2024-03-02T00:00:00.000Z,published,yes\n' +
+        'Bad rows check two,<p>After the bad rows</p>,,2024-03-04T00:00:00.000Z,published,false\n' +
+        'Bad rows check three,<p>A loose date format</p>,,01 May 2024 00:00:00 GMT,published,false\n',
     );
 
     await agent.post('posts/upload/').attach('postsfile', badRowsCsvPath).expectStatus(202);
@@ -286,7 +349,7 @@ describe('Posts Importer API', function () {
 
     assert.deepEqual(
       posts.map((post) => post.get('title')).sort(),
-      ['Bad rows check one', 'Bad rows check two'],
+      ['Bad rows check one', 'Bad rows check three', 'Bad rows check two'],
       'the good rows imported; the malformed ones did not',
     );
   });

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs/promises');
+const FormData = require('form-data');
 const os = require('node:os');
 const {
   agentProvider,
@@ -102,6 +103,62 @@ describe('Posts Importer API', function () {
     await agent.loginAsContributor();
 
     await agent.post('posts/upload/').attach('postsfile', csvPath).expectStatus(403);
+  });
+
+  it('Rejects an explicit mapping without a title target', async function () {
+    await agent.loginAsOwner();
+
+    const bodyOnlyCsvPath = await csvFile(
+      'posts-import-body-only-mapping.csv',
+      'Body\n<p>This mapping has no title target</p>\n',
+    );
+    const form = new FormData();
+    form.append('mapping[Body]', 'html');
+    form.append('postsfile', await fs.readFile(bodyOnlyCsvPath), {
+      filename: path.basename(bodyOnlyCsvPath),
+      contentType: 'text/csv',
+    });
+
+    const { body } = await agent.post('posts/upload/').body(form).expectStatus(422);
+
+    assert.match(body.errors[0].message, /mapping must include "title"/);
+  });
+
+  it('Rejects unsafe, unknown, and duplicate field mappings', async function () {
+    await agent.loginAsOwner();
+
+    const mappedCsvPath = await csvFile(
+      'posts-import-invalid-mappings.csv',
+      'First,Second\nOne,Two\n',
+    );
+    const cases = [
+      {
+        mapping: { constructor: 'title' },
+        reason: /Invalid CSV header mapping: "constructor"/,
+      },
+      {
+        mapping: { First: 'title', Second: 'authors' },
+        reason: /Unknown post field mapping: "authors"/,
+      },
+      {
+        mapping: { First: 'title', Second: 'title' },
+        reason: /Post field is mapped more than once: "title"/,
+      },
+    ];
+
+    for (const { mapping, reason } of cases) {
+      const form = new FormData();
+      for (const [header, field] of Object.entries(mapping)) {
+        form.append(`mapping[${header}]`, field);
+      }
+      form.append('postsfile', await fs.readFile(mappedCsvPath), {
+        filename: path.basename(mappedCsvPath),
+        contentType: 'text/csv',
+      });
+
+      const { body } = await agent.post('posts/upload/').body(form).expectStatus(422);
+      assert.match(body.errors[0].message, reason);
+    }
   });
 
   it('Imports each CSV row as a post with its content and publish date', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -23,6 +23,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const store = new ImportRunStore();
   let converterResolutions = 0;
   let markdownRendererResolutions = 0;
+  let cleanerResolutions = 0;
   // Late-bound: the importer captures deps at construction.
   let htmlToLexicalFactory: () => (html: string) => unknown = () => {
     converterResolutions += 1;
@@ -31,6 +32,10 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   let markdownToHtmlFactory: () => (markdown: string) => string = () => {
     markdownRendererResolutions += 1;
     return (markdown: string) => `<p>${markdown}</p>`;
+  };
+  let cleanHTMLFactory: () => (args: { html: string; opinionated: boolean }) => string = () => {
+    cleanerResolutions += 1;
+    return ({ html }) => html;
   };
 
   const deps = {
@@ -48,6 +53,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     },
     getHtmlToLexical: () => htmlToLexicalFactory(),
     getMarkdownToHtml: () => markdownToHtmlFactory(),
+    getCleanHTML: () => cleanHTMLFactory(),
     addJob: (job: { name: string; offloaded: boolean; job: () => Promise<void> }) => {
       jobs.push(job);
     },
@@ -84,6 +90,11 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const setMarkdownToHtmlFactory = (factory: () => (markdown: string) => string) => {
     markdownToHtmlFactory = factory;
   };
+  const setCleanHTMLFactory = (
+    factory: () => (args: { html: string; opinionated: boolean }) => string,
+  ) => {
+    cleanHTMLFactory = factory;
+  };
 
   return {
     importer,
@@ -97,8 +108,10 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     store,
     setHtmlToLexicalFactory,
     setMarkdownToHtmlFactory,
+    setCleanHTMLFactory,
     converterResolutions: () => converterResolutions,
     markdownRendererResolutions: () => markdownRendererResolutions,
+    cleanerResolutions: () => cleanerResolutions,
   };
 }
 
@@ -237,6 +250,14 @@ describe('ContentCSVImporter', function () {
     assert.equal(h.markdownRendererResolutions(), 1);
   });
 
+  it('resolves the HTML cleaner once per run, not per row', async function () {
+    const h = harness();
+
+    await h.run();
+
+    assert.equal(h.cleanerResolutions(), 1);
+  });
+
   it('rejects a file over the cap without scheduling any work', async function () {
     const h = harness(Array.from({ length: 101 }, (_, i) => row(`Post ${i + 1}`)));
 
@@ -361,6 +382,29 @@ describe('ContentCSVImporter', function () {
       title: 'Bad markdown',
       status: 'skipped',
       reason: 'markdown could not be converted',
+    });
+  });
+
+  it('isolates an HTML cleaning failure to its row', async function () {
+    const h = harness([row('First'), row('Bad clean'), row('Third')]);
+    h.setCleanHTMLFactory(() => ({ html }) => {
+      if (html.includes('Bad clean')) {
+        throw new Error('cleaner failed');
+      }
+      return html;
+    });
+
+    await h.run();
+
+    assert.deepEqual(
+      h.created.map((call) => call.data.title),
+      ['First', 'Third'],
+    );
+    assert.deepEqual(h.store.get('run_test')?.rows[1], {
+      line: 3,
+      title: 'Bad clean',
+      status: 'skipped',
+      reason: 'html could not be cleaned',
     });
   });
 

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -144,6 +144,22 @@ describe('ContentCSVImporter', function () {
     assert.equal(h.created.length, 2);
   });
 
+  it('passes a caller-supplied mapping to the CSV reader', async function () {
+    const h = harness();
+    let receivedMapping: Record<string, string> | undefined;
+    const importer = new ContentCSVImporter({
+      ...h.deps,
+      readRows: async (_path, mapping) => {
+        receivedMapping = mapping;
+        return [row('Mapped')];
+      },
+    });
+
+    await importer.importCSV({ filePath: '/tmp/posts.csv', mapping: { Headline: 'title' } });
+
+    assert.deepEqual(receivedMapping, { Headline: 'title' });
+  });
+
   it('writes one post per row, in order, under the importing options', async function () {
     const h = harness();
 

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -9,6 +9,7 @@ import type { PostData } from '../../../../../../core/server/services/content-im
 const row = (title: string, html = `<p>${title}</p>`): PostImportRow => ({
   title,
   html,
+  markdown: '',
   published_at: '2025-01-01T00:00:00.000Z',
 });
 
@@ -21,10 +22,15 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const urlFailures = new Map<string, unknown>();
   const store = new ImportRunStore();
   let converterResolutions = 0;
+  let markdownRendererResolutions = 0;
   // Late-bound: the importer captures deps at construction.
   let htmlToLexicalFactory: () => (html: string) => unknown = () => {
     converterResolutions += 1;
     return (html: string) => ({ converted: html });
+  };
+  let markdownToHtmlFactory: () => (markdown: string) => string = () => {
+    markdownRendererResolutions += 1;
+    return (markdown: string) => `<p>${markdown}</p>`;
   };
 
   const deps = {
@@ -41,6 +47,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
       },
     },
     getHtmlToLexical: () => htmlToLexicalFactory(),
+    getMarkdownToHtml: () => markdownToHtmlFactory(),
     addJob: (job: { name: string; offloaded: boolean; job: () => Promise<void> }) => {
       jobs.push(job);
     },
@@ -74,6 +81,9 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const setHtmlToLexicalFactory = (factory: () => (html: string) => unknown) => {
     htmlToLexicalFactory = factory;
   };
+  const setMarkdownToHtmlFactory = (factory: () => (markdown: string) => string) => {
+    markdownToHtmlFactory = factory;
+  };
 
   return {
     importer,
@@ -86,7 +96,9 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     urlFailures,
     store,
     setHtmlToLexicalFactory,
+    setMarkdownToHtmlFactory,
     converterResolutions: () => converterResolutions,
+    markdownRendererResolutions: () => markdownRendererResolutions,
   };
 }
 
@@ -217,6 +229,14 @@ describe('ContentCSVImporter', function () {
     assert.equal(h.converterResolutions(), 1);
   });
 
+  it('resolves the markdown renderer once per run, not per row', async function () {
+    const h = harness();
+
+    await h.run();
+
+    assert.equal(h.markdownRendererResolutions(), 1);
+  });
+
   it('rejects a file over the cap without scheduling any work', async function () {
     const h = harness(Array.from({ length: 101 }, (_, i) => row(`Post ${i + 1}`)));
 
@@ -295,7 +315,7 @@ describe('ContentCSVImporter', function () {
   it('skips a malformed row on its own and imports the rest', async function () {
     const h = harness([
       row('First'),
-      { title: '', html: '<p>No title</p>', published_at: undefined },
+      { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
       row('Third'),
     ]);
 
@@ -320,10 +340,34 @@ describe('ContentCSVImporter', function () {
     );
   });
 
+  it('isolates a markdown conversion failure to its row', async function () {
+    const badMarkdown = { ...row('Bad markdown', ''), markdown: 'bad' };
+    const h = harness([row('First'), badMarkdown, row('Third')]);
+    h.setMarkdownToHtmlFactory(() => (markdown: string) => {
+      if (markdown === 'bad') {
+        throw new Error('bad markdown');
+      }
+      return `<p>${markdown}</p>`;
+    });
+
+    await h.run();
+
+    assert.deepEqual(
+      h.created.map((call) => call.data.title),
+      ['First', 'Third'],
+    );
+    assert.deepEqual(h.store.get('run_test')?.rows[1], {
+      line: 3,
+      title: 'Bad markdown',
+      status: 'skipped',
+      reason: 'markdown could not be converted',
+    });
+  });
+
   it('completes without reporting when every row is skipped before a write', async function () {
     const h = harness([
-      { title: '', html: '<p>No title</p>', published_at: undefined },
-      { title: '', html: '<p>Still no title</p>', published_at: undefined },
+      { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
+      { title: '', html: '<p>Still no title</p>', markdown: '', published_at: undefined },
     ]);
 
     await h.run();

--- a/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
@@ -31,6 +31,16 @@ describe('buildPostData', function () {
     assert.equal(data.slug, 'a-post-with-a-comma-in-its-title');
   });
 
+  it('sanitizes an explicit slug instead of deriving it from the title', function () {
+    const data = buildPostData(
+      row({ title: 'Different title', slug: ' Custom Slug, Here ' }),
+      htmlToLexical,
+      TAGS,
+    );
+
+    assert.equal(data.slug, 'custom-slug-here');
+  });
+
   it('omits lexical for an empty html cell, leaving the model its blank document', function () {
     const data = buildPostData(row({ title: 'T' }), htmlToLexical, TAGS);
 
@@ -66,12 +76,97 @@ describe('buildPostData', function () {
     assert.equal('authors' in data, false);
   });
 
+  it('imports publishing, image, and advanced post fields', function () {
+    const data = buildPostData(
+      row({
+        title: 'Full post',
+        type: 'page',
+        status: 'draft',
+        visibility: 'members',
+        featured: '1',
+        show_title_and_feature_image: 'false',
+        custom_excerpt: 'Summary',
+        feature_image: 'https://example.com/image.jpg',
+        canonical_url: 'https://example.com/original',
+        custom_template: 'wide',
+        codeinjection_head: '<style>body{color:red}</style>',
+        codeinjection_foot: '<script>window.test=true</script>',
+      }),
+      htmlToLexical,
+      TAGS,
+    );
+
+    assert.equal(data.type, 'page');
+    assert.equal(data.status, 'draft');
+    assert.equal(data.visibility, 'members');
+    assert.equal(data.featured, true);
+    assert.equal(data.show_title_and_feature_image, false);
+    assert.equal(data.custom_excerpt, 'Summary');
+    assert.equal(data.feature_image, 'https://example.com/image.jpg');
+    assert.equal(data.canonical_url, 'https://example.com/original');
+    assert.equal(data.custom_template, 'wide');
+    assert.equal(data.codeinjection_head, '<style>body{color:red}</style>');
+    assert.equal(data.codeinjection_foot, '<script>window.test=true</script>');
+  });
+
+  it('puts feature metadata, SEO, social fields, and frontmatter in posts_meta', function () {
+    const data = buildPostData(
+      row({
+        title: 'Metadata post',
+        feature_image_alt: 'Alt text',
+        feature_image_caption: 'Caption',
+        meta_title: 'Meta title',
+        meta_description: 'Meta description',
+        og_image: 'https://example.com/og.jpg',
+        og_title: 'OG title',
+        og_description: 'OG description',
+        twitter_image: 'https://example.com/twitter.jpg',
+        twitter_title: 'Twitter title',
+        twitter_description: 'Twitter description',
+        frontmatter: 'key: value',
+      }),
+      htmlToLexical,
+      TAGS,
+    );
+
+    assert.deepEqual(data.posts_meta, {
+      feature_image_alt: 'Alt text',
+      feature_image_caption: 'Caption',
+      meta_title: 'Meta title',
+      meta_description: 'Meta description',
+      og_image: 'https://example.com/og.jpg',
+      og_title: 'OG title',
+      og_description: 'OG description',
+      twitter_image: 'https://example.com/twitter.jpg',
+      twitter_title: 'Twitter title',
+      twitter_description: 'Twitter description',
+      frontmatter: 'key: value',
+    });
+  });
+
   it('omits every date when the cell is absent, leaving the model to stamp now', function () {
     const data = buildPostData(row({ title: 'T' }), htmlToLexical, TAGS);
 
     assert.equal('published_at' in data, false);
     assert.equal('created_at' in data, false);
     assert.equal('updated_at' in data, false);
+  });
+
+  it('lets explicit created and updated dates override the published date fallback', function () {
+    const data = buildPostData(
+      row({
+        title: 'T',
+        published_at: '2025-01-01',
+        created_at: '2024-01-01',
+        updated_at: '2025-02-01',
+      }),
+      htmlToLexical,
+      TAGS,
+    );
+
+    assert.equal(data.published_at, '2025-01-01');
+    assert.equal(data.created_at, '2024-01-01');
+    assert.equal(data.updated_at, '2025-02-01');
   });
 
   const skipsWith = (cells: Record<string, string>, reason: string | RegExp) => {
@@ -131,6 +226,22 @@ describe('buildPostData', function () {
 
     assert.equal(data.published_at, 'May 1, 2024');
   });
+
+  for (const [field, value, reason] of [
+    ['type', 'article', 'type must be one of: post, page'],
+    ['status', 'scheduled', 'status must be one of: draft, published'],
+    ['visibility', 'private', 'visibility must be one of: public, members, paid'],
+    ['featured', 'yes', 'featured must be true, false, 1, or 0'],
+    [
+      'show_title_and_feature_image',
+      'sometimes',
+      'show_title_and_feature_image must be true, false, 1, or 0',
+    ],
+  ] as const) {
+    it(`skips a row with an invalid ${field}`, function () {
+      skipsWith({ title: 'T', [field]: value }, reason);
+    });
+  }
 
   it('skips a row whose html cannot be converted', function () {
     const throwingConverter = () => {

--- a/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
@@ -7,6 +7,7 @@ import { postImportRowSchema } from '../../../../../../core/server/services/cont
 // A stand-in converter that shows what it was given, so the test can assert both the
 // wiring (called with the row's html) and the stringification.
 const htmlToLexical = (html: string) => ({ converted: html });
+const markdownToHtml = (markdown: string) => `<h1>${markdown.slice(2)}</h1>`;
 
 const row = (cells: Record<string, string>) => postImportRowSchema.parse(cells);
 
@@ -45,6 +46,50 @@ describe('buildPostData', function () {
     const data = buildPostData(row({ title: 'T' }), htmlToLexical, TAGS);
 
     assert.equal('lexical' in data, false);
+  });
+
+  it('renders markdown to html before converting it to lexical', function () {
+    const data = buildPostData(
+      row({ title: 'T', markdown: '# Hello' }),
+      htmlToLexical,
+      TAGS,
+      markdownToHtml,
+    );
+
+    assert.equal(data.lexical, JSON.stringify({ converted: '<h1>Hello</h1>' }));
+  });
+
+  it('skips a row that supplies both html and markdown', function () {
+    assert.throws(
+      () =>
+        buildPostData(
+          row({ title: 'T', html: '<p>HTML</p>', markdown: 'Markdown' }),
+          htmlToLexical,
+          TAGS,
+          markdownToHtml,
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof RowSkipped);
+        assert.equal(error.message, 'html and markdown cannot both be provided');
+        return true;
+      },
+    );
+  });
+
+  it('skips a row when markdown rendering fails', function () {
+    const throwingRenderer = () => {
+      throw new Error('renderer exploded');
+    };
+
+    assert.throws(
+      () =>
+        buildPostData(row({ title: 'T', markdown: 'bad' }), htmlToLexical, TAGS, throwingRenderer),
+      (error: unknown) => {
+        assert.ok(error instanceof RowSkipped);
+        assert.equal(error.message, 'markdown could not be converted');
+        return true;
+      },
+    );
   });
 
   it('dates the whole post from the CSV date: published_at, created_at and updated_at', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { cleanHTML as officialCleanHTML } from '@tryghost/mg-clean-html';
 import buildPostData, {
   RowSkipped,
 } from '../../../../../../core/server/services/content-import/import/post-data';
@@ -20,6 +21,34 @@ describe('buildPostData', function () {
     assert.equal(data.lexical, JSON.stringify({ converted: '<p>Hello</p>' }));
     // the model strips client-supplied html when importing, so passing it would be a no-op
     assert.equal('html' in data, false);
+  });
+
+  it('runs opinionated HTML cleanup before lexical conversion', function () {
+    const source =
+      '<p style="text-align: center; color: red; background: blue"><span style="font-weight: bold">Hello</span></p><p><br></p><h2><strong>Header</strong></h2>';
+    const data = buildPostData(
+      row({ title: 'T', html: source }),
+      htmlToLexical,
+      TAGS,
+      markdownToHtml,
+      officialCleanHTML,
+    );
+
+    assert.equal(data.lexical, JSON.stringify({ converted: '<p><b>Hello</b></p><h2>Header</h2>' }));
+  });
+
+  it('preserves protected Instagram embed markup during cleanup', function () {
+    const source =
+      '<blockquote class="instagram-media"><p style="text-align: center; color: red">Protected</p></blockquote>';
+    const data = buildPostData(
+      row({ title: 'T', html: source }),
+      htmlToLexical,
+      TAGS,
+      markdownToHtml,
+      officialCleanHTML,
+    );
+
+    assert.equal(data.lexical, JSON.stringify({ converted: source }));
   });
 
   it('slugs the title with the standard rules, not the importing-mode pass', function () {
@@ -57,6 +86,19 @@ describe('buildPostData', function () {
     );
 
     assert.equal(data.lexical, JSON.stringify({ converted: '<h1>Hello</h1>' }));
+  });
+
+  it('cleans markdown-rendered HTML before converting it to lexical', function () {
+    const styledMarkdownRenderer = () => '<p style="text-align: right; color: red">Hello</p>';
+    const data = buildPostData(
+      row({ title: 'T', markdown: 'Hello' }),
+      htmlToLexical,
+      TAGS,
+      styledMarkdownRenderer,
+      officialCleanHTML,
+    );
+
+    assert.equal(data.lexical, JSON.stringify({ converted: '<p>Hello</p>' }));
   });
 
   it('skips a row that supplies both html and markdown', function () {
@@ -298,6 +340,28 @@ describe('buildPostData', function () {
       (error: unknown) => {
         assert.ok(error instanceof RowSkipped);
         assert.equal(error.message, 'html could not be converted');
+        return true;
+      },
+    );
+  });
+
+  it('skips a row whose html cannot be cleaned', function () {
+    const throwingCleaner = () => {
+      throw new Error('cleaner exploded');
+    };
+
+    assert.throws(
+      () =>
+        buildPostData(
+          row({ title: 'T', html: '<p>bad</p>' }),
+          htmlToLexical,
+          TAGS,
+          markdownToHtml,
+          throwingCleaner,
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof RowSkipped);
+        assert.equal(error.message, 'html could not be cleaned');
         return true;
       },
     );

--- a/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
@@ -25,7 +25,7 @@ describe('content import reader', function () {
       'Ignore me': '',
     });
 
-    assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>' }]);
+    assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>', markdown: '' }]);
   });
 
   it('keeps the existing identity headers when no mapping is supplied', async function () {
@@ -34,7 +34,9 @@ describe('content import reader', function () {
 
     const rows = await readPostRows(file);
 
-    assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>', published_at: '2025-01-01' }]);
+    assert.deepEqual(rows, [
+      { title: 'Hello', html: '<p>World</p>', markdown: '', published_at: '2025-01-01' },
+    ]);
   });
 
   it('keeps full editorial identity headers for direct API clients', async function () {
@@ -44,7 +46,14 @@ describe('content import reader', function () {
     const rows = await readPostRows(file);
 
     assert.deepEqual(rows, [
-      { title: 'Hello', slug: 'custom', featured: '1', meta_title: 'Search title', html: '' },
+      {
+        title: 'Hello',
+        slug: 'custom',
+        featured: '1',
+        meta_title: 'Search title',
+        html: '',
+        markdown: '',
+      },
     ]);
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import readPostRows from '../../../../../../core/server/services/content-import/import/reader';
+
+describe('content import reader', function () {
+  let directory: string;
+
+  beforeEach(async function () {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'content-import-reader-'));
+  });
+
+  afterEach(async function () {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+
+  it('maps arbitrary headers and drops explicitly ignored columns', async function () {
+    const file = path.join(directory, 'posts.csv');
+    await fs.writeFile(file, 'Headline,Body,Ignore me\nHello,<p>World</p>,unused\n');
+
+    const rows = await readPostRows(file, {
+      Headline: 'title',
+      Body: 'html',
+      'Ignore me': '',
+    });
+
+    assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>' }]);
+  });
+
+  it('keeps the existing identity headers when no mapping is supplied', async function () {
+    const file = path.join(directory, 'posts.csv');
+    await fs.writeFile(file, 'title,html,published_at\nHello,<p>World</p>,2025-01-01\n');
+
+    const rows = await readPostRows(file);
+
+    assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>', published_at: '2025-01-01' }]);
+  });
+});

--- a/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
@@ -36,4 +36,15 @@ describe('content import reader', function () {
 
     assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>', published_at: '2025-01-01' }]);
   });
+
+  it('keeps full editorial identity headers for direct API clients', async function () {
+    const file = path.join(directory, 'full-post.csv');
+    await fs.writeFile(file, 'title,slug,featured,meta_title\nHello,custom,1,Search title\n');
+
+    const rows = await readPostRows(file);
+
+    assert.deepEqual(rows, [
+      { title: 'Hello', slug: 'custom', featured: '1', meta_title: 'Search title', html: '' },
+    ]);
+  });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/row.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/row.test.ts
@@ -19,6 +19,11 @@ describe('post import row schema', function () {
     assert.equal(postImportRowSchema.parse({ html: '<p>Hi</p>' }).html, '<p>Hi</p>');
   });
 
+  it('defaults a missing markdown cell to the empty string', function () {
+    assert.equal(postImportRowSchema.parse({}).markdown, '');
+    assert.equal(postImportRowSchema.parse({ markdown: '# Hi' }).markdown, '# Hi');
+  });
+
   it('reads an empty (or literally "undefined") published_at cell as absent', function () {
     assert.equal(postImportRowSchema.parse({ published_at: '' }).published_at, undefined);
     assert.equal(postImportRowSchema.parse({ published_at: 'undefined' }).published_at, undefined);

--- a/ghost/core/test/unit/server/services/content-import/import/row.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/row.test.ts
@@ -28,6 +28,20 @@ describe('post import row schema', function () {
     );
   });
 
+  it('reads empty optional editorial cells as absent', function () {
+    const parsed = postImportRowSchema.parse({
+      slug: '',
+      feature_image: 'undefined',
+      meta_title: '',
+      frontmatter: '',
+    });
+
+    assert.equal(parsed.slug, undefined);
+    assert.equal(parsed.feature_image, undefined);
+    assert.equal(parsed.meta_title, undefined);
+    assert.equal(parsed.frontmatter, undefined);
+  });
+
   it('passes unknown columns through for later milestones to consume', function () {
     const parsed = postImportRowSchema.parse({ title: 'T', custom_thing: 'kept' });
     assert.equal(parsed.custom_thing, 'kept');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ catalogs:
     '@tryghost/metrics':
       specifier: 3.5.0
       version: 3.5.0
+    '@tryghost/mg-clean-html':
+      specifier: 0.12.6
+      version: 0.12.6
     '@tryghost/mongo-knex':
       specifier: 0.11.2
       version: 0.11.2
@@ -2323,6 +2326,9 @@ importers:
       '@tryghost/metrics':
         specifier: 'catalog:'
         version: 3.5.0(supports-color@10.2.2)
+      '@tryghost/mg-clean-html':
+        specifier: 'catalog:'
+        version: 0.12.6(encoding@0.1.13)
       '@tryghost/mongo-knex':
         specifier: 'catalog:'
         version: 0.11.2(supports-color@10.2.2)
@@ -6659,6 +6665,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -9374,6 +9383,17 @@ packages:
   '@tryghost/job-manager@1.0.9':
     resolution: {integrity: sha512-Wlwr1R8oeU6HLB7RB1g6VxAH6VEZIaXTVV2GdvCbipK+TA0MIo6YOQUgrIky25RpyRqKXR0UuDIfXDB4+S+GgQ==}
 
+  '@tryghost/kg-default-cards@10.3.5':
+    resolution: {integrity: sha512-eJ6V8MNarip8f0iDoowB6JpwFXXKjzFj3Z6AbxT/ErERIuLEO0F3nJLN7qMenef68j5btsV8+goGHcMS6ZiGfA==}
+    engines: {node: ^22.13.1 || ^24.0.0}
+
+  '@tryghost/kg-markdown-html-renderer@7.2.5':
+    resolution: {integrity: sha512-qAhuJd/ceIT80tAh2rhEYDrR2YJq+yttJgq0GWoysc3rRGgxJlXcW4WhGRpZ7NZXDU4cZhuFoGBySDJiL9CoCA==}
+    engines: {node: ^22.13.1 || ^24.0.0}
+
+  '@tryghost/kg-utils@1.1.5':
+    resolution: {integrity: sha512-SlS6C1+j6czfX61zAU38z4jC2hPKaXaOh1nN8UplKpEY2wvGTd99udtTZScl+7Fc2k9/CasTKFWErH6+KE4Qyg==}
+
   '@tryghost/limit-service@1.5.6':
     resolution: {integrity: sha512-wR+Hm2v5k2FjOUhLhfPZ0p0acCfaTQoSEhuw96uw8c15CLZtm/HKsLnxA5d3AXwYmjRo5gkYskP8UYxrCKNcoQ==}
 
@@ -9382,6 +9402,12 @@ packages:
 
   '@tryghost/metrics@3.5.0':
     resolution: {integrity: sha512-fBIKCodafcG23Eq5rjhmixI+CSzVZ555jNqj7tdDeCXtfVA9ws3X3H3dNo7jgxgZs2SbC7ElYbhBSj4dHX8RKw==}
+
+  '@tryghost/mg-clean-html@0.12.6':
+    resolution: {integrity: sha512-ped/cNQdKvcX4F0B8Z5j0VnLuFjyHthElxT4Gny2yWtPHczvFsbVQXlynuHPpQcM3ZLE6o9lemm7Bin1uG/whQ==}
+
+  '@tryghost/mg-utils@0.11.6':
+    resolution: {integrity: sha512-or0H4aZyInx8xWX/pe60PO9eeuaEgLxezlyc2/ypUIyCjAWl4AojELYsAKt/zjFVedLRVnZOz+SMdCFjx5NhYQ==}
 
   '@tryghost/mongo-knex@0.11.2':
     resolution: {integrity: sha512-0l7L/J609p+12+rA15Muya1JoIeSfBxIUZRB2FfROtJ2U+FTEOzZ/c0HgxB8eAArJMW2VXECmLCAbNUwygRzfg==}
@@ -10693,6 +10719,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   apache-arrow@21.1.0:
     resolution: {integrity: sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==}
     hasBin: true
@@ -11418,6 +11447,10 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -12642,6 +12675,10 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
+
   css-tree@1.0.0-alpha.29:
     resolution: {integrity: sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==}
     engines: {node: '>=0.10.0'}
@@ -12676,6 +12713,10 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -12747,6 +12788,9 @@ packages:
 
   cssom@0.4.4:
     resolution: {integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   cssstyle@2.3.0:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
@@ -13159,6 +13203,10 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domain-browser@1.2.0:
     resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
     engines: {node: '>=0.4', npm: '>=1.2'}
@@ -13168,6 +13216,10 @@ packages:
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domexception@2.0.1:
     resolution: {integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==}
@@ -13189,6 +13241,10 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
@@ -13203,6 +13259,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -14484,6 +14544,13 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fast-xml-builder@1.3.1:
+    resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
+
   fastboot-transform@0.1.3:
     resolution: {integrity: sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==}
 
@@ -15307,6 +15374,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
   html-minifier@4.0.0:
     resolution: {integrity: sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==}
     engines: {node: '>=6'}
@@ -15605,6 +15675,9 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  inline-style-parser@0.2.9:
+    resolution: {integrity: sha512-IttN8BqKLxzUrnTqHI+/hwAJQItBAUjdoHERCDv+oOuX48VP6bzW8+QjOXSfoevzq3YrYAwX1uLHp8TqO9yIeg==}
 
   inquirer@6.5.2:
     resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
@@ -15995,6 +16068,9 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-uri@1.2.14:
     resolution: {integrity: sha512-YhTAOlejk4o85c3bPk9ayhr6VLm3e01mp4pBhtYOEXXlkK+Eoj/Nr3x+bqTwZvUI0z0L6TVk0HZViXdxUtsWDQ==}
@@ -16777,6 +16853,15 @@ packages:
   lines-and-columns@2.0.3:
     resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  linkedom@0.18.13:
+    resolution: {integrity: sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   linkify-it@2.2.0:
     resolution: {integrity: sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==}
@@ -18237,6 +18322,10 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
+
   null-prototype-object@1.2.7:
     resolution: {integrity: sha512-pSZWCUew0zed2gxCerA4zdXRGg8ezLiWwvE8RvncezTcROXL0uz3PjSZXl5NsI04Egz0Uu46o1wyX6qr3u/ZWA==}
     engines: {node: '>= 20'}
@@ -18646,6 +18735,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -21088,6 +21181,9 @@ packages:
     resolution: {integrity: sha512-hrA79fjmN2Eb6K3kxkDzU4ODeVGGjXQsuVaAPSUro6I9MM3X+BvIsVqdphm3BXWfimAGFvUqWtPtHy25mICY1w==}
     engines: {node: ^8.1 || >=10.*}
 
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -21109,6 +21205,9 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  style-to-object@2.0.2:
+    resolution: {integrity: sha512-QmbXPUylqU80HAgTOJeEOdbA40W9KtxmjMhQy+tq+b8F2aoh3aQLuy82hh2jm2qsC9hR9eI0+eQidTMydKcqRA==}
 
   styled_string@0.0.1:
     resolution: {integrity: sha512-DU2KZiB6VbPkO2tGSqQ9n96ZstUPjW7X4sGO6V2m1myIQluX0p1Ol8BrA/l6/EesqhMqXOIXs3cJNOy1UuU2BA==}
@@ -21755,6 +21854,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   uid-safe@2.1.5:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
@@ -22660,6 +22762,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
@@ -26023,6 +26129,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@3.0.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -28890,6 +28998,34 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
+  '@tryghost/kg-default-cards@10.3.5(encoding@0.1.13)':
+    dependencies:
+      '@tryghost/kg-markdown-html-renderer': 7.2.5
+      '@tryghost/kg-utils': 1.1.5
+      '@tryghost/string': 0.3.5
+      '@tryghost/url-utils': 5.2.7
+      handlebars: 4.7.9
+      juice: 9.1.0(encoding@0.1.13)
+      luxon: 3.7.2
+    transitivePeerDependencies:
+      - encoding
+
+  '@tryghost/kg-markdown-html-renderer@7.2.5':
+    dependencies:
+      '@tryghost/kg-utils': 1.1.5
+      markdown-it: 14.3.0
+      markdown-it-footnote: 4.0.0
+      markdown-it-image-lazy-loading: 2.0.1
+      markdown-it-lazy-headers: 0.1.3
+      markdown-it-mark: 4.0.0
+      markdown-it-sub: 2.0.0
+      markdown-it-sup: 2.0.0
+      semver: 7.8.5
+
+  '@tryghost/kg-utils@1.1.5':
+    dependencies:
+      semver: 7.8.5
+
   '@tryghost/limit-service@1.5.6':
     dependencies:
       '@tryghost/errors': 3.3.9
@@ -28921,6 +29057,24 @@ snapshots:
     transitivePeerDependencies:
       - '@75lb/nature'
       - supports-color
+
+  '@tryghost/mg-clean-html@0.12.6(encoding@0.1.13)':
+    dependencies:
+      '@tryghost/mg-utils': 0.11.6(encoding@0.1.13)
+      escape-string-regexp: 5.0.0
+      style-to-object: 2.0.2
+    transitivePeerDependencies:
+      - canvas
+      - encoding
+
+  '@tryghost/mg-utils@0.11.6(encoding@0.1.13)':
+    dependencies:
+      '@tryghost/kg-default-cards': 10.3.5(encoding@0.1.13)
+      fast-xml-parser: 5.10.1
+      linkedom: 0.18.13
+    transitivePeerDependencies:
+      - canvas
+      - encoding
 
   '@tryghost/mongo-knex@0.11.2(supports-color@10.2.2)':
     dependencies:
@@ -30758,6 +30912,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.1: {}
+
   apache-arrow@21.1.0:
     dependencies:
       '@swc/helpers': 0.5.23
@@ -31869,6 +32025,8 @@ snapshots:
       lodash: 4.18.1
 
   boolbase@1.0.0: {}
+
+  boolbase@2.0.0: {}
 
   boolean@3.2.0: {}
 
@@ -33587,6 +33745,14 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-select@7.0.0:
+    dependencies:
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
+
   css-tree@1.0.0-alpha.29:
     dependencies:
       mdn-data: 1.1.4
@@ -33622,6 +33788,8 @@ snapshots:
   css-what@3.4.2: {}
 
   css-what@6.2.2: {}
+
+  css-what@8.0.0: {}
 
   css.escape@1.5.1: {}
 
@@ -33738,6 +33906,8 @@ snapshots:
   cssom@0.3.8: {}
 
   cssom@0.4.4: {}
+
+  cssom@0.5.0: {}
 
   cssstyle@2.3.0:
     dependencies:
@@ -34150,11 +34320,19 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domain-browser@1.2.0: {}
 
   domelementtype@1.3.1: {}
 
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domexception@2.0.1:
     dependencies:
@@ -34175,6 +34353,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   dompurify@3.4.13:
     optionalDependencies:
@@ -34201,6 +34383,12 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-case@3.0.4:
     dependencies:
@@ -36926,6 +37114,20 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.3.1:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.1
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
+
   fastboot-transform@0.1.3(supports-color@10.2.2):
     dependencies:
       broccoli-stew: 1.6.0(supports-color@10.2.2)
@@ -38001,6 +38203,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-escaper@3.0.3: {}
+
   html-minifier@4.0.0:
     dependencies:
       camel-case: 3.0.0
@@ -38316,6 +38520,8 @@ snapshots:
       xtend: 4.0.2
 
   inline-style-parser@0.2.7: {}
+
+  inline-style-parser@0.2.9: {}
 
   inquirer@6.5.2:
     dependencies:
@@ -38703,6 +38909,8 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-unsafe@2.0.0: {}
 
   is-uri@1.2.14:
     dependencies:
@@ -39837,6 +40045,14 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.3: {}
+
+  linkedom@0.18.13:
+    dependencies:
+      css-select: 7.0.0
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
 
   linkify-it@2.2.0:
     dependencies:
@@ -41608,6 +41824,10 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nth-check@3.0.1:
+    dependencies:
+      boolbase: 2.0.0
+
   null-prototype-object@1.2.7: {}
 
   num2fraction@1.2.2: {}
@@ -42250,6 +42470,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
+
+  path-expression-matcher@1.6.2: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -45167,6 +45389,10 @@ snapshots:
       '@types/node': 26.0.0
       qs: 6.15.3
 
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
+
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -45190,6 +45416,10 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  style-to-object@2.0.2:
+    dependencies:
+      inline-style-parser: 0.2.9
 
   styled_string@0.0.1: {}
 
@@ -46024,6 +46254,8 @@ snapshots:
   ufo@1.6.4: {}
 
   uglify-js@3.19.3: {}
+
+  uhyphen@0.2.0: {}
 
   uid-safe@2.1.5:
     dependencies:
@@ -47216,6 +47448,8 @@ snapshots:
   xml-name-validator@3.0.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.3.0: {}
 
   xml@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2311,6 +2311,9 @@ importers:
       '@tryghost/kg-lexical-html-renderer':
         specifier: workspace:*
         version: link:../../koenig/kg-lexical-html-renderer
+      '@tryghost/kg-markdown-html-renderer':
+        specifier: workspace:*
+        version: link:../../koenig/kg-markdown-html-renderer
       '@tryghost/limit-service':
         specifier: 'catalog:'
         version: 1.5.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalog:
   '@tryghost/helpers': 1.1.106
   '@tryghost/limit-service': 1.5.6
   '@tryghost/logging': 5.4.0
+  '@tryghost/mg-clean-html': 0.12.6
   '@tryghost/metrics': 3.5.0
   '@tryghost/mongo-knex': 0.11.2
   '@tryghost/nql': 0.13.4


### PR DESCRIPTION
ref https://linear.app/ghost/project/4b2edbd66469/ Milestone 4

Each commit references its own Linear issue

This PR adds the UI for mapping fields when importing a CSV file, borrowing patterns from the Member importer for consistency. It also adds some Markdown & HTML processing for post content by introducing a [`@tryghost/mg-clean-html`](https://github.com/TryGhost/migrate/tree/main/packages/mg-clean-html) from the `migrate` tools, which converts common HTML like `<span style="font-weight: bold;">Hello</span>` to `<b>Hello</b>` for imported content.

The importer now:
- Automatically maps exact, case-sensitive header matches
- Requires exactly one Title mapping
- Provides a searchable, grouped picker covering Ghost’s supported editorial post fields
- Supports content, publishing, image, SEO, social, and advanced metadata
- Validates and coerces supported boolean, type, status, and visibility values
- Handles explicit slugs and dates while preserving Ghost’s existing defaults
- Supports either HTML or Markdown content
- Cleans imported markup before converting it to Lexical
- Isolates malformed or failed rows so valid posts continue importing
- Preserves identity-header imports for direct API clients without a mapping