### PR TITLE
Added filtering tag to Automations session replays

### DIFF
--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -68,7 +68,10 @@ function setupAutomationsSessionReplay(replay, shouldStartRecording) {
         recordingStarted = true;
         clearTimeout(initialRouteCheck);
 
-        replay.stop().then(() => replay.start()).catch((error) => {
+        replay.stop().then(() => {
+            replay.start();
+            Sentry.setTag('replay_area', 'automations');
+        }).catch((error) => {
             try {
                 replay.startBuffering();
             } catch (e) {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1543/figure-out-tagging-for-automation-session-replays

Tag manually started Automations replays so they can be filtered reliably in Sentry. This only adds metadata and has no user-facing impact.