### PR TITLE
Removed the duplicated Unsplash config literal

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -1,6 +1,10 @@
 // Framework
 export type { StatsConfig, TopLevelFrameworkProps } from './providers/framework-provider';
-export { FrameworkProvider, useFramework } from './providers/framework-provider';
+export {
+  FrameworkProvider,
+  defaultUnsplashConfig,
+  useFramework,
+} from './providers/framework-provider';
 
 // App Context
 export type { AppSettings, AppContextType } from './providers/app-provider';

--- a/apps/admin-x-framework/src/providers/framework-provider.tsx
+++ b/apps/admin-x-framework/src/providers/framework-provider.tsx
@@ -56,6 +56,15 @@ export type TopLevelFrameworkProps = Omit<FrameworkProviderProps, 'children'>;
 
 export type FrameworkContextType = Omit<FrameworkProviderProps, 'children'>;
 
+// Ghost's registered Unsplash application; the Client-ID is a public API key
+export const defaultUnsplashConfig: FrameworkProviderProps['unsplashConfig'] = {
+  Authorization: 'Client-ID 8672af113b0a8573edae3aa3713886265d9bb741d707f6c01a486cde8c278980',
+  'Accept-Version': 'v1',
+  'Content-Type': 'application/json',
+  'App-Pragma': 'no-cache',
+  'X-Unsplash-Cache': true,
+};
+
 const FrameworkContext = createContext<FrameworkContextType>({
   ghostVersion: '',
   externalNavigate: () => {},

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { defaultUnsplashConfig } from '@tryghost/admin-x-framework';
 import './index.css';
 import { AdminAppRoot } from './app-root.tsx';
 import { navigateTo } from './utils/navigation';
@@ -8,13 +9,7 @@ const framework = {
   externalNavigate: (link: { route: string; isExternal: boolean; replace?: boolean }) => {
     navigateTo(link.route, { replace: link.replace });
   },
-  unsplashConfig: {
-    Authorization: 'Client-ID 8672af113b0a8573edae3aa3713886265d9bb741d707f6c01a486cde8c278980',
-    'Accept-Version': 'v1',
-    'Content-Type': 'application/json',
-    'App-Pragma': 'no-cache',
-    'X-Unsplash-Cache': true,
-  },
+  unsplashConfig: defaultUnsplashConfig,
   sentryDSN: null,
   onUpdate: (dataType: string, response: unknown) => {
     window.EmberBridge?.state.onUpdate(dataType, response);

--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { render } from 'vitest-browser-react';
 import { configResponse, settingsResponse } from '@tryghost/test-data';
-import type { TopLevelFrameworkProps } from '@tryghost/admin-x-framework';
+import { defaultUnsplashConfig, type TopLevelFrameworkProps } from '@tryghost/admin-x-framework';
 
 import '@/index.css';
 import { AdminAppRoot } from '@/app-root';
@@ -91,13 +91,8 @@ export async function renderAdminApp(
     externalNavigate: (link) => {
       document.body.dataset.externalNavigate = JSON.stringify(link);
     },
-    unsplashConfig: {
-      Authorization: '',
-      'Accept-Version': 'v1',
-      'Content-Type': 'application/json',
-      'App-Pragma': 'no-cache',
-      'X-Unsplash-Cache': true,
-    },
+    // Production shape, but without the real API key so tests never hit Unsplash
+    unsplashConfig: { ...defaultUnsplashConfig, Authorization: '' },
     sentryDSN: null,
     onUpdate: () => {},
     onInvalidate: () => {},


### PR DESCRIPTION
The React admin's Unsplash request config (including the hard-coded client key) was a literal in `main.tsx`, duplicated again in the acceptance harness. It now lives once in the framework as `defaultUnsplashConfig` (typed against `FrameworkProviderProps['unsplashConfig']`, exported from the root); `main.tsx` uses it and the harness shares the shape while keeping its deliberately empty `Authorization` so tests never hit Unsplash. Ember's two copies are untouched (they die with Ember).

**Scope note — the version header deliberately stays un-wired.** This slice was originally scoped to also make the React admin send `x-ghost-version`. Investigation showed that's stale: `ebb0ba2064` (BER-2969) made the fetch layer omit the header exactly so forward-admin deployments skip version checks, and `da379e31b4` later removed the header from Ember entirely — with Admin and Core on different release cadences, client-ahead-of-server skew is normal and the server's `version-match` middleware errors on it. Wiring the header back would reintroduce that failure mode. Worth a separate decision: whether the server's `VersionMismatchError` path should be removed outright now that no admin sends the header.

4 files.

**Verification:** framework build + `test:unit` (40 files / 511 tests) + lint green; admin `tsc -b`, eslint, `test:unit` (137 files) green; route-access acceptance smoke 7/7; `oxfmt --check` clean on touched files.