### PR TITLE
Renamed framework data hooks to carry the use prefix

### DIFF
--- a/apps/admin-x-framework/src/api/email-verification.ts
+++ b/apps/admin-x-framework/src/api/email-verification.ts
@@ -10,16 +10,18 @@ export interface EmailVerificationResponseType {
 }
 const dataType = 'SettingsResponseType';
 
-export const verifyEmailToken = createMutation<EmailVerificationResponseType, emailVerification>({
-  path: () => '/settings/verifications',
-  method: 'PUT',
-  body: ({ token }) => ({ token }),
-  updateQueries: {
-    dataType,
-    emberUpdateType: 'createOrUpdate',
-    update: (newData) => ({
-      ...newData,
-      settings: newData.settings,
-    }),
+export const useVerifyEmailToken = createMutation<EmailVerificationResponseType, emailVerification>(
+  {
+    path: () => '/settings/verifications',
+    method: 'PUT',
+    body: ({ token }) => ({ token }),
+    updateQueries: {
+      dataType,
+      emberUpdateType: 'createOrUpdate',
+      update: (newData) => ({
+        ...newData,
+        settings: newData.settings,
+      }),
+    },
   },
-});
+);

--- a/apps/admin-x-framework/src/api/featurebase.ts
+++ b/apps/admin-x-framework/src/api/featurebase.ts
@@ -24,7 +24,7 @@ const baseFeaturebaseTokenQuery = createQuery<FeaturebaseTokenResponseType>({
   path: '/featurebase/token/',
 });
 
-export const getFeaturebaseToken = (options: { enabled?: boolean } = {}) => {
+export const useFeaturebaseToken = (options: { enabled?: boolean } = {}) => {
   return baseFeaturebaseTokenQuery({
     ...FEATUREBASE_QUERY_OPTIONS,
     ...options,

--- a/apps/admin-x-framework/src/api/feedback.ts
+++ b/apps/admin-x-framework/src/api/feedback.ts
@@ -22,7 +22,7 @@ export interface FeedbackResponseType {
 
 const dataType = 'FeedbackResponseType';
 
-export const getPostFeedback = createQueryWithId<FeedbackResponseType>({
+export const usePostFeedbackQuery = createQueryWithId<FeedbackResponseType>({
   dataType,
   path: (id) => `/feedback/${id}/`,
 });

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -290,7 +290,7 @@ export const useImportMembers = createMutation<ImportMembersResponseType, Import
   invalidateQueries: { dataType },
 });
 
-export const getMember = createQueryWithId<MembersResponseType>({
+export const useMember = createQueryWithId<MembersResponseType>({
   dataType,
   path: (id) => `/members/${id}/`,
 });
@@ -575,7 +575,7 @@ export interface MemberSigninUrlResponseType {
 // The Admin API wraps the controller payload in the `member_signin_urls` array
 // envelope (see `member-signin-urls.js` + framework serializer). Unwrap here so
 // consumers get the flat `{member_id, url}` object they actually want.
-export const getMemberSigninUrl = createQueryWithId<MemberSigninUrlResponseType>({
+export const useMemberSigninUrl = createQueryWithId<MemberSigninUrlResponseType>({
   dataType: 'MemberSigninUrlResponseType',
   path: (id) => `/members/${id}/signin_urls/`,
   returnData: (originalData) => {

--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -76,7 +76,7 @@ export const useBrowsePostsInfinite = createInfiniteQuery<PostsResponseType & { 
   },
 });
 
-export const getPost = createQueryWithId<PostsResponseType>({
+export const usePost = createQueryWithId<PostsResponseType>({
   dataType,
   path: (id) => `/posts/${id}/`,
 });

--- a/apps/admin-x-framework/src/api/staff-token.ts
+++ b/apps/admin-x-framework/src/api/staff-token.ts
@@ -20,12 +20,12 @@ export interface StaffTokenResponseType {
 
 const dataType = 'StaffTokenResponseType';
 
-export const getStaffToken = createQuery<StaffTokenResponseType>({
+export const useStaffToken = createQuery<StaffTokenResponseType>({
   dataType,
   path: '/users/me/token/',
 });
 
-export const genStaffToken = createMutation<StaffTokenResponseType, []>({
+export const useGenerateStaffToken = createMutation<StaffTokenResponseType, []>({
   path: () => '/users/me/token/',
   method: 'PUT',
 });

--- a/apps/admin-x-framework/src/api/tags.ts
+++ b/apps/admin-x-framework/src/api/tags.ts
@@ -85,7 +85,7 @@ export const useBrowseTags = ({
 
 // Mirrors Ember's `queryRecord('tag', {slug})`, which the admin API serves at
 // the dedicated `/tags/slug/:slug/` route.
-export const getTagBySlug = createQueryWithId<TagsResponseType>({
+export const useTagBySlug = createQueryWithId<TagsResponseType>({
   dataType,
   path: (slug) => `/tags/slug/${slug}/`,
 });

--- a/apps/admin-x-framework/src/api/tinybird.ts
+++ b/apps/admin-x-framework/src/api/tinybird.ts
@@ -24,7 +24,7 @@ const baseTinybirdTokenQuery = createQuery<TinybirdTokenResponseType>({
   path: '/tinybird/token/',
 });
 
-export const getTinybirdToken = (options: { enabled?: boolean } = {}) => {
+export const useTinybirdTokenQuery = (options: { enabled?: boolean } = {}) => {
   return baseTinybirdTokenQuery({
     ...TINYBIRD_QUERY_OPTIONS,
     ...options,

--- a/apps/admin-x-framework/src/hooks/use-featurebase.ts
+++ b/apps/admin-x-framework/src/hooks/use-featurebase.ts
@@ -1,5 +1,5 @@
 import { type Deferred, deferred } from '../utils/deferred';
-import { getFeaturebaseToken } from '../api/featurebase';
+import { useFeaturebaseToken } from '../api/featurebase';
 import { useBrowseConfig } from '../api/config';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -126,7 +126,7 @@ export function useFeaturebase(): Featurebase {
   const { organization, enabled } = config?.config.featurebase ?? {};
   const isAvailable = !!enabled;
 
-  const { data: tokenData } = getFeaturebaseToken({
+  const { data: tokenData } = useFeaturebaseToken({
     enabled: isAvailable && shouldLoad,
   });
   const token = tokenData?.featurebase?.token;

--- a/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
@@ -1,4 +1,4 @@
-import { getTinybirdToken } from '../api/tinybird';
+import { useTinybirdTokenQuery } from '../api/tinybird';
 import { useWebAnalyticsEnabled } from '../providers/app-provider';
 
 export interface UseTinybirdTokenResult {
@@ -20,7 +20,7 @@ export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTiny
   // Web analytics is a global kill-switch read from context, so no call site threads it.
   const webAnalyticsEnabled = useWebAnalyticsEnabled();
   const effectiveEnabled = enabled && webAnalyticsEnabled;
-  const tinybirdQuery = getTinybirdToken({ enabled: effectiveEnabled });
+  const tinybirdQuery = useTinybirdTokenQuery({ enabled: effectiveEnabled });
 
   // A disabled React Query can keep cached data/errors, so return an idle
   // result — else direct consumers (the providers) leak a stale token.

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -5,7 +5,7 @@ import type { UserRoleType } from '../../../src/api/roles';
 import { createTestQueryClient, renderHookWithProviders } from '../../../src/test/test-utils';
 import {
   getMemberCountQueryKey,
-  getMemberSigninUrl,
+  useMemberSigninUrl,
   useAddMember,
   useBrowseMembersInfinite,
   useBulkDeleteMembers,
@@ -502,7 +502,7 @@ describe('members api', () => {
           },
         },
         async (mock) => {
-          const { result } = renderHookWithProviders(() => getMemberSigninUrl('member-1'), {
+          const { result } = renderHookWithProviders(() => useMemberSigninUrl('member-1'), {
             queryClient,
           });
 

--- a/apps/admin-x-framework/test/unit/api/tinybird.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/tinybird.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React, { ReactNode } from 'react';
-import { getTinybirdToken } from '../../../src/api/tinybird';
+import { useTinybirdTokenQuery } from '../../../src/api/tinybird';
 import { FrameworkProvider } from '../../../src/providers/framework-provider';
 import { withMockFetch } from '../../utils/mock-fetch';
 
@@ -44,7 +44,7 @@ const wrapper: React.FC<{ children: ReactNode }> = ({ children }) => (
   </FrameworkProvider>
 );
 
-describe('getTinybirdToken', () => {
+describe('useTinybirdTokenQuery', () => {
   afterEach(() => {
     queryClient.clear();
     vi.clearAllTimers();
@@ -57,7 +57,7 @@ describe('getTinybirdToken', () => {
         json: { tinybird: { token: 'test-token-123' } },
       },
       async (mock) => {
-        const { result } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
 
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -68,18 +68,18 @@ describe('getTinybirdToken', () => {
     );
   });
 
-  it('makes only one request for multiple getTinybirdToken calls (caching)', async () => {
+  it('makes only one request for multiple useTinybirdTokenQuery calls (caching)', async () => {
     await withMockFetch(
       {
         json: { tinybird: { token: 'cached-token' } },
       },
       async (mock) => {
         // First call
-        const { result: result1 } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result: result1 } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
         await waitFor(() => expect(result1.current.isLoading).toBe(false));
 
         // Second call should use cache
-        const { result: result2 } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result: result2 } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
         await waitFor(() => expect(result2.current.isLoading).toBe(false));
 
         // Both should have same data, but only 1 HTTP request
@@ -97,7 +97,7 @@ describe('getTinybirdToken', () => {
         json: { tinybird: { token: 'initial-token' } },
       },
       async (mock) => {
-        const { result } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 
         expect(mock.calls.length).toBe(1);
@@ -121,13 +121,13 @@ describe('getTinybirdToken', () => {
       },
       async (mock) => {
         // First call
-        const { result: result1 } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result: result1 } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
         await waitFor(() => expect(result1.current.isLoading).toBe(false));
 
         expect(mock.calls.length).toBe(1);
 
         // Second call immediately after should use cache
-        const { result: result2 } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result: result2 } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
         await waitFor(() => expect(result2.current.isLoading).toBe(false));
 
         // Should still be only 1 request due to built-in stale time
@@ -144,7 +144,7 @@ describe('getTinybirdToken', () => {
       },
       async () => {
         // Should work without any parameters
-        const { result } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
 
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -160,7 +160,7 @@ describe('getTinybirdToken', () => {
         json: { tinybird: { token: 'interface-token' } },
       },
       async () => {
-        const { result } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
 
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -182,7 +182,7 @@ describe('getTinybirdToken', () => {
         ok: false,
       },
       async () => {
-        const { result } = renderHook(() => getTinybirdToken(), { wrapper });
+        const { result } = renderHook(() => useTinybirdTokenQuery(), { wrapper });
 
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { AppProvider, AppSettings } from '../../../src/providers/app-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useTinybirdToken } from '../../../src/hooks/use-tinybird-token';
-import { getTinybirdToken } from '../../../src/api/tinybird';
+import { useTinybirdTokenQuery } from '../../../src/api/tinybird';
 import React from 'react';
 
 const buildAppSettings = (webAnalytics: boolean): AppSettings => ({
@@ -17,12 +17,12 @@ const buildAppSettings = (webAnalytics: boolean): AppSettings => ({
   },
 });
 
-// Mock the getTinybirdToken API
+// Mock the useTinybirdTokenQuery API
 vi.mock('../../../src/api/tinybird', () => ({
-  getTinybirdToken: vi.fn(),
+  useTinybirdTokenQuery: vi.fn(),
 }));
 
-const mockGetTinybirdToken = vi.mocked(getTinybirdToken);
+const mockUseTinybirdTokenQuery = vi.mocked(useTinybirdTokenQuery);
 
 describe('useTinybirdToken', () => {
   let queryClient: QueryClient;
@@ -46,7 +46,7 @@ describe('useTinybirdToken', () => {
   });
 
   it('returns token when API returns valid token', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 'valid-token-123' } },
       isLoading: false,
       error: null,
@@ -61,7 +61,7 @@ describe('useTinybirdToken', () => {
   });
 
   it('returns undefined when API returns null token', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: null } },
       isLoading: false,
       error: null,
@@ -76,7 +76,7 @@ describe('useTinybirdToken', () => {
   it('uses built-in query options without requiring consumer configuration', () => {
     const mockRefetch = vi.fn();
 
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 'cached-token' } },
       isLoading: false,
       error: null,
@@ -89,16 +89,16 @@ describe('useTinybirdToken', () => {
     // Second render in same QueryClient context
     renderHook(() => useTinybirdToken(), { wrapper });
 
-    // Verify that getTinybirdToken is called with default enabled: true
-    expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: true });
+    // Verify that useTinybirdTokenQuery is called with default enabled: true
+    expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: true });
 
     // Verify both calls used the default enabled option
-    expect(mockGetTinybirdToken.mock.calls[0]).toEqual([{ enabled: true }]);
-    expect(mockGetTinybirdToken.mock.calls[1]).toEqual([{ enabled: true }]);
+    expect(mockUseTinybirdTokenQuery.mock.calls[0]).toEqual([{ enabled: true }]);
+    expect(mockUseTinybirdTokenQuery.mock.calls[1]).toEqual([{ enabled: true }]);
   });
 
   it('uses built-in query options for optimal token refresh behavior', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 'test-token' } },
       isLoading: false,
       error: null,
@@ -108,12 +108,12 @@ describe('useTinybirdToken', () => {
     renderHook(() => useTinybirdToken(), { wrapper });
 
     // Verify default enabled option is passed
-    expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: true });
-    expect(mockGetTinybirdToken.mock.calls[0]).toEqual([{ enabled: true }]);
+    expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: true });
+    expect(mockUseTinybirdTokenQuery.mock.calls[0]).toEqual([{ enabled: true }]);
   });
 
   it('returns undefined for invalid token types without throwing error', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 123 } }, // number instead of string
       isLoading: false,
       error: null,
@@ -129,7 +129,7 @@ describe('useTinybirdToken', () => {
   it('passes through API errors', () => {
     const apiError = new Error('Network error');
 
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: null,
       isLoading: false,
       error: apiError,
@@ -145,7 +145,7 @@ describe('useTinybirdToken', () => {
   it('exposes refetch function', () => {
     const mockRefetch = vi.fn();
 
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 'test-token' } },
       isLoading: false,
       error: null,
@@ -169,7 +169,7 @@ describe('useTinybirdToken', () => {
       refetch: vi.fn(),
     };
 
-    mockGetTinybirdToken.mockImplementation(() => queryState as any);
+    mockUseTinybirdTokenQuery.mockImplementation(() => queryState as any);
 
     const { result, rerender } = renderHook(() => useTinybirdToken(), { wrapper });
 
@@ -211,7 +211,7 @@ describe('useTinybirdToken', () => {
       refetch: vi.fn(),
     };
 
-    mockGetTinybirdToken.mockImplementation(() => {
+    mockUseTinybirdTokenQuery.mockImplementation(() => {
       fetchCount += 1;
       return {
         ...queryState,
@@ -245,7 +245,7 @@ describe('useTinybirdToken', () => {
   });
 
   it('respects enabled option when true', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 'enabled-token' } },
       isLoading: false,
       error: null,
@@ -257,11 +257,11 @@ describe('useTinybirdToken', () => {
     expect(result.current.token).toBe('enabled-token');
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(null);
-    expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: true });
+    expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: true });
   });
 
   it('respects enabled option when false', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: null,
       isLoading: false,
       error: null,
@@ -273,11 +273,11 @@ describe('useTinybirdToken', () => {
     expect(result.current.token).toBeUndefined();
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(null);
-    expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: false });
   });
 
   it('defaults enabled to true when not specified', () => {
-    mockGetTinybirdToken.mockReturnValue({
+    mockUseTinybirdTokenQuery.mockReturnValue({
       data: { tinybird: { token: 'default-token' } },
       isLoading: false,
       error: null,
@@ -287,7 +287,7 @@ describe('useTinybirdToken', () => {
     const { result } = renderHook(() => useTinybirdToken(), { wrapper });
 
     expect(result.current.token).toBe('default-token');
-    expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: true });
+    expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: true });
   });
 
   describe('web analytics gate', () => {
@@ -304,7 +304,7 @@ describe('useTinybirdToken', () => {
         );
 
     beforeEach(() => {
-      mockGetTinybirdToken.mockReturnValue({
+      mockUseTinybirdTokenQuery.mockReturnValue({
         data: { tinybird: { token: 'test-token' } },
         isLoading: false,
         error: null,
@@ -315,13 +315,13 @@ describe('useTinybirdToken', () => {
     it('never loads a token when web analytics is disabled, even if enabled is true', () => {
       renderHook(() => useTinybirdToken({ enabled: true }), { wrapper: withAppSettings(false) });
 
-      expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: false });
+      expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: false });
     });
 
     it('returns an idle result when disabled, even if the query reports loading/error', () => {
       // A disabled React Query still reports isLoading:true and may retain a
       // cached error — the hook must normalize this so providers don't hang.
-      mockGetTinybirdToken.mockReturnValue({
+      mockUseTinybirdTokenQuery.mockReturnValue({
         data: { tinybird: { token: 'stale-token' } },
         isLoading: true,
         error: new Error('stale error'),
@@ -340,19 +340,19 @@ describe('useTinybirdToken', () => {
     it('loads a token when web analytics is enabled', () => {
       renderHook(() => useTinybirdToken({ enabled: true }), { wrapper: withAppSettings(true) });
 
-      expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: true });
+      expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: true });
     });
 
     it('stays disabled when web analytics is on but the caller passes enabled false', () => {
       renderHook(() => useTinybirdToken({ enabled: false }), { wrapper: withAppSettings(true) });
 
-      expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: false });
+      expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: false });
     });
 
     it('defaults to enabled when no AppProvider is mounted (preserves standalone behavior)', () => {
       renderHook(() => useTinybirdToken({ enabled: true }), { wrapper });
 
-      expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: true });
+      expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: true });
     });
 
     it('stays disabled while settings are still loading (provider mounted, appSettings undefined)', () => {
@@ -365,7 +365,7 @@ describe('useTinybirdToken', () => {
 
       renderHook(() => useTinybirdToken({ enabled: true }), { wrapper: loadingWrapper });
 
-      expect(mockGetTinybirdToken).toHaveBeenCalledWith({ enabled: false });
+      expect(mockUseTinybirdTokenQuery).toHaveBeenCalledWith({ enabled: false });
     });
   });
 });

--- a/apps/admin/src/automations/automations.test.tsx
+++ b/apps/admin/src/automations/automations.test.tsx
@@ -69,7 +69,7 @@ vi.mock('@tryghost/admin-x-framework', async () => {
   );
   return {
     ...actual,
-    getFeaturebaseToken: () => ({ data: undefined }),
+    useFeaturebaseToken: () => ({ data: undefined }),
     useFeaturebase: () => ({
       isAvailable: false,
       openFeedbackWidget: () => {},

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -37,7 +37,7 @@ import {
 import { dequal } from 'dequal';
 import { deriveMemberDetailBackPath } from './member-detail-nav';
 import { formatMemberName } from '@tryghost/shade/app';
-import { getMember, useAddMember, useEditMember } from '@tryghost/admin-x-framework/api/members';
+import { useMember, useAddMember, useEditMember } from '@tryghost/admin-x-framework/api/members';
 import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
 import { toast } from 'sonner';
 import { useBrowseNewsletters } from '@tryghost/admin-x-framework/api/newsletters';
@@ -74,7 +74,7 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({
   const customFieldsEnabled = useFeatureFlag('membersCustomFields');
 
   // `include=tiers` mirrors the Ember route so complimentary tiers arrive with the member.
-  const { data, isLoading, error, refetch } = getMember(memberId, {
+  const { data, isLoading, error, refetch } = useMember(memberId, {
     enabled: !!memberId && !isCreating,
     searchParams: { include: customFieldsEnabled ? 'tiers,custom_fields' : 'tiers' },
     defaultErrorHandler: false,

--- a/apps/admin/src/members/detail/member-impersonate-modal.tsx
+++ b/apps/admin/src/members/detail/member-impersonate-modal.tsx
@@ -11,7 +11,7 @@ import {
   Label,
   LoadingIndicator,
 } from '@tryghost/shade/components';
-import { getMemberSigninUrl } from '@tryghost/admin-x-framework/api/members';
+import { useMemberSigninUrl } from '@tryghost/admin-x-framework/api/members';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -44,7 +44,7 @@ const MemberImpersonateModal: React.FC<MemberImpersonateModalProps> = ({
     }
   }, [open, queryClient]);
 
-  const { data, isFetching, isError } = getMemberSigninUrl(memberId, {
+  const { data, isFetching, isError } = useMemberSigninUrl(memberId, {
     enabled: open,
     defaultErrorHandler: false,
   });

--- a/apps/admin/src/posts/analytics/hooks/use-post-feedback.ts
+++ b/apps/admin/src/posts/analytics/hooks/use-post-feedback.ts
@@ -1,4 +1,4 @@
-import { getPostFeedback } from '@tryghost/admin-x-framework/api/feedback';
+import { usePostFeedbackQuery } from '@tryghost/admin-x-framework/api/feedback';
 import { useMemo } from 'react';
 
 export const usePostFeedback = (postId: string, score?: number) => {
@@ -6,7 +6,7 @@ export const usePostFeedback = (postId: string, score?: number) => {
     data: feedbackResponse,
     isLoading,
     error,
-  } = getPostFeedback(postId, {
+  } = usePostFeedbackQuery(postId, {
     searchParams: {
       limit: '50', // Get more data for pagination
       ...(score !== undefined ? { score: score.toString() } : {}),

--- a/apps/admin/src/posts/analytics/hooks/use-post-newsletter-stats.ts
+++ b/apps/admin/src/posts/analytics/hooks/use-post-newsletter-stats.ts
@@ -4,7 +4,7 @@ import {
   useNewsletterBasicStats,
   useNewsletterClickStats,
 } from '@tryghost/admin-x-framework/api/stats';
-import { type Post, getPost } from '@tryghost/admin-x-framework/api/posts';
+import { type Post, usePost } from '@tryghost/admin-x-framework/api/posts';
 import { processAndGroupTopLinks } from '@/posts/analytics/utils/link-helpers';
 import { useMemo } from 'react';
 import { useTopLinks } from '@tryghost/admin-x-framework/api/links';
@@ -18,10 +18,10 @@ type PostWithNewsletter = Post & {
 
 export const usePostNewsletterStats = (postId: string) => {
   // Fetch the post with main stats (email, clicks)
-  const { data: postResponse, isLoading: isPostLoading } = getPost(postId);
+  const { data: postResponse, isLoading: isPostLoading } = usePost(postId);
 
   // Fetch the post with feedback count relations
-  const { data: feedbackPostResponse, isLoading: isFeedbackPostLoading } = getPost(postId, {
+  const { data: feedbackPostResponse, isLoading: isFeedbackPostLoading } = usePost(postId, {
     searchParams: {
       include: 'count.positive_feedback,count.negative_feedback',
     },

--- a/apps/admin/src/settings/general/users/staff-token.tsx
+++ b/apps/admin/src/settings/general/users/staff-token.tsx
@@ -1,18 +1,18 @@
 import APIKeys from '@/settings/advanced/integrations/api-keys';
 import { Text } from '@tryghost/shade/primitives';
-import { genStaffToken, getStaffToken } from '@tryghost/admin-x-framework/api/staff-token';
+import { useGenerateStaffToken, useStaffToken } from '@tryghost/admin-x-framework/api/staff-token';
 import { useConfirmation } from '@/settings/providers/confirmation-context';
 import { useEffect, useState } from 'react';
 import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 
 const StaffToken: React.FC = () => {
-  const { refetch: apiKey } = getStaffToken({
+  const { refetch: apiKey } = useStaffToken({
     enabled: false,
   });
   const handleError = useHandleError();
   const { confirm } = useConfirmation();
   const [token, setToken] = useState('');
-  const { mutateAsync: newApiKey } = genStaffToken();
+  const { mutateAsync: newApiKey } = useGenerateStaffToken();
 
   useEffect(() => {
     const getApiKey = async () => {

--- a/apps/admin/src/settings/membership/portal/portal-modal.tsx
+++ b/apps/admin/src/settings/membership/portal/portal-modal.tsx
@@ -19,7 +19,7 @@ import { useConfirmation } from '@/settings/providers/confirmation-context';
 import { useFocusContext } from '@tryghost/shade/app';
 import { useGlobalData } from '@/settings/providers/global-data-context';
 import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
-import { verifyEmailToken } from '@tryghost/admin-x-framework/api/email-verification';
+import { useVerifyEmailToken } from '@tryghost/admin-x-framework/api/email-verification';
 
 type PreviewTab = 'signup' | 'account' | 'links';
 type SidebarTab = 'signupOptions' | 'lookAndFeel' | 'accountPage';
@@ -111,7 +111,7 @@ const PortalModal: React.FC = () => {
   // const tiers = getPaidActiveTiers(allTiers || []);
 
   const { mutateAsync: editTier } = useEditTier();
-  const { mutateAsync: verifyToken } = verifyEmailToken();
+  const { mutateAsync: verifyToken } = useVerifyEmailToken();
 
   const { getParam } = useQueryParams();
 

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -34,7 +34,7 @@ import {
   validateTagDraft,
 } from './tag-detail-edit';
 import { dequal } from 'dequal';
-import { getTagBySlug, useAddTag, useEditTag } from '@tryghost/admin-x-framework/api/tags';
+import { useTagBySlug, useAddTag, useEditTag } from '@tryghost/admin-x-framework/api/tags';
 import { toast } from 'sonner';
 import { useBrowseSite } from '@tryghost/admin-x-framework/api/site';
 import { useUnsavedChangesGuard } from '@/hooks/use-unsaved-changes-guard';
@@ -58,7 +58,7 @@ const TagDetail: React.FC = () => {
 
   // `include=count.posts` mirrors the Ember route so the delete modal can
   // report how many posts the tag will be removed from.
-  const { data, isLoading, error, refetch } = getTagBySlug(tagSlug, {
+  const { data, isLoading, error, refetch } = useTagBySlug(tagSlug, {
     enabled: !!tagSlug && !isCreating,
     searchParams: { include: 'count.posts' },
     defaultErrorHandler: false,


### PR DESCRIPTION
Ten admin-x-framework exports are React hooks (built from the query factories) but were named `get*`/`gen*`/`verify*` — they dodge rules-of-hooks linting and misread as plain functions at call sites. Pure renames, no logic change:

| Old | New |
|---|---|
| `getMember` | `useMember` |
| `getPost` | `usePost` |
| `getMemberSigninUrl` | `useMemberSigninUrl` |
| `getTagBySlug` | `useTagBySlug` |
| `getStaffToken` | `useStaffToken` |
| `genStaffToken` | `useGenerateStaffToken` |
| `verifyEmailToken` | `useVerifyEmailToken` |
| `getFeaturebaseToken` | `useFeaturebaseToken` |
| `getPostFeedback` | `usePostFeedbackQuery` |
| `getTinybirdToken` | `useTinybirdTokenQuery` |

Collision scheme: where the natural `use*` name is already taken by the wrapper hook that consumes the factory hook (`useTinybirdToken`, `usePostFeedback`), the factory hook takes a `Query` suffix.

Untouched on purpose: the `verifyEmailToken` query-param locals in four settings/email files (plain variables, unrelated), comments-ui/activitypub API-client methods of the same names, and non-hook framework exports (`getActionTitle`, `getImageUrl`, …) which are correctly unprefixed.

21 files, +90/−88.

**Verification:** framework `pnpm build` + `test:unit` (40 files / 511 tests) + lint green; admin `tsc -b`, `eslint src`, `test:unit` (137 files / 1628 tests) green; repo-wide grep shows zero references to any old name; `oxfmt --check` clean.