### PR TITLE
Contained Ember bridge access and made the state bridge tolerant

### DIFF
--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -483,3 +483,65 @@ describe('useEmberRouting', () => {
     });
   });
 });
+
+describe('theme bridge helpers', () => {
+  test('isEmberThemeManaged reflects bridge presence', async () => {
+    const { isEmberThemeManaged } = await import('./ember-bridge');
+    expect(isEmberThemeManaged()).toBe(false);
+    window.EmberBridge = { state: createMockStateBridge().stateBridge };
+    expect(isEmberThemeManaged()).toBe(true);
+  });
+
+  test('applyEmberAdminThemePreference calls Ember when the method exists and reports it', async () => {
+    const { applyEmberAdminThemePreference } = await import('./ember-bridge');
+    const mock = createMockStateBridge();
+    const apply = vi.fn();
+    mock.stateBridge.applyAdminThemePreference = apply;
+    window.EmberBridge = { state: mock.stateBridge };
+
+    expect(applyEmberAdminThemePreference('dark')).toBe(true);
+    expect(apply).toHaveBeenCalledWith('dark');
+  });
+
+  test('applyEmberAdminThemePreference returns false without a bridge or method', async () => {
+    const { applyEmberAdminThemePreference } = await import('./ember-bridge');
+    expect(applyEmberAdminThemePreference('dark')).toBe(false);
+
+    // Bridge present but from an older Ember without the method
+    window.EmberBridge = { state: createMockStateBridge().stateBridge };
+    expect(applyEmberAdminThemePreference('dark')).toBe(false);
+  });
+
+  test('preloadEmberAdminThemeStylesheet resolves with and without the bridge', async () => {
+    const { preloadEmberAdminThemeStylesheet } = await import('./ember-bridge');
+    await expect(preloadEmberAdminThemeStylesheet()).resolves.toBeUndefined();
+
+    const mock = createMockStateBridge();
+    const preload = vi.fn().mockResolvedValue(undefined);
+    mock.stateBridge.preloadAdminThemeStylesheet = preload;
+    window.EmberBridge = { state: mock.stateBridge };
+    await preloadEmberAdminThemeStylesheet();
+    expect(preload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('emberMutationHandlers', () => {
+  test('resolves the bridge at call time, not import time', async () => {
+    // Import first, install the bridge after: forwarding must still work.
+    const { emberMutationHandlers } = await import('./ember-bridge');
+    expect(() => emberMutationHandlers.onUpdate('SettingsResponseType', {})).not.toThrow();
+
+    const mock = createMockStateBridge();
+    window.EmberBridge = { state: mock.stateBridge };
+
+    emberMutationHandlers.onUpdate('SettingsResponseType', { settings: [] });
+    emberMutationHandlers.onInvalidate('TagsResponseType');
+    emberMutationHandlers.onDelete('UsersResponseType', 'user-1');
+
+    expect(mock.stateBridge.onUpdate).toHaveBeenCalledWith('SettingsResponseType', {
+      settings: [],
+    });
+    expect(mock.stateBridge.onInvalidate).toHaveBeenCalledWith('TagsResponseType');
+    expect(mock.stateBridge.onDelete).toHaveBeenCalledWith('UsersResponseType', 'user-1');
+  });
+});

--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -235,42 +235,6 @@ describe('useEmberDataSync', () => {
   });
 
   queryTest(
-    'invalidates comment queries for mapped Ember comment events',
-    async ({ queryClient, wrapper }) => {
-      const mock = createMockStateBridge();
-      window.EmberBridge = { state: mock.stateBridge };
-
-      queryClient.setQueryData(['MembersResponseType', '/members'], { members: [] });
-      queryClient.setQueryData(['CommentsResponseType', '/comments'], { comments: [] });
-      queryClient.setQueryData(['PostsResponseType', '/posts'], { posts: [] });
-
-      renderHook(() => useEmberDataSync(), { wrapper });
-
-      await waitFor(() => {
-        expect(mock.onSpy).toHaveBeenCalledWith('emberDataChange', expect.any(Function));
-      });
-
-      act(() => {
-        mock.emit('emberDataChange', {
-          operation: 'update',
-          modelName: 'comment',
-          id: 'member-1',
-          data: null,
-        });
-      });
-
-      await waitFor(() => {
-        const queries = queryClient.getQueryCache().getAll();
-        const commentQueries = queries.filter((q) => q.queryKey[0] === 'CommentsResponseType');
-        const nonCommentQueries = queries.filter((q) => q.queryKey[0] !== 'CommentsResponseType');
-
-        expect(commentQueries.every((q) => q.state.isInvalidated)).toBe(true);
-        expect(nonCommentQueries.every((q) => !q.state.isInvalidated)).toBe(true);
-      });
-    },
-  );
-
-  queryTest(
     'does not subscribe if unmounted before the bridge becomes available',
     async ({ wrapper }) => {
       vi.useFakeTimers();

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -16,13 +16,15 @@ export type StateBridgeEventMap = {
   featureFlagsChange: undefined;
 };
 
+export type AdminThemeMode = 'light' | 'dark' | 'system';
+
 export interface StateBridge {
   onUpdate: (dataType: string, response: unknown) => void;
   onInvalidate: (dataType: string) => void;
   onDelete: (dataType: string, id: string) => void;
   isFeatureEnabled?: (name: string) => boolean | undefined;
   preloadAdminThemeStylesheet?: () => Promise<void>;
-  applyAdminThemePreference?: (mode: 'light' | 'dark' | 'system') => Promise<void> | void;
+  applyAdminThemePreference?: (mode: AdminThemeMode) => Promise<void> | void;
   on<K extends keyof StateBridgeEventMap>(
     event: K,
     callback: (event: StateBridgeEventMap[K]) => void,
@@ -96,10 +98,8 @@ const EMBER_TO_REACT_TYPE_MAPPING: Record<string, string> = {
   user: 'UsersResponseType',
   post: 'PostsResponseType',
   member: 'MembersResponseType',
-  comment: 'CommentsResponseType',
   tag: 'TagsResponseType',
   label: 'LabelsResponseType',
-  webhook: 'WebhooksResponseType',
 };
 
 /**
@@ -260,6 +260,59 @@ export function subscribeOpenGiftLinkModal(
 ): () => void {
   return onEmberStateBridgeEvent('openGiftLinkModal', handler);
 }
+
+/**
+ * Whether Ember owns the DOM theme. In the embedded admin, Ember manages the
+ * `dark` class and the dark stylesheet, and installs its own
+ * prefers-color-scheme listener, so React must not apply the theme itself.
+ *
+ * Deliberately a synchronous snapshot (no waitForStateBridge): theme effects
+ * need the answer at effect time and fall back to applying the theme
+ * themselves while the bridge is absent.
+ */
+export function isEmberThemeManaged(): boolean {
+  return typeof window !== 'undefined' && Boolean(window.EmberBridge);
+}
+
+/**
+ * Preloads Ember's dark stylesheet so a subsequent theme switch lands without
+ * a flash. Resolves immediately when no bridge (or an older Ember without the
+ * method) is present.
+ */
+export async function preloadEmberAdminThemeStylesheet(): Promise<void> {
+  await window.EmberBridge?.state.preloadAdminThemeStylesheet?.();
+}
+
+/**
+ * Asks Ember to apply an admin theme preference. Returns false when no bridge
+ * (or an older Ember without the method) is present, so the caller can fall
+ * back to applying the theme itself.
+ */
+export function applyEmberAdminThemePreference(mode: AdminThemeMode): boolean {
+  const stateBridge = window.EmberBridge?.state;
+  if (!stateBridge?.applyAdminThemePreference) {
+    return false;
+  }
+  void stateBridge.applyAdminThemePreference(mode);
+  return true;
+}
+
+/**
+ * React -> Ember mutation sync handlers for the FrameworkProvider. Each
+ * forwards a successful React mutation to Ember's store sync and no-ops when
+ * the bridge is absent (standalone React).
+ */
+export const emberMutationHandlers = {
+  onUpdate: (dataType: string, response: unknown): void => {
+    window.EmberBridge?.state.onUpdate(dataType, response);
+  },
+  onInvalidate: (dataType: string): void => {
+    window.EmberBridge?.state.onInvalidate(dataType);
+  },
+  onDelete: (dataType: string, id: string): void => {
+    window.EmberBridge?.state.onDelete(dataType, id);
+  },
+};
 
 // External store for sidebar visibility state
 function subscribeSidebarVisibility(callback: () => void): () => void {

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -12,5 +12,14 @@ export {
   useEmberRouting,
   useForceUpgrade,
   subscribeOpenGiftLinkModal,
+  isEmberThemeManaged,
+  preloadEmberAdminThemeStylesheet,
+  applyEmberAdminThemePreference,
+  emberMutationHandlers,
 } from './ember-bridge';
-export type { EmberDataChangeEvent, EmberRouting, OpenGiftLinkModalEvent } from './ember-bridge';
+export type {
+  AdminThemeMode,
+  EmberDataChangeEvent,
+  EmberRouting,
+  OpenGiftLinkModalEvent,
+} from './ember-bridge';

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -1,4 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  applyEmberAdminThemePreference,
+  isEmberThemeManaged,
+  preloadEmberAdminThemeStylesheet,
+} from '@/ember-bridge';
 import { useEditUserPreferences, useUserPreferences } from '@/hooks/user-preferences';
 
 export type ThemeMode = 'light' | 'dark' | 'system';
@@ -33,22 +38,11 @@ function applyThemeClass(resolvedTheme: ResolvedThemeMode) {
   });
 }
 
-// In the embedded admin, Ember owns the DOM theme: it manages both the `dark`
-// class and the dark stylesheet, and installs its own prefers-color-scheme
-// listener. The class-toggling and media-query effects below are only a fallback
-// for running this hook standalone (no EmberBridge), so they must not fight Ember.
-function isEmberManaged(): boolean {
-  return typeof window !== 'undefined' && Boolean(window.EmberBridge);
-}
-
-async function preloadAdminThemeStylesheet() {
-  await window.EmberBridge?.state.preloadAdminThemeStylesheet?.();
-}
-
+// The class-toggling and media-query effects below are only a fallback for
+// running this hook standalone (no EmberBridge), so they must not fight Ember
+// when it manages the DOM theme — see isEmberThemeManaged.
 function applyAdminTheme(mode: ThemeMode, resolvedTheme: ResolvedThemeMode) {
-  if (window.EmberBridge?.state.applyAdminThemePreference) {
-    void window.EmberBridge.state.applyAdminThemePreference(mode);
-  } else {
+  if (!applyEmberAdminThemePreference(mode)) {
     applyThemeClass(resolvedTheme);
   }
 }
@@ -68,7 +62,7 @@ export function useTheme() {
 
   useEffect(() => {
     if (
-      isEmberManaged() ||
+      isEmberThemeManaged() ||
       typeof window === 'undefined' ||
       typeof window.matchMedia !== 'function'
     ) {
@@ -97,7 +91,7 @@ export function useTheme() {
   }, []);
 
   useEffect(() => {
-    if (isEmberManaged()) {
+    if (isEmberThemeManaged()) {
       return;
     }
     applyThemeClass(resolvedTheme);
@@ -126,7 +120,7 @@ export function useTheme() {
 
       try {
         const nextResolvedTheme = mode === 'system' ? systemTheme : mode;
-        await preloadAdminThemeStylesheet().catch((error) => {
+        await preloadEmberAdminThemeStylesheet().catch((error) => {
           // eslint-disable-next-line no-console
           console.error('[Theme] Failed to preload admin theme stylesheet:', error);
         });

--- a/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { useSidebarBannerState } from './use-sidebar-banner-state';
 
-const mockUseSidebarVisibility = vi.fn<() => boolean>(() => true);
+const mockUseAdminSidebarVisibility = vi.fn<() => boolean>(() => true);
 const mockUseActiveThemeErrors = vi.fn<() => { hasErrors: boolean }>(() => ({ hasErrors: false }));
 const mockUseUpgradeStatus = vi.fn<
   () => { showUpgradeBanner: boolean; trialDaysRemaining: number }
@@ -12,8 +12,8 @@ const mockUseWhatsNewStatus = vi.fn<() => { showWhatsNewBanner: boolean }>(() =>
   showWhatsNewBanner: false,
 }));
 
-vi.mock('@/ember-bridge/ember-bridge', () => ({
-  useSidebarVisibility: () => mockUseSidebarVisibility(),
+vi.mock('@/layout/sidebar-visibility', () => ({
+  useAdminSidebarVisibility: () => mockUseAdminSidebarVisibility(),
 }));
 
 vi.mock('./use-theme-errors', () => ({
@@ -44,14 +44,14 @@ vi.mock('@/whats-new/components/whats-new-banner', () => ({
 
 describe('useSidebarBannerState', () => {
   beforeEach(() => {
-    mockUseSidebarVisibility.mockReturnValue(true);
+    mockUseAdminSidebarVisibility.mockReturnValue(true);
     mockUseActiveThemeErrors.mockReturnValue({ hasErrors: false });
     mockUseUpgradeStatus.mockReturnValue({ showUpgradeBanner: false, trialDaysRemaining: 0 });
     mockUseWhatsNewStatus.mockReturnValue({ showWhatsNewBanner: false });
   });
 
   test('returns no banner when editor is open', () => {
-    mockUseSidebarVisibility.mockReturnValue(false);
+    mockUseAdminSidebarVisibility.mockReturnValue(false);
     mockUseActiveThemeErrors.mockReturnValue({ hasErrors: true });
     mockUseUpgradeStatus.mockReturnValue({ showUpgradeBanner: true, trialDaysRemaining: 7 });
     mockUseWhatsNewStatus.mockReturnValue({ showWhatsNewBanner: true });

--- a/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.tsx
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 
-import { useSidebarVisibility } from '@/ember-bridge/ember-bridge';
 import ThemeErrorsBanner from '@/layout/app-sidebar/theme-errors-banner';
 import UpgradeBanner from '@/layout/app-sidebar/upgrade-banner';
+import { useAdminSidebarVisibility } from '@/layout/sidebar-visibility';
 import WhatsNewBanner from '@/whats-new/components/whats-new-banner';
 
 import { useUpgradeStatus } from './use-upgrade-status';
@@ -19,7 +19,7 @@ export function useSidebarBannerState(): SidebarBannerState {
   const { hasErrors } = useActiveThemeErrors();
   const { showUpgradeBanner, trialDaysRemaining } = useUpgradeStatus();
   const { showWhatsNewBanner } = useWhatsNewStatus();
-  const sidebarVisible = useSidebarVisibility();
+  const sidebarVisible = useAdminSidebarVisibility();
 
   if (!sidebarVisible) {
     return {

--- a/apps/admin/src/layout/app-sidebar/hooks/use-upgrade-status.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-upgrade-status.ts
@@ -1,4 +1,4 @@
-import { useSubscriptionStatus } from '@/ember-bridge/ember-bridge';
+import { useSubscriptionStatus } from '@/ember-bridge';
 
 export interface UpgradeStatus {
   showUpgradeBanner: boolean;

--- a/apps/admin/src/layout/sidebar-visibility.test.tsx
+++ b/apps/admin/src/layout/sidebar-visibility.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@tryghost/admin-x-framework', () => ({
   useMatches: () => useMatchesMock(),
 }));
 
-vi.mock('@/ember-bridge/ember-bridge', () => ({
+vi.mock('@/ember-bridge', () => ({
   useSidebarVisibility: () => useEmberSidebarVisibilityMock(),
 }));
 

--- a/apps/admin/src/layout/sidebar-visibility.ts
+++ b/apps/admin/src/layout/sidebar-visibility.ts
@@ -1,5 +1,5 @@
 import { type AdminRouteHandle, useMatches } from '@tryghost/admin-x-framework';
-import { useSidebarVisibility as useEmberSidebarVisibility } from '@/ember-bridge/ember-bridge';
+import { useSidebarVisibility as useEmberSidebarVisibility } from '@/ember-bridge';
 
 function hidesAdminSidebar(handle: unknown): handle is AdminRouteHandle {
   return (

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import { AdminAppRoot } from './app-root.tsx';
+import { emberMutationHandlers } from './ember-bridge';
 import { navigateTo } from './utils/navigation';
 
 const framework = {
@@ -16,15 +17,7 @@ const framework = {
     'X-Unsplash-Cache': true,
   },
   sentryDSN: null,
-  onUpdate: (dataType: string, response: unknown) => {
-    window.EmberBridge?.state.onUpdate(dataType, response);
-  },
-  onInvalidate: (dataType: string) => {
-    window.EmberBridge?.state.onInvalidate(dataType);
-  },
-  onDelete: (dataType: string, id: string) => {
-    window.EmberBridge?.state.onDelete(dataType, id);
-  },
+  ...emberMutationHandlers,
 };
 
 createRoot(document.getElementById('root')!).render(<AdminAppRoot framework={framework} />);

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -6,7 +6,6 @@ import {inject} from 'ghost-admin/decorators/inject';
 import {run} from '@ember/runloop';
 
 const emberDataTypeMapping = {
-    AutomatedEmailDesignResponseType: null, // automated email design settings only exist in React admin
     AutomatedEmailsResponseType: null, // automated emails only exist in React admin
     AutomationsResponseType: null, // automations only exist in React admin
     CommentsResponseType: null, // comments only exist in React admin
@@ -24,7 +23,7 @@ const emberDataTypeMapping = {
     ThemesResponseType: {type: 'theme'},
     TiersResponseType: {type: 'tier'},
     UsersResponseType: {type: 'user'},
-    CustomThemeSettingsResponseType: null // custom theme settings no longer exist in Admin
+    CustomThemeSettingsResponseType: null // invalidated by React theme activation; nothing to sync in Ember
 };
 
 export default class StateBridgeService extends Service.extend(Evented) {
@@ -81,23 +80,22 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     /* React -> Ember -------------------------------------------------------
 
-    The React admin shell app or a component that extends AdminXComponent will
-    call these methods any time they update their own data.
+    The React admin shell calls these methods any time it updates its own
+    data.
 
     These methods take the React data and push it into the Ember store to
     trigger reactivity, then trigger any other side effects needed to keep
     non-derived state in sync.
 
+    Data types without a model mapping — explicitly null or absent entirely —
+    are React-only and no-op; emberDataTypeMapping lists the Ember-relevant
+    types.
+
     */
 
     @action
     onUpdate(dataType, response) {
-        if (!(dataType in emberDataTypeMapping)) {
-            throw new Error(`A mutation updating ${dataType} succeeded in React Admin but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
-        }
-
-        // Skip processing if mapping is explicitly set to null
-        if (emberDataTypeMapping[dataType] === null) {
+        if (!emberDataTypeMapping[dataType]) {
             return;
         }
 
@@ -165,12 +163,7 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     @action
     onInvalidate(dataType) {
-        if (!(dataType in emberDataTypeMapping)) {
-            throw new Error(`A mutation invalidating ${dataType} succeeded in React Admin but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
-        }
-
-        // Skip processing if mapping is explicitly set to null
-        if (emberDataTypeMapping[dataType] === null) {
+        if (!emberDataTypeMapping[dataType]) {
             return;
         }
 
@@ -197,12 +190,7 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     @action
     onDelete(dataType, id) {
-        if (!(dataType in emberDataTypeMapping)) {
-            throw new Error(`A mutation deleting ${dataType} succeeded in React Admin but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
-        }
-
-        // Skip processing if mapping is explicitly set to null
-        if (emberDataTypeMapping[dataType] === null) {
+        if (!emberDataTypeMapping[dataType]) {
             return;
         }
 
@@ -264,7 +252,7 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     // The gift-link modal lives in React. Ember surfaces (the posts/pages
     // context menu) ask React to open it for a given post/page rather than
-    // duplicating the modal — see useOpenGiftLinkModal on the React side.
+    // duplicating the modal — see subscribeOpenGiftLinkModal on the React side.
     @action
     triggerOpenGiftLinkModal({id, resource}) {
         this.trigger('openGiftLinkModal', {id, resource});

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -74,10 +74,13 @@ describe('Unit: Service: state-bridge', function () {
     });
 
     describe('#onUpdate', function () {
-        it('throws error for unknown data type', function () {
-            expect(() => {
+        it('ignores unknown data types', function () {
+            run(() => {
                 service.onUpdate('UnknownType', {});
-            }).to.throw('A mutation updating UnknownType succeeded in React Admin but there is no mapping to an Ember type');
+            });
+
+            expect(store.pushPayload.called).to.be.false;
+            expect(store.push.called).to.be.false;
         });
 
         it('skips processing for null-mapped data types', function () {
@@ -85,16 +88,6 @@ describe('Unit: Service: state-bridge', function () {
 
             run(() => {
                 service.onUpdate('CustomThemeSettingsResponseType', response);
-            });
-
-            expect(store.pushPayload.called).to.be.false;
-        });
-
-        it('skips processing for automated email design data type', function () {
-            const response = {automated_email_design: [{id: '1'}]};
-
-            run(() => {
-                service.onUpdate('AutomatedEmailDesignResponseType', response);
             });
 
             expect(store.pushPayload.called).to.be.false;
@@ -276,23 +269,17 @@ describe('Unit: Service: state-bridge', function () {
     });
 
     describe('#onInvalidate', function () {
-        it('throws error for unknown data type', function () {
-            expect(() => {
-                service.onInvalidate('UnknownType');
-            }).to.throw('A mutation invalidating UnknownType succeeded in React Admin but there is no mapping to an Ember type');
-        });
-
-        it('skips processing for null-mapped data types', function () {
+        it('ignores unknown data types', function () {
             run(() => {
-                service.onInvalidate('CustomThemeSettingsResponseType');
+                service.onInvalidate('UnknownType');
             });
 
             expect(store.unloadAll.called).to.be.false;
         });
 
-        it('skips processing for automated email design data type', function () {
+        it('skips processing for null-mapped data types', function () {
             run(() => {
-                service.onInvalidate('AutomatedEmailDesignResponseType');
+                service.onInvalidate('CustomThemeSettingsResponseType');
             });
 
             expect(store.unloadAll.called).to.be.false;
@@ -340,10 +327,14 @@ describe('Unit: Service: state-bridge', function () {
     });
 
     describe('#onDelete', function () {
-        it('throws error for unknown data type', function () {
-            expect(() => {
+        it('ignores unknown data types', function () {
+            sinon.spy(store, 'peekRecord');
+
+            run(() => {
                 service.onDelete('UnknownType', '123');
-            }).to.throw('A mutation deleting UnknownType succeeded in React Admin but there is no mapping to an Ember type');
+            });
+
+            expect(store.peekRecord.called).to.be.false;
         });
 
         it('skips processing for null-mapped data types', function () {


### PR DESCRIPTION
Prepares the ground for a lint ban on out-of-bounds bridge access. Every `window.EmberBridge` read now lives in `src/ember-bridge`:

- `use-theme.ts` reached the global directly; three typed bridge helpers (`isEmberThemeManaged`, `preloadEmberAdminThemeStylesheet`, `applyEmberAdminThemePreference`) replace those reads with identical synchronous-snapshot semantics — no polling introduced, the DOM-fallback path unchanged.
- `main.tsx`'s three mutation forwarders become a typed `emberMutationHandlers` export spread into the framework config (same optional-chaining behaviour).
- The sidebar banner switches from the raw Ember `useSidebarVisibility` to `useAdminSidebarVisibility` — verified equivalent for its only consumers (they render inside `<AppSidebar/>`, which is itself gated on the stricter hook; the divergent case is unmounted).
- Three layout files stop deep-importing `@/ember-bridge/ember-bridge` past the barrel.

Ember side — `state-bridge.js` no longer throws on unknown mutation dataTypes (`onUpdate`/`onInvalidate`/`onDelete` no-op like the mapped-to-`null` React-only types), so a new React mutation dataType no longer requires a paired Ember edit to avoid a runtime error. Pruned the genuinely unreachable `AutomatedEmailDesignResponseType` entry; **kept `CustomThemeSettingsResponseType`** — `useActivateTheme` invalidates it, and its entry comment now records that so it doesn't get pruned later. Two stale comments fixed; the dead `comment`/`webhook` entries in `EMBER_TO_REACT_TYPE_MAPPING` removed (Ember has no comment model and no code path saves webhooks).

12 files, +118/−126.

**Verification:** admin `tsc -b`, eslint, `test:unit` 137 files / 1627 tests; ember state-bridge unit suite 65/65; `pnpm test:acceptance src/layout` 19/19; `oxfmt --check` clean (ember-admin is oxfmt-ignored, kept house style).