### PR TITLE
Migrate external-media-inliner job to the class-based jobs service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -644,7 +644,7 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     debug('Begin: Register job handlers');
     const jobsService = require('./server/services/jobs-service');
     const service = jobsService.init();
-    require('./server/services/jobs-service/register-job-handlers').default();
+    require('./server/services/jobs-service/register-job-handlers').default(service);
     await service.start();
     debug('End: Register job handlers');
     debug('End: Load Ghost Services & Apps');

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -414,7 +414,9 @@ async function initServices({ ghostServer, config, prometheusClient }) {
     linkTracking.init(),
     emailSuppressionList.init(),
     slackNotifications.init(),
-    mediaInliner.init(),
+    mediaInliner.init({
+      getJobsService: require('./server/services/jobs-service').getInstance,
+    }),
     contentImport.init(),
     donationService.init(),
     recommendationsService.init(),

--- a/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
+++ b/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
@@ -118,6 +118,13 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
     }
   }
 
+  async allSettled(): Promise<void> {
+    if (this._queue.idle()) {
+      return;
+    }
+    await this._queue.drained();
+  }
+
   async shutdown(options: JobsShutdownOptions = {}): Promise<void> {
     const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
     this._stopped = true;

--- a/ghost/core/core/server/services/jobs-service/index.ts
+++ b/ghost/core/core/server/services/jobs-service/index.ts
@@ -27,6 +27,13 @@ export function getInstance(): JobsService {
   return instance;
 }
 
+export function allSettled(): Promise<void> {
+  if (!instance) {
+    return Promise.resolve();
+  }
+  return instance.allSettled();
+}
+
 export function shutdown(options?: JobsShutdownOptions): Promise<void> {
   if (!instance) {
     return Promise.resolve();

--- a/ghost/core/core/server/services/jobs-service/jobs-service.ts
+++ b/ghost/core/core/server/services/jobs-service/jobs-service.ts
@@ -83,6 +83,10 @@ export class JobsService {
     });
   }
 
+  async allSettled(): Promise<void> {
+    await this.#backend.allSettled();
+  }
+
   async shutdown(options?: JobsShutdownOptions): Promise<void> {
     await this.#backend.shutdown(options);
   }

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,11 +1,10 @@
-import { getInstance } from './index';
+import type { JobsService } from './jobs-service';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
 
 const logging = require('@tryghost/logging');
 
-export default function registerJobHandlers(): void {
-  const jobsService = getInstance();
+export default function registerJobHandlers(jobsService: JobsService): void {
   const db = require('../../data/db');
 
   jobsService.handle(CleanTokensJob, async () => {

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,13 +1,26 @@
 import type { JobsService } from './jobs-service';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
+import ExternalMediaInlinerJob from '../media-inliner/external-media-inliner-job';
 
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const mediaInlinerService = require('../media-inliner');
 
 export default function registerJobHandlers(jobsService: JobsService): void {
   const db = require('../../data/db');
 
   jobsService.handle(CleanTokensJob, async () => {
     await cleanTokens({ db, logging });
+  });
+
+  jobsService.handle(ExternalMediaInlinerJob, async (job) => {
+    const inliner = mediaInlinerService.inliner;
+    if (!inliner) {
+      throw new errors.IncorrectUsageError({
+        message: 'media-inliner service used before init()',
+      });
+    }
+    await inliner.inline(job.domains);
   });
 }

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner-job.ts
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner-job.ts
@@ -1,0 +1,12 @@
+import { Job } from '../jobs-service/job';
+
+export default class ExternalMediaInlinerJob extends Job {
+  static type = 'external-media-inliner';
+
+  domains: string[];
+
+  constructor(data: { domains: string[] }) {
+    super();
+    this.domains = data.domains;
+  }
+}

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner.js
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner.js
@@ -377,7 +377,18 @@ class ExternalMediaInliner {
 
     await this.inlineSimpleFields(users, this.#UserModel, userInliningFields, domains);
 
-    logging.info('Finished inlining external media for posts, tags, and users');
+    logging.info(
+      {
+        system: {
+          event: 'external_media_inliner.completed',
+          posts_count: posts?.length ?? 0,
+          posts_meta_count: postsMetas?.length ?? 0,
+          tags_count: tags?.length ?? 0,
+          users_count: users?.length ?? 0,
+        },
+      },
+      'Finished inlining external media for posts, tags, and users',
+    );
   }
 }
 

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,10 +1,10 @@
 module.exports = {
-  async init() {
+  async init({ getJobsService }) {
     const debug = require('@tryghost/debug')('mediaInliner');
     const MediaInliner = require('./external-media-inliner');
+    const ExternalMediaInlinerJob = require('./external-media-inliner-job').default;
     const logging = require('@tryghost/logging');
     const models = require('../../models');
-    const jobsService = require('../jobs');
     const adapterManager = require('../../services/adapter-manager').default;
 
     const mediaStorage = adapterManager.getAdapter('storage:media');
@@ -40,31 +40,8 @@ module.exports = {
 
         debug('[Inliner] Starting media inlining job for domains: ', domains);
 
-        // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
-        //        limited to migrational, so there is no expectations for site's availability etc.
         logging.info('[Background Job] external-media-inliner queued');
-        await jobsService.addJob({
-          name: 'external-media-inliner',
-          job: async (data) => {
-            const startedAt = Date.now();
-            logging.info('[Background Job] external-media-inliner started');
-            try {
-              const result = await this.inliner.inline(data.domains);
-              logging.info(
-                `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
-              );
-              return result;
-            } catch (err) {
-              logging.error(
-                err,
-                `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
-              );
-              throw err;
-            }
-          },
-          data: { domains },
-          offloaded: false,
-        });
+        await getJobsService().dispatch(new ExternalMediaInlinerJob({ domains }));
 
         return {
           status: 'success',

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -13,7 +13,7 @@ module.exports = {
 
     const config = require('../../../shared/config');
 
-    const mediaInliner = new MediaInliner({
+    this.inliner = new MediaInliner({
       PostModel: models.Post,
       TagModel: models.Tag,
       UserModel: models.User,
@@ -49,7 +49,7 @@ module.exports = {
             const startedAt = Date.now();
             logging.info('[Background Job] external-media-inliner started');
             try {
-              const result = await mediaInliner.inline(data.domains);
+              const result = await this.inliner.inline(data.domains);
               logging.info(
                 `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
               );

--- a/ghost/core/test/integration/services/media-inliner/external-media-inliner.test.ts
+++ b/ghost/core/test/integration/services/media-inliner/external-media-inliner.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeAll } from 'vitest';
+
+// require() so the singletons are the same instances the code under test uses —
+// nock in particular installs its interceptors globally but keeps its registry
+// per module copy, so an ESM import would not see the suite's disableNetConnect.
+const nock = require('nock');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const models = require('../../../../core/server/models');
+const jobsService = require('../../../../core/server/services/jobs-service');
+const ExternalMediaInlinerJob =
+  require('../../../../core/server/services/media-inliner/external-media-inliner-job').default;
+
+const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
+
+describe('Job: External media inliner', function () {
+  beforeAll(async function () {
+    const agent = await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init();
+    await agent.loginAsOwner();
+  });
+
+  it("Inlines external media referenced by a post's feature image", async function () {
+    const imageURL = 'https://inliner.example.com/files/image.jpg';
+    nock('https://inliner.example.com').get('/files/image.jpg').reply(200, GIF1x1);
+
+    const post = await models.Post.add(
+      {
+        title: 'Post with external media',
+        feature_image: imageURL,
+      },
+      { context: { internal: true } },
+    );
+
+    await jobsService
+      .getInstance()
+      .dispatch(new ExternalMediaInlinerJob({ domains: ['https://inliner.example.com'] }));
+    await jobsService.allSettled();
+
+    const reloaded = await models.Post.findOne({ id: post.id }, { context: { internal: true } });
+    assert.match(reloaded.get('feature_image'), /\/content\/images\/.+\.gif$/);
+  });
+});

--- a/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
+++ b/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
@@ -30,6 +30,50 @@ describe('InMemoryJobsBackend', function () {
     assert.deepEqual(received, [{ type: 'buffered', payload: '{"n":1}' }]);
   });
 
+  it('allSettled resolves only once queued and in-flight deliveries have settled', async function () {
+    const completed: string[] = [];
+    const release: Array<() => void> = [];
+    const backend = new InMemoryJobsBackend({ concurrency: 1 });
+
+    backend.start({
+      processor: async (env) => {
+        await new Promise<void>((resolve) => {
+          release.push(resolve);
+        });
+        completed.push(env.type);
+      },
+    });
+
+    backend.enqueue({ type: 'first', payload: '{}' });
+    backend.enqueue({ type: 'second', payload: '{}' });
+
+    let settled = false;
+    const allSettled = backend.allSettled().then(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    assert.equal(settled, false, 'allSettled does not resolve while work is outstanding');
+
+    const releaser = setInterval(() => release.forEach((resolve) => resolve()), 5);
+    await allSettled;
+    clearInterval(releaser);
+
+    assert.deepEqual(completed, ['first', 'second']);
+    await backend.shutdown({ timeoutMs: 1000 });
+  });
+
+  it('allSettled resolves immediately when the queue is idle', async function () {
+    const backend = new InMemoryJobsBackend();
+    backend.start({ processor: async () => {} });
+
+    await backend.allSettled();
+
+    await backend.shutdown({ timeoutMs: 1000 });
+  });
+
   it('caps concurrent deliveries at the default concurrency', async function () {
     let running = 0;
     let maxConcurrent = 0;

--- a/ghost/core/test/unit/server/services/jobs-service/index.test.js
+++ b/ghost/core/test/unit/server/services/jobs-service/index.test.js
@@ -15,6 +15,10 @@ describe('jobs-service wrapper', function () {
     await assert.doesNotReject(() => jobsService.shutdown());
   });
 
+  it('allSettled before init resolves without constructing a service', async function () {
+    await assert.doesNotReject(() => jobsService.allSettled());
+  });
+
   it('getInstance throws before init', function () {
     assert.throws(() => jobsService.getInstance(), /used before init/);
   });
@@ -26,6 +30,7 @@ describe('jobs-service wrapper', function () {
       enqueue() {},
       scheduleRecurring() {},
       async shutdown() {},
+      async allSettled() {},
     };
     sinon.stub(adapterManager, 'getAdapter').withArgs('jobs').returns(fakeBackend);
 

--- a/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
@@ -21,6 +21,7 @@ class FakeBackend implements JobsBackendBase {
   enqueued: JobEnvelope[] = [];
   recurring: { envelope: JobEnvelope; schedule: RecurringSchedule }[] = [];
   shutdownCalls: (JobsShutdownOptions | undefined)[] = [];
+  allSettledCalls = 0;
 
   start(options: JobsStartOptions): void {
     this.processor = options.processor;
@@ -36,6 +37,10 @@ class FakeBackend implements JobsBackendBase {
 
   shutdown(options?: JobsShutdownOptions): void {
     this.shutdownCalls.push(options);
+  }
+
+  async allSettled(): Promise<void> {
+    this.allSettledCalls = this.allSettledCalls + 1;
   }
 
   async deliver(index = 0): Promise<void> {
@@ -233,6 +238,14 @@ describe('JobsService', function () {
         /Invalid cron expression/,
       );
       assert.equal(backend.recurring.length, 0);
+    });
+  });
+
+  describe('allSettled', function () {
+    it('delegates to the backend', async function () {
+      const service = makeService();
+      await service.allSettled();
+      assert.equal(backend.allSettledCalls, 1);
     });
   });
 

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import sinon from 'sinon';
-import { describe, it } from 'vitest';
+import { describe, it, afterEach } from 'vitest';
 import type { JobsService } from '../../../../../core/server/services/jobs-service/jobs-service';
 
 // require() so the singletons are the same instances the code under test uses
@@ -8,22 +8,63 @@ const registerJobHandlers =
   require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
 const CleanTokensJob =
   require('../../../../../core/server/services/members/jobs/clean-tokens-job').default;
+const ExternalMediaInlinerJob =
+  require('../../../../../core/server/services/media-inliner/external-media-inliner-job').default;
+const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
+
+type Handler = (job: unknown) => Promise<void>;
 
 function createFakeJobsService() {
-  const handle = sinon.stub();
-  return { handle } as unknown as JobsService & { handle: sinon.SinonStub };
+  const handlers = new Map<unknown, Handler>();
+  const handle = sinon.stub().callsFake((JobClass: unknown, handler: Handler) => {
+    handlers.set(JobClass, handler);
+  });
+  return {
+    jobsService: { handle } as unknown as JobsService,
+    handlerFor: (JobClass: unknown) => handlers.get(JobClass),
+  };
 }
 
 describe('registerJobHandlers', function () {
+  const originalInliner = mediaInlinerService.inliner;
+
+  afterEach(function () {
+    mediaInlinerService.inliner = originalInliner;
+    sinon.restore();
+  });
+
   it('registers a handler for every job type on the given jobs service', function () {
-    const jobsService = createFakeJobsService();
+    const { jobsService, handlerFor } = createFakeJobsService();
 
     registerJobHandlers(jobsService);
 
-    const registeredJobClasses = jobsService.handle.getCalls().map((call) => call.args[0]);
-    assert.ok(
-      registeredJobClasses.includes(CleanTokensJob),
-      'clean-tokens is registered on the injected jobs service',
-    );
+    assert.ok(handlerFor(CleanTokensJob), 'clean-tokens is registered');
+    assert.ok(handlerFor(ExternalMediaInlinerJob), 'external-media-inliner is registered');
+  });
+
+  describe('external-media-inliner handler', function () {
+    it('inlines the domains carried by the job', async function () {
+      const inline = sinon.stub().resolves();
+      mediaInlinerService.inliner = { inline };
+      const { jobsService, handlerFor } = createFakeJobsService();
+      registerJobHandlers(jobsService);
+
+      await handlerFor(ExternalMediaInlinerJob)!(
+        new ExternalMediaInlinerJob({ domains: ['https://example.com'] }),
+      );
+
+      sinon.assert.calledOnceWithExactly(inline, ['https://example.com']);
+    });
+
+    it('throws when the media-inliner service has not been initialised', async function () {
+      mediaInlinerService.inliner = undefined;
+      const { jobsService, handlerFor } = createFakeJobsService();
+      registerJobHandlers(jobsService);
+
+      await assert.rejects(
+        () => handlerFor(ExternalMediaInlinerJob)!(new ExternalMediaInlinerJob({ domains: [] })),
+        /media-inliner service used before init/,
+      );
+    });
   });
 });

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { describe, it } from 'vitest';
+import type { JobsService } from '../../../../../core/server/services/jobs-service/jobs-service';
+
+// require() so the singletons are the same instances the code under test uses
+const registerJobHandlers =
+  require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
+const CleanTokensJob =
+  require('../../../../../core/server/services/members/jobs/clean-tokens-job').default;
+
+function createFakeJobsService() {
+  const handle = sinon.stub();
+  return { handle } as unknown as JobsService & { handle: sinon.SinonStub };
+}
+
+describe('registerJobHandlers', function () {
+  it('registers a handler for every job type on the given jobs service', function () {
+    const jobsService = createFakeJobsService();
+
+    registerJobHandlers(jobsService);
+
+    const registeredJobClasses = jobsService.handle.getCalls().map((call) => call.args[0]);
+    assert.ok(
+      registeredJobClasses.includes(CleanTokensJob),
+      'clean-tokens is registered on the injected jobs service',
+    );
+  });
+});

--- a/ghost/core/test/unit/server/services/media-inliner/service.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/service.test.ts
@@ -5,6 +5,13 @@ import { describe, it, afterEach } from 'vitest';
 // require() so the singletons are the same instances the service under test uses
 const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
 const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
+const ExternalMediaInlinerJob =
+  require('../../../../../core/server/services/media-inliner/external-media-inliner-job').default;
+
+function initServiceWithJobsService(dispatch: sinon.SinonStub) {
+  sinon.stub(adapterManager, 'getAdapter').returns({});
+  return mediaInlinerService.init({ getJobsService: () => ({ dispatch }) });
+}
 
 describe('media-inliner service', function () {
   // init() mutates the process-wide service singleton, and the unit project runs
@@ -18,10 +25,46 @@ describe('media-inliner service', function () {
   });
 
   it('exposes the configured inliner after init', async function () {
-    sinon.stub(adapterManager, 'getAdapter').returns({});
-
-    await mediaInlinerService.init();
+    await initServiceWithJobsService(sinon.stub().resolves());
 
     assert.equal(typeof mediaInlinerService.inliner.inline, 'function');
+  });
+
+  describe('startMediaInliner', function () {
+    it('dispatches a job for the requested domains', async function () {
+      const dispatch = sinon.stub().resolves();
+      await initServiceWithJobsService(dispatch);
+
+      const result = await mediaInlinerService.api.startMediaInliner(['https://example.com']);
+
+      assert.deepEqual(result, { status: 'success' });
+      sinon.assert.calledOnce(dispatch);
+      const job = dispatch.firstCall.args[0];
+      assert.ok(job instanceof ExternalMediaInlinerJob);
+      assert.deepEqual(job.domains, ['https://example.com']);
+    });
+
+    it('dispatches a job for the default domains when none are given', async function () {
+      const dispatch = sinon.stub().resolves();
+      await initServiceWithJobsService(dispatch);
+
+      await mediaInlinerService.api.startMediaInliner([]);
+
+      assert.deepEqual(dispatch.firstCall.args[0].domains, [
+        'https://s3.amazonaws.com/revue',
+        'https://substackcdn.com',
+      ]);
+    });
+  });
+
+  describe('ExternalMediaInlinerJob', function () {
+    it('has a stable type and a serialisable payload', function () {
+      assert.equal(ExternalMediaInlinerJob.type, 'external-media-inliner');
+
+      const job = new ExternalMediaInlinerJob({ domains: ['https://example.com'] });
+      const roundTripped = new ExternalMediaInlinerJob(JSON.parse(JSON.stringify(job)));
+
+      assert.deepEqual(roundTripped.domains, ['https://example.com']);
+    });
   });
 });

--- a/ghost/core/test/unit/server/services/media-inliner/service.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/service.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { describe, it, afterEach } from 'vitest';
+
+// require() so the singletons are the same instances the service under test uses
+const mediaInlinerService = require('../../../../../core/server/services/media-inliner');
+const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
+
+describe('media-inliner service', function () {
+  // init() mutates the process-wide service singleton, and the unit project runs
+  // with isolate:false — put it back or it leaks into the next file.
+  const original = { inliner: mediaInlinerService.inliner, api: mediaInlinerService.api };
+
+  afterEach(function () {
+    mediaInlinerService.inliner = original.inliner;
+    mediaInlinerService.api = original.api;
+    sinon.restore();
+  });
+
+  it('exposes the configured inliner after init', async function () {
+    sinon.stub(adapterManager, 'getAdapter').returns({});
+
+    await mediaInlinerService.init();
+
+    assert.equal(typeof mediaInlinerService.inliner.inline, 'function');
+  });
+});

--- a/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
+++ b/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
@@ -68,6 +68,38 @@ describe('ExternalMediaInliner', function () {
   });
 
   describe('inline', function () {
+    it('logs a structured completion event counting each resource type it walked', async function () {
+      // Distinct page sizes per resource type, so a miswired count is visible.
+      postModelStub.findAll.resolves([]);
+      const resource = (id) => ({ id, get: () => null });
+      postMetaModelStub.findPage.resolves({ data: [resource('meta-1')] });
+      tagModelStub.findPage.resolves({ data: [resource('tag-1'), resource('tag-2')] });
+      userModelStub.findPage.resolves({
+        data: [resource('user-1'), resource('user-2'), resource('user-3')],
+      });
+      const inliner = new ExternalMediaInliner({
+        PostModel: postModelStub,
+        PostMetaModel: postMetaModelStub,
+        TagModel: tagModelStub,
+        UserModel: userModelStub,
+        getMediaStorage: sinon.stub().returns(null),
+      });
+
+      await inliner.inline(['https://example.com']);
+
+      const completionLog = logging.info
+        .getCalls()
+        .find((call) => call.args[0]?.system?.event === 'external_media_inliner.completed');
+      assert.ok(completionLog, 'inline() logs a structured external_media_inliner.completed event');
+      assert.deepEqual(completionLog.args[0].system, {
+        event: 'external_media_inliner.completed',
+        posts_count: 0,
+        posts_meta_count: 1,
+        tags_count: 2,
+        users_count: 3,
+      });
+    });
+
     it("inlines image in the post's mobiledoc content", async function () {
       const imageURL = 'https://img.stockfresh.com/files/f/image.jpg';
       const requestMock = nock('https://img.stockfresh.com')

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -31,6 +31,7 @@ const urlServiceUtils = require('./url-service-utils');
 const mockManager = require('./e2e-framework-mock-manager');
 const mentionsJobsService = require('../../core/server/services/mentions-jobs');
 const jobsService = require('../../core/server/services/jobs');
+const classBasedJobsService = require('../../core/server/services/jobs-service');
 
 const boot = require('../../core/boot');
 const {
@@ -65,6 +66,7 @@ let totalBoots = 0;
 const startGhost = async (options = {}) => {
   await mentionsJobsService.allSettled();
   await jobsService.allSettled();
+  await classBasedJobsService.allSettled();
   await DomainEvents.allSettled();
 
   /**

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -226,6 +226,7 @@ afterEach(async () => {
   const domainEvents = require('@tryghost/domain-events');
   const mentionsJobsService = require('../../core/server/services/mentions-jobs');
   const jobsService = require('../../core/server/services/jobs');
+  const classBasedJobsService = require('../../core/server/services/jobs-service');
 
   const timeout = setTimeout(() => {
     // eslint-disable-next-line no-console
@@ -240,6 +241,7 @@ afterEach(async () => {
   await domainEvents.allSettled();
   await mentionsJobsService.allSettled();
   await jobsService.allSettled();
+  await classBasedJobsService.allSettled();
   // Last time for events emitted during jobs
   await domainEvents.allSettled();
 

--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -124,6 +124,7 @@ afterEach(async () => {
   const domainEvents = require('@tryghost/domain-events');
   const mentionsJobsService = require('../../core/server/services/mentions-jobs');
   const jobsService = require('../../core/server/services/jobs');
+  const classBasedJobsService = require('../../core/server/services/jobs-service');
 
   const timeout = setTimeout(() => {
     // eslint-disable-next-line no-console
@@ -138,6 +139,7 @@ afterEach(async () => {
   await domainEvents.allSettled();
   await mentionsJobsService.allSettled();
   await jobsService.allSettled();
+  await classBasedJobsService.allSettled();
   await domainEvents.allSettled();
 
   clearTimeout(timeout);

--- a/packages/adapters/jobs-base/src/base.ts
+++ b/packages/adapters/jobs-base/src/base.ts
@@ -37,4 +37,14 @@ export abstract class JobsBackendBase {
   ): void | Promise<void>;
 
   abstract shutdown(options?: JobsShutdownOptions): void | Promise<void>;
+
+  /**
+   * Resolve once every already-accepted job has settled. Backends that cannot
+   * observe their own queue depth (a durable/remote queue) may keep this
+   * default no-op; an in-process backend must override it, because the test
+   * harness relies on it to keep a job's work inside the test that enqueued it.
+   */
+  allSettled(): Promise<void> {
+    return Promise.resolve();
+  }
 }


### PR DESCRIPTION
Migrates `external-media-inliner` off the legacy job queue and onto the class-based jobs service. This job had no legacy registration file or schedule — it was a closure built at its only dispatch site (`POST /db/media/inline`) — so the migration is two preparatory refactors plus a transport swap, three commits:

1. **Exposed the media inliner instance on the media-inliner service** — hangs `ExternalMediaInliner` off `this.inliner` instead of trapping it in the closure. Behavior-preserving.
2. **Injected the jobs service into registerJobHandlers** — replaces an internal `getInstance()` reach with DI from boot, matching the module's existing DI convention and making handler registration testable without touching the jobs-service singleton.
3. **Migrated external-media-inliner job to the class-based jobs service** — swaps `addJob` for a real `ExternalMediaInlinerJob`, wired via boot passing `getJobsService` uncalled (the jobs service doesn't exist yet at `initServices` time; dispatch only happens at request time).

Behavior differences, all deliberate: closure logs are replaced by the jobs service's own lifecycle logs (same format) plus a new structured `external_media_inliner.completed` event; failures now get Sentry `captureException` tagging (new, since legacy inline jobs never reached `JobManager`'s error handler); `jobManager.awaitCompletion('external-media-inliner')` is no longer possible (no callers exist).

Look out for: `register-job-handlers.ts` uses `require()` not `import` for the untyped media-inliner service (`allowJs: false`), so `inliner` is typed `any` — a follow-up should convert that service to TS/constructor DI. Also note `InMemoryJobsBackend` gained `allSettled()` so the test harness's per-test drain barrier still covers this job's async work.

Verified: full unit suite, new unit/integration tests, and `test/e2e-api/admin/db.test.js` (unchanged, byte-identical response — asserts legacy-absence). `pnpm lint:types` and `pnpm format:check` clean.
