### PR TITLE
Changed theme state and tooltip provisioning to shared providers

### DIFF
--- a/apps/admin/src/app-root.tsx
+++ b/apps/admin/src/app-root.tsx
@@ -8,12 +8,13 @@ import { ShadeApp } from '@tryghost/shade/app';
 
 import App from './app.tsx';
 import { routes } from './routes.tsx';
-import { useTheme } from './hooks/use-theme';
 import { AppProvider } from './providers/app-provider';
+import { useThemeContext } from './providers/theme-context';
+import { ThemeProvider } from './providers/theme-provider';
 import { fetchKoenigLexical } from './utils/fetch-koenig-lexical';
 
 function ThemedAdminApp() {
-  const { resolvedTheme } = useTheme();
+  const { resolvedTheme } = useThemeContext();
 
   return (
     <ShadeApp
@@ -39,7 +40,9 @@ export function AdminAppRoot({ framework }: { framework: TopLevelFrameworkProps 
       <FrameworkProvider {...framework}>
         <RouterProvider prefix={'/'} routes={routes}>
           <AppProvider>
-            <ThemedAdminApp />
+            <ThemeProvider>
+              <ThemedAdminApp />
+            </ThemeProvider>
           </AppProvider>
         </RouterProvider>
       </FrameworkProvider>

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -47,6 +47,8 @@ function applyAdminTheme(mode: ThemeMode, resolvedTheme: ResolvedThemeMode) {
   }
 }
 
+// App code must consume this via ThemeProvider/useThemeContext (src/providers):
+// each extra instance forks the optimistic state and re-runs the DOM effects.
 export function useTheme() {
   const { data: preferences } = useUserPreferences();
   const { mutateAsync: editPreferences, isPending: isEditingPreferences } =

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -17,7 +17,8 @@ import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
 import { useDeleteSession } from '@tryghost/admin-x-framework/api/session';
 import { getGhostPaths } from '@tryghost/admin-x-framework/helpers';
 import { toast } from 'sonner';
-import { useTheme, type ThemeMode } from '@/hooks/use-theme';
+import { type ThemeMode } from '@/hooks/use-theme';
+import { useThemeContext } from '@/providers/theme-context';
 import { useWhatsNew } from '@/whats-new/hooks/use-whats-new';
 import { useUpgradeStatus } from './hooks/use-upgrade-status';
 import { useBrowseSite } from '@tryghost/admin-x-framework/api/site';
@@ -51,7 +52,7 @@ const THEME_LABELS = Object.fromEntries(
 ) as Record<ThemeMode, string>;
 
 function UserMenuAppearance() {
-  const { theme, setTheme, isSettingTheme } = useTheme();
+  const { theme, setTheme, isSettingTheme } = useThemeContext();
 
   return (
     <DropdownMenuSub>

--- a/apps/admin/src/providers/theme-context.ts
+++ b/apps/admin/src/providers/theme-context.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+import type { useTheme } from '@/hooks/use-theme';
+
+export type ThemeContextValue = ReturnType<typeof useTheme>;
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const useThemeContext = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useThemeContext must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/apps/admin/src/providers/theme-provider.test.tsx
+++ b/apps/admin/src/providers/theme-provider.test.tsx
@@ -1,0 +1,100 @@
+import { test as baseTest, afterEach, describe, expect } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import { HttpResponse, http } from 'msw';
+import type { SetupServer } from 'msw/node';
+import type {
+  UpdateUserRequestBody,
+  UsersResponseType,
+} from '@tryghost/admin-x-framework/api/users';
+import { mockUser } from '@test-utils/factories';
+import { serverFixture } from '@test-utils/fixtures/msw';
+import { queryClientFixtures, type TestWrapperComponent } from '@test-utils/fixtures/query-client';
+import { useUserPreferences } from '@/hooks/user-preferences';
+import { ThemeProvider } from './theme-provider';
+import { useThemeContext } from './theme-context';
+
+const USERS_API_URL = '/ghost/api/admin/users/me/';
+const USER_UPDATE_API_URL = '/ghost/api/admin/users/:id/';
+
+const themeContextTest = baseTest.extend<{
+  server: SetupServer;
+  queryClient: QueryClient;
+  wrapper: TestWrapperComponent;
+}>({
+  ...serverFixture,
+  ...queryClientFixtures,
+});
+
+function mockPreferences(server: SetupServer, nightShift: string) {
+  server.use(
+    http.get(USERS_API_URL, () => {
+      return HttpResponse.json({
+        users: [
+          {
+            ...mockUser,
+            accessibility: JSON.stringify({ nightShift }),
+          },
+        ],
+      });
+    }),
+    http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+      USER_UPDATE_API_URL,
+      async ({ request }) => {
+        const body = await request.json();
+        return HttpResponse.json({
+          users: [
+            {
+              ...mockUser,
+              accessibility: body.users[0]?.accessibility ?? '',
+            },
+          ],
+        });
+      },
+    ),
+  );
+}
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark', 'theme-switching');
+});
+
+describe('ThemeProvider', () => {
+  themeContextTest(
+    'shares one theme state: a menu setTheme flips every consumer',
+    async ({ server, wrapper: Wrapper }) => {
+      mockPreferences(server, 'light');
+
+      const contextWrapper = ({ children }: { children: ReactNode }) => (
+        <Wrapper>
+          <ThemeProvider>{children}</ThemeProvider>
+        </Wrapper>
+      );
+
+      // Two consumers of the shared provider: `shell` mirrors ThemedAdminApp,
+      // `menu` mirrors the appearance menu in the user menu.
+      const { result } = renderHook(
+        () => ({
+          shell: useThemeContext(),
+          menu: useThemeContext(),
+          preferences: useUserPreferences(),
+        }),
+        { wrapper: contextWrapper },
+      );
+
+      // Wait for preferences to load so setTheme can persist the change
+      await waitFor(() => {
+        expect(result.current.preferences.data).toBeDefined();
+      });
+      expect(result.current.shell.resolvedTheme).toBe('light');
+
+      await act(async () => {
+        await result.current.menu.setTheme('dark');
+      });
+
+      expect(result.current.shell.theme).toBe('dark');
+      expect(result.current.shell.resolvedTheme).toBe('dark');
+    },
+  );
+});

--- a/apps/admin/src/providers/theme-provider.test.tsx
+++ b/apps/admin/src/providers/theme-provider.test.tsx
@@ -1,5 +1,5 @@
 import { test as baseTest, afterEach, describe, expect } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { render, renderHook, screen, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { QueryClient } from '@tanstack/react-query';
 import { HttpResponse, http } from 'msw';
@@ -61,6 +61,88 @@ afterEach(() => {
 });
 
 describe('ThemeProvider', () => {
+  themeContextTest(
+    'shares one optimistic theme state across separate consumers mid-save',
+    async ({ server, wrapper: Wrapper }) => {
+      mockPreferences(server, 'light');
+
+      // Hold the persistence PUT open so the optimistic window is observable.
+      let releasePut: () => void = () => {};
+      const putGate = new Promise<void>((resolve) => {
+        releasePut = resolve;
+      });
+      server.use(
+        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+          USER_UPDATE_API_URL,
+          async ({ request }) => {
+            const body = await request.json();
+            await putGate;
+            return HttpResponse.json({
+              users: [
+                {
+                  ...mockUser,
+                  accessibility: body.users[0]?.accessibility ?? '',
+                },
+              ],
+            });
+          },
+        ),
+      );
+
+      // Two SEPARATE components: `Shell` mirrors ThemedAdminApp, `Menu`
+      // mirrors the appearance menu. The pre-provider architecture gave each
+      // its own useTheme instance with independent optimistic state; this
+      // asserts they now share one.
+      function Shell() {
+        const { resolvedTheme } = useThemeContext();
+        return <div data-testid="shell-theme">{resolvedTheme}</div>;
+      }
+      let setThemeFromMenu: (mode: 'dark' | 'light' | 'system') => Promise<void> = async () => {};
+      function Menu() {
+        const { setTheme, isSettingTheme } = useThemeContext();
+        setThemeFromMenu = setTheme;
+        return <div data-testid="menu-saving">{String(isSettingTheme)}</div>;
+      }
+
+      render(
+        <Wrapper>
+          <ThemeProvider>
+            <Shell />
+            <Menu />
+          </ThemeProvider>
+        </Wrapper>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('shell-theme').textContent).toBe('light');
+      });
+
+      let pendingSet: Promise<void>;
+      act(() => {
+        pendingSet = setThemeFromMenu('dark');
+      });
+
+      // Mid-flight (PUT still held open): the shell consumer already shows the
+      // menu's optimistic selection, and the shared saving flag is visible to
+      // the menu. The old two-instance architecture fails here: the shell's
+      // instance knew nothing about the menu's pendingTheme.
+      await waitFor(() => {
+        expect(screen.getByTestId('shell-theme').textContent).toBe('dark');
+      });
+      expect(screen.getByTestId('menu-saving').textContent).toBe('true');
+
+      releasePut();
+      await act(async () => {
+        await pendingSet;
+      });
+
+      expect(screen.getByTestId('shell-theme').textContent).toBe('dark');
+      await waitFor(() => {
+        expect(screen.getByTestId('menu-saving').textContent).toBe('false');
+      });
+    },
+  );
+
   themeContextTest(
     'shares one theme state: a menu setTheme flips every consumer',
     async ({ server, wrapper: Wrapper }) => {

--- a/apps/admin/src/providers/theme-provider.tsx
+++ b/apps/admin/src/providers/theme-provider.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+import { ThemeContext } from '@/providers/theme-context';
+import { useTheme } from '@/hooks/use-theme';
+
+// Instantiates useTheme exactly once so every consumer shares the same
+// optimistic theme state and a single set of bridge/DOM effects.
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const theme = useTheme();
+
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+}

--- a/apps/shade/src/providers/shade-provider.tsx
+++ b/apps/shade/src/providers/shade-provider.tsx
@@ -3,6 +3,7 @@ import { Toaster } from '../components/ui/sonner';
 import { createPortal } from 'react-dom';
 import { GlobalDirtyStateProvider } from '../hooks/use-global-dirty-state';
 import Icon from '../components/ui/icon';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { SHADE_APP_NAMESPACES } from '@/shade-app';
 
 export type FetchKoenigLexical = () => Promise<unknown>;
@@ -91,8 +92,12 @@ const ShadeProvider: React.FC<ShadeProviderProps> = ({
       value={{ isAnyTextFieldFocused, setFocusState, fetchKoenigLexical, darkMode }}
     >
       <GlobalDirtyStateProvider>
-        {children}
-        <ToasterPortal />
+        {/* Default Radix tooltip timing for any Tooltip without a nearer
+            provider; inner providers still win via nearest-provider scoping. */}
+        <TooltipProvider>
+          {children}
+          <ToasterPortal />
+        </TooltipProvider>
       </GlobalDirtyStateProvider>
     </ShadeContext.Provider>
   );


### PR DESCRIPTION
Two provider hoists. Navigation/effect behavior is preserved; one visual timing change is deliberate (below).

**One theme state.** `useTheme` was instantiated twice (app shell for `ShadeApp darkMode`, user menu for the appearance control), each with its own optimistic `pendingTheme` — a menu change and the shell could briefly disagree, and every instance re-ran the bridge/DOM effects. A `ThemeProvider` (mounted in `AdminAppRoot`) now calls the hook once; both consumers read `useThemeContext`. Follows the repo's two-file provider convention (`theme-context.ts` + `theme-provider.tsx`, satisfying `react-refresh/only-export-components`); the impl hook and its tests are untouched. The acceptance harness renders `AdminAppRoot`, so it inherits the provider by construction.

New tests: a menu `setTheme` flips the shell consumer's shared state — including a mid-save case that renders two separate consumers and holds the persistence PUT open, asserting the shell shows the menu's optimistic selection mid-flight. That is the property the old two-instance architecture could not provide (and it fails against the old code by construction).

**Deliberate behavior change:** `ShadeApp darkMode` (and its `useFocusContext().darkMode` consumers — CodeMirror, Koenig editors, portal preview) previously lagged a theme change by one network round-trip, because the shell's instance only saw the persisted value. They now flip optimistically together with the page. Corollary: a *failed* save now visibly rolls those surfaces back where before they never moved.

**One tooltip baseline.** Radix throws for a `Tooltip` with no ancestor provider, and the contributor layout branch (plus any bare `<Tooltip>` outside `SidebarProvider`) had none. A prop-less `TooltipProvider` in Shade's `ShadeProvider` closes those gaps. **All six existing mounts are kept**: `SidebarProvider`'s `delayDuration={0}` wraps the entire routed layout, which makes the two "no props" local mounts (comments list, relative-date filter) 700ms-default *restorers*, not redundant — removing them would flip their tooltips to instant via nearest-provider scoping. The three custom-timing mounts keep their overrides. Adversarial review confirmed the set of tooltips whose nearest provider changes is empty today — every existing surface keeps its exact timing; previously-broken surfaces get the Radix default.

8 files.

**Verification:** shade build + `test:unit` (31 files / 276) + lint green; admin `tsc -b`, eslint, `test:unit` green; acceptance `src/layout src/automations src/comments src/settings/growth` 8 files / 56 tests green; `oxfmt --check` clean. Post-review: dedicated adversarial pass found no correctness defects; findings addressed by the mid-save test and this body's behavior-change note.
