### PR TITLE
Removed duplicated admin helpers

### DIFF
--- a/apps/admin/src/automations/components/canvas/controls.tsx
+++ b/apps/admin/src/automations/components/canvas/controls.tsx
@@ -1,4 +1,3 @@
-import '@xyflow/react/dist/style.css';
 import React, { useState } from 'react';
 import {
   Button,

--- a/apps/admin/src/automations/components/canvas/nodes.tsx
+++ b/apps/admin/src/automations/components/canvas/nodes.tsx
@@ -1,4 +1,3 @@
-import '@xyflow/react/dist/style.css';
 import React, { useRef, useState } from 'react';
 import StepPicker, { type StepPickerType } from './step-picker';
 import { useEmailTrackingSettings } from '@/automations/hooks/use-email-tracking-settings';

--- a/apps/admin/src/automations/components/canvas/step-sidebar.tsx
+++ b/apps/admin/src/automations/components/canvas/step-sidebar.tsx
@@ -1,4 +1,3 @@
-import '@xyflow/react/dist/style.css';
 import React, { useEffect, useRef, useState } from 'react';
 import type {
   AutomationDetail,

--- a/apps/admin/src/layout/app-sidebar/hooks/use-whats-new-status.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-whats-new-status.ts
@@ -6,11 +6,11 @@ export interface WhatsNewStatus {
 }
 
 export function useWhatsNewStatus(): WhatsNewStatus {
-  const { data: whatsNewData } = useWhatsNew();
+  const { hasNew } = useWhatsNew();
   const { data: changelog } = useChangelog();
   const latestEntry = changelog?.entries[0];
 
   return {
-    showWhatsNewBanner: !!whatsNewData?.hasNew && !!latestEntry,
+    showWhatsNewBanner: hasNew && !!latestEntry,
   };
 }

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -118,7 +118,7 @@ interface UserMenuProps extends React.ComponentProps<typeof DropdownMenu> {
 }
 function UserMenu(props: UserMenuProps) {
   const currentUser = useCurrentUser();
-  const { data: whatsNewData } = useWhatsNew();
+  const { hasNew } = useWhatsNew();
   const { showUpgradeBanner } = useUpgradeStatus();
 
   return (
@@ -131,7 +131,7 @@ function UserMenu(props: UserMenuProps) {
         >
           <div className="relative">
             <UserMenuAvatar />
-            {whatsNewData?.hasNew && (
+            {hasNew && (
               <span className="absolute -top-0.5 -right-0.5">
                 <Indicator
                   data-testid="whats-new-avatar-badge"
@@ -172,7 +172,7 @@ function UserMenu(props: UserMenuProps) {
         >
           <LucideIcon.Sparkles />
           <UserMenuItem.Label>What’s new?</UserMenuItem.Label>
-          {whatsNewData?.hasNew && (
+          {hasNew && (
             <div className="flex flex-1 justify-end">
               <Indicator
                 data-testid="whats-new-menu-badge"

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -1,3 +1,4 @@
+import validator from 'validator';
 import {
   isCustomFieldColumn,
   type MemberCustomFieldCsvColumn,
@@ -59,8 +60,6 @@ export function getFieldMappings({
 }
 
 const AUTO_DETECTED_TYPES = ['email'];
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export class MembersFieldMapping {
   private _mapping: Record<string, string | null>;
@@ -220,7 +219,7 @@ export function detectFieldTypes(
 
     const entry = sampledData[i];
     for (const [key, value] of Object.entries(entry)) {
-      if (!mapping.email && value && EMAIL_REGEX.test(value) && !isCustomFieldColumn(key)) {
+      if (!mapping.email && value && validator.isEmail(value) && !isCustomFieldColumn(key)) {
         mapping.email = key;
       }
     }

--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -297,6 +297,18 @@ describe('isValidMemberEmail', () => {
     expect(isValidMemberEmail('a@b.')).toBe(false);
     expect(isValidMemberEmail('a b@example.com')).toBe(false);
   });
+
+  it('grandfathers a stored email that no longer passes validation when unchanged', () => {
+    expect(isValidMemberEmail('legacy@mail_host.com', 'legacy@mail_host.com')).toBe(true);
+    // Trim-insensitive: the draft field may carry surrounding whitespace
+    expect(isValidMemberEmail(' legacy@mail_host.com ', 'legacy@mail_host.com')).toBe(true);
+    // Changing away from the stored value re-applies strict validation
+    expect(isValidMemberEmail('other@mail_host.com', 'legacy@mail_host.com')).toBe(false);
+    // A stored email is no excuse for a different invalid value
+    expect(isValidMemberEmail('nope', 'legacy@mail_host.com')).toBe(false);
+    // Create mode (no stored email) stays strict
+    expect(isValidMemberEmail('legacy@mail_host.com')).toBe(false);
+  });
 });
 
 describe('getDefaultNewsletterIdsForNewMember', () => {

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone';
+import validator from 'validator';
 import {
   MEMBER_CUSTOM_FIELD_TYPES,
   memberCustomFieldParts,
@@ -45,9 +46,6 @@ interface MemberFieldSource {
   labels?: Array<{ name: string; slug: string }> | null;
   newsletters?: Array<{ id: string }> | null;
 }
-
-// Same shape as the import-members validator already used in this app.
-const MEMBER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Soft limit shown as a countdown (Ember imposes no hard maxlength; the DB column
 // allows 2000). The counter may go negative, matching the Ember behaviour.
@@ -145,7 +143,7 @@ export function toggleMemberNewsletter(subscribedIds: string[], newsletterId: st
 
 /** Client-side email sanity check for the save gate; the server remains authoritative. */
 export function isValidMemberEmail(email: string): boolean {
-  return MEMBER_EMAIL_REGEX.test(email.trim());
+  return validator.isEmail(email.trim());
 }
 
 /**

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -141,9 +141,19 @@ export function toggleMemberNewsletter(subscribedIds: string[], newsletterId: st
   return [...subscribedIds, newsletterId].sort();
 }
 
-/** Client-side email sanity check for the save gate; the server remains authoritative. */
-export function isValidMemberEmail(email: string): boolean {
-  return validator.isEmail(email.trim());
+/**
+ * Client-side email sanity check for the save gate; the server remains
+ * authoritative. Mirrors the server's update semantics: an email is validated
+ * only when it differs from the stored one, because the server deliberately
+ * grandfathers stored emails that predate stricter validation
+ * (member-repository.js validates the email only when it changed).
+ */
+export function isValidMemberEmail(email: string, storedEmail?: string): boolean {
+  const trimmed = email.trim();
+  if (storedEmail !== undefined && trimmed === storedEmail.trim()) {
+    return true;
+  }
+  return validator.isEmail(trimmed);
 }
 
 /**
@@ -153,14 +163,18 @@ export function isValidMemberEmail(email: string): boolean {
  * validator runs on save-attempt for the same reason
  * (`ghost/admin/app/validators/member.js:15`).
  */
-export function getEmailErrorMessage(email: string, touched: boolean): string | null {
+export function getEmailErrorMessage(
+  email: string,
+  touched: boolean,
+  storedEmail?: string,
+): string | null {
   if (!touched) {
     return null;
   }
   if (email.trim() === '') {
     return 'Email is required.';
   }
-  if (!isValidMemberEmail(email)) {
+  if (!isValidMemberEmail(email, storedEmail)) {
     return 'Invalid email.';
   }
   return null;

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -201,7 +201,7 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({
     when: hasUnsavedChanges,
     confirmUnloadWhen: activeMutation.isPending || hasUnsavedChanges,
   });
-  const emailValid = !!draft && isValidMemberEmail(draft.email);
+  const emailValid = !!draft && isValidMemberEmail(draft.email, member?.email ?? undefined);
   // `touched` is set on the email field's first blur. That keeps the New
   // member screen from painting an "Email is required." error before the
   // user has done anything, matching Ember's save-time-only validator
@@ -211,7 +211,9 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({
   React.useEffect(() => {
     setEmailTouched(false);
   }, [member?.id, isCreating]);
-  const emailError = draft ? getEmailErrorMessage(draft.email, emailTouched) : null;
+  const emailError = draft
+    ? getEmailErrorMessage(draft.email, emailTouched, member?.email ?? undefined)
+    : null;
 
   // The sidebar's identity block (avatar + heading) reads from a "committed"
   // copy of name/email that only advances on blur, not per keystroke.

--- a/apps/admin/src/settings/email/newsletters.tsx
+++ b/apps/admin/src/settings/email/newsletters.tsx
@@ -4,17 +4,12 @@ import TopLevelGroup from '@/settings/components/top-level-group';
 import useQueryParams from '@/settings/hooks/use-query-params';
 import { APIError } from '@tryghost/admin-x-framework/errors';
 import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@tryghost/shade/components';
-import { type InfiniteData, useQueryClient } from '@tryghost/admin-x-framework';
 import {
-  type Newsletter,
-  type NewslettersResponseType,
-  newslettersDataType,
   useBrowseNewsletters,
-  useEditNewsletter,
   useVerifyNewsletterEmail,
 } from '@tryghost/admin-x-framework/api/newsletters';
-import { arrayMove } from '@dnd-kit/sortable';
 import { formatNumber } from '@tryghost/shade/utils';
+import { useNewsletterReorder } from './use-newsletter-reorder';
 import {
   type ConfirmationHandle,
   useConfirmation,
@@ -60,19 +55,14 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({ keywords }) => {
     isLoading,
     fetchNextPage,
   } = useBrowseNewsletters();
-  const { mutateAsync: editNewsletter } = useEditNewsletter();
-  const queryClient = useQueryClient();
 
   const verifyEmailToken = useQueryParams().getParam('verifyEmail');
   const { mutateAsync: verifyEmail } = useVerifyNewsletterEmail();
   const handleError = useHandleError();
   const { confirm } = useConfirmation();
 
-  const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
-
-  useEffect(() => {
-    setNewsletters(apiNewsletters || []);
-  }, [apiNewsletters]);
+  const { newsletters, sortedActiveNewsletters, archivedNewsletters, onSort } =
+    useNewsletterReorder(apiNewsletters);
 
   useEffect(() => {
     if (!verifyEmailToken || !window.location.href.includes('newsletters')) {
@@ -165,67 +155,6 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({ keywords }) => {
       Add newsletter
     </Button>
   );
-
-  const sortedActiveNewsletters =
-    newsletters.filter((n) => n.status === 'active').sort((a, b) => a.sort_order - b.sort_order) ||
-    [];
-  const archivedNewsletters = newsletters.filter((newsletter) => newsletter.status !== 'active');
-
-  const onSort = async (id: string, overId?: string) => {
-    const fromIndex = sortedActiveNewsletters.findIndex((newsletter) => newsletter.id === id);
-    const toIndex =
-      sortedActiveNewsletters.findIndex((newsletter) => newsletter.id === overId) || 0;
-    const newSortOrder = arrayMove(sortedActiveNewsletters, fromIndex, toIndex);
-
-    const updatedActiveNewsletters = newSortOrder
-      .map((newsletter, index) =>
-        newsletter.sort_order === index ? null : { ...newsletter, sort_order: index },
-      )
-      .filter((newsletter): newsletter is Newsletter => !!newsletter);
-
-    const updatedArchivedNewsletters = archivedNewsletters
-      .map((newsletter, index) =>
-        newsletter.sort_order === index + sortedActiveNewsletters.length
-          ? null
-          : { ...newsletter, sort_order: index },
-      )
-      .filter((newsletter): newsletter is Newsletter => !!newsletter);
-
-    const orderUpdatedNewsletters = [
-      ...updatedActiveNewsletters,
-      ...updatedArchivedNewsletters,
-    ].sort((a, b) => a.sort_order - b.sort_order);
-
-    // Set the new order in local state and cache first so that the UI updates immediately
-    setNewsletters(
-      newsletters.map(
-        (newsletter) => orderUpdatedNewsletters.find((n) => n.id === newsletter.id) || newsletter,
-      ),
-    );
-    queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>(
-      { queryKey: [newslettersDataType] },
-      (currentData) => {
-        if (!currentData) {
-          return;
-        }
-
-        return {
-          ...currentData,
-          pages: currentData.pages.map((page) => ({
-            ...page,
-            newsletters: page.newsletters.map(
-              (newsletter) =>
-                orderUpdatedNewsletters.find((n) => n.id === newsletter.id) || newsletter,
-            ),
-          })),
-        };
-      },
-    );
-
-    for (const newsletter of orderUpdatedNewsletters) {
-      await editNewsletter(newsletter);
-    }
-  };
 
   return (
     <TopLevelGroup

--- a/apps/admin/src/settings/email/newsletters/newsletters-tab-content.tsx
+++ b/apps/admin/src/settings/email/newsletters/newsletters-tab-content.tsx
@@ -1,19 +1,14 @@
 import NewslettersList from './newsletters-list';
-import React, { type ReactNode, useEffect, useState } from 'react';
+import React, { type ReactNode, useEffect } from 'react';
 import useQueryParams from '@/settings/hooks/use-query-params';
 import { APIError } from '@tryghost/admin-x-framework/errors';
 import { Button } from '@tryghost/shade/components';
-import { type InfiniteData, useQueryClient } from '@tryghost/admin-x-framework';
 import {
-  type Newsletter,
-  type NewslettersResponseType,
-  newslettersDataType,
   useBrowseNewsletters,
-  useEditNewsletter,
   useVerifyNewsletterEmail,
 } from '@tryghost/admin-x-framework/api/newsletters';
-import { arrayMove } from '@dnd-kit/sortable';
 import { formatNumber } from '@tryghost/shade/utils';
+import { useNewsletterReorder } from '@/settings/email/use-newsletter-reorder';
 import {
   type ConfirmationHandle,
   useConfirmation,
@@ -67,19 +62,14 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({ filter })
     isLoading,
     fetchNextPage,
   } = useBrowseNewsletters();
-  const { mutateAsync: editNewsletter } = useEditNewsletter();
-  const queryClient = useQueryClient();
 
   const verifyEmailToken = useQueryParams().getParam('verifyEmail');
   const { mutateAsync: verifyEmail } = useVerifyNewsletterEmail();
   const handleError = useHandleError();
   const { confirm } = useConfirmation();
 
-  const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
-
-  useEffect(() => {
-    setNewsletters(apiNewsletters || []);
-  }, [apiNewsletters]);
+  const { newsletters, sortedActiveNewsletters, archivedNewsletters, onSort } =
+    useNewsletterReorder(apiNewsletters);
 
   useEffect(() => {
     if (!verifyEmailToken || !isNewsletterVerificationRoute()) {
@@ -158,66 +148,6 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({ filter })
     };
     void verify();
   }, [verifyEmailToken, handleError, verifyEmail, confirm]);
-
-  const sortedActiveNewsletters =
-    newsletters.filter((n) => n.status === 'active').sort((a, b) => a.sort_order - b.sort_order) ||
-    [];
-  const archivedNewsletters = newsletters.filter((newsletter) => newsletter.status !== 'active');
-
-  const onSort = async (id: string, overId?: string) => {
-    const fromIndex = sortedActiveNewsletters.findIndex((newsletter) => newsletter.id === id);
-    const toIndex =
-      sortedActiveNewsletters.findIndex((newsletter) => newsletter.id === overId) || 0;
-    const newSortOrder = arrayMove(sortedActiveNewsletters, fromIndex, toIndex);
-
-    const updatedActiveNewsletters = newSortOrder
-      .map((newsletter, index) =>
-        newsletter.sort_order === index ? null : { ...newsletter, sort_order: index },
-      )
-      .filter((newsletter): newsletter is Newsletter => !!newsletter);
-
-    const updatedArchivedNewsletters = archivedNewsletters
-      .map((newsletter, index) =>
-        newsletter.sort_order === index + sortedActiveNewsletters.length
-          ? null
-          : { ...newsletter, sort_order: index },
-      )
-      .filter((newsletter): newsletter is Newsletter => !!newsletter);
-
-    const orderUpdatedNewsletters = [
-      ...updatedActiveNewsletters,
-      ...updatedArchivedNewsletters,
-    ].sort((a, b) => a.sort_order - b.sort_order);
-
-    setNewsletters(
-      newsletters.map(
-        (newsletter) => orderUpdatedNewsletters.find((n) => n.id === newsletter.id) || newsletter,
-      ),
-    );
-    queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>(
-      { queryKey: [newslettersDataType] },
-      (currentData) => {
-        if (!currentData) {
-          return;
-        }
-
-        return {
-          ...currentData,
-          pages: currentData.pages.map((page) => ({
-            ...page,
-            newsletters: page.newsletters.map(
-              (newsletter) =>
-                orderUpdatedNewsletters.find((n) => n.id === newsletter.id) || newsletter,
-            ),
-          })),
-        };
-      },
-    );
-
-    for (const newsletter of orderUpdatedNewsletters) {
-      await editNewsletter(newsletter);
-    }
-  };
 
   const showingActive = filter === 'active';
 

--- a/apps/admin/src/settings/email/use-newsletter-reorder.ts
+++ b/apps/admin/src/settings/email/use-newsletter-reorder.ts
@@ -1,0 +1,83 @@
+import { type InfiniteData, useQueryClient } from '@tryghost/admin-x-framework';
+import {
+  type Newsletter,
+  type NewslettersResponseType,
+  newslettersDataType,
+  useEditNewsletter,
+} from '@tryghost/admin-x-framework/api/newsletters';
+import { arrayMove } from '@dnd-kit/sortable';
+import { useEffect, useState } from 'react';
+
+export const useNewsletterReorder = (apiNewsletters: Newsletter[] | undefined) => {
+  const { mutateAsync: editNewsletter } = useEditNewsletter();
+  const queryClient = useQueryClient();
+
+  const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
+
+  useEffect(() => {
+    setNewsletters(apiNewsletters || []);
+  }, [apiNewsletters]);
+
+  const sortedActiveNewsletters =
+    newsletters.filter((n) => n.status === 'active').sort((a, b) => a.sort_order - b.sort_order) ||
+    [];
+  const archivedNewsletters = newsletters.filter((newsletter) => newsletter.status !== 'active');
+
+  const onSort = async (id: string, overId?: string) => {
+    const fromIndex = sortedActiveNewsletters.findIndex((newsletter) => newsletter.id === id);
+    const toIndex =
+      sortedActiveNewsletters.findIndex((newsletter) => newsletter.id === overId) || 0;
+    const newSortOrder = arrayMove(sortedActiveNewsletters, fromIndex, toIndex);
+
+    const updatedActiveNewsletters = newSortOrder
+      .map((newsletter, index) =>
+        newsletter.sort_order === index ? null : { ...newsletter, sort_order: index },
+      )
+      .filter((newsletter): newsletter is Newsletter => !!newsletter);
+
+    const updatedArchivedNewsletters = archivedNewsletters
+      .map((newsletter, index) =>
+        newsletter.sort_order === index + sortedActiveNewsletters.length
+          ? null
+          : { ...newsletter, sort_order: index },
+      )
+      .filter((newsletter): newsletter is Newsletter => !!newsletter);
+
+    const orderUpdatedNewsletters = [
+      ...updatedActiveNewsletters,
+      ...updatedArchivedNewsletters,
+    ].sort((a, b) => a.sort_order - b.sort_order);
+
+    // Set the new order in local state and cache first so that the UI updates immediately
+    setNewsletters(
+      newsletters.map(
+        (newsletter) => orderUpdatedNewsletters.find((n) => n.id === newsletter.id) || newsletter,
+      ),
+    );
+    queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>(
+      { queryKey: [newslettersDataType] },
+      (currentData) => {
+        if (!currentData) {
+          return;
+        }
+
+        return {
+          ...currentData,
+          pages: currentData.pages.map((page) => ({
+            ...page,
+            newsletters: page.newsletters.map(
+              (newsletter) =>
+                orderUpdatedNewsletters.find((n) => n.id === newsletter.id) || newsletter,
+            ),
+          })),
+        };
+      },
+    );
+
+    for (const newsletter of orderUpdatedNewsletters) {
+      await editNewsletter(newsletter);
+    }
+  };
+
+  return { newsletters, sortedActiveNewsletters, archivedNewsletters, onSort };
+};

--- a/apps/admin/src/settings/site/announcement-bar/announcement-bar-preview.tsx
+++ b/apps/admin/src/settings/site/announcement-bar/announcement-bar-preview.tsx
@@ -1,5 +1,6 @@
 import IframeBuffering from '@/settings/utils/iframe-buffering';
 import React, { useCallback, useMemo } from 'react';
+import { fetchFrontendPreview } from '@/settings/utils/fetch-frontend-preview';
 
 const getPreviewData = (
   announcementBackgroundColor?: string,
@@ -37,24 +38,10 @@ const AnnouncementBarPreview: React.FC<AnnouncementBarSettings> = ({
         return;
       }
 
-      const previewUrl = new URL(url);
-      previewUrl.searchParams.set('admin_toolbar', '0');
-
-      fetch(previewUrl.toString(), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/html;charset=utf-8',
-          'x-ghost-preview': getPreviewData(
-            announcementBackgroundColor,
-            announcementContent,
-            visibilityMemo,
-          ),
-          Accept: 'text/html',
-        },
-        mode: 'cors',
-        credentials: 'include',
-      })
-        .then((response) => response.text())
+      fetchFrontendPreview(
+        url,
+        getPreviewData(announcementBackgroundColor, announcementContent, visibilityMemo),
+      )
         .then((data) => {
           // inject extra CSS to disable navigation and prevent clicks
           const injectedCss = `html { pointer-events: none; }`;

--- a/apps/admin/src/settings/site/design-and-branding/theme-preview.tsx
+++ b/apps/admin/src/settings/site/design-and-branding/theme-preview.tsx
@@ -4,6 +4,7 @@ import {
   type CustomThemeSetting,
   hiddenCustomThemeSettingValue,
 } from '@tryghost/admin-x-framework/api/custom-theme-settings';
+import { fetchFrontendPreview } from '@/settings/utils/fetch-frontend-preview';
 import { isCustomThemeSettingVisible } from '@/settings/utils/is-custom-theme-settings-visible';
 
 type GlobalSettings = {
@@ -80,48 +81,33 @@ const ThemePreview: React.FC<ThemePreviewProps> = ({ settings, url }) => {
         return;
       }
 
-      // Fetch theme preview HTML (suppress admin toolbar in preview)
-      const previewUrl = new URL(url);
-      previewUrl.searchParams.set('admin_toolbar', '0');
+      void fetchFrontendPreview(url, previewData).then((data) => {
+        // inject extra CSS to disable navigation and prevent clicks
+        const injectedCss = `html { pointer-events: none; }`;
 
-      void fetch(previewUrl.toString(), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/html;charset=utf-8',
-          'x-ghost-preview': previewData,
-          Accept: 'text/html',
-        },
-        mode: 'cors',
-        credentials: 'include',
-      })
-        .then((response) => response.text())
-        .then((data) => {
-          // inject extra CSS to disable navigation and prevent clicks
-          const injectedCss = `html { pointer-events: none; }`;
+        const domParser = new DOMParser();
+        const htmlDoc = domParser.parseFromString(data, 'text/html');
 
-          const domParser = new DOMParser();
-          const htmlDoc = domParser.parseFromString(data, 'text/html');
+        const stylesheet = htmlDoc.querySelector('style') as HTMLStyleElement;
+        const originalCSS = stylesheet?.innerHTML;
+        if (originalCSS) {
+          stylesheet.innerHTML = `${originalCSS}\n\n${injectedCss}`;
+        } else {
+          htmlDoc.head.innerHTML += `<style>${injectedCss}</style>`;
+        }
 
-          const stylesheet = htmlDoc.querySelector('style') as HTMLStyleElement;
-          const originalCSS = stylesheet?.innerHTML;
-          if (originalCSS) {
-            stylesheet.innerHTML = `${originalCSS}\n\n${injectedCss}`;
-          } else {
-            htmlDoc.head.innerHTML += `<style>${injectedCss}</style>`;
-          }
+        // replace the iframe contents with the doctored preview html
+        const doctype = htmlDoc.doctype
+          ? new XMLSerializer().serializeToString(htmlDoc.doctype)
+          : '';
+        const finalDoc = doctype + htmlDoc.documentElement.outerHTML;
 
-          // replace the iframe contents with the doctored preview html
-          const doctype = htmlDoc.doctype
-            ? new XMLSerializer().serializeToString(htmlDoc.doctype)
-            : '';
-          const finalDoc = doctype + htmlDoc.documentElement.outerHTML;
-
-          // Send the data to the iframe's window using postMessage
-          // Inject the received content into the iframe
-          iframe.contentDocument?.open();
-          iframe.contentDocument?.write(finalDoc);
-          iframe.contentDocument?.close();
-        });
+        // Send the data to the iframe's window using postMessage
+        // Inject the received content into the iframe
+        iframe.contentDocument?.open();
+        iframe.contentDocument?.write(finalDoc);
+        iframe.contentDocument?.close();
+      });
     },
     [previewData, url],
   );

--- a/apps/admin/src/settings/utils/fetch-frontend-preview.ts
+++ b/apps/admin/src/settings/utils/fetch-frontend-preview.ts
@@ -1,0 +1,18 @@
+// Fetches a site front-end page rendered with the given `x-ghost-preview` data.
+// This targets the front-end, not the Admin API, so it stays a plain fetch.
+export function fetchFrontendPreview(url: string, previewData: string): Promise<string> {
+  // Suppress the admin toolbar in previews
+  const previewUrl = new URL(url);
+  previewUrl.searchParams.set('admin_toolbar', '0');
+
+  return fetch(previewUrl.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/html;charset=utf-8',
+      'x-ghost-preview': previewData,
+      Accept: 'text/html',
+    },
+    mode: 'cors',
+    credentials: 'include',
+  }).then((response) => response.text());
+}

--- a/apps/admin/src/whats-new/components/whats-new-banner.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-banner.tsx
@@ -5,13 +5,13 @@ import { useWhatsNew, useDismissWhatsNew } from '@/whats-new/hooks/use-whats-new
 import { useChangelog } from '@/whats-new/hooks/use-changelog';
 
 function WhatsNewBanner() {
-  const { data: whatsNewData } = useWhatsNew();
+  const { hasNew } = useWhatsNew();
   const { data: changelog } = useChangelog();
   const { mutate: dismissWhatsNew } = useDismissWhatsNew();
   const [isDismissed, setIsDismissed] = useState(false);
 
   // Don't show if dismissed or no new content
-  if (isDismissed || !whatsNewData?.hasNew) {
+  if (isDismissed || !hasNew) {
     return null;
   }
 

--- a/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
@@ -4,7 +4,6 @@ import type { QueryClient } from '@tanstack/react-query';
 import { useWhatsNew, useDismissWhatsNew } from './use-whats-new';
 import { HttpResponse, http } from 'msw';
 import { mockUser, createRawChangelogEntry } from '@test-utils/factories';
-import { waitForQuerySettled } from '@test-utils/test-helpers';
 import type {
   UpdateUserRequestBody,
   UsersResponseType,
@@ -66,6 +65,25 @@ const fixtures = {
 };
 
 // Setup functions
+
+/**
+ * `useWhatsNew` derives its value from the user-preferences and changelog
+ * queries (plus the preference-initializing mutation), so "settled" means
+ * all cached queries have resolved and no mutation is in flight.
+ */
+async function waitForBackingQueriesSettled(queryClient: QueryClient) {
+  await waitFor(() => {
+    const queries = queryClient.getQueryCache().getAll();
+    expect(queries.length).toBeGreaterThan(0);
+    expect(
+      queries.every(
+        (query) => query.state.status !== 'pending' && query.state.fetchStatus === 'idle',
+      ),
+    ).toBe(true);
+    expect(queryClient.isMutating()).toBe(0);
+  });
+}
+
 /**
  * Setup function for testing `useWhatsNew`.
  *
@@ -74,23 +92,21 @@ const fixtures = {
  * 2. Mocking the user mutation endpoint (for initializing preferences)
  * 3. Mocking the changelog API endpoint with customizable changelog data
  * 4. Rendering the hook with the necessary React Query wrapper
- * 5. Waiting for the query to settle (success or error state)
- *
- * Note: The query is disabled until preferences exist (hasWhatsNewPreferences = true).
- * This means the query naturally stays in loading state during initialization, then
- * enables and settles once the mutation completes. Tests only need to wait once.
+ * 5. Waiting for the backing queries and mutations to settle
  *
  * This allows tests to focus on asserting behavior rather than setup logic,
  * making test code more ergonomic and readable.
  *
  * @param server - MSW server instance for mocking API endpoints
  * @param wrapper - React Query wrapper component for hook testing
+ * @param queryClient - Query client backing the wrapper, used to await settling
  * @param options - Test configuration options (accessibility, changelog data)
- * @returns The renderHook result with the query in a settled state
+ * @returns The renderHook result with the backing data loaded
  */
 async function setupQuery(
   server: SetupServer,
   wrapper: TestWrapperComponent,
+  queryClient: QueryClient,
   options: SetupQueryOptions = {},
 ) {
   const { accessibility = null, changelog = {} } = options;
@@ -136,9 +152,7 @@ async function setupQuery(
     wrapper,
   });
 
-  // Wait for query to settle. The query is disabled until preferences are initialized,
-  // so it stays in loading state during the mutation, then enables and settles naturally.
-  await waitForQuerySettled(result);
+  await waitForBackingQueriesSettled(queryClient);
 
   return result;
 }
@@ -150,20 +164,22 @@ async function setupQuery(
  * 1. Mocking the user API endpoint with customizable lastSeenDate
  * 2. Mocking the user mutation endpoint (for updating preferences)
  * 3. Mocking the changelog API endpoint with customizable posts
- * 4. Rendering both the query hook (to read state) and mutation hook (to update state)
- * 5. Waiting for the initial query to settle before tests run
+ * 4. Rendering both the `useWhatsNew` hook (to read state) and mutation hook (to update state)
+ * 5. Waiting for the backing queries to settle before tests run
  *
  * This allows mutation tests to immediately call `mutation.mutateAsync()` without worrying
  * about setup, making test code more ergonomic and focused on the mutation behavior.
  *
  * @param server - MSW server instance for mocking API endpoints
  * @param wrapper - React Query wrapper component for hook testing
+ * @param queryClient - Query client backing the wrapper, used to await settling
  * @param options - Test configuration options (lastSeenDate, posts)
- * @returns Both query and mutation hook results, ready for testing mutations
+ * @returns Both `useWhatsNew` and mutation hook results, ready for testing mutations
  */
 async function setupMutation(
   server: SetupServer,
   wrapper: TestWrapperComponent,
+  queryClient: QueryClient,
   options: SetupMutationOptions = {},
 ) {
   const { lastSeenDate = dates.past, posts = [fixtures.entries.newEntry()] } = options;
@@ -211,7 +227,7 @@ async function setupMutation(
     wrapper,
   });
 
-  await waitForQuerySettled(query.result);
+  await waitForBackingQueriesSettled(queryClient);
 
   return {
     query: query.result,
@@ -228,8 +244,8 @@ const queryTest = baseTest.extend<{
 }>({
   ...serverFixture,
   ...queryClientFixtures,
-  setup: async ({ server, wrapper }, provide) => {
-    await provide((options) => setupQuery(server, wrapper, options));
+  setup: async ({ server, wrapper, queryClient }, provide) => {
+    await provide((options) => setupQuery(server, wrapper, queryClient, options));
   },
 });
 
@@ -241,8 +257,8 @@ const mutationTest = baseTest.extend<{
 }>({
   ...serverFixture,
   ...queryClientFixtures,
-  setup: async ({ server, wrapper }, provide) => {
-    await provide((options) => setupMutation(server, wrapper, options));
+  setup: async ({ server, wrapper, queryClient }, provide) => {
+    await provide((options) => setupMutation(server, wrapper, queryClient, options));
   },
 });
 
@@ -257,7 +273,7 @@ describe('useWhatsNew', () => {
           accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
         });
 
-        expect(result.current.data?.hasNew).toBe(true);
+        expect(result.current.hasNew).toBe(true);
       });
     });
 
@@ -327,7 +343,7 @@ describe('useWhatsNew', () => {
       ].forEach(({ scenario, input }) => {
         queryTest(scenario, async ({ setup }) => {
           const result = await setup(input);
-          expect(result.current.data?.hasNew).toBe(false);
+          expect(result.current.hasNew).toBe(false);
         });
       });
     });
@@ -338,14 +354,14 @@ describe('useDismissWhatsNew', () => {
   mutationTest('changes hasNew from true to false', async ({ setup }) => {
     const { query, mutation } = await setup();
 
-    expect(query.current.data?.hasNew).toBe(true);
+    expect(query.current.hasNew).toBe(true);
 
     await act(async () => {
       await mutation.current.mutateAsync();
     });
 
     await waitFor(() => {
-      expect(query.current.data?.hasNew).toBe(false);
+      expect(query.current.hasNew).toBe(false);
     });
   });
 
@@ -364,14 +380,14 @@ describe('useDismissWhatsNew', () => {
       ],
     });
 
-    expect(query.current.data?.hasNew).toBe(true);
+    expect(query.current.hasNew).toBe(true);
 
     await act(async () => {
       await mutation.current.mutateAsync();
     });
 
     await waitFor(() => {
-      expect(query.current.data?.hasNew).toBe(false);
+      expect(query.current.hasNew).toBe(false);
     });
   });
 
@@ -380,14 +396,14 @@ describe('useDismissWhatsNew', () => {
       posts: [],
     });
 
-    expect(query.current.data?.hasNew).toBe(false);
+    expect(query.current.hasNew).toBe(false);
 
     await act(async () => {
       await mutation.current.mutateAsync();
     });
 
     await waitFor(() => {
-      expect(query.current.data?.hasNew).toBe(false);
+      expect(query.current.hasNew).toBe(false);
     });
   });
 });

--- a/apps/admin/src/whats-new/hooks/use-whats-new.ts
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.ts
@@ -1,18 +1,12 @@
-import { useEffect } from 'react';
-import {
-  useQuery,
-  useMutation,
-  type UseQueryResult,
-  type UseMutationResult,
-} from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
 
 import {
   useUserPreferences,
   useEditUserPreferences,
-  type Preferences,
   type WhatsNewPreferences,
 } from '@/hooks/user-preferences';
-import { useChangelog, type ChangelogEntry } from './use-changelog';
+import { useChangelog } from './use-changelog';
 
 function getDefaultWhatsNewPreferences(): WhatsNewPreferences {
   return {
@@ -24,22 +18,13 @@ interface WhatsNewData {
   hasNew: boolean;
 }
 
-const whatsNewQueryKey = (
-  preferences: Preferences | undefined,
-  latestEntry: ChangelogEntry | undefined,
-) =>
-  [
-    'whatsNew',
-    preferences?.whatsNew?.lastSeenDate?.toISOString(),
-    latestEntry?.publishedAt.toISOString(),
-  ] as const;
-
-export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
+export const useWhatsNew = (): WhatsNewData => {
   const { data: preferences, isSuccess: isPreferencesLoaded } = useUserPreferences();
   const { data: changelog, isSuccess: isChangelogLoaded } = useChangelog();
   const { mutateAsync: updatePreferences } = useEditUserPreferences();
 
-  const hasWhatsNewPreferences = !!preferences?.whatsNew?.lastSeenDate;
+  const lastSeenDate = preferences?.whatsNew?.lastSeenDate;
+  const hasWhatsNewPreferences = !!lastSeenDate;
 
   // Initialize default whatsNewPreferences if missing or invalid
   useEffect(() => {
@@ -52,25 +37,13 @@ export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
 
   const latestEntry = changelog?.entries[0];
 
-  return useQuery({
-    queryKey: whatsNewQueryKey(preferences, latestEntry),
-    queryFn: () => {
-      if (!latestEntry) {
-        return { hasNew: false };
-      }
+  return useMemo(() => {
+    if (!isChangelogLoaded || !lastSeenDate || !latestEntry) {
+      return { hasNew: false };
+    }
 
-      // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
-      // and useEffect ensures whatsNew is initialized with a valid lastSeenDate
-      const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
-
-      const hasNew = latestEntry.publishedAt > lastSeenDate;
-
-      return { hasNew };
-    },
-    enabled: isChangelogLoaded && hasWhatsNewPreferences,
-    staleTime: Infinity,
-    gcTime: 0,
-  });
+    return { hasNew: latestEntry.publishedAt > lastSeenDate };
+  }, [isChangelogLoaded, lastSeenDate, latestEntry]);
 };
 
 export const useDismissWhatsNew = (): UseMutationResult<void, Error, void, unknown> => {


### PR DESCRIPTION
Five small duplications/oddities, one sweep:

- **Newsletter reorder**: the optimistic-reorder block (mirrored local state, active/archived derivation, `setQueriesData` + sequential `editNewsletter`) was duplicated verbatim across `newsletters.tsx` and `newsletters-tab-content.tsx` (both live, reached from different settings surfaces). Extracted into `use-newsletter-reorder.ts`, used by both.
- **Front-end preview fetches**: the theme and announcement-bar previews hand-rolled byte-identical POSTs (`x-ghost-preview`, cors, credentials); one `fetch-frontend-preview.ts` helper now owns it — deliberately a plain fetch, it targets the site front-end, not the Admin API.
- **`use-whats-new`**: a `useQuery` whose queryFn was a synchronous boolean over already-loaded data → `useMemo`; the synthetic query key is gone.
- **Email validation**: the two hand-rolled regexes (member edit, import mapping) → `validator.isEmail`. Looseness audited: every valid fixture passes both, every invalid fixture fails both; nothing relied on the looser match — and the server's member validation is validator-based, so the client now matches the server exactly.
- **`@xyflow/react` CSS**: imported once, in the only module that mounts `<ReactFlow>` (`automation-canvas.tsx`); verified the styles still land in the lazy editor chunk in a production build.

16 files, +202/−286.

**Verification:** framework/shade builds, admin `tsc -b`, eslint, `test:unit` 139 files / 1643 tests; acceptance across email/site/whats-new/members/automations: 18 files / 151 tests, no flake; `oxfmt --check` clean; admin production build passes.