### PR TITLE
Added lint guardrails for the admin boundaries

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -135,10 +135,10 @@ module.exports = {
     {
       name: 'admin-is-app',
       comment:
-        'Libraries and sibling apps (shade, admin-x-framework, activitypub) must not depend on @tryghost/admin. Admin sits at the top of the layer stack.',
+        'No sibling app or library may depend on @tryghost/admin - whether by package specifier or by relative reach-in. Admin sits at the top of the layer stack.',
       severity: 'error',
-      from: { path: '^apps/(admin-x-framework|shade|activitypub)/' },
-      to: { path: '^@tryghost/admin($|/)' },
+      from: { path: '^apps/', pathNot: '^apps/admin/' },
+      to: { path: '^@tryghost/admin($|/)|^apps/admin/' },
     },
     // ============================================================
     // apps/admin — shared/ must stay domain-free
@@ -150,7 +150,7 @@ module.exports = {
       severity: 'error',
       from: { path: '^apps/admin/src/shared/' },
       to: {
-        path: '^(@/|apps/admin/src/)(members|settings|analytics|posts|tags|comments|automations|onboarding|whats-new|layout)/',
+        path: '^(@/|apps/admin/src/)(members|settings|analytics|posts|tags|comments|automations|onboarding|whats-new|layout)($|/)',
       },
     },
   ],

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -129,6 +129,30 @@ module.exports = {
       },
       to: { path: '^@tryghost/(shade|admin-x-framework)' },
     },
+    // ============================================================
+    // apps/ — admin is an app, not a library
+    // ============================================================
+    {
+      name: 'admin-is-app',
+      comment:
+        'Libraries and sibling apps (shade, admin-x-framework, activitypub) must not depend on @tryghost/admin. Admin sits at the top of the layer stack.',
+      severity: 'error',
+      from: { path: '^apps/(admin-x-framework|shade|activitypub)/' },
+      to: { path: '^@tryghost/admin($|/)' },
+    },
+    // ============================================================
+    // apps/admin — shared/ must stay domain-free
+    // ============================================================
+    {
+      name: 'admin-shared-no-domains',
+      comment:
+        'apps/admin/src/shared must not import from feature domains. Move code used by a single domain into that domain; keep shared/ generic. In-app imports use the @/ alias, which the cruiser sees as an unresolved @/-prefixed specifier.',
+      severity: 'error',
+      from: { path: '^apps/admin/src/shared/' },
+      to: {
+        path: '^(@/|apps/admin/src/)(members|settings|analytics|posts|tags|comments|automations|onboarding|whats-new|layout)/',
+      },
+    },
   ],
   options: {
     doNotFollow: { path: 'node_modules' },

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -130,7 +130,7 @@ module.exports = {
     ];
   },
   'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': (files) => buildBoundaryCommand(files),
-  'apps/{shade,admin-x-framework,activitypub,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}':
+  'apps/{admin,shade,admin-x-framework,activitypub,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}':
     (files) => buildBoundaryCommand(files),
   '*.{mjs,mts,cts,json,jsonc,json5,yml,yaml,css,mdx}': (files) => buildOxfmtCommand(files),
   '**/*.md': (files) => [buildOxfmtCommand(files), ...buildMarkdownCommands(files)],

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -84,6 +84,7 @@ export {
 export { useNavigationStack } from './providers/navigation-stack-provider';
 export {
   Link,
+  NavigationType,
   Outlet,
   useBlocker,
   useLocation,
@@ -95,6 +96,7 @@ export {
   useMatch,
   useMatches,
 } from 'react-router';
+export type { BlockerFunction } from 'react-router';
 
 // Lazy component loader
 export { lazyComponent } from './utils/lazy-component';

--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -9,7 +9,7 @@ const shadeRestrictedPaths = shadeLayeredImportsRule['no-restricted-imports'][1]
 
 const emberBridgeImportPatterns = [
   {
-    group: ['@/ember-bridge/ember-bridge', '**/ember-bridge/ember-bridge'],
+    group: ['@/ember-bridge/*', '**/ember-bridge/ember-bridge'],
     message: 'Import bridge helpers from the @/ember-bridge barrel, not the implementation module.',
   },
 ];
@@ -122,7 +122,14 @@ export default tseslint.config(
                 'Import routing APIs (and their types) from @tryghost/admin-x-framework instead of react-router directly.',
             },
           ],
-          patterns: emberBridgeImportPatterns,
+          patterns: [
+            ...emberBridgeImportPatterns,
+            {
+              group: ['react-router/*'],
+              message:
+                'Import routing APIs (and their types) from @tryghost/admin-x-framework instead of react-router directly.',
+            },
+          ],
         },
       ],
       'no-restricted-syntax': [
@@ -134,6 +141,12 @@ export default tseslint.config(
         },
         {
           selector: "MemberExpression[property.value='EmberBridge']",
+          message:
+            'Access Ember through the @/ember-bridge helpers, not window.EmberBridge directly.',
+        },
+        {
+          selector:
+            "VariableDeclarator[init.name=/^(window|globalThis)$/] Property[key.name='EmberBridge']",
           message:
             'Access Ember through the @/ember-bridge helpers, not window.EmberBridge directly.',
         },

--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -1,6 +1,18 @@
 import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
 import * as tseslint from 'typescript-eslint';
 import { reactAppConfig } from '@internal/cfg-eslint-react';
+import { shadeLayeredImportsRule } from '@internal/cfg-eslint';
+
+// The factory's shade restriction and this file's boundary bans share the
+// `no-restricted-imports` rule slot, so the boundary blocks must re-include it.
+const shadeRestrictedPaths = shadeLayeredImportsRule['no-restricted-imports'][1].paths;
+
+const emberBridgeImportPatterns = [
+  {
+    group: ['@/ember-bridge/ember-bridge', '**/ember-bridge/ember-bridge'],
+    message: 'Import bridge helpers from the @/ember-bridge barrel, not the implementation module.',
+  },
+];
 
 const noHardcodedGhostPaths = {
   meta: {
@@ -91,6 +103,88 @@ export default tseslint.config(
     plugins: { 'no-relative-import-paths': noRelativeImportPaths },
     rules: {
       'no-relative-import-paths/no-relative-import-paths': ['error', { allowSameFolder: true }],
+    },
+  },
+  // Boundary guardrails. Product code must reach react-router, the Ember
+  // bridge, and the Admin API through their owning layers.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.*', 'src/ember-bridge/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            ...shadeRestrictedPaths,
+            {
+              name: 'react-router',
+              message:
+                'Import routing APIs (and their types) from @tryghost/admin-x-framework instead of react-router directly.',
+            },
+          ],
+          patterns: emberBridgeImportPatterns,
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "MemberExpression[property.name='EmberBridge']",
+          message:
+            'Access Ember through the @/ember-bridge helpers, not window.EmberBridge directly.',
+        },
+        {
+          selector: "MemberExpression[property.value='EmberBridge']",
+          message:
+            'Access Ember through the @/ember-bridge helpers, not window.EmberBridge directly.',
+        },
+        {
+          selector: "CallExpression[callee.name='fetch']",
+          message:
+            'Admin API requests belong in the @tryghost/admin-x-framework API layer. For non-Ghost URLs (external services, front-end previews), disable this rule for the line with a reason.',
+        },
+        {
+          selector: "CallExpression[callee.object.name='window'][callee.property.name='fetch']",
+          message:
+            'Admin API requests belong in the @tryghost/admin-x-framework API layer. For non-Ghost URLs (external services, front-end previews), disable this rule for the line with a reason.',
+        },
+        {
+          selector: "CallExpression[callee.object.name='globalThis'][callee.property.name='fetch']",
+          message:
+            'Admin API requests belong in the @tryghost/admin-x-framework API layer. For non-Ghost URLs (external services, front-end previews), disable this rule for the line with a reason.',
+        },
+      ],
+    },
+  },
+  // Test files keep react-router scaffolding (MemoryRouter, createMemoryRouter)
+  // and window.EmberBridge stubs, but must still import the bridge barrel.
+  {
+    files: ['src/**/*.test.*'],
+    ignores: ['src/ember-bridge/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        { paths: [...shadeRestrictedPaths], patterns: emberBridgeImportPatterns },
+      ],
+    },
+  },
+  // Advisory only — warnings do not fail CI (`eslint .` without --max-warnings).
+  // Steers new code to the shade utilities without forcing a bulk conversion.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.*'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            { name: 'clsx', message: 'Use cn from @tryghost/shade/utils.' },
+            {
+              name: 'lucide-react',
+              message: 'Use the LucideIcon namespace from @tryghost/shade/utils.',
+            },
+          ],
+        },
+      ],
     },
   },
 );

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -66,6 +66,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@internal/cfg-eslint": "workspace:*",
     "@internal/cfg-eslint-react": "workspace:*",
     "@tailwindcss/vite": "catalog:",
     "@testing-library/jest-dom": "catalog:",

--- a/apps/admin/src/hooks/use-unsaved-changes-guard.ts
+++ b/apps/admin/src/hooks/use-unsaved-changes-guard.ts
@@ -1,9 +1,13 @@
 import React from 'react';
-import { NavigationType, useBlocker } from 'react-router';
 import { isOnRouterHistoryEntry } from '@/hooks/use-router-history-entry';
-import { useConfirmUnload, useLocation } from '@tryghost/admin-x-framework';
+import {
+  NavigationType,
+  useBlocker,
+  useConfirmUnload,
+  useLocation,
+} from '@tryghost/admin-x-framework';
 import { useHashLinkNavigationGuard } from '@/hooks/use-hash-link-navigation-guard';
-import type { BlockerFunction } from 'react-router';
+import type { BlockerFunction } from '@tryghost/admin-x-framework';
 
 type BlockerFunctionArgs = Parameters<BlockerFunction>[0];
 

--- a/apps/admin/src/settings/growth/explore/testimonials-modal.tsx
+++ b/apps/admin/src/settings/growth/explore/testimonials-modal.tsx
@@ -63,6 +63,7 @@ const TestimonialsModal = () => {
         throw new Error('Something went wrong, please try again later.');
       }
 
+      // eslint-disable-next-line no-restricted-syntax -- external Ghost Explore service, not the Admin API
       const response = await fetch(exploreTestimonialsUrl, {
         method: 'POST',
         headers: {

--- a/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
+++ b/apps/admin/src/settings/layout/dirty-navigation-guard.tsx
@@ -1,5 +1,5 @@
 import { DirtyConfirmDialog } from '@tryghost/shade/patterns';
-import { NavigationType, useBlocker } from 'react-router';
+import { NavigationType, useBlocker } from '@tryghost/admin-x-framework';
 import { useConfirmUnload } from '@tryghost/admin-x-framework/hooks';
 import { useGlobalDirtyState } from '@tryghost/shade/utils';
 import { isOnRouterHistoryEntry } from '@/hooks/use-router-history-entry';

--- a/apps/admin/src/settings/site/announcement-bar/announcement-bar-preview.tsx
+++ b/apps/admin/src/settings/site/announcement-bar/announcement-bar-preview.tsx
@@ -1,6 +1,5 @@
 import IframeBuffering from '@/settings/utils/iframe-buffering';
 import React, { useCallback, useMemo } from 'react';
-import { fetchFrontendPreview } from '@/settings/utils/fetch-frontend-preview';
 
 const getPreviewData = (
   announcementBackgroundColor?: string,
@@ -38,10 +37,25 @@ const AnnouncementBarPreview: React.FC<AnnouncementBarSettings> = ({
         return;
       }
 
-      fetchFrontendPreview(
-        url,
-        getPreviewData(announcementBackgroundColor, announcementContent, visibilityMemo),
-      )
+      const previewUrl = new URL(url);
+      previewUrl.searchParams.set('admin_toolbar', '0');
+
+      // eslint-disable-next-line no-restricted-syntax -- posts preview data to the site front-end, not the Admin API
+      fetch(previewUrl.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/html;charset=utf-8',
+          'x-ghost-preview': getPreviewData(
+            announcementBackgroundColor,
+            announcementContent,
+            visibilityMemo,
+          ),
+          Accept: 'text/html',
+        },
+        mode: 'cors',
+        credentials: 'include',
+      })
+        .then((response) => response.text())
         .then((data) => {
           // inject extra CSS to disable navigation and prevent clicks
           const injectedCss = `html { pointer-events: none; }`;

--- a/apps/admin/src/settings/site/design-and-branding/theme-preview.tsx
+++ b/apps/admin/src/settings/site/design-and-branding/theme-preview.tsx
@@ -4,7 +4,6 @@ import {
   type CustomThemeSetting,
   hiddenCustomThemeSettingValue,
 } from '@tryghost/admin-x-framework/api/custom-theme-settings';
-import { fetchFrontendPreview } from '@/settings/utils/fetch-frontend-preview';
 import { isCustomThemeSettingVisible } from '@/settings/utils/is-custom-theme-settings-visible';
 
 type GlobalSettings = {
@@ -81,33 +80,49 @@ const ThemePreview: React.FC<ThemePreviewProps> = ({ settings, url }) => {
         return;
       }
 
-      void fetchFrontendPreview(url, previewData).then((data) => {
-        // inject extra CSS to disable navigation and prevent clicks
-        const injectedCss = `html { pointer-events: none; }`;
+      // Fetch theme preview HTML (suppress admin toolbar in preview)
+      const previewUrl = new URL(url);
+      previewUrl.searchParams.set('admin_toolbar', '0');
 
-        const domParser = new DOMParser();
-        const htmlDoc = domParser.parseFromString(data, 'text/html');
+      // eslint-disable-next-line no-restricted-syntax -- posts preview data to the site front-end, not the Admin API
+      void fetch(previewUrl.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/html;charset=utf-8',
+          'x-ghost-preview': previewData,
+          Accept: 'text/html',
+        },
+        mode: 'cors',
+        credentials: 'include',
+      })
+        .then((response) => response.text())
+        .then((data) => {
+          // inject extra CSS to disable navigation and prevent clicks
+          const injectedCss = `html { pointer-events: none; }`;
 
-        const stylesheet = htmlDoc.querySelector('style') as HTMLStyleElement;
-        const originalCSS = stylesheet?.innerHTML;
-        if (originalCSS) {
-          stylesheet.innerHTML = `${originalCSS}\n\n${injectedCss}`;
-        } else {
-          htmlDoc.head.innerHTML += `<style>${injectedCss}</style>`;
-        }
+          const domParser = new DOMParser();
+          const htmlDoc = domParser.parseFromString(data, 'text/html');
 
-        // replace the iframe contents with the doctored preview html
-        const doctype = htmlDoc.doctype
-          ? new XMLSerializer().serializeToString(htmlDoc.doctype)
-          : '';
-        const finalDoc = doctype + htmlDoc.documentElement.outerHTML;
+          const stylesheet = htmlDoc.querySelector('style') as HTMLStyleElement;
+          const originalCSS = stylesheet?.innerHTML;
+          if (originalCSS) {
+            stylesheet.innerHTML = `${originalCSS}\n\n${injectedCss}`;
+          } else {
+            htmlDoc.head.innerHTML += `<style>${injectedCss}</style>`;
+          }
 
-        // Send the data to the iframe's window using postMessage
-        // Inject the received content into the iframe
-        iframe.contentDocument?.open();
-        iframe.contentDocument?.write(finalDoc);
-        iframe.contentDocument?.close();
-      });
+          // replace the iframe contents with the doctored preview html
+          const doctype = htmlDoc.doctype
+            ? new XMLSerializer().serializeToString(htmlDoc.doctype)
+            : '';
+          const finalDoc = doctype + htmlDoc.documentElement.outerHTML;
+
+          // Send the data to the iframe's window using postMessage
+          // Inject the received content into the iframe
+          iframe.contentDocument?.open();
+          iframe.contentDocument?.write(finalDoc);
+          iframe.contentDocument?.close();
+        });
     },
     [previewData, url],
   );

--- a/apps/admin/src/settings/utils/fetch-frontend-preview.ts
+++ b/apps/admin/src/settings/utils/fetch-frontend-preview.ts
@@ -5,6 +5,7 @@ export function fetchFrontendPreview(url: string, previewData: string): Promise<
   const previewUrl = new URL(url);
   previewUrl.searchParams.set('admin_toolbar', '0');
 
+  // eslint-disable-next-line no-restricted-syntax -- targets the site front-end, not the Admin API
   return fetch(previewUrl.toString(), {
     method: 'POST',
     headers: {

--- a/apps/admin/src/whats-new/hooks/use-changelog.ts
+++ b/apps/admin/src/whats-new/hooks/use-changelog.ts
@@ -45,6 +45,7 @@ export const useChangelog = () =>
   useQuery({
     queryKey: ['changelog'],
     queryFn: async () => {
+      // eslint-disable-next-line no-restricted-syntax -- external ghost.org changelog feed, not the Admin API
       const response = await fetch('https://ghost.org/changelog.json');
 
       if (!response.ok) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@internal/cfg-eslint':
+        specifier: workspace:*
+        version: link:../../configs/eslint
       '@internal/cfg-eslint-react':
         specifier: workspace:*
         version: link:../../configs/eslint-react


### PR DESCRIPTION
The recent cleanup established several invariants by hand; this makes them self-enforcing. Every rule was proven to fire (deliberate violation → error → revert), and product code carries **zero** eslint-disables except four documented ones:

- **`react-router` imports banned in `apps/admin` src** — the framework's re-exports are the path (its surface gained `NavigationType`/`BlockerFunction` and the last two files converted as pre-fixes). Test files are excluded: 8 specs legitimately use router scaffolding the framework shouldn't re-export (`MemoryRouter`, `Routes`, …).
- **Bridge containment** — `window.EmberBridge` access (plain, optional-chained, and computed forms) and deep `ember-bridge/ember-bridge` imports are banned outside `src/ember-bridge`. The deep-import ban applies to tests too; the syntax ban excludes tests (two gate specs stub the global).
- **Bare `fetch` banned in admin src** — the framework layer owns Admin API requests. Four inline disables mark the sanctioned externals (Ghost Explore testimonials, ghost.org changelog, the two front-end preview POSTs) and double as their documentation; `reportUnusedDisableDirectives: 'error'` keeps each one honest. The "ban `apiRoot` composition instead" alternative was rejected as both leaky and false-positive-prone.
- **`clsx` and direct `lucide-react` imports → warn-tier** (via `@typescript-eslint/no-restricted-imports`, so the error-tier entries aren't clobbered). CI runs eslint without `--max-warnings`, so the existing 41 usages stay green while new ones get flagged in editors and PR annotations.
- **dependency-cruiser**: `admin-is-app` (framework/shade/activitypub may not depend on `@tryghost/admin`; anchored so `admin-x-framework` can't self-match) and `admin-shared-no-domains` (`src/shared/` may not import domain folders — covers both `@/` and relative import shapes). `.lintstagedrc` now depcruises staged admin files (~1s marginal, exercised by this commit's own pre-commit run).

**Verification:** admin `eslint .` exit 0 (41 advisory warnings), `tsc -b`, `test:unit` 1643/1643; framework build/lint/unit green; `pnpm lint:boundaries` clean (5,146 modules); per-rule proof-of-firing documented in the commit.