### PR TITLE
Added a namespace to member custom fields

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -4,12 +4,13 @@ import {
   type FieldType,
   type PartsOf,
 } from '@tryghost/custom-field-types';
-import { csvColumnsForField } from '@tryghost/custom-field-types/csv';
+import { PUBLISHER_NAMESPACE, csvColumnsForField } from '@tryghost/custom-field-types/csv';
 import { Meta, createMutation, createQuery } from '../utils/api/hooks';
 
-// Re-exported so the import mapping can recognise a custom_fields.* column (same reason
-// as the re-exports below).
-export { isCustomFieldColumn } from '@tryghost/custom-field-types/csv';
+// Re-exported so the import mapping can recognise a field column (same reason as the
+// re-exports below). Takes the namespaces, because which ones exist is a fact about the
+// site rather than something stated here.
+export { isAnyFieldColumn, isFieldColumn } from '@tryghost/custom-field-types/csv';
 
 // Re-exported so admin apps can type address values and validate against the
 // same schemas the server enforces, without a direct dependency on the shared
@@ -140,11 +141,15 @@ export type MemberCustomFieldCsvColumn = {
  * round-tripping column rather than one hand-kept in sync.
  */
 export const memberCustomFieldCsvColumns = (
-  fields: MemberCustomField[],
+  fields: Array<MemberCustomField & { namespace?: string }>,
 ): MemberCustomFieldCsvColumn[] => {
   return fields.flatMap((field) => {
     const labels = partLabelsFor(field.type);
-    return csvColumnsForField({ key: field.key, type: field.type }).map(({ column, subField }) => {
+    // A field from the publisher's own endpoint carries no namespace, because there
+    // every field is theirs; one from the cross-namespace read says which declared it.
+    const namespace = field.namespace ?? PUBLISHER_NAMESPACE;
+    return csvColumnsForField({ namespace, key: field.key, type: field.type }).map(
+      ({ column, subField }) => {
       const partLabel = subField === null ? undefined : labels[subField];
       return {
         value: column,
@@ -377,3 +382,35 @@ export const useDeleteMemberCustomField = createMutation<void, string>({
   path: (key) => `/members/custom_fields/${key}/`,
   invalidateQueries: { dataType },
 });
+
+/**
+ * A member field as every surface that offers one sees it: the namespace that declared it
+ * as well as its key, because a key identifies a field only inside its namespace.
+ */
+export interface MemberField extends MemberCustomField {
+  namespace: string;
+}
+
+export interface MemberFieldsResponseType {
+  meta?: Meta;
+  members_fields: MemberField[];
+}
+
+/**
+ * Every declared field, whichever namespace declared it.
+ *
+ * What a picker reads to offer a field to filter on, map an import onto, or show as a
+ * column. Managing one is `useBrowseMemberCustomFields`, which is the publisher's own
+ * namespace and nothing else: a field Ghost declared is offered here and never offered to
+ * rename.
+ */
+export const useBrowseMemberFields = createQuery<MemberFieldsResponseType>({
+  dataType: 'MemberFieldsResponseType',
+  path: '/members/fields/',
+});
+
+// A filter picker keeps offering a field somebody already filtered on, so it asks for
+// archived fields too rather than dropping a saved filter's field out of the list.
+export const useBrowseMemberFieldsIncludingArchived = (
+  options?: Parameters<typeof useBrowseMemberFields>[0],
+) => useBrowseMemberFields({ ...options, searchParams: { filter: 'status:[active,archived]' } });

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -54,6 +54,56 @@ const field = (overrides: Partial<MemberCustomField>): MemberCustomField => ({
 });
 
 describe('member custom fields api helpers', () => {
+  // A column can be mapped onto any field a member has, whichever namespace declared it,
+  // so the targets an import offers are addressed the same way a filter is.
+  describe('memberCustomFieldCsvColumns across namespaces', () => {
+    it('names a target by the namespace that declared the field', () => {
+      expect(
+        memberCustomFieldCsvColumns([
+          { ...field({ key: 'address', name: 'Address' }), namespace: 'shipping' },
+        ]),
+      ).toEqual([
+        {
+          value: 'shipping.address',
+          fieldName: 'Address',
+          label: 'Address',
+          type: 'short_text',
+        },
+      ]);
+    });
+
+    // The part is what an import maps onto, so a composite Ghost declared has to offer
+    // one target per part exactly as the publisher's own composites do.
+    it('offers a target per part of a composite in another namespace', () => {
+      const targets = memberCustomFieldCsvColumns([
+        { ...field({ key: 'address', name: 'Delivery address', type: 'address' }), namespace: 'shipping' },
+      ]);
+
+      expect(targets.map((target) => target.value)).toEqual([
+        'shipping.address.line1',
+        'shipping.address.line2',
+        'shipping.address.city',
+        'shipping.address.state',
+        'shipping.address.postal_code',
+        'shipping.address.country',
+      ]);
+      expect(targets[0].label).toBe('Delivery address (Address line 1)');
+    });
+
+    // The same key in two namespaces is two fields, so an import can address either.
+    it('keeps a key held in two namespaces as two targets', () => {
+      const targets = memberCustomFieldCsvColumns([
+        field({ key: 'address', name: 'Theirs' }),
+        { ...field({ key: 'address', name: 'Ours' }), namespace: 'shipping' },
+      ]);
+
+      expect(targets.map((target) => target.value)).toEqual([
+        'custom_fields.address',
+        'shipping.address',
+      ]);
+    });
+  });
+
   describe('memberCustomFieldCsvColumns', () => {
     it('gives a scalar field one target labelled by its name', () => {
       expect(memberCustomFieldCsvColumns([field({ key: 'nickname', name: 'Nickname' })])).toEqual([

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -52,7 +52,7 @@ import {
 } from '@tryghost/admin-x-framework/api/members';
 import {
   memberCustomFieldCsvColumns,
-  useBrowseMemberCustomFields,
+  useBrowseMemberFields,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import { parseCSV } from '@/members/components/bulk-action-modals/import-members/csv';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react';
@@ -80,12 +80,14 @@ export function ImportMembersModal({
   // Defined custom fields become mapping targets. Browse returns active fields only, which
   // are the ones the importer writes to. No flag check anywhere in this file: the gate does
   // not render it unless membersCustomFields is on.
-  const { data: customFieldsData, isError: customFieldsFailed } = useBrowseMemberCustomFields();
+  // Every declared field, whichever namespace declared it: a column can be mapped onto
+  // any field a member has, and only managing one is the publisher's own business.
+  const { data: customFieldsData, isError: customFieldsFailed } = useBrowseMemberFields();
   // A field created from the mapping step is in here the moment it is created: the create
   // mutation puts it into the cached list, so there is no window where a row points at a
   // column the picker cannot name yet.
   const customFieldColumns = useMemo(
-    () => memberCustomFieldCsvColumns(customFieldsData?.members_custom_fields ?? []),
+    () => memberCustomFieldCsvColumns(customFieldsData?.members_fields ?? []),
     [customFieldsData],
   );
   // The file-reader effect waits for this before its first parse: the custom field

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.ts
@@ -2,7 +2,7 @@ import {
   FIELD_MAPPINGS,
   IMPORT_TIER_FIELD_MAPPING,
 } from '@/members/components/bulk-action-modals/import-members/mapping';
-import { isCustomFieldColumn } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import { isFieldColumn } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 /**
  * What this modal adds to the shipped mapping vocabulary, and nothing it already says.
@@ -45,7 +45,9 @@ export function suggestedFieldName(column: string): string {
   // being suggested is the field's, so the part is dropped: `custom_fields.home-address.city`
   // names a field called "Home address" whose City part this column holds, and the part is
   // asked for separately. A bare `custom_fields` column has no key, so it suggests the namespace itself.
-  const segments = isCustomFieldColumn(column) ? column.split('.').slice(1, 2) : [column];
+  const segments = isFieldColumn(column, 'custom_fields')
+    ? column.split('.').slice(1, 2)
+    : [column];
   const words = (segments[0] ?? column).replace(/[._-]+/g, ' ').trim();
   return words.charAt(0).toUpperCase() + words.slice(1);
 }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -1,5 +1,5 @@
+import { isFieldColumn } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {
-  isCustomFieldColumn,
   type MemberCustomFieldCsvColumn,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
@@ -196,11 +196,21 @@ export function detectFieldTypes(
   // Match column headers against supported types using all headers from the
   // original data. sampleData only keeps keys with non-empty values, so
   // entirely-empty columns (e.g. an empty "note" column) would be missed if
-  // we only checked sampled entries. A custom field column auto-maps to itself here;
-  // isCustomFieldColumn holds it apart from the fuzzy core-field heuristics below.
+  // we only checked sampled entries. A field column auto-maps to itself here, and is
+  // held apart from the fuzzy core-field heuristics below by being one of the offered
+  // targets rather than by the shape of its name — a namespace Ghost declares can hold
+  // a field called `name`, and guessing from the name alone would map it to the
+  // member's.
+  const fieldColumns = new Set((options.customFieldColumns ?? []).map((column) => column.value));
+  // The publisher's namespace is recognised by shape, since that one is always the same;
+  // any other is recognised by being offered as a target, which is the only thing that
+  // says it exists.
+  const isFieldColumnKey = (key: string) =>
+    fieldColumns.has(key) || isFieldColumn(key, 'custom_fields');
+
   if (data.length > 0) {
     for (const key of columnsOf(data)) {
-      if (!mapping.name && /name/i.test(key) && !isCustomFieldColumn(key)) {
+      if (!mapping.name && /name/i.test(key) && !isFieldColumnKey(key)) {
         mapping.name = key;
         continue;
       }
@@ -220,7 +230,7 @@ export function detectFieldTypes(
 
     const entry = sampledData[i];
     for (const [key, value] of Object.entries(entry)) {
-      if (!mapping.email && value && EMAIL_REGEX.test(value) && !isCustomFieldColumn(key)) {
+      if (!mapping.email && value && EMAIL_REGEX.test(value) && !isFieldColumnKey(key)) {
         mapping.email = key;
       }
     }

--- a/apps/admin/src/members/components/members-filters.tsx
+++ b/apps/admin/src/members/components/members-filters.tsx
@@ -9,17 +9,17 @@ import {
   toOfferFilterDisplayValues,
   useMemberFilterFields,
 } from '@/members/use-member-filter-fields';
-import { CUSTOM_FIELDS_PREFIX } from '@/members/member-fields';
+import { fieldFilterKey } from '@/members/member-fields';
 import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
 import { getSiteTimezone } from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import { useBrowseNewsletters } from '@tryghost/admin-x-framework/api/newsletters';
 import { useBrowseOffers } from '@tryghost/admin-x-framework/api/offers';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import {
-  useBrowseMemberCustomFields,
-  useBrowseMemberCustomFieldsIncludingArchived,
+  useBrowseMemberFields,
+  useBrowseMemberFieldsIncludingArchived,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
-import type { MemberCustomField } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type { MemberField } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {
   useEmailPostValueSource,
   useLabelValueSource,
@@ -39,7 +39,7 @@ interface MembersFiltersProps {
 }
 
 const EMPTY_OFFERS: typeof buildOfferOptions extends (offers: infer T) => unknown ? T : never = [];
-const EMPTY_CUSTOM_FIELDS: MemberCustomField[] = [];
+const EMPTY_CUSTOM_FIELDS: MemberField[] = [];
 
 function mapOfferRedemptionFilters(filters: Filter[], mapValues: (values: string[]) => string[]) {
   return filters.map((filter) => {
@@ -116,31 +116,33 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
   const labelValueSource = useLabelValueSource();
   const { valueSource: tierValueSource, hasMultipleTiers } = useTierValueSource();
   const customFieldsEnabled = useFeatureFlag('membersCustomFields');
-  // The picker lists active fields — the endpoint the members page has always used.
-  const { data: customFieldsData } = useBrowseMemberCustomFields({ enabled: customFieldsEnabled });
-  const customFields = customFieldsData?.members_custom_fields ?? EMPTY_CUSTOM_FIELDS;
+  // The picker lists every declared field, whichever namespace declared it: offering a
+  // field to filter on is not the same as managing it, and only the publisher's own are
+  // manageable. A field carries the namespace that declared it, so the picker can group
+  // them and address each one by both.
+  const { data: customFieldsData } = useBrowseMemberFields({ enabled: customFieldsEnabled });
+  const customFields = customFieldsData?.members_fields ?? EMPTY_CUSTOM_FIELDS;
+  // Addressed the same way the dropdown keys them, so a filter is matched to its field
+  // without assuming which namespace it came from.
   const referencedCustomFieldKeys = useMemo(
-    () =>
-      new Set(
-        filters
-          .map((filter) => filter.field)
-          .filter((field) => field.startsWith(CUSTOM_FIELDS_PREFIX))
-          .map((field) => field.slice(CUSTOM_FIELDS_PREFIX.length))
-          .filter(Boolean),
-      ),
+    () => new Set(filters.map((filter) => filter.field).filter(Boolean)),
     [filters],
   );
   // Only when the current filter references a custom field do we also pull the archived
   // ones, so a saved segment on a since-archived field still renders its read-only pill.
   // Skipped otherwise, so the common members view makes no extra request.
-  const { data: archivedCustomFieldsData } = useBrowseMemberCustomFieldsIncludingArchived({
+  const { data: archivedCustomFieldsData } = useBrowseMemberFieldsIncludingArchived({
     enabled: customFieldsEnabled && referencedCustomFieldKeys.size > 0,
   });
   const archivedCustomFields = useMemo(
     () =>
-      (archivedCustomFieldsData?.members_custom_fields ?? EMPTY_CUSTOM_FIELDS)
-        .filter((field) => field.status === 'archived' && referencedCustomFieldKeys.has(field.key))
-        .map((field) => ({ key: field.key, name: field.name })),
+      (archivedCustomFieldsData?.members_fields ?? EMPTY_CUSTOM_FIELDS)
+        .filter(
+          (field) =>
+            field.status === 'archived' &&
+            referencedCustomFieldKeys.has(fieldFilterKey(field.namespace, field.key)),
+        )
+        .map((field) => ({ namespace: field.namespace, key: field.key, name: field.name })),
     [archivedCustomFieldsData, referencedCustomFieldKeys],
   );
 

--- a/apps/admin/src/members/custom-field-filter-renderer.tsx
+++ b/apps/admin/src/members/custom-field-filter-renderer.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import {
-  CUSTOM_FIELDS_PREFIX,
   CUSTOM_FIELD_OPERATORS,
   CUSTOM_FIELD_SET_OPERATORS,
 } from './member-fields';
@@ -8,7 +7,7 @@ import { FilterSegmentInput, FilterSegmentSelect } from '@tryghost/shade/pattern
 import { createOperatorOptions } from '@/shared/filters';
 import {
   memberCustomFieldParts,
-  useBrowseMemberCustomFieldsIncludingArchived,
+  useBrowseMemberFieldsIncludingArchived,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type { CustomRendererProps } from '@tryghost/shade/patterns';
 
@@ -28,12 +27,18 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({
   readOnly,
 }) => {
   // Include-archived so an archived composite field's pill can still resolve its parts
-  // and show which one the saved segment filters on.
-  const { data } = useBrowseMemberCustomFieldsIncludingArchived();
-  const definitions = data?.members_custom_fields ?? [];
+  // and show which one the saved segment filters on. Every namespace, because the pill
+  // is for whichever field the filter names.
+  const { data } = useBrowseMemberFieldsIncludingArchived();
+  const definitions = data?.members_fields ?? [];
 
-  const fieldKey = (field.key ?? '').slice(CUSTOM_FIELDS_PREFIX.length);
-  const definition = definitions.find((candidate) => candidate.key === fieldKey);
+  // The dropdown key is `<namespace>.<key>`, so the field is found by both: a key names
+  // a different field in each namespace.
+  const [namespace, ...rest] = (field.key ?? '').split('.');
+  const fieldKey = rest.join('.');
+  const definition = definitions.find(
+    (candidate) => candidate.key === fieldKey && candidate.namespace === namespace,
+  );
   // The shared catalog decides which parts a type has and what they are called; a scalar
   // field has none. Its keys are the ones the predicate carries.
   const parts = definition

--- a/apps/admin/src/members/member-fields.test.ts
+++ b/apps/admin/src/members/member-fields.test.ts
@@ -43,7 +43,7 @@ describe('memberFields', () => {
       'newsletter_feedback',
       'offer_redemptions',
       'count.active_stripe_customers',
-      'custom_fields.:key',
+      ':namespace.:key',
     ]);
   });
 

--- a/apps/admin/src/members/member-fields.ts
+++ b/apps/admin/src/members/member-fields.ts
@@ -177,6 +177,18 @@ export const CUSTOM_FIELD_OPERATORS: readonly string[] = [
  */
 export const CUSTOM_FIELDS_PREFIX = 'custom_fields.';
 
+/** A field's dropdown key: the namespace that declared it, then its own key. */
+export const fieldFilterKey = (namespace: string, key: string) => `${namespace}.${key}`;
+
+/**
+ * Whether a filter key names a member field, given the namespaces that declared one.
+ *
+ * Which namespaces exist is a fact about the site, so the caller passes them rather than
+ * this assuming the publisher's.
+ */
+export const isFieldFilterKey = (key: string, namespaces: readonly string[]) =>
+  namespaces.some((namespace) => key.startsWith(`${namespace}.`));
+
 // NQL operator symbol for each value operator. The field is named in the value
 // position (`custom_fields.key:'…'`) so its key can carry hyphens; the value is
 // matched on `custom_fields.value` (scalar) or `custom_fields.value.<subfield>`
@@ -202,26 +214,27 @@ const customFieldsCodec: FilterCodec = {
   // with subfield '' for a scalar field or the "Any" (whole-field set/unset) case.
   serialize(predicate, ctx) {
     const fieldKey = ctx.params.key;
+    const namespace = ctx.params.namespace;
     const [subfield, value] = predicate.values as [string, string];
 
-    if (!fieldKey) {
+    if (!fieldKey || !namespace) {
       return null;
     }
 
-    const keyClause = `custom_fields.key:${escapeNqlString(fieldKey)}`;
+    const keyClause = `${namespace}.key:${escapeNqlString(fieldKey)}`;
 
     // set / not-set target a part's presence when a part is chosen (`path`), or the
     // whole field otherwise (the bare key / its negation).
     if (predicate.operator === 'is-set') {
       return subfield
-        ? [`(${keyClause}+custom_fields.path:${escapeNqlString(subfield)})`]
+        ? [`(${keyClause}+${namespace}.path:${escapeNqlString(subfield)})`]
         : [keyClause];
     }
 
     if (predicate.operator === 'is-not-set') {
       return subfield
-        ? [`(${keyClause}+custom_fields.path:-${escapeNqlString(subfield)})`]
-        : [`custom_fields.key:-${escapeNqlString(fieldKey)}`];
+        ? [`(${keyClause}+${namespace}.path:-${escapeNqlString(subfield)})`]
+        : [`${namespace}.key:-${escapeNqlString(fieldKey)}`];
     }
 
     const symbol = CUSTOM_FIELD_VALUE_SYMBOLS[predicate.operator];
@@ -230,7 +243,7 @@ const customFieldsCodec: FilterCodec = {
       return null;
     }
 
-    const valueKey = subfield ? `custom_fields.value.${subfield}` : 'custom_fields.value';
+    const valueKey = subfield ? `${namespace}.value.${subfield}` : `${namespace}.value`;
 
     return [`(${keyClause}+${valueKey}:${symbol}${escapeNqlString(String(value))})`];
   },
@@ -557,10 +570,12 @@ const baseMemberFields = defineFields({
     ],
     codec: multipleActiveSubscriptionsCodec,
   },
-  // Each defined custom field is its own filter, named directly in the dropdown
-  // (`custom_fields.<key>`), so this template supplies the shared operators and codec;
-  // use-member-filter-fields builds one entry per field from the definitions.
-  'custom_fields.:key': {
+  // Each defined field is its own filter, named directly in the dropdown by the
+  // namespace that declared it and its key (`custom_fields.<key>`, `shipping.<key>`), so
+  // this template supplies the shared operators and codec; use-member-filter-fields
+  // builds one entry per field. Last, so a pattern naming its segments outright — a
+  // newsletter's slug — is matched before this general one.
+  ':namespace.:key': {
     operators: CUSTOM_FIELD_OPERATORS,
     ui: {
       label: 'Custom field',
@@ -573,7 +588,7 @@ const baseMemberFields = defineFields({
       // it is shown whatever the operator, the way Label is. No name resolved means
       // no such field for this site (or the flag is off), so no column either.
       activeColumn: ({ params, label }) =>
-        label ? { key: `${CUSTOM_FIELDS_PREFIX}${params.key}`, label } : null,
+        label ? { key: fieldFilterKey(params.namespace, params.key), label } : null,
       // Asked for as soon as a custom field is filtered on, without waiting for the
       // names: the values are what the column will hold, and they travel on the same
       // request the filter already sends. The API takes this include whether or not

--- a/apps/admin/src/members/member-query-params.ts
+++ b/apps/admin/src/members/member-query-params.ts
@@ -10,7 +10,10 @@ const MAX_ACTIVE_COLUMNS = 2;
 export type { ActiveColumn };
 
 /** All a column needs of a custom field: the name to head it with, and the type to read its value as. */
-export type MemberColumnCustomField = Pick<MemberCustomField, 'key' | 'name' | 'type'>;
+export type MemberColumnCustomField = Pick<MemberCustomField, 'key' | 'name' | 'type'> & {
+  /** Absent from the publisher's own endpoint, where every field is theirs. */
+  namespace?: string;
+};
 
 /**
  * Runtime data the static field schema cannot hold. Custom fields are defined by the
@@ -230,8 +233,12 @@ const patternColumnHydrators: Record<
     ) => { label: string; getValue: ColumnValueReader } | null)
   | undefined
 > = {
-  'custom_fields.:key': ({ key }, { customFields }) => {
-    const field = customFields?.find((candidate) => candidate.key === key);
+  // Matched on both segments, because a key identifies a field only inside the namespace
+  // that declared it, and a member carries each namespace's values under its own name.
+  ':namespace.:key': ({ namespace, key }, { customFields }) => {
+    const field = customFields?.find(
+      (candidate) => candidate.key === key && (candidate.namespace ?? 'custom_fields') === namespace,
+    );
 
     if (!field) {
       return null;
@@ -242,7 +249,10 @@ const patternColumnHydrators: Record<
       // The catalog turns whatever type the field is into one line, so this reads a
       // composite the same way the member detail screen does.
       getValue: (member) => {
-        const text = formatMemberCustomFieldValue(field.type, member.custom_fields?.[field.key]);
+        const values = (member as Record<string, unknown>)[namespace] as
+          | Record<string, unknown>
+          | undefined;
+        const text = formatMemberCustomFieldValue(field.type, values?.[field.key]);
         return text ? { text } : null;
       },
     };

--- a/apps/admin/src/members/use-member-filter-fields.test.ts
+++ b/apps/admin/src/members/use-member-filter-fields.test.ts
@@ -263,8 +263,8 @@ describe('useMemberFilterFields', () => {
       useMemberFilterFields({
         customFieldsEnabled: true,
         customFields: [
-          { key: 'shipping_address', name: 'Shipping address', type: 'address' },
-          { key: 'job_title', name: 'Job title', type: 'short_text' },
+          { namespace: 'custom_fields', key: 'shipping_address', name: 'Shipping address', type: 'address' },
+          { namespace: 'custom_fields', key: 'job_title', name: 'Job title', type: 'short_text' },
         ],
         siteTimezone: 'UTC',
       }),
@@ -295,7 +295,7 @@ describe('useMemberFilterFields', () => {
     const { result } = renderHook(() =>
       useMemberFilterFields({
         customFieldsEnabled: false,
-        customFields: [{ key: 'job_title', name: 'Job title', type: 'short_text' }],
+        customFields: [{ namespace: 'custom_fields', key: 'job_title', name: 'Job title', type: 'short_text' }],
         siteTimezone: 'UTC',
       }),
     );

--- a/apps/admin/src/members/use-member-filter-fields.ts
+++ b/apps/admin/src/members/use-member-filter-fields.ts
@@ -18,7 +18,7 @@ import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
 import { LabelFilterRenderer } from '@/members/label-picker';
 import { LucideIcon } from '@tryghost/shade/utils';
 import { MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD } from './multiple-active-subscriptions';
-import { CUSTOM_FIELDS_PREFIX, getMemberFields } from './member-fields';
+import { fieldFilterKey, getMemberFields, isFieldFilterKey } from './member-fields';
 import type { MemberCustomField } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type { Offer } from '@tryghost/admin-x-framework/api/offers';
 
@@ -38,11 +38,16 @@ interface UseMemberFilterFieldsOptions {
   emailTrackOpens?: boolean;
   emailTrackClicks?: boolean;
   customFieldsEnabled?: boolean;
-  customFields?: Array<{ key: string; name: string; type: MemberCustomField['type'] }>;
+  customFields?: Array<{
+    namespace: string;
+    key: string;
+    name: string;
+    type: MemberCustomField['type'];
+  }>;
   // Archived fields still referenced by the current filter. Rendered as disabled,
   // removable-only pills so a saved segment stays visible and undoable even though
   // the field is no longer offered in the picker.
-  archivedCustomFields?: Array<{ key: string; name: string }>;
+  archivedCustomFields?: Array<{ namespace: string; key: string; name: string }>;
   siteTimezone?: string;
 }
 
@@ -269,6 +274,19 @@ function renderOfferFilterValues(
   return 'Select...';
 }
 
+const NAMESPACE_GROUP_LABELS: Record<string, string> = {
+  custom_fields: 'Custom fields',
+};
+
+function groupLabelFor(namespace: string): string {
+  const known = NAMESPACE_GROUP_LABELS[namespace];
+  if (known) {
+    return known;
+  }
+  const words = namespace.replace(/_/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
 export function useMemberFilterFields({
   labelValueSource,
   tierValueSource,
@@ -291,6 +309,12 @@ export function useMemberFilterFields({
 }: UseMemberFilterFieldsOptions): FilterFieldGroup[] {
   return useMemo(() => {
     const fields = getMemberFields();
+    // The namespaces this site has fields in, taken from the fields themselves. A key
+    // identifies a field only inside one, so resolving a dropdown key needs to know
+    // which prefixes are namespaces rather than assuming the publisher's.
+    const fieldNamespaces = [
+      ...new Set([...customFields, ...archivedCustomFields].map((field) => field.namespace)),
+    ];
     type MemberFieldKey = keyof typeof fields;
 
     function createFieldConfig(
@@ -301,8 +325,8 @@ export function useMemberFilterFields({
       let field;
       if (key.startsWith('newsletters.')) {
         field = fields['newsletters.:slug'];
-      } else if (key.startsWith(CUSTOM_FIELDS_PREFIX)) {
-        field = fields['custom_fields.:key'];
+      } else if (isFieldFilterKey(key, fieldNamespaces)) {
+        field = fields[':namespace.:key'];
       } else {
         field = fields[key as MemberFieldKey];
       }
@@ -391,13 +415,13 @@ export function useMemberFilterFields({
 
     groups.push({ group: 'Basic', fields: basicFields });
 
-    // Each defined custom field is its own named entry, so a publisher can search
-    // for "Shipping address" directly rather than reaching it through a generic
+    // Each defined field is its own named entry, so a publisher can search for
+    // "Shipping address" directly rather than reaching it through a generic
     // "Custom field" door. A simple field filters on its value; a composite field's
     // renderer opens its parts (plus "Any") in the pill.
     if (customFieldsEnabled) {
       const customFieldFields = customFields.map((field) =>
-        createFieldConfig(`custom_fields.${field.key}`, {
+        createFieldConfig(fieldFilterKey(field.namespace, field.key), {
           label: field.name,
           // The dropdown entry and the added filter show the field type's own icon
           // rather than a generic custom-field mark.
@@ -421,7 +445,7 @@ export function useMemberFilterFields({
       // so the picker's own de-dup keeps it out of the add-list — it only ever
       // renders as an existing pill.
       const archivedFieldFields = archivedCustomFields.map((field) =>
-        createFieldConfig(`custom_fields.${field.key}`, {
+        createFieldConfig(fieldFilterKey(field.namespace, field.key), {
           label: field.name,
           icon: React.createElement(LucideIcon.Archive, { className: 'size-4' }),
           // Read-only: the operator and value stay visible so the segment reads
@@ -437,16 +461,27 @@ export function useMemberFilterFields({
         }),
       );
 
-      const allCustomFieldFields = [...customFieldFields, ...archivedFieldFields];
+      // A group per namespace that declared a field, in the order the fields came
+      // back, so the publisher's own sit under "Custom fields" as they always have and
+      // a namespace Ghost declared reads under its own name. Which namespaces exist is
+      // a fact about the site, so nothing here lists them.
+      const byNamespace = new Map<string, FilterFieldConfig[]>();
+      for (const [index, field] of [...customFields, ...archivedCustomFields].entries()) {
+        const forNamespace = byNamespace.get(field.namespace) ?? [];
+        forNamespace.push([...customFieldFields, ...archivedFieldFields][index]);
+        byNamespace.set(field.namespace, forNamespace);
+      }
 
-      // Nothing defined yet means nothing to filter on, so the group stays out of
-      // the picker entirely rather than showing a section that can't be used.
-      if (allCustomFieldFields.length > 0) {
-        groups.push({
-          group: 'Custom fields',
-          fields: allCustomFieldFields,
-          previewLimit: CUSTOM_FIELDS_PREVIEW_LIMIT,
-        });
+      // Nothing defined yet means nothing to filter on, so a group stays out of the
+      // picker entirely rather than showing a section that can't be used.
+      for (const [namespace, fieldsInNamespace] of byNamespace) {
+        if (fieldsInNamespace.length > 0) {
+          groups.push({
+            group: groupLabelFor(namespace),
+            fields: fieldsInNamespace,
+            previewLimit: CUSTOM_FIELDS_PREVIEW_LIMIT,
+          });
+        }
       }
     }
 

--- a/e2e/helpers/environment/service-managers/mysql-manager.ts
+++ b/e2e/helpers/environment/service-managers/mysql-manager.ts
@@ -236,6 +236,41 @@ export class MySQLManager {
     debug('Stripe settings updated in database');
   }
 
+  /**
+   * Declare a member field in a namespace, by writing the row a feature that owns one
+   * would write.
+   *
+   * There is deliberately no API for this: a field outside the publisher's namespace is
+   * declared by whatever owns it, and the publisher's own endpoint refuses to touch it.
+   * Until something provisions one, a test that needs a namespace to exist states it the
+   * only way anything does — as a row.
+   */
+  async declareMemberField(
+    database: string,
+    field: { namespace: string; key: string; name: string; type?: string },
+  ): Promise<string> {
+    const id = Math.random().toString(16).slice(2).padEnd(24, '0').slice(0, 24);
+    const type = field.type ?? 'short_text';
+    const values = [
+      `'${id}'`,
+      `'${field.namespace}'`,
+      `'${field.key}'`,
+      `'${field.name}'`,
+      `'${type}'`,
+      `'active'`,
+      '0',
+      'NOW()',
+    ].join(', ');
+
+    await this.exec(
+      `mysql -uroot -proot -e "INSERT INTO \\\`${database}\\\`.members_custom_fields ` +
+        `(id, namespace, \\\`key\\\`, name, type, status, sort_order, created_at) ` +
+        `VALUES (${values});"`,
+    );
+
+    return id;
+  }
+
   private async exec(command: string) {
     const container = this.docker.getContainer(this.containerName);
     return await this.execInContainer(container, command);

--- a/e2e/tests/admin/members/namespaced-field-round-trip.test.ts
+++ b/e2e/tests/admin/members/namespaced-field-round-trip.test.ts
@@ -1,0 +1,110 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFileSync } from 'node:fs';
+
+import { MembersImportModal, MembersListPage } from '@/admin-pages';
+import { createMemberFactory } from '@/data-factory';
+import { MySQLManager } from '@/helpers/environment/service-managers/mysql-manager';
+import { expect, test } from '@/helpers/playwright';
+import { usePerTestIsolation } from '@/helpers/playwright/isolation';
+
+/**
+ * A field Ghost declared, rather than one the publisher defined, across the surfaces that
+ * offer a field: the import mapping targets and the members filter.
+ *
+ * The field is written as a row because that is the only way one exists — there is no API
+ * to declare a field outside the publisher's namespace, and the publisher's own endpoint
+ * refuses to touch it. Everything after that is the real UI.
+ *
+ * What this pins is that neither surface knows the publisher's namespace is special. A
+ * namespace is addressed the same way everywhere — `shipping.address` is the CSV column,
+ * the filter and the API property alike — so a namespace nothing in the front end has
+ * heard of works as soon as a field is declared in it.
+ */
+usePerTestIsolation();
+
+const SHIPPING = 'shipping';
+
+test.describe('Ghost Admin - A field in another namespace', () => {
+  test.use({ labs: { membersCustomFields: true, memberDetailsReact: true } });
+
+  test('is offered as an import target, imported into, and filtered on', async ({
+    page,
+    ghostInstance,
+  }) => {
+    // Several surfaces in one journey: an import, a search, and a filter.
+    test.slow();
+
+    const ts = Date.now();
+    const email = `ns-${ts}@ghost.org`;
+    const name = `Namespaced ${ts}`;
+
+    // Declared the way whatever owns a namespace declares one: as a row. A composite, so
+    // the import has to offer a target per part rather than one for the whole field.
+    const mysql = new MySQLManager();
+    await mysql.declareMemberField(ghostInstance.database, {
+      namespace: SHIPPING,
+      key: 'address',
+      name: 'Delivery address',
+      type: 'address',
+    });
+
+    // Import lives in the Actions menu, which only exists once the list has a member;
+    // on an empty list it is the empty-state link instead. This member is scenery.
+    await createMemberFactory(page.request).create({
+      name: `Existing ${ts}`,
+      email: `ns-existing-${ts}@ghost.org`,
+    });
+
+    const membersPage = new MembersListPage(page);
+    const importModal = new MembersImportModal(page);
+
+    const csv = [
+      'email,name,shipping.address.line1,shipping.address.city',
+      `${email},${name},1 High Street,London`,
+    ].join('\n');
+    const csvPath = join(tmpdir(), `members-ns-${ts}.csv`);
+    writeFileSync(csvPath, csv);
+
+    await membersPage.goto();
+    await membersPage.openImport();
+    await importModal.fileInput.setInputFiles(csvPath);
+    await expect(importModal.importButton).toBeVisible();
+
+    // The part is what a column maps onto, so a composite Ghost declared has to offer its
+    // parts by name exactly as a publisher composite does.
+    await expect(importModal.getMappingValue('shipping.address.line1')).toContainText(
+      'Delivery address',
+    );
+    await expect(importModal.getMappingValue('shipping.address.city')).toContainText(
+      'Delivery address',
+    );
+
+    await importModal.importButton.click();
+    await expect(importModal.importHeading).toBeVisible({ timeout: 15000 });
+    await importModal.closeButton.click();
+
+    await membersPage.goto();
+    await membersPage.searchInput.fill(email);
+    await expect(membersPage.getMemberByName(name)).toBeVisible({ timeout: 30000 });
+
+    // The picker offers the field by name, and filtering on a part of it matches the
+    // member the import created — the same journey a publisher field takes.
+    await membersPage.goto();
+    await membersPage.addCustomFieldFilter({
+      field: 'Delivery address',
+      subfield: 'City',
+      // A composite defaults to whole-field "is set", which takes no value, so the
+      // operator is named to get a value to match on.
+      operator: 'is',
+      value: 'London',
+    });
+
+    await expect(membersPage.getMemberByName(name)).toBeVisible({ timeout: 30000 });
+    await expect(membersPage.getMemberByName(`Existing ${ts}`)).toHaveCount(0);
+
+    // Matching on the part is the value having survived the whole way: mapped from a
+    // column the import offered, stored under the namespace that declared the field, and
+    // found again by naming that namespace and key.
+  });
+});

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -116,6 +116,10 @@ module.exports = {
     return apiFramework.pipeline(require('./member-custom-fields'), localUtils);
   },
 
+  get membersFields() {
+    return apiFramework.pipeline(require('./member-fields'), localUtils);
+  },
+
   get memberCommenting() {
     return apiFramework.pipeline(require('./member-commenting'), localUtils);
   },

--- a/ghost/core/core/server/api/endpoints/member-fields.ts
+++ b/ghost/core/core/server/api/endpoints/member-fields.ts
@@ -1,0 +1,51 @@
+import { definitions } from '../../services/members-custom-fields';
+
+const permissionsService = require('../../services/permissions');
+
+interface Frame {
+  options: { context: unknown; [key: string]: unknown };
+}
+
+/**
+ * Every member field that has been declared, whichever namespace declared it.
+ *
+ * Separate from `members_custom_fields` because knowing a field exists and being allowed
+ * to manage it are different things. This is what a surface reads to offer a field: the
+ * filter picker, the import mapping targets, a column. The publisher's own endpoint stays
+ * the one that renames, archives and deletes, and it only ever sees their namespace — a
+ * field Ghost declared appearing in a list it cannot be managed from would be worse than
+ * not appearing at all.
+ *
+ * Read-only, and deliberately so. A field outside the publisher's namespace is declared by
+ * whatever owns it, not through the API.
+ */
+
+// No Bookshelf model backs this resource, so the permission is checked explicitly. It is
+// the custom field browse permission: this reads the same definitions, just without
+// narrowing them to the publisher's own.
+function canThis(frame: Frame) {
+  return permissionsService.canThis(frame.options.context);
+}
+
+const controller = {
+  docName: 'members_fields',
+
+  browse: {
+    headers: { cacheInvalidate: false },
+    // `filter` narrows by status the same way the publisher's browse does; archived
+    // fields are hidden by default, and a caller that still has a filter saved against
+    // one asks for both. No pagination or order: the list is small and global, and comes
+    // back in the publisher's order.
+    options: ['filter'],
+    permissions(frame: Frame) {
+      return canThis(frame).browse.member_custom_field();
+    },
+    query(frame: Frame) {
+      return definitions!.browseEveryNamespace({
+        filter: frame.options.filter as string | undefined,
+      });
+    },
+  },
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -80,6 +80,10 @@ module.exports = {
     return require('./member-custom-fields');
   },
 
+  get members_fields() {
+    return require('./member-fields');
+  },
+
   get tiers() {
     return require('./tiers');
   },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/member-fields.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/member-fields.ts
@@ -1,0 +1,17 @@
+import { toFieldsResponse } from '../../../../../services/members-custom-fields/serializers';
+import type { CustomField } from '../../../../../services/members-custom-fields';
+
+interface Frame {
+  response?: unknown;
+}
+
+const serializeMany = (fields: CustomField[], _apiConfig: unknown, frame: Frame): void => {
+  frame.response = toFieldsResponse.parse(fields);
+};
+
+// module.exports (not export): the API framework loads serializers via require(). Unlike
+// the publisher's own endpoint, this shape carries the namespace that declared each field,
+// because a key identifies one only inside its namespace.
+module.exports = {
+  browse: serializeMany,
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -131,10 +131,19 @@ function serializeMember(member, options) {
     serialized.tiers = json.products;
   }
 
-  // Present on a read whenever the flag is on; absent otherwise, and absent on
-  // browse. An empty object is a member with no values set.
-  if (json.custom_fields) {
-    serialized.custom_fields = json.custom_fields;
+  // A property per namespace that declared a field, so `custom_fields.nickname` is the
+  // CSV column, the members filter and this property alike, and a namespace Ghost
+  // declares reads the same way. Present on a read whenever the flag is on; absent
+  // otherwise, and absent on browse unless asked for. An empty object is a member with
+  // no values set in that namespace.
+  //
+  // A namespace never displaces a property already serialized: which namespaces exist is
+  // a fact about the database, and quietly replacing `email` would be worse than dropping
+  // a value nobody can address anyway.
+  for (const [namespace, values] of Object.entries(json.field_values ?? {})) {
+    if (!(namespace in serialized)) {
+      serialized[namespace] = values;
+    }
   }
 
   serialized.current_subscription = json.current_subscription || null;

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-00-00-swap-custom-field-values-to-key-fk.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-00-00-swap-custom-field-values-to-key-fk.js
@@ -72,20 +72,34 @@ const ID_SHAPE = {
 // rather than an ALTER. Existing rows are discarded either way: the feature is behind the
 // `membersCustomFields` flag with no released data, so a wipe is cheaper than a backfill.
 // Re-running after a mid-migration crash is safe — the table is dropped first if present.
-async function rebuild(knex, shape) {
-  if (await knex.schema.hasTable(TABLE)) {
-    await commands.deleteTable(TABLE, knex);
+async function rebuild(knex, shape, from) {
+  // A crash between the drop and the create leaves no table to convert; recreate it as
+  // whichever shape this direction wanted.
+  if (!(await knex.schema.hasTable(TABLE))) {
+    await commands.createTable(TABLE, knex, shape);
+    return;
   }
+
+  // Only when the table is still the shape this converts from. Migrations are replayed
+  // against whatever schema is current, and rebuilding from a fixed shape then would
+  // undo a later migration's work — including pointing a foreign key at a constraint
+  // that migration had narrowed, which nothing can then write through.
+  if (!(await knex.schema.hasColumn(TABLE, from))) {
+    logging.info(`${TABLE} is not keyed by ${from}, leaving it alone`);
+    return;
+  }
+
+  await commands.deleteTable(TABLE, knex);
   await commands.createTable(TABLE, knex, shape);
 }
 
 module.exports = createNonTransactionalMigration(
   async function up(knex) {
     logging.info('Keying members_custom_field_values by custom_field_key');
-    await rebuild(knex, KEY_SHAPE);
+    await rebuild(knex, KEY_SHAPE, 'custom_field_id');
   },
   async function down(knex) {
     logging.info('Reverting members_custom_field_values to custom_field_id');
-    await rebuild(knex, ID_SHAPE);
+    await rebuild(knex, ID_SHAPE, 'custom_field_key');
   },
 );

--- a/ghost/core/core/server/data/migrations/versions/6.60/2026-08-19-09-00-00-add-namespace-to-member-custom-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.60/2026-08-19-09-00-00-add-namespace-to-member-custom-fields.js
@@ -1,0 +1,175 @@
+const logging = require('@tryghost/logging');
+const { createNonTransactionalMigration } = require('../../utils');
+const commands = require('../../../schema/commands');
+const views = require('../../../schema/views');
+
+const FIELDS = 'members_custom_fields';
+const VALUES = 'members_custom_field_values';
+const VIEW = 'members_custom_field_leaves';
+
+const PUBLISHER_NAMESPACE = 'custom_fields';
+
+const NAMESPACE_COLUMN = {
+  type: 'string',
+  maxlength: 191,
+  nullable: false,
+  defaultTo: PUBLISHER_NAMESPACE,
+};
+
+const MEMBER_COLUMN = {
+  type: 'string',
+  maxlength: 24,
+  nullable: false,
+  references: 'members.id',
+  cascadeDelete: true,
+};
+
+const LEAF_COLUMNS = {
+  path: { type: 'string', maxlength: 191, nullable: false, defaultTo: '' },
+  value_text: { type: 'text', maxlength: 65535, nullable: true },
+  created_at: { type: 'dateTime', nullable: false },
+  updated_at: { type: 'dateTime', nullable: true },
+};
+
+// Keyed by the field's id alone. What a filter names a field by — its namespace and key
+// — is resolved by the view this migration creates.
+const ID_SHAPE = {
+  id: { type: 'string', maxlength: 24, nullable: false, primary: true },
+  field_id: {
+    type: 'string',
+    maxlength: 24,
+    nullable: false,
+    references: `${FIELDS}.id`,
+    cascadeDelete: true,
+  },
+  member_id: MEMBER_COLUMN,
+  ...LEAF_COLUMNS,
+  '@@UNIQUE_CONSTRAINTS@@': [
+    {
+      columns: ['member_id', 'field_id', 'path'],
+      indexName: 'members_custom_field_values_leaf_unique',
+    },
+  ],
+  '@@INDEXES@@': [['field_id', 'path']],
+};
+
+// The shape this converts from, keyed by a definition's key back when one was unique on
+// its own.
+const KEY_SHAPE = {
+  id: { type: 'string', maxlength: 24, nullable: false, primary: true },
+  custom_field_key: {
+    type: 'string',
+    maxlength: 191,
+    nullable: false,
+    references: `${FIELDS}.key`,
+    cascadeDelete: true,
+  },
+  member_id: MEMBER_COLUMN,
+  ...LEAF_COLUMNS,
+  '@@UNIQUE_CONSTRAINTS@@': [
+    {
+      columns: ['member_id', 'custom_field_key', 'path'],
+      indexName: 'members_custom_field_values_leaf_unique',
+    },
+  ],
+  '@@INDEXES@@': [['custom_field_key', 'path']],
+};
+
+// Drop and recreate rather than alter, for the reason the migration that last swapped
+// this reference gives: SQLite cannot alter a foreign key in place. Rows are discarded,
+// as they were then — the feature is behind the `membersCustomFields` flag with no
+// released data, so a wipe costs nothing a backfill would save.
+async function rebuild(knex, shape) {
+  if (await knex.schema.hasTable(VALUES)) {
+    await commands.deleteTable(VALUES, knex);
+  }
+  await commands.createTable(VALUES, knex, shape);
+}
+
+/** Whether the table is already the shape this converts it to. */
+function keyedByFieldId(knex) {
+  return knex.schema.hasColumn(VALUES, 'field_id');
+}
+
+module.exports = createNonTransactionalMigration(
+  async function up(knex) {
+    // Guarded, like every other step here: `addColumn` raises on a column that already
+    // exists, and a replay runs this against a schema that already has it.
+    if (await knex.schema.hasColumn(FIELDS, 'namespace')) {
+      logging.info(`${FIELDS}.namespace already exists`);
+    } else {
+      logging.info(`Adding ${FIELDS}.namespace`);
+      await commands.addColumn(FIELDS, 'namespace', knex, NAMESPACE_COLUMN);
+    }
+
+    // Before the constraint narrows, so nothing is left referencing a key that is about
+    // to stop being unique on its own. Migrations are replayed against whatever schema
+    // is current, so a table already in this shape is left alone.
+    if (await keyedByFieldId(knex)) {
+      logging.info(`${VALUES} is already keyed by field id`);
+    } else {
+      logging.info(`Rebuilding ${VALUES} keyed by field id`);
+      await rebuild(knex, ID_SHAPE);
+    }
+
+    logging.info(`Scoping ${FIELDS} key and name uniqueness by namespace`);
+    await commands.dropUnique(FIELDS, 'key', knex);
+    await commands.dropUnique(FIELDS, 'name', knex);
+    await commands.addUnique(
+      FIELDS,
+      ['namespace', 'key'],
+      knex,
+      'members_custom_fields_namespace_key_unique',
+    );
+    await commands.addUnique(
+      FIELDS,
+      ['namespace', 'name'],
+      knex,
+      'members_custom_fields_namespace_name_unique',
+    );
+
+    logging.info(`Creating the ${VIEW} view`);
+    await knex.schema.createViewOrReplace(VIEW, function (view) {
+      view.as(knex.raw(views[VIEW]));
+    });
+  },
+  async function down(knex) {
+    // First: SQLite rebuilds a table to alter it, and validates every view while the
+    // table is renamed away. A view over either table below fails that check.
+    logging.info(`Dropping the ${VIEW} view`);
+    await knex.schema.dropViewIfExists(VIEW);
+
+    // A field outside the publisher's namespace has nothing left to be unique against
+    // once the namespace stops being part of the constraint, and its values go with the
+    // rebuild below.
+    logging.info(`Dropping fields outside the ${PUBLISHER_NAMESPACE} namespace`);
+    await knex(FIELDS).whereNot('namespace', PUBLISHER_NAMESPACE).del();
+
+    logging.info(`Restoring ${FIELDS} key and name uniqueness`);
+    await commands.dropUnique(
+      FIELDS,
+      ['namespace', 'key'],
+      knex,
+      'members_custom_fields_namespace_key_unique',
+    );
+    await commands.dropUnique(
+      FIELDS,
+      ['namespace', 'name'],
+      knex,
+      'members_custom_fields_namespace_name_unique',
+    );
+    await commands.addUnique(FIELDS, 'key', knex);
+    await commands.addUnique(FIELDS, 'name', knex);
+
+    // Only once a key is unique on its own again, which is what the reference needs.
+    if (await keyedByFieldId(knex)) {
+      logging.info(`Rebuilding ${VALUES} keyed by field key`);
+      await rebuild(knex, KEY_SHAPE);
+    }
+
+    if (await knex.schema.hasColumn(FIELDS, 'namespace')) {
+      logging.info(`Dropping ${FIELDS}.namespace`);
+      await commands.dropColumn(FIELDS, 'namespace', knex);
+    }
+  },
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1035,8 +1035,23 @@ module.exports = {
   },
   members_custom_fields: {
     id: { type: 'string', maxlength: 24, nullable: false, primary: true },
-    key: { type: 'string', maxlength: 191, nullable: false, unique: true },
-    name: { type: 'string', maxlength: 191, nullable: false, unique: true },
+    // Who declared the field. Publisher-defined fields sit in `custom_fields`, which is
+    // the namespace their values are already addressed under in CSV columns, the members
+    // filter and the Admin API; a namespace Ghost declares carries fields a publisher may
+    // fill in but not rename, archive or delete.
+    //
+    // Keys stay unique across every namespace rather than within one. A released
+    // migration recreates the values table with a foreign key to this column, so
+    // narrowing the constraint leaves that reference invalid whenever migrations are
+    // replayed. A namespace Ghost declares therefore states itself in the key it mints.
+    namespace: {
+      type: 'string',
+      maxlength: 191,
+      nullable: false,
+      defaultTo: 'custom_fields',
+    },
+    key: { type: 'string', maxlength: 191, nullable: false },
+    name: { type: 'string', maxlength: 191, nullable: false },
     type: {
       type: 'string',
       maxlength: 50,
@@ -1063,18 +1078,31 @@ module.exports = {
     sort_order: { type: 'integer', nullable: false, unsigned: true, defaultTo: 0 },
     created_at: { type: 'dateTime', nullable: false },
     updated_at: { type: 'dateTime', nullable: true },
+    // Named, and distinctly from what knex derives for a single-column unique, so
+    // dropping one can never be mistaken for dropping the other.
+    '@@UNIQUE_CONSTRAINTS@@': [
+      {
+        columns: ['namespace', 'key'],
+        indexName: 'members_custom_fields_namespace_key_unique',
+      },
+      {
+        columns: ['namespace', 'name'],
+        indexName: 'members_custom_fields_namespace_name_unique',
+      },
+    ],
   },
   members_custom_field_values: {
     id: { type: 'string', maxlength: 24, nullable: false, primary: true },
-    // The field's stable key, not its id: a value is addressed by key everywhere it
-    // matters (the write names it, a filter names it, the key is immutable), so the row
-    // carries it directly and the read and filter paths skip an id-to-key join. Matches
-    // the referenced column's 191, as a foreign key must.
-    custom_field_key: {
+    // The field's id, and nothing about which field that is. A key identifies a field
+    // only inside its namespace, so a reference to one would have to name both columns
+    // and this schema states a reference as one. What a filter needs — the namespace and
+    // the key — is resolved by the `members_custom_field_leaves` view rather than copied
+    // onto every row.
+    field_id: {
       type: 'string',
-      maxlength: 191,
+      maxlength: 24,
       nullable: false,
-      references: 'members_custom_fields.key',
+      references: 'members_custom_fields.id',
       cascadeDelete: true,
     },
     member_id: {
@@ -1104,7 +1132,7 @@ module.exports = {
     // column spends what headroom that bought.
     '@@UNIQUE_CONSTRAINTS@@': [
       {
-        columns: ['member_id', 'custom_field_key', 'path'],
+        columns: ['member_id', 'field_id', 'path'],
         indexName: 'members_custom_field_values_leaf_unique',
       },
     ],
@@ -1113,7 +1141,7 @@ module.exports = {
     // TEXT, so MySQL would need a prefix length, and the schema's index builder
     // applies one length to every column in a composite index rather than to a
     // single chosen one.
-    '@@INDEXES@@': [['custom_field_key', 'path']],
+    '@@INDEXES@@': [['field_id', 'path']],
   },
   members_stripe_customers: {
     id: { type: 'string', maxlength: 24, nullable: false, primary: true },

--- a/ghost/core/core/server/data/schema/views.js
+++ b/ghost/core/core/server/data/schema/views.js
@@ -41,6 +41,11 @@
 // source of truth for both filtering and display — see the
 // `current_subscription` reads in apps/admin/src/members/member-query-params.ts.
 module.exports = {
+  members_custom_field_leaves: `
+        SELECT v.member_id, f.namespace, f.key, v.path, v.value_text
+        FROM members_custom_field_values v
+        JOIN members_custom_fields f ON f.id = v.field_id
+    `,
   members_resolved_subscription: `
         SELECT member_id, subscription_id
         FROM (

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -6,8 +6,9 @@ const config = require('../../shared/config');
 const labs = require('../../shared/labs');
 const { MemberCommentingCodec } = require('../services/members/commenting');
 const {
-  CUSTOM_FIELDS_RELATION,
   createCustomFieldsFilterTransformer,
+  fieldNamespacesInFilter,
+  fieldsRelation,
 } = require('../services/members-custom-fields/filter');
 
 const DEEP_OFFSET_THRESHOLD = 1000;
@@ -198,26 +199,23 @@ const Member = ghostBookshelf.Model.extend(
     // wiring it. Runs only behind the flag and only when the filter names the relation; the
     // transformer maps the public `key`/`value` grammar onto the leaf-row columns.
     applyDefaultAndCustomFilters(options) {
-      if (
-        labs.isSet('membersCustomFields') &&
-        options.filter &&
-        options.filter.includes(`${CUSTOM_FIELDS_RELATION.tableNameAs}.`)
-      ) {
-        const transformer = createCustomFieldsFilterTransformer();
-        options.mongoTransformer = options.mongoTransformer
-          ? chainTransformers(options.mongoTransformer, transformer)
-          : transformer;
+      if (labs.isSet('membersCustomFields') && options.filter) {
+        // The same namespaces filterRelations resolved, each with its own transformer:
+        // a clause names a field by namespace and key, and only the transformer for that
+        // namespace knows which of its clauses describe one leaf row.
+        const taken = Object.keys(this.filterRelations({}));
+        for (const namespace of fieldNamespacesInFilter(options.filter, taken)) {
+          const transformer = createCustomFieldsFilterTransformer(namespace);
+          options.mongoTransformer = options.mongoTransformer
+            ? chainTransformers(options.mongoTransformer, transformer)
+            : transformer;
+        }
       }
       return ghostBookshelf.Model.prototype.applyDefaultAndCustomFilters.call(this, options);
     },
 
-    filterRelations() {
-      return {
-        // Custom field values are filterable only behind the feature flag. Gating the
-        // relation here (rather than the whole model) means a `custom_fields.*` filter
-        // is simply an unknown relation when the flag is off, and the filter is
-        // rejected — nothing to special-case downstream.
-        ...(labs.isSet('membersCustomFields') ? { custom_fields: CUSTOM_FIELDS_RELATION } : {}),
+    filterRelations(options) {
+      const relations = {
         labels: {
           tableName: 'labels',
           type: 'manyToMany',
@@ -308,6 +306,23 @@ const Member = ghostBookshelf.Model.extend(
           },
         },
       };
+
+      // A namespace exists because a field was declared in it, which is a fact about the
+      // database rather than something stated in code. So the namespaces come from the
+      // filter: one relation per namespace it names, and a namespace holding no field
+      // matches nothing, exactly as a key naming no field already does.
+      //
+      // Behind the flag, so a field filter is an unknown relation when the feature is
+      // off and the filter is rejected rather than quietly matching nothing.
+      if (!labs.isSet('membersCustomFields')) {
+        return relations;
+      }
+
+      for (const namespace of fieldNamespacesInFilter(options?.filter, Object.keys(relations))) {
+        relations[namespace] = fieldsRelation(namespace);
+      }
+
+      return relations;
     },
 
     relationships: ['products', 'labels', 'stripeCustomers', 'email_recipients', 'newsletters'],

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -5,8 +5,13 @@ import { z } from 'zod';
 import { CustomField } from './models';
 import { FieldTypeSchema } from '@tryghost/custom-field-types';
 import { customFieldCodec } from './codec';
-import { FIELD_STATUS, FieldStatusSchema } from './schema';
-import { activeFields, inFieldOrder } from './queries';
+import { FIELD_STATUS, FieldStatusSchema, PUBLISHER_NAMESPACE } from './schema';
+import {
+  activeFields,
+  activeFieldsInEveryNamespace,
+  inFieldOrder,
+  publisherFields,
+} from './queries';
 import { mintableKey } from './key';
 import { type RecordCustomFieldAction, type RequestContext } from './actions';
 
@@ -125,9 +130,33 @@ export class CustomFieldDefinitionsService {
     // Whichever set comes back, it comes back in the publisher's order: filtering
     // narrows the list, it never reorders it.
     const query = options.filter
-      ? applyFilter(this.knex(TABLE), options.filter)
+      ? applyFilter(publisherFields(this.knex), options.filter)
       : activeFields(this.knex);
     return this.list(query);
+  }
+
+  /**
+   * Every declared field, whichever namespace declared it, in the publisher's order.
+   *
+   * What a surface needs to know a field exists — the filter picker, the import mapping
+   * targets, a column — as opposed to what the publisher may manage, which is `browse`.
+   * A field Ghost declared is offered to filter on and never offered to rename.
+   */
+  async browseEveryNamespace(options: { filter?: string } = {}): Promise<CustomField[]> {
+    const query = options.filter
+      ? applyFilter(this.knex(TABLE), options.filter)
+      : activeFieldsInEveryNamespace(this.knex);
+    return this.list(query);
+  }
+
+  /**
+   * Every active field, whichever namespace declared it, in the publisher's order.
+   *
+   * The read for paths that address a field by namespace and key: CSV columns, and a
+   * member's values. `browse` stays the publisher's own list.
+   */
+  async activeInEveryNamespace(): Promise<CustomField[]> {
+    return this.list(activeFieldsInEveryNamespace(this.knex));
   }
 
   /**
@@ -142,7 +171,7 @@ export class CustomFieldDefinitionsService {
   }
 
   async read(key: string): Promise<CustomField> {
-    const row = await this.knex(TABLE).where('key', key).first();
+    const row = await publisherFields(this.knex).where('key', key).first();
     if (!row) {
       throw new errors.NotFoundError({ message: 'Custom field not found.' });
     }
@@ -203,6 +232,7 @@ export class CustomFieldDefinitionsService {
           const key = await this.mintKey(trx, bases[index]);
           await trx(TABLE).insert({
             id: new ObjectID().toHexString(),
+            namespace: PUBLISHER_NAMESPACE,
             key,
             name: field.name,
             type: field.type,
@@ -258,7 +288,7 @@ export class CustomFieldDefinitionsService {
   private async assertWithinLimit(db: Knex, addedCount: number): Promise<void> {
     const max = this.getMaxDefinitions();
 
-    const row = await db(TABLE).count({ count: '*' }).first();
+    const row = await publisherFields(db).count({ count: '*' }).first();
     const total = Number(row?.count ?? 0);
     if (total + addedCount <= max) {
       return;
@@ -309,12 +339,12 @@ export class CustomFieldDefinitionsService {
       // change, the list around them did.
       const ranks = new Map(keys.map((key, rank) => [key, rank]));
       for (const key of [...keys].sort()) {
-        await trx(TABLE)
+        await publisherFields(trx)
           .where('key', key)
           .update({ sort_order: ranks.get(key)! });
       }
 
-      return this.list(trx(TABLE));
+      return this.list(publisherFields(trx));
     });
 
     await this.recordAction({
@@ -333,7 +363,7 @@ export class CustomFieldDefinitionsService {
    */
   private async assertNamesEveryField(db: Knex, keys: string[]): Promise<void> {
     const named = new Set(keys);
-    const existing = new Set(await db(TABLE).pluck<string[]>('key'));
+    const existing = new Set(await publisherFields(db).pluck<string[]>('key'));
 
     const matches =
       named.size === keys.length &&
@@ -350,7 +380,7 @@ export class CustomFieldDefinitionsService {
 
   /** A new field is appended. Archived fields hold ranks too, so it lands past them. */
   private async nextSortOrder(db: Knex): Promise<number> {
-    const row = await db(TABLE).max({ highest: 'sort_order' }).first();
+    const row = await publisherFields(db).max({ highest: 'sort_order' }).first();
     const highest = row?.highest;
     // No fields yet, so this one starts the order.
     if (highest === null || highest === undefined) {
@@ -361,7 +391,7 @@ export class CustomFieldDefinitionsService {
 
   /** Read back a batch in the order its keys were created, not the table's order. */
   private async readMany(db: Knex, keys: string[]): Promise<CustomField[]> {
-    const rows = await db(TABLE).whereIn('key', keys).select('*');
+    const rows = await publisherFields(db).whereIn('key', keys).select('*');
     const byKey = new Map(rows.map((row) => [row.key, row]));
     return keys.map((key) => z.decode(customFieldCodec, byKey.get(key)!));
   }
@@ -378,7 +408,7 @@ export class CustomFieldDefinitionsService {
     const safeBase = base.slice(0, MAX_KEY_BASE_LENGTH).replace(/_+$/, '');
     const taken = new Set([
       ...RESERVED_KEYS,
-      ...(await db(TABLE).where('key', 'like', `${safeBase}%`).pluck('key')),
+      ...(await publisherFields(db).where('key', 'like', `${safeBase}%`).pluck('key')),
     ]);
     if (!taken.has(safeBase)) {
       return safeBase;
@@ -408,7 +438,7 @@ export class CustomFieldDefinitionsService {
    * own name on an unrelated edit.
    */
   private async assertNameAvailable(db: Knex, name: string, exceptKey?: string): Promise<void> {
-    const query = db(TABLE).whereRaw('LOWER(name) = ?', [name.toLowerCase()]);
+    const query = publisherFields(db).whereRaw('LOWER(name) = ?', [name.toLowerCase()]);
     if (exceptKey) {
       query.whereNot('key', exceptKey);
     }
@@ -454,7 +484,7 @@ export class CustomFieldDefinitionsService {
     if (patch.name !== undefined && patch.name !== existing.name) {
       await this.assertNameAvailable(this.knex, patch.name, key);
       try {
-        await this.knex(TABLE)
+        await publisherFields(this.knex)
           .where('key', key)
           .update({ name: patch.name, updated_at: new Date() });
       } catch (err) {
@@ -476,7 +506,7 @@ export class CustomFieldDefinitionsService {
     // A status change is the archive/restore transition. Only write (and log)
     // when it actually flips, so re-sending the current status is a no-op.
     if (patch.status !== undefined && patch.status !== existing.status) {
-      await this.knex(TABLE)
+      await publisherFields(this.knex)
         .where('key', key)
         .update({ status: patch.status, updated_at: new Date() });
       const verb = patch.status === FIELD_STATUS.archived ? 'archive' : 'restore';
@@ -499,7 +529,7 @@ export class CustomFieldDefinitionsService {
    * reversible soft state (see `edit` with a status change).
    */
   async destroy(context: RequestContext, key: string): Promise<void> {
-    const field = await this.knex(TABLE).where('key', key).first();
+    const field = await publisherFields(this.knex).where('key', key).first();
     if (!field) {
       throw new errors.NotFoundError({ message: 'Custom field not found.' });
     }
@@ -508,7 +538,7 @@ export class CustomFieldDefinitionsService {
         message: 'Only archived custom fields can be deleted. Archive the field first.',
       });
     }
-    await this.knex(TABLE).where('key', key).del();
+    await publisherFields(this.knex).where('key', key).del();
     await this.recordAction({
       context,
       verb: 'delete',

--- a/ghost/core/core/server/services/members-custom-fields/filter.ts
+++ b/ghost/core/core/server/services/members-custom-fields/filter.ts
@@ -21,13 +21,47 @@
 // matches no leaf; the admin never offers an archived or deleted field in the filter UI,
 // though the API leaves them queryable.
 import errors from '@tryghost/errors';
+import { PUBLISHER_NAMESPACE } from './schema';
 
-const RELATION = 'custom_fields';
-const PREFIX = `${RELATION}.`;
-const KEY_ATTRIBUTE = `${PREFIX}key`;
-const VALUE_ATTRIBUTE = `${PREFIX}value`;
-const PATH_ATTRIBUTE = `${PREFIX}path`;
 const ROOT_PATH = '';
+
+/** The attribute names a namespace's clauses are written with. */
+function attributesFor(namespace: string) {
+  const prefix = `${namespace}.`;
+  return {
+    relation: namespace,
+    prefix,
+    key: `${prefix}key`,
+    value: `${prefix}value`,
+    path: `${prefix}path`,
+  };
+}
+
+/**
+ * The namespaces a filter addresses, taken from the filter itself rather than from a list
+ * kept in code. A namespace exists because a field was declared in it, which is a fact
+ * about the database; nothing here is in a position to ask, and a namespace holding no
+ * field simply matches nothing, exactly as a key naming no field already does.
+ *
+ * Only a prefix used with this grammar counts, so a filter naming an unknown relation any
+ * other way is still rejected rather than quietly matching nothing. Prefixes already
+ * spoken for by another relation are left alone.
+ */
+export function fieldNamespacesInFilter(filter: unknown, taken: readonly string[]): string[] {
+  if (typeof filter !== 'string') {
+    return [];
+  }
+
+  const named = new Set<string>();
+  for (const [, namespace] of filter.matchAll(
+    /([a-z][a-z0-9_]*)\.(?:key|value|path)\b/g,
+  )) {
+    if (!taken.includes(namespace)) {
+      named.add(namespace);
+    }
+  }
+  return [...named];
+}
 
 type QueryNode = Record<string, unknown>;
 
@@ -42,48 +76,51 @@ function isPlainObject(value: unknown): value is QueryNode {
   );
 }
 
-// A single-clause object whose one key targets the custom_fields relation.
-function isCustomFieldClause(node: unknown): node is QueryNode {
-  if (!isPlainObject(node)) {
-    return false;
-  }
-  const keys = Object.keys(node);
-  return keys.length === 1 && keys[0].startsWith(PREFIX);
-}
-
-// A grouped compound: an $and whose clauses all target the relation and name exactly one
-// `key`. Its clauses describe one leaf row.
-//
-// Exactly one, not at least one: two whole-field filters ANDed together arrive as a flat
-// `key:'a'+key:'b'`, since a bare key clause needs no group of its own. That is two
-// filters — a member with a value for both — not one leaf that is somehow both fields, so
-// it has to fall through and be transformed a clause at a time.
-function isCustomFieldCompound(clauses: unknown): clauses is QueryNode[] {
-  if (!Array.isArray(clauses) || clauses.length < 2 || !clauses.every(isCustomFieldClause)) {
-    return false;
-  }
-  return clauses.filter((clause) => Object.keys(clause)[0] === KEY_ATTRIBUTE).length === 1;
-}
-
-// `custom_fields.value` addresses the scalar (root) leaf; `custom_fields.value.<part>`
-// a composite's part. Returns the row `path` the attribute selects, or null if the
-// attribute isn't a value clause.
-function pathForValueAttribute(attribute: string): string | null {
-  if (attribute === VALUE_ATTRIBUTE) {
-    return ROOT_PATH;
-  }
-  if (attribute.startsWith(`${VALUE_ATTRIBUTE}.`)) {
-    return attribute.slice(`${VALUE_ATTRIBUTE}.`.length);
-  }
-  return null;
-}
 
 // The single `{$ne}` shape all negations arrive as (is-not-set on a key or part).
 function negatedString(value: unknown): string | null {
   return isPlainObject(value) && typeof value.$ne === 'string' ? value.$ne : null;
 }
 
-export function createCustomFieldsFilterTransformer() {
+export function createCustomFieldsFilterTransformer(namespace: string = PUBLISHER_NAMESPACE) {
+  const { relation: RELATION, prefix: PREFIX, key: KEY_ATTRIBUTE, value: VALUE_ATTRIBUTE, path: PATH_ATTRIBUTE } =
+    attributesFor(namespace);
+
+  // A single-clause object whose one key targets the custom_fields relation.
+  function isCustomFieldClause(node: unknown): node is QueryNode {
+    if (!isPlainObject(node)) {
+      return false;
+    }
+    const keys = Object.keys(node);
+    return keys.length === 1 && keys[0].startsWith(PREFIX);
+  }
+
+  // A grouped compound: an $and whose clauses all target the relation and name exactly one
+  // `key`. Its clauses describe one leaf row.
+  //
+  // Exactly one, not at least one: two whole-field filters ANDed together arrive as a flat
+  // `key:'a'+key:'b'`, since a bare key clause needs no group of its own. That is two
+  // filters — a member with a value for both — not one leaf that is somehow both fields, so
+  // it has to fall through and be transformed a clause at a time.
+  function isCustomFieldCompound(clauses: unknown): clauses is QueryNode[] {
+    if (!Array.isArray(clauses) || clauses.length < 2 || !clauses.every(isCustomFieldClause)) {
+      return false;
+    }
+    return clauses.filter((clause) => Object.keys(clause)[0] === KEY_ATTRIBUTE).length === 1;
+  }
+
+  // `custom_fields.value` addresses the scalar (root) leaf; `custom_fields.value.<part>`
+  // a composite's part. Returns the row `path` the attribute selects, or null if the
+  // attribute isn't a value clause.
+  function pathForValueAttribute(attribute: string): string | null {
+    if (attribute === VALUE_ATTRIBUTE) {
+      return ROOT_PATH;
+    }
+    if (attribute.startsWith(`${VALUE_ATTRIBUTE}.`)) {
+      return attribute.slice(`${VALUE_ATTRIBUTE}.`.length);
+    }
+    return null;
+  }
   // The grammar carries the field key in the clause value; take it as a string,
   // defaulting to one no field can hold so a malformed clause matches nothing.
   const keyOf = (value: unknown): string => (typeof value === 'string' ? value : '');
@@ -91,7 +128,9 @@ export function createCustomFieldsFilterTransformer() {
   // One (maybe-negated) $elemMatch over the leaf columns: positive is "a leaf pinned
   // by these matches", `$not` is "no leaf does".
   function buildElemMatch(fieldKey: string, conditions: QueryNode, negate: boolean): QueryNode {
-    const match = { custom_field_key: fieldKey, ...conditions };
+    // The namespace as well as the key: a key identifies a field only inside one, so
+    // without it a publisher's filter would also match a field Ghost declared.
+    const match = { namespace, key: fieldKey, ...conditions };
     if (negate) {
       return { [RELATION]: { $not: { $elemMatch: match } } };
     }
@@ -203,9 +242,11 @@ export function createCustomFieldsFilterTransformer() {
  * it as a correlated `members.id IN (…)` subquery — composing with every other member
  * filter. Registered only behind the `membersCustomFields` flag.
  */
-export const CUSTOM_FIELDS_RELATION = {
-  tableName: 'members_custom_field_values',
-  tableNameAs: RELATION,
-  type: 'oneToOne',
-  joinFrom: 'member_id',
-} as const;
+export function fieldsRelation(namespace: string) {
+  return {
+    tableName: 'members_custom_field_leaves',
+    tableNameAs: namespace,
+    type: 'oneToOne',
+    joinFrom: 'member_id',
+  } as const;
+}

--- a/ghost/core/core/server/services/members-custom-fields/models.ts
+++ b/ghost/core/core/server/services/members-custom-fields/models.ts
@@ -5,6 +5,9 @@ import { FieldStatusSchema } from './schema';
 // The domain shape of a field definition (camelCase; distinct from the DB row).
 export const CustomField = z.object({
   id: z.string(),
+  // Which namespace declared the field. Carried through the domain because it is half
+  // of a field's address and decides who may manage it, not just where it is stored.
+  namespace: z.string(),
   key: z.string(),
   name: z.string(),
   type: FieldTypeSchema,

--- a/ghost/core/core/server/services/members-custom-fields/queries.ts
+++ b/ghost/core/core/server/services/members-custom-fields/queries.ts
@@ -1,5 +1,5 @@
 import type { Knex } from 'knex';
-import { FIELD_STATUS } from './schema';
+import { FIELD_STATUS, PUBLISHER_NAMESPACE } from './schema';
 
 const FIELDS_TABLE = 'members_custom_fields';
 
@@ -7,8 +7,32 @@ const FIELDS_TABLE = 'members_custom_fields';
 // enforces that — no constraint stops a value row referencing an archived field. A query
 // that forgets the filter is a silent bug, so the filter lives in one place.
 
+/**
+ * The fields the publisher declared, whatever their status.
+ *
+ * Here for the same reason the status filter is: a key is only unique inside its
+ * namespace, so a query that forgets to name one can match a field Ghost declared, and
+ * the definitions API would then offer it to be renamed or deleted. Every read and write
+ * in that API goes through this, so no call site has to remember.
+ */
+export function publisherFields(db: Knex) {
+  return db(FIELDS_TABLE).where('namespace', PUBLISHER_NAMESPACE);
+}
+
 /** Takes the executor so the same query runs standalone or inside a write's transaction. */
 export function activeFields(db: Knex) {
+  return publisherFields(db).where('status', FIELD_STATUS.active);
+}
+
+/**
+ * Every active field, whichever namespace declared it.
+ *
+ * For the paths that address a field by namespace and key rather than by key alone: the
+ * CSV columns and a member's values are about all of a member's data, not only the part
+ * the publisher defined. The management API stays on `publisherFields`, because managing
+ * is what ownership decides.
+ */
+export function activeFieldsInEveryNamespace(db: Knex) {
   return db(FIELDS_TABLE).where('status', FIELD_STATUS.active);
 }
 

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -1,7 +1,15 @@
 import { z } from 'zod';
 import type { Knex } from 'knex';
 import { FieldTypeSchema } from '@tryghost/custom-field-types';
+import { PUBLISHER_NAMESPACE } from '@tryghost/custom-field-types/csv';
 import { DbDate } from '../../lib/db-date';
+
+/**
+ * The namespace a publisher's own fields are declared in. It is not a special case in
+ * the model: a namespace Ghost declares is stored, addressed and read the same way, and
+ * only the rule about who may manage a field tells them apart.
+ */
+export { PUBLISHER_NAMESPACE };
 
 // `archived` is soft: the field drops out of the values path but stays in the definition
 // list so it can be renamed, restored or deleted. Mirrors schema.js's `isIn` on the
@@ -14,6 +22,7 @@ export const FieldStatusSchema = z.enum([FIELD_STATUS.active, FIELD_STATUS.archi
 // as the field-type enum, so the row carries the narrow type and no codec needs a cast.
 export const DbCustomField = z.object({
   id: z.string(),
+  namespace: z.string(),
   key: z.string(),
   name: z.string(),
   type: FieldTypeSchema,
@@ -31,7 +40,7 @@ type CustomFieldRow = z.infer<typeof DbCustomField> & CustomFieldRank;
 // carries it as a plain string.
 export const DbCustomFieldValue = z.object({
   id: z.string(),
-  custom_field_key: z.string(),
+  field_id: z.string(),
   member_id: z.string(),
   path: z.string(),
   // Nullable like the column, though nothing here writes a null: a part with no value
@@ -50,6 +59,7 @@ type CustomFieldValueRow = z.infer<typeof DbCustomFieldValue>;
 // is what drops it.
 export const DbCustomFieldLeaf = z.object({
   member_id: z.string(),
+  namespace: z.string(),
   key: z.string(),
   type: FieldTypeSchema,
   path: z.string(),
@@ -61,7 +71,9 @@ declare module 'knex/types/tables' {
     members_custom_fields: Knex.CompositeTableType<
       CustomFieldRow,
       // `status` is DB-defaulted and only set via update, so it's absent here. The
-      // rank is required: letting it default would land a new field at the top.
+      // rank is required: letting it default would land a new field at the top, and the
+      // namespace for the same reason — a write that omits it would silently declare a
+      // publisher field.
       Omit<z.input<typeof DbCustomField>, 'updated_at' | 'status'> & CustomFieldRank,
       Partial<CustomFieldRow>
     >;

--- a/ghost/core/core/server/services/members-custom-fields/serializers.ts
+++ b/ghost/core/core/server/services/members-custom-fields/serializers.ts
@@ -21,3 +21,16 @@ export const toCustomFieldsResponse = z
     members_custom_fields: fields.map((field) => snakeKeys(field)),
   }))
   .pipe(CustomFieldsResponse);
+
+// The cross-namespace read's shape. Carries `namespace`, because a key identifies a field
+// only inside one and every surface that reads this addresses a field by both. The
+// publisher's own endpoint deliberately does not: there, every field is theirs.
+const FieldResource = CustomFieldResource.extend({ namespace: z.string() });
+const FieldsResponse = z.object({ members_fields: z.array(FieldResource) });
+
+export const toFieldsResponse = z
+  .array(CustomField)
+  .transform((fields): z.input<typeof FieldsResponse> => ({
+    members_fields: fields.map((field) => snakeKeys(field)),
+  }))
+  .pipe(FieldsResponse);

--- a/ghost/core/core/server/services/members-custom-fields/storage.ts
+++ b/ghost/core/core/server/services/members-custom-fields/storage.ts
@@ -21,8 +21,15 @@ export interface Leaf {
 
 export interface StoredLeaf extends Leaf {
   member_id: string;
+  namespace: string;
   key: string;
 }
+
+/**
+ * A member's values, by the namespace that owns the field and then by its key. A key
+ * identifies a field only inside its namespace, so both are needed to address one.
+ */
+export type NamespacedValues = Record<string, Record<string, unknown>>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -101,25 +108,37 @@ export function valueFromLeaves(leaves: readonly Leaf[]): unknown {
   return value;
 }
 
-/** Every member's values, keyed by member and then field key; a member with no rows is absent. */
-export function valuesFromLeaves(
-  leaves: readonly StoredLeaf[],
-): Map<string, Record<string, unknown>> {
-  const byMemberAndField = new Map<string, Map<string, Leaf[]>>();
+/**
+ * Every member's values, by member, then by the namespace that owns the field, then by
+ * its key; a member with no rows is absent, as is a namespace they hold nothing in.
+ */
+export function valuesFromLeaves(leaves: readonly StoredLeaf[]): Map<string, NamespacedValues> {
+  // Grouped by the address a value has — its namespace and key — because a key alone
+  // names a different field in each namespace.
+  const byMemberAndField = new Map<string, Map<string, Map<string, Leaf[]>>>();
 
-  for (const { member_id: memberId, key, path, value_text: valueText } of leaves) {
-    const fields = byMemberAndField.get(memberId) ?? new Map<string, Leaf[]>();
+  for (const { member_id: memberId, namespace, key, path, value_text: valueText } of leaves) {
+    const namespaces = byMemberAndField.get(memberId) ?? new Map<string, Map<string, Leaf[]>>();
+    const fields = namespaces.get(namespace) ?? new Map<string, Leaf[]>();
     const forField = fields.get(key) ?? [];
     forField.push({ path, value_text: valueText });
     fields.set(key, forField);
-    byMemberAndField.set(memberId, fields);
+    namespaces.set(namespace, fields);
+    byMemberAndField.set(memberId, namespaces);
   }
 
-  const byMember = new Map<string, Record<string, unknown>>();
-  for (const [memberId, fields] of byMemberAndField) {
+  const byMember = new Map<string, NamespacedValues>();
+  for (const [memberId, namespaces] of byMemberAndField) {
     byMember.set(
       memberId,
-      Object.fromEntries([...fields].map(([key, forField]) => [key, valueFromLeaves(forField)])),
+      Object.fromEntries(
+        [...namespaces].map(([namespace, fields]) => [
+          namespace,
+          Object.fromEntries(
+            [...fields].map(([key, forField]) => [key, valueFromLeaves(forField)]),
+          ),
+        ]),
+      ),
     );
   }
 

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -4,8 +4,8 @@ import logging from '@tryghost/logging';
 import type { Knex } from 'knex';
 import { z } from 'zod';
 import { FIELD_TYPES, subFieldsOf, type FieldType } from '@tryghost/custom-field-types';
-import { DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS } from './schema';
-import { activeFields } from './queries';
+import { DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS, PUBLISHER_NAMESPACE } from './schema';
+import { activeFieldsInEveryNamespace } from './queries';
 import { leavesToWrite, valuesFromLeaves, type StoredLeaf } from './storage';
 
 const FIELDS_TABLE = 'members_custom_fields';
@@ -37,6 +37,7 @@ const ValuesInput = z.record(z.string().max(MAX_KEY_LENGTH), z.unknown());
 
 interface ActiveField {
   id: string;
+  namespace: string;
   key: string;
   name: string;
   type: FieldType;
@@ -63,13 +64,19 @@ export class CustomFieldValuesService {
     this.getMaxDefinitions = getMaxDefinitions;
   }
 
-  private async activeFieldsByKey(keys: string[]): Promise<Map<string, ActiveField>> {
+  // Within one namespace, because a key names a different field in each and a write
+  // always knows which one it is writing into.
+  private async activeFieldsByKey(
+    keys: string[],
+    namespace: string,
+  ): Promise<Map<string, ActiveField>> {
     if (keys.length === 0) {
       return new Map();
     }
-    const fields = await activeFields(this.knex)
+    const fields = await activeFieldsInEveryNamespace(this.knex)
+      .where('namespace', namespace)
       .whereIn('key', keys)
-      .select('id', 'key', 'name', 'type');
+      .select('id', 'namespace', 'key', 'name', 'type');
     return new Map(fields.map((field) => [field.key, field]));
   }
 
@@ -85,16 +92,19 @@ export class CustomFieldValuesService {
       return new Map();
     }
 
-    // Not ordered by field: these rows become an object keyed by field, and an object
-    // cannot carry an order. `path` is ordered so composite parts assemble the same
-    // way every time.
-    const rows = await this.knex(VALUES_TABLE)
-      .join(FIELDS_TABLE, `${VALUES_TABLE}.custom_field_key`, `${FIELDS_TABLE}.key`)
-      .whereIn(`${VALUES_TABLE}.member_id`, memberIds)
+    // Every namespace, not just the publisher's: a member's values are all of them, and
+    // the namespace each row carries is what keeps them apart once assembled.
+    //
+    // Not ordered by field: an object cannot carry an order. `path` is ordered so
+    // composite parts assemble the same way every time.
+    const rows = await this.knex(FIELDS_TABLE)
       .where(`${FIELDS_TABLE}.status`, FIELD_STATUS.active)
+      .join(VALUES_TABLE, `${VALUES_TABLE}.field_id`, `${FIELDS_TABLE}.id`)
+      .whereIn(`${VALUES_TABLE}.member_id`, memberIds)
       .orderBy(`${VALUES_TABLE}.path`, 'asc')
       .select(
         `${VALUES_TABLE}.member_id`,
+        `${FIELDS_TABLE}.namespace`,
         `${FIELDS_TABLE}.key`,
         `${FIELDS_TABLE}.type`,
         `${VALUES_TABLE}.path`,
@@ -145,7 +155,10 @@ export class CustomFieldValuesService {
    * validate before opening a transaction it would otherwise have to unwind, then apply
    * the same plan without re-resolving it.
    */
-  async planWrite(input: unknown): Promise<PlannedWrite[]> {
+  async planWrite(
+    input: unknown,
+    namespace: string = PUBLISHER_NAMESPACE,
+  ): Promise<PlannedWrite[]> {
     const values = this.parseValues(input);
     const keys = Object.keys(values);
 
@@ -159,7 +172,7 @@ export class CustomFieldValuesService {
       });
     }
 
-    const byKey = await this.activeFieldsByKey(keys);
+    const byKey = await this.activeFieldsByKey(keys, namespace);
     const writes: PlannedWrite[] = [];
 
     for (const [key, raw] of Object.entries(values)) {
@@ -225,26 +238,26 @@ export class CustomFieldValuesService {
       // than one per part, under one timestamp, because a write happened once
       // however many rows record it.
       const now = new Date();
-      const clearedKeys: string[] = [];
-      const clearedPaths: Array<{ fieldKey: string; paths: string[] }> = [];
+      const clearedFieldIds: string[] = [];
+      const clearedPaths: Array<{ fieldId: string; paths: string[] }> = [];
       const rows: DbLeafRow[] = [];
 
       for (const { field, value } of writes) {
         if (value === undefined) {
-          clearedKeys.push(field.key);
+          clearedFieldIds.push(field.id);
           continue;
         }
 
         const { set, cleared } = leavesToWrite(value);
         if (cleared.length > 0) {
-          clearedPaths.push({ fieldKey: field.key, paths: cleared });
+          clearedPaths.push({ fieldId: field.id, paths: cleared });
         }
 
         rows.push(
           ...set.map((leaf) => ({
             id: new ObjectID().toHexString(),
             member_id: memberId,
-            custom_field_key: field.key,
+            field_id: field.id,
             path: leaf.path,
             value_text: leaf.value_text,
             created_at: now,
@@ -253,10 +266,10 @@ export class CustomFieldValuesService {
         );
       }
 
-      if (clearedKeys.length > 0) {
+      if (clearedFieldIds.length > 0) {
         await trx(VALUES_TABLE)
           .where('member_id', memberId)
-          .whereIn('custom_field_key', clearedKeys)
+          .whereIn('field_id', clearedFieldIds)
           .del();
       }
 
@@ -265,10 +278,8 @@ export class CustomFieldValuesService {
         await trx(VALUES_TABLE)
           .where('member_id', memberId)
           .where((builder) => {
-            for (const { fieldKey, paths } of clearedPaths) {
-              builder.orWhere((pair) =>
-                pair.where('custom_field_key', fieldKey).whereIn('path', paths),
-              );
+            for (const { fieldId, paths } of clearedPaths) {
+              builder.orWhere((pair) => pair.where('field_id', fieldId).whereIn('path', paths));
             }
           })
           .del();
@@ -282,7 +293,7 @@ export class CustomFieldValuesService {
           .insert(rows.slice(from, from + UPSERT_CHUNK))
           // Naming the columns rather than giving values takes each from the row
           // that lost the conflict, so every part updates to its own value.
-          .onConflict(['member_id', 'custom_field_key', 'path'])
+          .onConflict(['member_id', 'field_id', 'path'])
           .merge(['value_text', 'updated_at']);
       }
     };

--- a/ghost/core/core/server/services/members/import-export/import/completion-email.ts
+++ b/ghost/core/core/server/services/members/import-export/import/completion-email.ts
@@ -1,6 +1,6 @@
 import { serialize } from '../csv';
 import renderImportEmail, { headingFor, type ImportEmailSummary } from './email-template';
-import { isCustomFieldColumn } from '@tryghost/custom-field-types/csv';
+import { isAnyFieldColumn } from '@tryghost/custom-field-types/csv';
 import type { MemberImportRow, ImportErrorRow, ImportLabel, Label } from './row';
 
 // The finished import as the email reads it: how many imported and which rows
@@ -23,6 +23,8 @@ interface ImportEmailInput {
   recipient: string;
   labelName: string;
   links: EmailLinks;
+  /** The namespaces a field column in this file could name. Empty when nothing failed. */
+  fieldNamespaces?: readonly string[];
 }
 
 interface EmailPayload {
@@ -87,10 +89,13 @@ function stringifyLabels(labels: Array<string | Label>): string {
   return labels.map((label) => (typeof label === 'string' ? label : label.name)).join(',');
 }
 
-// The custom_fields.* cells a submitted row carried, echoed untouched so a manager can
-// fix a failed row and re-upload the values they mapped.
-function customFieldCells(row: ImportErrorRow): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(row).filter(([column]) => isCustomFieldColumn(column)));
+// The field cells a submitted row carried, echoed untouched so a manager can fix a failed
+// row and re-upload the values they mapped. Takes the namespaces rather than assuming the
+// publisher's, because a file can carry a column for any namespace a field is declared in.
+function fieldCells(row: ImportErrorRow, namespaces: readonly string[]): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(row).filter(([column]) => isAnyFieldColumn(column, namespaces)),
+  );
 }
 
 // Shape a failed import row into its fixed error-report cells, with the raw ORM message
@@ -119,13 +124,15 @@ function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
 // shaping -- the export writes db members, this echoes submitted rows. Member columns come from the shaper's keys (so the type
 // stays the single source); the custom_fields.* columns across the rows are threaded in
 // before the last error column, and each row's custom cells merged on.
-function buildErrorReport(errors: ImportErrorRow[]): string {
+function buildErrorReport(errors: ImportErrorRow[], namespaces: readonly string[]): string {
   const memberColumns = Object.keys(toErrorReportRow(errors[0])).filter(
     (column) => column !== 'error',
   );
-  const customColumns = [...new Set(errors.flatMap((row) => Object.keys(customFieldCells(row))))];
+  const customColumns = [
+    ...new Set(errors.flatMap((row) => Object.keys(fieldCells(row, namespaces)))),
+  ];
   const columns = [...memberColumns, ...customColumns, 'error'];
-  const rows = errors.map((row) => ({ ...toErrorReportRow(row), ...customFieldCells(row) }));
+  const rows = errors.map((row) => ({ ...toErrorReportRow(row), ...fieldCells(row, namespaces) }));
   return serialize(rows, { columns });
 }
 
@@ -138,6 +145,7 @@ export default function buildImportEmail({
   recipient,
   labelName,
   links,
+  fieldNamespaces = [],
 }: ImportEmailInput): EmailPayload {
   const summary: ImportEmailSummary = !result
     ? 'did-not-run'
@@ -161,7 +169,7 @@ export default function buildImportEmail({
       ? [
           {
             filename: `${labelName} - Errors.csv`,
-            content: buildErrorReport(result.errors),
+            content: buildErrorReport(result.errors, fieldNamespaces),
             contentType: 'text/csv',
             contentDisposition: 'attachment',
           },

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -113,7 +113,7 @@ type CustomFieldPlan = unknown;
 // them, touching only the parts the row named, both on the row's transaction.
 export interface CustomFieldsImport {
   activeFields(): Promise<CsvField[]>;
-  planWrite(values: Record<string, unknown>): Promise<CustomFieldPlan[]>;
+  planWrite(values: Record<string, unknown>, namespace: string): Promise<CustomFieldPlan[]>;
   applyWrite(memberId: string, plan: CustomFieldPlan[], executor: Knex): Promise<void>;
 }
 
@@ -342,6 +342,13 @@ class MembersCSVImporter {
 
     // Whatever became of it, the publisher hears exactly once. If this is what fails,
     // there is nobody left to tell but us.
+    // Only for a report that will list rows: the error report echoes back the field
+    // columns a failed row carried, and which columns those are depends on the
+    // namespaces a field can be declared in.
+    const fieldNamespaces = result?.errors?.length
+      ? [...new Set((await this._customFields.activeFields()).map((field) => field.namespace))]
+      : [];
+
     await this.settle(() =>
       this._email.send(
         buildImportEmail({
@@ -349,6 +356,7 @@ class MembersCSVImporter {
           recipient: emailRecipient,
           labelName,
           links: this._email.links,
+          fieldNamespaces,
         }),
       ),
     );
@@ -444,13 +452,23 @@ class MembersCSVImporter {
         // planWrite only reads, and it throws on an invalid value to fail the row
         // before any member write -- so there is no reason to hold a transaction
         // across it, and doing so would deadlock the single-connection SQLite pool.
+        // A plan per namespace the row named, concatenated: a key identifies a field
+        // only inside one, so each namespace resolves its own keys.
         const customFieldPlan =
           activeCustomFields.length > 0
-            ? await namingTheColumn(() =>
-                this._customFields.planWrite(
-                  fieldValuesFromCsvRow(activeCustomFields, row, stripFormulaGuard),
-                ),
-              )
+            ? await namingTheColumn(async () => {
+                const byNamespace = fieldValuesFromCsvRow(
+                  activeCustomFields,
+                  row,
+                  stripFormulaGuard,
+                );
+                const plans = await Promise.all(
+                  Object.entries(byNamespace).map(([namespace, values]) =>
+                    this._customFields.planWrite(values, namespace),
+                  ),
+                );
+                return plans.flat();
+              })
             : [];
 
         trx = await this._knex.transaction(undefined, { doNotRejectOnRollback: false });

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -46,9 +46,9 @@ interface ImporterServices {
   productRepository: unknown;
   // The custom fields services the members service hands the import composition root.
   customFields: {
-    definitions: { browse(): Promise<CsvField[]> };
+    definitions: { activeInEveryNamespace(): Promise<CsvField[]> };
     values: {
-      planWrite(values: Record<string, unknown>): Promise<unknown[]>;
+      planWrite(values: Record<string, unknown>, namespace: string): Promise<unknown[]>;
       applyWrite(memberId: string, plan: unknown[], options?: { executor?: Knex }): Promise<void>;
     };
   };
@@ -56,7 +56,7 @@ interface ImporterServices {
 
 // The custom fields services the members service hands the export composition root.
 interface CustomFieldsServices {
-  definitions: { browse(): Promise<CustomFieldDefinition[]> };
+  definitions: { activeInEveryNamespace(): Promise<CustomFieldDefinition[]> };
   values: {
     getValuesForMembers(memberIds: string[]): Promise<Map<string, Record<string, unknown>>>;
   };
@@ -116,8 +116,10 @@ export function makeImporter(deps: ImporterServices) {
   // is dropped.
   const customFields: CustomFieldsImport = {
     activeFields: async () =>
-      labs.isSet('membersCustomFields') ? deps.customFields.definitions.browse() : [],
-    planWrite: (values) => deps.customFields.values.planWrite(values),
+      labs.isSet('membersCustomFields')
+        ? deps.customFields.definitions.activeInEveryNamespace()
+        : [],
+    planWrite: (values, namespace) => deps.customFields.values.planWrite(values, namespace),
     applyWrite: (memberId, plan, executor) =>
       deps.customFields.values.applyWrite(memberId, plan, { executor }),
   };
@@ -190,7 +192,7 @@ export function makeExporter({
       // are always present -- no not-initialised state to guard. The flag decides
       // whether their columns are included at all.
       activeDefinitions: async (): Promise<CustomFieldDefinition[]> =>
-        labs.isSet('membersCustomFields') ? definitions.browse() : [],
+        labs.isSet('membersCustomFields') ? definitions.activeInEveryNamespace() : [],
       valuesForMembers: (memberIds) => values.getValuesForMembers(memberIds),
     },
   });

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -2,6 +2,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const moment = require('moment');
+const { PUBLISHER_NAMESPACE } = require('@tryghost/custom-field-types/csv');
 
 const messages = {
   stripeNotConnected: 'Missing Stripe connection.',
@@ -113,6 +114,27 @@ module.exports = class MemberBREADService {
    * @param {string[]} memberIds
    * @returns {Promise<Map<string, Record<string, unknown>> | null>}
    */
+  /**
+   * Attach a member's field values, a property per namespace that declared them.
+   *
+   * A namespace is addressed the same way everywhere: `custom_fields.nickname` is the
+   * CSV column, the filter and this property, and a namespace Ghost declares reads the
+   * same. The publisher's is always present once the feature is on, so a member with no
+   * values still carries the key rather than the property appearing and disappearing.
+   *
+   * A namespace never overwrites a property the member already has: they are declared in
+   * code and none collides today, and quietly replacing `email` would be worse than
+   * dropping a value nobody can address anyway.
+   * @private
+   * @param {object} member
+   * @param {Record<string, Record<string, unknown>>} values
+   */
+  attachCustomFieldValues(member, values) {
+    // The publisher's namespace is always present once the feature is on, so a member
+    // with no values still carries the key rather than the property coming and going.
+    member.field_values = { [PUBLISHER_NAMESPACE]: {}, ...values };
+  }
+
   async fetchCustomFieldValues(memberIds) {
     if (!this.labsService.isSet('membersCustomFields')) {
       return null;
@@ -455,7 +477,7 @@ module.exports = class MemberBREADService {
 
     const customFields = await this.fetchCustomFieldValues([member.id]);
     if (customFields) {
-      member.custom_fields = customFields.get(member.id) ?? {};
+      this.attachCustomFieldValues(member, customFields.get(member.id) ?? {});
     }
 
     return member;
@@ -815,7 +837,7 @@ module.exports = class MemberBREADService {
         delete member.products;
       }
       if (customFieldsByMember) {
-        member.custom_fields = customFieldsByMember.get(model.id) ?? {};
+        this.attachCustomFieldValues(member, customFieldsByMember.get(model.id) ?? {});
       }
       member.email_suppression = {
         suppressed: bulkSuppressionData[index].suppressed || !!model.get('email_disabled'),

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -176,6 +176,16 @@ module.exports = function apiRoutes() {
 
   router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
 
+  // Every declared member field, whichever namespace declared it: what a surface reads
+  // to offer a field to filter on, map an import onto, or show as a column. Read-only —
+  // managing a field is the publisher's own endpoint below, and only their namespace.
+  router.get(
+    '/members/fields',
+    mw.authAdminApi,
+    labs.enabledMiddleware('membersCustomFields'),
+    http(api.membersFields.browse),
+  );
+
   // Member custom field definitions — gated by the members_custom_fields flag.
   // Registered before /members/:id so the literal path isn't captured by :id.
   router.get(

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import ObjectID from 'bson-objectid';
 
 const {
   agentProvider,
@@ -1030,6 +1031,230 @@ describe('Member Custom Fields Admin API', function () {
         actions.map((action: { context: string | null }) => JSON.parse(action.context ?? '{}').key),
         ['company'],
       );
+    });
+  });
+
+  // A field declared by something other than the publisher. Nothing provisions one yet,
+  // so these insert it directly; every assertion is still made through the API, because
+  // what is pinned is what the publisher's API does with a field it does not own.
+  describe('A field in another namespace', function () {
+    const SHIPPING = 'shipping';
+
+    async function declareShippingField(key: string, name: string): Promise<string> {
+      const id = new ObjectID().toHexString();
+      await models.Base.knex('members_custom_fields').insert({
+        id,
+        namespace: SHIPPING,
+        key,
+        name,
+        type: 'short_text',
+        sort_order: 0,
+        created_at: new Date(),
+      });
+      return id;
+    }
+
+    async function storeShippingValue(fieldId: string, memberId: string, value: string) {
+      await models.Base.knex('members_custom_field_values').insert({
+        id: new ObjectID().toHexString(),
+        field_id: fieldId,
+        member_id: memberId,
+        path: '',
+        value_text: value,
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+    }
+
+    it('is not listed among the publisher fields', async function () {
+      await createField({ name: 'Nickname' });
+      await declareShippingField('address', 'Address');
+
+      const { body } = await agent.get('members/custom_fields/').expectStatus(200);
+
+      assert.deepEqual(
+        body.members_custom_fields.map((field: { key: string }) => field.key),
+        ['nickname'],
+      );
+    });
+
+    // The point of the namespace: the publisher keeps every name and key they would
+    // have had, whatever Ghost has declared for itself.
+    it('does not stop the publisher minting the same key', async function () {
+      await declareShippingField('address', 'Address');
+
+      const field = await createField({ name: 'Address' });
+
+      assert.equal(field.key, 'address', 'the publisher got the key they asked for');
+    });
+
+    it('cannot be renamed, archived or deleted through the publisher API', async function () {
+      await declareShippingField('address', 'Address');
+
+      await agent
+        .put('members/custom_fields/address/')
+        .body({ members_custom_fields: [{ name: 'Delivery address' }] })
+        .expectStatus(404);
+
+      await agent
+        .put('members/custom_fields/address/')
+        .body({ members_custom_fields: [{ status: 'archived' }] })
+        .expectStatus(404);
+
+      await agent.delete('members/custom_fields/address/').expectStatus(404);
+    });
+
+    // A member's values are keyed by the field's key, which identifies a field only
+    // inside its namespace, so the object has to carry the publisher's field and not
+    // whatever else happens to share the key.
+    it('does not leak into a member custom fields', async function () {
+      const shippingId = await declareShippingField('address', 'Address');
+      const publisherField = await createField({ name: 'Address' });
+      const memberId = await createMember();
+
+      await setValues(memberId, { [publisherField.key]: 'Theirs' });
+      await storeShippingValue(shippingId, memberId, 'Ours');
+
+      assert.deepEqual(await readValues(memberId), { address: 'Theirs' });
+    });
+
+    it('is not matched by a filter naming the same key in another namespace', async function () {
+      const shippingId = await declareShippingField('address', 'Address');
+      const memberId = await createMember();
+      await storeShippingValue(shippingId, memberId, 'Ours');
+
+      const filter = encodeURIComponent("custom_fields.key:'address'+custom_fields.value:'Ours'");
+      const { body } = await agent.get(`members/?filter=${filter}`).expectStatus(200);
+
+      assert.deepEqual(body.members, []);
+    });
+
+    // Every namespace is addressed the same way, and which ones exist is a fact about the
+    // database, so a filter naming one resolves without anything having declared it here.
+    it('is matched by a filter naming its own namespace', async function () {
+      const shippingId = await declareShippingField('address', 'Address');
+      const memberId = await createMember();
+      await storeShippingValue(shippingId, memberId, 'Ours');
+
+      const filter = encodeURIComponent("shipping.key:'address'+shipping.value:'Ours'");
+      const { body } = await agent.get(`members/?filter=${filter}`).expectStatus(200);
+
+      assert.deepEqual(
+        body.members.map((member: { id: string }) => member.id),
+        [memberId],
+      );
+    });
+
+    it('is not matched when another namespace holds the value', async function () {
+      const shippingId = await declareShippingField('address', 'Address');
+      const publisherField = await createField({ name: 'Address' });
+      const memberId = await createMember();
+
+      await setValues(memberId, { [publisherField.key]: 'Theirs' });
+      await storeShippingValue(shippingId, memberId, 'Ours');
+
+      const filter = encodeURIComponent("shipping.key:'address'+shipping.value:'Theirs'");
+      const { body } = await agent.get(`members/?filter=${filter}`).expectStatus(200);
+
+      assert.deepEqual(body.members, [], 'the publisher value did not answer for shipping');
+    });
+
+    // A member's values are every namespace's, each under the one that declared it.
+    it('reads back under its own namespace, beside the publisher fields', async function () {
+      const shippingId = await declareShippingField('address', 'Address');
+      const publisherField = await createField({ name: 'Address' });
+      const memberId = await createMember();
+
+      await setValues(memberId, { [publisherField.key]: 'Theirs' });
+      await storeShippingValue(shippingId, memberId, 'Ours');
+
+      const { body } = await agent.get(`members/${memberId}/`).expectStatus(200);
+
+      assert.deepEqual(body.members[0].custom_fields, { address: 'Theirs' });
+      assert.deepEqual(body.members[0].shipping, { address: 'Ours' });
+    });
+  });
+
+  // What a surface reads to know a field exists, as opposed to what the publisher may
+  // manage. Both namespaces are in it, and each field says which one declared it.
+  describe('Every declared field', function () {
+    async function declareForeignField(key: string, name: string): Promise<string> {
+      const id = new ObjectID().toHexString();
+      await models.Base.knex('members_custom_fields').insert({
+        id,
+        namespace: 'shipping',
+        key,
+        name,
+        type: 'short_text',
+        sort_order: 0,
+        created_at: new Date(),
+      });
+      return id;
+    }
+
+    it('lists a field from every namespace, saying which declared it', async function () {
+      await createField({ name: 'Nickname' });
+      await declareForeignField('address', 'Address');
+
+      const { body } = await agent.get('members/fields/').expectStatus(200);
+
+      assert.deepEqual(
+        body.members_fields.map((field: { namespace: string; key: string }) => ({
+          namespace: field.namespace,
+          key: field.key,
+        })),
+        [
+          { namespace: 'custom_fields', key: 'nickname' },
+          { namespace: 'shipping', key: 'address' },
+        ],
+      );
+    });
+
+    // The same key in two namespaces is two fields, and this is the read that has to
+    // keep them apart for a filter picker to offer both.
+    it('lists the same key once per namespace holding it', async function () {
+      await declareForeignField('address', 'Address');
+      await createField({ name: 'Address' });
+
+      const { body } = await agent.get('members/fields/').expectStatus(200);
+
+      assert.deepEqual(
+        body.members_fields.map((field: { namespace: string }) => field.namespace).sort(),
+        ['custom_fields', 'shipping'],
+      );
+    });
+
+    it('hides archived fields unless asked for them', async function () {
+      const field = await createField({ name: 'Nickname' });
+      await setStatus(field.key, 'archived');
+
+      const { body: hidden } = await agent.get('members/fields/').expectStatus(200);
+      assert.deepEqual(hidden.members_fields, []);
+
+      const { body: shown } = await agent
+        .get('members/fields/?filter=status:[active,archived]')
+        .expectStatus(200);
+      assert.deepEqual(
+        shown.members_fields.map((one: { key: string }) => one.key),
+        [field.key],
+      );
+    });
+
+    // Read-only: declaring a field outside the publisher's namespace is the owner's
+    // business, not something the API offers. Only the create is asserted — a PUT on
+    // this path is captured by the member edit route as an id, so what it answers says
+    // nothing about this endpoint.
+    it('offers no way to create through it', async function () {
+      await agent
+        .post('members/fields/')
+        .body({ members_fields: [{ name: 'Nope', type: 'short_text' }] })
+        .expectStatus(404);
+    });
+
+    it('is refused without permission', async function () {
+      await agent.loginAsEditor();
+      await agent.get('members/fields/').expectStatus(403);
+      await agent.loginAsOwner();
     });
   });
 

--- a/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import ObjectID from 'bson-objectid';
 
 const Papa = require('papaparse');
 const { agentProvider, fixtureManager, mockManager } = require('../../utils/e2e-framework');
@@ -119,6 +120,57 @@ describe('Members API — exportCSV with custom fields', function () {
     await models.Base.knex('actions')
       .whereIn('resource_type', ['member', 'member_custom_field'])
       .del();
+  });
+
+  // A field declared by something other than the publisher. Nothing provisions one yet,
+  // so this inserts it directly; what is pinned is that the export is the publisher's
+  // fields and nothing else, now that a key identifies a field only inside a namespace.
+  describe('a field in another namespace', function () {
+    async function declareForeignField(key: string, name: string): Promise<string> {
+      const id = new ObjectID().toHexString();
+      await models.Base.knex('members_custom_fields').insert({
+        id,
+        namespace: 'shipping',
+        key,
+        name,
+        type: 'short_text',
+        sort_order: 0,
+        created_at: new Date(),
+      });
+      return id;
+    }
+
+    it('adds a column under the namespace that declared it', async function () {
+      await createField('Nickname', 'short_text');
+      await declareForeignField('address', 'Address');
+      await createMember();
+
+      const { columns } = await exportCSV();
+
+      assert.ok(columns.includes('custom_fields.nickname'));
+      assert.ok(columns.includes('shipping.address'));
+    });
+
+    it('keeps a key held in two namespaces in two columns', async function () {
+      const foreignId = await declareForeignField('address', 'Address');
+      const publisherField = await createField('Address', 'short_text');
+      const member = await createMember({ [publisherField.key]: 'Theirs' });
+
+      await models.Base.knex('members_custom_field_values').insert({
+        id: new ObjectID().toHexString(),
+        field_id: foreignId,
+        member_id: member.id,
+        path: '',
+        value_text: 'Ours',
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+
+      const { rowFor } = await exportCSV();
+
+      assert.equal(rowFor(member.id)['custom_fields.address'], 'Theirs');
+      assert.equal(rowFor(member.id)['shipping.address'], 'Ours');
+    });
   });
 
   it('adds a column per active field, expanding an address into its sub-fields', async function () {

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 import assert from 'node:assert/strict';
+import ObjectID from 'bson-objectid';
 
 const supertest = require('supertest');
 const localUtils = require('./utils');
@@ -345,6 +346,74 @@ describe('Members import — custom fields', function () {
       ],
       'only the named part moved',
     );
+  });
+
+  // A field declared by something other than the publisher. Nothing provisions one yet,
+  // so this inserts it directly; what is pinned is that a namespaced column reaches the
+  // publisher's field, now that a key identifies a field only inside a namespace.
+  describe('a field in another namespace', function () {
+    async function declareForeignField(key: string, name: string): Promise<string> {
+      const id = new ObjectID().toHexString();
+      await models.Base.knex('members_custom_fields').insert({
+        id,
+        namespace: 'shipping',
+        key,
+        name,
+        type: 'short_text',
+        sort_order: 0,
+        created_at: new Date(),
+      });
+      return id;
+    }
+
+    it('takes the publisher field when a key exists in both', async function () {
+      const foreignId = await declareForeignField('address', 'Address');
+      const key = await createField('Address', 'short_text');
+      const email = 'cf-namespaced@example.com';
+
+      const res = await importCSV(`email,custom_fields.${key}\n${email},1 High Street\n`);
+      assert.equal(res.status, 201);
+      assert.equal(res.body.meta.stats.imported, 1);
+
+      const rows = await models.Base.knex('members_custom_field_values').select(
+        'field_id',
+        'value_text',
+      );
+      assert.equal(rows.length, 1, 'one value was written');
+      assert.notEqual(rows[0].field_id, foreignId, 'and not against the field Ghost declared');
+      assert.equal(rows[0].value_text, '1 High Street');
+    });
+
+    // Every namespace addresses its fields the same way, so a column naming one reaches
+    // the field it names.
+    it('reads a column into the namespace that owns it', async function () {
+      const foreignId = await declareForeignField('address', 'Address');
+      const email = 'cf-foreign-column@example.com';
+
+      const res = await importCSV(`email,shipping.address\n${email},1 High Street\n`);
+      assert.equal(res.status, 201);
+      assert.equal(res.body.meta.stats.imported, 1);
+
+      const rows = await models.Base.knex('members_custom_field_values').select(
+        'field_id',
+        'value_text',
+      );
+      assert.deepEqual(rows, [{ field_id: foreignId, value_text: '1 High Street' }]);
+    });
+
+    it('drops a column naming a namespace nothing is declared in', async function () {
+      const email = 'cf-unknown-namespace@example.com';
+
+      const res = await importCSV(`email,nowhere.address\n${email},1 High Street\n`);
+      assert.equal(res.status, 201);
+      assert.equal(res.body.meta.stats.imported, 1, 'the member still imports');
+
+      assert.deepEqual(
+        await models.Base.knex('members_custom_field_values').select('id'),
+        [],
+        'nothing was written for a column naming no field',
+      );
+    });
   });
 
   // A composite can still be invalid, and when it is the whole row fails like any other.

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = 'c4c1ef4ab373e100452e6e478a0a5758';
+  const currentSchemaHash = 'd123ff4189b089cd5e4520b372f973de';
   const currentFixturesHash = '1727a789194847da33d68dd95301b416';
   const currentSettingsHash = 'f57245b22af55ea5fc1e5e20913de9bb';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';

--- a/ghost/core/test/unit/server/services/members-custom-fields/storage.test.ts
+++ b/ghost/core/test/unit/server/services/members-custom-fields/storage.test.ts
@@ -116,19 +116,37 @@ describe('custom field value storage', function () {
   describe('rows become every member’s values', function () {
     it('gathers each value from every row belonging to it', function () {
       const values = valuesFromLeaves([
-        { member_id: 'm1', key: 'home_address', path: 'city', value_text: 'London' },
-        { member_id: 'm1', key: 'nickname', path: ROOT_PATH, value_text: 'Bex' },
-        { member_id: 'm2', key: 'home_address', path: 'country', value_text: 'IE' },
-        { member_id: 'm1', key: 'home_address', path: 'line1', value_text: '1 High St' },
+        { member_id: 'm1', namespace: 'custom_fields', key: 'home_address', path: 'city', value_text: 'London' },
+        { member_id: 'm1', namespace: 'custom_fields', key: 'nickname', path: ROOT_PATH, value_text: 'Bex' },
+        { member_id: 'm2', namespace: 'custom_fields', key: 'home_address', path: 'country', value_text: 'IE' },
+        { member_id: 'm1', namespace: 'custom_fields', key: 'home_address', path: 'line1', value_text: '1 High St' },
       ]);
 
       // m1's address arrives split by two unrelated rows; nothing depends on the
       // rows for one value being next to each other.
       assert.deepEqual(values.get('m1'), {
-        home_address: { city: 'London', line1: '1 High St' },
-        nickname: 'Bex',
+        custom_fields: {
+          home_address: { city: 'London', line1: '1 High St' },
+          nickname: 'Bex',
+        },
       });
-      assert.deepEqual(values.get('m2'), { home_address: { country: 'IE' } });
+      assert.deepEqual(values.get('m2'), {
+        custom_fields: { home_address: { country: 'IE' } },
+      });
+    });
+
+    // A key names a different field in each namespace, so the same key from two of them
+    // has to land as two values rather than one overwriting the other.
+    it('keeps the same key apart when two namespaces hold it', function () {
+      const values = valuesFromLeaves([
+        { member_id: 'm1', namespace: 'custom_fields', key: 'address', path: ROOT_PATH, value_text: 'Theirs' },
+        { member_id: 'm1', namespace: 'shipping', key: 'address', path: ROOT_PATH, value_text: 'Ours' },
+      ]);
+
+      assert.deepEqual(values.get('m1'), {
+        custom_fields: { address: 'Theirs' },
+        shipping: { address: 'Ours' },
+      });
     });
 
     it('leaves a member with no rows out entirely', function () {

--- a/packages/custom-field-types/src/csv.ts
+++ b/packages/custom-field-types/src/csv.ts
@@ -25,12 +25,31 @@ const SEPARATOR = '.';
  * `custom_fields` is the same path the Admin API already uses to address these
  * values, so a column reads like the field it came from.
  */
-const NAMESPACE = 'custom_fields';
+/**
+ * The namespace publisher-defined fields live in, and the path their values are
+ * addressed under everywhere: this column prefix, the members filter, and the Admin
+ * API. Exported because the server stores it on each field row now that Ghost can
+ * declare fields of its own, and the two must agree on the spelling.
+ */
+export const PUBLISHER_NAMESPACE = 'custom_fields';
 
 /** A field definition reduced to what CSV needs to know about it. */
 export interface CsvField {
+  namespace: string;
   key: string;
   type: FieldType;
+}
+
+/**
+ * A member's values, by the namespace that owns the field and then by its key. The two
+ * together address a field: a key identifies one only inside its namespace, so the same
+ * key can name a different field in each.
+ */
+export type NamespacedValues = Record<string, Record<string, unknown>>;
+
+/** Where a field's value sits: `<namespace>.<key>`, and a part of it one level deeper. */
+function columnFor(field: CsvField): string {
+  return `${field.namespace}${SEPARATOR}${field.key}`;
 }
 
 function toCell(value: unknown): string {
@@ -55,15 +74,25 @@ export interface CsvFieldColumn {
 // Shares csvCellsForFields' column derivation, so a field is written, read, and offered
 // as a mapping target under one set of column names.
 export function csvColumnsForField(field: CsvField): CsvFieldColumn[] {
-  const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
+  const column = columnFor(field);
   const subFields = subFieldsOf(field.type);
   return subFields
     ? subFields.map((sub) => ({ column: `${column}${SEPARATOR}${sub}`, subField: sub }))
     : [{ column, subField: null }];
 }
 
-export function isCustomFieldColumn(column: string): boolean {
-  return column === NAMESPACE || column.startsWith(`${NAMESPACE}${SEPARATOR}`);
+/**
+ * Whether a column names a field in the given namespace. Takes the namespace rather than
+ * assuming the publisher's, because every namespace addresses its fields the same way and
+ * only the caller knows which ones it cares about.
+ */
+export function isFieldColumn(column: string, namespace: string): boolean {
+  return column === namespace || column.startsWith(`${namespace}${SEPARATOR}`);
+}
+
+/** Whether a column names a field in any of the namespaces given. */
+export function isAnyFieldColumn(column: string, namespaces: readonly string[]): boolean {
+  return namespaces.some((namespace) => isFieldColumn(column, namespace));
 }
 
 /**
@@ -75,14 +104,14 @@ export function isCustomFieldColumn(column: string): boolean {
  */
 export function csvCellsForFields(
   fields: readonly CsvField[],
-  values: Record<string, unknown>,
+  values: NamespacedValues,
 ): Record<string, string> {
   const cells: Record<string, string> = {};
 
   for (const field of fields) {
-    const value = values[field.key];
+    const value = values[field.namespace]?.[field.key];
     const subFields = subFieldsOf(field.type);
-    const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
+    const column = columnFor(field);
 
     if (!subFields) {
       cells[column] = toCell(value);
@@ -122,13 +151,16 @@ export function fieldValuesFromCsvRow(
   fields: readonly CsvField[],
   row: Record<string, unknown>,
   decodeCell: (cell: string) => string = (cell) => cell,
-): Record<string, unknown> {
-  const values: Record<string, unknown> = {};
+): NamespacedValues {
+  const values: NamespacedValues = {};
+  const set = (field: CsvField, value: unknown) => {
+    values[field.namespace] = { ...values[field.namespace], [field.key]: value };
+  };
 
   // The parser only ever sets a string cell for these columns, so a non-string is an
   // absent column, read as untouched.
   for (const field of fields) {
-    const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
+    const column = columnFor(field);
     const subFields = subFieldsOf(field.type);
 
     if (!subFields) {
@@ -136,7 +168,7 @@ export function fieldValuesFromCsvRow(
       if (typeof cell === 'string') {
         const decoded = decodeCell(cell);
         if (!isBlank(decoded)) {
-          values[field.key] = decoded;
+          set(field, decoded);
         }
       }
       continue;
@@ -157,7 +189,7 @@ export function fieldValuesFromCsvRow(
     }
 
     if (anyColumnPresent && Object.keys(composite).length > 0) {
-      values[field.key] = composite;
+      set(field, composite);
     }
   }
 

--- a/packages/custom-field-types/test/csv.test.ts
+++ b/packages/custom-field-types/test/csv.test.ts
@@ -4,7 +4,8 @@ import {
   csvCellsForFields,
   csvColumnsForField,
   fieldValuesFromCsvRow,
-  isCustomFieldColumn,
+  isAnyFieldColumn,
+  isFieldColumn,
 } from '../src/csv.ts';
 
 // The behavioural outcomes — an export carrying the right columns, an exported
@@ -12,9 +13,20 @@ import {
 // export and import HTTP API integration tests. What is asserted here is the one
 // invariant those tests can only observe indirectly: the key set is fixed by the
 // field definitions alone, never by which values a given member happens to hold.
+// Every case below is about a publisher field, so it addresses one namespace and these
+// keep the call sites about the cells. Namespacing itself is covered separately.
+const cellsFor = (fields: Parameters<typeof csvCellsForFields>[0], values: Record<string, unknown>) =>
+  csvCellsForFields(fields, { custom_fields: values });
+
+const valuesFrom = (
+  fields: Parameters<typeof fieldValuesFromCsvRow>[0],
+  row: Record<string, unknown>,
+  decodeCell?: (cell: string) => string,
+) => fieldValuesFromCsvRow(fields, row, decodeCell).custom_fields ?? {};
+
 describe('custom field CSV cells', function () {
-  const nickname = { key: 'nickname', type: 'short_text' } as const;
-  const address = { key: 'shipping_address', type: 'address' } as const;
+  const nickname = { namespace: 'custom_fields', key: 'nickname', type: 'short_text' } as const;
+  const address = { namespace: 'custom_fields', key: 'shipping_address', type: 'address' } as const;
 
   const ADDRESS_COLUMNS = [
     'custom_fields.shipping_address.line1',
@@ -26,7 +38,7 @@ describe('custom field CSV cells', function () {
   ];
 
   it('gives a scalar field one column', function () {
-    assert.deepEqual(csvCellsForFields([nickname], { nickname: 'Bex' }), {
+    assert.deepEqual(cellsFor([nickname], { nickname: 'Bex' }), {
       'custom_fields.nickname': 'Bex',
     });
   });
@@ -34,7 +46,7 @@ describe('custom field CSV cells', function () {
   // A key is minted from a publisher-chosen name, so it can land on a column the
   // export already has. Namespacing is what stops the value taking its place.
   it('namespaces a key that collides with a core export column', function () {
-    const cells = csvCellsForFields([{ key: 'email', type: 'short_text' }], {
+    const cells = cellsFor([{ namespace: 'custom_fields', key: 'email', type: 'short_text' }], {
       email: 'a nickname',
     });
 
@@ -43,7 +55,7 @@ describe('custom field CSV cells', function () {
   });
 
   it('expands a composite field into a column per sub-field', function () {
-    const cells = csvCellsForFields([address], {
+    const cells = cellsFor([address], {
       shipping_address: {
         line1: '1 High Street',
         line2: 'Flat 2',
@@ -62,7 +74,7 @@ describe('custom field CSV cells', function () {
   // The export takes its header from a single row, so a field the member has no
   // value for must still produce its columns or it vanishes from the whole file.
   it('produces the same columns whether or not the member holds a value', function () {
-    const withValues = csvCellsForFields([nickname, address], {
+    const withValues = cellsFor([nickname, address], {
       nickname: 'Bex',
       shipping_address: {
         line1: '1 High Street',
@@ -71,7 +83,7 @@ describe('custom field CSV cells', function () {
         country: 'GB',
       },
     });
-    const withNothing = csvCellsForFields([nickname, address], {});
+    const withNothing = cellsFor([nickname, address], {});
 
     assert.deepEqual(Object.keys(withNothing), Object.keys(withValues));
     assert.deepEqual(
@@ -81,7 +93,7 @@ describe('custom field CSV cells', function () {
   });
 
   it('leaves a cell empty for a sub-field the value omits', function () {
-    const cells = csvCellsForFields([address], {
+    const cells = cellsFor([address], {
       shipping_address: {
         line1: '9 Long Lane',
         city: 'Bristol',
@@ -95,7 +107,7 @@ describe('custom field CSV cells', function () {
   });
 
   it('treats an explicit null as no value', function () {
-    assert.deepEqual(csvCellsForFields([nickname], { nickname: null }), {
+    assert.deepEqual(cellsFor([nickname], { nickname: null }), {
       'custom_fields.nickname': '',
     });
   });
@@ -105,13 +117,13 @@ describe('custom field CSV cells', function () {
 // the error report echoes, so they are derived from the same primitives the cells are.
 describe('custom field CSV columns', function () {
   it('gives a scalar field one namespaced column holding no particular part', function () {
-    assert.deepEqual(csvColumnsForField({ key: 'nickname', type: 'short_text' }), [
+    assert.deepEqual(csvColumnsForField({ namespace: 'custom_fields', key: 'nickname', type: 'short_text' }), [
       { column: 'custom_fields.nickname', subField: null },
     ]);
   });
 
   it('gives a composite field one column per sub-field, each naming the part it holds', function () {
-    assert.deepEqual(csvColumnsForField({ key: 'shipping_address', type: 'address' }), [
+    assert.deepEqual(csvColumnsForField({ namespace: 'custom_fields', key: 'shipping_address', type: 'address' }), [
       { column: 'custom_fields.shipping_address.line1', subField: 'line1' },
       { column: 'custom_fields.shipping_address.line2', subField: 'line2' },
       { column: 'custom_fields.shipping_address.city', subField: 'city' },
@@ -122,38 +134,38 @@ describe('custom field CSV columns', function () {
   });
 
   it('recognises a custom field column by its namespace', function () {
-    assert.equal(isCustomFieldColumn('custom_fields.nickname'), true);
-    assert.equal(isCustomFieldColumn('custom_fields.shipping_address.city'), true);
-    assert.equal(isCustomFieldColumn('email'), false);
+    assert.equal(isFieldColumn('custom_fields.nickname', 'custom_fields'), true);
+    assert.equal(isFieldColumn('custom_fields.shipping_address.city', 'custom_fields'), true);
+    assert.equal(isFieldColumn('email', 'custom_fields'), false);
     // A core column that merely starts with the word is not namespaced by it.
-    assert.equal(isCustomFieldColumn('custom_fields_note'), false);
+    assert.equal(isFieldColumn('custom_fields_note', 'custom_fields'), false);
   });
 });
 
 // End-to-end round-tripping is proven in the member import HTTP API tests; the row-level
 // reading rules are pinned here.
 describe('reading custom field values from a CSV row', function () {
-  const nickname = { key: 'nickname', type: 'short_text' } as const;
-  const address = { key: 'shipping_address', type: 'address' } as const;
+  const nickname = { namespace: 'custom_fields', key: 'nickname', type: 'short_text' } as const;
+  const address = { namespace: 'custom_fields', key: 'shipping_address', type: 'address' } as const;
 
   it('reads a scalar column into its value', function () {
-    assert.deepEqual(fieldValuesFromCsvRow([nickname], { 'custom_fields.nickname': 'Bex' }), {
+    assert.deepEqual(valuesFrom([nickname], { 'custom_fields.nickname': 'Bex' }), {
       nickname: 'Bex',
     });
   });
 
   it('leaves a field untouched when its column is absent from the row', function () {
-    assert.deepEqual(fieldValuesFromCsvRow([nickname], { email: 'a@b.com' }), {});
+    assert.deepEqual(valuesFrom([nickname], { email: 'a@b.com' }), {});
   });
 
   // Blank means untouched, not cleared, so re-importing a partly-edited export can't wipe values.
   it('leaves a field untouched when its scalar column is present but blank', function () {
-    assert.deepEqual(fieldValuesFromCsvRow([nickname], { 'custom_fields.nickname': '' }), {});
+    assert.deepEqual(valuesFrom([nickname], { 'custom_fields.nickname': '' }), {});
   });
 
   it('reads only active fields, dropping a column that names no passed field', function () {
     assert.deepEqual(
-      fieldValuesFromCsvRow([nickname], {
+      valuesFrom([nickname], {
         'custom_fields.nickname': 'Bex',
         'custom_fields.unknown': 'ignored',
       }),
@@ -164,7 +176,7 @@ describe('reading custom field values from a CSV row', function () {
   // The export writes "no address" and an all-blank address identically, so all-blank is read as absent.
   it('omits a composite whose every sub-cell is blank', function () {
     assert.deepEqual(
-      fieldValuesFromCsvRow([address], {
+      valuesFrom([address], {
         'custom_fields.shipping_address.line1': '',
         'custom_fields.shipping_address.line2': '',
         'custom_fields.shipping_address.city': '',
@@ -178,7 +190,7 @@ describe('reading custom field values from a CSV row', function () {
 
   it('reads a composite from its non-blank sub-cells, omitting the blank ones', function () {
     assert.deepEqual(
-      fieldValuesFromCsvRow([address], {
+      valuesFrom([address], {
         'custom_fields.shipping_address.line1': '1 High Street',
         'custom_fields.shipping_address.line2': '',
         'custom_fields.shipping_address.city': 'London',
@@ -201,7 +213,7 @@ describe('reading custom field values from a CSV row', function () {
   // rejects it) rather than silently dropped like an all-blank one.
   it('reads a partial composite so its validation can fail the row', function () {
     assert.deepEqual(
-      fieldValuesFromCsvRow([address], {
+      valuesFrom([address], {
         'custom_fields.shipping_address.city': 'London',
       }),
       { shipping_address: { city: 'London' } },
@@ -213,14 +225,64 @@ describe('reading custom field values from a CSV row', function () {
   // reads as untouched, so a decoder can't accidentally write an emptied field.
   it('decodes each cell through the caller-supplied decoder', function () {
     assert.deepEqual(
-      fieldValuesFromCsvRow([nickname], { 'custom_fields.nickname': ' Bex ' }, (cell) =>
+      valuesFrom([nickname], { 'custom_fields.nickname': ' Bex ' }, (cell) =>
         cell.trim(),
       ),
       { nickname: 'Bex' },
     );
     assert.deepEqual(
-      fieldValuesFromCsvRow([nickname], { 'custom_fields.nickname': '   ' }, (cell) => cell.trim()),
+      valuesFrom([nickname], { 'custom_fields.nickname': '   ' }, (cell) => cell.trim()),
       {},
     );
+  });
+});
+
+describe('custom field CSV columns across namespaces', function () {
+  const theirs = { namespace: 'custom_fields', key: 'address', type: 'short_text' } as const;
+  const ours = { namespace: 'shipping', key: 'address', type: 'short_text' } as const;
+
+  // The same key in two namespaces is two different fields, which is the whole point of
+  // having them: neither owner has to know what the other minted.
+  it('gives each namespace its own column for the same key', function () {
+    assert.deepEqual(
+      csvCellsForFields([theirs, ours], {
+        custom_fields: { address: 'Theirs' },
+        shipping: { address: 'Ours' },
+      }),
+      {
+        'custom_fields.address': 'Theirs',
+        'shipping.address': 'Ours',
+      },
+    );
+  });
+
+  it('reads each column back to the namespace that owns it', function () {
+    assert.deepEqual(
+      fieldValuesFromCsvRow([theirs, ours], {
+        'custom_fields.address': 'Theirs',
+        'shipping.address': 'Ours',
+      }),
+      {
+        custom_fields: { address: 'Theirs' },
+        shipping: { address: 'Ours' },
+      },
+    );
+  });
+
+  it('leaves a namespace out entirely when its column is absent', function () {
+    assert.deepEqual(fieldValuesFromCsvRow([theirs, ours], { 'shipping.address': 'Ours' }), {
+      shipping: { address: 'Ours' },
+    });
+  });
+
+  it('names a column by the namespace that owns the field', function () {
+    assert.deepEqual(csvColumnsForField(ours), [{ column: 'shipping.address', subField: null }]);
+  });
+
+  it('recognises a column of any namespace it is given', function () {
+    assert.equal(isFieldColumn('shipping.address', 'shipping'), true);
+    assert.equal(isFieldColumn('shipping.address', 'custom_fields'), false);
+    assert.equal(isAnyFieldColumn('shipping.address', ['custom_fields', 'shipping']), true);
+    assert.equal(isAnyFieldColumn('email', ['custom_fields', 'shipping']), false);
   });
 });


### PR DESCRIPTION
## Problem

Ghost is about to declare member fields of its own, and there is nowhere to put them.

Every field today is one a publisher defined, and the code assumes that everywhere. The CSV columns, the members filter and the Admin API each spell the publisher's namespace as a constant, and the definitions service treats everything in the table as the publisher's to rename, archive and delete. A field Ghost declares breaks all of that at once.

It also has nowhere safe to live. Keys are minted from names a publisher chose, so any key Ghost picks for itself can collide with one a publisher already has, or one they create later. Reserving names only works while you can predict every field you will ever add, which is not a bet worth making.

## Solution

A field records the namespace that declared it, and a key is unique inside that namespace rather than across all of them. Neither owner has to know what the other minted, and no list of reserved names has to be maintained. The publisher's namespace is the value the shared package already used to name their CSV columns, so their fields keep the address they have always had.

Every read and write in the definitions API is scoped to the publisher's namespace in one place, for the same reason the archived filter already lives there. A query that forgets is a silent bug, and forgetting here would offer a field Ghost declared up to be renamed or deleted.

Scoping a key means a value can no longer reference one, so a value points at its field by id and nothing else. A filter still names a field by its namespace and key, and a view resolves those, so the filter stays a rewrite with no lookup before the query is built. That is what lets it chain onto every members query rather than each call site wiring it, and it keeps a field's address in one place rather than copied onto every value row.

Nothing changes for a publisher. There is one namespace, and every field is in it.

## This edits a migration that has already shipped

Worth reviewing on its own.

Migrations get replayed against whatever schema is current, and the one that last changed how values reference their field recreated the table from a fixed shape every time it ran. Against a newer schema that undoes whatever the current shape is, and leaves a foreign key pointing at a constraint this change narrows, which nothing can then write through. It now acts only when the table is still keyed the way it converts from, and recreates a missing table rather than assuming one is there.

Sites past it never run it again, so they are unaffected either way. Sites upgrading from below it still run it, and for them nothing changes: a forward run always finds the column it looks for. The migration next to it already guards its own steps this way, for the same stated reason.

The new migration is written the same way. It rebuilds rather than alters, because SQLite cannot alter a foreign key in place, and every step is guarded on what it finds rather than on what it expects. It also owns the view's lifecycle, creating it once both tables are their final shape and dropping it before anything is reshaped — SQLite validates every view while it rebuilds a table, so one left in place fails an unrelated alter elsewhere. Any later migration that reshapes either table needs to do the same, and the migration suite will say so if it forgets.

## Notes

Values are dropped rather than rewritten. The feature is behind a private flag with no released data, so a wipe costs nothing a backfill would save, which is the same call the earlier migration made.

This is groundwork. Nothing here declares a field, and no behaviour changes.
