### PR TITLE
fix(analytics): incorrect links from Top sources by requiring dot in domain regex

### DIFF
--- a/apps/admin-x-framework/src/utils/source-utils.ts
+++ b/apps/admin-x-framework/src/utils/source-utils.ts
@@ -1,5 +1,7 @@
 // Source domain mapping for favicons
 export const SOURCE_DOMAIN_MAP: Record<string, string> = {
+  GitHub: 'github.com',
+  github: 'github.com',
   Reddit: 'reddit.com',
   'www.reddit.com': 'reddit.com',
   Facebook: 'facebook.com',
@@ -235,7 +237,7 @@ export const getFaviconDomain = (
 
   // If not in mapping, check if it's already a domain
   const isDomain =
-    /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
+    /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/.test(
       source,
     );
   if (isDomain) {

--- a/apps/admin-x-framework/test/unit/utils/source-utils.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/source-utils.test.ts
@@ -196,6 +196,14 @@ describe('source-utils', () => {
         domain: 'google.com',
         isDirectTraffic: false,
       });
+      expect(getFaviconDomain('GitHub')).toEqual({
+        domain: 'github.com',
+        isDirectTraffic: false,
+      });
+      expect(getFaviconDomain('github')).toEqual({
+        domain: 'github.com',
+        isDirectTraffic: false,
+      });
     });
 
     it('identifies direct traffic for site domains', () => {
@@ -246,9 +254,9 @@ describe('source-utils', () => {
       });
     });
 
-    it('treats non-domain strings as domains', () => {
+    it('rejects non-domain strings', () => {
       expect(getFaviconDomain('not-a-domain')).toEqual({
-        domain: 'not-a-domain',
+        domain: null,
         isDirectTraffic: false,
       });
       expect(getFaviconDomain('invalid url string')).toEqual({


### PR DESCRIPTION
Resolves #24607 by requiring at least one dot in the domain string (e.g. \example.com\) so single words like 'GitHub' aren't mistakenly treated as valid domains.