### PR TITLE
🎨 Improved gift date picker positioning

### DIFF
--- a/apps/portal/src/components/common/date-picker.jsx
+++ b/apps/portal/src/components/common/date-picker.jsx
@@ -170,7 +170,10 @@ export const DatePickerStyles = `
         color: var(--grey7);
     }
 
+    /* Sizing the cell keeps every row a row tall whether or not it has
+       anything in it. */
     .gh-portal-datepicker-day {
+        height: 30px;
         padding: 0;
     }
 
@@ -221,8 +224,11 @@ export const DatePickerStyles = `
         opacity: 0.92;
     }
 
-    .gh-portal-datepicker-disabled .gh-portal-datepicker-day-button,
     .gh-portal-datepicker-outside .gh-portal-datepicker-day-button {
+        color: var(--grey8);
+    }
+
+    .gh-portal-datepicker-disabled .gh-portal-datepicker-day-button {
         color: var(--grey8);
         cursor: default;
     }
@@ -336,8 +342,7 @@ const DatePicker = ({
 
   const weekStartsOn = useMemo(() => getWeekStart(locale), [locale]);
 
-  // Measures after render in the portal host's coordinate space — the
-  // calendar's height varies by month.
+  // Measures after render in the portal host's coordinate space.
   const position = useCallback(() => {
     const field = fieldRef.current;
     const target = getPopoverHost(field);
@@ -354,9 +359,12 @@ const DatePicker = ({
     const spaceAbove = visible ? rect.top - visible.top : 0;
     const flip = spaceBelow < height + POPOVER_GAP && spaceAbove > spaceBelow;
 
+    // translateY rather than a measured height, so a flipped box hangs from
+    // the field's top edge and grows away from it.
     setPopoverStyle({
-      top: flip ? rect.top - host.top - height - POPOVER_GAP : rect.bottom - host.top + POPOVER_GAP,
+      top: flip ? rect.top - host.top - POPOVER_GAP : rect.bottom - host.top + POPOVER_GAP,
       right: host.right - rect.right,
+      transform: flip ? 'translateY(-100%)' : undefined,
     });
   }, []);
 
@@ -476,6 +484,9 @@ const DatePicker = ({
                 ...(maxDate ? [{ after: maxDate }] : []),
               ]}
               endMonth={maxDate}
+              // Six rows every month, so paging can't change the height the
+              // placement above was measured from.
+              fixedWeeks
               formatters={{
                 formatCaption: (date) => formats.monthCaption.format(date),
                 formatWeekdayName: (date) => formats.weekday.format(date),
@@ -483,9 +494,9 @@ const DatePicker = ({
               }}
               mode="single"
               selected={selected}
+              showOutsideDays
               startMonth={minDate}
               weekStartsOn={weekStartsOn}
-              onMonthChange={position}
               onSelect={handleSelect}
             />
           </div>,

--- a/apps/portal/test/unit/components/common/date-picker.test.tsx
+++ b/apps/portal/test/unit/components/common/date-picker.test.tsx
@@ -3,6 +3,7 @@ import DatePicker from '../../../../src/components/common/date-picker';
 
 const MIN = '2026-08-03';
 const MAX = '2027-08-03';
+const SIX_FULL_WEEKS = [7, 7, 7, 7, 7, 7];
 
 type RenderPickerUtils = ReturnType<typeof render> & { onChange: ReturnType<typeof vi.fn> };
 
@@ -29,6 +30,14 @@ const renderPicker = (
 const openPicker = ({ getByTestId }: RenderPickerUtils) => {
   fireEvent.click(getByTestId('datepicker-toggle'));
 };
+
+// Day buttons per week row. `fixedWeeks` always renders six rows, but rows at
+// the navigation bounds can contain no buttons because their filler days are
+// hidden. The explicit day-cell height keeps those empty rows full-height.
+const rowFills = (utils: RenderPickerUtils): number[] =>
+  Array.from(
+    utils.getByTestId('datepicker-popover').querySelectorAll('.gh-portal-datepicker-grid tbody tr'),
+  ).map((row) => row.querySelectorAll('.gh-portal-datepicker-day-button').length);
 
 const field = ({ container }: RenderPickerUtils): HTMLInputElement => {
   const input = container.querySelector<HTMLInputElement>('.gh-portal-datepicker-field input');
@@ -132,7 +141,7 @@ describe('DatePicker', () => {
     const utils = renderPicker();
     openPicker(utils);
 
-    fireEvent.click(dayButton(utils, 2));
+    fireEvent.click(utils.getByLabelText(/August 2nd, 2026/));
 
     expect(utils.onChange).not.toHaveBeenCalled();
   });
@@ -159,6 +168,130 @@ describe('DatePicker', () => {
     expect(popover.style.top).not.toBe('');
     expect(popover.style.right).not.toBe('');
     expect(popover.style.visibility).not.toBe('hidden');
+  });
+
+  // September 2026 spans five weeks of its own, August 2026 six. Filling the
+  // short ones out with the neighbouring month's days keeps the calendar one
+  // height whatever month is showing.
+  describe('fixed height', () => {
+    it('fills every cell of a month inside the range', () => {
+      const utils = renderPicker();
+      openPicker(utils);
+
+      fireEvent.click(utils.getByLabelText(/next month/i));
+
+      expect(rowFills(utils)).toEqual(SIX_FULL_WEEKS);
+    });
+
+    // At the edges of the range the filler belongs to months that can't be
+    // navigated to, and react-day-picker suppresses those days. The rows are
+    // still there, and `.gh-portal-datepicker-day` is sized so a row holding
+    // nothing keeps a row's height instead of collapsing — which is layout,
+    // and so beyond what jsdom can tell us.
+    it('keeps six rows in the first selectable month', () => {
+      const utils = renderPicker();
+      openPicker(utils);
+
+      expect(rowFills(utils)).toHaveLength(SIX_FULL_WEEKS.length);
+    });
+
+    it('keeps six rows in the last selectable month', () => {
+      const utils = renderPicker({ min: '2027-08-01', value: '2027-08-01' });
+      openPicker(utils);
+
+      expect(rowFills(utils)).toHaveLength(SIX_FULL_WEEKS.length);
+    });
+
+    // Filler days are real days: the ones past the maximum have to refuse the
+    // click like any other out-of-range day. July 2027 trails into August,
+    // where the 3rd is the last selectable date.
+    it('disables filler days that fall past the maximum', () => {
+      const utils = renderPicker({ min: '2027-07-01', value: '2027-07-01' });
+      openPicker(utils);
+
+      expect(utils.getByLabelText(/August 2nd, 2027/)).toBeEnabled();
+      expect(utils.getByLabelText(/August 5th, 2027/)).toBeDisabled();
+    });
+  });
+
+  // Nothing below is measurable in jsdom: every rect and every offsetHeight
+  // reads zero. The placement maths is pure geometry, so the measurements are
+  // fed in directly, with the popover's height derived from the rows it
+  // actually rendered.
+  describe('placement', () => {
+    const VIEWPORT_HEIGHT = 768; // jsdom's window.innerHeight
+    const FIELD_HEIGHT = 40;
+    const ROW_HEIGHT = 30;
+    // Padding, caption and weekday header — everything but the week rows.
+    const POPOVER_CHROME = 60;
+    const GAP = 6;
+
+    const mockLayoutAtFieldTop = (fieldTop: number) => {
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+        function (this: Element) {
+          const isField = this.classList.contains('gh-portal-datepicker-field');
+          const top = isField ? fieldTop : 0;
+          const bottom = isField ? fieldTop + FIELD_HEIGHT : 0;
+          return { top, bottom, left: 0, right: 300, width: 300, height: bottom - top } as DOMRect;
+        },
+      );
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(
+        function (this: HTMLElement) {
+          if (this.classList.contains('gh-portal-datepicker-popover')) {
+            // Every rendered row keeps its height even when react-day-picker
+            // hides all of its out-of-bounds filler days.
+            const rows = this.querySelectorAll('.gh-portal-datepicker-grid tbody tr');
+            return POPOVER_CHROME + rows.length * ROW_HEIGHT;
+          }
+          return this.tagName === 'TR' ? ROW_HEIGHT : 0;
+        },
+      );
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    it('flips above the field when the space below cannot hold it', () => {
+      mockLayoutAtFieldTop(VIEWPORT_HEIGHT - FIELD_HEIGHT - 20);
+      const utils = renderPicker();
+      openPicker(utils);
+
+      const popover = utils.getByTestId('datepicker-popover');
+      // Pulled up its own height from the field's top edge, so the box's
+      // bottom sits a gap above the field whatever the box measures.
+      expect(popover.style.transform).toBe('translateY(-100%)');
+      expect(popover.style.top).toBe(`${VIEWPORT_HEIGHT - FIELD_HEIGHT - 20 - GAP}px`);
+    });
+
+    it('hangs below the field without a transform when there is room', () => {
+      mockLayoutAtFieldTop(20);
+      const utils = renderPicker();
+      openPicker(utils);
+
+      const popover = utils.getByTestId('datepicker-popover');
+      expect(popover.style.transform).toBe('');
+      expect(popover.style.top).toBe(`${20 + FIELD_HEIGHT + GAP}px`);
+    });
+
+    // The popover is placed once, from the height it had when it opened, so a
+    // calendar that changed height on paging used to drag a flipped box with
+    // it. Padding every month to the same height is what makes that safe.
+    it('keeps its placement when the month changes', () => {
+      mockLayoutAtFieldTop(VIEWPORT_HEIGHT - FIELD_HEIGHT - 20);
+      const utils = renderPicker();
+      openPicker(utils);
+
+      const popover = utils.getByTestId('datepicker-popover');
+      const placedAt = popover.style.top;
+
+      fireEvent.click(utils.getByLabelText(/next month/i));
+
+      expect(rowFills(utils)).toEqual(SIX_FULL_WEEKS);
+      expect(popover.style.top).toBe(placedAt);
+      expect(popover.style.transform).toBe('translateY(-100%)');
+    });
   });
 
   it('marks the field as invalid when asked', () => {


### PR DESCRIPTION
Ref https://ghost.slack.com/archives/C09D3RD4M88/p1787592510553609

Kept the gift delivery calendar anchored and consistently sized when it flips above the field and buyers browse between months.
