### PR TITLE
🐛  Fixed dropped newsletter recipients when batch creation is interrupted

### DIFF
--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -322,6 +322,24 @@ class BatchSendingService {
    * @throws {errors.EmailError} If one of the batches fails
    */
   async sendEmail(email) {
+    // Track the whole operation (batch creation + sending) so onShutdown awaits it
+    // before ghost-server schedules process.exit. Covers both creating batches and the
+    // Mailgun POST + EmailBatch status write, so neither is killed mid-flight.
+    const work = this.#sendEmailInner(email);
+    this.#inFlight.add(work);
+    try {
+      return await work;
+    } finally {
+      this.#inFlight.delete(work);
+    }
+  }
+
+  /**
+   * @private
+   * @param {Email} email
+   * @throws {errors.EmailError} If one of the batches fails
+   */
+  async #sendEmailInner(email) {
     logging.info(`Sending email ${email.id}`);
 
     // Load required relations
@@ -349,16 +367,16 @@ class BatchSendingService {
       },
     );
 
-    let batches = await this.retryDb(
+    const existingBatches = await this.retryDb(
       async () => {
         return await this.getBatches(email);
       },
       { ...this.#getBeforeRetryConfig(email), description: `getBatches for email ${email.id}` },
     );
 
-    if (batches.length === 0) {
-      batches = await this.createBatches({ email, newsletter, post });
-    }
+    // Always reconcile: createBatches is idempotent and resumes an interrupted creation
+    // (e.g. a container restart) instead of treating any existing batches as complete.
+    const batches = await this.createBatches({ email, newsletter, post, existingBatches });
     await this.sendBatches({ email, batches, post, newsletter });
   }
 
@@ -378,11 +396,13 @@ class BatchSendingService {
   }
 
   /**
+   * Idempotent: builds only the batches not already present, resuming an interrupted
+   * creation from each segment's watermark. Returns the full set (existing + created).
    * @private
-   * @param {{email: Email, newsletter: Newsletter, post: Post}} data
+   * @param {{email: Email, newsletter: Newsletter, post: Post, existingBatches?: EmailBatch[]}} data
    * @returns {Promise<EmailBatch[]>}
    */
-  async createBatches({ email, post, newsletter }) {
+  async createBatches({ email, post, newsletter, existingBatches = [] }) {
     logging.info(`Creating batches for email ${email.id}`);
 
     // Infinity implies all emails should be sent from the primary domain
@@ -393,10 +413,32 @@ class BatchSendingService {
         : Infinity;
     }
 
+    // What a prior run already built, grouped by segment. We resume from each segment's
+    // watermark rather than rebuilding, which keeps this idempotent.
+    const coverage = await this.retryDb(
+      async () => {
+        return await this.#getExistingCoverage(email.id);
+      },
+      {
+        ...this.#getBeforeRetryConfig(email),
+        description: `getExistingCoverage for email ${email.id}`,
+      },
+    );
+
     const segments = await this.#emailRenderer.getSegments(post);
-    const batches = [];
+    // Seed with existing batches so the returned set and the domain-warmup accounting
+    // below span existing + newly created.
+    const batches = [...existingBatches];
     const BATCH_SIZE = this.#sendingService.getMaximumRecipients();
     let totalCount = 0;
+    for (const { count } of coverage.values()) {
+      totalCount += count;
+    }
+    if (totalCount > 0) {
+      logging.info(
+        `Resuming batch creation for email ${email.id}: ${totalCount} recipient(s) across ${coverage.size} segment(s) already built`,
+      );
+    }
 
     for (const segment of segments) {
       logging.info(`Creating batches for email ${email.id} segment ${segment}`);
@@ -412,9 +454,22 @@ class BatchSendingService {
 
       // Start with the id of the email, which is an objectId. We'll only fetch members that are created before the email. This is a special property of ObjectIds.
       // Note: we use ID and not created_at, because imported members could set a created_at in the future or past and avoid limit checking.
-      let lastId = email.id;
+      // On a resume, start below this segment's watermark so we only build the un-built
+      // tail (coverage is a contiguous id-descending prefix, so nothing is skipped).
+      const segmentCoverage = coverage.get(segment ?? null);
+      let lastId = segmentCoverage ? segmentCoverage.minMemberId : email.id;
 
       while (!members || lastId) {
+        // Stop claiming new creation work on shutdown. Bailing at a batch boundary
+        // (createBatch is atomic) leaves a consistent partial that resumes next boot;
+        // SHUTDOWN_CODE keeps the email in `submitting` rather than sending it incomplete.
+        if (this.#shuttingDown) {
+          throw new errors.InternalServerError({
+            code: SHUTDOWN_CODE,
+            message: 'Email batch creation stopped because the container is shutting down',
+          });
+        }
+
         logging.info(
           `Fetching members batch for email ${email.id} segment ${segment}, lastId: ${lastId}`,
         );
@@ -505,6 +560,35 @@ class BatchSendingService {
       await email.save(newEmailUpdate, { patch: true, require: false, autoRefresh: false });
     }
     return batches;
+  }
+
+  /**
+   * Coverage already built for an email, grouped by member segment. Batches are created
+   * atomically in descending member-id order, so MIN(member_id) is the watermark to
+   * resume below.
+   * @private
+   * @param {string} emailId
+   * @returns {Promise<Map<string|null, {count: number, minMemberId: string}>>}
+   */
+  async #getExistingCoverage(emailId) {
+    const rows =
+      (await this.#db
+        .knex('email_recipients as r')
+        .join('email_batches as b', 'r.batch_id', 'b.id')
+        .where('r.email_id', emailId)
+        .groupBy('b.member_segment')
+        .select('b.member_segment as member_segment')
+        .count('r.id as count')
+        .min('r.member_id as min_member_id')) || [];
+
+    const coverage = new Map();
+    for (const row of rows) {
+      coverage.set(row.member_segment ?? null, {
+        count: Number(row.count),
+        minMemberId: row.min_member_id,
+      });
+    }
+    return coverage;
   }
 
   /**
@@ -603,20 +687,6 @@ class BatchSendingService {
   }
 
   async sendBatches({ email, batches, post, newsletter }) {
-    // Track the in-flight call so onShutdown can await it. The cleanup task
-    // must wait for the Mailgun POST + EmailBatch DB write to settle before
-    // ghost-server schedules process.exit, otherwise mid-flight requests get
-    // killed and EmailBatch rows never record what Mailgun actually accepted.
-    const work = this.#sendBatchesInner({ email, batches, post, newsletter });
-    this.#inFlight.add(work);
-    try {
-      return await work;
-    } finally {
-      this.#inFlight.delete(work);
-    }
-  }
-
-  async #sendBatchesInner({ email, batches, post, newsletter }) {
     logging.info(`Sending ${batches.length} batches for email ${email.id}`);
     const deadline = this.getDeliveryDeadline(email);
 

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -256,9 +256,14 @@ describe('Batch Sending Service', function () {
   });
 
   describe('sendEmail', function () {
-    it('does not create batches if already created', async function () {
+    it('always reconciles via createBatches, passing existing batches (idempotent resume)', async function () {
+      // Existing batches from a prior run are handed to createBatches, which is
+      // idempotent: it resumes any un-built tail rather than being skipped. The old
+      // behaviour skipped creation entirely when batches existed, silently abandoning
+      // the tail of a creation interrupted by a container restart.
+      const existingBatches = [createModel({}), createModel({})];
       const EmailBatch = createModelClass({
-        findAll: [{}, {}],
+        findAll: existingBatches,
       });
       const service = new BatchSendingService({
         models: { EmailBatch },
@@ -275,13 +280,17 @@ describe('Batch Sending Service', function () {
       });
 
       const sendBatches = sinon.stub(service, 'sendBatches').resolves();
-      const createBatches = sinon.stub(service, 'createBatches').resolves();
+      // Reconcile finds nothing new to build, so it returns just the existing set.
+      const createBatches = sinon.stub(service, 'createBatches').resolves(existingBatches);
       const result = await service.sendEmail(email);
       assert.equal(result, undefined);
       sinon.assert.calledOnce(sendBatches);
-      sinon.assert.notCalled(createBatches);
+      sinon.assert.calledOnce(createBatches);
 
-      // Check called with batches
+      // createBatches receives the existing batches so it can resume from their watermark
+      assert.equal(createBatches.firstCall.args[0].existingBatches.length, 2);
+
+      // sendBatches gets the reconciled set
       const argument = sendBatches.firstCall.args[0];
       assert.equal(argument.batches.length, 2);
     });
@@ -734,6 +743,221 @@ describe('Batch Sending Service', function () {
 
       // Check email_count set
       assert.equal(email.get('email_count'), 3);
+    });
+
+    describe('resume (idempotent creation)', function () {
+      // Builds a setup where `builtCount` recipients (the highest member ids) were
+      // already created by a prior run, leaving `watermark` as the lowest built id.
+      // createBatches must resume below the watermark and build only the un-built tail.
+      function createResumeSetup({
+        builtCount,
+        watermark,
+        totalMembers,
+        email_count,
+        maxRecipients = 5,
+      }) {
+        const newsletter = createModel({});
+        const domainWarmingService = { isEnabled: () => false };
+
+        // Intended members id00..id{N-1}, all subscribed to the newsletter
+        const members = new Array(totalMembers).fill(0).map((_, i) => {
+          const idx = String(i).padStart(2, '0');
+          return createModel({
+            id: `id${idx}`,
+            email: `example${idx}@example.com`,
+            uuid: `member${idx}`,
+            name: `Member ${idx}`,
+            newsletters: [newsletter],
+          });
+        });
+
+        const seenFilters = [];
+        const Member = createModelClass({});
+        Member.getFilteredCollectionQuery = ({ filter }) => {
+          seenFilters.push(filter);
+          const q = nql(filter);
+          const all = members
+            .filter((m) => q.queryJSON(m.toJSON()))
+            .sort((a, b) => b.id.localeCompare(a.id));
+          return createDb({ all: all.map((m) => m.toJSON()) });
+        };
+
+        const EmailBatch = createModelClass({});
+
+        // The service #db resolves the existing coverage for #getExistingCoverage
+        const coverageRows =
+          builtCount > 0
+            ? [{ member_segment: null, count: builtCount, min_member_id: watermark }]
+            : [];
+        const db = createDb({ all: coverageRows });
+        const insert = sinon.spy(db, 'insert');
+
+        const service = new BatchSendingService({
+          models: { Member, EmailBatch },
+          domainWarmingService,
+          emailRenderer: {
+            getSegments() {
+              return [null];
+            },
+          },
+          sendingService: {
+            getMaximumRecipients() {
+              return maxRecipients;
+            },
+          },
+          emailSegmenter: {
+            getMemberFilterForSegment(n) {
+              return `newsletters.id:'${n.id}'`;
+            },
+          },
+          db,
+        });
+
+        // Email id sorts above every member id, so a fresh cursor includes them all
+        const email = createModel({ id: 'idZZ', email_count });
+        return { service, email, newsletter, insert, seenFilters };
+      }
+
+      it('resumes from the segment watermark and only builds the un-built tail', async function () {
+        // Top 10 (id10..id19) already built; watermark = id10, tail = id00..id09
+        const { service, email, newsletter, insert, seenFilters } = createResumeSetup({
+          builtCount: 10,
+          watermark: 'id10',
+          totalMembers: 20,
+          email_count: 20,
+        });
+
+        const batches = await service.createBatches({ email, post: createModel({}), newsletter });
+
+        // Only the tail is built: 10 members / 5 per batch = 2 new batches
+        assert.equal(batches.length, 2);
+        const inserted = insert.getCalls().flatMap((c) => c.args[0]);
+        assert.equal(inserted.length, 10);
+        assert.deepEqual(inserted.map((r) => r.member_id).sort(), [
+          'id00',
+          'id01',
+          'id02',
+          'id03',
+          'id04',
+          'id05',
+          'id06',
+          'id07',
+          'id08',
+          'id09',
+        ]);
+
+        // First member fetch started below the watermark, not the email id
+        assert.match(seenFilters[0], /id:<'id10'/);
+
+        // email_count reconciled to existing (10) + built (10)
+        assert.equal(email.get('email_count'), 20);
+      });
+
+      it('creates nothing when coverage is already complete (idempotent re-run)', async function () {
+        // All 20 built; watermark = id00 (lowest), nothing below it to build
+        const { service, email, newsletter, insert, seenFilters } = createResumeSetup({
+          builtCount: 20,
+          watermark: 'id00',
+          totalMembers: 20,
+          email_count: 20,
+        });
+
+        const existingBatches = [createModel({}), createModel({})];
+        const batches = await service.createBatches({
+          email,
+          post: createModel({}),
+          newsletter,
+          existingBatches,
+        });
+
+        // No new recipients inserted; returned set is exactly the existing batches
+        assert.equal(insert.getCalls().length, 0);
+        assert.equal(batches.length, 2);
+        assert.match(seenFilters[0], /id:<'id00'/);
+        assert.equal(email.get('email_count'), 20);
+      });
+
+      it('builds the full set on a fresh send (no coverage), starting from the email id', async function () {
+        const { service, email, newsletter, insert, seenFilters } = createResumeSetup({
+          builtCount: 0,
+          watermark: null,
+          totalMembers: 20,
+          email_count: 20,
+        });
+
+        const batches = await service.createBatches({ email, post: createModel({}), newsletter });
+
+        assert.equal(batches.length, 4); // 20 / 5
+        assert.equal(insert.getCalls().flatMap((c) => c.args[0]).length, 20);
+        // Fresh send starts the cursor at the email id
+        assert.match(seenFilters[0], /id:<'idZZ'/);
+        assert.equal(email.get('email_count'), 20);
+      });
+
+      it('aborts at a batch boundary during shutdown (SHUTDOWN_CODE), leaving a resumable partial', async function () {
+        const newsletter = createModel({});
+        const members = new Array(20).fill(0).map((_, i) => {
+          const idx = String(i).padStart(2, '0');
+          return createModel({
+            id: `id${idx}`,
+            email: `example${idx}@example.com`,
+            uuid: `member${idx}`,
+            name: `Member ${idx}`,
+            newsletters: [newsletter],
+          });
+        });
+
+        let service;
+        let fetchCount = 0;
+        const Member = createModelClass({});
+        Member.getFilteredCollectionQuery = ({ filter }) => {
+          fetchCount += 1;
+          // Signal shutdown after the first page is fetched and built, so the next
+          // loop iteration bails at the batch boundary rather than mid-batch.
+          if (fetchCount === 1) {
+            service.onPreStop();
+          }
+          const q = nql(filter);
+          const all = members
+            .filter((m) => q.queryJSON(m.toJSON()))
+            .sort((a, b) => b.id.localeCompare(a.id));
+          return createDb({ all: all.map((m) => m.toJSON()) });
+        };
+
+        const db = createDb({ all: [] });
+        const insert = sinon.spy(db, 'insert');
+        service = new BatchSendingService({
+          models: { Member, EmailBatch: createModelClass({}) },
+          domainWarmingService: { isEnabled: () => false },
+          emailRenderer: {
+            getSegments() {
+              return [null];
+            },
+          },
+          sendingService: {
+            getMaximumRecipients() {
+              return 5;
+            },
+          },
+          emailSegmenter: {
+            getMemberFilterForSegment(n) {
+              return `newsletters.id:'${n.id}'`;
+            },
+          },
+          db,
+        });
+        const email = createModel({ id: 'idZZ', email_count: 20 });
+
+        await assert.rejects(
+          service.createBatches({ email, post: createModel({}), newsletter }),
+          (err) => err.code === BatchSendingService.SHUTDOWN_CODE,
+        );
+
+        // Only the first batch (5 recipients) was committed before the abort; the
+        // remaining tail is left un-built for the next boot to resume.
+        const inserted = insert.getCalls().flatMap((c) => c.args[0]);
+        assert.equal(inserted.length, 5);
+      });
     });
 
     describe('Domain warming', function () {
@@ -2214,62 +2438,127 @@ describe('Batch Sending Service', function () {
       );
     });
 
-    it('onShutdown does not resolve until in-flight sendBatches settles', async function () {
+    it('onShutdown does not resolve until an in-flight send settles', async function () {
+      const EmailBatch = createModelClass({ findAll: [] });
       const service = new BatchSendingService({
+        models: { EmailBatch },
         sendingService: {
           getTargetDeliveryWindow() {
             return 0;
           },
         },
       });
-      // Gate sendBatch behind a manual promise so we can observe the order
-      // in which onShutdown and the in-flight sendBatches resolve.
+      // Reach the real send loop (with its worker fan-out) through sendEmail, the single
+      // in-flight tracker. sendBatch is gated so a send stays in flight; `reachedSend`
+      // lets us hold off calling onShutdown until a worker is already past the shutdown
+      // check — otherwise the synchronous flag flip would make the workers bail before
+      // sending, and we'd be testing the wrong path.
+      sinon.stub(service, 'createBatches').resolves([createModel({}), createModel({})]);
+      let markReached;
+      const reachedSend = new Promise((resolve) => {
+        markReached = resolve;
+      });
       let releaseGate;
       const gate = new Promise((resolve) => {
         releaseGate = resolve;
       });
       const sendBatch = sinon.stub(service, 'sendBatch').callsFake(async () => {
+        markReached();
         await gate;
         return true;
       });
 
-      // Kick off sendBatches; do NOT await — it must remain in flight.
-      const sendPromise = service.sendBatches({
-        email: createModel({}),
-        batches: [createModel({}), createModel({})],
-        post: createModel({}),
+      const email = createModel({
+        status: 'submitting',
         newsletter: createModel({}),
+        post: createModel({}),
       });
 
-      // Tag each promise so we can observe resolution order.
+      // Kick off sendEmail; do NOT await — it must remain in flight.
+      const sendPromise = service.sendEmail(email);
+      let sendEmailDone = false;
+      sendPromise
+        .then(() => {
+          sendEmailDone = true;
+        })
+        .catch(() => {
+          sendEmailDone = true;
+        });
+
+      // Wait until a batch send is actually in flight, then start the drain.
+      await reachedSend;
       let onShutdownDone = false;
-      let sendBatchesDone = false;
       const onShutdownPromise = service.onShutdown().then(() => {
         onShutdownDone = true;
       });
-      sendPromise
-        .then(() => {
-          sendBatchesDone = true;
-        })
-        .catch(() => {
-          sendBatchesDone = true;
-        });
 
-      // Yield the microtask queue. Neither sendBatches nor onShutdown can have settled
+      // Yield the microtask queue. Neither the send nor onShutdown can have settled
       // because sendBatch is still awaiting the gate.
       await new Promise((resolve) => {
         setImmediate(resolve);
       });
-      assert.equal(sendBatchesDone, false, 'sendBatches should still be in flight');
-      assert.equal(onShutdownDone, false, 'onShutdown must wait for in-flight sendBatches');
+      assert.equal(sendEmailDone, false, 'sendEmail should still be in flight');
+      assert.equal(onShutdownDone, false, 'onShutdown must wait for the in-flight send');
 
-      // Release the gate; sendBatches finishes, then onShutdown resolves.
+      // Release the gate; the send finishes, then onShutdown resolves.
       releaseGate();
       await onShutdownPromise;
       await sendPromise;
       assert.equal(onShutdownDone, true);
-      assert.equal(sendBatchesDone, true);
+      assert.equal(sendEmailDone, true);
       sinon.assert.called(sendBatch);
+    });
+
+    it('onShutdown does not resolve until in-flight batch creation settles', async function () {
+      const EmailBatch = createModelClass({ findAll: [] });
+      const service = new BatchSendingService({
+        models: { EmailBatch },
+        sendingService: {
+          getTargetDeliveryWindow() {
+            return 0;
+          },
+        },
+      });
+
+      // Gate batch creation so it stays in flight while we observe the drain.
+      let releaseCreation;
+      const creationGate = new Promise((resolve) => {
+        releaseCreation = resolve;
+      });
+      sinon.stub(service, 'createBatches').callsFake(async () => {
+        await creationGate;
+        return [];
+      });
+      const sendBatches = sinon.stub(service, 'sendBatches').resolves();
+
+      const email = createModel({
+        status: 'submitting',
+        newsletter: createModel({}),
+        post: createModel({}),
+      });
+
+      // Kick off sendEmail; do NOT await — creation must remain in flight.
+      const sendPromise = service.sendEmail(email);
+
+      let onShutdownDone = false;
+      const onShutdownPromise = service.onShutdown().then(() => {
+        onShutdownDone = true;
+      });
+
+      // Yield the microtask queue. onShutdown must not settle: createBatches is gated
+      // and sendBatches has not been reached yet.
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      assert.equal(onShutdownDone, false, 'onShutdown must wait for in-flight batch creation');
+      sinon.assert.notCalled(sendBatches);
+
+      // Release creation; sending proceeds, then onShutdown resolves.
+      releaseCreation();
+      await onShutdownPromise;
+      await sendPromise;
+      assert.equal(onShutdownDone, true);
+      sinon.assert.calledOnce(sendBatches);
     });
 
     it('emailJob leaves email in submitting status when sendEmail rejects with SHUTDOWN_CODE', async function () {

--- a/ghost/core/test/unit/server/services/email-service/utils/index.ts
+++ b/ghost/core/test/unit/server/services/email-service/utils/index.ts
@@ -157,6 +157,18 @@ const createDb = ({ first, all }: DbOptions = {}) => {
     whereNull: function () {
       return this;
     },
+    join: function () {
+      return this;
+    },
+    groupBy: function () {
+      return this;
+    },
+    count: function () {
+      return this;
+    },
+    min: function () {
+      return this;
+    },
     select: function () {
       return this;
     },


### PR DESCRIPTION
no ref

If a container restarted while an email's batches were still being built, the next run treated the partial batch set as complete: sendEmail skipped createBatches whenever any batches already existed, silently abandoning the un-built tail of recipients. The email was then marked submitted with an email_count reflecting the pre-send estimate, so recipients below the interruption point were never batched or sent.

createBatches is now idempotent. It reads the coverage a prior run already built (per segment: recipient count and the lowest built member id) and resumes each segment below that watermark, so re-running builds only the un-built tail and never duplicates. sendEmail always reconciles instead of skipping, and totalCount is seeded from existing coverage so the domain-warmup split and the email_count correction stay accurate. Batch creation also now aborts at a batch boundary on shutdown, mirroring the send loop, leaving a consistent partial that resumes on the next boot.