### PR TITLE
🐛 Fixed private-site landing page for signed-in members

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -41,6 +41,19 @@
         </script>
     </head>
     <body{{#if @site.accent_color}} style="--gh-private-accent-color: {{@site.accent_color}}; --gh-private-accent-color-rgba: {{color_to_rgba @site.accent_color 0.25}}; --gh-private-accent-contrast-color: {{contrast_text_color @site.accent_color}};"{{/if}}>
+        {{#*inline "private-access-form"}}
+            <form class="gh-signin gh-private-signin gh-private-access-form" method="post" novalidate="novalidate">
+                <div class="gh-private-signup-fields">
+                    <div class="form-group gh-private-access-input-wrap{{#if error}} error{{/if}}">
+                        {{input_password class="gh-input gh-private-signup-input" placeholder=(t "Access code") data-1p-ignore="true"}}
+                        {{#if error}}
+                            <p class="main-error">{{error.message}}</p>
+                        {{/if}}
+                    </div>
+                    <button class="gh-btn gh-private-signup-btn" type="submit"><span>{{t "Enter"}} &rarr;</span></button>
+                </div>
+            </form>
+        {{/inline}}
         <div class="gh-app">
             <div class="gh-viewport">
                 <main class="gh-main" role="main">
@@ -56,42 +69,37 @@
                                         <p class="gh-private-description">{{@site.description}}</p>
                                     {{/if}}
                                     {{#if @site.allow_self_signup}}
-                                        <form class="gh-private-signup-form gh-signin" data-ghost-private-subscribe-form data-members-form="subscribe" data-site-url="{{@site.url}}" data-state="idle" novalidate="novalidate">
-                                            <div class="gh-private-signup-fields">
-                                                <input class="gh-input gh-private-signup-input" type="email" placeholder="{{t "Your email address"}}" aria-label="{{t "Your email address"}}" autocomplete="email" required data-members-email>
-                                                <button class="gh-btn gh-private-signup-btn" type="submit">
-                                                    <span class="gh-private-signup-btn-content">
-                                                        <b class="gh-private-signup-btn-label">{{t "Subscribe"}}</b>
-                                                        <svg class="gh-private-signup-btn-loading" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                                            <circle cx="4" cy="12" r="3"></circle>
-                                                            <circle cx="12" cy="12" r="3"></circle>
-                                                            <circle cx="20" cy="12" r="3"></circle>
-                                                        </svg>
-                                                        <svg class="gh-private-signup-btn-success" viewBox="0 0 15 14" aria-hidden="true" focusable="false">
-                                                            <path d="M1 6.89286L6.10714 12L13.9643 1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                                                        </svg>
-                                                    </span>
-                                                </button>
-                                            </div>
-                                            <p class="gh-private-signup-feedback" data-ghost-private-subscribe-feedback data-state="idle" aria-live="polite"></p>
-                                        </form>
+                                        {{#if @member}}
+                                            {{> private-access-form}}
+                                        {{else}}
+                                            <form class="gh-private-signup-form gh-signin" data-ghost-private-subscribe-form data-members-form="subscribe" data-site-url="{{@site.url}}" data-state="idle" novalidate="novalidate">
+                                                <div class="gh-private-signup-fields">
+                                                    <input class="gh-input gh-private-signup-input" type="email" placeholder="{{t "Your email address"}}" aria-label="{{t "Your email address"}}" autocomplete="email" required data-members-email>
+                                                    <button class="gh-btn gh-private-signup-btn" type="submit">
+                                                        <span class="gh-private-signup-btn-content">
+                                                            <b class="gh-private-signup-btn-label">{{t "Subscribe"}}</b>
+                                                            <svg class="gh-private-signup-btn-loading" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                                                <circle cx="4" cy="12" r="3"></circle>
+                                                                <circle cx="12" cy="12" r="3"></circle>
+                                                                <circle cx="20" cy="12" r="3"></circle>
+                                                            </svg>
+                                                            <svg class="gh-private-signup-btn-success" viewBox="0 0 15 14" aria-hidden="true" focusable="false">
+                                                                <path d="M1 6.89286L6.10714 12L13.9643 1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                            </svg>
+                                                        </span>
+                                                    </button>
+                                                </div>
+                                                <p class="gh-private-signup-feedback" data-ghost-private-subscribe-feedback data-state="idle" aria-live="polite"></p>
+                                            </form>
+                                        {{/if}}
                                     {{/if}}
                                 </header>
                                 {{#unless @site.allow_self_signup}}
-                                    <form class="gh-signin gh-private-signin gh-private-access-form" method="post" novalidate="novalidate">
-                                        <div class="gh-private-signup-fields">
-                                            <div class="form-group gh-private-access-input-wrap{{#if error}} error{{/if}}">
-                                                    {{input_password class="gh-input gh-private-signup-input" placeholder=(t "Access code") data-1p-ignore="true"}}
-                                                    {{#if error}}
-                                                        <p class="main-error">{{error.message}}</p>
-                                                    {{/if}}
-                                            </div>
-                                            <button class="gh-btn gh-private-signup-btn" type="submit"><span>{{t "Enter"}} &rarr;</span></button>
-                                        </div>
-                                    </form>
+                                    {{> private-access-form}}
                                 {{/unless}}
                             </section>
                             {{#if @site.allow_self_signup}}
+                                {{#unless @member}}
                                 <dialog class="gh-private-dialog" id="access" aria-labelledby="private-access-title" {{#if @site.accent_color}} style="--gh-private-accent-color: {{@site.accent_color}}; --gh-private-accent-color-rgba: {{color_to_rgba @site.accent_color 0.25}}; --gh-private-accent-contrast-color: {{contrast_text_color @site.accent_color}};"{{/if}} {{#if error}}data-auto-open="true"{{/if}}>
                                     <div class="gh-private-dialog-panel">
                                         <button class="gh-private-dialog-close" type="button" data-ghost-private-close aria-label="{{t "Close"}}">
@@ -103,19 +111,10 @@
                                         <header class="gh-private-dialog-header">
                                             <h2 id="private-access-title">{{t "Enter access code"}}</h2>
                                         </header>
-                                        <form class="gh-signin gh-private-signin gh-private-access-form" method="post" novalidate="novalidate">
-                                            <div class="gh-private-signup-fields">
-                                                <div class="form-group gh-private-access-input-wrap{{#if error}} error{{/if}}">
-                                                        {{input_password class="gh-input gh-private-signup-input" placeholder=(t "Access code") data-1p-ignore="true"}}
-                                                        {{#if error}}
-                                                            <p class="main-error">{{error.message}}</p>
-                                                        {{/if}}
-                                                </div>
-                                                <button class="gh-btn gh-private-signup-btn" type="submit"><span>{{t "Enter"}} &rarr;</span></button>
-                                            </div>
-                                        </form>
+                                        {{> private-access-form}}
                                     </div>
                                 </dialog>
+                                {{/unless}}
                             {{/if}}
                             <div class="gh-private-trigger-wrap">
                                 <div class="gh-private-footer-links">
@@ -127,8 +126,10 @@
                                     </a>
                                     <span class="gh-private-footer-separator" aria-hidden="true">|</span>
                                     {{#if @site.allow_self_signup}}
-                                        <a class="gh-private-trigger" href="#access" data-ghost-private-trigger>{{t "Enter access code"}}</a>
-                                        <span class="gh-private-footer-separator" aria-hidden="true">|</span>
+                                        {{#unless @member}}
+                                            <a class="gh-private-trigger" href="#access" data-ghost-private-trigger>{{t "Enter access code"}}</a>
+                                            <span class="gh-private-footer-separator" aria-hidden="true">|</span>
+                                        {{/unless}}
                                     {{/if}}
                                     <a href="{{@site.admin_url}}">{{t "Site owner login"}}</a>
                                 </div>

--- a/ghost/core/core/frontend/public/ghost.css
+++ b/ghost/core/core/frontend/public/ghost.css
@@ -740,7 +740,7 @@ h2 {
 }
 
 .gh-private-signup-form,
-.gh-flow-content.private > .gh-private-access-form {
+.gh-flow-content.private .gh-private-access-form {
   width: min(100%, 550px);
   margin: 40px auto 0;
 }

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -256,6 +256,32 @@ describe('private.hbs template translation', function () {
         assert(html.includes('src="/private.js"'));
       });
 
+      it('renders the access-code form instead of the signup form for an authenticated member', function () {
+        const context = {
+          member: { email: 'member@example.com' },
+          site: {
+            title: 'Test',
+            url: 'http://test.local',
+            locale: 'en',
+            allow_self_signup: true,
+            admin_url: 'http://test.local/ghost/',
+          },
+        };
+        const html = renderPrivateTemplate(context);
+
+        assertExists(html);
+        assert(!html.includes('data-ghost-private-subscribe-form'));
+        assert.equal(
+          (html.match(/<form class="gh-signin gh-private-signin gh-private-access-form"/g) || [])
+            .length,
+          1,
+        );
+        assert(html.includes('placeholder="Access code"'));
+        assert(html.includes('type="submit"'));
+        assert(!html.includes('id="access"'));
+        assert(!html.includes('data-ghost-private-trigger'));
+      });
+
       it('uses the site accent color for the signup button when available', function () {
         const context = {
           site: {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1539

Members who completed magic-link signup on a private site returned to the signup form even though their member session was active. This made signup appear incomplete and obscured the separate access-code step.

The private page now shows the access-code form when a member session is present and keeps the signup form for anonymous visitors. We use this access code form in a few different scenarios, so there's a small refactor as well to make it more reusable.

quick overview of this page if an access code hasn't been entered:
- if signups are turned off, or only paid signups allowed: access code form shows (existing behavior)
- if signups are turned on and a user is not signed in on that browser: subscribe form shows (existing behavior)
- if signups are turned on and a user IS signed in: access code form shows (new behavior)

<img width="534" height="942" alt="image" src="https://github.com/user-attachments/assets/2f2f302f-7365-4d9a-bc0c-86067640af22" />
