### PR TITLE
Added structured alert fields to email analytics job completion log

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.ts
@@ -155,7 +155,18 @@ export class EmailAnalyticsServiceWrapper {
       `Events: opened=${result.opened} delivered=${result.delivered} failed=${result.permanentFailed + result.temporaryFailed} unprocessable=${result.unprocessable}`,
     ].join(' | ');
 
-    logging.info(logMessage);
+    logging.info(
+      {
+        system: {
+          event: 'job.completed',
+          job_type: this.#backgroundJobName,
+          task: jobType,
+          event_count: eventCount,
+          duration_ms: totalDurationMs,
+        },
+      },
+      logMessage,
+    );
 
     // We're only concerned with open throughput as this is displayed to users and is most sensitive to being up to date
     if (jobType === 'latest-opened') {

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.ts
@@ -110,7 +110,27 @@ describe('EmailAnalyticsServiceWrapper', function () {
 
     sinon.assert.calledWith(
       infoLog,
+      sinon.match.object,
       sinon.match('[Background Job] email-analytics-gift-fetch-latest processed'),
+    );
+  });
+
+  it('tags job completions with the fields the email analytics alert queries', function () {
+    const infoLog = sinon.stub(logging, 'info');
+
+    logLatestOpenedJob('newsletters');
+
+    sinon.assert.calledWith(
+      infoLog,
+      sinon.match({
+        system: {
+          event: 'job.completed',
+          job_type: 'email-analytics-fetch-latest',
+          task: 'latest-opened',
+          event_count: 10,
+        },
+      }),
+      sinon.match('[Background Job] email-analytics-fetch-latest processed'),
     );
   });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1990/add-baseline-execution-logging-to-existing-background-jobs

## What happened

The `ghost/email-analytics-failing` Elastic rule counts log lines and alerts when they drop below 100/hour. Its query was:

```
message:/\[EmailAnalytics(:[a-z]+)?\] Job complete.*/ AND NOT message:/.*No events.*/
```

[#30134](https://github.com/TryGhost/Ghost/pull/30134) reworded that string to the shared `[Background Job]` format:

```diff
- [EmailAnalytics:newsletters] Job complete: latest-opened | 42 events in ...
+ [Background Job] email-analytics-fetch-latest processed latest-opened | [EmailAnalytics:newsletters] | 42 events in ...
```

`Job complete` no longer exists, and the `[EmailAnalytics:…]` prefix is no longer leading (Lucene regexp is fully anchored), so the count went to a hard zero and the rule fired continuously. **Mailgun ingestion was never affected** — the alert measures a log line, not events.

That PR's description flagged the risk ("external dashboards might" depend on these strings) but the check was repo-only, and the dependency lived in `pro-infra`.

## The change

Emit the completion as structured fields so the alert can key on them instead of a message regex:

```ts
logging.info(
  {
    system: {
      event: 'job.completed',
      job_type: this.#backgroundJobName,  // email-analytics-fetch-latest / -automation- / -gift-
      task: jobType,                       // latest-opened / latest-non-opened / missing / scheduled
      event_count: eventCount,
      duration_ms: totalDurationMs,
    },
  },
  logMessage,
);
```

This uses the `system: {event, job_type, duration_ms}` shape [jobs-service already logs completions with](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/services/jobs-service/jobs-service.ts#L129-L138) — the established core convention, also emitted by remote-flags, gifts, and automations. Shared keys match jobs-service exactly; `task` and `event_count` are additive domain fields in the style gift-service uses. Restoring the old `Job complete` string instead would have re-introduced the per-job wording #30134 deliberately unified, and left the alert breakable by the next reword.

Two useful properties of this shape:

- `system.*` is the namespace live Elastic rules already query (`system.error.code` etc.), and Ghost emits `system.event` in production today — so field indexing is verifiable in Kibana **before** this deploys.
- When email analytics moves onto the durable jobs interface, jobs-service will emit `system.event: "job.completed"` for every run — including empty ones, without an `event_count`. The alert's `system.event_count > 0` clause (carrying the intent of the old `AND NOT … No events` exclusion) excludes those automatically, so the alert survives that migration with no query change.

## No behaviour change

Same call site, same conditions, same message text. `_logJobCompletion` still returns early at zero events, so these documents keep meaning "events were actually processed" — which is what the old `Job complete` minus `No events` computed, so the threshold of 100 stays calibrated.
