### PR TITLE
🐛 Fixed Redis cache adapters ignoring per-feature TTLs on shared connections

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -166,6 +166,23 @@ class AdapterCacheRedis extends CacheBase {
   }
 
   /**
+   * Write through cache-manager with this adapter's own TTL. The TTL must be
+   * passed per-call: with `reuseConnection` (the default) every Redis cache
+   * adapter in the process shares one store, and the store-level TTL is
+   * whatever the first-instantiated adapter was configured with — so relying
+   * on it would silently apply that adapter's TTL to every feature.
+   *
+   * @param {string} internalKey
+   * @param {*} value
+   */
+  async _cacheSet(internalKey, value) {
+    if (typeof this.ttl === 'number') {
+      return await this.cache.set(internalKey, value, { ttl: this.ttl });
+    }
+    return await this.cache.set(internalKey, value);
+  }
+
+  /**
    *
    * @param {string} internalKey
    */
@@ -311,7 +328,7 @@ class AdapterCacheRedis extends CacheBase {
           .then(async (data) => {
             try {
               debug('set', internalKey);
-              await this.cache.set(internalKey, data);
+              await this._cacheSet(internalKey, data);
             } catch (err) {
               this._metric('cache-error', { operation: 'set' });
               logging.error(err);
@@ -343,7 +360,7 @@ class AdapterCacheRedis extends CacheBase {
     try {
       const internalKey = await this._buildKey(key);
       debug('set', internalKey);
-      return await this.cache.set(internalKey, value);
+      return await this._cacheSet(internalKey, value);
     } catch (err) {
       this._metric('cache-error', { operation: 'set' });
       logging.error(err);

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -517,6 +517,61 @@ describe('Adapter Cache Redis', function () {
       assert.equal(value, 'new value');
       assert.equal(cacheStub.set.args[0][0], `testing-prefix:${PREFIX_HASH}key-here`);
     });
+
+    it('passes the configured ttl on every write', async function () {
+      const cacheStub = createCacheStub();
+      const cache = new RedisCache({ cache: cacheStub, ttl: 900 });
+
+      await cache.set('key-here', 'new value');
+
+      assert.deepEqual(cacheStub.set.args[0], [
+        `${PREFIX_HASH}key-here`,
+        'new value',
+        { ttl: 900 },
+      ]);
+    });
+
+    it('omits the ttl option when no ttl is configured', async function () {
+      const cacheStub = createCacheStub();
+      const cache = new RedisCache({ cache: cacheStub });
+
+      await cache.set('key-here', 'new value');
+
+      assert.deepEqual(cacheStub.set.args[0], [`${PREFIX_HASH}key-here`, 'new value']);
+    });
+
+    it("applies each adapter's own ttl when two adapters share one store", async function () {
+      // With reuseConnection (the default) every Redis cache adapter shares
+      // one store, whose store-level ttl is whatever the first-instantiated
+      // adapter was configured with. Each adapter must therefore pass its
+      // own ttl per write rather than rely on the store default.
+      const sharedStub = createCacheStub();
+      const imageSizesCache = new RedisCache({ cache: sharedStub, ttl: 604800 });
+      const postsPublicCache = new RedisCache({ cache: sharedStub, ttl: 900 });
+
+      await imageSizesCache.set('image-key', 'image value');
+      await postsPublicCache.set('post-key', 'post value');
+
+      assert.deepEqual(sharedStub.set.args[0][2], { ttl: 604800 });
+      assert.deepEqual(sharedStub.set.args[1][2], { ttl: 900 });
+    });
+
+    it('passes the configured ttl when populating the cache after a read miss', async function () {
+      const cacheStub = createCacheStub();
+      cacheStub.get.resolves(null);
+      const cache = new RedisCache({ cache: cacheStub, ttl: 900 });
+      const fetchData = sinon.stub().resolves('fetched value');
+
+      const value = await cache.get('key-here', fetchData);
+      await flushMicrotasks();
+
+      assert.equal(value, 'fetched value');
+      assert.deepEqual(cacheStub.set.args[0], [
+        `${PREFIX_HASH}key-here`,
+        'fetched value',
+        { ttl: 900 },
+      ]);
+    });
   });
 
   describe('reset', function () {


### PR DESCRIPTION
no ref

**Why are you making it?**

With `reuseConnection` enabled (the default), every Redis cache adapter in the process shares one singleton store (`redis-store-factory.js`), created with whichever adapter happened to be instantiated first at boot. Because writes never passed a per-call TTL, `cache-manager` fell back to that store's creation-time TTL — so the first adapter's TTL was silently applied to every cache feature. A per-feature `adapters:cache` config like `postsPublic: {adapter: "Redis", ttl: 900}` had no effect on the actual Redis expiry; the feature-level `ttl` only skewed the refresh-ahead calculation, which compared against an expiry that was never in force.

**What does it do?**

`AdapterCacheRedis` now routes both write paths (the public `set()` and the read-through population after a cache miss) through a `_cacheSet()` helper that passes the adapter's own configured TTL explicitly on every write. A per-call TTL takes precedence over the store default in `cache-manager-ioredis`, so each feature's TTL applies even over the shared store. Adapters without a configured TTL keep the previous fallback-to-store-default behaviour.

Note: entries already in Redis keep the expiry they were written with — corrected TTLs apply as keys are rewritten or expire.

**Why is this something Ghost users or developers need?**

Any operator configuring different TTLs per cache feature (e.g. long-lived `imageSizes` vs short-lived `postsPublic`) is currently getting one arbitrary TTL — decided by boot order — applied to everything, with no error or warning. This makes per-feature TTL config mean what it says, without giving up the shared Redis connection.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJYFdJZj2nXpZXZUyVL9wW)_