### PR TITLE
Migrate the external-media-inliner job to the class-based jobs service

### DIFF
--- a/ghost/core/core/server/services/jobs-service/index.ts
+++ b/ghost/core/core/server/services/jobs-service/index.ts
@@ -31,5 +31,7 @@ export function shutdown(options?: JobsShutdownOptions): Promise<void> {
   if (!instance) {
     return Promise.resolve();
   }
-  return instance.shutdown(options);
+  const current = instance;
+  instance = undefined;
+  return current.shutdown(options);
 }

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,8 +1,10 @@
 import { getInstance } from './index';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
+import ExternalMediaInlinerJob from '../media-inliner/external-media-inliner-job';
 
 const logging = require('@tryghost/logging');
+const mediaInliner = require('../media-inliner');
 
 export default function registerJobHandlers(): void {
   const jobsService = getInstance();
@@ -10,5 +12,9 @@ export default function registerJobHandlers(): void {
 
   jobsService.handle(CleanTokensJob, async () => {
     await cleanTokens({ db, logging });
+  });
+
+  jobsService.handle(ExternalMediaInlinerJob, async (job) => {
+    await mediaInliner.getInstance().inline(job.domains);
   });
 }

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner-job.ts
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner-job.ts
@@ -1,0 +1,12 @@
+import { Job } from '../jobs-service/job';
+
+export default class ExternalMediaInlinerJob extends Job {
+  static type = 'external-media-inliner';
+
+  readonly domains: string[];
+
+  constructor(data: { domains: string[] }) {
+    super();
+    this.domains = data.domains;
+  }
+}

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,4 +1,67 @@
+const errors = require('@tryghost/errors');
+
+class MediaInlinerService {
+  #inliner;
+  #jobsService;
+  #logging;
+  #debug;
+
+  constructor({ inliner, jobsService, logging, debug }) {
+    this.#inliner = inliner;
+    this.#jobsService = jobsService;
+    this.#logging = logging;
+    this.#debug = debug;
+  }
+
+  async inline(domains) {
+    return this.#inliner.inline(domains);
+  }
+
+  async startMediaInliner(domains) {
+    if (!domains || !domains.length) {
+      // default domains to inline from if none are provided
+      domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+    }
+
+    this.#debug('[Inliner] Starting media inlining job for domains: ', domains);
+
+    // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
+    //        limited to migrational, so there is no expectations for site's availability etc.
+    this.#logging.info('[Background Job] external-media-inliner queued');
+    await this.#jobsService.addJob({
+      name: 'external-media-inliner',
+      job: async (data) => {
+        const startedAt = Date.now();
+        this.#logging.info('[Background Job] external-media-inliner started');
+        try {
+          const result = await this.inline(data.domains);
+          this.#logging.info(
+            `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
+          );
+          return result;
+        } catch (err) {
+          this.#logging.error(
+            err,
+            `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
+          );
+          throw err;
+        }
+      },
+      data: { domains },
+      offloaded: false,
+    });
+
+    return {
+      status: 'success',
+    };
+  }
+}
+
+let instance;
+
 module.exports = {
+  MediaInlinerService,
+
   async init() {
     const debug = require('@tryghost/debug')('mediaInliner');
     const MediaInliner = require('./external-media-inliner');
@@ -31,45 +94,24 @@ module.exports = {
       },
     });
 
+    instance = new MediaInlinerService({
+      inliner: mediaInliner,
+      jobsService,
+      logging,
+      debug,
+    });
+
     this.api = {
-      startMediaInliner: async (domains) => {
-        if (!domains || !domains.length) {
-          // default domains to inline from if none are provided
-          domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
-        }
-
-        debug('[Inliner] Starting media inlining job for domains: ', domains);
-
-        // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
-        //        limited to migrational, so there is no expectations for site's availability etc.
-        logging.info('[Background Job] external-media-inliner queued');
-        await jobsService.addJob({
-          name: 'external-media-inliner',
-          job: async (data) => {
-            const startedAt = Date.now();
-            logging.info('[Background Job] external-media-inliner started');
-            try {
-              const result = await mediaInliner.inline(data.domains);
-              logging.info(
-                `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
-              );
-              return result;
-            } catch (err) {
-              logging.error(
-                err,
-                `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
-              );
-              throw err;
-            }
-          },
-          data: { domains },
-          offloaded: false,
-        });
-
-        return {
-          status: 'success',
-        };
-      },
+      startMediaInliner: (domains) => instance.startMediaInliner(domains),
     };
+  },
+
+  getInstance() {
+    if (!instance) {
+      throw new errors.IncorrectUsageError({
+        message: 'Media inliner service used before init(). Call init() from boot first.',
+      });
+    }
+    return instance;
   },
 };

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,14 +1,15 @@
 const errors = require('@tryghost/errors');
+const ExternalMediaInlinerJob = require('./external-media-inliner-job').default;
 
 class MediaInlinerService {
   #inliner;
-  #jobsService;
+  #getJobsService;
   #logging;
   #debug;
 
-  constructor({ inliner, jobsService, logging, debug }) {
+  constructor({ inliner, getJobsService, logging, debug }) {
     this.#inliner = inliner;
-    this.#jobsService = jobsService;
+    this.#getJobsService = getJobsService;
     this.#logging = logging;
     this.#debug = debug;
   }
@@ -25,31 +26,8 @@ class MediaInlinerService {
 
     this.#debug('[Inliner] Starting media inlining job for domains: ', domains);
 
-    // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
-    //        limited to migrational, so there is no expectations for site's availability etc.
     this.#logging.info('[Background Job] external-media-inliner queued');
-    await this.#jobsService.addJob({
-      name: 'external-media-inliner',
-      job: async (data) => {
-        const startedAt = Date.now();
-        this.#logging.info('[Background Job] external-media-inliner started');
-        try {
-          const result = await this.inline(data.domains);
-          this.#logging.info(
-            `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
-          );
-          return result;
-        } catch (err) {
-          this.#logging.error(
-            err,
-            `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
-          );
-          throw err;
-        }
-      },
-      data: { domains },
-      offloaded: false,
-    });
+    await this.#getJobsService().dispatch(new ExternalMediaInlinerJob({ domains }));
 
     return {
       status: 'success',
@@ -67,7 +45,6 @@ module.exports = {
     const MediaInliner = require('./external-media-inliner');
     const logging = require('@tryghost/logging');
     const models = require('../../models');
-    const jobsService = require('../jobs');
     const adapterManager = require('../../services/adapter-manager').default;
 
     const mediaStorage = adapterManager.getAdapter('storage:media');
@@ -96,7 +73,7 @@ module.exports = {
 
     instance = new MediaInlinerService({
       inliner: mediaInliner,
-      jobsService,
+      getJobsService: () => require('../jobs-service').getInstance(),
       logging,
       debug,
     });

--- a/ghost/core/test/integration/services/media-inliner/external-media-inliner-job.test.ts
+++ b/ghost/core/test/integration/services/media-inliner/external-media-inliner-job.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import nock from 'nock';
+
+const logging = require('@tryghost/logging');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const models = require('../../../../core/server/models');
+const { getInstance: getJobsService } = require('../../../../core/server/services/jobs-service');
+const ExternalMediaInlinerJob =
+  require('../../../../core/server/services/media-inliner/external-media-inliner-job').default;
+
+async function waitFor(
+  check: () => Promise<boolean>,
+  { timeoutMs = 5000, intervalMs = 25 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+  return false;
+}
+
+describe('Job: External media inliner', function () {
+  beforeAll(async function () {
+    const agent = await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('posts');
+    await agent.loginAsOwner();
+  });
+
+  afterAll(function () {
+    sinon.restore();
+    nock.cleanAll();
+  });
+
+  it('inlines external media when the dispatched job runs', async function () {
+    const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
+    nock('https://external-media.example.com').get('/image.gif').reply(200, GIF1x1);
+
+    const post = await models.Post.add(
+      {
+        title: 'Post with external feature image',
+        status: 'draft',
+        feature_image: 'https://external-media.example.com/image.gif',
+      },
+      { context: { internal: true } },
+    );
+
+    const loggingInfoSpy = sinon.spy(logging, 'info');
+
+    await getJobsService().dispatch(
+      new ExternalMediaInlinerJob({ domains: ['https://external-media.example.com'] }),
+    );
+
+    const inlined = await waitFor(async () => {
+      const updated = await models.Post.findOne({ id: post.id, status: 'all' });
+      const featureImage = updated.get('feature_image');
+      return Boolean(featureImage?.includes('/content/images/'));
+    });
+    assert.ok(inlined, 'The feature image is replaced with a locally stored copy');
+
+    const lifecycleLog = loggingInfoSpy.getCalls().find((call) => {
+      return (
+        call.args[0]?.system?.event === 'job.completed' &&
+        call.args[0]?.system?.job_type === 'external-media-inliner'
+      );
+    });
+    assert.ok(lifecycleLog, 'The jobs service logs a structured job.completed lifecycle event');
+    assert.equal(typeof lifecycleLog!.args[0].system.duration_ms, 'number');
+  });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/index.test.js
+++ b/ghost/core/test/unit/server/services/jobs-service/index.test.js
@@ -37,4 +37,20 @@ describe('jobs-service wrapper', function () {
       'getInstance returns the instance built by init',
     );
   });
+
+  it('getInstance throws again after shutdown', async function () {
+    const fakeBackend = {
+      requiredFns: ['start', 'enqueue', 'scheduleRecurring', 'shutdown'],
+      start() {},
+      enqueue() {},
+      scheduleRecurring() {},
+      async shutdown() {},
+    };
+    sinon.stub(adapterManager, 'getAdapter').withArgs('jobs').returns(fakeBackend);
+    jobsService.init();
+
+    await jobsService.shutdown();
+
+    assert.throws(() => jobsService.getInstance(), /used before init/);
+  });
 });

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import logging from '@tryghost/logging';
+import type { JobEnvelope } from '@tryghost/adapter-base-jobs';
+
+// require, not import: these must resolve to the same CommonJS module
+// instances register-job-handlers loads, so the init() and stubs here are the
+// ones the handlers read.
+const jobsService = require('../../../../../core/server/services/jobs-service');
+const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
+const mediaInliner = require('../../../../../core/server/services/media-inliner');
+const registerJobHandlers =
+  require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
+
+describe('registerJobHandlers', function () {
+  let processor: (envelope: JobEnvelope) => Promise<void>;
+  let getInstanceStub: sinon.SinonStub;
+  let inlineStub: sinon.SinonStub;
+
+  beforeEach(async function () {
+    const fakeBackend = {
+      start({ processor: p }: { processor: typeof processor }) {
+        processor = p;
+      },
+      enqueue() {},
+      scheduleRecurring() {},
+      async shutdown() {},
+    };
+    sinon.stub(adapterManager, 'getAdapter').withArgs('jobs').returns(fakeBackend);
+    sinon.stub(logging, 'info');
+
+    inlineStub = sinon.stub().resolves();
+    getInstanceStub = sinon.stub(mediaInliner, 'getInstance').returns({ inline: inlineStub });
+
+    jobsService.init();
+    registerJobHandlers();
+    await jobsService.getInstance().start();
+  });
+
+  afterEach(async function () {
+    await jobsService.shutdown({ timeoutMs: 100 });
+    sinon.restore();
+  });
+
+  it('registers the external-media-inliner handler on the class-based service', async function () {
+    await processor({
+      type: 'external-media-inliner',
+      payload: JSON.stringify({ domains: ['https://example.com'] }),
+    });
+
+    assert.ok(inlineStub.calledOnceWithExactly(['https://example.com']));
+  });
+
+  it('reads the live media-inliner instance at execution time, not registration time', async function () {
+    assert.ok(getInstanceStub.notCalled);
+
+    await processor({
+      type: 'external-media-inliner',
+      payload: JSON.stringify({ domains: ['https://example.com'] }),
+    });
+
+    assert.ok(getInstanceStub.calledOnce);
+  });
+});

--- a/ghost/core/test/unit/server/services/media-inliner/external-media-inliner-job.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/external-media-inliner-job.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import ExternalMediaInlinerJob from '../../../../../core/server/services/media-inliner/external-media-inliner-job';
+
+describe('ExternalMediaInlinerJob', function () {
+  it('keeps the legacy job name as its type', function () {
+    assert.equal(ExternalMediaInlinerJob.type, 'external-media-inliner');
+  });
+
+  it('survives the payload JSON round-trip', function () {
+    const job = new ExternalMediaInlinerJob({ domains: ['https://example.com'] });
+
+    const rehydrated = new ExternalMediaInlinerJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(rehydrated.domains, ['https://example.com']);
+  });
+});

--- a/ghost/core/test/unit/server/services/media-inliner/media-inliner-service.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/media-inliner-service.test.ts
@@ -4,20 +4,24 @@ import { describe, it, beforeEach } from 'vitest';
 
 const mediaInlinerModule = require('../../../../../core/server/services/media-inliner/service');
 const { MediaInlinerService } = mediaInlinerModule;
+const ExternalMediaInlinerJob =
+  require('../../../../../core/server/services/media-inliner/external-media-inliner-job').default;
 
 describe('MediaInlinerService', function () {
   let inliner: { inline: sinon.SinonStub };
-  let jobsService: { addJob: sinon.SinonStub };
+  let dispatch: sinon.SinonStub;
+  let getJobsService: sinon.SinonStub;
   let logging: { info: sinon.SinonStub; error: sinon.SinonStub };
   let debug: sinon.SinonStub;
   let service: InstanceType<typeof MediaInlinerService>;
 
   beforeEach(function () {
     inliner = { inline: sinon.stub().resolves('inlined') };
-    jobsService = { addJob: sinon.stub().resolves() };
+    dispatch = sinon.stub().resolves();
+    getJobsService = sinon.stub().returns({ dispatch });
     logging = { info: sinon.stub(), error: sinon.stub() };
     debug = sinon.stub();
-    service = new MediaInlinerService({ inliner, jobsService, logging, debug });
+    service = new MediaInlinerService({ inliner, getJobsService, logging, debug });
   });
 
   describe('inline', function () {
@@ -32,14 +36,13 @@ describe('MediaInlinerService', function () {
   describe('startMediaInliner', function () {
     const defaultDomains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
 
-    it('enqueues an inline job with default domains when none are provided', async function () {
+    it('dispatches a job with default domains when none are provided', async function () {
       const result = await service.startMediaInliner(undefined);
 
-      assert.ok(jobsService.addJob.calledOnce);
-      const jobArgs = jobsService.addJob.firstCall.firstArg;
-      assert.equal(jobArgs.name, 'external-media-inliner');
-      assert.equal(jobArgs.offloaded, false);
-      assert.deepEqual(jobArgs.data, { domains: defaultDomains });
+      assert.ok(dispatch.calledOnce);
+      const job = dispatch.firstCall.firstArg;
+      assert.ok(job instanceof ExternalMediaInlinerJob);
+      assert.deepEqual(job.domains, defaultDomains);
       assert.ok(logging.info.calledWithExactly('[Background Job] external-media-inliner queued'));
       assert.deepEqual(result, { status: 'success' });
     });
@@ -47,36 +50,21 @@ describe('MediaInlinerService', function () {
     it('applies default domains for an empty array', async function () {
       await service.startMediaInliner([]);
 
-      assert.deepEqual(jobsService.addJob.firstCall.firstArg.data, { domains: defaultDomains });
+      assert.deepEqual(dispatch.firstCall.firstArg.domains, defaultDomains);
     });
 
     it('passes explicit domains through', async function () {
       await service.startMediaInliner(['https://example.com']);
 
-      assert.deepEqual(jobsService.addJob.firstCall.firstArg.data, {
-        domains: ['https://example.com'],
-      });
+      assert.deepEqual(dispatch.firstCall.firstArg.domains, ['https://example.com']);
     });
 
-    it('enqueues a job body that runs the inliner with the payload domains', async function () {
+    it('resolves the jobs service at dispatch time, not construction time', async function () {
+      assert.ok(getJobsService.notCalled);
+
       await service.startMediaInliner(['https://example.com']);
 
-      const { job, data } = jobsService.addJob.firstCall.firstArg;
-      const result = await job(data);
-
-      assert.ok(inliner.inline.calledOnceWithExactly(['https://example.com']));
-      assert.equal(result, 'inlined');
-    });
-
-    it('enqueues a job body that logs and rethrows failures', async function () {
-      const err = new Error('inlining failed');
-      inliner.inline.rejects(err);
-      await service.startMediaInliner(['https://example.com']);
-
-      const { job, data } = jobsService.addJob.firstCall.firstArg;
-      await assert.rejects(() => job(data), err);
-      assert.ok(logging.error.calledOnce);
-      assert.equal(logging.error.firstCall.args[0], err);
+      assert.ok(getJobsService.calledOnce);
     });
   });
 

--- a/ghost/core/test/unit/server/services/media-inliner/media-inliner-service.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/media-inliner-service.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { describe, it, beforeEach } from 'vitest';
+
+const mediaInlinerModule = require('../../../../../core/server/services/media-inliner/service');
+const { MediaInlinerService } = mediaInlinerModule;
+
+describe('MediaInlinerService', function () {
+  let inliner: { inline: sinon.SinonStub };
+  let jobsService: { addJob: sinon.SinonStub };
+  let logging: { info: sinon.SinonStub; error: sinon.SinonStub };
+  let debug: sinon.SinonStub;
+  let service: InstanceType<typeof MediaInlinerService>;
+
+  beforeEach(function () {
+    inliner = { inline: sinon.stub().resolves('inlined') };
+    jobsService = { addJob: sinon.stub().resolves() };
+    logging = { info: sinon.stub(), error: sinon.stub() };
+    debug = sinon.stub();
+    service = new MediaInlinerService({ inliner, jobsService, logging, debug });
+  });
+
+  describe('inline', function () {
+    it('delegates to the inliner', async function () {
+      const result = await service.inline(['https://example.com']);
+
+      assert.ok(inliner.inline.calledOnceWithExactly(['https://example.com']));
+      assert.equal(result, 'inlined');
+    });
+  });
+
+  describe('startMediaInliner', function () {
+    const defaultDomains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+
+    it('enqueues an inline job with default domains when none are provided', async function () {
+      const result = await service.startMediaInliner(undefined);
+
+      assert.ok(jobsService.addJob.calledOnce);
+      const jobArgs = jobsService.addJob.firstCall.firstArg;
+      assert.equal(jobArgs.name, 'external-media-inliner');
+      assert.equal(jobArgs.offloaded, false);
+      assert.deepEqual(jobArgs.data, { domains: defaultDomains });
+      assert.ok(logging.info.calledWithExactly('[Background Job] external-media-inliner queued'));
+      assert.deepEqual(result, { status: 'success' });
+    });
+
+    it('applies default domains for an empty array', async function () {
+      await service.startMediaInliner([]);
+
+      assert.deepEqual(jobsService.addJob.firstCall.firstArg.data, { domains: defaultDomains });
+    });
+
+    it('passes explicit domains through', async function () {
+      await service.startMediaInliner(['https://example.com']);
+
+      assert.deepEqual(jobsService.addJob.firstCall.firstArg.data, {
+        domains: ['https://example.com'],
+      });
+    });
+
+    it('enqueues a job body that runs the inliner with the payload domains', async function () {
+      await service.startMediaInliner(['https://example.com']);
+
+      const { job, data } = jobsService.addJob.firstCall.firstArg;
+      const result = await job(data);
+
+      assert.ok(inliner.inline.calledOnceWithExactly(['https://example.com']));
+      assert.equal(result, 'inlined');
+    });
+
+    it('enqueues a job body that logs and rethrows failures', async function () {
+      const err = new Error('inlining failed');
+      inliner.inline.rejects(err);
+      await service.startMediaInliner(['https://example.com']);
+
+      const { job, data } = jobsService.addJob.firstCall.firstArg;
+      await assert.rejects(() => job(data), err);
+      assert.ok(logging.error.calledOnce);
+      assert.equal(logging.error.firstCall.args[0], err);
+    });
+  });
+
+  describe('getInstance', function () {
+    it('throws before init', function () {
+      assert.throws(() => mediaInlinerModule.getInstance(), /used before init/);
+    });
+  });
+});


### PR DESCRIPTION
`external-media-inliner` was the last piece of the media inliner still wired to the
legacy `JobManager.addJob` closure. This moves it onto the class-based jobs service so
the job body is a named, testable function and lifecycle logging comes from one place.

Three commits, meant to be read in order:

1. **Clear the jobs service singleton on shutdown** — `shutdown()` now drops the instance,
   so `getInstance()` throws instead of handing back a stopped service. Needed so the new
   handler-registration test can restore uninitialised state between cases.
2. **Refactor** (no behavior change) — the `startMediaInliner` closure becomes
   `MediaInlinerService` with injected deps, plus a `getInstance()` guard. `init()` keeps the
   `api.startMediaInliner` shape, so the `db.js` endpoint is untouched.
3. **Migrate** — pure-data `ExternalMediaInlinerJob` (`type` = the legacy job name) dispatched
   through the jobs service; the handler resolves the live inliner at execution time. Legacy
   `require('../jobs')` goes in the same commit, so it is never registered twice.

Reviewer notes: the `getJobsService` thunk is the one non-mechanical bit — `mediaInliner.init()`
runs at boot.js:417, before the jobs service exists at :646, and dispatch is only reachable after
maintenance mode lifts at :654. One behavior change: failures now also go to Sentry tagged with
`job_type`. Concurrency is unchanged — old and new pools are both 3.