### PR TITLE
Stop Accept-header markdown on HTML permalinks

### DIFF
--- a/ghost/core/core/frontend/services/llms/markdown.js
+++ b/ghost/core/core/frontend/services/llms/markdown.js
@@ -53,22 +53,6 @@ function getResourcePathFromMarkdownPath(pathname) {
   return stripped.endsWith('/') ? stripped : `${stripped}/`;
 }
 
-function getAcceptedMarkdownContentType(req) {
-  const acceptHeader = (req.get('Accept') || '').toLowerCase();
-
-  if (!acceptHeader.includes('text/markdown') && !acceptHeader.includes('text/plain')) {
-    return null;
-  }
-
-  const preferredType = req.accepts(['text/markdown', 'text/plain', 'text/html']);
-
-  if (!preferredType || preferredType === 'text/html') {
-    return null;
-  }
-
-  return preferredType;
-}
-
 function markdownFromHtml(html) {
   const markdown = nhm.translate(html || '').trim();
 
@@ -227,7 +211,6 @@ module.exports = {
   MAX_DESCRIPTION_LENGTH,
   collapseWhitespace,
   formatIsoDate,
-  getAcceptedMarkdownContentType,
   getGatedNotice,
   getMarkdownPath,
   getMarkdownUrl,

--- a/ghost/core/core/frontend/services/routing/controllers/entry.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.ts
@@ -61,11 +61,8 @@ export async function entryController(
 
   try {
     // A gift view is html-only. Redirecting before the lookup keeps the
-    // token off the read, so markdown paths can never see an unlocked entry.
-    if (
-      giftLinks.isGiftRequest(req) &&
-      (markdown.isMdRequest(res) || markdown.isAcceptsRequest(req))
-    ) {
+    // token off the read, so `.md` paths can never see an unlocked entry.
+    if (giftLinks.isGiftRequest(req) && markdown.isMdRequest(res)) {
       return giftLinks.stripGiftAndRedirect(req, res);
     }
 
@@ -105,13 +102,6 @@ export async function entryController(
     if (isPermalinkStale(req, entry)) {
       debug('redirect');
       return urlUtils.redirect301(res, buildCanonicalUrl(req, entry));
-    }
-
-    // MUST run after the permalink redirect above: negotiation rides on the
-    // canonical URL, so a stale dated-permalink URL is 301'd to canonical
-    // first, then markdown is served.
-    if (markdown.isAcceptsRequest(req) && markdown.isPublic(entry)) {
-      return markdown.serveAcceptsRequest(res, entry);
     }
 
     if (giftLinks.isGiftRequest(req)) {

--- a/ghost/core/core/frontend/services/routing/controllers/entry/markdown.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/markdown.ts
@@ -3,12 +3,7 @@ import type { Entry, EntryResponse } from '../entry';
 import buildCanonicalUrl from './canonical-url';
 
 const urlUtils = require('../../../../../shared/url-utils').default;
-const {
-  getAcceptedMarkdownContentType,
-  getGatedNotice,
-  getMarkdownPath,
-  renderEntryMarkdown,
-} = require('../../../llms/markdown');
+const { getGatedNotice, getMarkdownPath, renderEntryMarkdown } = require('../../../llms/markdown');
 
 const MEMBERS_ONLY_MARKDOWN =
   '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n';
@@ -196,23 +191,5 @@ export async function serveMdRequest(req: Request, res: EntryResponse, entry: En
     return servePreviewMarkdown(res, entry);
   }
 
-  return serveMarkdown(res, entry);
-}
-
-/**
- * Whether the request negotiates markdown via the Accept header (and the llms
- * feature is on) — request knowledge only, so it can be decided before the
- * entry lookup. Whether markdown is actually served still depends on the
- * entry: see `isPublic`.
- */
-export function isAcceptsRequest(req: Request): boolean {
-  return Boolean(getAcceptedMarkdownContentType(req)) && llmsEnabled(req);
-}
-
-/**
- * Serve markdown negotiated via the Accept header.
- */
-export function serveAcceptsRequest(res: Response, entry: Entry) {
-  res.vary('Accept');
   return serveMarkdown(res, entry);
 }

--- a/ghost/core/core/frontend/services/routing/controllers/entry/markdown.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/markdown.ts
@@ -49,7 +49,7 @@ async function copyFetchResponse(fetchResponse: globalThis.Response, res: Respon
  * Only public entries ever render as markdown without payment; gated entries
  * stay html (or preview / 402 on an explicit `.md` URL).
  */
-export function isPublic(entry: Entry): boolean {
+function isPublic(entry: Entry): boolean {
   return entry.visibility === 'public';
 }
 

--- a/ghost/core/core/server/services/machine-payments/README.md
+++ b/ghost/core/core/server/services/machine-payments/README.md
@@ -6,7 +6,7 @@ Accept pay-per-request access to paid-members markdown (`.md`) URLs from AI agen
 
 - **Protocol:** Machine Payments Protocol (MPP) — Tempo USDC + Shared Payment Tokens (card / Link Agent Wallet). x402 (Base USDC via ExactEvmScheme) is a second adapter behind the same payment-authorization boundary; agents that don't speak it ignore it. Neither rail changes membership.
 - **Access model:** One-shot unlock of markdown bytes for that request. No member session, tier grant, or change to `content-gating` / Portal.
-- **Surface:** Explicit `.md` URLs only. Accept-header markdown stays public-only. HTML theme views and the Content API stay membership-gated.
+- **Surface:** Explicit `.md` URLs only. Canonical HTML URLs always render HTML (Accept headers are ignored). HTML theme views and the Content API stay membership-gated.
 - **Pricing:** Site-wide amount. SPT charges use the configured fiat currency (Stripe card minimum applies). Tempo charges USDC using the same minor-unit amount; publishers should treat the crypto rail as USDC, not as on-chain publisher currency.
 - **Eligibility:** `visibility: paid`, or `visibility: tiers` where every related tier is paid. Free-members-only (`visibility: members`) is out of scope.
 - **Enablement:** Labs `machinePayments` + `llms_enabled` + `machine_payments_enabled` + Stripe connected.

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -320,10 +320,9 @@ describe('Front-end gift links', function () {
   });
 
   describe('markdown variants', function () {
-    // A gift view is html-only. The markdown paths (`.md` URLs and Accept
-    // negotiation) redirect gift requests to the clean URL instead of
-    // serving an unlocked variant — which would carry the llms path's
-    // public Cache-Control and none of the gift headers.
+    // A gift view is html-only. `.md` URLs redirect gift requests to the
+    // clean URL instead of serving an unlocked variant — which would carry
+    // the llms path's public Cache-Control and none of the gift headers.
     it('301s a .md request away from a gift view without unlocking it', async function () {
       const res = await request.get(`/${slug}.md?gift=${token}`).redirects(0).expect(301);
 
@@ -332,32 +331,26 @@ describe('Front-end gift links', function () {
       assert.match(res.headers['cache-control'], /no-store/);
     });
 
-    it('301s an Accept-negotiated markdown request away from a gift view', async function () {
+    it('ignores Accept: text/markdown on a gift HTML URL', async function () {
       const res = await request
         .get(`/${publicGatedBlocksSlug}/?gift=${publicGatedBlocksToken}`)
         .set('Accept', 'text/markdown')
-        .redirects(0)
-        .expect(301);
+        .expect(200)
+        .expect('Content-Type', /html/);
 
-      assert.equal(res.headers.location, `/${publicGatedBlocksSlug}/`);
-      assert.doesNotMatch(
-        res.text || '',
-        /Paid-member gated content/,
-        'the unlocked variant must never be served as markdown',
-      );
+      assert.doesNotMatch(res.text, /## Content Index/);
+      assert.match(res.text, /Paid-member gated content/);
     });
 
-    it('301s an Accept-negotiated markdown request away from a gift view on a gated entry too', async function () {
-      // The redirect is decided from the request alone, before the entry
-      // lookup — a markdown-negotiating client gets the canonical URL,
-      // never a gift view, whatever the entry's visibility.
+    it('ignores Accept: text/markdown on a gated gift HTML URL', async function () {
       const res = await request
         .get(`/${slug}/?gift=${token}`)
         .set('Accept', 'text/markdown')
-        .redirects(0)
-        .expect(301);
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(assertUnlocked);
 
-      assert.equal(res.headers.location, `/${slug}/`);
+      assert.doesNotMatch(res.text, /## Content Index/);
     });
 
     it('serves the gated markdown variant on the clean .md URL', async function () {

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -53,6 +53,17 @@ describe('llms.txt routing', function () {
     );
   });
 
+  it('serves HTML on the canonical URL even when Accept prefers markdown', async function () {
+    const res = await request
+      .get('/welcome/')
+      .set('Accept', 'text/markdown')
+      .expect('Content-Type', /html/)
+      .expect(200);
+
+    assert.doesNotMatch(res.text, /## Content Index/);
+    assert.match(res.text, /<html/i);
+  });
+
   it('serves llms-full.txt with entry bodies and absolute urls', async function () {
     const res = await request
       .get('/llms-full.txt')

--- a/ghost/core/test/e2e-frontend/machine-payments-markdown.test.js
+++ b/ghost/core/test/e2e-frontend/machine-payments-markdown.test.js
@@ -224,10 +224,10 @@ describe('Machine payments markdown routing', function () {
     assert.equal(res.headers['www-authenticate'], undefined);
   });
 
-  it('ignores Payment credentials on Accept markdown negotiation for gated posts', async function () {
+  it('ignores Payment credentials on HTML permalinks even when Accept prefers markdown', async function () {
     const challengeOrFulfill = sinon.stub(machinePayments, 'challengeOrFulfill');
 
-    // Accept negotiation only unlocks public entries; paid HTML stays membership-gated.
+    // Canonical URLs always render HTML; markdown lives on explicit `.md` URLs.
     const res = await request
       .get(`/${paidSlug}/`)
       .set('Accept', 'text/markdown')

--- a/ghost/core/test/integration/services/machine-payments/orchestration.test.js
+++ b/ghost/core/test/integration/services/machine-payments/orchestration.test.js
@@ -12,7 +12,6 @@ const {
   getMarkdownPath,
   getMarkdownUrl,
   getResourcePathFromMarkdownPath,
-  getAcceptedMarkdownContentType,
   markdownFromHtml,
   getPrimaryAuthorName,
   getTagNames,
@@ -161,20 +160,6 @@ describe('Integration: machine-payments orchestration coverage', function () {
       assert.deepEqual(getTagNames({ tags: [{ name: 'A' }, { name: 'B' }] }), ['A', 'B']);
       assert.deepEqual(getTagNames({ primary_tag: { name: 'Solo' } }), ['Solo']);
       assert.deepEqual(getTagNames({}), []);
-      assert.equal(
-        getAcceptedMarkdownContentType({
-          get: () => 'text/markdown',
-          accepts: () => 'text/markdown',
-        }),
-        'text/markdown',
-      );
-      assert.equal(
-        getAcceptedMarkdownContentType({
-          get: () => 'text/html',
-          accepts: () => 'text/html',
-        }),
-        null,
-      );
     });
   });
 

--- a/ghost/core/test/unit/frontend/services/llms/markdown.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/markdown.test.js
@@ -6,7 +6,6 @@ const {
   getMarkdownPath,
   getMarkdownUrl,
   getResourcePathFromMarkdownPath,
-  getAcceptedMarkdownContentType,
   getGatedNotice,
   markdownFromHtml,
   renderEntryMarkdown,
@@ -81,42 +80,6 @@ describe('Unit: frontend/services/llms/markdown', function () {
 
     it('returns null for null', function () {
       assert.equal(getResourcePathFromMarkdownPath(null), null);
-    });
-  });
-
-  describe('getAcceptedMarkdownContentType', function () {
-    function fakeReq(accept) {
-      return {
-        get(header) {
-          if (header === 'Accept') {
-            return accept;
-          }
-          return null;
-        },
-        accepts(types) {
-          if (!accept) {
-            return false;
-          }
-          for (const type of types) {
-            if (accept.includes(type)) {
-              return type;
-            }
-          }
-          return false;
-        },
-      };
-    }
-
-    it('returns text/markdown when accepted', function () {
-      assert.equal(getAcceptedMarkdownContentType(fakeReq('text/markdown')), 'text/markdown');
-    });
-
-    it('returns null for text/html only', function () {
-      assert.equal(getAcceptedMarkdownContentType(fakeReq('text/html')), null);
-    });
-
-    it('returns null when no accept header', function () {
-      assert.equal(getAcceptedMarkdownContentType(fakeReq(null)), null);
     });
   });
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.ts
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.ts
@@ -368,7 +368,7 @@ describe('Unit - services/routing/controllers/entry', function () {
     });
   });
 
-  describe('Accept header markdown negotiation', function () {
+  describe('Accept header does not negotiate markdown', function () {
     let llmsService: { isEnabled: sinon.SinonStub };
 
     beforeEach(function () {
@@ -385,41 +385,8 @@ describe('Unit - services/routing/controllers/entry', function () {
       post.visibility = 'public';
     });
 
-    it('serves markdown when the entry is public, Accept negotiates markdown and llms is enabled', async function () {
-      post.url = 'http://localhost:2368/does-exist/';
-      // serveMarkdown needs an absolute entry.url; keep req.path canonical
-      // so the permalink-redirect guard doesn't fire first.
-      req.path = urlUtils.absoluteToRelative(post.url, { withoutSubdirectory: true });
-      req.originalUrl = req.path;
-      llmsService.isEnabled.returns(true);
-
-      entryLookUpStub.withArgs(req.path, res.routerOptions).resolves({ entry: post });
-
-      await controllers.entry(req, res, sinon.stub());
-
-      sinon.assert.calledWith(res.vary, 'Accept');
-      sinon.assert.calledWith(res.type, 'text/markdown');
-      sinon.assert.calledOnce(res.send);
-      sinon.assert.notCalled(renderStub);
-    });
-
-    it('renders normally when llms is disabled', async function () {
+    it('renders HTML on the canonical URL even when Accept prefers markdown', async function () {
       post.url = '/does-exist/';
-      llmsService.isEnabled.returns(false);
-      const renderEntry = sinon.spy();
-      renderStub.returns(renderEntry);
-
-      entryLookUpStub.withArgs(req.path, res.routerOptions).resolves({ entry: post });
-
-      await controllers.entry(req, res, sinon.stub());
-
-      sinon.assert.notCalled(res.send);
-      sinon.assert.calledWith(renderEntry, post);
-    });
-
-    it('renders normally when the entry is not public', async function () {
-      post.url = '/does-exist/';
-      post.visibility = 'paid';
       llmsService.isEnabled.returns(true);
       const renderEntry = sinon.spy();
       renderStub.returns(renderEntry);
@@ -429,6 +396,7 @@ describe('Unit - services/routing/controllers/entry', function () {
       await controllers.entry(req, res, sinon.stub());
 
       sinon.assert.notCalled(res.send);
+      sinon.assert.notCalled(res.vary);
       sinon.assert.calledWith(renderEntry, post);
     });
   });


### PR DESCRIPTION
When `llms_enabled` is on, Ghost served markdown from the **canonical HTML URL** if the client sent `Accept: text/markdown` (or `text/plain`). Those responses were publicly cacheable and only `Vary: Accept`. CDNs that don't key on `Accept` (including typical Cloudflare setups) then served that markdown body to browsers requesting `text/html`.

A self-hoster hit this after enabling Settings → Meta data → "Enable structured data for LLMs and AI search engines": pages like `/pacifica-hospital-of-the-valley/` returned `content-type: text/markdown` with `content-location: …md` and `cf-cache-status: HIT`.

Markdown is now **only** served on explicit `.md` URLs (`llms.txt`, `rel=alternate`, `/post.md`). Canonical permalinks always render HTML, regardless of `Accept`.

## Test plan
- [x] `GET /welcome/` with `Accept: text/markdown` is `text/html` (no Content Index block)
- [x] `GET /welcome.md` is still `text/markdown`
- [x] Gated HTML permalinks stay HTML; paid `.md` still 402s when machine payments apply
- [x] Gift HTML URLs with `Accept: text/markdown` still render the gift view (`.md?gift=` still 301s to strip the token)