### PR TITLE
Fixed gift option for free members choosing plans

### DIFF
--- a/apps/portal/src/components/common/signup-gift-promotion.jsx
+++ b/apps/portal/src/components/common/signup-gift-promotion.jsx
@@ -1,0 +1,40 @@
+import AppContext from '../../app-context';
+import { useContext } from 'react';
+import { canShowSignupGiftPromotion } from '../../utils/gift-subscriptions';
+import { t } from '../../utils/i18n';
+
+const SignupGiftPromotion = ({ className, lastPage, showSeparator = false }) => {
+  const { brandColor, doAction, site } = useContext(AppContext);
+
+  if (!canShowSignupGiftPromotion({ site })) {
+    return null;
+  }
+
+  const promotion = (
+    <>
+      {showSeparator && (
+        <span aria-hidden="true" className="gh-portal-signup-message-separator">
+          &middot;
+        </span>
+      )}
+      <div>{t('Buying for someone else?')}</div>
+      <button
+        data-test-button="gift-switch"
+        data-testid="gift-switch"
+        className="gh-portal-btn gh-portal-btn-link"
+        style={{ color: brandColor }}
+        onClick={() => doAction('switchPage', { page: 'gift', lastPage })}
+      >
+        <span>{t('Gift a membership')}</span>
+      </button>
+    </>
+  );
+
+  if (className) {
+    return <div className={className}>{promotion}</div>;
+  }
+
+  return promotion;
+};
+
+export default SignupGiftPromotion;

--- a/apps/portal/src/components/pages/account-plan-page.jsx
+++ b/apps/portal/src/components/pages/account-plan-page.jsx
@@ -694,6 +694,9 @@ export default class AccountPlanPage extends React.Component {
   onBack() {
     if (this.state.showConfirmation) {
       this.cancelConfirmPage();
+    } else if (this.context.lastPage === 'accountPlan') {
+      // Returning from gift checkout leaves lastPage pointing back to this page.
+      this.context.doAction('switchPage', { page: 'accountHome' });
     } else {
       this.context.doAction('back');
     }

--- a/apps/portal/src/components/pages/account-plan-page.jsx
+++ b/apps/portal/src/components/pages/account-plan-page.jsx
@@ -3,6 +3,7 @@ import AppContext from '../../app-context';
 import ActionButton from '../common/action-button';
 import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
+import SignupGiftPromotion from '../common/signup-gift-promotion';
 import { MultipleProductsPlansSection } from '../common/plans-section';
 import { getDateString } from '../../utils/date-time';
 import {
@@ -467,6 +468,7 @@ const RetentionOfferSection = ({ subscription, offer, onAcceptOffer, onDeclineOf
 
 // For free members
 const UpgradePlanSection = ({ plans, selectedPlan, onPlanSelect, onPlanCheckout }) => {
+  const { member } = useContext(AppContext);
   // const {action, brandColor} = useContext(AppContext);
   // const isRunning = ['checkoutPlan:running'].includes(action);
   let singlePlanClass = '';
@@ -484,6 +486,9 @@ const UpgradePlanSection = ({ plans, selectedPlan, onPlanSelect, onPlanCheckout 
           onPlanCheckout={onPlanCheckout}
         />
       </div>
+      {!isPaidMember({ member }) && (
+        <SignupGiftPromotion className="gh-portal-signup-message" lastPage="accountPlan" />
+      )}
       {/* <ActionButton
                 onClick={e => onPlanCheckout(e)}
                 isRunning={isRunning}

--- a/apps/portal/src/components/pages/signup-page.jsx
+++ b/apps/portal/src/components/pages/signup-page.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ActionButton from '../common/action-button';
 import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
+import SignupGiftPromotion from '../common/signup-gift-promotion';
 import SiteTitleBackButton from '../common/site-title-back-button';
 import NewsletterSelectionPage from './newsletter-selection-page';
 import ProductsSection from '../common/products-section';
@@ -25,7 +26,6 @@ import InvitationIcon from '../../images/icons/invitation.svg?react';
 import { interceptAnchorClicks } from '../../utils/links';
 import { sanitizeHtml } from '../../utils/sanitize-html';
 import { t } from '../../utils/i18n';
-import { canShowSignupGiftPromotion } from '../../utils/gift-subscriptions';
 
 export const SignupPageStyles = `
 .gh-portal-back-sitetitle {
@@ -712,8 +712,7 @@ class SignupPage extends React.Component {
   }
 
   renderLoginMessage({ showGiftPromotion = true } = {}) {
-    const { brandColor, doAction, site } = this.context;
-    const canPromoteGift = showGiftPromotion && canShowSignupGiftPromotion({ site });
+    const { brandColor, doAction } = this.context;
 
     return (
       <div>
@@ -729,23 +728,7 @@ class SignupPage extends React.Component {
           >
             <span>{t('Sign in')}</span>
           </button>
-          {canPromoteGift && (
-            <>
-              <span aria-hidden="true" className="gh-portal-signup-message-separator">
-                &middot;
-              </span>
-              <div>{t('Buying for someone else?')}</div>
-              <button
-                data-test-button="gift-switch"
-                data-testid="gift-switch"
-                className="gh-portal-btn gh-portal-btn-link"
-                style={{ color: brandColor }}
-                onClick={() => doAction('switchPage', { page: 'gift', lastPage: 'signup' })}
-              >
-                <span>{t('Gift a membership')}</span>
-              </button>
-            </>
-          )}
+          {showGiftPromotion && <SignupGiftPromotion lastPage="signup" showSeparator={true} />}
         </div>
       </div>
     );

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.jsx
@@ -150,6 +150,14 @@ describe('Account Plan Page', () => {
     });
   });
 
+  test('returns to account home after returning from gift checkout', () => {
+    const { getByRole, mockDoActionFn } = customSetup({ lastPage: 'accountPlan' });
+
+    fireEvent.click(getByRole('button', { name: 'Back' }));
+
+    expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', { page: 'accountHome' });
+  });
+
   test.each([
     {
       label: 'the setting is disabled',

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.jsx
@@ -134,6 +134,48 @@ describe('Account Plan Page', () => {
     });
   });
 
+  test('shows the signup gift promotion to free members choosing a plan', () => {
+    const site = {
+      ...getSiteData({ labs: { giftSubCustomization: true } }),
+      portal_signup_gift_promotion: true,
+    };
+    const member = getMemberData({ paid: false });
+    const { getByRole, mockDoActionFn } = customSetup({ site, member });
+
+    fireEvent.click(getByRole('button', { name: 'Gift a membership' }));
+
+    expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', {
+      page: 'gift',
+      lastPage: 'accountPlan',
+    });
+  });
+
+  test.each([
+    {
+      label: 'the setting is disabled',
+      site: {
+        ...getSiteData({ labs: { giftSubCustomization: true } }),
+        portal_signup_gift_promotion: false,
+      },
+    },
+    {
+      label: 'the feature flag is disabled',
+      site: { ...getSiteData(), portal_signup_gift_promotion: true },
+    },
+    {
+      label: 'there is no giftable offering',
+      site: {
+        ...getSiteData({ labs: { giftSubCustomization: true }, portalPlans: ['free'] }),
+        portal_signup_gift_promotion: true,
+      },
+    },
+  ])('hides the signup gift promotion when $label', ({ site }) => {
+    const member = getMemberData({ paid: false });
+    const { queryByRole } = customSetup({ site, member });
+
+    expect(queryByRole('button', { name: 'Gift a membership' })).not.toBeInTheDocument();
+  });
+
   test('can cancel subscription for member on hidden tier', async () => {
     const overrides = generateAccountPlanFixture();
     const { queryByRole, queryByText } = customSetup(overrides);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3891/show-gifting-option-for-free-members-choosing-a-plan

Free members choose paid plans from their account after signing in, so the signup gift promotion was never rendered for them. This reuses the signup promotion beneath the plan picker while preserving its existing setting, labs flag, and giftable offering gates.