### PR TITLE
Changed gift email replies to use support address

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-email-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-email-service.ts
@@ -16,6 +16,7 @@ interface TransactionalMailer {
     html: string;
     text: string;
     from: string;
+    replyTo: string;
     forceTextContent: boolean;
     tags?: string[];
     trackOpens?: boolean;
@@ -31,6 +32,7 @@ interface BulkMailer {
       html: string;
       plaintext: string;
       from: string;
+      replyTo: string;
       tags: string[];
       disable_tracking: boolean;
     },
@@ -101,6 +103,7 @@ export class GiftEmailService {
   private readonly settingsCache: SettingsCache;
   private readonly urlUtils: UrlUtils;
   private readonly getFromAddress: () => string;
+  private readonly getReplyToAddress: () => string;
   private readonly blogIcon: BlogIcon;
   private readonly renderer: GiftEmailRenderer;
   private readonly t: Translate;
@@ -111,6 +114,7 @@ export class GiftEmailService {
     settingsCache,
     urlUtils,
     getFromAddress,
+    getReplyToAddress,
     blogIcon,
     t,
   }: {
@@ -119,6 +123,7 @@ export class GiftEmailService {
     settingsCache: SettingsCache;
     urlUtils: UrlUtils;
     getFromAddress: () => string;
+    getReplyToAddress: () => string;
     blogIcon: BlogIcon;
     t: Translate;
   }) {
@@ -127,6 +132,7 @@ export class GiftEmailService {
     this.settingsCache = settingsCache;
     this.urlUtils = urlUtils;
     this.getFromAddress = getFromAddress;
+    this.getReplyToAddress = getReplyToAddress;
     this.blogIcon = blogIcon;
     this.t = t;
 
@@ -216,6 +222,7 @@ export class GiftEmailService {
       html,
       text,
       from: this.getFromAddress(),
+      replyTo: this.getReplyToAddress(),
       forceTextContent: true,
       disableTracking: true,
     });
@@ -268,6 +275,7 @@ export class GiftEmailService {
       html,
       text,
       from: this.getFromAddress(),
+      replyTo: this.getReplyToAddress(),
       forceTextContent: true,
       disableTracking: true,
     });
@@ -307,6 +315,7 @@ export class GiftEmailService {
       html,
       text,
       from: this.getFromAddress(),
+      replyTo: this.getReplyToAddress(),
       forceTextContent: true,
     });
   }
@@ -362,6 +371,7 @@ export class GiftEmailService {
         html,
         text,
         from: this.getFromAddress(),
+        replyTo: this.getReplyToAddress(),
         forceTextContent: true,
         tags: [GIFT_DELIVERY_EMAIL_TAG],
         disableTracking: true,
@@ -376,6 +386,7 @@ export class GiftEmailService {
         html,
         plaintext: text,
         from: this.getFromAddress(),
+        replyTo: this.getReplyToAddress(),
         tags: [GIFT_DELIVERY_EMAIL_TAG],
         disable_tracking: true,
       },

--- a/ghost/core/core/server/services/gifts/index.ts
+++ b/ghost/core/core/server/services/gifts/index.ts
@@ -81,6 +81,7 @@ export async function init(options: GiftServiceInitOptions): Promise<void> {
     settingsCache,
     urlUtils,
     getFromAddress: () => EmailAddressParser.stringify(settingsHelpers.getDefaultEmail()),
+    getReplyToAddress: () => settingsHelpers.getMembersSupportAddress(),
     blogIcon,
     t,
   });

--- a/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
+++ b/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
@@ -27,6 +27,7 @@ describe('GiftEmailService', function () {
   };
 
   const getFromAddress = () => 'Test Site <noreply@example.com>';
+  const getReplyToAddress = () => 'support@example.com';
 
   const blogIcon = {
     getIconUrl: () => 'https://example.com/icon.png',
@@ -80,6 +81,7 @@ describe('GiftEmailService', function () {
       settingsCache,
       urlUtils,
       getFromAddress,
+      getReplyToAddress,
       blogIcon,
       t: translate(),
     });
@@ -99,6 +101,7 @@ describe('GiftEmailService', function () {
         to: 'buyer@example.com',
         subject: 'Your gift is ready',
         from: 'Test Site <noreply@example.com>',
+        replyTo: 'support@example.com',
         disableTracking: true,
       }),
     );
@@ -151,6 +154,7 @@ describe('GiftEmailService', function () {
     sinon.assert.match(message, {
       to: 'buyer@example.com',
       subject: 'Your gift has been sent',
+      replyTo: 'support@example.com',
       disableTracking: true,
     });
     for (const field of ['html', 'text']) {
@@ -171,6 +175,7 @@ describe('GiftEmailService', function () {
     sinon.assert.match(message, {
       to: 'buyer@example.com',
       subject: "We couldn't deliver your gift",
+      replyTo: 'support@example.com',
       disableTracking: true,
     });
     assert.equal(message.tags, undefined);
@@ -224,6 +229,7 @@ describe('GiftEmailService', function () {
       settingsCache: localizedSettingsCache,
       urlUtils,
       getFromAddress,
+      getReplyToAddress,
       blogIcon,
       t: translate(),
     });
@@ -262,6 +268,7 @@ describe('GiftEmailService', function () {
       settingsCache: noTitleSettingsCache,
       urlUtils,
       getFromAddress,
+      getReplyToAddress,
       blogIcon,
       t: translate(),
     });
@@ -292,6 +299,7 @@ describe('GiftEmailService', function () {
       settingsCache: hostileSettingsCache,
       urlUtils,
       getFromAddress,
+      getReplyToAddress,
       blogIcon,
       t: translate(),
     });
@@ -343,6 +351,7 @@ describe('GiftEmailService', function () {
       const message = bulkMailer.send.firstCall.firstArg;
       sinon.assert.match(message, {
         subject: 'Buyer sent you a gift',
+        replyTo: 'support@example.com',
         tags: ['gift-delivery'],
         disable_tracking: true,
       });
@@ -389,6 +398,7 @@ describe('GiftEmailService', function () {
         settingsCache,
         urlUtils,
         getFromAddress,
+        getReplyToAddress,
         blogIcon: { getIconUrl: () => null },
         t: translate(),
       });
@@ -436,6 +446,7 @@ describe('GiftEmailService', function () {
         settingsCache: siteSettingsCache,
         urlUtils,
         getFromAddress,
+        getReplyToAddress,
         blogIcon,
         t: translate(),
       });
@@ -477,6 +488,7 @@ describe('GiftEmailService', function () {
         settingsCache: invalidLocaleSettingsCache,
         urlUtils,
         getFromAddress,
+        getReplyToAddress,
         blogIcon,
         t: translate(),
       });
@@ -510,6 +522,7 @@ describe('GiftEmailService', function () {
         settingsCache: invalidColorSettingsCache,
         urlUtils,
         getFromAddress,
+        getReplyToAddress,
         blogIcon,
         t: translate(),
       });
@@ -558,6 +571,7 @@ describe('GiftEmailService', function () {
           to: 'recipient@example.com',
           subject: 'Buyer sent you a gift',
           from: 'Test Site <noreply@example.com>',
+          replyTo: 'support@example.com',
           tags: ['gift-delivery'],
           disableTracking: true,
           forceTextContent: true,
@@ -635,6 +649,7 @@ describe('GiftEmailService', function () {
         settingsCache: literalSettingsCache,
         urlUtils,
         getFromAddress,
+        getReplyToAddress,
         blogIcon,
         t: translate(),
       });
@@ -728,6 +743,7 @@ describe('GiftEmailService', function () {
           to: 'member@example.com',
           subject: 'Your gift subscription is ending soon',
           from: 'Test Site <noreply@example.com>',
+          replyTo: 'support@example.com',
         }),
       );
     });
@@ -800,6 +816,7 @@ describe('GiftEmailService', function () {
         settingsCache: localizedSettingsCache,
         urlUtils,
         getFromAddress,
+        getReplyToAddress,
         blogIcon,
         t: translate(),
       });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3892/use-support-email-for-reply-to-on-gift-emails

Gift emails currently use the default sender without a reply-to address, so replies do not reliably reach site owners.

This uses the configured member support address, including its existing default-address fallback, for buyer confirmations, recipient deliveries, and reminder emails. It covers both transactional mail and direct bulk Mailgun delivery.