### PR TITLE
Added worktree-safe Core type checking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ Start with:
 - Run `pnpm setup` before other commands in a fresh checkout or worktree.
 - Use `pnpm check` as the default full validation command. Browser E2E and Ember
   Admin tests run separately; follow the testing guide.
+- For Ghost Core type-only validation from the repository root, run
+  `CI=true pnpm typecheck:core`.
+  The target builds workspace dependencies without emitting Core JavaScript;
+  `ghost:build:tsc` is a production packaging target that emits beside source.
 - Read the nearest `AGENTS.md`, `CLAUDE.md`, and README before changing a package
   or subsystem. More specific guidance overrides this file.
 - When committing, load and follow `.agents/skills/commit/SKILL.md`.

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -52,6 +52,7 @@
     "migrate:create": "node bin/create-migration.js",
     "build:assets:css": "postcss core/frontend/public/ghost.css --no-map --use cssnano -o core/frontend/public/ghost.min.css",
     "build:tsc": "tsc",
+    "typecheck": "tsc --noEmit",
     "pretest": "pnpm build:assets",
     "test": "pnpm test:unit",
     "test:watch": "vitest --reporter=default",
@@ -322,6 +323,12 @@
     ],
     "targets": {
       "build:tsc": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
+      "typecheck": {
+        "cache": true,
         "dependsOn": [
           "^build"
         ]

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "format": "node scripts/format.js",
     "format:check": "oxfmt --check",
     "check": "pnpm format:check && pnpm lint && pnpm test",
+    "typecheck:core": "NX_CACHE_DIRECTORY=\"$PWD/.nxcache\" NX_WORKSPACE_DATA_DIRECTORY=\"$PWD/.nx/workspace-data\" nx run ghost:typecheck",
     "test": "pnpm nx run-many -t test --exclude @tryghost/e2e --exclude ghost-admin",
     "test:unit": "pnpm nx run-many -t test:unit",
     "test:watch": "vitest",


### PR DESCRIPTION
no issue

Ghost Core's production TypeScript build intentionally emits JavaScript beside its TypeScript sources so those files can be packaged. Agents have been using that target for type validation when a direct no-emit check fails in fresh worktrees because workspace dependency outputs have not been built. That leaves hundreds of untracked JavaScript files which can shadow the TypeScript source during later validation.

Nx also shares workspace data and its task cache with the primary checkout across Git worktrees. Sandboxed agents cannot write to that checkout, so dependency-aware validation can fail before the Core type check runs.

This adds a cached, non-emitting Core typecheck target which builds its workspace dependencies through Nx. The root typecheck:core wrapper keeps Nx workspace data and task cache inside the current worktree, and the agent guidance makes CI=true pnpm typecheck:core the canonical command while reserving ghost:build:tsc for production packaging.