### PR TITLE
🎨 Moved x402 adapter dependencies off of boot hotpath

### DIFF
--- a/ghost/core/core/server/services/machine-payments/adapters/x402-adapter.ts
+++ b/ghost/core/core/server/services/machine-payments/adapters/x402-adapter.ts
@@ -21,13 +21,14 @@ function normalizeFacilitatorUrl(urlString: string): string {
 
 const x402ConfigSchema = z
   .object({
+    enabled: z.boolean().optional().default(false),
     network: z.string().regex(/^eip155:\d+$/, {
       message: 'machinePayments.x402.network must be a CAIP-2 EVM network (eip155:<chainId>)',
     }),
     stripeNetwork: z.enum(['base'], {
       message: 'machinePayments.x402.stripeNetwork must be "base"',
     }),
-    facilitatorUrl: z.string().url({
+    facilitatorUrl: z.url({
       message: 'machinePayments.x402.facilitatorUrl must be a valid URL',
     }),
   })
@@ -110,16 +111,19 @@ type X402RuntimeModules = {
   Hono: new () => HonoLike;
 };
 
+type X402RawConfig = {
+  enabled?: unknown;
+  network?: unknown;
+  stripeNetwork?: unknown;
+  facilitatorUrl?: unknown;
+};
+
 type X402AdapterDeps = {
   depositAddressStore: DepositAddressStoreLike;
   facilitatorClient?: FacilitatorClientLike;
   maxCachedApps?: number;
   runtimeFactory?: () => X402RuntimeModules;
-  configProvider?: () => {
-    network?: unknown;
-    stripeNetwork?: unknown;
-    facilitatorUrl?: unknown;
-  };
+  configProvider?: () => X402RawConfig;
 };
 
 /**
@@ -163,12 +167,9 @@ export class BoundedRouteCache<V> {
   }
 }
 
-export function parseX402Config(raw: {
-  network?: unknown;
-  stripeNetwork?: unknown;
-  facilitatorUrl?: unknown;
-}): X402Config | null {
+export function parseX402Config(raw: X402RawConfig): X402Config | null {
   const parsed = x402ConfigSchema.safeParse({
+    enabled: raw.enabled ?? false,
     network: raw.network ?? BASE_MAINNET,
     stripeNetwork: raw.stripeNetwork ?? 'base',
     facilitatorUrl: raw.facilitatorUrl ?? DEFAULT_FACILITATOR_URL,
@@ -236,13 +237,14 @@ export class X402Adapter implements PaymentAdapter {
     const rawConfig = this.#configProvider
       ? this.#configProvider()
       : {
+          enabled: config.get('machinePayments:x402:enabled'),
           network: config.get('machinePayments:x402:network'),
           stripeNetwork: config.get('machinePayments:x402:stripeNetwork'),
           facilitatorUrl: config.get('machinePayments:x402:facilitatorUrl'),
         };
 
     const parsedConfig = parseX402Config(rawConfig);
-    if (!parsedConfig) {
+    if (!parsedConfig?.enabled) {
       return false;
     }
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -279,6 +279,7 @@
   "stripeDirect": false,
   "machinePayments": {
     "x402": {
+      "enabled": false,
       "network": "eip155:8453",
       "stripeNetwork": "base",
       "facilitatorUrl": "https://facilitator.xpay.sh"

--- a/ghost/core/test/integration/services/machine-payments/orchestration.test.js
+++ b/ghost/core/test/integration/services/machine-payments/orchestration.test.js
@@ -536,11 +536,13 @@ describe('Integration: machine-payments orchestration coverage', function () {
     it('validates facilitator URLs and settlement helpers', function () {
       assert.deepEqual(
         parseX402Config({
+          enabled: true,
           network: 'eip155:8453',
           stripeNetwork: 'base',
           facilitatorUrl: 'https://facilitator.xpay.sh',
         }),
         {
+          enabled: true,
           network: 'eip155:8453',
           stripeNetwork: 'base',
           facilitatorUrl: 'https://facilitator.xpay.sh',
@@ -570,11 +572,13 @@ describe('Integration: machine-payments orchestration coverage', function () {
 
       assert.deepEqual(
         parseX402Config({
+          enabled: true,
           network: 'eip155:84532',
           stripeNetwork: 'base',
           facilitatorUrl: 'https://X402.ORG:443/facilitator/',
         }),
         {
+          enabled: true,
           network: 'eip155:84532',
           stripeNetwork: 'base',
           facilitatorUrl: 'https://X402.ORG:443/facilitator/',
@@ -607,6 +611,7 @@ describe('Integration: machine-payments orchestration coverage', function () {
           getOrCreateAddress: async () => '0xrecipient',
         },
         configProvider: () => ({
+          enabled: true,
           network: 'eip155:8453',
           stripeNetwork: 'base',
           facilitatorUrl: 'https://facilitator.xpay.sh',

--- a/ghost/core/test/unit/server/services/machine-payments/adapters.test.js
+++ b/ghost/core/test/unit/server/services/machine-payments/adapters.test.js
@@ -26,6 +26,7 @@ function createX402Adapter(overrides = {}) {
     },
     facilitatorClient: {},
     configProvider: () => ({
+      enabled: true,
       network: 'eip155:8453',
       stripeNetwork: 'base',
       facilitatorUrl: 'https://facilitator.xpay.sh',
@@ -193,11 +194,29 @@ describe('Unit: server/services/machine-payments/adapters', function () {
   it('accepts supported x402 config values', function () {
     assert.deepEqual(
       parseX402Config({
+        enabled: true,
         network: 'eip155:8453',
         stripeNetwork: 'base',
         facilitatorUrl: 'https://facilitator.xpay.sh',
       }),
       {
+        enabled: true,
+        network: 'eip155:8453',
+        stripeNetwork: 'base',
+        facilitatorUrl: 'https://facilitator.xpay.sh',
+      },
+    );
+  });
+
+  it('defaults x402 enabled to false when omitted', function () {
+    assert.deepEqual(
+      parseX402Config({
+        network: 'eip155:8453',
+        stripeNetwork: 'base',
+        facilitatorUrl: 'https://facilitator.xpay.sh',
+      }),
+      {
+        enabled: false,
         network: 'eip155:8453',
         stripeNetwork: 'base',
         facilitatorUrl: 'https://facilitator.xpay.sh',
@@ -270,11 +289,13 @@ describe('Unit: server/services/machine-payments/adapters', function () {
     ]) {
       assert.deepEqual(
         parseX402Config({
+          enabled: true,
           network: 'eip155:84532',
           stripeNetwork: 'base',
           facilitatorUrl,
         }),
         {
+          enabled: true,
           network: 'eip155:84532',
           stripeNetwork: 'base',
           facilitatorUrl,
@@ -371,6 +392,26 @@ describe('Unit: server/services/machine-payments/adapters', function () {
       assert.equal(await adapter.init(), false);
       assert.equal(adapter.isReady, false);
       assert.equal(await adapter.challenge(new Request('http://example.com/paid.md'), terms), null);
+    });
+
+    it('stays unready and never loads runtime modules when x402 is disabled', async function () {
+      let runtimeLoads = 0;
+      const adapter = createX402Adapter({
+        configProvider: () => ({
+          enabled: false,
+          network: 'eip155:8453',
+          stripeNetwork: 'base',
+          facilitatorUrl: 'https://facilitator.xpay.sh',
+        }),
+        runtimeFactory: () => {
+          runtimeLoads += 1;
+          return createX402RuntimeFactory().factory();
+        },
+      });
+
+      assert.equal(await adapter.init(), false);
+      assert.equal(adapter.isReady, false);
+      assert.equal(runtimeLoads, 0);
     });
 
     it('reuses cached route apps and evicts stale routes when the cache is full', async function () {


### PR DESCRIPTION
no ref
- x402 adapters dependencies were loaded unconditionally on boot due to configuration defaults, even if machinePayments is not configured or enabled
- adds a enabled flag to x402 config block to only load deps when actually used