### PR TITLE
Fixed generator metadata on private sites

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -29,6 +29,7 @@
         {{/if}}
 
         <meta name="referrer" content="no-referrer-when-downgrade">
+        <meta name="generator" content="Ghost {{@root.safeVersion}}">
         <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -17,6 +17,7 @@ const configUtils = require('../utils/config-utils');
 const config = require('../../core/shared/config');
 const settingsCache = require('../../core/shared/settings-cache');
 const { cardAssets } = require('../../core/frontend/services/assets-minification');
+const ghostVersion = require('@tryghost/version');
 const origCache = _.cloneDeep(settingsCache);
 
 function assertCorrectFrontendHeaders(res) {
@@ -595,7 +596,11 @@ describe('Default Frontend routing', function () {
       await request
         .get('/private/?r=%2Fwelcome%2F')
         .expect(200)
-        .expect(assertCorrectFrontendHeaders);
+        .expect(assertCorrectFrontendHeaders)
+        .expect((res) => {
+          const $ = cheerio.load(res.text);
+          assert.equal($('meta[name="generator"]').attr('content'), `Ghost ${ghostVersion.safe}`);
+        });
     });
 
     it('should redirect, NOT 404 for private route with extra path', async function () {

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -189,6 +189,22 @@ describe('private.hbs template translation', function () {
         );
       });
 
+      it('renders the Ghost version in the generator meta tag', function () {
+        const context = {
+          safeVersion: '6.60',
+          site: {
+            title: 'Test',
+            url: 'http://test.local',
+            locale: 'en',
+            admin_url: 'http://test.local/ghost/',
+          },
+        };
+        const html = renderPrivateTemplate(context);
+
+        assertExists(html);
+        assert(html.includes('<meta name="generator" content="Ghost 6.60">'));
+      });
+
       it('renders the site description below the site title when present', function () {
         const context = {
           site: {


### PR DESCRIPTION
no ref

Private-site landing pages bypass ghost_head, so they did not identify their Ghost version like other frontend pages.
