### PR TITLE
Updated x402 adapter to load modules on first request

### DIFF
--- a/ghost/core/core/server/services/machine-payments/README.md
+++ b/ghost/core/core/server/services/machine-payments/README.md
@@ -25,11 +25,15 @@ Defaults target **Base mainnet** (`eip155:8453`) with real USDC settlement via t
 
 Supported values are validated at boot:
 
+- `enabled`: defaults to `true` — the x402 rail rides along whenever machine payments is enabled. Set to `false` to keep the x402 rail off (and its `@x402/*` modules out of the process) while MPP stays on.
 - `network`: `eip155:8453` (Base mainnet) or `eip155:84532` (Base Sepolia)
 - `stripeNetwork`: `base`
 - `facilitatorUrl`: HTTPS URL; mainnet cannot use the x402.org testnet facilitator
 
-Invalid x402 config disables the rail at boot (MPP continues to work).
+The `@x402/*` runtime modules load lazily on the first real x402 challenge, not
+at boot — so a site that never receives an x402 payment never pays the import
+cost, and toggling machine payments on at runtime needs no restart. Invalid x402
+config disables the rail at boot (MPP continues to work).
 
 For local development against the x402.org testnet facilitator, override in `config.local.json`:
 

--- a/ghost/core/core/server/services/machine-payments/adapters/x402-adapter.ts
+++ b/ghost/core/core/server/services/machine-payments/adapters/x402-adapter.ts
@@ -21,7 +21,9 @@ function normalizeFacilitatorUrl(urlString: string): string {
 
 const x402ConfigSchema = z
   .object({
-    enabled: z.boolean().optional().default(false),
+    // Per-rail override: x402 rides along whenever machine payments is on.
+    // Set to false to keep the x402 rail off while leaving mpp enabled.
+    enabled: z.boolean().optional().default(true),
     network: z.string().regex(/^eip155:\d+$/, {
       message: 'machinePayments.x402.network must be a CAIP-2 EVM network (eip155:<chainId>)',
     }),
@@ -169,7 +171,7 @@ export class BoundedRouteCache<V> {
 
 export function parseX402Config(raw: X402RawConfig): X402Config | null {
   const parsed = x402ConfigSchema.safeParse({
-    enabled: raw.enabled ?? false,
+    enabled: raw.enabled ?? true,
     network: raw.network ?? BASE_MAINNET,
     stripeNetwork: raw.stripeNetwork ?? 'base',
     facilitatorUrl: raw.facilitatorUrl ?? DEFAULT_FACILITATOR_URL,
@@ -224,8 +226,8 @@ export class X402Adapter implements PaymentAdapter {
   }
 
   /**
-   * Boot-owned initialization: validate config, load x402 runtime modules, and
-   * construct the shared facilitator/scheme before the first paid markdown request.
+   * Boot-owned initialization: validate config only. Runtime modules load
+   * lazily on the first challenge (see #ensureRuntime).
    */
   async init(): Promise<boolean> {
     if (this.#initAttempted) {
@@ -248,26 +250,34 @@ export class X402Adapter implements PaymentAdapter {
       return false;
     }
 
-    try {
-      const runtime = this.#loadRuntimeModules();
-      const { HTTPFacilitatorClient, ExactEvmScheme } = runtime;
+    this.#config = parsedConfig;
+    this.#ready = true;
+    return true;
+  }
 
-      this.#config = parsedConfig;
-      this.#runtime = runtime;
-      this.#facilitator =
-        this.facilitatorClient || new HTTPFacilitatorClient({ url: parsedConfig.facilitatorUrl });
-      this.#scheme = new ExactEvmScheme();
-      this.#ready = true;
-      return true;
-    } catch (err) {
-      logging.warn(err);
-      this.#config = null;
-      this.#runtime = null;
-      this.#facilitator = null;
-      this.#scheme = null;
-      this.#ready = false;
-      return false;
+  /**
+   * Lazily load the x402 runtime modules and build the shared facilitator/scheme
+   * on first use. Idempotent; throws if the modules fail to load so the caller
+   * can fall back (challenge swallows it, returning null).
+   */
+  #ensureRuntime(): void {
+    if (this.#runtime) {
+      return;
     }
+
+    if (!this.#config) {
+      throw new errors.InternalServerError({
+        message: 'x402 adapter used before boot initialization',
+      });
+    }
+
+    const runtime = this.#loadRuntimeModules();
+    const { HTTPFacilitatorClient, ExactEvmScheme } = runtime;
+
+    this.#runtime = runtime;
+    this.#facilitator =
+      this.facilitatorClient || new HTTPFacilitatorClient({ url: this.#config.facilitatorUrl });
+    this.#scheme = new ExactEvmScheme();
   }
 
   canHandle(request: Request): boolean {
@@ -337,6 +347,8 @@ export class X402Adapter implements PaymentAdapter {
     terms: PaymentTerms,
     responseData: DispatchOptions,
   ): Promise<Response> {
+    this.#ensureRuntime();
+
     if (!this.#config || !this.#runtime || !this.#facilitator || !this.#scheme) {
       throw new errors.InternalServerError({
         message: 'x402 adapter used before boot initialization',

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -279,7 +279,7 @@
   "stripeDirect": false,
   "machinePayments": {
     "x402": {
-      "enabled": false,
+      "enabled": true,
       "network": "eip155:8453",
       "stripeNetwork": "base",
       "facilitatorUrl": "https://facilitator.xpay.sh"

--- a/ghost/core/test/unit/server/services/machine-payments/adapters.test.js
+++ b/ghost/core/test/unit/server/services/machine-payments/adapters.test.js
@@ -208,7 +208,7 @@ describe('Unit: server/services/machine-payments/adapters', function () {
     );
   });
 
-  it('defaults x402 enabled to false when omitted', function () {
+  it('defaults x402 enabled to true so it rides along with machine payments', function () {
     assert.deepEqual(
       parseX402Config({
         network: 'eip155:8453',
@@ -216,7 +216,7 @@ describe('Unit: server/services/machine-payments/adapters', function () {
         facilitatorUrl: 'https://facilitator.xpay.sh',
       }),
       {
-        enabled: false,
+        enabled: true,
         network: 'eip155:8453',
         stripeNetwork: 'base',
         facilitatorUrl: 'https://facilitator.xpay.sh',
@@ -357,7 +357,7 @@ describe('Unit: server/services/machine-payments/adapters', function () {
       );
     });
 
-    it('initializes runtime modules and facilitator at boot', async function () {
+    it('defers runtime module loading until the first challenge, then caches it', async function () {
       let runtimeLoads = 0;
       const adapter = createX402Adapter({
         runtimeFactory: () => {
@@ -368,9 +368,15 @@ describe('Unit: server/services/machine-payments/adapters', function () {
 
       assert.equal(await adapter.init(), true);
       assert.equal(adapter.isReady, true);
-      assert.equal(runtimeLoads, 1);
+      assert.equal(runtimeLoads, 0);
 
       await adapter.challenge(new Request('http://example.com/a.md'), terms);
+      assert.equal(runtimeLoads, 1);
+
+      await adapter.challenge(new Request('http://example.com/b.md'), {
+        ...terms,
+        url: 'http://example.com/b.md',
+      });
       assert.equal(runtimeLoads, 1);
     });
 


### PR DESCRIPTION
no ref
- enabled is now set to true by default
- lazy-load x402 modules on first payment challenge, mirroring the mppx adapter