### PR TITLE
Make toggle card accessible to screen readers

### DIFF
--- a/ghost/core/core/frontend/src/cards/js/toggle.js
+++ b/ghost/core/core/frontend/src/cards/js/toggle.js
@@ -1,8 +1,30 @@
 (function () {
   const toggleHeadingElements = document.getElementsByClassName('kg-toggle-heading');
 
+  const syncAriaState = function (headingElement) {
+    const parentElement = headingElement.closest('.kg-toggle-card');
+    const contentElement = parentElement.querySelector('.kg-toggle-content');
+    const buttonElement = headingElement.querySelector('.kg-toggle-card-icon');
+    const isOpen = parentElement.getAttribute('data-kg-toggle-state') === 'open';
+
+    if (buttonElement) {
+      // Some older/hand-authored cards may be missing this label entirely.
+      if (!buttonElement.hasAttribute('aria-label')) {
+        buttonElement.setAttribute('aria-label', 'Expand toggle to read content');
+      }
+      buttonElement.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    }
+
+    if (contentElement) {
+      // Prevents screen readers from reading/navigating into content that is
+      // visually hidden (height: 0; overflow: hidden) while the toggle is closed.
+      contentElement.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+    }
+  };
+
   const toggleFn = function (event) {
     const targetElement = event.target;
+    const headingElement = targetElement.closest('.kg-toggle-heading');
     const parentElement = targetElement.closest('.kg-toggle-card');
     var toggleState = parentElement.getAttribute('data-kg-toggle-state');
     if (toggleState === 'close') {
@@ -10,9 +32,12 @@
     } else {
       parentElement.setAttribute('data-kg-toggle-state', 'close');
     }
+    syncAriaState(headingElement);
   };
 
   for (let i = 0; i < toggleHeadingElements.length; i++) {
     toggleHeadingElements[i].addEventListener('click', toggleFn, false);
+    // Reflect the initial (usually closed) state for screen readers on page load.
+    syncAriaState(toggleHeadingElements[i]);
   }
 })();

--- a/koenig/kg-default-cards/src/cards/toggle.ts
+++ b/koenig/kg-default-cards/src/cards/toggle.ts
@@ -19,11 +19,11 @@ const toggleCard: Card = {
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">{{{heading}}}</h4>
-                    <button class="kg-toggle-card-icon">
+                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content" aria-expanded="false">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
                     </button>
                 </div>
-                <div class="kg-toggle-content">{{{content}}}</div>
+                <div class="kg-toggle-content" aria-hidden="true">{{{content}}}</div>
             </div>
         `;
 

--- a/koenig/kg-default-cards/test/cards/toggle.test.ts
+++ b/koenig/kg-default-cards/test/cards/toggle.test.ts
@@ -14,7 +14,7 @@ describe('Toggle card', function () {
       };
 
       expect(serializer.serialize(card.render(opts))).toBe(
-        '<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content">This is toggle content</div></div>',
+        '<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon" aria-label="Expand toggle to read content" aria-expanded="false"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content" aria-hidden="true">This is toggle content</div></div>',
       );
     });
   });

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
@@ -16,13 +16,13 @@ function cardTemplate({node}: {node: ToggleNodeData}) {
         <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
             <div class="kg-toggle-heading">
                 <h4 class="kg-toggle-heading-text">${node.heading}</h4>
-                <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content" aria-expanded="false">
                     <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                     </svg>
                 </button>
             </div>
-            <div class="kg-toggle-content">${node.content}</div>
+            <div class="kg-toggle-content" aria-hidden="true">${node.content}</div>
         </div>
         `
     );

--- a/koenig/kg-default-nodes/test/nodes/toggle.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/toggle.test.ts
@@ -174,13 +174,13 @@ describe('ToggleNode', function () {
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">Heading</h4>
-                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content" aria-expanded="false">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                         </svg>
                     </button>
                 </div>
-                <div class="kg-toggle-content">Content</div>
+                <div class="kg-toggle-content" aria-hidden="true">Content</div>
             </div>
             `);
         }));
@@ -221,7 +221,7 @@ describe('ToggleNode', function () {
     describe('importDOM', function () {
         it('parses toggle card', editorTest(function () {
             const document = createDocument(html`
-                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon" aria-label="Expand toggle to read content"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content">Content</div></div>
+                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon" aria-label="Expand toggle to read content" aria-expanded="false"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content" aria-hidden="true">Content</div></div>
             `);
             const nodes = $generateNodesFromDOM(editor, document) as ToggleNode[];
             expect(nodes.length).toBe(1);


### PR DESCRIPTION
## Summary

Fixes #27462.

The toggle card's expand/collapse control wasn't usable with a screen reader:

1. In the legacy Mobiledoc card template, the icon `<button>` had **no `aria-label` at all** — VoiceOver just announced "button" with no indication of what it does.
2. Neither template communicated expanded/collapsed **state** (`aria-expanded`).
3. The collapsed content is hidden purely via `height: 0; overflow: hidden; opacity: 0` (see `toggle.css`), which some screen readers/browsers still expose in the accessibility tree — matching the issue's report that the screenreader cursor could still land on "hidden" content.

## Fix

- `koenig/kg-default-cards/src/cards/toggle.ts` (legacy Mobiledoc renderer): added the missing `aria-label`, plus `aria-expanded="false"`.
- `koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts` (Lexical renderer): already had `aria-label`; added `aria-expanded="false"` for consistency.
- Both templates: mark `.kg-toggle-content` as `aria-hidden="true"` by default (closed state).
- `ghost/core/core/frontend/src/cards/js/toggle.js` (frontend runtime): now keeps `aria-expanded`/`aria-hidden` in sync with `data-kg-toggle-state` on every click, and normalizes state on page load. This last part also **self-heals already-published posts** rendered with the old, unlabelled markup, without needing republishing.

Native `<button>` semantics already made the control keyboard-operable (Enter/Space triggers a bubbled `click`), so no separate keydown handling was needed.

## Test plan

- Updated the two renderer snapshot tests (`kg-default-cards/test/cards/toggle.test.ts`, `kg-default-nodes/test/nodes/toggle.test.ts`) to match the new markup.
- Manually traced the runtime script logic against both the closed→open and open→closed transitions and page-load normalization.
- Note: I made this change via a sparse checkout of just the affected packages (the full monorepo install wasn't practical in my environment), so I wasn't able to run `pnpm check` end-to-end — happy to address any CI feedback.