### PR TITLE
Moved navigationIcons lab flag to public beta

### DIFF
--- a/apps/admin/src/settings/advanced/labs/beta-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/beta-features.tsx
@@ -125,6 +125,16 @@ const BetaFeatures: React.FC = () => {
           title="Additional payment methods"
         />
         <LabItem
+          action={<FeatureToggle flag="navigationIcons" />}
+          detail={
+            <>
+              Add icons and member-visibility controls to navigation menu items. Requires theme
+              support to render icons.
+            </>
+          }
+          title="Navigation icons & visibility"
+        />
+        <LabItem
           action={
             <Stack align="end" gap="xs">
               <Inline gap="sm">

--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -73,12 +73,6 @@ const features: Feature[] = [
     flag: 'getHelperDeduplication',
   },
   {
-    title: 'Navigation icons & visibility',
-    description:
-      'Add icons and member-visibility controls to navigation menu items. Requires theme support to render icons.',
-    flag: 'navigationIcons',
-  },
-  {
     title: 'React tag details',
     description:
       'Renders the tag detail screen (/tags/:slug) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -30,7 +30,12 @@ const messages = {
 const GA_FEATURES = ['automationAnalytics'];
 
 // These features are considered publicly available and can be enabled/disabled by users
-const PUBLIC_BETA_FEATURES = ['superEditors', 'editorExcerpt', 'additionalPaymentMethods'];
+const PUBLIC_BETA_FEATURES = [
+  'superEditors',
+  'editorExcerpt',
+  'additionalPaymentMethods',
+  'navigationIcons',
+];
 
 // These features are considered private they live in the private tab of the labs settings page
 // Which is only visible if the developer experiments flag is enabled
@@ -46,7 +51,6 @@ const PRIVATE_FEATURES = [
   'themeTranslation',
   'pictureImageFormats',
   'getHelperDeduplication',
-  'navigationIcons',
   'membersCustomFields',
   'paywallImprovements',
   'giftSubCustomization',


### PR DESCRIPTION
## Summary
- Moved `navigationIcons` from private Labs (`PRIVATE_FEATURES`) to public beta (`PUBLIC_BETA_FEATURES`)
- Updated Admin Labs UI: removed the toggle from Private features and added it to Beta features
- Feature gating call sites are unchanged — they still check the same flag key

## Test plan
- [ ] Open Settings → Labs without developer experiments enabled
- [ ] Confirm **Navigation icons & visibility** appears under Beta features
- [ ] Confirm it no longer appears under Private features (with developer experiments on)
- [ ] Enable the flag and verify navigation icons/visibility still work in Settings → Navigation
- [ ] Disable the flag and verify legacy nav markup behavior still applies


Made with [Cursor](https://cursor.com)