### PR TITLE
Migrate external media inlining to the class-based jobs service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -653,10 +653,17 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     await initServices({ ghostServer, config, prometheusClient });
 
     debug('Begin: Register job handlers');
-    const jobsService = require('./server/services/jobs-service');
-    const service = jobsService.init();
-    require('./server/services/jobs-service/register-job-handlers').default();
-    await service.start();
+    const jobsServiceWrapper = require('./server/services/jobs-service');
+    const registerJobHandlers =
+      require('./server/services/jobs-service/register-job-handlers').default;
+    const db = require('./server/data/db');
+    const jobsService = jobsServiceWrapper.init();
+    registerJobHandlers({
+      jobsService,
+      db,
+      logging,
+    });
+    await jobsService.start();
     debug('End: Register job handlers');
     debug('End: Load Ghost Services & Apps');
 

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -656,12 +656,14 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     const jobsServiceWrapper = require('./server/services/jobs-service');
     const registerJobHandlers =
       require('./server/services/jobs-service/register-job-handlers').default;
+    const mediaInliner = require('./server/services/media-inliner');
     const db = require('./server/data/db');
     const jobsService = jobsServiceWrapper.init();
     registerJobHandlers({
       jobsService,
       db,
       logging,
+      mediaInliner: mediaInliner.getInstance(),
     });
     await jobsService.start();
     debug('End: Register job handlers');

--- a/ghost/core/core/server/api/endpoints/db.js
+++ b/ghost/core/core/server/api/endpoints/db.js
@@ -3,11 +3,16 @@ const path = require('path');
 const dbBackup = require('../../data/db/backup');
 const exporter = require('../../data/exporter');
 const importer = require('../../data/importer');
-const mediaInliner = require('../../services/media-inliner');
+const jobsService = require('../../services/jobs-service');
+const ExternalMediaInlinerJob =
+  require('../../services/media-inliner/external-media-inliner-job').default;
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const { promisePool } = require('../../lib/promise-pool');
 const models = require('../../models');
 const settingsCache = require('../../../shared/settings-cache');
+
+const DEFAULT_MEDIA_INLINER_DOMAINS = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -125,7 +130,16 @@ const controller = {
       },
     },
     async query(frame) {
-      return mediaInliner.api.startMediaInliner(frame.data.domains);
+      const domains = frame.data.domains?.length
+        ? frame.data.domains
+        : DEFAULT_MEDIA_INLINER_DOMAINS;
+
+      logging.info('[Background Job] external-media-inliner queued');
+      await jobsService.getInstance().dispatch(new ExternalMediaInlinerJob({ domains }));
+
+      return {
+        status: 'success',
+      };
     },
   },
 

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -4,17 +4,21 @@ import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
 import * as gifts from '../gifts';
 import CleanGiftsJob from '../gifts/jobs/clean-gifts-job';
+import ExternalMediaInliner from '../media-inliner/external-media-inliner';
+import ExternalMediaInlinerJob from '../media-inliner/external-media-inliner-job';
 
 interface RegisterJobHandlersDependencies {
   jobsService: JobsService;
   db: typeof import('../../data/db');
   logging: typeof import('@tryghost/logging');
+  mediaInliner: ExternalMediaInliner;
 }
 
 export default function registerJobHandlers({
   jobsService,
   db,
   logging,
+  mediaInliner,
 }: RegisterJobHandlersDependencies): void {
   jobsService.handle(CleanTokensJob, async () => {
     await cleanTokens({ db, logging });
@@ -27,5 +31,9 @@ export default function registerJobHandlers({
       });
     }
     await gifts.service.cleanup();
+  });
+
+  jobsService.handle(ExternalMediaInlinerJob, async (job) => {
+    await mediaInliner.inline(job.domains);
   });
 }

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,16 +1,21 @@
 import errors from '@tryghost/errors';
-import { getInstance } from './index';
+import { JobsService } from './jobs-service';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
 import * as gifts from '../gifts';
 import CleanGiftsJob from '../gifts/jobs/clean-gifts-job';
 
-const logging = require('@tryghost/logging');
+interface RegisterJobHandlersDependencies {
+  jobsService: JobsService;
+  db: typeof import('../../data/db');
+  logging: typeof import('@tryghost/logging');
+}
 
-export default function registerJobHandlers(): void {
-  const jobsService = getInstance();
-  const db = require('../../data/db');
-
+export default function registerJobHandlers({
+  jobsService,
+  db,
+  logging,
+}: RegisterJobHandlersDependencies): void {
   jobsService.handle(CleanTokensJob, async () => {
     await cleanTokens({ db, logging });
   });

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner-job.ts
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner-job.ts
@@ -1,0 +1,12 @@
+import { Job } from '../jobs-service/job';
+
+export default class ExternalMediaInlinerJob extends Job {
+  static type = 'external-media-inliner';
+
+  readonly domains: string[];
+
+  constructor({ domains }: { domains: string[] }) {
+    super();
+    this.domains = domains;
+  }
+}

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner.d.ts
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner.d.ts
@@ -1,0 +1,7 @@
+declare class ExternalMediaInliner {
+  constructor(deps: object);
+
+  inline(domains: string[]): Promise<void>;
+}
+
+export = ExternalMediaInliner;

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -4,11 +4,8 @@ let instance;
 
 module.exports = {
   async init() {
-    const debug = require('@tryghost/debug')('mediaInliner');
     const MediaInliner = require('./external-media-inliner');
-    const logging = require('@tryghost/logging');
     const models = require('../../models');
-    const jobsService = require('../jobs');
     const adapterManager = require('../../services/adapter-manager').default;
 
     const mediaStorage = adapterManager.getAdapter('storage:media');
@@ -36,47 +33,6 @@ module.exports = {
     });
 
     instance = mediaInliner;
-
-    this.api = {
-      startMediaInliner: async (domains) => {
-        if (!domains || !domains.length) {
-          // default domains to inline from if none are provided
-          domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
-        }
-
-        debug('[Inliner] Starting media inlining job for domains: ', domains);
-
-        // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
-        //        limited to migrational, so there is no expectations for site's availability etc.
-        logging.info('[Background Job] external-media-inliner queued');
-        await jobsService.addJob({
-          name: 'external-media-inliner',
-          job: async (data) => {
-            const startedAt = Date.now();
-            logging.info('[Background Job] external-media-inliner started');
-            try {
-              const result = await mediaInliner.inline(data.domains);
-              logging.info(
-                `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
-              );
-              return result;
-            } catch (err) {
-              logging.error(
-                err,
-                `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
-              );
-              throw err;
-            }
-          },
-          data: { domains },
-          offloaded: false,
-        });
-
-        return {
-          status: 'success',
-        };
-      },
-    };
   },
 
   getInstance() {

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,3 +1,7 @@
+const errors = require('@tryghost/errors');
+
+let instance;
+
 module.exports = {
   async init() {
     const debug = require('@tryghost/debug')('mediaInliner');
@@ -30,6 +34,8 @@ module.exports = {
         }
       },
     });
+
+    instance = mediaInliner;
 
     this.api = {
       startMediaInliner: async (domains) => {
@@ -71,5 +77,15 @@ module.exports = {
         };
       },
     };
+  },
+
+  getInstance() {
+    if (!instance) {
+      throw new errors.IncorrectUsageError({
+        message: 'Media inliner used before init(). Call init() from boot first.',
+      });
+    }
+
+    return instance;
   },
 };

--- a/ghost/core/test/integration/services/media-inliner/external-media-inliner-job.test.ts
+++ b/ghost/core/test/integration/services/media-inliner/external-media-inliner-job.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import nock from 'nock';
+
+const logging = require('@tryghost/logging');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const models = require('../../../../core/server/models');
+const { getInstance: getJobsService } = require('../../../../core/server/services/jobs-service');
+const ExternalMediaInlinerJob =
+  require('../../../../core/server/services/media-inliner/external-media-inliner-job').default;
+
+async function waitFor(
+  check: () => boolean | Promise<boolean>,
+  { timeoutMs = 5000, intervalMs = 25 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+  return false;
+}
+
+describe('Job: External media inliner', function () {
+  beforeAll(async function () {
+    const agent = await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('posts');
+    await agent.loginAsOwner();
+  });
+
+  afterAll(function () {
+    sinon.restore();
+    nock.cleanAll();
+  });
+
+  it('inlines external media when the dispatched job runs', async function () {
+    const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
+    nock('https://external-media.example.com').get('/image.gif').reply(200, GIF1x1);
+
+    const post = await models.Post.add(
+      {
+        title: 'Post with external feature image',
+        status: 'draft',
+        feature_image: 'https://external-media.example.com/image.gif',
+      },
+      { context: { internal: true } },
+    );
+
+    const loggingInfoSpy = sinon.spy(logging, 'info');
+
+    await getJobsService().dispatch(
+      new ExternalMediaInlinerJob({ domains: ['https://external-media.example.com'] }),
+    );
+
+    const completed = await waitFor(() => {
+      return loggingInfoSpy.getCalls().some((call) => {
+        return (
+          call.args[0]?.system?.event === 'job.completed' &&
+          call.args[0]?.system?.job_type === 'external-media-inliner'
+        );
+      });
+    });
+    assert.ok(completed, 'The external-media-inliner job completed');
+
+    const updated = await models.Post.findOne({ id: post.id, status: 'all' });
+    assert.ok(
+      updated.get('feature_image')?.includes('/content/images/'),
+      'The feature image is replaced with a locally stored copy',
+    );
+
+    const lifecycleLog = loggingInfoSpy.getCalls().find((call) => {
+      return (
+        call.args[0]?.system?.event === 'job.completed' &&
+        call.args[0]?.system?.job_type === 'external-media-inliner'
+      );
+    });
+    assert.equal(typeof lifecycleLog!.args[0].system.duration_ms, 'number');
+  });
+});

--- a/ghost/core/test/unit/api/endpoints/db.test.js
+++ b/ghost/core/test/unit/api/endpoints/db.test.js
@@ -1,11 +1,18 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
-const dbController = require('../../../../core/server/api/endpoints/db');
+const dbControllerPath = require.resolve('../../../../core/server/api/endpoints/db');
+const jobsServicePath = require.resolve('../../../../core/server/services/jobs-service');
+const dbController = require(dbControllerPath);
+const jobsService = require(jobsServicePath);
+const ExternalMediaInlinerJob =
+  require('../../../../core/server/services/media-inliner/external-media-inliner-job').default;
 
 describe('DB controller', function () {
-  let settingsCache, importer;
+  let settingsCache, importer, jobsServiceInitialised;
 
   beforeEach(function () {
+    jobsServiceInitialised = false;
     settingsCache = require('../../../../core/shared/settings-cache');
     importer = require('../../../../core/server/data/importer');
 
@@ -16,8 +23,17 @@ describe('DB controller', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(async function () {
+    if (jobsServiceInitialised) {
+      await jobsService.shutdown({ timeoutMs: 100 });
+      jobsServiceInitialised = false;
+    }
     sinon.restore();
+  });
+
+  afterAll(function () {
+    delete require.cache[dbControllerPath];
+    delete require.cache[jobsServicePath];
   });
 
   describe('importContent', function () {
@@ -66,6 +82,46 @@ describe('DB controller', function () {
           user: { email: 'owner@example.com' },
         }),
       );
+    });
+  });
+
+  describe('inlineMedia', function () {
+    let dispatch;
+
+    beforeEach(function () {
+      const service = jobsService.init();
+      jobsServiceInitialised = true;
+      dispatch = sinon.stub(service, 'dispatch').resolves();
+    });
+
+    it('dispatches explicit domains', async function () {
+      const result = await dbController.inlineMedia.query({
+        data: { domains: ['https://example.com'] },
+      });
+
+      sinon.assert.calledOnce(dispatch);
+      const job = dispatch.firstCall.firstArg;
+      assert.ok(job instanceof ExternalMediaInlinerJob);
+      assert.deepEqual(job.domains, ['https://example.com']);
+      assert.deepEqual(result, { status: 'success' });
+    });
+
+    it('dispatches the default domains when domains are missing', async function () {
+      await dbController.inlineMedia.query({ data: {} });
+
+      assert.deepEqual(dispatch.firstCall.firstArg.domains, [
+        'https://s3.amazonaws.com/revue',
+        'https://substackcdn.com',
+      ]);
+    });
+
+    it('dispatches the default domains when domains are empty', async function () {
+      await dbController.inlineMedia.query({ data: { domains: [] } });
+
+      assert.deepEqual(dispatch.firstCall.firstArg.domains, [
+        'https://s3.amazonaws.com/revue',
+        'https://substackcdn.com',
+      ]);
     });
   });
 });

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -1,32 +1,26 @@
 import assert from 'node:assert/strict';
 import sinon from 'sinon';
 import { describe, it, beforeEach, afterEach } from 'vitest';
+import logging from '@tryghost/logging';
+import { JobsService } from '../../../../../core/server/services/jobs-service/jobs-service';
 
-// require, not import: these must resolve to the same CommonJS module instances
-// that register-job-handlers.ts reaches for at execution time.
-const jobsService = require('../../../../../core/server/services/jobs-service');
-const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
 const registerJobHandlers =
   require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
 
-type Processor = (envelope: { type: string; payload: string }) => Promise<void>;
-
 describe('register-job-handlers', function () {
-  let deliver: Processor;
+  let jobsService: sinon.SinonStubbedInstance<JobsService>;
+  let db: { knex: sinon.SinonStub };
+  let loggingStub: sinon.SinonStubbedInstance<typeof logging>;
 
-  beforeEach(async function () {
-    jobsService.init();
-    const backend = adapterManager.getAdapter('jobs');
-    sinon.stub(backend, 'start').callsFake((...args: unknown[]) => {
-      deliver = (args[0] as { processor: Processor }).processor;
-    });
+  beforeEach(function () {
+    jobsService = sinon.createStubInstance(JobsService);
+    db = { knex: sinon.stub() };
+    loggingStub = sinon.stub(logging);
 
-    registerJobHandlers();
-    await jobsService.getInstance().start();
+    registerJobHandlers({ jobsService, db, logging: loggingStub });
   });
 
-  afterEach(async function () {
-    await jobsService.shutdown({ timeoutMs: 100 });
+  afterEach(function () {
     sinon.restore();
   });
 
@@ -34,9 +28,24 @@ describe('register-job-handlers', function () {
   // exists for: a dispatch that lands before boot has built the service must
   // fail loudly rather than reading undefined off the module.
   it('fails a clean-gifts delivery when the gift service is not initialised', async function () {
+    const cleanGiftsHandler = jobsService.handle.secondCall.args[1];
+
     await assert.rejects(
-      () => deliver({ type: 'clean-gifts', payload: '{}' }),
+      () => cleanGiftsHandler({}),
       /clean-gifts ran before the gifts service was initialised/,
     );
+  });
+
+  it('runs clean-tokens with the injected database and logger', async function () {
+    const deleteStub = sinon.stub().resolves(2);
+    const whereStub = sinon.stub().returns({ delete: deleteStub });
+    db.knex.withArgs('tokens').returns({ where: whereStub });
+    const cleanTokensHandler = jobsService.handle.firstCall.args[1];
+
+    await cleanTokensHandler({});
+
+    assert.ok(db.knex.calledOnceWithExactly('tokens'));
+    assert.ok(loggingStub.info.calledOnce);
+    assert.equal(loggingStub.info.firstCall.args[0].system.deleted_count, 2);
   });
 });

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import logging from '@tryghost/logging';
 import { JobsService } from '../../../../../core/server/services/jobs-service/jobs-service';
+import ExternalMediaInliner from '../../../../../core/server/services/media-inliner/external-media-inliner';
+import ExternalMediaInlinerJob from '../../../../../core/server/services/media-inliner/external-media-inliner-job';
 
 const registerJobHandlers =
   require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
@@ -11,13 +13,15 @@ describe('register-job-handlers', function () {
   let jobsService: sinon.SinonStubbedInstance<JobsService>;
   let db: { knex: sinon.SinonStub };
   let loggingStub: sinon.SinonStubbedInstance<typeof logging>;
+  let mediaInliner: sinon.SinonStubbedInstance<ExternalMediaInliner>;
 
   beforeEach(function () {
     jobsService = sinon.createStubInstance(JobsService);
     db = { knex: sinon.stub() };
     loggingStub = sinon.stub(logging);
+    mediaInliner = sinon.createStubInstance(ExternalMediaInliner);
 
-    registerJobHandlers({ jobsService, db, logging: loggingStub });
+    registerJobHandlers({ jobsService, db, logging: loggingStub, mediaInliner });
   });
 
   afterEach(function () {
@@ -30,10 +34,9 @@ describe('register-job-handlers', function () {
   it('fails a clean-gifts delivery when the gift service is not initialised', async function () {
     const cleanGiftsHandler = jobsService.handle.secondCall.args[1];
 
-    await assert.rejects(
-      () => cleanGiftsHandler({}),
-      /clean-gifts ran before the gifts service was initialised/,
-    );
+    await assert.rejects(async () => {
+      await cleanGiftsHandler({});
+    }, /clean-gifts ran before the gifts service was initialised/);
   });
 
   it('runs clean-tokens with the injected database and logger', async function () {
@@ -46,6 +49,29 @@ describe('register-job-handlers', function () {
 
     assert.ok(db.knex.calledOnceWithExactly('tokens'));
     assert.ok(loggingStub.info.calledOnce);
-    assert.equal(loggingStub.info.firstCall.args[0].system.deleted_count, 2);
+    const metadata = loggingStub.info.firstCall.args[0] as {
+      system: { deleted_count: number };
+    };
+    assert.equal(metadata.system.deleted_count, 2);
+  });
+
+  it('runs external-media-inliner with the injected media inliner', async function () {
+    const externalMediaInlinerHandler = jobsService.handle.thirdCall.args[1];
+    const job = new ExternalMediaInlinerJob({ domains: ['https://example.com'] });
+
+    await externalMediaInlinerHandler(job);
+
+    assert.ok(mediaInliner.inline.calledOnceWithExactly(['https://example.com']));
+  });
+
+  it('propagates external-media-inliner failures', async function () {
+    const error = new Error('Inlining failed');
+    mediaInliner.inline.rejects(error);
+    const externalMediaInlinerHandler = jobsService.handle.thirdCall.args[1];
+    const job = new ExternalMediaInlinerJob({ domains: ['https://example.com'] });
+
+    await assert.rejects(async () => {
+      await externalMediaInlinerHandler(job);
+    }, error);
   });
 });

--- a/ghost/core/test/unit/server/services/media-inliner/external-media-inliner-job.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/external-media-inliner-job.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import ExternalMediaInlinerJob from '../../../../../core/server/services/media-inliner/external-media-inliner-job';
+
+describe('ExternalMediaInlinerJob', function () {
+  it('keeps the legacy job name as its type', function () {
+    assert.equal(ExternalMediaInlinerJob.type, 'external-media-inliner');
+  });
+
+  it('survives the payload JSON round-trip', function () {
+    const job = new ExternalMediaInlinerJob({ domains: ['https://example.com'] });
+
+    const rehydrated = new ExternalMediaInlinerJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(rehydrated.domains, ['https://example.com']);
+  });
+});


### PR DESCRIPTION
## What changed

External media inlining now runs through the class-based JobsService without adding another service wrapper or a lazy dependency getter.

- Job-handler registration is an explicit composition boundary: boot injects JobsService, the database, logging, and the concrete initialized ExternalMediaInliner.
- The media-inliner module exposes its initialized ExternalMediaInliner instance while retaining the legacy API unchanged until the migration commit.
- The Admin API endpoint resolves explicit or default domains and dispatches a serializable ExternalMediaInlinerJob directly through JobsService.
- The registered handler delegates execution to the injected ExternalMediaInliner. The old legacy jobs registration and its duplicate lifecycle wrapper are removed.

## Behavior

The endpoint still returns success after the job is accepted, and missing or empty domain lists still use the Revue and Substack defaults. Jobs remain in-memory and use the existing jobs backend concurrency and lifecycle logging/error reporting. There are no persistence, retry, scheduling, or schema changes.

## Commit structure

1. Inject dependencies into job-handler registration.
2. Expose the initialized ExternalMediaInliner without changing controller or dispatch behavior.
3. Switch external media inlining from the legacy jobs manager to JobsService.

## Validation

- Focused unit suites: 53 tests passed.
- External media inliner database integration test passed against the real jobs backend and models.
- Type linting and TypeScript checks passed.
- Targeted ESLint and formatting checks passed.
- Repository-wide package/unit tests passed until Koenig Playwright acceptance tests, which cannot launch browsers in the local environment because required GTK/X11 system libraries are absent.
- pnpm check completed formatting, lint, and dependency-boundary validation, then stopped in agent-guidance lint because this Jujutsu checkout has no .git metadata for git ls-files.