### PR TITLE
🐛 Fixed Portal modal elastic scroll reveal

### DIFF
--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -308,7 +308,7 @@ html[dir="rtl"] .gh-portal-btn-site-title-back span {
 /* Global layout styles
 /* ----------------------------------------------------- */
 .gh-portal-popup-background {
-    position: absolute;
+    position: fixed;
     display: block;
     top: 0;
     right: 0;
@@ -345,6 +345,7 @@ html[dir="rtl"] .gh-portal-btn-site-title-back span {
     height: 100%;
     max-height: 100vh;
     overflow: scroll;
+    overscroll-behavior-y: none;
 }
 
 /* Hiding scrollbars */


### PR DESCRIPTION
no issue

Apple devices can elastically scroll Portal's popup surface beyond its bounds, briefly exposing the host page behind the modal.

This keeps the backdrop fixed to the viewport and disables vertical overscroll on the popup scroller, preserving the existing modal layout and scroll lock.