### PR TITLE
Fixed gift form state across Stripe checkout

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -14,6 +14,8 @@ import {
   getRefDomain,
 } from './utils/helpers';
 import { t } from './utils/i18n';
+import { clearGiftFormState } from './components/pages/beta-gift/form-state';
+import { restoreGiftEntryRoute } from './components/pages/beta-gift/navigation';
 
 const CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION = 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION';
 
@@ -43,6 +45,10 @@ function openPopup({ data }) {
 }
 
 function back({ state }) {
+  if (state.page === 'gift') {
+    clearGiftFormState();
+  }
+
   if (state.lastPage) {
     return {
       page: state.lastPage,
@@ -53,7 +59,15 @@ function back({ state }) {
 }
 
 function closePopup({ state }) {
-  removePortalLinkFromUrl();
+  let restoredGiftEntryRoute = false;
+  if (state.page === 'gift') {
+    clearGiftFormState();
+    restoredGiftEntryRoute = restoreGiftEntryRoute();
+  }
+
+  if (!restoredGiftEntryRoute) {
+    removePortalLinkFromUrl();
+  }
   // Drop any one-shot post-sign-in redirect (e.g. set when sign-in is opened
   // from a comment "Reply") so a dismissed sign-in can't leak its redirect into
   // a later, unrelated sign-in on the same page. Other pageData is preserved.

--- a/apps/portal/src/app.jsx
+++ b/apps/portal/src/app.jsx
@@ -14,7 +14,8 @@ import { transformPortalAnchorToRelative } from './utils/transform-portal-anchor
 import { getActivePage, isAccountPage, isOfferPage } from './pages';
 import ActionHandler from './actions';
 import { getGiftRedemptionErrorMessage } from './utils/gift-redemption-notification';
-import { GIFT_DURATION_CATALOGUE } from './utils/gift-subscriptions';
+import { GIFT_DURATION_CATALOGUE, isGiftCustomizationEnabled } from './utils/gift-subscriptions';
+import { clearGiftFormState } from './components/pages/beta-gift/form-state';
 import './app.css';
 import {
   hasRecommendations,
@@ -211,7 +212,7 @@ export default class App extends React.Component {
       event.preventDefault();
       const target = event.currentTarget;
       const pagePath = target && target.dataset.portal;
-      const linkData = this.getPageFromLinkPath(pagePath);
+      const linkData = this.getPageFromLinkPath(pagePath, this.state.site);
       if (!linkData) {
         return;
       }
@@ -679,6 +680,7 @@ export default class App extends React.Component {
         'gift_scheduled_at',
       ]);
       if (token) {
+        clearGiftFormState();
         return {
           showPopup: true,
           page: 'giftSuccess',
@@ -1142,7 +1144,7 @@ export default class App extends React.Component {
   }
 
   /**Get Portal page from Link/Data-attribute path*/
-  getPageFromLinkPath(path) {
+  getPageFromLinkPath(path, site) {
     const customPricesSignupRegex = /^signup\/?(?:\/(\w+?))?\/?$/;
     const customMonthlyProductSignup = /^signup\/?(?:\/(\w+?))\/monthly\/?$/;
     const customYearlyProductSignup = /^signup\/?(?:\/(\w+?))\/yearly\/?$/;
@@ -1246,7 +1248,21 @@ export default class App extends React.Component {
           signup: false,
         },
       };
-    } else if (path === 'gift') {
+    } else if (path === 'gift' && isGiftCustomizationEnabled({ site })) {
+      return {
+        page: 'gift',
+        pageData: {
+          giftStep: 'plan',
+        },
+      };
+    } else if (path === 'gift/delivery' && isGiftCustomizationEnabled({ site })) {
+      return {
+        page: 'gift',
+        pageData: {
+          giftStep: 'delivery',
+        },
+      };
+    } else if (path === 'gift' || path === 'gift/delivery') {
       return {
         page: 'gift',
       };

--- a/apps/portal/src/app.jsx
+++ b/apps/portal/src/app.jsx
@@ -1048,6 +1048,11 @@ export default class App extends React.Component {
     }
 
     const { site: linkSite, ...restLinkData } = linkData;
+    const isLeavingGiftPage = this.state.page === 'gift' && restLinkData.page !== 'gift';
+    if (isLeavingGiftPage) {
+      clearGiftFormState();
+    }
+    const shouldCloseGiftPopup = isLeavingGiftPage && !restLinkData.page;
 
     const updatedState = {
       site: {
@@ -1062,6 +1067,7 @@ export default class App extends React.Component {
       },
       ...restLinkData,
       ...restPreviewData,
+      ...(shouldCloseGiftPopup ? { showPopup: false, lastPage: null } : {}),
     };
     this.handleSignupQuery({ site: updatedState.site, pageQuery: updatedState.pageQuery });
     this.setState(updatedState);

--- a/apps/portal/src/components/pages/beta-gift-page.tsx
+++ b/apps/portal/src/components/pages/beta-gift-page.tsx
@@ -19,10 +19,20 @@ import { getGiftDurationAttributiveLabel } from '../../utils/gift-redemption-not
 import { ValidateInputForm } from '../../utils/form';
 import { t } from '../../utils/i18n';
 import useCardTilt from '../../utils/use-card-tilt';
+import useSessionStorageState from '../../utils/use-session-storage-state';
 import { formatGiftValue } from './gift-page';
 import GiftDeliveryStep from './beta-gift/delivery-step';
+import {
+  GIFT_EMAIL_MAX_LENGTH,
+  GIFT_FORM_STATE_KEY,
+  GIFT_MESSAGE_MAX_LENGTH,
+  GIFT_NAME_MAX_LENGTH,
+  createGiftFormState,
+  parseGiftFormState,
+} from './beta-gift/form-state';
 import GiftPlanStep from './beta-gift/plan-step';
 import GiftPreviewPanel from './beta-gift/preview-panel';
+import { ensureGiftPlanRoute, restoreGiftEntryRoute, setGiftRoute } from './beta-gift/navigation';
 import type {
   GiftDeliveryMethod,
   GiftCadenceDuration,
@@ -35,9 +45,6 @@ const validateInputForm = ValidateInputForm as unknown as (data: {
   fields: GiftInputField[];
 }) => GiftFormErrors;
 
-const GIFT_EMAIL_MAX_LENGTH = 191;
-const GIFT_NAME_MAX_LENGTH = 191;
-const GIFT_MESSAGE_MAX_LENGTH = 250;
 // Mirrors GIFT_MAX_SCHEDULE_DAYS in ghost/core's gifts constants — change them together.
 const GIFT_MAX_SCHEDULE_DAYS = 365;
 
@@ -51,6 +58,9 @@ interface GiftPageContext {
   doAction: (action: string, data?: Record<string, unknown>) => void;
   lastPage: string | null;
   member: GiftPageMember | null;
+  pageData?: {
+    giftStep?: GiftStep;
+  };
   site: Site | null;
 }
 
@@ -58,30 +68,74 @@ function getTierPriceLabel(product: GiftProduct, months: GiftDuration) {
   return formatGiftValue(getGiftPrice(product, months));
 }
 
+function getPortalHash(page: string | null) {
+  if (page === 'signup') {
+    return '#/portal/signup';
+  }
+  if (page === 'accountHome') {
+    return '#/portal/account';
+  }
+  if (page === 'accountPlan') {
+    return '#/portal/account/plans';
+  }
+  return null;
+}
+
 const BetaGiftPage = () => {
-  const { site, member, brandColor, action, doAction, lastPage } = useContext(
+  const { site, member, brandColor, action, doAction, lastPage, pageData } = useContext(
     AppContext,
   ) as GiftPageContext;
-  const [step, setStep] = useState<GiftStep>('plan');
-  const [selectedDuration, setSelectedDuration] = useState<GiftDuration | null>(null);
-  const [selectedProductId, setSelectedProductId] = useState<string | null>(null);
-  const [email, setEmail] = useState('');
-  const [recipientEmail, setRecipientEmail] = useState('');
-  const [recipientName, setRecipientName] = useState('');
-  const [buyerName, setBuyerName] = useState(member?.name || '');
-  const [giftMessage, setGiftMessage] = useState('');
-  const [deliveryMethod, setDeliveryMethod] = useState<GiftDeliveryMethod>('email');
-  // null means untouched: the effective date then tracks "today" in the site's timezone on every
-  // render, so an untouched form still means "send now" after the page sits open across midnight.
-  const [deliveryDate, setDeliveryDate] = useState<string | null>(null);
+  const routeStep: GiftStep = pageData?.giftStep === 'delivery' ? 'delivery' : 'plan';
+  const [step, setStep] = useState<GiftStep>(routeStep);
+  const [formState, setFormState] = useSessionStorageState({
+    key: GIFT_FORM_STATE_KEY,
+    initialState: () => createGiftFormState({ buyerName: member?.name || '' }),
+    parse: parseGiftFormState,
+  });
   const [errors, setErrors] = useState<GiftFormErrors>({});
   const { cardRef, containerProps: cardTiltProps } = useCardTilt();
+  const handledRouteStepRef = useRef<GiftStep | null>(null);
+  const enteredDeliveryFromPlanRef = useRef(false);
+
+  const { plan, delivery } = formState;
+  const { selectedDuration, selectedProductId, buyerEmail: email, buyerName } = plan;
+  const { method: deliveryMethod, emailDraft } = delivery;
+  const {
+    recipientEmail,
+    recipientName,
+    message: giftMessage,
+    timing: deliveryTiming,
+  } = emailDraft;
 
   // Prefill the "from" name once the logged-in member loads, without clobbering anything the buyer
   // has already typed.
   useEffect(() => {
-    setBuyerName((current) => current || member?.name || '');
+    setFormState((current) => {
+      if (current.plan.buyerName || !member?.name) {
+        return current;
+      }
+
+      return {
+        ...current,
+        plan: { ...current.plan, buyerName: member.name },
+      };
+    });
   }, [member?.name]);
+
+  useEffect(() => {
+    if (routeStep === 'delivery' && !plan.completed) {
+      setStep('plan');
+      setGiftRoute({ step: 'plan', replace: true });
+      return;
+    }
+
+    if (handledRouteStepRef.current === routeStep) {
+      return;
+    }
+    handledRouteStepRef.current = routeStep;
+
+    setStep(routeStep);
+  }, [plan.completed, routeStep]);
 
   // Anchors us to the popup's real (iframe) document for scroll control.
   const contentRef = useRef<HTMLDivElement>(null);
@@ -116,25 +170,55 @@ const BetaGiftPage = () => {
     return () => cancelAnimationFrame(raf);
   }, [step]);
 
-  if (!site) {
-    return <LoadingPage />;
-  }
+  const handleExit = () => {
+    const lastPageHash = getPortalHash(lastPage);
+    if (!restoreGiftEntryRoute() && lastPageHash) {
+      window.history.replaceState(window.history.state, '', lastPageHash);
+    }
+    doAction('back');
+  };
 
-  const { portal_default_plan: portalDefaultPlan } = site;
+  const handleClose = () => {
+    doAction('closePopup');
+  };
+
+  const portalDefaultPlan = site?.portal_default_plan ?? null;
   const offeredDurations = getAvailableGiftDurations({ site });
   const activeDuration = getActiveGiftDuration({
     availableDurations: offeredDurations,
-    portalDefaultPlan: portalDefaultPlan ?? null,
+    portalDefaultPlan,
     selectedDuration,
   });
   const products = activeDuration ? getGiftProducts({ site, duration: activeDuration }) : [];
+  const restoredSelectionAvailable =
+    selectedDuration !== null &&
+    offeredDurations.includes(selectedDuration) &&
+    selectedProductId !== null &&
+    products.some((product) => product.id === selectedProductId);
+
+  useEffect(() => {
+    if (!site || !plan.completed || restoredSelectionAvailable) {
+      return;
+    }
+
+    setFormState((current) => ({
+      ...current,
+      plan: { ...current.plan, completed: false },
+    }));
+    setStep('plan');
+    setGiftRoute({ step: 'plan', replace: true });
+  }, [plan.completed, restoredSelectionAvailable, site]);
+
+  if (!site) {
+    return <LoadingPage />;
+  }
 
   const siteIcon = site.icon;
   const siteTitle = site.title || '';
   if (!activeDuration || products.length === 0) {
     return (
       <div className="gh-portal-content gift">
-        <CloseButton />
+        <CloseButton onClick={handleClose} />
         <div className="gh-portal-gift-checkout">
           <div className="gh-portal-gift-checkout-left">
             <div aria-hidden="true" className="gh-portal-gift-checkout-bg" />
@@ -180,7 +264,8 @@ const BetaGiftPage = () => {
   const showEmailPreview = step === 'delivery' && deliveryMethod === 'email';
   const minDeliveryDate = getDateInputValue(new Date(), site.timezone);
   const maxDeliveryDate = addCalendarDays(minDeliveryDate, GIFT_MAX_SCHEDULE_DAYS);
-  const effectiveDeliveryDate = deliveryDate ?? minDeliveryDate;
+  const effectiveDeliveryDate =
+    deliveryTiming.type === 'scheduled' ? deliveryTiming.date : minDeliveryDate;
 
   const emailField: GiftInputField = {
     type: 'email',
@@ -228,12 +313,18 @@ const BetaGiftPage = () => {
 
   const handleEmailChange = (value: string) => {
     setErrors((currentErrors) => ({ ...currentErrors, email: '' }));
-    setEmail(value);
+    setFormState((current) => ({
+      ...current,
+      plan: { ...current.plan, buyerEmail: value, completed: false },
+    }));
   };
 
   const handleBuyerNameChange = (value: string) => {
     setErrors((currentErrors) => ({ ...currentErrors, buyerName: '' }));
-    setBuyerName(value);
+    setFormState((current) => ({
+      ...current,
+      plan: { ...current.plan, buyerName: value, completed: false },
+    }));
   };
 
   const handleRecipientEmailChange = (value: string) => {
@@ -242,7 +333,13 @@ const BetaGiftPage = () => {
       recipientEmail: '',
       deliveryDate: '',
     }));
-    setRecipientEmail(value);
+    setFormState((current) => ({
+      ...current,
+      delivery: {
+        ...current.delivery,
+        emailDraft: { ...current.delivery.emailDraft, recipientEmail: value },
+      },
+    }));
   };
 
   const handleDeliveryMethodChange = (method: GiftDeliveryMethod) => {
@@ -251,14 +348,61 @@ const BetaGiftPage = () => {
       recipientEmail: '',
       deliveryDate: '',
     }));
-    setDeliveryMethod(method);
+    setFormState((current) => ({
+      ...current,
+      delivery: { ...current.delivery, method },
+    }));
   };
 
   const handleDeliveryDateChange = (nextDate: string) => {
     setErrors((currentErrors) => ({ ...currentErrors, deliveryDate: '' }));
-    // Store today as null so "send now" keeps tracking the site day across midnight; a typed past
-    // date stays put for validation to call out.
-    setDeliveryDate(nextDate === minDeliveryDate ? null : nextDate);
+    setFormState((current) => ({
+      ...current,
+      delivery: {
+        ...current.delivery,
+        emailDraft: {
+          ...current.delivery.emailDraft,
+          timing:
+            nextDate === minDeliveryDate
+              ? { type: 'immediate' }
+              : { type: 'scheduled', date: nextDate },
+        },
+      },
+    }));
+  };
+
+  const handleSelectDuration = (duration: GiftDuration) => {
+    setFormState((current) => ({
+      ...current,
+      plan: { ...current.plan, selectedDuration: duration, completed: false },
+    }));
+  };
+
+  const handleSelectProduct = (productId: string) => {
+    setFormState((current) => ({
+      ...current,
+      plan: { ...current.plan, selectedProductId: productId, completed: false },
+    }));
+  };
+
+  const handleRecipientNameChange = (value: string) => {
+    setFormState((current) => ({
+      ...current,
+      delivery: {
+        ...current.delivery,
+        emailDraft: { ...current.delivery.emailDraft, recipientName: value },
+      },
+    }));
+  };
+
+  const handleGiftMessageChange = (value: string) => {
+    setFormState((current) => ({
+      ...current,
+      delivery: {
+        ...current.delivery,
+        emailDraft: { ...current.delivery.emailDraft, message: value },
+      },
+    }));
   };
 
   const handleContinueToDelivery = () => {
@@ -277,12 +421,30 @@ const BetaGiftPage = () => {
     if (formHasErrors) {
       return;
     }
+    setFormState((current) => ({
+      ...current,
+      plan: {
+        ...current.plan,
+        selectedDuration: activeDuration,
+        selectedProductId: activeProduct.id,
+        completed: true,
+      },
+    }));
+    ensureGiftPlanRoute();
+    enteredDeliveryFromPlanRef.current = true;
     setStep('delivery');
+    setGiftRoute({ step: 'delivery' });
   };
 
   const handleBackToPlan = () => {
     setErrors({});
     setStep('plan');
+    if (enteredDeliveryFromPlanRef.current) {
+      enteredDeliveryFromPlanRef.current = false;
+      window.history.back();
+    } else {
+      setGiftRoute({ step: 'plan', replace: true });
+    }
   };
 
   const handlePurchase = () => {
@@ -299,6 +461,10 @@ const BetaGiftPage = () => {
     const isScheduled = isEmailDelivery && effectiveDeliveryDate > minDeliveryDate;
 
     const fieldsToValidate: GiftInputField[] = [];
+    // A persisted draft can outlive the member session that originally hid this field.
+    if (!isLoggedIn) {
+      fieldsToValidate.push({ ...emailField, value: customerEmail });
+    }
     if (isEmailDelivery && trimmedRecipientEmail) {
       fieldsToValidate.push({ ...recipientEmailField, value: trimmedRecipientEmail });
     }
@@ -326,6 +492,14 @@ const BetaGiftPage = () => {
     setErrors(formErrors);
 
     if (formHasErrors) {
+      if (formErrors.email) {
+        setStep('plan');
+        setFormState((current) => ({
+          ...current,
+          plan: { ...current.plan, completed: false },
+        }));
+        setGiftRoute({ step: 'plan', replace: true });
+      }
       return;
     }
 
@@ -344,14 +518,14 @@ const BetaGiftPage = () => {
 
   return (
     <div ref={contentRef} className="gh-portal-content gift">
-      <CloseButton />
+      <CloseButton onClick={handleClose} />
       <div className="gh-portal-gift-checkout">
         <div className="gh-portal-gift-checkout-left" data-step={step}>
           <div aria-hidden="true" className="gh-portal-gift-checkout-bg" />
           {/* One back button in the corner for both jobs, as the other Portal modals do it. */}
           {(step === 'delivery' || lastPage) && (
             <SiteTitleBackButton
-              onBack={() => (step === 'delivery' ? handleBackToPlan() : doAction('back'))}
+              onBack={() => (step === 'delivery' ? handleBackToPlan() : handleExit())}
             />
           )}
           <div className="gh-portal-gift-checkout-inner">
@@ -371,8 +545,8 @@ const BetaGiftPage = () => {
                 tierPriceLabel={getTierPriceLabel}
                 onBuyerEmailChange={handleEmailChange}
                 onBuyerNameChange={handleBuyerNameChange}
-                onSelectDuration={setSelectedDuration}
-                onSelectProduct={setSelectedProductId}
+                onSelectDuration={handleSelectDuration}
+                onSelectProduct={handleSelectProduct}
               />
             ) : (
               <GiftDeliveryStep
@@ -387,9 +561,9 @@ const BetaGiftPage = () => {
                 recipientNameField={recipientNameField}
                 onChangeDeliveryDate={handleDeliveryDateChange}
                 onChangeDeliveryMethod={handleDeliveryMethodChange}
-                onChangeGiftMessage={setGiftMessage}
+                onChangeGiftMessage={handleGiftMessageChange}
                 onChangeRecipientEmail={handleRecipientEmailChange}
-                onChangeRecipientName={setRecipientName}
+                onChangeRecipientName={handleRecipientNameChange}
               />
             )}
             <div className="gh-portal-gift-checkout-cta-wrapper">

--- a/apps/portal/src/components/pages/beta-gift/form-state.ts
+++ b/apps/portal/src/components/pages/beta-gift/form-state.ts
@@ -1,0 +1,101 @@
+import { GIFT_DURATION_CATALOGUE } from '../../../utils/gift-subscriptions';
+import type { GiftDeliveryMethod, GiftDuration } from './types';
+import { removeSessionStorageState } from '../../../utils/use-session-storage-state';
+
+export const GIFT_FORM_STATE_KEY = 'ghost-portal-gift-form-state';
+export const GIFT_EMAIL_MAX_LENGTH = 191;
+export const GIFT_NAME_MAX_LENGTH = 191;
+export const GIFT_MESSAGE_MAX_LENGTH = 250;
+
+export type GiftDeliveryTiming = { type: 'immediate' } | { type: 'scheduled'; date: string };
+
+export interface GiftFormState {
+  version: 1;
+  plan: {
+    selectedDuration: GiftDuration | null;
+    selectedProductId: string | null;
+    buyerEmail: string;
+    buyerName: string;
+    completed: boolean;
+  };
+  delivery: {
+    method: GiftDeliveryMethod;
+    emailDraft: {
+      recipientEmail: string;
+      recipientName: string;
+      message: string;
+      timing: GiftDeliveryTiming;
+    };
+  };
+}
+
+export function createGiftFormState({
+  buyerName = '',
+}: { buyerName?: string } = {}): GiftFormState {
+  return {
+    version: 1,
+    plan: {
+      selectedDuration: null,
+      selectedProductId: null,
+      buyerEmail: '',
+      buyerName,
+      completed: false,
+    },
+    delivery: {
+      method: 'email',
+      emailDraft: {
+        recipientEmail: '',
+        recipientName: '',
+        message: '',
+        timing: { type: 'immediate' },
+      },
+    },
+  };
+}
+
+function isBoundedString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && value.length <= maxLength;
+}
+
+export function parseGiftFormState(value: unknown): GiftFormState | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Partial<GiftFormState>;
+  const plan = candidate.plan;
+  const delivery = candidate.delivery;
+  const emailDraft = delivery?.emailDraft;
+  const timing = emailDraft?.timing;
+  const validDuration =
+    plan?.selectedDuration === null ||
+    GIFT_DURATION_CATALOGUE.includes(plan?.selectedDuration as GiftDuration);
+  const validTiming =
+    timing?.type === 'immediate' ||
+    (timing?.type === 'scheduled' && typeof timing.date === 'string');
+
+  if (
+    candidate.version !== 1 ||
+    !plan ||
+    !delivery ||
+    !emailDraft ||
+    !validDuration ||
+    !(plan.selectedProductId === null || typeof plan.selectedProductId === 'string') ||
+    !isBoundedString(plan.buyerEmail, GIFT_EMAIL_MAX_LENGTH) ||
+    !isBoundedString(plan.buyerName, GIFT_NAME_MAX_LENGTH) ||
+    typeof plan.completed !== 'boolean' ||
+    !['email', 'link'].includes(delivery.method) ||
+    !isBoundedString(emailDraft.recipientEmail, GIFT_EMAIL_MAX_LENGTH) ||
+    !isBoundedString(emailDraft.recipientName, GIFT_NAME_MAX_LENGTH) ||
+    !isBoundedString(emailDraft.message, GIFT_MESSAGE_MAX_LENGTH) ||
+    !validTiming
+  ) {
+    return null;
+  }
+
+  return candidate as GiftFormState;
+}
+
+export function clearGiftFormState() {
+  removeSessionStorageState({ key: GIFT_FORM_STATE_KEY });
+}

--- a/apps/portal/src/components/pages/beta-gift/navigation.ts
+++ b/apps/portal/src/components/pages/beta-gift/navigation.ts
@@ -1,0 +1,76 @@
+import type { GiftStep } from './types';
+
+const GIFT_HISTORY_STATE_KEY = 'ghostPortalGiftHistory';
+
+interface GiftHistoryState {
+  depth: number;
+}
+
+function getHistoryState(): Record<string, unknown> {
+  const state = window.history.state;
+  return state && typeof state === 'object' ? state : {};
+}
+
+function getGiftHistoryState(): GiftHistoryState | null {
+  const value = getHistoryState()[GIFT_HISTORY_STATE_KEY];
+  if (!value || typeof value !== 'object' || !('depth' in value)) {
+    return null;
+  }
+
+  const { depth } = value as { depth?: unknown };
+  return typeof depth === 'number' && depth > 0 ? { depth } : null;
+}
+
+function getGiftHash(step: GiftStep) {
+  return step === 'delivery' ? '#/portal/gift/delivery' : '#/portal/gift';
+}
+
+function dispatchHashChange() {
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
+}
+
+export function setGiftRoute({ step, replace = false }: { step: GiftStep; replace?: boolean }) {
+  const hash = getGiftHash(step);
+
+  if (replace) {
+    window.history.replaceState(window.history.state, '', hash);
+    dispatchHashChange();
+    return;
+  }
+
+  const giftHistoryState = getGiftHistoryState();
+  const nextState = giftHistoryState
+    ? {
+        ...getHistoryState(),
+        [GIFT_HISTORY_STATE_KEY]: { depth: giftHistoryState.depth + 1 },
+      }
+    : window.history.state;
+
+  window.history.pushState(nextState, '', hash);
+  dispatchHashChange();
+}
+
+export function ensureGiftPlanRoute() {
+  if (window.location.hash === '#/portal/gift') {
+    return;
+  }
+
+  window.history.pushState(
+    {
+      ...getHistoryState(),
+      [GIFT_HISTORY_STATE_KEY]: { depth: 1 },
+    },
+    '',
+    '#/portal/gift',
+  );
+}
+
+export function restoreGiftEntryRoute() {
+  const giftHistoryState = getGiftHistoryState();
+  if (!giftHistoryState) {
+    return false;
+  }
+
+  window.history.go(-giftHistoryState.depth);
+  return true;
+}

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -728,7 +728,7 @@ function setupGhostApi({ siteUrl = window.location.origin, apiUrl, apiKey }) {
       const cancelUrlObj = window.location.href.startsWith(siteUrlObj.href)
         ? new URL(window.location.href)
         : new URL(siteUrl);
-      cancelUrlObj.hash = '#/portal/gift';
+      cancelUrlObj.hash = duration === undefined ? '#/portal/gift' : '#/portal/gift/delivery';
 
       const body = {
         identity,

--- a/apps/portal/src/utils/use-session-storage-state.ts
+++ b/apps/portal/src/utils/use-session-storage-state.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+interface SessionStorageStateOptions<T> {
+  initialState: T | (() => T);
+  key: string;
+  parse: (value: unknown) => T | null;
+}
+
+export default function useSessionStorageState<T>({
+  initialState,
+  key,
+  parse,
+}: SessionStorageStateOptions<T>): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    const fallback =
+      typeof initialState === 'function' ? (initialState as () => T)() : initialState;
+
+    try {
+      const storedValue = window.sessionStorage.getItem(key);
+      if (storedValue === null) {
+        return fallback;
+      }
+
+      return parse(JSON.parse(storedValue)) ?? fallback;
+    } catch {
+      return fallback;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // Storage may be disabled or full. The in-memory state remains usable.
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+export function removeSessionStorageState({ key }: { key: string }) {
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Storage may be disabled. There is nothing else to clear.
+  }
+}

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -1,7 +1,21 @@
 import ActionHandler from '../src/actions';
 import { vi, type MockInstance } from 'vitest';
+import {
+  GIFT_FORM_STATE_KEY,
+  createGiftFormState,
+} from '../src/components/pages/beta-gift/form-state';
+import { ensureGiftPlanRoute, setGiftRoute } from '../src/components/pages/beta-gift/navigation';
 
 describe('closePopup action', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('clears a one-shot redirect from pageData so it cannot leak into a later sign-in', async () => {
     const result = await ActionHandler({
       action: 'closePopup',
@@ -31,6 +45,28 @@ describe('closePopup action', () => {
       state: { page: 'signin' },
     });
     expect(result.pageData).toEqual({});
+  });
+
+  test('clears a gift draft and returns past its gift history entries', async () => {
+    window.history.replaceState(null, '', '/post#comments');
+    window.sessionStorage.setItem(
+      GIFT_FORM_STATE_KEY,
+      JSON.stringify(createGiftFormState({ buyerName: 'Jamie' })),
+    );
+    ensureGiftPlanRoute();
+    setGiftRoute({ step: 'delivery' });
+    const historyGoSpy = vi.spyOn(window.history, 'go').mockImplementation(() => undefined);
+
+    const result = await ActionHandler({
+      action: 'closePopup',
+      data: {},
+      api: {},
+      state: { page: 'gift' },
+    });
+
+    expect(historyGoSpy).toHaveBeenCalledWith(-2);
+    expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).toBeNull();
+    expect(result.showPopup).toBe(false);
   });
 });
 

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -294,6 +294,7 @@ describe('Portal API gift checkout', () => {
       type: 'gift',
       tierId: 'tier_123',
       duration: 3,
+      cancelUrl: 'https://example.com/#/portal/gift/delivery',
     });
     expect(body).not.toHaveProperty('cadence');
   });

--- a/apps/portal/test/app.test.jsx
+++ b/apps/portal/test/app.test.jsx
@@ -189,6 +189,23 @@ describe('App', function () {
     expect(app.fetchGiftRedemptionData).not.toHaveBeenCalled();
   });
 
+  test('maps customized gift routes to explicit form steps', () => {
+    const app = new App({ siteUrl: 'http://example.com' });
+    const site = {
+      ...FixtureSite.singleTier.basic,
+      labs: { giftSubCustomization: true },
+    };
+
+    expect(app.getPageFromLinkPath('gift', site)).toEqual({
+      page: 'gift',
+      pageData: { giftStep: 'plan' },
+    });
+    expect(app.getPageFromLinkPath('gift/delivery', site)).toEqual({
+      page: 'gift',
+      pageData: { giftStep: 'delivery' },
+    });
+  });
+
   test('ignores malformed gift redemption tokens in trigger links', async () => {
     const app = new App({ siteUrl: 'http://example.com' });
     app.dispatchAction = vi.fn();

--- a/apps/portal/test/portal-links.test.jsx
+++ b/apps/portal/test/portal-links.test.jsx
@@ -7,6 +7,10 @@ import {
 import { appRender, fireEvent, waitFor, within } from './utils/test-utils';
 import setupGhostApi from '../src/utils/api';
 import { toDateValue } from '../src/utils/date-time';
+import {
+  GIFT_FORM_STATE_KEY,
+  createGiftFormState,
+} from '../src/components/pages/beta-gift/form-state';
 
 const defaultGiftResponse = {
   gifts: [
@@ -98,6 +102,7 @@ const setup = async ({
 
 describe('Portal Data links:', () => {
   beforeEach(() => {
+    window.sessionStorage.clear();
     // Mock global fetch
     vi.spyOn(window, 'fetch').mockImplementation((url) => {
       if (url.includes('send-magic-link')) {
@@ -467,6 +472,53 @@ describe('Portal Data links:', () => {
       ).toBeInTheDocument();
     });
 
+    test('opens a completed personalized gift at the delivery step', async () => {
+      const site = {
+        ...FixtureSite.singleTier.basic,
+        labs: { giftSubCustomization: true },
+      };
+      const productId = site.products.find((product) => product.type === 'paid').id;
+      const draft = createGiftFormState({ buyerName: 'Jamie' });
+      draft.plan.selectedDuration = 1;
+      draft.plan.selectedProductId = productId;
+      draft.plan.completed = true;
+      draft.delivery.emailDraft.recipientEmail = 'recipient@example.com';
+      draft.delivery.emailDraft.recipientName = 'Taylor';
+      draft.delivery.emailDraft.message = 'Enjoy!';
+      window.sessionStorage.setItem(GIFT_FORM_STATE_KEY, JSON.stringify(draft));
+      window.location.hash = '#/portal/gift/delivery';
+
+      let { popupFrame, ...utils } = await setup({ site, showPopup: false });
+      popupFrame = await utils.findByTitle(/portal-popup/i);
+      const popupDocument = popupFrame.contentDocument;
+
+      expect(within(popupDocument).getByLabelText("Recipient's email")).toHaveValue(
+        'recipient@example.com',
+      );
+      expect(within(popupDocument).getByLabelText("Recipient's name")).toHaveValue('Taylor');
+      expect(within(popupDocument).getByLabelText('Optional message')).toHaveValue('Enjoy!');
+    });
+
+    test('clears a personalized gift draft when Escape closes Portal', async () => {
+      window.location.hash = '#/portal/gift';
+      const site = {
+        ...FixtureSite.singleTier.basic,
+        labs: { giftSubCustomization: true },
+      };
+      let { popupFrame, ...utils } = await setup({ site, showPopup: false });
+      popupFrame = await utils.findByTitle(/portal-popup/i);
+      const popupDocument = popupFrame.contentDocument;
+      fireEvent.change(within(popupDocument).getByLabelText('Your name'), {
+        target: { value: 'Jamie' },
+      });
+      expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).not.toBeNull();
+
+      fireEvent.keyUp(popupDocument.body, { key: 'Escape' });
+
+      await waitFor(() => expect(utils.queryByTitle(/portal-popup/i)).not.toBeInTheDocument());
+      expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).toBeNull();
+    });
+
     test('does not open when Stripe is disconnected', async () => {
       window.location.hash = '#/portal/gift';
 
@@ -625,6 +677,7 @@ describe('Portal Data links:', () => {
       window.location.search = `?stripe=gift-purchase-success&gift_token=abc123&gift_tier=${tierId}&gift_cadence=year&gift_duration=12&gift_delivery=email`;
       window.location.hash = '';
       window.location.pathname = '/';
+      window.sessionStorage.setItem(GIFT_FORM_STATE_KEY, 'saved-draft');
 
       let { popupFrame, triggerButtonFrame, ...utils } = await setup({
         site,
@@ -644,6 +697,7 @@ describe('Portal Data links:', () => {
 
       const duration = within(popupFrame.contentDocument).queryByText('1 year');
       expect(duration).toBeInTheDocument();
+      expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).toBeNull();
     });
 
     test('opens gift success page with scheduled delivery wording for a future date', async () => {
@@ -696,6 +750,7 @@ describe('Portal Data links:', () => {
       window.location.search = '?stripe=gift-purchase-success';
       window.location.hash = '';
       window.location.pathname = '/';
+      window.sessionStorage.setItem(GIFT_FORM_STATE_KEY, 'saved-draft');
 
       let { popupFrame, triggerButtonFrame } = await setup({
         site: FixtureSite.singleTier.basic,
@@ -704,6 +759,7 @@ describe('Portal Data links:', () => {
 
       expect(triggerButtonFrame).toBeInTheDocument();
       expect(popupFrame).not.toBeInTheDocument();
+      expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).toBe('saved-draft');
     });
   });
 

--- a/apps/portal/test/portal-links.test.jsx
+++ b/apps/portal/test/portal-links.test.jsx
@@ -519,6 +519,42 @@ describe('Portal Data links:', () => {
       expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).toBeNull();
     });
 
+    test('closes Portal when browser Back returns from Gift to a non-Portal fragment', async () => {
+      window.location.hash = '#/portal/gift';
+      const site = {
+        ...FixtureSite.singleTier.basic,
+        labs: { giftSubCustomization: true },
+      };
+      let { popupFrame, ...utils } = await setup({ site, showPopup: false });
+      popupFrame = await utils.findByTitle(/portal-popup/i);
+      expect(popupFrame).toBeInTheDocument();
+
+      window.location.hash = '#comments';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+
+      await waitFor(() => expect(utils.queryByTitle(/portal-popup/i)).not.toBeInTheDocument());
+    });
+
+    test('clears a personalized gift draft when browser Back returns to another Portal page', async () => {
+      window.location.hash = '#/portal/gift';
+      const site = {
+        ...FixtureSite.singleTier.basic,
+        labs: { giftSubCustomization: true },
+      };
+      let { popupFrame, ...utils } = await setup({ site, showPopup: false });
+      popupFrame = await utils.findByTitle(/portal-popup/i);
+      const popup = within(popupFrame.contentDocument);
+
+      fireEvent.change(popup.getByLabelText('Your name'), { target: { value: 'Jamie' } });
+      expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).not.toBeNull();
+
+      window.location.hash = '#/portal/signup';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+
+      await waitFor(() => expect(popup.getByLabelText('Name')).toBeInTheDocument());
+      expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).toBeNull();
+    });
+
     test('does not open when Stripe is disconnected', async () => {
       window.location.hash = '#/portal/gift';
 

--- a/apps/portal/test/unit/components/pages/beta-gift-page.test.tsx
+++ b/apps/portal/test/unit/components/pages/beta-gift-page.test.tsx
@@ -1,5 +1,9 @@
-import { fireEvent, render } from '../../../utils/test-utils';
+import { fireEvent, render, waitFor } from '../../../utils/test-utils';
 import BetaGiftPage from '../../../../src/components/pages/beta-gift-page';
+import {
+  GIFT_FORM_STATE_KEY,
+  createGiftFormState,
+} from '../../../../src/components/pages/beta-gift/form-state';
 import {
   getPriceData,
   getProductData,
@@ -38,6 +42,11 @@ function setup(site: SiteData, overrideContext: Record<string, unknown> = {}) {
 }
 
 describe('BetaGiftPage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState(null, '', '/');
+  });
+
   test('preserves focus on the checkout action when moving to delivery', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
     const { getByLabelText, getByRole } = setup(site);
@@ -68,6 +77,164 @@ describe('BetaGiftPage', () => {
     expect(container.querySelector('.gh-portal-gift-email-lede')).toContainHTML(
       `<strong>${durationLabel}</strong>`,
     );
+  });
+
+  test('returns an incomplete direct delivery route to the plan step', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const { getByRole, queryByLabelText } = setup(site, {
+      pageData: { giftStep: 'delivery' },
+    });
+
+    expect(getByRole('heading', { name: 'Gift a membership' })).toBeInTheDocument();
+    expect(queryByLabelText("Recipient's email")).not.toBeInTheDocument();
+    expect(window.location.hash).toBe('#/portal/gift');
+  });
+
+  test('creates a plan history entry before navigating an internal flow to delivery', async () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    window.history.pushState(null, '', '#/portal/signup');
+    const { getByLabelText, getByRole } = setup(site, { lastPage: 'signup' });
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    expect(window.location.hash).toBe('#/portal/gift/delivery');
+
+    window.history.back();
+
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/gift'));
+
+    window.history.back();
+
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/signup'));
+  });
+
+  test('preserves the original fragment when navigating through the gift form', async () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    window.history.pushState(null, '', '/post#comments');
+    const { getByLabelText, getByRole } = setup(site);
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    expect(window.location.hash).toBe('#/portal/gift/delivery');
+
+    window.history.back();
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/gift'));
+
+    window.history.back();
+    await waitFor(() => expect(window.location.hash).toBe('#comments'));
+  });
+
+  test('restores the internal entry route when leaving the plan', async () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    window.history.pushState(null, '', '#/portal/signup');
+    const { getByLabelText, getByRole, mockDoActionFn } = setup(site, { lastPage: 'signup' });
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.click(getByRole('button', { name: /Back/ }));
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/gift'));
+    fireEvent.click(getByRole('button', { name: /Back/ }));
+
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/signup'));
+    expect(mockDoActionFn).toHaveBeenCalledWith('back');
+
+    window.history.back();
+    await waitFor(() => expect(window.location.hash).toBe(''));
+  });
+
+  test('restores the Account Plans route when leaving the plan', async () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    window.history.pushState(null, '', '#/portal/account/plans');
+    const { getByLabelText, getByRole, mockDoActionFn } = setup(site, {
+      lastPage: 'accountPlan',
+    });
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.click(getByRole('button', { name: /Back/ }));
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/gift'));
+    fireEvent.click(getByRole('button', { name: /Back/ }));
+
+    await waitFor(() => expect(window.location.hash).toBe('#/portal/account/plans'));
+    expect(mockDoActionFn).toHaveBeenCalledWith('back');
+  });
+
+  test('dispatches the shared close action when the form is closed', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const { getByLabelText, getByRole, mockDoActionFn } = setup(site);
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    expect(window.sessionStorage.getItem(GIFT_FORM_STATE_KEY)).not.toBeNull();
+
+    fireEvent.click(getByRole('button', { name: 'Close popup' }));
+
+    expect(mockDoActionFn).toHaveBeenCalledWith('closePopup');
+  });
+
+  test('keeps the form usable when session storage is unavailable', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+
+    const { getByLabelText } = setup(site);
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+
+    expect(getByLabelText('Your name')).toHaveValue('Jamie');
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
+  });
+
+  test('restores delivery details after the page remounts', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const firstRender = setup(site);
+
+    fireEvent.click(firstRender.getByRole('radio', { name: '3 months' }));
+    fireEvent.change(firstRender.getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(firstRender.getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.change(firstRender.getByLabelText("Recipient's name"), {
+      target: { value: 'Taylor' },
+    });
+    fireEvent.change(firstRender.getByLabelText("Recipient's email"), {
+      target: { value: 'recipient@example.com' },
+    });
+    fireEvent.change(firstRender.getByLabelText('Optional message'), {
+      target: { value: 'Enjoy!' },
+    });
+    firstRender.unmount();
+
+    const restoredRender = setup(site, { pageData: { giftStep: 'delivery' } });
+
+    expect(restoredRender.container.querySelector('.gh-portal-gift-email-lede')).toHaveTextContent(
+      'Jamie has gifted you a 3-month Premium membership to The Blueprint',
+    );
+    expect(restoredRender.getByLabelText("Recipient's name")).toHaveValue('Taylor');
+    expect(restoredRender.getByLabelText("Recipient's email")).toHaveValue('recipient@example.com');
+    expect(restoredRender.getByLabelText('Optional message')).toHaveValue('Enjoy!');
+  });
+
+  test('returns an expired signed-in draft to the visible buyer email field', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const productId = site.products[0].id;
+    const draft = createGiftFormState({ buyerName: 'Jamie' });
+    draft.plan.selectedDuration = 1;
+    draft.plan.selectedProductId = productId;
+    draft.plan.completed = true;
+    draft.delivery.method = 'link';
+    window.sessionStorage.setItem(GIFT_FORM_STATE_KEY, JSON.stringify(draft));
+
+    const { getByLabelText, getByRole, getByText } = setup(site, {
+      member: null,
+      pageData: { giftStep: 'delivery' },
+    });
+
+    fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
+
+    expect(getByLabelText('Your email')).toBeInTheDocument();
+    expect(getByText('Enter your email address')).toBeInTheDocument();
   });
 
   test('offers the full fixed-duration catalogue and updates the price and request', () => {

--- a/apps/portal/test/unit/utils/use-session-storage-state.test.tsx
+++ b/apps/portal/test/unit/utils/use-session-storage-state.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '../../utils/test-utils';
+import useSessionStorageState from '../../../src/utils/use-session-storage-state';
+
+interface TestState {
+  value: string;
+}
+
+const parseTestState = (value: unknown): TestState | null => {
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as Partial<TestState>).value === 'string'
+  ) {
+    return value as TestState;
+  }
+  return null;
+};
+
+function TestComponent() {
+  const [state, setState] = useSessionStorageState<TestState>({
+    key: 'test-session-state',
+    initialState: { value: 'initial' },
+    parse: parseTestState,
+  });
+
+  return (
+    <button type="button" onClick={() => setState((current) => ({ value: `${current.value}!` }))}>
+      {state.value}
+    </button>
+  );
+}
+
+describe('useSessionStorageState', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('restores parsed state and persists callback updates', () => {
+    window.sessionStorage.setItem('test-session-state', JSON.stringify({ value: 'restored' }));
+    render(<TestComponent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'restored' }));
+
+    expect(screen.getByRole('button', { name: 'restored!' })).toBeInTheDocument();
+    expect(JSON.parse(window.sessionStorage.getItem('test-session-state') || '')).toEqual({
+      value: 'restored!',
+    });
+  });
+
+  test('falls back when stored state is malformed', () => {
+    window.sessionStorage.setItem('test-session-state', '{not json');
+
+    render(<TestComponent />);
+
+    expect(screen.getByRole('button', { name: 'initial' })).toBeInTheDocument();
+  });
+
+  test('keeps in-memory state working when storage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+    render(<TestComponent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'initial' }));
+
+    expect(screen.getByRole('button', { name: 'initial!' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

Returning from Stripe currently recreates an empty personalised gift form, losing the buyer, recipient, message, delivery, and plan details. Browser Back and swipe navigation also need distinct plan and delivery history entries.

## What changed

- Persisted the gift form as one typed session-storage state object, failing open when storage is unavailable.
- Added explicit plan and delivery routes so browser navigation returns between steps correctly.
- Retained and restored the entry history record, including non-Portal fragments, when leaving or closing an internally opened gift flow.
- Centralised draft cleanup through Portal close/back actions while preserving the draft during Stripe navigation.
- Cleared the saved draft after a valid Stripe success return.
- Returned expired-session buyers to the visible email field when it becomes required again.

This is intentionally a Portal-only change using the existing gift checkout API contract. Cross-origin Portal embeds are outside the scope of this issue.

## Verification

- Portal lint and TypeScript checks passed.
- Portal unit suite: 698 passed, 1 skipped.
- Changed-file formatting checks passed.

fixes https://linear.app/ghost/issue/BER-3890

- [x] I've read and followed the Contributor Guide.
- [x] I've explained my change.
- [x] I've written automated tests to prove the change works.
