### PR TITLE
Fixed 500 on newsletter verification with a non-newsletter token

### DIFF
--- a/ghost/core/core/server/services/newsletters/newsletters-service.js
+++ b/ghost/core/core/server/services/newsletters/newsletters-service.js
@@ -13,7 +13,12 @@ const messages = {
   newsletterNotFound: 'Newsletter not found.',
   senderEmailNotAllowed: 'You cannot set the sender email address to {email}',
   replyToNotAllowed: 'You cannot set the reply-to email address to {email}',
+  invalidVerificationToken: 'This verification link is not valid for a newsletter.',
 };
+
+// Properties a verification token is allowed to update, in case the token was
+// issued for a different flow (e.g. the support address) or by an older version
+const VERIFIABLE_PROPERTIES = ['sender_email', 'sender_reply_to'];
 
 class NewslettersService {
   /**
@@ -269,6 +274,12 @@ class NewslettersService {
   async verifyPropertyUpdate(token) {
     const data = await this.magicLinkService.getDataFromToken(token);
     const { id, property, value } = data;
+
+    if (!id || !VERIFIABLE_PROPERTIES.includes(property)) {
+      throw new errors.BadRequestError({
+        message: tpl(messages.invalidVerificationToken),
+      });
+    }
 
     const attrs = {};
     attrs[property] = value;

--- a/ghost/core/test/unit/server/services/newsletters/service.test.js
+++ b/ghost/core/test/unit/server/services/newsletters/service.test.js
@@ -314,5 +314,31 @@ describe('NewslettersService', function () {
         { id: 'abc123' },
       );
     });
+
+    it('rejects a token issued for a different flow', async function () {
+      // support address tokens carry {key, value}, so id and property are missing
+      const token = JSON.stringify({
+        key: 'members_support_address',
+        value: 'test@example.com',
+      });
+
+      await assert.rejects(newsletterService.verifyPropertyUpdate(token), {
+        name: 'BadRequestError',
+      });
+      sinon.assert.notCalled(editStub);
+    });
+
+    it('rejects a token for a property that cannot be verified', async function () {
+      const token = JSON.stringify({
+        id: 'abc123',
+        property: 'name',
+        value: 'New name',
+      });
+
+      await assert.rejects(newsletterService.verifyPropertyUpdate(token), {
+        name: 'BadRequestError',
+      });
+      sinon.assert.notCalled(editStub);
+    });
   });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-375

## Why

The newsletters service and the settings BREAD service each construct their own `MagicLink` with a separate `SingleUseTokenProvider`, but both providers wrap the same `SingleUseToken` model. There's no type discriminator on the token, so a support address verification token validates cleanly against the newsletter verification endpoint.

The payloads differ: settings tokens carry `{key, value}`, while `verifyPropertyUpdate` destructures `{id, property, value}`. A support token therefore leaves `id` undefined, which reaches `Newsletter.edit(attrs, {id: undefined})` and makes knex throw at query-compile time:

```
Undefined binding(s) detected when compiling SELECT. Undefined column(s): [id]
```

That's a raw error rather than a Ghost API error, so it surfaces as a 500. It never degrades into a clean 404, because the throw happens before the row lookup runs.

## What changed

`verifyPropertyUpdate` now validates the token payload before touching the model: `id` must be present, and `property` must be one of `sender_email` / `sender_reply_to`. Anything else gets a `BadRequestError`.

This mirrors the guard the settings service already applies in `verifyKeyUpdate`, which rejects keys outside its `EMAIL_KEYS` allowlist for the same reason — tokens issued for another flow, or by an older version.

## Notes for reviewers

- No user-facing behaviour change, so no release-note emoji. Admin routes each verification link to a single handler, so this path isn't reachable through the UI today; the fix is about the endpoint not 500ing on a token it shouldn't accept.
- Two unit tests added: a support-address token payload, and a token naming a property that can't be verified. Both assert `BadRequestError` and that the model is never touched.
- `test/unit/server/services/newsletters/service.test.js` passes (17 tests), eslint and oxfmt clean.