### PR TITLE
Improved post relation import lookup performance

### DIFF
--- a/ghost/core/core/server/data/importer/importers/data/posts-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/posts-importer.js
@@ -77,12 +77,12 @@ class PostsImporter extends BaseImporter {
    */
   addNestedRelations() {
     const postsById = new Map();
-    for (const post of this.dataToImport) {
+    _.each(this.dataToImport, (post) => {
       const postId = post.id;
       if (!postsById.has(postId)) {
         postsById.set(postId, post);
       }
-    }
+    });
 
     this.requiredFromFile.posts_tags = _.orderBy(
       this.requiredFromFile.posts_tags,

--- a/ghost/core/core/server/data/importer/importers/data/posts-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/posts-importer.js
@@ -76,7 +76,13 @@ class PostsImporter extends BaseImporter {
    * Attaches related tags, authors, and products.
    */
   addNestedRelations() {
-    const postsById = new Map(this.dataToImport.map((post) => [post.id, post]));
+    const postsById = new Map();
+    for (const post of this.dataToImport) {
+      const postId = post.id;
+      if (!postsById.has(postId)) {
+        postsById.set(postId, post);
+      }
+    }
 
     this.requiredFromFile.posts_tags = _.orderBy(
       this.requiredFromFile.posts_tags,

--- a/ghost/core/core/server/data/importer/importers/data/posts-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/posts-importer.js
@@ -73,9 +73,11 @@ class PostsImporter extends BaseImporter {
   }
 
   /**
-   * Naive function to attach related tags, authors, and products.
+   * Attaches related tags, authors, and products.
    */
   addNestedRelations() {
+    const postsById = new Map(this.dataToImport.map((post) => [post.id, post]));
+
     this.requiredFromFile.posts_tags = _.orderBy(
       this.requiredFromFile.posts_tags,
       ['post_id', 'sort_order'],
@@ -103,7 +105,7 @@ class PostsImporter extends BaseImporter {
           return;
         }
 
-        let postToImport = _.find(this.dataToImport, { id: relation.post_id });
+        const postToImport = postsById.get(relation.post_id);
 
         // CASE: we won't import a relation when the target post does not exist
         if (!postToImport) {

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -56,6 +56,25 @@ describe('PostsImporter', function () {
       assert.deepEqual(firstPost.tags, [{ id: 'tag-1' }]);
       assert.equal(secondPost.tags, undefined);
     });
+
+    it('attaches relations when posts data is keyed by property', function () {
+      const post = { id: 'post-1' };
+      const importer = new PostsImporter({ posts: [] });
+      importer.dataToImport = { first: post };
+      importer.requiredFromFile.posts_tags = [
+        {
+          post_id: 'post-1',
+          tag_id: 'tag-1',
+          sort_order: 0,
+        },
+      ];
+      importer.requiredFromFile.posts_authors = [];
+      importer.requiredFromFile.posts_products = [];
+
+      importer.addNestedRelations();
+
+      assert.deepEqual(post.tags, [{ id: 'tag-1' }]);
+    });
   });
 
   describe('#beforeImport', function () {

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -35,6 +35,27 @@ describe('PostsImporter', function () {
       assert.equal(postIdReads, postCount);
       assert.deepEqual(posts[99].tags, [{ id: 'tag-99' }]);
     });
+
+    it('attaches relations to the first post when IDs are duplicated', function () {
+      const firstPost = { id: 'duplicate-post' };
+      const secondPost = { id: 'duplicate-post' };
+      const importer = new PostsImporter({ posts: [] });
+      importer.dataToImport = [firstPost, secondPost];
+      importer.requiredFromFile.posts_tags = [
+        {
+          post_id: 'duplicate-post',
+          tag_id: 'tag-1',
+          sort_order: 0,
+        },
+      ];
+      importer.requiredFromFile.posts_authors = [];
+      importer.requiredFromFile.posts_products = [];
+
+      importer.addNestedRelations();
+
+      assert.deepEqual(firstPost.tags, [{ id: 'tag-1' }]);
+      assert.equal(secondPost.tags, undefined);
+    });
   });
 
   describe('#beforeImport', function () {

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -4,6 +4,39 @@ const find = require('lodash/find');
 const PostsImporter = require('../../../../../../../core/server/data/importer/importers/data/posts-importer');
 
 describe('PostsImporter', function () {
+  describe('#addNestedRelations', function () {
+    it('indexes posts before attaching their relations', function () {
+      const postCount = 100;
+      let postIdReads = 0;
+      const posts = Array.from({ length: postCount }, (_, index) => {
+        const post = {};
+        Object.defineProperty(post, 'id', {
+          enumerable: true,
+          get() {
+            postIdReads += 1;
+            return `post-${index}`;
+          },
+        });
+        return post;
+      });
+      const postsTags = Array.from({ length: postCount }, (_, index) => ({
+        post_id: `post-${index}`,
+        tag_id: `tag-${index}`,
+        sort_order: 0,
+      }));
+      const importer = new PostsImporter({ posts: [] });
+      importer.dataToImport = posts;
+      importer.requiredFromFile.posts_tags = postsTags;
+      importer.requiredFromFile.posts_authors = [];
+      importer.requiredFromFile.posts_products = [];
+
+      importer.addNestedRelations();
+
+      assert.equal(postIdReads, postCount);
+      assert.deepEqual(posts[99].tags, [{ id: 'tag-99' }]);
+    });
+  });
+
   describe('#beforeImport', function () {
     it('converts post.page to post.type', function () {
       const fakePosts = [


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Post imports currently scan the complete post list for every tag, author, and tier relation. This makes relation attachment quadratic for large exports.

This change builds a post ID index once before attaching relations. Each relation then uses a constant-time lookup while preserving the existing ordering, duplicate detection, and missing-post behavior.

The regression test instruments post ID reads for 100 posts and 100 relations. It observes 5,050 reads before the change and 100 reads after it.

Validation:

- `pnpm test:unit test/unit/server/data/importer/importers/data/posts.test.js --reporter=dot` — 6 tests passed
- `TZ=UTC pnpm test` for the Ghost server — 8,192 tests passed
- `pnpm check` formatting, lint, and dependency-boundary stages passed. The remaining monorepo test failure reproduces on the current `admin-x-framework` TypeScript tests and does not touch this change's dependency path.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
