### PR TITLE
Fixed gift redemption recipient name

### DIFF
--- a/apps/portal/src/components/pages/beta-gift-redemption-page.jsx
+++ b/apps/portal/src/components/pages/beta-gift-redemption-page.jsx
@@ -59,7 +59,7 @@ const BetaGiftRedemptionPage = () => {
   const { action, brandColor, doAction, member, pageData, site } = useContext(AppContext);
   const gift = pageData?.gift;
   const isLoggedIn = !!member;
-  const [name, setName] = useState(member?.name || gift?.recipient_name || '');
+  const [name, setName] = useState(gift?.recipient_name || member?.name || '');
   const [email, setEmail] = useState(member?.email || '');
   const [errors, setErrors] = useState({});
   const [showDetails, setShowDetails] = useState(false);
@@ -68,7 +68,7 @@ const BetaGiftRedemptionPage = () => {
   useEffect(() => {
     // Prefill with the recipient name the buyer entered, so the gift card
     // is personal before the recipient types anything.
-    setName(member?.name || gift?.recipient_name || '');
+    setName(gift?.recipient_name || member?.name || '');
     setEmail(member?.email || '');
     setErrors({});
   }, [member?.email, member?.name, gift?.recipient_name]);

--- a/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
@@ -123,6 +123,24 @@ describe.each([
 });
 
 describe('BetaGiftRedemptionPage', () => {
+  test('shows the intended recipient name when a different member is logged in', () => {
+    const personalizedGift = {
+      ...gift,
+      buyer_name: 'Morgan',
+      recipient_name: 'Taylor',
+    };
+    const { getByText, queryByText } = renderGiftRedemptionPage(BetaGiftRedemptionPage, {
+      member: member.free,
+      pageData: {
+        token: 'gift-token-123',
+        gift: personalizedGift,
+      },
+    });
+
+    expect(getByText('Taylor')).toBeInTheDocument();
+    expect(queryByText(member.free.name)).not.toBeInTheDocument();
+  });
+
   test('presents the buyer details and prefills the intended recipient name', () => {
     const personalizedGift = {
       ...gift,


### PR DESCRIPTION
no issue

Gift redemption should keep a personalized gift addressed to its intended recipient, even when the buyer or another member opens the link while signed in.

- Preferred the stored recipient name over the signed-in member name
- Retained the member name as a fallback for gifts without a recipient name
- Added regression coverage for signed-in viewers