### PR TITLE
Added gift recipient email prefill

### DIFF
--- a/apps/portal/src/components/pages/beta-gift-redemption-page.jsx
+++ b/apps/portal/src/components/pages/beta-gift-redemption-page.jsx
@@ -60,7 +60,7 @@ const BetaGiftRedemptionPage = () => {
   const gift = pageData?.gift;
   const isLoggedIn = !!member;
   const [name, setName] = useState(gift?.recipient_name || member?.name || '');
-  const [email, setEmail] = useState(member?.email || '');
+  const [email, setEmail] = useState(member?.email || gift?.recipient_email || '');
   const [errors, setErrors] = useState({});
   const [showDetails, setShowDetails] = useState(false);
   const { cardRef, containerProps: cardTiltProps } = useCardTilt();
@@ -69,9 +69,9 @@ const BetaGiftRedemptionPage = () => {
     // Prefill with the recipient name the buyer entered, so the gift card
     // is personal before the recipient types anything.
     setName(gift?.recipient_name || member?.name || '');
-    setEmail(member?.email || '');
+    setEmail(member?.email || gift?.recipient_email || '');
     setErrors({});
-  }, [member?.email, member?.name, gift?.recipient_name]);
+  }, [member?.email, member?.name, gift?.recipient_email, gift?.recipient_name]);
 
   useEffect(() => {
     if (gift) {

--- a/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
@@ -141,17 +141,17 @@ describe('BetaGiftRedemptionPage', () => {
     expect(queryByText(member.free.name)).not.toBeInTheDocument();
   });
 
-  test('presents the buyer details and prefills the intended recipient name', () => {
+  test('presents the buyer details and prefills the intended recipient details', async () => {
     const personalizedGift = {
       ...gift,
       buyer_name: 'Jamie',
       recipient_name: 'Taylor',
+      recipient_email: 'taylor@example.com',
       message: 'Enjoy this!',
       expires_at: '2030-01-01T00:00:00.000Z',
     };
-    const { container, getByLabelText, getByTestId, getByText } = renderGiftRedemptionPage(
-      BetaGiftRedemptionPage,
-      {
+    const { container, getByLabelText, getByRole, getByTestId, getByText, mockDoActionFn } =
+      renderGiftRedemptionPage(BetaGiftRedemptionPage, {
         site: {
           ...testSite,
           url: 'https://example.com/',
@@ -162,10 +162,10 @@ describe('BetaGiftRedemptionPage', () => {
           token: 'gift-token-123',
           gift: personalizedGift,
         },
-      },
-    );
+      });
 
     expect(getByLabelText(/your name/i)).toHaveValue('Taylor');
+    expect(getByLabelText(/your email/i)).toHaveValue('taylor@example.com');
     expect(getByLabelText(/your email/i)).toHaveFocus();
     const subtitle = container.querySelector('.gh-portal-gift-checkout-subtitle');
     expect(subtitle).toHaveTextContent(
@@ -175,6 +175,16 @@ describe('BetaGiftRedemptionPage', () => {
     expect(getByTestId('gift-message')).toHaveTextContent('Enjoy this!');
     expect(getByTestId('gift-message')).toHaveTextContent('Jamie');
     expect(getByText(/This gift can only be redeemed once and expires on/i)).toBeInTheDocument();
+
+    fireEvent.click(getByRole('button', { name: 'Redeem your gift' }));
+
+    await waitFor(() => {
+      expect(mockDoActionFn).toHaveBeenCalledWith('redeemGift', {
+        email: 'taylor@example.com',
+        name: 'Taylor',
+        giftToken: 'gift-token-123',
+      });
+    });
   });
 
   test('presents the claim deadline in the publication locale and timezone', () => {

--- a/ghost/core/core/server/services/gifts/CONTEXT.md
+++ b/ghost/core/core/server/services/gifts/CONTEXT.md
@@ -37,7 +37,7 @@ The buyer's chosen way of handing over a gift subscription: the publication emai
 _Avoid_: Delivery mode
 
 **Redemption link**:
-A single-use, time-limited link through which a purchased gift subscription can be viewed and claimed. Its bearer may see the gift's buyer name, intended recipient name, and personal message, but not email-routing or delivery details.
+A single-use, time-limited link through which a purchased gift subscription can be viewed and claimed. Its bearer may see the gift's buyer name, intended recipient name, recipient email, and personal message; the intended recipient does not reserve redemption.
 _Avoid_: Gift Link
 
 **Gift redemption**:

--- a/ghost/core/core/server/services/gifts/gift-delivery-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-delivery-bookshelf-repository.ts
@@ -24,6 +24,10 @@ export interface GiftDeliveryRepository {
     giftId: string,
     options?: RepositoryTransactionOptions,
   ): Promise<GiftDeliveryData | null>;
+  getByGiftToken(
+    giftToken: string,
+    options?: RepositoryTransactionOptions,
+  ): Promise<GiftDeliveryData | null>;
   getByProviderMessageId(providerMessageId: string): Promise<GiftDeliveryData | null>;
   findRecoverableForPurchasedGifts(
     now: Date,
@@ -122,6 +126,20 @@ export class GiftDeliveryBookshelfRepository implements GiftDeliveryRepository {
     const model = await this.model.findOne({ gift_id: giftId }, { require: false, ...options });
 
     return model ? decodeGiftDeliveryRow(model.toJSON()) : null;
+  }
+
+  async getByGiftToken(
+    giftToken: string,
+    options: RepositoryTransactionOptions = {},
+  ): Promise<GiftDeliveryData | null> {
+    const db = options.transacting ?? this.knex;
+    const row = await db('gift_deliveries')
+      .select('gift_deliveries.*')
+      .join('gifts', 'gifts.id', 'gift_deliveries.gift_id')
+      .where('gifts.token', giftToken)
+      .first();
+
+    return row ? decodeGiftDeliveryRow(row) : null;
   }
 
   async getByProviderMessageId(providerMessageId: string): Promise<GiftDeliveryData | null> {

--- a/ghost/core/core/server/services/gifts/gift-delivery-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-delivery-service.ts
@@ -124,6 +124,15 @@ export class GiftDeliveryService {
     return delivery.id;
   }
 
+  async getRecipientEmailForGift(
+    giftToken: string,
+    options: RepositoryTransactionOptions = {},
+  ): Promise<string | null> {
+    const delivery = await this.deps.giftDeliveryRepository.getByGiftToken(giftToken, options);
+
+    return delivery?.recipientEmail ?? null;
+  }
+
   async dispatchForGift({
     giftId,
   }: {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -9,6 +9,7 @@ import type {
   GiftEventBrowseOptions,
   GiftEventPage,
   GiftRepository,
+  RepositoryTransactionOptions,
 } from './gift-bookshelf-repository';
 import type { GiftDeliveryDispatchResult, GiftDeliveryService } from './gift-delivery-service';
 import type { SignedFlushScheduler } from '../../adapters/scheduling/signed-flush-scheduler';
@@ -175,7 +176,11 @@ interface GiftServiceDeps {
   giftRepository: GiftRepository;
   giftDeliveryService: Pick<
     GiftDeliveryService,
-    'createForCheckout' | 'dispatchForGift' | 'cancelPendingForGift' | 'recoverPending'
+    | 'createForCheckout'
+    | 'getRecipientEmailForGift'
+    | 'dispatchForGift'
+    | 'cancelPendingForGift'
+    | 'recoverPending'
   >;
   memberRepository: MemberRepository;
   tiersService: TiersService;
@@ -286,6 +291,7 @@ export interface GiftRedemption {
   amount: number;
   buyer_name: string | null;
   recipient_name: string | null;
+  recipient_email: string | null;
   message: string | null;
   expires_at: Date;
   consumes_at: Date | null;
@@ -893,7 +899,7 @@ export class GiftService {
         transacting,
         newMember: input.newMember,
       });
-      const redemption = await this.serializeRedemption(redeemed);
+      const redemption = await this.serializeRedemption(redeemed, { transacting });
 
       return { redeemed, member, redemption };
     };
@@ -1567,7 +1573,14 @@ export class GiftService {
     return true;
   }
 
-  private async serializeRedemption(gift: Gift): Promise<GiftRedemption> {
+  private async serializeRedemption(
+    gift: Gift,
+    options: RepositoryTransactionOptions = {},
+  ): Promise<GiftRedemption> {
+    const recipientEmail = await this.deps.giftDeliveryService.getRecipientEmailForGift(
+      gift.token,
+      options,
+    );
     const tier = await this.deps.tiersService.api.read(gift.tierId);
 
     if (!tier) {
@@ -1586,6 +1599,7 @@ export class GiftService {
       amount: gift.amount,
       buyer_name: gift.buyerName,
       recipient_name: gift.recipientName,
+      recipient_email: recipientEmail,
       message: gift.personalMessage,
       expires_at: gift.expiresAt!,
       consumes_at: gift.consumesAt,

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -856,6 +856,12 @@ describe('Gift Subscriptions', function () {
         recipient_name: 'Taylor',
         personal_message: 'Enjoy!',
       });
+      await models.GiftDelivery.add({
+        gift_id: gift.id,
+        recipient_email: 'taylor@example.com',
+        status: 'failed',
+        outcome: 'permanent_failed',
+      });
 
       const { body } = await membersAgent
         .get(`/api/gifts/${gift.get('token')}/redeem/`)
@@ -869,6 +875,7 @@ describe('Gift Subscriptions', function () {
       assert.equal(body.gifts[0].amount, 5000);
       assert.equal(body.gifts[0].buyer_name, 'Jamie');
       assert.equal(body.gifts[0].recipient_name, 'Taylor');
+      assert.equal(body.gifts[0].recipient_email, 'taylor@example.com');
       assert.equal(body.gifts[0].message, 'Enjoy!');
       assert.equal(body.gifts[0].expires_at, new Date(gift.get('expires_at')).toISOString());
       assert.deepEqual(body.gifts[0].tier, {
@@ -881,7 +888,6 @@ describe('Gift Subscriptions', function () {
           .map((item) => item.name),
       });
       assert.equal(body.gifts[0].buyer_email, undefined);
-      assert.equal(body.gifts[0].recipient_email, undefined);
       assert.equal(body.gifts[0].delivery_status, undefined);
       assert.equal(body.gifts[0].redeemed_at, undefined);
       assert.equal(body.gifts[0].status, undefined);
@@ -897,6 +903,7 @@ describe('Gift Subscriptions', function () {
       const { body } = await agent.get(`/api/gifts/${gift.get('token')}/redeem/`).expectStatus(200);
 
       assert.equal(body.gifts[0].token, gift.get('token'));
+      assert.equal(body.gifts[0].recipient_email, null);
     });
 
     it('returns 404 when the gift token does not exist', async function () {
@@ -975,6 +982,11 @@ describe('Gift Subscriptions', function () {
         const agent = membersAgent.duplicate();
         const email = `gift-post-free-${giftSequence + 1}@example.com`;
         const gift = await createGift();
+        await models.GiftDelivery.add({
+          gift_id: gift.id,
+          recipient_email: 'recipient@example.com',
+          status: 'pending',
+        });
 
         await agent.loginAs(email);
 
@@ -990,6 +1002,7 @@ describe('Gift Subscriptions', function () {
         const member = await models.Member.findOne({ email }, { require: true });
 
         assert.equal(body.gifts[0].token, gift.get('token'));
+        assert.equal(body.gifts[0].recipient_email, 'recipient@example.com');
         assert.equal(body.gifts[0].status, undefined);
         assert.ok(body.gifts[0].consumes_at);
         assert.equal(member.get('status'), 'gift');

--- a/ghost/core/test/integration/services/gifts/gift-delivery-bookshelf-repository.test.ts
+++ b/ghost/core/test/integration/services/gifts/gift-delivery-bookshelf-repository.test.ts
@@ -117,6 +117,16 @@ describe('GiftDeliveryBookshelfRepository (integration)', function () {
     return { gift, delivery };
   }
 
+  it('finds an email delivery by gift token', async function () {
+    const { gift, delivery } = await createPendingEmailGift({ deliveryStatus: 'failed' });
+
+    assert.equal(
+      (await deliveryRepository.getByGiftToken(gift.get('token')))?.recipientEmail,
+      delivery.get('recipient_email'),
+    );
+    assert.equal(await deliveryRepository.getByGiftToken('missing-token'), null);
+  });
+
   it('allows exactly one concurrent caller to start a pending delivery', async function () {
     const startedAt = new Date();
     startedAt.setMilliseconds(0);

--- a/ghost/core/test/unit/server/services/gifts/gift-delivery-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-delivery-service.test.ts
@@ -50,6 +50,7 @@ describe('GiftDeliveryService', function () {
     giftDeliveryRepository = {
       getById: sinon.stub().resolves(null),
       getByGiftId: sinon.stub().resolves(null),
+      getByGiftToken: sinon.stub().resolves(null),
       getByProviderMessageId: sinon.stub().resolves(null),
       findRecoverableForPurchasedGifts: sinon.stub().resolves([]),
       findScheduledTimesForPurchasedGifts: sinon.stub().resolves([]),
@@ -109,6 +110,31 @@ describe('GiftDeliveryService', function () {
 
   afterEach(function () {
     sinon.restore();
+  });
+
+  it('returns the recipient email for a gift regardless of delivery state', async function () {
+    giftDeliveryRepository.getByGiftToken.resolves(
+      buildGiftDelivery({
+        recipientEmail: 'recipient@example.com',
+        status: 'failed',
+        outcome: 'permanent_failed',
+      }),
+    );
+    const service = createService();
+
+    assert.equal(
+      await service.getRecipientEmailForGift('gift-token', { transacting }),
+      'recipient@example.com',
+    );
+    sinon.assert.calledOnceWithExactly(giftDeliveryRepository.getByGiftToken, 'gift-token', {
+      transacting,
+    });
+  });
+
+  it('returns null when a gift has no email delivery', async function () {
+    const service = createService();
+
+    assert.equal(await service.getRecipientEmailForGift('gift-token'), null);
   });
 
   it('dispatches an immediate send for a pending delivery after purchase', async function () {

--- a/ghost/core/test/unit/server/services/gifts/gift-service-interface.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service-interface.test.ts
@@ -65,6 +65,7 @@ describe('GiftService interface', function () {
     };
     const giftDeliveryService = {
       createForCheckout: sinon.stub().resolves(),
+      getRecipientEmailForGift: sinon.stub().resolves(null),
       dispatchForGift: sinon.stub().resolves(null),
       cancelPendingForGift: sinon.stub().resolves(false),
     };
@@ -652,6 +653,7 @@ describe('GiftService interface', function () {
       amount: 5000,
       buyer_name: 'Jamie',
       recipient_name: 'Taylor',
+      recipient_email: null,
       message: 'Enjoy!',
       expires_at: new Date('2030-01-01T00:00:00.000Z'),
       consumes_at: null,

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -87,6 +87,7 @@ describe('GiftService', function () {
   let giftRepository: GiftRepositoryStub;
   let giftDeliveryService: {
     createForCheckout: sinon.SinonStub;
+    getRecipientEmailForGift: sinon.SinonStub;
     dispatchForGift: sinon.SinonStub;
     cancelPendingForGift: sinon.SinonStub;
     recoverPending: sinon.SinonStub;
@@ -177,6 +178,7 @@ describe('GiftService', function () {
     };
     giftDeliveryService = {
       createForCheckout: sinon.stub().resolves(undefined),
+      getRecipientEmailForGift: sinon.stub().resolves(null),
       dispatchForGift: sinon.stub().resolves(null),
       cancelPendingForGift: sinon.stub().resolves(false),
       recoverPending: sinon.stub().resolves({ sentCount: 0, skippedCount: 0, failedCount: 0 }),
@@ -838,11 +840,18 @@ describe('GiftService', function () {
       const service = createService();
 
       giftRepository.getByToken.resolves(gift);
+      giftDeliveryService.getRecipientEmailForGift.resolves('recipient@example.com');
 
       const result = await service.getRedeemable({ token: 'gift-token', memberStatus: 'free' });
 
       sinon.assert.calledOnceWithExactly(giftRepository.getByToken, 'gift-token');
+      sinon.assert.calledOnceWithExactly(
+        giftDeliveryService.getRecipientEmailForGift,
+        'gift-token',
+        {},
+      );
       assert.equal(result.token, gift.token);
+      assert.equal(result.recipient_email, 'recipient@example.com');
       assert.equal('buyerEmail' in result, false);
     });
 
@@ -1668,6 +1677,7 @@ describe('GiftService', function () {
       memberGet.withArgs('email').returns('member@example.com');
 
       giftRepository.getByToken.resolves(gift);
+      giftDeliveryService.getRecipientEmailForGift.resolves('recipient@example.com');
       memberRepository.get.resolves({
         id: 'member_1',
         get: memberGet,
@@ -1707,6 +1717,11 @@ describe('GiftService', function () {
       sinon.assert.calledOnceWithExactly(giftDeliveryService.cancelPendingForGift, redeemed.token, {
         transacting,
       });
+      sinon.assert.calledOnceWithExactly(
+        giftDeliveryService.getRecipientEmailForGift,
+        redeemed.token,
+        { transacting },
+      );
       sinon.assert.calledTwice(tiersService.api.read);
       sinon.assert.alwaysCalledWithExactly(tiersService.api.read, 'tier_1');
       sinon.assert.calledOnceWithExactly(staffServiceEmails.notifyGiftSubscriptionStarted, {
@@ -1722,6 +1737,7 @@ describe('GiftService', function () {
       assert.equal(redeemed.redeemerMemberId, 'member_1');
       assert.notEqual(redeemed.consumesAt, null);
       assert.equal(redemption.token, 'gift-token');
+      assert.equal(redemption.recipient_email, 'recipient@example.com');
       assert.deepEqual(redemption.consumes_at, redeemed.consumesAt);
     });
 


### PR DESCRIPTION
no issue

Email-delivered gifts already know the intended recipient address, so the customized redemption flow can use it as an editable prefill instead of asking the recipient to enter it again.

- Added nullable recipient email to the shared GET and POST redemption DTO
- Read delivery details through GiftDelivery without changing the Gift model
- Prefilled only the customized Portal redemption page
- Updated the bearer-link domain contract and regression coverage