### PR TITLE
Fixed admin-x-framework typecheck assertions

### DIFF
--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -7,8 +7,8 @@ import {
 } from '../../../src/api/member-custom-fields';
 
 // Compile-time cases: the build failing is the assertion. Each `@ts-expect-error` fails the
-// build if the case it names stops being an error. Declared on one line each, because the
-// directive only covers the line below it and a spread literal reports on its inner line.
+// build if the case it names stops being an error. Directives sit immediately above the
+// property where TypeScript reports the error.
 const composite = { line1: 'a', line2: 'b', city: 'c', state: 'd', postal_code: 'e', country: 'f' };
 
 const labelled: FieldTypePresentation<'address'> = {
@@ -17,27 +17,27 @@ const labelled: FieldTypePresentation<'address'> = {
   subFields: composite,
 };
 
-// @ts-expect-error a composite missing one of the parts its value schema declares
 const missingPart: FieldTypePresentation<'address'> = {
   label: 'Address',
   input: 'address',
+  // @ts-expect-error a composite missing one of the parts its value schema declares
   subFields: { line1: 'a', line2: 'b', city: 'c', state: 'd', country: 'f' },
 };
 
-// @ts-expect-error a composite naming a part its value schema does not declare
 const unknownPart: FieldTypePresentation<'address'> = {
   label: 'Address',
   input: 'address',
+  // @ts-expect-error a composite naming a part its value schema does not declare
   subFields: { ...composite, county: 'g' },
 };
 
 // @ts-expect-error a composite with no part labels at all
 const unlabelled: FieldTypePresentation<'address'> = { label: 'Address', input: 'address' };
 
-// @ts-expect-error a type whose value is one thing has no parts to name
 const scalarWithParts: FieldTypePresentation<'short_text'> = {
   label: 'Short text',
   input: 'text',
+  // @ts-expect-error a type whose value is one thing has no parts to name
   subFields: { line1: 'a' },
 };
 


### PR DESCRIPTION
no refs

## Context

These compile-time assertions were deliberately written with each invalid declaration on a single line. Because `@ts-expect-error` only applies to the immediately following line, TypeScript originally reported and suppressed each expected error on the declaration line.

The repository-wide `oxfmt` migration in #30184 expanded several of those object declarations across multiple lines. TypeScript then reported the invalid `subFields` values on their property lines, while the expectations remained above the `const` declarations. That left the expectations unused (`TS2578`) and allowed the intended type errors to escape. Because these typechecks were not running as a discrete CI task, the formatting-only change landed without exposing the regression.

## Changes

- Moved each affected `@ts-expect-error` directly above the `subFields` property where TypeScript now reports the error.
- Kept the single-line assertion unchanged where TypeScript still reports the error on the declaration line.
- Updated the explanatory comment to document the formatter-compatible placement requirement.

This preserves the original intent: the file passes while the invalid examples remain rejected, and it will fail if those type constraints are accidentally weakened.

## Testing

- `pnpm nx run @tryghost/admin-x-framework:test:types --skip-nx-cache`
- `pnpm nx run @tryghost/admin-x-framework:lint`