### PR TITLE
🐛 Fixed multi-domain email analytics cursors

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -24,6 +24,11 @@ type FetchDataScheduled = FetchData & { schedule?: { begin: Date; end: Date } };
 
 type EmailAnalyticsEvent = 'delivered' | 'opened' | 'failed' | 'unsubscribed' | 'complained';
 
+type FetchEventsResult = {
+  /** Earliest processed timestamp for a sending domain that stopped at its event limit. */
+  safeCursor?: Date;
+};
+
 /**
  * Names of the jobs this service runs. Each pipeline needs its own set so their
  * cursors don't overwrite each other in the jobs table.
@@ -68,7 +73,7 @@ type FetchEvents = (options: {
   end: Date;
   maxEvents: number;
   events?: EmailAnalyticsEvent[];
-}) => Promise<void>;
+}) => Promise<FetchEventsResult | void>;
 
 const TRUST_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 const FETCH_LATEST_END_MARGIN_MS = 1 * 60 * 1000; // Do not fetch events newer than 1 minute (yet). Reduces the chance of having missed events in fetchLatest.
@@ -539,13 +544,20 @@ export class EmailAnalyticsService {
     };
 
     try {
-      await this.#fetchEvents({
+      const fetchResult = await this.#fetchEvents({
         batchHandler: processBatch,
         begin,
         end,
         maxEvents,
         events: eventTypes,
       });
+
+      if (
+        fetchResult?.safeCursor &&
+        (!fetchData.lastEventTimestamp || fetchResult.safeCursor < fetchData.lastEventTimestamp)
+      ) {
+        fetchData.lastEventTimestamp = fetchResult.safeCursor;
+      }
     } catch (err) {
       if (!(err instanceof Error) || err.message !== 'Fetching canceled') {
         logging.error('[EmailAnalytics] Error while fetching');

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -559,6 +559,10 @@ export class EmailAnalyticsService {
         fetchData.lastEventTimestamp = fetchResult.safeCursor;
       }
     } catch (err) {
+      // A fetch can process events from one domain before another domain fails. Keep the
+      // in-memory cursor at the start of this run so the next attempt retries every domain.
+      fetchData.lastEventTimestamp = begin;
+
       if (!(err instanceof Error) || err.message !== 'Fetching canceled') {
         logging.error('[EmailAnalytics] Error while fetching');
         logging.error(err);

--- a/ghost/core/core/server/services/email-analytics/fetch-mailgun-events.ts
+++ b/ghost/core/core/server/services/email-analytics/fetch-mailgun-events.ts
@@ -9,7 +9,7 @@ type FetchMailgunEventsOptions = {
   settings: { get: (key: string) => unknown };
   tags: string[];
   batchHandler: Function;
-  /** Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks. */
+  /** Per-domain soft maximum. We stop fetching a domain after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks. */
   maxEvents?: number;
   begin?: Date;
   end?: Date;

--- a/ghost/core/core/server/services/lib/mailgun-client.js
+++ b/ghost/core/core/server/services/lib/mailgun-client.js
@@ -165,8 +165,8 @@ module.exports = class MailgunClient {
    * @param {Object} mailgunOptions
    * @param {Function} batchHandler
    * @param {Object} options
-   * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
-   * @returns {Promise<void>}
+   * @param {number} [options.maxEvents] Per-domain soft maximum. We stop fetching a domain after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+   * @returns {Promise<{safeCursor?: Date} | void>}
    */
   async fetchEvents(mailgunOptions, batchHandler, { maxEvents = Infinity } = {}) {
     const mailgunInstance = this.getInstance();
@@ -184,12 +184,33 @@ module.exports = class MailgunClient {
     // Determine which domains to fetch from
     const domains = this.#getDomainsToFetch(mailgunConfig);
 
+    const cappedDomainCursors = [];
+
     // Fetch events from each domain
     for (const domain of domains) {
-      await this.#fetchEventsFromDomain(domain, mailgunInstance, mailgunOptions, batchHandler, {
-        maxEvents,
-      });
+      const result = await this.#fetchEventsFromDomain(
+        domain,
+        mailgunInstance,
+        mailgunOptions,
+        batchHandler,
+        { maxEvents },
+      );
+
+      if (
+        result.capped &&
+        result.lastEventTimestamp &&
+        Number.isFinite(result.lastEventTimestamp.getTime())
+      ) {
+        cappedDomainCursors.push(result.lastEventTimestamp);
+      }
     }
+
+    const safeCursor = cappedDomainCursors.reduce(
+      (earliest, cursor) => (!earliest || cursor < earliest ? cursor : earliest),
+      undefined,
+    );
+
+    return { safeCursor };
   }
 
   /**
@@ -220,7 +241,7 @@ module.exports = class MailgunClient {
    * @param {Function} batchHandler
    * @param {Object} options
    * @param {number} options.maxEvents
-   * @returns {Promise<void>}
+   * @returns {Promise<{capped: boolean, eventCount: number, lastEventTimestamp?: Date}>}
    */
   async #fetchEventsFromDomain(
     domain,
@@ -235,6 +256,9 @@ module.exports = class MailgunClient {
 
     let batchCount = 0;
     let totalBatchTime = 0;
+    let eventCount = 0;
+    let lastEventTimestamp;
+    let capped = false;
 
     try {
       let page = await this.getEventsFromMailgun(mailgunInstance, domain, mailgunOptions);
@@ -248,7 +272,6 @@ module.exports = class MailgunClient {
         `[MailgunClient fetchEventsFromDomain ${domain}]: finished fetching first page with ${events.length} events`,
       );
 
-      let eventCount = 0;
       const beginTimestamp = mailgunOptions.begin
         ? Math.ceil(mailgunOptions.begin * 1000)
         : undefined; // ceil here if we have rounding errors
@@ -263,6 +286,13 @@ module.exports = class MailgunClient {
         totalBatchTime += batchDuration;
 
         eventCount += events.length;
+        const batchLastEventTimestamp = events[events.length - 1].timestamp;
+        if (
+          batchLastEventTimestamp &&
+          (!lastEventTimestamp || batchLastEventTimestamp > lastEventTimestamp)
+        ) {
+          lastEventTimestamp = batchLastEventTimestamp;
+        }
 
         if (
           eventCount >= maxEvents &&
@@ -270,6 +300,7 @@ module.exports = class MailgunClient {
             !events[events.length - 1].timestamp ||
             events[events.length - 1].timestamp.getTime() > beginTimestamp)
         ) {
+          capped = true;
           break;
         }
 
@@ -294,10 +325,15 @@ module.exports = class MailgunClient {
       const overallEndTime = Date.now();
       const totalDuration = overallEndTime - overallStartTime;
       const averageBatchTime = batchCount > 0 ? totalBatchTime / batchCount : 0;
+      const cursor = Number.isFinite(lastEventTimestamp?.getTime())
+        ? lastEventTimestamp.toISOString()
+        : 'none';
 
       logging.info(
-        `[MailgunClient fetchEventsFromDomain ${domain}]: Processed ${batchCount} batches in ${(totalDuration / 1000).toFixed(2)}s. Average batch time: ${(averageBatchTime / 1000).toFixed(2)}s`,
+        `[MailgunClient fetchEventsFromDomain ${domain}]: Processed ${eventCount} events in ${batchCount} batches in ${(totalDuration / 1000).toFixed(2)}s. Average batch time: ${(averageBatchTime / 1000).toFixed(2)}s. Status: ${capped ? 'capped' : 'exhausted'}. Cursor: ${cursor}`,
       );
+
+      return { capped, eventCount, lastEventTimestamp };
     } catch (error) {
       logging.error(`[MailgunClient fetchEventsFromDomain ${domain}]: Error fetching events`);
       logging.error(error);

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -740,6 +740,35 @@ describe('EmailAnalyticsService', function () {
         );
       });
 
+      it('retries from the original cursor after a fetch error', async function () {
+        const initialCursor = new Date(Date.now() - 10 * 60 * 1000);
+        const fetchBegins: Date[] = [];
+        const eventProcessor = createStubEventProcessor();
+        eventProcessor.processBatch.callsFake(async (_events, _result, fetchData) => {
+          fetchData.lastEventTimestamp = new Date(initialCursor.getTime() + 1000);
+        });
+        const fetchEvents = sinon.stub().callsFake(async ({ batchHandler, begin }) => {
+          fetchBegins.push(begin);
+          await batchHandler([{ timestamp: new Date(initialCursor.getTime() + 1000) }]);
+          throw new Error('fallback fetch failed');
+        });
+        const service = createService({
+          queries: {
+            getLastEventTimestamp: sinon.stub().resolves(initialCursor),
+            setJobTimestamp: sinon.stub().resolves(),
+            setJobStatus: sinon.stub().resolves(),
+          },
+          fetchEvents,
+          createEventProcessor: () => eventProcessor,
+        });
+
+        await assert.rejects(service.fetchLatestNonOpenedEvents(), /fallback fetch failed/);
+        await assert.rejects(service.fetchLatestNonOpenedEvents(), /fallback fetch failed/);
+
+        assert.deepEqual(fetchBegins, [initialCursor, initialCursor]);
+        assert.deepEqual(service.getStatus().latest.lastEventTimestamp, initialCursor);
+      });
+
       it('persists and advances the last processed event timestamp', async function () {
         const lastEventTimestamp = new Date(Date.now() - 10_000);
         const setJobTimestamp = sinon.stub().resolves();

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -772,6 +772,72 @@ describe('EmailAnalyticsService', function () {
           new Date(lastEventTimestamp.getTime() + 1000),
         );
       });
+
+      it('resumes from a capped sending domain until all of its events are processed', async function () {
+        const newerDomainTimestamp = new Date(Date.now() - 70_000);
+        const fallbackTimestamps = [
+          new Date(Date.now() - 120_000),
+          new Date(Date.now() - 119_000),
+          new Date(Date.now() - 118_000),
+          new Date(Date.now() - 117_000),
+        ];
+        const setJobTimestamp = sinon.stub().resolves();
+        const processedEventIds = new Set<string>();
+        const eventProcessor = createStubEventProcessor();
+        eventProcessor.processBatch.callsFake(async (events, _result, fetchData) => {
+          for (const event of events) {
+            processedEventIds.add(event.id);
+            if (!fetchData.lastEventTimestamp || event.timestamp > fetchData.lastEventTimestamp) {
+              fetchData.lastEventTimestamp = event.timestamp;
+            }
+          }
+        });
+        const service = createService({
+          queries: {
+            getLastEventTimestamp: sinon.stub().resolves(),
+            setJobTimestamp,
+            setJobStatus: sinon.stub().resolves(),
+          },
+          fetchEvents: async ({ batchHandler, begin }) => {
+            const fetchIndex = fetchBegins.push(begin) - 1;
+            const firstFallbackIndex = fetchIndex;
+            const safeCursor = fallbackTimestamps[firstFallbackIndex + 1];
+
+            await batchHandler([{ id: 'primary-10', timestamp: newerDomainTimestamp }]);
+            await batchHandler([
+              {
+                id: `fallback-${firstFallbackIndex + 1}`,
+                timestamp: fallbackTimestamps[firstFallbackIndex],
+              },
+              {
+                id: `fallback-${firstFallbackIndex + 2}`,
+                timestamp: safeCursor,
+              },
+            ]);
+            return { safeCursor };
+          },
+          createEventProcessor: () => eventProcessor,
+        });
+        const fetchBegins: Date[] = [];
+
+        await service.fetchLatestNonOpenedEvents({ maxEvents: 2 });
+        await service.fetchLatestNonOpenedEvents({ maxEvents: 2 });
+        await service.fetchLatestNonOpenedEvents({ maxEvents: 2 });
+
+        assert.deepEqual(
+          setJobTimestamp
+            .getCalls()
+            .filter((call) => call.args[1] === 'finished')
+            .map((call) => call.args[2]),
+          fallbackTimestamps.slice(1),
+        );
+        assert.deepEqual(fetchBegins.slice(1), fallbackTimestamps.slice(1, 3));
+        assert.deepEqual(
+          [...processedEventIds],
+          ['primary-10', 'fallback-1', 'fallback-2', 'fallback-3', 'fallback-4'],
+        );
+        assert.deepEqual(service.getStatus().latest.lastEventTimestamp, fallbackTimestamps[3]);
+      });
     });
 
     describe('restoreScheduled', function () {

--- a/ghost/core/test/unit/server/services/email-analytics/fetch-mailgun-events.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/fetch-mailgun-events.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import sinon from 'sinon';
 
 // @ts-expect-error This module lacks type definitions.
@@ -56,6 +57,20 @@ describe('fetchMailgunEvents', function () {
     sinon.assert.calledOnceWithExactly(mailgunFetchEventsStub, MAILGUN_OPTIONS, batchHandler, {
       maxEvents: undefined,
     });
+  });
+
+  it('returns the domain-safe cursor from the Mailgun client', async function () {
+    const safeCursor = new Date('Thu Feb 25 2021 13:00:00 GMT+0000');
+    sinon.stub(MailgunClient.prototype, 'fetchEvents').resolves({ safeCursor });
+
+    const result = await fetchMailgunEvents({
+      config,
+      settings,
+      tags: DEFAULT_TAGS,
+      batchHandler: sinon.spy(),
+    });
+
+    assert.deepEqual(result, { safeCursor });
   });
 
   it('uses supplied end timestamp and max events', async function () {

--- a/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
+++ b/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
@@ -30,6 +30,31 @@ const createBatchCounter = (customHandler) => {
   return batchCounter;
 };
 
+const createEventsPage = ({ domain, nextPage, timestamps }) => ({
+  items: timestamps.map((timestamp, index) => ({
+    event: 'delivered',
+    recipient: `recipient${index}@example.com`,
+    'user-variables': {
+      'email-id': '5fbe5d9607bdfa3765dc3819',
+    },
+    message: {
+      headers: {
+        'message-id': `message-${index}@${domain}`,
+      },
+    },
+    timestamp,
+  })),
+  paging: {
+    next: `https://api.mailgun.net/v3/${domain}/events/${nextPage}`,
+  },
+});
+
+const mockEventsPage = ({ domain, mailgunOptions, nextPage, page, timestamps }) =>
+  nock('https://api.mailgun.net')
+    .get(`/v3/${domain}/events${page ? `/${page}` : ''}`)
+    .query(mailgunOptions)
+    .reply(200, createEventsPage({ domain, nextPage, timestamps }));
+
 describe('MailgunClient', function () {
   let config, settings;
 
@@ -1119,6 +1144,165 @@ describe('MailgunClient', function () {
       nock.cleanAll();
     });
 
+    it('returns the capped fallback cursor when the primary domain is exhausted further ahead', async function () {
+      setupDomainWarmingConfig(true);
+
+      const begin = 1606399300;
+      const mailgunOptions = { ...MAILGUN_OPTIONS, begin };
+
+      const primaryPageMock = mockEventsPage({
+        domain: 'primary.com',
+        mailgunOptions,
+        nextPage: 'primary-next',
+        timestamps: [begin + 10],
+      });
+      const primaryEmptyPageMock = mockEventsPage({
+        domain: 'primary.com',
+        mailgunOptions,
+        nextPage: 'primary-empty',
+        page: 'primary-next',
+        timestamps: [],
+      });
+      const fallbackPageMock = mockEventsPage({
+        domain: 'fallback.com',
+        mailgunOptions,
+        nextPage: 'fallback-unconsumed',
+        timestamps: [begin + 1, begin + 2],
+      });
+      const fallbackNextPageMock = mockEventsPage({
+        domain: 'fallback.com',
+        mailgunOptions,
+        nextPage: 'fallback-empty',
+        page: 'fallback-unconsumed',
+        timestamps: [begin + 3],
+      });
+
+      const processedTimestamps = [];
+
+      const result = await new MailgunClient({ config, settings }).fetchEvents(
+        mailgunOptions,
+        (events) => {
+          processedTimestamps.push(...events.map((event) => event.timestamp));
+        },
+        { maxEvents: 2 },
+      );
+
+      assert.equal(primaryPageMock.isDone(), true);
+      assert.equal(primaryEmptyPageMock.isDone(), true);
+      assert.equal(fallbackPageMock.isDone(), true);
+      assert.equal(fallbackNextPageMock.isDone(), false);
+      assert.deepEqual(processedTimestamps, [
+        new Date((begin + 10) * 1000),
+        new Date((begin + 1) * 1000),
+        new Date((begin + 2) * 1000),
+      ]);
+      assert.deepEqual(result, {
+        safeCursor: new Date((begin + 2) * 1000),
+      });
+    });
+
+    it('returns the capped primary cursor when the fallback domain is exhausted further ahead', async function () {
+      setupDomainWarmingConfig(true);
+
+      const begin = 1606399300;
+      const mailgunOptions = { ...MAILGUN_OPTIONS, begin };
+
+      const primaryPageMock = mockEventsPage({
+        domain: 'primary.com',
+        mailgunOptions,
+        nextPage: 'primary-unconsumed',
+        timestamps: [begin + 1, begin + 2],
+      });
+      const primaryNextPageMock = mockEventsPage({
+        domain: 'primary.com',
+        mailgunOptions,
+        nextPage: 'primary-empty',
+        page: 'primary-unconsumed',
+        timestamps: [begin + 3],
+      });
+      const fallbackPageMock = mockEventsPage({
+        domain: 'fallback.com',
+        mailgunOptions,
+        nextPage: 'fallback-next',
+        timestamps: [begin + 10],
+      });
+      const fallbackEmptyPageMock = mockEventsPage({
+        domain: 'fallback.com',
+        mailgunOptions,
+        nextPage: 'fallback-empty',
+        page: 'fallback-next',
+        timestamps: [],
+      });
+
+      const processedTimestamps = [];
+      const result = await new MailgunClient({ config, settings }).fetchEvents(
+        mailgunOptions,
+        (events) => {
+          processedTimestamps.push(...events.map((event) => event.timestamp));
+        },
+        { maxEvents: 2 },
+      );
+
+      assert.equal(primaryPageMock.isDone(), true);
+      assert.equal(primaryNextPageMock.isDone(), false);
+      assert.equal(fallbackPageMock.isDone(), true);
+      assert.equal(fallbackEmptyPageMock.isDone(), true);
+      assert.deepEqual(processedTimestamps, [
+        new Date((begin + 1) * 1000),
+        new Date((begin + 2) * 1000),
+        new Date((begin + 10) * 1000),
+      ]);
+      assert.deepEqual(result, {
+        safeCursor: new Date((begin + 2) * 1000),
+      });
+    });
+
+    it('returns the earliest capped cursor when both domains reach their limits', async function () {
+      setupDomainWarmingConfig(true);
+
+      const begin = 1606399300;
+      const mailgunOptions = { ...MAILGUN_OPTIONS, begin };
+
+      mockEventsPage({
+        domain: 'primary.com',
+        mailgunOptions,
+        nextPage: 'primary-unconsumed',
+        timestamps: [begin + 5, begin + 6],
+      });
+      const primaryNextPageMock = mockEventsPage({
+        domain: 'primary.com',
+        mailgunOptions,
+        nextPage: 'primary-empty',
+        page: 'primary-unconsumed',
+        timestamps: [begin + 7],
+      });
+      mockEventsPage({
+        domain: 'fallback.com',
+        mailgunOptions,
+        nextPage: 'fallback-unconsumed',
+        timestamps: [begin + 1, begin + 2],
+      });
+      const fallbackNextPageMock = mockEventsPage({
+        domain: 'fallback.com',
+        mailgunOptions,
+        nextPage: 'fallback-empty',
+        page: 'fallback-unconsumed',
+        timestamps: [begin + 3],
+      });
+
+      const result = await new MailgunClient({ config, settings }).fetchEvents(
+        mailgunOptions,
+        () => {},
+        { maxEvents: 2 },
+      );
+
+      assert.equal(primaryNextPageMock.isDone(), false);
+      assert.equal(fallbackNextPageMock.isDone(), false);
+      assert.deepEqual(result, {
+        safeCursor: new Date((begin + 2) * 1000),
+      });
+    });
+
     it('fetches from both primary and fallback domains when enabled', async function () {
       setupDomainWarmingConfig(true);
 
@@ -1141,12 +1325,13 @@ describe('MailgunClient', function () {
 
       const counter = createBatchCounter();
       const mailgunClient = new MailgunClient({ config, settings });
-      await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
+      const result = await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
       assert.equal(primaryMock.isDone(), true);
       assert.equal(fallbackMock.isDone(), true);
       assert.equal(counter.batches, 2);
       assert.equal(counter.events, 6);
+      assert.deepEqual(result, { safeCursor: undefined });
     });
 
     it('only fetches from primary when disabled', async function () {


### PR DESCRIPTION
closes [ONC-1965](https://linear.app/ghost/issue/ONC-1965/email-analytics-prevent-a-shared-cursor-from-skipping-capped-sending)

## Why

During custom sending-domain warming, Ghost fetches analytics events from both the custom and fallback Mailgun domains. Both domains update one shared cursor.

If one domain reached its event limit while the other returned newer events and finished pagination, the shared cursor advanced to the newer timestamp. The next run then started after events that were still waiting on the capped domain.

## What changed

`MailgunClient` now returns the last processed timestamp for each domain that stopped at its event limit. `EmailAnalyticsService` stores the earliest of those timestamps, which keeps the remaining pages reachable. A domain that reaches the end of its pages does not hold the cursor back.

The fix uses the existing shared fetch path, so it applies to every analytics lane. Mailgun request behavior stays the same: domain order, filters, pagination, request count, per-domain limit, and same-timestamp handling are unchanged.

Tests cover either domain being capped, both domains being capped, and progress over repeated runs.

## Testing

- Focused email analytics and Mailgun unit suite: 213 tests passed
- Focused unit coverage run: 92.72% line coverage and 91.74% branch coverage across the changed production files; every changed executable statement was hit
- `pnpm --dir ghost/core lint:types`

Codecov reports 22.03% patch coverage because Ghost currently uploads only E2E and integration coverage, and those suites stub `MailgunClient`. Patch coverage is disabled in `.github/codecov.yml`; the project coverage check passed.