### PR TITLE
🎨 Improved resilience by skipping renders for disconnected clients

### DIFF
--- a/ghost/core/core/frontend/services/rendering/renderer.js
+++ b/ghost/core/core/frontend/services/rendering/renderer.js
@@ -15,6 +15,14 @@ const messages = {
  * @param {Object} data
  */
 module.exports = function renderer(req, res, data) {
+  // CASE: client hung up while we fetched data. Rendering into a dead socket is
+  // wasted work that lengthens the queue under load. 499 = client closed request.
+  if (res.destroyed && !res.writableEnded) {
+    debug('Client gone before render, skipping: ' + req.originalUrl);
+    res.statusCode = 499;
+    return;
+  }
+
   // Set response context
   setContext(req, res, data);
 
@@ -42,6 +50,13 @@ module.exports = function renderer(req, res, data) {
         );
       }
       return req.next(err);
+    }
+
+    // The render itself can take seconds; the client may have gone in the meantime.
+    if (res.destroyed && !res.writableEnded) {
+      debug('Client gone during render, discarding: ' + req.originalUrl);
+      res.statusCode = 499;
+      return;
     }
 
     // CASE: a {{#get}} or {{#collection}} helper aborted during rendering, so the

--- a/ghost/core/test/unit/frontend/services/rendering/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/renderer.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const renderer = require('../../../../../core/frontend/services/rendering/renderer');
 
@@ -14,6 +15,9 @@ describe('Renderer', function () {
     res = {
       locals: {},
       routerOptions: {},
+      // an open response: both are always booleans on a real ServerResponse
+      destroyed: false,
+      writableEnded: false,
       // pre-set so templates.setTemplate returns early
       _template: 'index',
       render: sinon.stub().callsArgWith(2, null, '<html></html>'),
@@ -85,6 +89,54 @@ describe('Renderer', function () {
 
     renderer(req, res, {});
 
+    sinon.assert.calledOnce(req.next);
+    sinon.assert.notCalled(res.send);
+  });
+
+  it('skips the render when the client hung up before it started', function () {
+    res.destroyed = true;
+    res.writableEnded = false;
+
+    renderer(req, res, {});
+
+    sinon.assert.notCalled(res.render);
+    sinon.assert.notCalled(res.send);
+    assert.equal(res.statusCode, 499);
+  });
+
+  it('discards the html when the client hung up during the render', function () {
+    res.render = sinon.stub().callsFake(function (template, data, callback) {
+      res.destroyed = true;
+      res.writableEnded = false;
+      callback(null, '<html></html>');
+    });
+
+    renderer(req, res, {});
+
+    sinon.assert.calledOnce(res.render);
+    sinon.assert.notCalled(res.send);
+    assert.equal(res.statusCode, 499);
+  });
+
+  it('does not treat an already-sent response as a disconnect', function () {
+    res.destroyed = true;
+    res.writableEnded = true;
+
+    renderer(req, res, {});
+
+    sinon.assert.calledOnceWithExactly(res.send, '<html></html>');
+  });
+
+  it('forwards render errors even when the client has hung up', function () {
+    req.next = sinon.spy();
+    res.render = sinon.stub().callsFake(function (template, data, callback) {
+      res.destroyed = true;
+      callback(new Error('render failed'));
+    });
+
+    renderer(req, res, {});
+
+    // a broken template is worth logging whether or not anyone is still listening
     sinon.assert.calledOnce(req.next);
     sinon.assert.notCalled(res.send);
   });


### PR DESCRIPTION
ref INC-323

Under sustained load a Ghost site can queue requests for minutes. By the time a queued request reaches the renderer, the CDN or browser in front of it has usually timed out and destroyed the socket, but Ghost renders it anyway: a full template pass plus any {{#get}} queries the template makes, written to a socket nobody is reading.

That waste is self-reinforcing. It occupies the single event loop, which lengthens the queue, which causes the next request to time out. In a recent incident an origin sat pegged at 100% CPU for two hours largely serving requests its CDN had already abandoned.

The renderer now bails out when the response socket is already destroyed, checked both before the render starts and after it completes, since a slow render gives the client plenty of time to leave. The status is set to 499 (client closed request) so these are distinguishable in the access log from the phantom 200s they are currently recorded as.

Only sockets Node has already destroyed are skipped, so there is no case where a client still waiting for a response gets it dropped.