### PR TITLE
Fixed missing import & add specific test tsconfig

### DIFF
--- a/ghost/core/core/server/ghost-server.ts
+++ b/ghost/core/core/server/ghost-server.ts
@@ -15,6 +15,7 @@ import type { Promisable } from 'type-fest';
 import type * as express from 'express';
 import type * as http from 'node:http';
 import { promisify } from 'node:util';
+import assert from 'node:assert';
 
 type ServerConfig = {
   host: string;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -72,7 +72,7 @@
     "lint:frontend": "eslint 'core/frontend/**/*.js' --cache",
     "lint:test": "eslint 'test/**/*.js' --cache",
     "lint:code": "pnpm run '/^lint:(server|shared|frontend)$/'",
-    "lint:types": "eslint '**/*.ts' --cache && tsc --noEmit",
+    "lint:types": "eslint '**/*.ts' --cache && tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
     "lint": "pnpm run '/^lint:(server|shared|frontend|test|types)$/'"
   },
   "dependencies": {

--- a/ghost/core/test/tsconfig.json
+++ b/ghost/core/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  /* Vitest's globals live here only, so they can't mask a missing import in core source. */
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["**/*.ts", "../bin/**/*.d.ts", "../core/**/*.d.ts", "../types/**/*.d.ts"]
+}

--- a/ghost/core/tsconfig.json
+++ b/ghost/core/tsconfig.json
@@ -30,8 +30,7 @@
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
-      "node",
-      "vitest/globals"
+      "node"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
@@ -102,5 +101,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["bin/**/*.ts", "core/**/*.ts", "test/**/*.ts", "types/**/*.d.ts"]
+  "include": ["bin/**/*.ts", "core/**/*.ts", "types/**/*.d.ts"]
 }


### PR DESCRIPTION
no ref
- using the same tsconfig for both tests and source allowed vitest globals to leak into source code and cause runtime errors
- splitting tsconfig into an explicit test config ensures that missing imports correctly flag type errors