### PR TITLE
Migrated external-media-inliner to the class-based jobs service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -650,11 +650,12 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
       await initAppService();
     }
 
+    const jobsService = require('./server/services/jobs-service');
+    const service = jobsService.init();
+
     await initServices({ ghostServer, config, prometheusClient });
 
     debug('Begin: Register job handlers');
-    const jobsService = require('./server/services/jobs-service');
-    const service = jobsService.init();
     require('./server/services/jobs-service/register-job-handlers').default();
     await service.start();
     debug('End: Register job handlers');

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -327,7 +327,7 @@ async function initAppService() {
  * These services should all be part of core, frontend services should be loaded with the frontend
  * We are working towards this being a service loader, with the ability to make certain services optional
  */
-async function initServices({ ghostServer, config, prometheusClient }) {
+async function initServices({ ghostServer, config, prometheusClient, jobsService }) {
   debug('Begin: initServices');
 
   debug('Begin: Services');
@@ -414,7 +414,7 @@ async function initServices({ ghostServer, config, prometheusClient }) {
     linkTracking.init(),
     emailSuppressionList.init(),
     slackNotifications.init(),
-    mediaInliner.init(),
+    mediaInliner.init({ jobsService }),
     contentImport.init(),
     donationService.init(),
     recommendationsService.init(),
@@ -653,10 +653,12 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     const jobsService = require('./server/services/jobs-service');
     const service = jobsService.init();
 
-    await initServices({ ghostServer, config, prometheusClient });
+    await initServices({ ghostServer, config, prometheusClient, jobsService: service });
 
     debug('Begin: Register job handlers');
-    require('./server/services/jobs-service/register-job-handlers').default();
+    require('./server/services/jobs-service/register-job-handlers').default({
+      mediaInliner: require('./server/services/media-inliner').inliner,
+    });
     await service.start();
     debug('End: Register job handlers');
     debug('End: Load Ghost Services & Apps');

--- a/ghost/core/core/server/api/endpoints/db.js
+++ b/ghost/core/core/server/api/endpoints/db.js
@@ -125,7 +125,7 @@ const controller = {
       },
     },
     async query(frame) {
-      return mediaInliner.api.startMediaInliner(frame.data.domains);
+      return mediaInliner.service.startMediaInliner(frame.data.domains);
     },
   },
 

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -4,10 +4,15 @@ import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
 import * as gifts from '../gifts';
 import CleanGiftsJob from '../gifts/jobs/clean-gifts-job';
+import ExternalMediaInlinerJob from '../media-inliner/jobs/external-media-inliner-job';
 
 const logging = require('@tryghost/logging');
 
-export default function registerJobHandlers(): void {
+export interface JobHandlerDeps {
+  mediaInliner: { inline(domains: string[]): Promise<unknown> };
+}
+
+export default function registerJobHandlers({ mediaInliner }: JobHandlerDeps): void {
   const jobsService = getInstance();
   const db = require('../../data/db');
 
@@ -22,5 +27,9 @@ export default function registerJobHandlers(): void {
       });
     }
     await gifts.service.cleanup();
+  });
+
+  jobsService.handle(ExternalMediaInlinerJob, async (job) => {
+    await mediaInliner.inline(job.domains);
   });
 }

--- a/ghost/core/core/server/services/media-inliner/jobs/external-media-inliner-job.ts
+++ b/ghost/core/core/server/services/media-inliner/jobs/external-media-inliner-job.ts
@@ -1,0 +1,12 @@
+import { Job } from '../../jobs-service/job';
+
+export default class ExternalMediaInlinerJob extends Job {
+  static type = 'external-media-inliner';
+
+  readonly domains: string[];
+
+  constructor(data: { domains: string[] }) {
+    super();
+    this.domains = data.domains;
+  }
+}

--- a/ghost/core/core/server/services/media-inliner/media-inliner-service.ts
+++ b/ghost/core/core/server/services/media-inliner/media-inliner-service.ts
@@ -1,0 +1,34 @@
+import ExternalMediaInlinerJob from './jobs/external-media-inliner-job';
+import type { Job } from '../jobs-service/job';
+
+const logging = require('@tryghost/logging');
+const debug = require('@tryghost/debug')('mediaInliner');
+
+const DEFAULT_DOMAINS = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+
+export interface MediaInlinerServiceDeps {
+  jobsService: { dispatch(job: Job): Promise<void> };
+}
+
+export class MediaInlinerService {
+  readonly #jobsService: MediaInlinerServiceDeps['jobsService'];
+
+  constructor({ jobsService }: MediaInlinerServiceDeps) {
+    this.#jobsService = jobsService;
+  }
+
+  async startMediaInliner(domains?: string[]): Promise<{ status: string }> {
+    if (!domains || !domains.length) {
+      domains = DEFAULT_DOMAINS;
+    }
+
+    debug('[Inliner] Starting media inlining job for domains: ', domains);
+
+    logging.info('[Background Job] external-media-inliner queued');
+    await this.#jobsService.dispatch(new ExternalMediaInlinerJob({ domains }));
+
+    return {
+      status: 'success',
+    };
+  }
+}

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,9 +1,8 @@
 module.exports = {
-  async init() {
+  async init({ jobsService }) {
     const MediaInliner = require('./external-media-inliner');
     const { MediaInlinerService } = require('./media-inliner-service');
     const models = require('../../models');
-    const jobsService = require('../jobs');
     const adapterManager = require('../../services/adapter-manager').default;
 
     const mediaStorage = adapterManager.getAdapter('storage:media');

--- a/ghost/core/core/server/services/media-inliner/service.js
+++ b/ghost/core/core/server/services/media-inliner/service.js
@@ -1,8 +1,7 @@
 module.exports = {
   async init() {
-    const debug = require('@tryghost/debug')('mediaInliner');
     const MediaInliner = require('./external-media-inliner');
-    const logging = require('@tryghost/logging');
+    const { MediaInlinerService } = require('./media-inliner-service');
     const models = require('../../models');
     const jobsService = require('../jobs');
     const adapterManager = require('../../services/adapter-manager').default;
@@ -13,7 +12,7 @@ module.exports = {
 
     const config = require('../../../shared/config');
 
-    const mediaInliner = new MediaInliner({
+    this.inliner = new MediaInliner({
       PostModel: models.Post,
       TagModel: models.Tag,
       UserModel: models.User,
@@ -31,45 +30,6 @@ module.exports = {
       },
     });
 
-    this.api = {
-      startMediaInliner: async (domains) => {
-        if (!domains || !domains.length) {
-          // default domains to inline from if none are provided
-          domains = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
-        }
-
-        debug('[Inliner] Starting media inlining job for domains: ', domains);
-
-        // @NOTE: the job is "inline" (aka non-offloaded into a thread), because usecases are currently
-        //        limited to migrational, so there is no expectations for site's availability etc.
-        logging.info('[Background Job] external-media-inliner queued');
-        await jobsService.addJob({
-          name: 'external-media-inliner',
-          job: async (data) => {
-            const startedAt = Date.now();
-            logging.info('[Background Job] external-media-inliner started');
-            try {
-              const result = await mediaInliner.inline(data.domains);
-              logging.info(
-                `[Background Job] external-media-inliner completed in ${Date.now() - startedAt}ms`,
-              );
-              return result;
-            } catch (err) {
-              logging.error(
-                err,
-                `[Background Job] external-media-inliner failed after ${Date.now() - startedAt}ms`,
-              );
-              throw err;
-            }
-          },
-          data: { domains },
-          offloaded: false,
-        });
-
-        return {
-          status: 'success',
-        };
-      },
-    };
+    this.service = new MediaInlinerService({ jobsService });
   },
 };

--- a/ghost/core/test/integration/services/media-inliner/external-media-inliner.test.ts
+++ b/ghost/core/test/integration/services/media-inliner/external-media-inliner.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import nock from 'nock';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import ExternalMediaInlinerJob from '../../../../core/server/services/media-inliner/jobs/external-media-inliner-job';
+
+const models = require('../../../../core/server/models');
+const config = require('../../../../core/shared/config');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const { getInstance: getJobsService } = require('../../../../core/server/services/jobs-service');
+
+const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
+const LOCAL_IMAGES_PATH = '/content/images/';
+
+async function waitFor(
+  check: () => Promise<boolean>,
+  { timeoutMs = 5000, intervalMs = 25 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+  return false;
+}
+
+describe('Job: External media inliner', function () {
+  const inlinedFiles: string[] = [];
+
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init();
+  });
+
+  afterAll(async function () {
+    for (const file of inlinedFiles) {
+      await fs.unlink(file).catch(() => {});
+    }
+  });
+
+  it('stores a post feature image hosted on a dispatched domain locally', async function () {
+    nock('https://inliner.example')
+      .get('/feature.gif')
+      .reply(200, GIF1x1, { 'content-type': 'image/gif' });
+
+    const post = await models.Post.add(
+      {
+        title: 'External media inliner job',
+        slug: 'external-media-inliner-job',
+        status: 'published',
+        feature_image: 'https://inliner.example/feature.gif',
+      },
+      { context: { internal: true } },
+    );
+
+    await getJobsService().dispatch(
+      new ExternalMediaInlinerJob({ domains: ['https://inliner.example'] }),
+    );
+
+    let featureImage: string | undefined;
+    const inlined = await waitFor(async () => {
+      const reloaded = await models.Post.findOne({ id: post.id }, { context: { internal: true } });
+      featureImage = reloaded.get('feature_image');
+      return Boolean(featureImage?.includes(LOCAL_IMAGES_PATH));
+    });
+
+    assert.ok(inlined, `the dispatched job inlines the feature image (got ${featureImage})`);
+
+    const storedFile = path.join(
+      config.getContentPath('images'),
+      featureImage!.split(LOCAL_IMAGES_PATH)[1],
+    );
+    inlinedFiles.push(storedFile);
+    assert.ok(await fs.stat(storedFile), 'the inlined image is written to local storage');
+  });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -13,6 +13,7 @@ type Processor = (envelope: { type: string; payload: string }) => Promise<void>;
 
 describe('register-job-handlers', function () {
   let deliver: Processor;
+  let mediaInliner: { inline: sinon.SinonStub };
 
   beforeEach(async function () {
     jobsService.init();
@@ -21,13 +22,23 @@ describe('register-job-handlers', function () {
       deliver = (args[0] as { processor: Processor }).processor;
     });
 
-    registerJobHandlers();
+    mediaInliner = { inline: sinon.stub().resolves() };
+    registerJobHandlers({ mediaInliner });
     await jobsService.getInstance().start();
   });
 
   afterEach(async function () {
     await jobsService.shutdown({ timeoutMs: 100 });
     sinon.restore();
+  });
+
+  it('runs the media inliner for the domains an external-media-inliner delivery carries', async function () {
+    await deliver({
+      type: 'external-media-inliner',
+      payload: '{"domains":["https://example.com"]}',
+    });
+
+    assert.deepEqual(mediaInliner.inline.firstCall.args, [['https://example.com']]);
   });
 
   // Nothing initialises the gifts service here, which is the state the guard

--- a/ghost/core/test/unit/server/services/media-inliner/jobs/external-media-inliner-job.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/jobs/external-media-inliner-job.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import { Job } from '../../../../../../core/server/services/jobs-service/job';
+import ExternalMediaInlinerJob from '../../../../../../core/server/services/media-inliner/jobs/external-media-inliner-job';
+
+describe('ExternalMediaInlinerJob', function () {
+  it('has a stable type', function () {
+    assert.equal(ExternalMediaInlinerJob.type, 'external-media-inliner');
+  });
+
+  it('is a job', function () {
+    assert.ok(new ExternalMediaInlinerJob({ domains: [] }) instanceof Job);
+  });
+
+  it('carries its domains through a serialisation round trip', function () {
+    const job = new ExternalMediaInlinerJob({ domains: ['https://example.com'] });
+
+    const restored = new ExternalMediaInlinerJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(restored.domains, ['https://example.com']);
+  });
+});

--- a/ghost/core/test/unit/server/services/media-inliner/media-inliner-service.test.ts
+++ b/ghost/core/test/unit/server/services/media-inliner/media-inliner-service.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { describe, it, beforeEach } from 'vitest';
+import { MediaInlinerService } from '../../../../../core/server/services/media-inliner/media-inliner-service';
+import ExternalMediaInlinerJob from '../../../../../core/server/services/media-inliner/jobs/external-media-inliner-job';
+
+const DEFAULT_DOMAINS = ['https://s3.amazonaws.com/revue', 'https://substackcdn.com'];
+
+describe('MediaInlinerService', function () {
+  let dispatch: sinon.SinonStub;
+  let service: MediaInlinerService;
+
+  beforeEach(function () {
+    dispatch = sinon.stub().resolves();
+    service = new MediaInlinerService({ jobsService: { dispatch } });
+  });
+
+  function dispatchedJob(): ExternalMediaInlinerJob {
+    assert.equal(dispatch.calledOnce, true);
+    const job = dispatch.firstCall.args[0];
+    assert.ok(job instanceof ExternalMediaInlinerJob);
+    return job;
+  }
+
+  it('dispatches an external-media-inliner job for the given domains', async function () {
+    await service.startMediaInliner(['https://example.com']);
+
+    assert.deepEqual(dispatchedJob().domains, ['https://example.com']);
+  });
+
+  it('falls back to the default domains when none are given', async function () {
+    await service.startMediaInliner();
+
+    assert.deepEqual(dispatchedJob().domains, DEFAULT_DOMAINS);
+  });
+
+  it('falls back to the default domains when the list is empty', async function () {
+    await service.startMediaInliner([]);
+
+    assert.deepEqual(dispatchedJob().domains, DEFAULT_DOMAINS);
+  });
+
+  it('reports success to the caller once the job is dispatched', async function () {
+    assert.deepEqual(await service.startMediaInliner(['https://example.com']), {
+      status: 'success',
+    });
+  });
+});


### PR DESCRIPTION
Migrates `external-media-inliner` off the legacy JobManager onto the class-based jobs service. Same job as #30276 — this is the alternative implementation, planned under a human-reviewed design and built by a different model, opened so the two can be compared.

Three commits, meant to be read in order:

1. **Moved jobs service creation ahead of initServices** — `mediaInliner.init()` runs inside `initServices` (boot.js), while the jobs service was created after it, so the service that needs the instance was constructed before the instance existed. Boot now creates it first and passes it through `initServices`, keeping handler registration and queue start exactly where they were. Isolated here because it changes shared boot ordering.
2. **Extracted MediaInlinerService** — dispatch moves out of the `init()` closure into a small class taking `{jobsService}` as a constructor dependency; `MediaInliner` keeps doing the work. `db.js` calls `mediaInliner.service.startMediaInliner(domains)`; no behaviour change.
3. **Migrated the job** — pure-data `ExternalMediaInlinerJob` carrying only `domains`, dispatched through the jobs service; the handler is one line delegating to the executor, with the instance injected from boot. The legacy `addJob` registration goes in the same commit, so the job is never registered in both systems.

Worth a look during review: the boot-order change in commit 1 (verified that `jobsService.init()` needs only the jobs adapter, which is already resolved by then), and the fact that a queued job can still be discarded if the process shuts down between dispatch and execution — pre-existing for in-memory queueing, and what the durable-queue phase is for.
