### PR TITLE
Changed a composite field's summary to come from its declared parts

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -191,30 +191,62 @@ const isPartRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
 /**
- * How each composite type reads as one line. Written per type rather than walked from
- * `subFieldsOf`, because where a part sits in the sentence is a fact about how the value
- * reads, not one the value schema can supply — an address fuses state and postal code the
- * way people write them. A part added upstream stays out of the line until someone decides
- * where it belongs.
+ * Parts that read as one run rather than as separate items — "NY 00001", not "NY, 00001".
  *
- * Total over the field types, the way the presentation catalog above is: a type added
- * upstream fails to compile here until someone has decided how its value reads, rather
- * than reaching every surface as a blank cell. A scalar declares `undefined`, which is
- * how "its value is already a line" is said.
+ * This is the whole of what a composite's one-line form needs stated. Everything else
+ * comes from the value schema's declaration order, so a part added to a type upstream
+ * appears in the line on its own, without anyone knowing to come here. That was the point:
+ * the previous version wrote each type's line out by hand, and a part left out of it was
+ * collected, stored, exported and filtered on while being invisible in every summary —
+ * a silent omission, which is the worst way for this to fail.
+ *
+ * Typed against the parts each type declares, so renaming or removing one upstream fails
+ * the build here. Deliberately not exhaustive: a part nobody mentions is one that reads
+ * perfectly well on its own, and requiring an entry for each would put the omission
+ * problem straight back.
  */
-const compositeValueFormatters: {
-  [T in FieldType]: [PartsOf<T>] extends [never]
-    ? undefined
-    : (value: Record<string, unknown>) => string;
-} = {
-  short_text: undefined,
-  long_text: undefined,
-  address: (value) => {
-    const { line1, line2, city, state, postal_code: postalCode, country } = value;
-    const statePostal = [state, postalCode].filter(Boolean).join(' ');
-    return [line1, line2, city, statePostal, country].filter(Boolean).join(', ');
-  },
+export type CompositePartRuns = { [T in FieldType]?: ReadonlyArray<readonly PartsOf<T>[]> };
+
+const fusedParts: CompositePartRuns = {
+  address: [['state', 'postal_code']],
 };
+
+/**
+ * A composite type's parts grouped into the runs its line is built from: declaration
+ * order, with anything fused above kept together.
+ *
+ * A fused pair that is not adjacent in declaration order simply reads as two runs, so
+ * reordering a type upstream costs a comma rather than a wrong sentence.
+ */
+function partRunsFor(type: FieldType): string[][] {
+  const parts: string[] | null = subFieldsOf(type);
+  if (!parts) {
+    return [];
+  }
+
+  const runOf = new Map<string, number>();
+  ((fusedParts[type] ?? []) as ReadonlyArray<readonly string[]>).forEach((group, index) => {
+    group.forEach((part) => runOf.set(part, index));
+  });
+
+  const runs: string[][] = [];
+  let openRun: number | undefined;
+  for (const part of parts) {
+    const run = runOf.get(part);
+    if (run !== undefined && run === openRun) {
+      runs[runs.length - 1].push(part);
+      continue;
+    }
+    runs.push([part]);
+    openRun = run;
+  }
+  return runs;
+}
+
+// Resolved once: the catalog is static, and this is read for every row of a member list.
+const partRuns = Object.fromEntries(
+  FIELD_TYPE_IDS.map((type) => [type, partRunsFor(type)]),
+) as Record<FieldType, string[][]>;
 
 /**
  * A member's value for one field as a single readable line: the string itself for a
@@ -228,13 +260,25 @@ const compositeValueFormatters: {
  * table cell than in a detail row.
  */
 export const formatMemberCustomFieldValue = (type: FieldType, value: unknown): string => {
-  const formatComposite = compositeValueFormatters[type];
-
-  if (formatComposite) {
-    return isPartRecord(value) ? formatComposite(value) : '';
+  // Null for a scalar, and for a type this build has never heard of — both of which read
+  // as text or as nothing.
+  if (subFieldsOf(type) === null) {
+    return typeof value === 'string' ? value : '';
   }
 
-  return typeof value === 'string' ? value : '';
+  if (!isPartRecord(value)) {
+    return '';
+  }
+
+  return (partRuns[type] ?? [])
+    .map((run) =>
+      run
+        .map((part) => value[part])
+        .filter((part): part is string => typeof part === 'string' && part !== '')
+        .join(' '),
+    )
+    .filter(Boolean)
+    .join(', ');
 };
 
 export interface MemberCustomFieldsResponseType {

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -1,4 +1,5 @@
 import {
+  type CompositePartRuns,
   type FieldTypePresentation,
   type MemberCustomField,
   formatMemberCustomFieldValue,
@@ -41,7 +42,27 @@ const scalarWithParts: FieldTypePresentation<'short_text'> = {
   subFields: { line1: 'a' },
 };
 
-export { labelled, missingPart, unknownPart, unlabelled, scalarWithParts };
+// A run is how the one-line form is told which parts read together. It names parts rather
+// than listing them all, so a part *added* upstream needs no entry — but a part renamed or
+// removed upstream has to be caught, or the run would silently stop fusing anything.
+const fusedRun: CompositePartRuns = { address: [['state', 'postal_code']] };
+
+// @ts-expect-error a run naming a part its value schema does not declare
+const unknownFusedPart: CompositePartRuns = { address: [['state', 'postcode']] };
+
+// @ts-expect-error a scalar type has no parts to run together
+const scalarWithRun: CompositePartRuns = { short_text: [['line1']] };
+
+export {
+  labelled,
+  missingPart,
+  unknownPart,
+  unlabelled,
+  scalarWithParts,
+  fusedRun,
+  unknownFusedPart,
+  scalarWithRun,
+};
 
 const field = (overrides: Partial<MemberCustomField>): MemberCustomField => ({
   key: 'nickname',
@@ -122,7 +143,9 @@ describe('member custom fields api helpers', () => {
         field({ key: 'address_home', name: 'Address (Home)', type: 'address' }),
       ]);
 
-      expect(columns[2]).toEqual({
+      // Found rather than indexed: what this is about is the label, not the position
+      // of a part in the address.
+      expect(columns.find((column) => column.partLabel === 'City')).toEqual({
         label: 'Address (Home) (City)',
         fieldName: 'Address (Home)',
         partLabel: 'City',
@@ -192,6 +215,24 @@ describe('member custom fields api helpers', () => {
           country: 'US',
         }),
       ).toBe('1 Main St, 12 apt B, New York, NY 00001, US');
+    });
+
+    // The property this is built for. A part added to a type upstream has to appear in
+    // the line on its own, because the alternative is a value that is collected, stored,
+    // exported and filtered on while being invisible in every summary. Asserted through
+    // the catalog rather than against a hardcoded list, so it keeps holding as the
+    // catalog grows.
+    it('includes every part a type declares, in the order it declares them', () => {
+      const parts = memberCustomFieldParts('address')!;
+      const value = Object.fromEntries(parts.map(({ key }) => [key, key]));
+
+      const line = formatMemberCustomFieldValue('address', value);
+
+      for (const { key } of parts) {
+        expect(line, `${key} is missing from the line`).toContain(key);
+      }
+      // Separators aside, the parts read in the order the value schema declares them.
+      expect(line.split(/,\s|\s/)).toEqual(parts.map(({ key }) => key));
     });
 
     it('pairs state and postal code, and drops missing parts cleanly', () => {

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -187,6 +187,12 @@ export const FIELD_TYPES = defineFieldTypes({
   long_text: longText(),
   // An address is a delivery address, so its bounds are what a courier will accept
   // rather than what the column could hold. Modelled on Stripe's Address object.
+  //
+  // Who the parcel is addressed to is not here. A parcel needs a name as well as an
+  // address, but that is a fact about posting parcels rather than about either type,
+  // and the name is often not the account name — gift subscriptions, workplace
+  // deliveries, c/o. A site that needs one keeps it in a field of its own, which is
+  // also how Stripe hands it back: beside the address rather than inside it.
   address: record(
     {
       line1: shortText(),

--- a/packages/custom-field-types/test/csv.test.ts
+++ b/packages/custom-field-types/test/csv.test.ts
@@ -197,6 +197,20 @@ describe('reading custom field values from a CSV row', function () {
     );
   });
 
+  // The sub-cells a composite occupies are the parts its value schema declares, so a
+  // column naming anything else is dropped the way a column naming no field is. A
+  // recipient's name is the one that gets written by hand: a parcel needs one, but it
+  // belongs to a field of its own rather than to the address.
+  it('drops a sub-cell that names no part of the composite', function () {
+    assert.deepEqual(
+      fieldValuesFromCsvRow([address], {
+        'custom_fields.shipping_address.name': 'Bex Jones',
+        'custom_fields.shipping_address.city': 'London',
+      }),
+      { shipping_address: { city: 'London' } },
+    );
+  });
+
   // A partial composite is read as a value (validation, run by the caller, is what
   // rejects it) rather than silently dropped like an all-blank one.
   it('reads a partial composite so its validation can fail the row', function () {

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -97,6 +97,13 @@ describe('custom-field-types catalog', function () {
       assert.equal(parse({ line1: 'Cloonlara', state: 'Co. Clare', country: 'IE' }), true);
     });
 
+    // A recipient's name is not part of an address. A parcel needs both, which is a
+    // fact about posting parcels rather than about either type, so a site that collects
+    // a name keeps it in a field of its own.
+    it('is not where a recipient name lives', function () {
+      assert.equal(parse({ name: 'Bex Jones' }), false);
+    });
+
     it('rejects an address that names nothing', function () {
       assert.equal(parse({}), false);
       // A key present but explicitly undefined names nothing either: undefined is


### PR DESCRIPTION
## Problem

A custom field can be made of parts — an address is a line, a city, a postcode, a country. Admin shows a member's value for one of these as a short summary, and that summary was assembled from a list of parts written out by hand beside the code that renders it.

The parts are already declared once, in the shared field type catalog. So the hand-written list was a second copy of something the catalog knows, and the two could disagree. A part added to the catalog simply never appeared in a summary, silently, and nothing failed to say so.

## Solution

The summary is derived from the parts the type declares. Adding a part to the catalog is now the whole of adding it, and there is no second list to keep in step.

ref https://linear.app/ghost/issue/BER-3872
