### PR TITLE
Added a record of who wrote each member custom field value

### DIFF
--- a/ghost/core/core/server/api/endpoints/member-custom-fields.ts
+++ b/ghost/core/core/server/api/endpoints/member-custom-fields.ts
@@ -1,4 +1,4 @@
-import { definitions, type RequestContext } from '../../services/members-custom-fields';
+import { actingContext, definitions } from '../../services/members-custom-fields';
 
 const permissionsService = require('../../services/permissions');
 
@@ -15,17 +15,6 @@ interface Frame {
 // `permissions: true` handler would try to load a model that doesn't exist).
 function canThis(frame: Frame) {
   return permissionsService.canThis(frame.options.context);
-}
-
-function requestContextFromFrame(frame: Frame): RequestContext {
-  const context = (frame.options.context ?? {}) as { user?: string; integration?: { id: string } };
-  if (context.integration) {
-    return { actor: { id: context.integration.id, type: 'integration' } };
-  }
-  if (context.user) {
-    return { actor: { id: context.user, type: 'user' } };
-  }
-  return { actor: null };
 }
 
 const noCacheInvalidation = { cacheInvalidate: false };
@@ -71,7 +60,10 @@ const controller = {
     // all-or-nothing. A client sending a single definition (as Admin does)
     // is just the one-item case and sees no change.
     query(frame: Frame) {
-      return definitions!.add(requestContextFromFrame(frame), frame.data.members_custom_fields);
+      return definitions!.add(
+        actingContext(frame.options.context),
+        frame.data.members_custom_fields,
+      );
     },
   },
 
@@ -83,7 +75,10 @@ const controller = {
       return canThis(frame).edit.member_custom_field();
     },
     query(frame: Frame) {
-      return definitions!.reorder(requestContextFromFrame(frame), frame.data.members_custom_fields);
+      return definitions!.reorder(
+        actingContext(frame.options.context),
+        frame.data.members_custom_fields,
+      );
     },
   },
 
@@ -96,7 +91,7 @@ const controller = {
     },
     query(frame: Frame) {
       return definitions!.edit(
-        requestContextFromFrame(frame),
+        actingContext(frame.options.context),
         frame.options.key,
         frame.data.members_custom_fields[0],
       );
@@ -112,7 +107,7 @@ const controller = {
       return canThis(frame).destroy.member_custom_field(frame.options.key);
     },
     async query(frame: Frame) {
-      await definitions!.destroy(requestContextFromFrame(frame), frame.options.key);
+      await definitions!.destroy(actingContext(frame.options.context), frame.options.key);
       return null;
     },
   },

--- a/ghost/core/core/server/data/migrations/versions/6.61/2026-08-19-14-30-20-add-written-by-to-members-custom-field-values.js
+++ b/ghost/core/core/server/data/migrations/versions/6.61/2026-08-19-14-30-20-add-written-by-to-members-custom-field-values.js
@@ -1,18 +1,40 @@
-const { combineNonTransactionalMigrations, createAddColumnMigration } = require('../../utils');
+const logging = require('@tryghost/logging');
+const {
+  combineNonTransactionalMigrations,
+  createAddColumnMigration,
+  createNonTransactionalMigration,
+} = require('../../utils');
+
+const TABLE = 'members_custom_field_values';
 
 // Who wrote the value that is here now: a type and an id, the way `actions` records an
-// actor. Both nullable rather than defaulted. Every write from here on names its writer —
-// the values service takes it as a required argument, so no call site can omit one — but
-// rows written before these columns existed have a writer nobody can recover, and an import
-// has no id to give until runs are tracked. Null says exactly that, where a default would
-// assert something we would be inventing.
+// actor. The type is required because it is the namespace the id resolves in, and a value
+// nobody can be traced to is not a record of provenance. The id is nullable for the one
+// writer that resolves in no table — an import, until runs are tracked.
+//
+// Existing rows have a writer nobody can recover, so they go rather than get backfilled:
+// the feature is behind the `membersCustomFields` flag with no released data, and adding
+// a required column over them ends either in an error, as SQLite refuses one with no
+// default, or in an invented writer wherever the engine supplies its own empty string.
 module.exports = combineNonTransactionalMigrations(
-  createAddColumnMigration('members_custom_field_values', 'written_by_type', {
+  createNonTransactionalMigration(
+    async function up(knex) {
+      if (!(await knex.schema.hasColumn(TABLE, 'written_by_type'))) {
+        logging.info(`Clearing ${TABLE} of values with no recorded writer`);
+        await knex(TABLE).del();
+      }
+    },
+    async function down() {
+      // Nothing to undo: the rows are gone, and dropping the columns below is what a
+      // rollback is for.
+    },
+  ),
+  createAddColumnMigration(TABLE, 'written_by_type', {
     type: 'string',
     maxlength: 50,
-    nullable: true,
+    nullable: false,
   }),
-  createAddColumnMigration('members_custom_field_values', 'written_by_id', {
+  createAddColumnMigration(TABLE, 'written_by_id', {
     type: 'string',
     maxlength: 24,
     nullable: true,

--- a/ghost/core/core/server/data/migrations/versions/6.61/2026-08-19-14-30-20-add-written-by-to-members-custom-field-values.js
+++ b/ghost/core/core/server/data/migrations/versions/6.61/2026-08-19-14-30-20-add-written-by-to-members-custom-field-values.js
@@ -1,0 +1,20 @@
+const { combineNonTransactionalMigrations, createAddColumnMigration } = require('../../utils');
+
+// Who wrote the value that is here now: a type and an id, the way `actions` records an
+// actor. Both nullable rather than defaulted. Every write from here on names its writer —
+// the values service takes it as a required argument, so no call site can omit one — but
+// rows written before these columns existed have a writer nobody can recover, and an import
+// has no id to give until runs are tracked. Null says exactly that, where a default would
+// assert something we would be inventing.
+module.exports = combineNonTransactionalMigrations(
+  createAddColumnMigration('members_custom_field_values', 'written_by_type', {
+    type: 'string',
+    maxlength: 50,
+    nullable: true,
+  }),
+  createAddColumnMigration('members_custom_field_values', 'written_by_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+  }),
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1096,6 +1096,22 @@ module.exports = {
     // column a fresh install bounds at 65,535 bytes. The bound matching long_text's
     // exactly is worth more than the schema restating what the write path enforces.
     value_text: { type: 'text', maxlength: 65535, nullable: true },
+    // Who wrote the value that is here now.
+    //
+    // Shaped like `actions`: a type and an id, no foreign key. A type because not every
+    // write comes through a binding — a person edits a member's fields, an import reads a
+    // file — and an id so the writer can be resolved back rather than merely named. A
+    // binding id resolves to the tier, the port and the field it routed into, which is
+    // everything worth knowing about how a value got here.
+    //
+    // No foreign key, because provenance has to outlive its cause: that a value arrived
+    // through a tier's shipping port stays true after someone deletes that binding, even
+    // though it stops being joinable.
+    //
+    // Both nullable. Rows written before these columns existed have a writer nobody can
+    // recover, and an import has no id to give until runs are tracked.
+    written_by_type: { type: 'string', maxlength: 50, nullable: true },
+    written_by_id: { type: 'string', maxlength: 24, nullable: true },
     created_at: { type: 'dateTime', nullable: false },
     updated_at: { type: 'dateTime', nullable: true },
     // Named, because the name knex derives from the table and all three columns

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1108,9 +1108,10 @@ module.exports = {
     // through a tier's shipping port stays true after someone deletes that binding, even
     // though it stops being joinable.
     //
-    // Both nullable. Rows written before these columns existed have a writer nobody can
-    // recover, and an import has no id to give until runs are tracked.
-    written_by_type: { type: 'string', maxlength: 50, nullable: true },
+    // The type is the namespace the id resolves in, so every row carries one. The id is
+    // nullable for the one writer that resolves in no table: an import has none to give
+    // until runs are tracked.
+    written_by_type: { type: 'string', maxlength: 50, nullable: false },
     written_by_id: { type: 'string', maxlength: 24, nullable: true },
     created_at: { type: 'dateTime', nullable: false },
     updated_at: { type: 'dateTime', nullable: true },

--- a/ghost/core/core/server/services/members-custom-fields/actions.ts
+++ b/ghost/core/core/server/services/members-custom-fields/actions.ts
@@ -9,6 +9,25 @@ export interface RequestContext {
   actor: Actor | null;
 }
 
+/**
+ * Who is acting, read off an API frame's context.
+ *
+ * Here rather than in each endpoint, because two resources now record custom field history
+ * and a second reading of the same shape is a second chance to disagree about it. An
+ * integration and a user are both actors; a request that is neither — a webhook, a job —
+ * has none, and the history says so rather than guessing.
+ */
+export function actingContext(context: unknown): RequestContext {
+  const frame = (context ?? {}) as { user?: string; integration?: { id: string } };
+  if (frame.integration) {
+    return { actor: { id: frame.integration.id, type: 'integration' } };
+  }
+  if (frame.user) {
+    return { actor: { id: frame.user, type: 'user' } };
+  }
+  return { actor: null };
+}
+
 export interface ActionRecorder {
   add(data: Record<string, unknown>, options: { autoRefresh: boolean }): Promise<unknown>;
 }

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -6,7 +6,6 @@ import { resolveMaxDefinitions } from './config';
 export type { CustomField } from './models';
 export type { RequestContext } from './actions';
 export { actingContext } from './actions';
-export { WRITTEN_BY } from './schema';
 export type { WrittenBy } from './schema';
 
 // Two services from one module, split along an aggregate boundary rather than a

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -5,6 +5,9 @@ import { resolveMaxDefinitions } from './config';
 
 export type { CustomField } from './models';
 export type { RequestContext } from './actions';
+export { actingContext } from './actions';
+export { WRITTEN_BY } from './schema';
+export type { WrittenBy } from './schema';
 
 // Two services from one module, split along an aggregate boundary rather than a
 // technical layer: `definitions` owns the field definitions, which belong to the

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -27,6 +27,25 @@ type CustomFieldRank = { sort_order: number };
 
 type CustomFieldRow = z.infer<typeof DbCustomField> & CustomFieldRank;
 
+/**
+ * How a value arrived, not who caused it: who edited a member's fields is already an
+ * action, and Stripe is not a person. Open rather than a closed list, so a new integration
+ * does not have to be added to a central enumeration.
+ */
+export const WRITTEN_BY = {
+  binding: 'binding',
+  user: 'user',
+  integration: 'integration',
+  import: 'import',
+} as const;
+
+export const WrittenBy = z.object({
+  type: z.string(),
+  /** Absent for a writer with no identity to give: an import, until runs are tracked. */
+  id: z.string().nullable(),
+});
+export type WrittenBy = z.infer<typeof WrittenBy>;
+
 // One part of a member's value. What a `path` means is storage.ts's business, so the row
 // carries it as a plain string.
 export const DbCustomFieldValue = z.object({
@@ -37,6 +56,9 @@ export const DbCustomFieldValue = z.object({
   // Nullable like the column, though nothing here writes a null: a part with no value
   // has no row.
   value_text: z.string().nullable(),
+  // Nullable only for rows written before the columns existed; every write states a type.
+  written_by_type: z.string().nullable(),
+  written_by_id: z.string().nullable(),
   created_at: DbDate,
   updated_at: DbDate.nullable(),
 });

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -29,21 +29,16 @@ type CustomFieldRow = z.infer<typeof DbCustomField> & CustomFieldRank;
 
 /**
  * How a value arrived, not who caused it: who edited a member's fields is already an
- * action, and Stripe is not a person. Open rather than a closed list, so a new integration
- * does not have to be added to a central enumeration.
+ * action, and Stripe is not a person. `type` is the namespace that makes `id` resolvable —
+ * `users`, `integrations`, `members_custom_field_bindings` — so the one writer that
+ * resolves in no table is the one with no id to give.
  */
-export const WRITTEN_BY = {
-  binding: 'binding',
-  user: 'user',
-  integration: 'integration',
-  import: 'import',
-} as const;
-
-export const WrittenBy = z.object({
-  type: z.string(),
-  /** Absent for a writer with no identity to give: an import, until runs are tracked. */
-  id: z.string().nullable(),
-});
+export const WrittenBy = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('user'), id: z.string() }),
+  z.object({ type: z.literal('integration'), id: z.string() }),
+  z.object({ type: z.literal('binding'), id: z.string() }),
+  z.object({ type: z.literal('import'), id: z.null() }),
+]);
 export type WrittenBy = z.infer<typeof WrittenBy>;
 
 // One part of a member's value. What a `path` means is storage.ts's business, so the row
@@ -56,8 +51,10 @@ export const DbCustomFieldValue = z.object({
   // Nullable like the column, though nothing here writes a null: a part with no value
   // has no row.
   value_text: z.string().nullable(),
-  // Nullable only for rows written before the columns existed; every write states a type.
-  written_by_type: z.string().nullable(),
+  // Plain columns rather than the `WrittenBy` union: the rule holds at the write
+  // boundary, so one malformed row cannot throw away a member's whole profile on read.
+  written_by_type: z.string(),
+  // Null for the one writer that resolves nowhere: an import, until runs are tracked.
   written_by_id: z.string().nullable(),
   created_at: DbDate,
   updated_at: DbDate.nullable(),

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -4,7 +4,7 @@ import logging from '@tryghost/logging';
 import type { Knex } from 'knex';
 import { z } from 'zod';
 import { FIELD_TYPES, subFieldsOf, type FieldType } from '@tryghost/custom-field-types';
-import { DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS } from './schema';
+import { DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS, type WrittenBy } from './schema';
 import { activeFields } from './queries';
 import { leavesToWrite, valuesFromLeaves, type StoredLeaf } from './storage';
 
@@ -43,7 +43,7 @@ interface ActiveField {
 }
 
 /** An absent `value` means clear the field. */
-interface PlannedWrite {
+export interface PlannedWrite {
   field: ActiveField;
   value?: unknown;
 }
@@ -208,13 +208,16 @@ export class CustomFieldValuesService {
    * them, and saying nothing about a path leaves it alone. There is no whole-value
    * replace, so a caller that does not know about a field cannot erase it.
    *
+   * `writtenBy` is required and has no default: every writer has to name itself, so a new
+   * one cannot quietly inherit the identity of whichever was written first.
+   *
    * Always transactional. Given an executor it joins that transaction, so the importer's
    * failed value write takes its member with it; given none it opens its own.
    */
   async applyWrite(
     memberId: string,
     writes: PlannedWrite[],
-    { executor = this.knex }: { executor?: Knex } = {},
+    { writtenBy, executor = this.knex }: { writtenBy: WrittenBy; executor?: Knex },
   ): Promise<void> {
     if (writes.length === 0) {
       return;
@@ -247,6 +250,8 @@ export class CustomFieldValuesService {
             custom_field_key: field.key,
             path: leaf.path,
             value_text: leaf.value_text,
+            written_by_type: writtenBy.type,
+            written_by_id: writtenBy.id,
             created_at: now,
             updated_at: now,
           })),
@@ -283,7 +288,9 @@ export class CustomFieldValuesService {
           // Naming the columns rather than giving values takes each from the row
           // that lost the conflict, so every part updates to its own value.
           .onConflict(['member_id', 'custom_field_key', 'path'])
-          .merge(['value_text', 'updated_at']);
+          // The writer is merged with the value, so a leaf names who wrote what
+          // it currently holds rather than who wrote its first value.
+          .merge(['value_text', 'written_by_type', 'written_by_id', 'updated_at']);
       }
     };
 

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -1,5 +1,6 @@
 import type { Knex } from 'knex';
 import type { CsvField } from '@tryghost/custom-field-types/csv';
+import type { WrittenBy } from '../../members-custom-fields';
 import MembersCSVImporter, {
   type MembersRepository,
   type GiftService,
@@ -52,7 +53,7 @@ interface ImporterServices {
       applyWrite(
         memberId: string,
         plan: unknown[],
-        options: { writtenBy: { type: string; id: string | null }; executor?: Knex },
+        options: { writtenBy: WrittenBy; executor?: Knex },
       ): Promise<void>;
     };
   };

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -49,7 +49,11 @@ interface ImporterServices {
     definitions: { browse(): Promise<CsvField[]> };
     values: {
       planWrite(values: Record<string, unknown>): Promise<unknown[]>;
-      applyWrite(memberId: string, plan: unknown[], options?: { executor?: Knex }): Promise<void>;
+      applyWrite(
+        memberId: string,
+        plan: unknown[],
+        options: { writtenBy: { type: string; id: string | null }; executor?: Knex },
+      ): Promise<void>;
     };
   };
 }
@@ -118,8 +122,13 @@ export function makeImporter(deps: ImporterServices) {
     activeFields: async () =>
       labs.isSet('membersCustomFields') ? deps.customFields.definitions.browse() : [],
     planWrite: (values) => deps.customFields.values.planWrite(values),
+    // Every value the import writes came out of the file, whichever column carried it.
+    // An import has no id to give until runs are tracked, so it names its kind only.
     applyWrite: (memberId, plan, executor) =>
-      deps.customFields.values.applyWrite(memberId, plan, { executor }),
+      deps.customFields.values.applyWrite(memberId, plan, {
+        writtenBy: { type: 'import', id: null },
+        executor,
+      }),
   };
 
   // Inline jobs never reach the job manager's Sentry handler, which is wired to the

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -1,5 +1,4 @@
 const errors = require('@tryghost/errors');
-const { WRITTEN_BY } = require('../../../members-custom-fields');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const moment = require('moment');
@@ -10,6 +9,8 @@ const messages = {
   memberNotFound: 'Member not found.',
   customFieldsOnAdd:
     'Custom field values cannot be set while creating a member. Create the member, then set values with an edit.',
+  customFieldsWithoutWriter:
+    'Custom field values cannot be set by a request with no authenticated user or integration.',
 };
 
 // Stored in the action's `context.action_name`; Admin maps it to a display label.
@@ -658,10 +659,19 @@ module.exports = class MemberBREADService {
       // Every value reaching here was typed into the Admin API, so the writer is
       // whoever made the request — the same pair the action log records, so the two
       // agree about who did it rather than one saying only that it was "admin".
+      //
+      // The only route to this branch is the authenticated Admin API, so an anonymous
+      // request is a mistake somewhere upstream rather than a writer to invent a name
+      // for. Refusing keeps every stored writer resolvable.
       const context = options.context || {};
+      if (!context.integration && !context.user) {
+        throw new errors.IncorrectUsageError({
+          message: tpl(messages.customFieldsWithoutWriter),
+        });
+      }
       const writtenBy = context.integration
-        ? { type: WRITTEN_BY.integration, id: context.integration.id }
-        : { type: WRITTEN_BY.user, id: context.user || null };
+        ? { type: 'integration', id: context.integration.id }
+        : { type: 'user', id: context.user };
       await this.customFieldValues.applyWrite(model.id, plannedCustomFields, { writtenBy });
 
       // Custom fields aren't a member column or relation, so an edit touching

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -1,4 +1,5 @@
 const errors = require('@tryghost/errors');
+const { WRITTEN_BY } = require('../../../members-custom-fields');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const moment = require('moment');
@@ -654,7 +655,14 @@ module.exports = class MemberBREADService {
     }
 
     if (plannedCustomFields) {
-      await this.customFieldValues.applyWrite(model.id, plannedCustomFields);
+      // Every value reaching here was typed into the Admin API, so the writer is
+      // whoever made the request — the same pair the action log records, so the two
+      // agree about who did it rather than one saying only that it was "admin".
+      const context = options.context || {};
+      const writtenBy = context.integration
+        ? { type: WRITTEN_BY.integration, id: context.integration.id }
+        : { type: WRITTEN_BY.user, id: context.user || null };
+      await this.customFieldValues.applyWrite(model.id, plannedCustomFields, { writtenBy });
 
       // Custom fields aren't a member column or relation, so an edit touching
       // only them leaves `model._changed` empty and the save fires nothing.

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.60.1-rc.0",
+  "version": "6.61.0-rc.0",
   "description": "The professional publishing platform",
   "keywords": [
     "blog",

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -17,6 +17,7 @@ describe('Member Custom Fields Admin API', function () {
     delete: (_url: string) => any;
     loginAsOwner: () => Promise<void>;
     loginAsEditor: () => Promise<void>;
+    useZapierAdminAPIKey: () => Promise<void>;
   };
 
   // The key is minted server-side from the name, so callers pass just a name
@@ -1439,41 +1440,61 @@ describe('Member Custom Fields Admin API', function () {
     // The record has to be made at the moment of the write; nothing can reconstruct it
     // later. What reads it is a separate question — this pins only that it is written,
     // and that it names where the value currently held came from rather than the first.
-    // Provenance is observable nowhere else yet, so this reads the columns directly. What
-    // it pins is the outcome: every part records who wrote it, and a re-write says who
-    // wrote what is there now rather than who wrote it first.
+    // Provenance is observable nowhere else yet, so this reads the columns directly.
+    //
+    // The second write comes from an integration rather than the owner, because a
+    // re-write by the same writer cannot tell "the writer follows the value" apart from
+    // "the writer is whoever wrote first" — the two agree on every row.
     it('records who wrote each value, and re-records it on every write', async function () {
       const field = await createField({ name: 'Postal address', type: 'address' });
       const memberId = await createMember();
       await setValues(memberId, { [field.key]: { line1: '1 High Street', city: 'London' } });
 
-      const writersOf = async () =>
+      type WrittenRow = { path: string; written_by_type: string; written_by_id: string | null };
+      const writersOf = async (): Promise<WrittenRow[]> =>
         models.Base.knex('members_custom_field_values')
           .where('member_id', memberId)
           .orderBy('path')
-          .select('path', 'written_by_type');
+          .select('path', 'written_by_type', 'written_by_id');
 
-      assert.deepEqual(await writersOf(), [
-        { path: 'city', written_by_type: 'user' },
-        { path: 'line1', written_by_type: 'user' },
-      ]);
-
-      // The owner made both writes, so every part names them rather than only the
-      // first, and the id resolves back to the actual person.
-      const [{ written_by_id: actor }] = await models.Base.knex('members_custom_field_values')
-        .where('member_id', memberId)
-        .select('written_by_id');
-      assert.ok(actor, 'the writer is identified, not merely named');
-
-      await setValues(memberId, { [field.key]: { city: 'Bristol' } });
+      const firstWrite = await writersOf();
       assert.deepEqual(
-        await writersOf(),
+        firstWrite.map(({ path, written_by_type: type }) => ({ path, type })),
         [
-          { path: 'city', written_by_type: 'user' },
-          { path: 'line1', written_by_type: 'user' },
+          { path: 'city', type: 'user' },
+          { path: 'line1', type: 'user' },
         ],
-        'a re-write keeps naming who wrote what is there now',
       );
+
+      // The owner made the write, so every part names them rather than only the
+      // first, and the id resolves back to the actual person.
+      const owner = firstWrite[0].written_by_id;
+      assert.ok(owner, 'the writer is identified, not merely named');
+      assert.deepEqual(
+        firstWrite.map(({ written_by_id: id }) => id),
+        [owner, owner],
+      );
+
+      await agent.useZapierAdminAPIKey();
+      try {
+        await setValues(memberId, { [field.key]: { city: 'Bristol' } });
+      } finally {
+        await agent.loginAsOwner();
+      }
+
+      // Only the part the second write touched changes hands, and it names the writer
+      // of the value there now rather than the one who put the first value there.
+      const secondWrite = await writersOf();
+      assert.deepEqual(
+        secondWrite.map(({ path, written_by_type: type }) => ({ path, type })),
+        [
+          { path: 'city', type: 'integration' },
+          { path: 'line1', type: 'user' },
+        ],
+      );
+      assert.notEqual(secondWrite[0].written_by_id, owner, 'the integration is identified too');
+      assert.ok(secondWrite[0].written_by_id);
+      assert.equal(secondWrite[1].written_by_id, owner);
     });
 
     it("drops a field's values when the field is permanently deleted", async function () {

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1436,6 +1436,46 @@ describe('Member Custom Fields Admin API', function () {
       assert.equal(rows.length, 1);
     });
 
+    // The record has to be made at the moment of the write; nothing can reconstruct it
+    // later. What reads it is a separate question — this pins only that it is written,
+    // and that it names where the value currently held came from rather than the first.
+    // Provenance is observable nowhere else yet, so this reads the columns directly. What
+    // it pins is the outcome: every part records who wrote it, and a re-write says who
+    // wrote what is there now rather than who wrote it first.
+    it('records who wrote each value, and re-records it on every write', async function () {
+      const field = await createField({ name: 'Postal address', type: 'address' });
+      const memberId = await createMember();
+      await setValues(memberId, { [field.key]: { line1: '1 High Street', city: 'London' } });
+
+      const writersOf = async () =>
+        models.Base.knex('members_custom_field_values')
+          .where('member_id', memberId)
+          .orderBy('path')
+          .select('path', 'written_by_type');
+
+      assert.deepEqual(await writersOf(), [
+        { path: 'city', written_by_type: 'user' },
+        { path: 'line1', written_by_type: 'user' },
+      ]);
+
+      // The owner made both writes, so every part names them rather than only the
+      // first, and the id resolves back to the actual person.
+      const [{ written_by_id: actor }] = await models.Base.knex('members_custom_field_values')
+        .where('member_id', memberId)
+        .select('written_by_id');
+      assert.ok(actor, 'the writer is identified, not merely named');
+
+      await setValues(memberId, { [field.key]: { city: 'Bristol' } });
+      assert.deepEqual(
+        await writersOf(),
+        [
+          { path: 'city', written_by_type: 'user' },
+          { path: 'line1', written_by_type: 'user' },
+        ],
+        'a re-write keeps naming who wrote what is there now',
+      );
+    });
+
     it("drops a field's values when the field is permanently deleted", async function () {
       const field = await createField({ name: 'Favourite topic' });
       const memberId = await createMember();

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -445,4 +445,30 @@ describe('Members import — custom fields', function () {
     const member = await findMember(email);
     assert.equal(member.custom_fields?.[key], '=SUM(A1:A9)');
   });
+
+  // Recorded at the moment of the write because it cannot be reconstructed afterwards.
+  // Asserted per row, since that is the granularity a write touches.
+  it('records that the import wrote each value', async function () {
+    const key = await createField('Shipping Address', 'address');
+    const email = 'cf-import-source@example.com';
+    const columns = ['line1', 'city'].map((sub) => `custom_fields.${key}.${sub}`).join(',');
+
+    await importCSV(`email,${columns}\n${email},1 High Street,London\n`);
+
+    const member = await findMember(email);
+    const writers: Array<{ written_by_type: string; written_by_id: string | null }> =
+      await models.Base.knex('members_custom_field_values')
+        .where('member_id', member.id)
+        .orderBy('path')
+        .select('written_by_type', 'written_by_id');
+
+    // An import has no id to give until runs are tracked, so it names its kind only.
+    assert.deepEqual(
+      writers.map(({ written_by_type: type, written_by_id: id }) => ({ type, id })),
+      [
+        { type: 'import', id: null },
+        { type: 'import', id: null },
+      ],
+    );
+  });
 });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = 'a16d1b0f377fdaa35ad51073c0ff1085';
+  const currentSchemaHash = 'dff334a3ab0ee69919d330d3c46752a2';
   const currentFixturesHash = '1727a789194847da33d68dd95301b416';
   const currentSettingsHash = '6ea42a00cca61a1ba87f66eb6e25a78a';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = 'c4c1ef4ab373e100452e6e478a0a5758';
+  const currentSchemaHash = 'a16d1b0f377fdaa35ad51073c0ff1085';
   const currentFixturesHash = '1727a789194847da33d68dd95301b416';
   const currentSettingsHash = '6ea42a00cca61a1ba87f66eb6e25a78a';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';


### PR DESCRIPTION
## Problem

A member's custom field values can be written by more than one thing. A person edits them in admin. An import reads them from a file. Soon, data collected during payment will land in them without anyone typing it.

Nothing recorded which. So a value that looks wrong cannot be traced back to whatever put it there, and a value someone typed cannot be told apart from one a machine supplied. That matters most for the case that has not shipped yet: when something starts writing on a member's behalf, "did a person say this?" becomes a question worth being able to answer.

It is also not a question that can be answered later. Provenance has to be recorded at the moment of the write or it is gone, so it goes in before anything depends on it.

## Solution

Every write names its writer, as a type and an id, shaped the way the activity log already records an actor.

It is required at every call site with no default, so a new writer has to say what it is rather than quietly inheriting the identity of whichever wrote first. There is no foreign key, because provenance has to outlive its cause: that a value arrived by some route stays true after that route is deleted, even though it stops being joinable.

Nothing reads it yet. This is the recording, not the reporting.

ref https://linear.app/ghost/issue/BER-3872

