### PR TITLE
Updated automation table to handle missing stats

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -19,7 +19,7 @@ export type AutomationStats = {
 };
 
 export type AutomationBrowseItem = Automation & {
-  stats: AutomationStats;
+  stats?: AutomationStats;
 };
 
 export type AutomationWaitAction = {

--- a/apps/admin/src/automations/automations.acceptance.test.tsx
+++ b/apps/admin/src/automations/automations.acceptance.test.tsx
@@ -52,4 +52,21 @@ describe('Automations list', () => {
     // Stripe is disconnected in the default boot, which hides the paid welcome flow.
     await expect(automationsScreen.rows()).toHaveCount(1);
   });
+
+  it('hides run analytics when the backend does not return stats', async () => {
+    fakeAutomations([
+      automation({
+        name: 'Free member welcome flow',
+        slug: 'member-welcome-email-free',
+        status: 'active',
+        stats: undefined,
+      }),
+    ]);
+    await renderAdminApp('/automations', AUTOMATIONS_ENABLED);
+
+    await expect.element(automationsScreen.link('Free member welcome flow')).toBeVisible();
+    await expect.element(automationsScreen.columnHeader('Last entry')).not.toBeInTheDocument();
+    await expect.element(automationsScreen.columnHeader('Total entries')).not.toBeInTheDocument();
+    await expect.element(automationsScreen.columnHeader('In progress')).not.toBeInTheDocument();
+  });
 });

--- a/apps/admin/src/automations/components/automations-list.test.tsx
+++ b/apps/admin/src/automations/components/automations-list.test.tsx
@@ -83,6 +83,19 @@ describe('AutomationsList', () => {
     expect(screen.getByText('Never')).toBeInTheDocument();
   });
 
+  it('hides run analytics when stats are unavailable', () => {
+    const automationsWithoutStats = automations.map(
+      ({ stats: _stats, ...automation }) => automation,
+    );
+
+    renderWithRouter(<AutomationsList automations={automationsWithoutStats} />);
+
+    expect(screen.queryByRole('columnheader', { name: 'Last entry' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Total entries' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'In progress' })).not.toBeInTheDocument();
+    expect(screen.queryByText('1,432')).not.toBeInTheDocument();
+  });
+
   it('links each row to the automation sequence by id', () => {
     renderWithRouter(<AutomationsList automations={automations} />);
 

--- a/apps/admin/src/automations/components/automations-list.tsx
+++ b/apps/admin/src/automations/components/automations-list.tsx
@@ -97,37 +97,41 @@ const AutomationsList: React.FC<AutomationsListProps> = ({
     return <AutomationsListSkeleton />;
   }
 
+  const showRunAnalytics = automations.every((automation) => automation.stats !== undefined);
+
   return (
     <Table
       aria-label="Automations"
-      className="flex table-fixed flex-col lg:table"
+      className={cn('flex table-fixed flex-col lg:table', !showRunAnalytics && 'border-t')}
       data-testid="automations-list"
     >
-      <TableHeader className="hidden lg:table-header-group">
-        <TableRow className="hover:bg-transparent">
-          <TableHead className="lg:px-4" scope="col">
-            Name
-          </TableHead>
-          {AUTOMATION_STAT_COLUMNS.map((column) => (
-            <TableHead
-              key={column.key}
-              className={cn('lg:px-4', column.widthClassName)}
-              scope="col"
-            >
-              {column.label}
+      {showRunAnalytics && (
+        <TableHeader className="hidden lg:table-header-group">
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="lg:px-4" scope="col">
+              Name
             </TableHead>
-          ))}
-          <TableHead className="w-28 lg:px-4" scope="col">
-            Status
-          </TableHead>
-        </TableRow>
-      </TableHeader>
+            {AUTOMATION_STAT_COLUMNS.map((column) => (
+              <TableHead
+                key={column.key}
+                className={cn('lg:px-4', column.widthClassName)}
+                scope="col"
+              >
+                {column.label}
+              </TableHead>
+            ))}
+            <TableHead className="w-28 lg:px-4" scope="col">
+              Status
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+      )}
       <TableBody className="flex flex-col lg:table-row-group">
         {automations.map((automation) => {
           const description = AUTOMATION_DESCRIPTIONS[automation.slug];
-          const lastEntry = automation.stats.last_run_created_at;
-          const totalEntries = automation.stats.total_run_count;
-          const inProgressEntries = automation.stats.in_progress_run_count;
+          const lastEntry = automation.stats?.last_run_created_at;
+          const totalEntries = automation.stats?.total_run_count ?? 0;
+          const inProgressEntries = automation.stats?.in_progress_run_count ?? 0;
           const statCells = {
             lastEntry: {
               content: lastEntry ? (
@@ -166,23 +170,29 @@ const AutomationsList: React.FC<AutomationsListProps> = ({
                 </Link>
                 {description && <span className="block text-muted-foreground">{description}</span>}
               </TableHead>
-              {AUTOMATION_STAT_COLUMNS.map((column) => {
-                const cell = statCells[column.key];
+              {showRunAnalytics &&
+                AUTOMATION_STAT_COLUMNS.map((column) => {
+                  const cell = statCells[column.key];
 
-                return (
-                  <TableCell
-                    key={column.key}
-                    className={cn(
-                      'hidden lg:table-cell lg:p-4',
-                      column.widthClassName,
-                      cell.isEmpty && 'text-muted-foreground',
-                    )}
-                  >
-                    {cell.content}
-                  </TableCell>
-                );
-              })}
-              <TableCell className="w-auto p-0 text-right lg:table-cell lg:w-28 lg:p-4 lg:text-left">
+                  return (
+                    <TableCell
+                      key={column.key}
+                      className={cn(
+                        'hidden lg:table-cell lg:p-4',
+                        column.widthClassName,
+                        cell.isEmpty && 'text-muted-foreground',
+                      )}
+                    >
+                      {cell.content}
+                    </TableCell>
+                  );
+                })}
+              <TableCell
+                className={cn(
+                  'w-auto p-0 text-right lg:table-cell lg:p-4',
+                  showRunAnalytics ? 'lg:w-28 lg:text-left' : 'lg:w-32',
+                )}
+              >
                 <AutomationStatusBadge status={automation.status} />
               </TableCell>
             </TableRow>

--- a/packages/testing/test-data/src/builders/automation.ts
+++ b/packages/testing/test-data/src/builders/automation.ts
@@ -8,7 +8,7 @@ export interface Automation {
   name: string;
   slug: string;
   status: 'active' | 'inactive';
-  stats: {
+  stats?: {
     last_run_created_at: string | null;
     total_run_count: number;
     in_progress_run_count: number;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1547

Hide the analytics columns when the automations browse response omits stats. For now, this will make it look the same as we had before we added the stats columns (i.e. no visible header).

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cac0e31b-6323-4f92-9d73-8a17ac341b02" />
