### PR TITLE
Added event loop lag based load shedding

### DIFF
--- a/ghost/core/core/server/web/parent/app.js
+++ b/ghost/core/core/server/web/parent/app.js
@@ -17,6 +17,16 @@ module.exports = function setupParentApp() {
   // Register event emitter on req/res to trigger cache invalidation webhook event
   parentApp.use(mw.emitEvents);
 
+  // Shed load as early as the stack allows, and ahead of the queue rather than
+  // behind it: a request that has already waited in the queue has paid the
+  // cost shedding exists to avoid. Sits after requestId/logRequest so shed
+  // responses are still traceable and show up in the access log.
+  const eventLoopLagConfig = config.get('optimization:eventLoopLag');
+
+  if (eventLoopLagConfig) {
+    parentApp.use(mw.eventLoopLag(eventLoopLagConfig));
+  }
+
   // enabled gzip compression by default
   if (config.get('compress') !== false) {
     parentApp.use(compress());

--- a/ghost/core/core/server/web/parent/app.js
+++ b/ghost/core/core/server/web/parent/app.js
@@ -20,10 +20,10 @@ module.exports = function setupParentApp() {
   // Shed load as early as the stack allows, and ahead of the queue rather than
   // behind it: a request that has already waited in the queue has paid the
   // cost shedding exists to avoid. Sits after requestId/logRequest so shed
-  // responses are still traceable and show up in the access log.
-  const eventLoopLagConfig = config.get('optimization:eventLoopLag');
+  // responses stay traceable and show up in the access log.
+  const eventLoopLagConfig = mw.parseEventLoopLagConfig(config.get('optimization:eventLoopLag'));
 
-  if (eventLoopLagConfig) {
+  if (eventLoopLagConfig.enabled) {
     parentApp.use(mw.eventLoopLag(eventLoopLagConfig));
   }
 

--- a/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
+++ b/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
@@ -13,8 +13,50 @@ const DEFAULTS = {
   retryAfterSeconds: 5,
   // The admin client and its API. Locking the owner out of their own site
   // during an incident is worse than serving readers a little slower.
-  exemptPathPattern: /^\/ghost\//,
+  exemptPathPrefixes: ['/ghost/'],
 };
+
+/**
+ * Config reaches us through nconf, which layers JSON files over argv and env
+ * vars - so a value that is a number in config.production.json arrives as a
+ * string when it is set via GHOST_optimization__eventLoopLag__... Comparing
+ * those directly is silently wrong rather than loudly broken: '60' >= '250'
+ * is true, so an env-var-configured site would fail validation for no reason.
+ */
+function toFiniteNumber(value: unknown, name: string): number {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+
+  if (typeof parsed !== 'number' || !Number.isFinite(parsed)) {
+    throw new errors.IncorrectUsageError({
+      message: `eventLoopLag ${name} must be a finite number, got ${JSON.stringify(value)}`,
+    });
+  }
+
+  return parsed;
+}
+
+/**
+ * Plain prefixes rather than a regular expression: nconf can only ever hand us
+ * JSON, so a RegExp is unreachable from config, and compiling one supplied by
+ * an operator would put an unbounded backtracking risk on the hot path of the
+ * middleware whose whole job is to protect the CPU. startsWith is also cheaper
+ * per request, and matches how max-limit-cap.js exempts endpoints.
+ */
+function toPathPrefixes(value: unknown): string[] {
+  if (value === undefined) {
+    return DEFAULTS.exemptPathPrefixes;
+  }
+
+  const prefixes = typeof value === 'string' ? [value] : value;
+
+  if (!Array.isArray(prefixes) || prefixes.some((prefix) => typeof prefix !== 'string')) {
+    throw new errors.IncorrectUsageError({
+      message: `eventLoopLag exemptPathPrefixes must be a string or an array of strings, got ${JSON.stringify(value)}`,
+    });
+  }
+
+  return prefixes;
+}
 
 export type EventLoopLagConfig = Readonly<{
   /** Lag at or above which the origin starts shedding, in ms. */
@@ -29,8 +71,8 @@ export type EventLoopLagConfig = Readonly<{
   resolutionMs?: number;
   /** Retry-After sent on shed responses, in seconds. */
   retryAfterSeconds?: number;
-  /** Paths that are never shed. */
-  exemptPathPattern?: RegExp;
+  /** Path prefixes that are never shed. Replaces the default, it does not merge. */
+  exemptPathPrefixes?: string[] | string;
 }>;
 
 export type LagMonitor = Readonly<{
@@ -51,13 +93,18 @@ export type LagMonitor = Readonly<{
  * hour ago never looks healthy again.
  */
 export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
-  const windowMs = config.sampleWindowMs ?? DEFAULTS.sampleWindowMs;
-  const percentile = config.percentile ?? DEFAULTS.percentile;
-  const resolution = config.resolutionMs ?? DEFAULTS.resolutionMs;
+  const windowMs = toFiniteNumber(
+    config.sampleWindowMs ?? DEFAULTS.sampleWindowMs,
+    'sampleWindowMs',
+  );
+  const percentile = toFiniteNumber(config.percentile ?? DEFAULTS.percentile, 'percentile');
+  const resolution = toFiniteNumber(config.resolutionMs ?? DEFAULTS.resolutionMs, 'resolutionMs');
+  const highWaterMarkMs = toFiniteNumber(config.highWaterMarkMs, 'highWaterMarkMs');
+  const lowWaterMarkMs = toFiniteNumber(config.lowWaterMarkMs, 'lowWaterMarkMs');
 
-  if (config.lowWaterMarkMs >= config.highWaterMarkMs) {
+  if (lowWaterMarkMs >= highWaterMarkMs) {
     throw new errors.IncorrectUsageError({
-      message: `eventLoopLag lowWaterMarkMs (${config.lowWaterMarkMs}) must be below highWaterMarkMs (${config.highWaterMarkMs})`,
+      message: `eventLoopLag lowWaterMarkMs (${lowWaterMarkMs}) must be below highWaterMarkMs (${highWaterMarkMs})`,
     });
   }
 
@@ -65,9 +112,9 @@ export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
   // the histogram measures how late each sample was, and a sample is never
   // early. A low water mark under the resolution can therefore never be
   // reached, and the origin would shed until it was restarted.
-  if (config.lowWaterMarkMs <= resolution) {
+  if (lowWaterMarkMs <= resolution) {
     throw new errors.IncorrectUsageError({
-      message: `eventLoopLag lowWaterMarkMs (${config.lowWaterMarkMs}) must exceed resolutionMs (${resolution}); an idle event loop reports ~${resolution}ms of delay`,
+      message: `eventLoopLag lowWaterMarkMs (${lowWaterMarkMs}) must exceed resolutionMs (${resolution}); an idle event loop reports ~${resolution}ms of delay`,
     });
   }
 
@@ -88,16 +135,16 @@ export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
     // shedding lowers lag, which immediately re-admits the traffic that raised
     // it. Flapping every window would make the CDN cache a mix of real pages
     // and 503s.
-    if (!overloaded && lagMs >= config.highWaterMarkMs) {
+    if (!overloaded && lagMs >= highWaterMarkMs) {
       overloaded = true;
       shedSinceTransition = 0;
       logging.warn(
-        `[event-loop-lag] Shedding: p${percentile} lag ${Math.round(lagMs)}ms >= ${config.highWaterMarkMs}ms`,
+        `[event-loop-lag] Shedding: p${percentile} lag ${Math.round(lagMs)}ms >= ${highWaterMarkMs}ms`,
       );
-    } else if (overloaded && lagMs <= config.lowWaterMarkMs) {
+    } else if (overloaded && lagMs <= lowWaterMarkMs) {
       overloaded = false;
       logging.info(
-        `[event-loop-lag] Recovered: p${percentile} lag ${Math.round(lagMs)}ms <= ${config.lowWaterMarkMs}ms after shedding ${shedSinceTransition} requests`,
+        `[event-loop-lag] Recovered: p${percentile} lag ${Math.round(lagMs)}ms <= ${lowWaterMarkMs}ms after shedding ${shedSinceTransition} requests`,
       );
     }
   };
@@ -140,8 +187,10 @@ export function eventLoopLag(
   config: EventLoopLagConfig,
   monitor: LagMonitor = createLagMonitor(config),
 ): RequestHandler {
-  const retryAfter = String(config.retryAfterSeconds ?? DEFAULTS.retryAfterSeconds);
-  const exemptPathPattern = config.exemptPathPattern ?? DEFAULTS.exemptPathPattern;
+  const retryAfter = String(
+    toFiniteNumber(config.retryAfterSeconds ?? DEFAULTS.retryAfterSeconds, 'retryAfterSeconds'),
+  );
+  const exemptPathPrefixes = toPathPrefixes(config.exemptPathPrefixes);
 
   const isSheddable = (req: Request) => {
     // Only idempotent reads. A shed GET costs the client a retry; a shed POST
@@ -157,7 +206,7 @@ export function eventLoopLag(
       return false;
     }
 
-    return !exemptPathPattern.test(req.path);
+    return !exemptPathPrefixes.some((prefix) => req.path.startsWith(prefix));
   };
 
   return function eventLoopLagMw(req, res, next) {

--- a/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
+++ b/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
@@ -1,0 +1,182 @@
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import path from 'node:path';
+import * as errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
+import type { Request, RequestHandler } from 'express';
+
+const NS_PER_MS = 1e6;
+
+const DEFAULTS = {
+  sampleWindowMs: 500,
+  percentile: 90,
+  resolutionMs: 20,
+  retryAfterSeconds: 5,
+  // The admin client and its API. Locking the owner out of their own site
+  // during an incident is worse than serving readers a little slower.
+  exemptPathPattern: /^\/ghost\//,
+};
+
+export type EventLoopLagConfig = Readonly<{
+  /** Lag at or above which the origin starts shedding, in ms. */
+  highWaterMarkMs: number;
+  /** Lag at or below which it resumes serving, in ms. Must be below the high mark. */
+  lowWaterMarkMs: number;
+  /** How often the histogram is summarised and reset, in ms. */
+  sampleWindowMs?: number;
+  /** Which percentile of the window is compared against the water marks. */
+  percentile?: number;
+  /** libuv sampling resolution, in ms. */
+  resolutionMs?: number;
+  /** Retry-After sent on shed responses, in seconds. */
+  retryAfterSeconds?: number;
+  /** Paths that are never shed. */
+  exemptPathPattern?: RegExp;
+}>;
+
+export type LagMonitor = Readonly<{
+  isOverloaded: () => boolean;
+  lagMs: () => number;
+  recordShed: () => void;
+  stop: () => void;
+}>;
+
+/**
+ * Tracks event loop delay as a rolling window and flips between a healthy and
+ * an overloaded state with hysteresis.
+ *
+ * monitorEventLoopDelay is sampled by libuv itself rather than by a JS timer,
+ * so it stays accurate exactly when a JS timer would not: while the loop is
+ * blocked. The histogram it returns is cumulative, though, so it has to be
+ * reset each window - read without resetting, a site that was briefly busy an
+ * hour ago never looks healthy again.
+ */
+export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
+  const windowMs = config.sampleWindowMs ?? DEFAULTS.sampleWindowMs;
+  const percentile = config.percentile ?? DEFAULTS.percentile;
+  const resolution = config.resolutionMs ?? DEFAULTS.resolutionMs;
+
+  if (config.lowWaterMarkMs >= config.highWaterMarkMs) {
+    throw new errors.IncorrectUsageError({
+      message: `eventLoopLag lowWaterMarkMs (${config.lowWaterMarkMs}) must be below highWaterMarkMs (${config.highWaterMarkMs})`,
+    });
+  }
+
+  // An idle loop reports a delay of roughly one sampling interval, not zero -
+  // the histogram measures how late each sample was, and a sample is never
+  // early. A low water mark under the resolution can therefore never be
+  // reached, and the origin would shed until it was restarted.
+  if (config.lowWaterMarkMs <= resolution) {
+    throw new errors.IncorrectUsageError({
+      message: `eventLoopLag lowWaterMarkMs (${config.lowWaterMarkMs}) must exceed resolutionMs (${resolution}); an idle event loop reports ~${resolution}ms of delay`,
+    });
+  }
+
+  const histogram = monitorEventLoopDelay({ resolution });
+  histogram.enable();
+
+  let lagMs = 0;
+  let overloaded = false;
+  let shedSinceTransition = 0;
+  let lastSampleAt = Date.now();
+
+  const sample = () => {
+    lagMs = histogram.count === 0 ? 0 : histogram.percentile(percentile) / NS_PER_MS;
+    histogram.reset();
+    lastSampleAt = Date.now();
+
+    // Two water marks rather than one: a single threshold oscillates, because
+    // shedding lowers lag, which immediately re-admits the traffic that raised
+    // it. Flapping every window would make the CDN cache a mix of real pages
+    // and 503s.
+    if (!overloaded && lagMs >= config.highWaterMarkMs) {
+      overloaded = true;
+      shedSinceTransition = 0;
+      logging.warn(
+        `[event-loop-lag] Shedding: p${percentile} lag ${Math.round(lagMs)}ms >= ${config.highWaterMarkMs}ms`,
+      );
+    } else if (overloaded && lagMs <= config.lowWaterMarkMs) {
+      overloaded = false;
+      logging.info(
+        `[event-loop-lag] Recovered: p${percentile} lag ${Math.round(lagMs)}ms <= ${config.lowWaterMarkMs}ms after shedding ${shedSinceTransition} requests`,
+      );
+    }
+  };
+
+  const timer = setInterval(sample, windowMs);
+  // Don't hold the process open on shutdown.
+  timer.unref();
+
+  return {
+    isOverloaded: () => {
+      // CASE: the sampler is a timer, so a fully blocked loop stops it running
+      // and leaves `overloaded` stale at whatever it was before the block. If
+      // it has missed its window by a wide margin, the loop is by definition
+      // too congested to be serving - treat that as overloaded regardless.
+      if (Date.now() - lastSampleAt > windowMs * 4) {
+        return true;
+      }
+
+      return overloaded;
+    },
+    lagMs: () => lagMs,
+    recordShed: () => {
+      shedSinceTransition += 1;
+    },
+    stop: () => {
+      clearInterval(timer);
+      histogram.disable();
+    },
+  };
+}
+
+/**
+ * Sheds idempotent frontend reads while the event loop is too far behind to
+ * serve them within any timeout the CDN in front of it is willing to wait for.
+ *
+ * This has to sit ahead of the request queue: shedding a request that has
+ * already waited in the queue has paid the cost it was meant to avoid.
+ */
+export function eventLoopLag(
+  config: EventLoopLagConfig,
+  monitor: LagMonitor = createLagMonitor(config),
+): RequestHandler {
+  const retryAfter = String(config.retryAfterSeconds ?? DEFAULTS.retryAfterSeconds);
+  const exemptPathPattern = config.exemptPathPattern ?? DEFAULTS.exemptPathPattern;
+
+  const isSheddable = (req: Request) => {
+    // Only idempotent reads. A shed GET costs the client a retry; a shed POST
+    // could drop a member signup, a comment, or a Stripe webhook.
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return false;
+    }
+
+    // Static assets are served off disk without touching the renderer, so they
+    // are not what is burning the loop - and shedding them breaks the pages
+    // that did get rendered.
+    if (path.extname(req.path)) {
+      return false;
+    }
+
+    return !exemptPathPattern.test(req.path);
+  };
+
+  return function eventLoopLagMw(req, res, next) {
+    if (!monitor.isOverloaded() || !isSheddable(req)) {
+      return next();
+    }
+
+    res.setHeader('Retry-After', retryAfter);
+    // Never let a shed response be cached. Without this the CDN can pin a 503
+    // over a perfectly good URL for the whole TTL, long outliving the spike.
+    res.setHeader('Cache-Control', 'no-store, private');
+    res.status(503);
+    monitor.recordShed();
+
+    // Deliberately not routed through the error handler: rendering an error
+    // page costs the loop time we are shedding to reclaim. The 503 is recorded
+    // in the access log by the logRequest middleware either way, so there is
+    // no per-request logging here - at the rate this fires, that would itself
+    // be meaningful load.
+    return res.end();
+  };
+}

--- a/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
+++ b/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
@@ -2,6 +2,7 @@ import { monitorEventLoopDelay } from 'node:perf_hooks';
 import path from 'node:path';
 import * as errors from '@tryghost/errors';
 import logging from '@tryghost/logging';
+import { z } from 'zod';
 import type { Request, RequestHandler } from 'express';
 
 const NS_PER_MS = 1e6;
@@ -17,63 +18,105 @@ const DEFAULTS = {
 };
 
 /**
- * Config reaches us through nconf, which layers JSON files over argv and env
- * vars - so a value that is a number in config.production.json arrives as a
- * string when it is set via GHOST_optimization__eventLoopLag__... Comparing
- * those directly is silently wrong rather than loudly broken: '60' >= '250'
- * is true, so an env-var-configured site would fail validation for no reason.
+ * Resolving Ghost's config into the values this middleware runs on.
+ *
+ * Config arrives untyped: nconf layers an operator's config file, environment
+ * variables and argv over defaults.json, so any value can be anything - and a
+ * number set through an environment variable arrives as a string.
+ *
+ * A numeric string is accepted for that reason. z.coerce.number() is not used
+ * because it also accepts null, true, [] and '' - all of which become 0, which
+ * here would silently mean "shed everything".
  */
-function toFiniteNumber(value: unknown, name: string): number {
-  const parsed = typeof value === 'string' ? Number(value) : value;
+const Milliseconds = z
+  .union([z.number(), z.string().trim().min(1)])
+  .transform(Number)
+  .pipe(z.number().positive().finite());
 
-  if (typeof parsed !== 'number' || !Number.isFinite(parsed)) {
-    throw new errors.IncorrectUsageError({
-      message: `eventLoopLag ${name} must be a finite number, got ${JSON.stringify(value)}`,
-    });
-  }
-
-  return parsed;
-}
+const Percentile = z
+  .union([z.number(), z.string().trim().min(1)])
+  .transform(Number)
+  .pipe(z.number().gt(0).lte(100));
 
 /**
- * Plain prefixes rather than a regular expression: nconf can only ever hand us
+ * Path prefixes rather than a regular expression: nconf can only ever hand us
  * JSON, so a RegExp is unreachable from config, and compiling one supplied by
  * an operator would put an unbounded backtracking risk on the hot path of the
  * middleware whose whole job is to protect the CPU. startsWith is also cheaper
  * per request, and matches how max-limit-cap.js exempts endpoints.
+ *
+ * A bare string is accepted because an environment variable can only supply one.
  */
-function toPathPrefixes(value: unknown): string[] {
-  if (value === undefined) {
-    return DEFAULTS.exemptPathPrefixes;
-  }
+const PathPrefixes = z.union([
+  z
+    .string()
+    .min(1)
+    .transform((prefix) => [prefix]),
+  z.array(z.string().min(1)),
+]);
 
-  const prefixes = typeof value === 'string' ? [value] : value;
+/**
+ * The water marks are required and deliberately have no shipped fallback: a
+ * site that opts into shedding must say where its thresholds are, and inventing
+ * them silently could shed everything. The tuning values below do fall back to
+ * the shipped default rather than throwing, because an operator can correct a
+ * typo live and one must not take the site down.
+ */
+const EventLoopLagConfigSchema = z
+  .object({
+    highWaterMarkMs: Milliseconds,
+    lowWaterMarkMs: Milliseconds,
+    sampleWindowMs: Milliseconds.catch(DEFAULTS.sampleWindowMs),
+    percentile: Percentile.catch(DEFAULTS.percentile),
+    resolutionMs: Milliseconds.catch(DEFAULTS.resolutionMs),
+    retryAfterSeconds: Milliseconds.catch(DEFAULTS.retryAfterSeconds),
+    exemptPathPrefixes: PathPrefixes.catch(DEFAULTS.exemptPathPrefixes),
+  })
+  .superRefine((config, ctx) => {
+    // One threshold oscillates: shedding lowers lag, which re-admits the
+    // traffic that raised it. The gap between the marks is the hysteresis.
+    if (config.lowWaterMarkMs >= config.highWaterMarkMs) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `lowWaterMarkMs (${config.lowWaterMarkMs}) must be below highWaterMarkMs (${config.highWaterMarkMs})`,
+      });
+    }
 
-  if (!Array.isArray(prefixes) || prefixes.some((prefix) => typeof prefix !== 'string')) {
+    // An idle loop reports a delay of roughly one sampling interval, not zero -
+    // the histogram measures how late each sample was, and a sample is never
+    // early. A low water mark under the resolution can therefore never be
+    // reached, and the origin would shed until it was restarted.
+    if (config.lowWaterMarkMs <= config.resolutionMs) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `lowWaterMarkMs (${config.lowWaterMarkMs}) must exceed resolutionMs (${config.resolutionMs}); an idle event loop reports ~${config.resolutionMs}ms of delay`,
+      });
+    }
+  });
+
+/** The config this middleware actually runs on, once resolved. */
+export type EventLoopLagConfig = z.infer<typeof EventLoopLagConfigSchema>;
+
+/**
+ * Parses whatever config supplied into the values the middleware runs on,
+ * reporting a bad one as a Ghost error so it fails at boot rather than on the
+ * first request.
+ */
+export function parseEventLoopLagConfig(configured: unknown): EventLoopLagConfig {
+  const result = EventLoopLagConfigSchema.safeParse(configured);
+
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => [issue.path.join('.'), issue.message].filter(Boolean).join(' '))
+      .join('; ');
+
     throw new errors.IncorrectUsageError({
-      message: `eventLoopLag exemptPathPrefixes must be a string or an array of strings, got ${JSON.stringify(value)}`,
+      message: `Invalid optimization.eventLoopLag config: ${detail}`,
     });
   }
 
-  return prefixes;
+  return result.data;
 }
-
-export type EventLoopLagConfig = Readonly<{
-  /** Lag at or above which the origin starts shedding, in ms. */
-  highWaterMarkMs: number;
-  /** Lag at or below which it resumes serving, in ms. Must be below the high mark. */
-  lowWaterMarkMs: number;
-  /** How often the histogram is summarised and reset, in ms. */
-  sampleWindowMs?: number;
-  /** Which percentile of the window is compared against the water marks. */
-  percentile?: number;
-  /** libuv sampling resolution, in ms. */
-  resolutionMs?: number;
-  /** Retry-After sent on shed responses, in seconds. */
-  retryAfterSeconds?: number;
-  /** Path prefixes that are never shed. Replaces the default, it does not merge. */
-  exemptPathPrefixes?: string[] | string;
-}>;
 
 export type LagMonitor = Readonly<{
   isOverloaded: () => boolean;
@@ -93,32 +136,9 @@ export type LagMonitor = Readonly<{
  * hour ago never looks healthy again.
  */
 export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
-  const windowMs = toFiniteNumber(
-    config.sampleWindowMs ?? DEFAULTS.sampleWindowMs,
-    'sampleWindowMs',
-  );
-  const percentile = toFiniteNumber(config.percentile ?? DEFAULTS.percentile, 'percentile');
-  const resolution = toFiniteNumber(config.resolutionMs ?? DEFAULTS.resolutionMs, 'resolutionMs');
-  const highWaterMarkMs = toFiniteNumber(config.highWaterMarkMs, 'highWaterMarkMs');
-  const lowWaterMarkMs = toFiniteNumber(config.lowWaterMarkMs, 'lowWaterMarkMs');
+  const { highWaterMarkMs, lowWaterMarkMs, sampleWindowMs: windowMs, percentile } = config;
 
-  if (lowWaterMarkMs >= highWaterMarkMs) {
-    throw new errors.IncorrectUsageError({
-      message: `eventLoopLag lowWaterMarkMs (${lowWaterMarkMs}) must be below highWaterMarkMs (${highWaterMarkMs})`,
-    });
-  }
-
-  // An idle loop reports a delay of roughly one sampling interval, not zero -
-  // the histogram measures how late each sample was, and a sample is never
-  // early. A low water mark under the resolution can therefore never be
-  // reached, and the origin would shed until it was restarted.
-  if (lowWaterMarkMs <= resolution) {
-    throw new errors.IncorrectUsageError({
-      message: `eventLoopLag lowWaterMarkMs (${lowWaterMarkMs}) must exceed resolutionMs (${resolution}); an idle event loop reports ~${resolution}ms of delay`,
-    });
-  }
-
-  const histogram = monitorEventLoopDelay({ resolution });
+  const histogram = monitorEventLoopDelay({ resolution: config.resolutionMs });
   histogram.enable();
 
   let lagMs = 0;
@@ -183,14 +203,11 @@ export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
  * This has to sit ahead of the request queue: shedding a request that has
  * already waited in the queue has paid the cost it was meant to avoid.
  */
-export function eventLoopLag(
-  config: EventLoopLagConfig,
-  monitor: LagMonitor = createLagMonitor(config),
-): RequestHandler {
-  const retryAfter = String(
-    toFiniteNumber(config.retryAfterSeconds ?? DEFAULTS.retryAfterSeconds, 'retryAfterSeconds'),
-  );
-  const exemptPathPrefixes = toPathPrefixes(config.exemptPathPrefixes);
+export function eventLoopLag(configured: unknown, monitor?: LagMonitor): RequestHandler {
+  const config = parseEventLoopLagConfig(configured);
+  const lagMonitor = monitor ?? createLagMonitor(config);
+  const retryAfter = String(config.retryAfterSeconds);
+  const { exemptPathPrefixes } = config;
 
   const isSheddable = (req: Request) => {
     // Only idempotent reads. A shed GET costs the client a retry; a shed POST
@@ -210,7 +227,7 @@ export function eventLoopLag(
   };
 
   return function eventLoopLagMw(req, res, next) {
-    if (!monitor.isOverloaded() || !isSheddable(req)) {
+    if (!lagMonitor.isOverloaded() || !isSheddable(req)) {
       return next();
     }
 
@@ -219,7 +236,7 @@ export function eventLoopLag(
     // over a perfectly good URL for the whole TTL, long outliving the spike.
     res.setHeader('Cache-Control', 'no-store, private');
     res.status(503);
-    monitor.recordShed();
+    lagMonitor.recordShed();
 
     // Deliberately not routed through the error handler: rendering an error
     // page costs the loop time we are shedding to reclaim. The 503 is recorded

--- a/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
+++ b/ghost/core/core/server/web/parent/middleware/event-loop-lag.ts
@@ -7,46 +7,18 @@ import type { Request, RequestHandler } from 'express';
 
 const NS_PER_MS = 1e6;
 
-const DEFAULTS = {
-  sampleWindowMs: 500,
-  percentile: 90,
-  resolutionMs: 20,
-  retryAfterSeconds: 5,
-  // The admin client and its API. Locking the owner out of their own site
-  // during an incident is worse than serving readers a little slower.
-  exemptPathPrefixes: ['/ghost/'],
-};
+// Config is untyped, and a value set through an environment variable or argv
+// arrives as a string. Not z.coerce.number(): it also accepts null, true, []
+// and '', turning each into 0 - which for a water mark means "shed everything".
+const Numeric = z.union([z.number(), z.string().trim().min(1)]).transform(Number);
+const Milliseconds = Numeric.pipe(z.number().positive().finite());
+const Percentile = Numeric.pipe(z.number().gt(0).lte(100));
+const Flag = z.union([z.boolean(), z.enum(['true', 'false']).transform((v) => v === 'true')]);
 
-/**
- * Resolving Ghost's config into the values this middleware runs on.
- *
- * Config arrives untyped: nconf layers an operator's config file, environment
- * variables and argv over defaults.json, so any value can be anything - and a
- * number set through an environment variable arrives as a string.
- *
- * A numeric string is accepted for that reason. z.coerce.number() is not used
- * because it also accepts null, true, [] and '' - all of which become 0, which
- * here would silently mean "shed everything".
- */
-const Milliseconds = z
-  .union([z.number(), z.string().trim().min(1)])
-  .transform(Number)
-  .pipe(z.number().positive().finite());
-
-const Percentile = z
-  .union([z.number(), z.string().trim().min(1)])
-  .transform(Number)
-  .pipe(z.number().gt(0).lte(100));
-
-/**
- * Path prefixes rather than a regular expression: nconf can only ever hand us
- * JSON, so a RegExp is unreachable from config, and compiling one supplied by
- * an operator would put an unbounded backtracking risk on the hot path of the
- * middleware whose whole job is to protect the CPU. startsWith is also cheaper
- * per request, and matches how max-limit-cap.js exempts endpoints.
- *
- * A bare string is accepted because an environment variable can only supply one.
- */
+// Prefixes rather than a RegExp: nconf can only produce JSON, and an
+// operator-supplied regex would put backtracking risk on the hot path of the
+// middleware whose job is to protect the CPU. A bare string is accepted
+// because an environment variable can only ever supply one.
 const PathPrefixes = z.union([
   z
     .string()
@@ -55,26 +27,45 @@ const PathPrefixes = z.union([
   z.array(z.string().min(1)),
 ]);
 
-/**
- * The water marks are required and deliberately have no shipped fallback: a
- * site that opts into shedding must say where its thresholds are, and inventing
- * them silently could shed everything. The tuning values below do fall back to
- * the shipped default rather than throwing, because an operator can correct a
- * typo live and one must not take the site down.
- */
+const fields = {
+  enabled: Flag,
+  highWaterMarkMs: Milliseconds,
+  lowWaterMarkMs: Milliseconds,
+  sampleWindowMs: Milliseconds,
+  percentile: Percentile,
+  resolutionMs: Milliseconds,
+  retryAfterSeconds: Milliseconds,
+  exemptPathPrefixes: PathPrefixes,
+};
+
+// defaults.json is the single source of the shipped values - it is the lowest
+// config layer and the file an operator actually edits, so it is read rather
+// than restated. Parsed eagerly and strictly: a bad value there is our bug and
+// should fail at boot, not become the fallback for everything below.
+const shipped = z
+  .object(fields)
+  .parse(require('../../../../shared/config/defaults.json').optimization.eventLoopLag);
+
 const EventLoopLagConfigSchema = z
   .object({
-    highWaterMarkMs: Milliseconds,
-    lowWaterMarkMs: Milliseconds,
-    sampleWindowMs: Milliseconds.catch(DEFAULTS.sampleWindowMs),
-    percentile: Percentile.catch(DEFAULTS.percentile),
-    resolutionMs: Milliseconds.catch(DEFAULTS.resolutionMs),
-    retryAfterSeconds: Milliseconds.catch(DEFAULTS.retryAfterSeconds),
-    exemptPathPrefixes: PathPrefixes.catch(DEFAULTS.exemptPathPrefixes),
+    enabled: fields.enabled.catch(shipped.enabled),
+    // Each field falls back to the shipped value on its own, so one typo does
+    // not take the site down.
+    highWaterMarkMs: fields.highWaterMarkMs.catch(shipped.highWaterMarkMs),
+    lowWaterMarkMs: fields.lowWaterMarkMs.catch(shipped.lowWaterMarkMs),
+    sampleWindowMs: fields.sampleWindowMs.catch(shipped.sampleWindowMs),
+    percentile: fields.percentile.catch(shipped.percentile),
+    resolutionMs: fields.resolutionMs.catch(shipped.resolutionMs),
+    retryAfterSeconds: fields.retryAfterSeconds.catch(shipped.retryAfterSeconds),
+    exemptPathPrefixes: fields.exemptPathPrefixes.catch(shipped.exemptPathPrefixes),
   })
+  // Individually valid values can still be incoherent together. These throw
+  // rather than falling back, because there is no way to guess which of the two
+  // the operator meant.
   .superRefine((config, ctx) => {
-    // One threshold oscillates: shedding lowers lag, which re-admits the
-    // traffic that raised it. The gap between the marks is the hysteresis.
+    // The gap between the marks is the hysteresis. A single threshold
+    // oscillates: shedding lowers lag, which re-admits the traffic that raised
+    // it, and the CDN caches a mix of real pages and 503s.
     if (config.lowWaterMarkMs >= config.highWaterMarkMs) {
       ctx.addIssue({
         code: 'custom',
@@ -82,10 +73,9 @@ const EventLoopLagConfigSchema = z
       });
     }
 
-    // An idle loop reports a delay of roughly one sampling interval, not zero -
-    // the histogram measures how late each sample was, and a sample is never
-    // early. A low water mark under the resolution can therefore never be
-    // reached, and the origin would shed until it was restarted.
+    // An idle loop reports roughly one sampling interval of delay, not zero, so
+    // a mark under the resolution can never be reached and the origin would
+    // shed until it was restarted.
     if (config.lowWaterMarkMs <= config.resolutionMs) {
       ctx.addIssue({
         code: 'custom',
@@ -94,16 +84,11 @@ const EventLoopLagConfigSchema = z
     }
   });
 
-/** The config this middleware actually runs on, once resolved. */
 export type EventLoopLagConfig = z.infer<typeof EventLoopLagConfigSchema>;
 
-/**
- * Parses whatever config supplied into the values the middleware runs on,
- * reporting a bad one as a Ghost error so it fails at boot rather than on the
- * first request.
- */
+/** Resolves configured values, failing at boot rather than on the first request. */
 export function parseEventLoopLagConfig(configured: unknown): EventLoopLagConfig {
-  const result = EventLoopLagConfigSchema.safeParse(configured);
+  const result = EventLoopLagConfigSchema.safeParse(configured ?? {});
 
   if (!result.success) {
     const detail = result.error.issues
@@ -126,14 +111,13 @@ export type LagMonitor = Readonly<{
 }>;
 
 /**
- * Tracks event loop delay as a rolling window and flips between a healthy and
- * an overloaded state with hysteresis.
+ * Tracks event loop delay as a rolling window, flipping between healthy and
+ * overloaded with hysteresis.
  *
- * monitorEventLoopDelay is sampled by libuv itself rather than by a JS timer,
- * so it stays accurate exactly when a JS timer would not: while the loop is
- * blocked. The histogram it returns is cumulative, though, so it has to be
- * reset each window - read without resetting, a site that was briefly busy an
- * hour ago never looks healthy again.
+ * monitorEventLoopDelay is sampled by libuv rather than by a JS timer, so it
+ * stays accurate exactly when a timer would not: while the loop is blocked. Its
+ * histogram is cumulative, so it has to be reset each window - read without
+ * resetting, a site that was briefly busy an hour ago never reads healthy again.
  */
 export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
   const { highWaterMarkMs, lowWaterMarkMs, sampleWindowMs: windowMs, percentile } = config;
@@ -151,10 +135,6 @@ export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
     histogram.reset();
     lastSampleAt = Date.now();
 
-    // Two water marks rather than one: a single threshold oscillates, because
-    // shedding lowers lag, which immediately re-admits the traffic that raised
-    // it. Flapping every window would make the CDN cache a mix of real pages
-    // and 503s.
     if (!overloaded && lagMs >= highWaterMarkMs) {
       overloaded = true;
       shedSinceTransition = 0;
@@ -175,10 +155,9 @@ export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
 
   return {
     isOverloaded: () => {
-      // CASE: the sampler is a timer, so a fully blocked loop stops it running
-      // and leaves `overloaded` stale at whatever it was before the block. If
-      // it has missed its window by a wide margin, the loop is by definition
-      // too congested to be serving - treat that as overloaded regardless.
+      // The sampler is itself a timer, so a fully blocked loop stops it running
+      // and leaves the flag stale. A badly overdue sample means the loop is too
+      // congested to be serving anyway.
       if (Date.now() - lastSampleAt > windowMs * 4) {
         return true;
       }
@@ -198,10 +177,10 @@ export function createLagMonitor(config: EventLoopLagConfig): LagMonitor {
 
 /**
  * Sheds idempotent frontend reads while the event loop is too far behind to
- * serve them within any timeout the CDN in front of it is willing to wait for.
+ * serve them within the timeout of whatever is in front of it.
  *
- * This has to sit ahead of the request queue: shedding a request that has
- * already waited in the queue has paid the cost it was meant to avoid.
+ * Belongs ahead of the request queue: shedding a request that has already
+ * waited in the queue has paid the cost shedding exists to avoid.
  */
 export function eventLoopLag(configured: unknown, monitor?: LagMonitor): RequestHandler {
   const config = parseEventLoopLagConfig(configured);
@@ -210,15 +189,14 @@ export function eventLoopLag(configured: unknown, monitor?: LagMonitor): Request
   const { exemptPathPrefixes } = config;
 
   const isSheddable = (req: Request) => {
-    // Only idempotent reads. A shed GET costs the client a retry; a shed POST
-    // could drop a member signup, a comment, or a Stripe webhook.
+    // A shed GET costs the client a retry; a shed POST could drop a member
+    // signup, a comment, or a Stripe webhook.
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       return false;
     }
 
-    // Static assets are served off disk without touching the renderer, so they
-    // are not what is burning the loop - and shedding them breaks the pages
-    // that did get rendered.
+    // Static assets don't touch the renderer, and shedding them breaks the
+    // pages that did get rendered.
     if (path.extname(req.path)) {
       return false;
     }
@@ -232,17 +210,16 @@ export function eventLoopLag(configured: unknown, monitor?: LagMonitor): Request
     }
 
     res.setHeader('Retry-After', retryAfter);
-    // Never let a shed response be cached. Without this the CDN can pin a 503
-    // over a perfectly good URL for the whole TTL, long outliving the spike.
+    // Never let a shed response be cached, or the CDN can pin a 503 over a good
+    // URL for the whole TTL, long outliving the spike.
     res.setHeader('Cache-Control', 'no-store, private');
     res.status(503);
     lagMonitor.recordShed();
 
-    // Deliberately not routed through the error handler: rendering an error
-    // page costs the loop time we are shedding to reclaim. The 503 is recorded
-    // in the access log by the logRequest middleware either way, so there is
-    // no per-request logging here - at the rate this fires, that would itself
-    // be meaningful load.
+    // Not routed through the error handler: rendering an error page costs the
+    // loop time we are shedding to reclaim. logRequest still records the 503,
+    // so there is no per-request logging here - at the rate this fires that
+    // would itself be real load.
     return res.end();
   };
 }

--- a/ghost/core/core/server/web/parent/middleware/index.js
+++ b/ghost/core/core/server/web/parent/middleware/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   emitEvents: require('./emit-events'),
+  eventLoopLag: require('./event-loop-lag').eventLoopLag,
   ghostLocals: require('./ghost-locals').ghostLocals,
   logRequest: require('./log-request'),
   queueRequest: require('./queue-request'),

--- a/ghost/core/core/server/web/parent/middleware/index.js
+++ b/ghost/core/core/server/web/parent/middleware/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   emitEvents: require('./emit-events'),
   eventLoopLag: require('./event-loop-lag').eventLoopLag,
+  parseEventLoopLagConfig: require('./event-loop-lag').parseEventLoopLagConfig,
   ghostLocals: require('./ghost-locals').ghostLocals,
   logRequest: require('./log-request'),
   queueRequest: require('./queue-request'),

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -247,6 +247,16 @@
   "optimization": {
     "maxLimit": 100,
     "allowLimitAll": false,
+    "eventLoopLag": {
+      "enabled": false,
+      "highWaterMarkMs": 500,
+      "lowWaterMarkMs": 100,
+      "sampleWindowMs": 500,
+      "percentile": 90,
+      "resolutionMs": 20,
+      "retryAfterSeconds": 5,
+      "exemptPathPrefixes": ["/ghost/"]
+    },
     "getHelper": {
       "timeout": {
         "threshold": 5000,

--- a/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
+++ b/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
@@ -5,11 +5,11 @@ import sinon from 'sinon';
 import {
   createLagMonitor,
   eventLoopLag,
-  type EventLoopLagConfig,
+  parseEventLoopLagConfig,
   type LagMonitor,
 } from '../../../../../../core/server/web/parent/middleware/event-loop-lag';
 
-const CONFIG: EventLoopLagConfig = {
+const CONFIG = {
   highWaterMarkMs: 250,
   lowWaterMarkMs: 60,
 };
@@ -23,7 +23,7 @@ function fakeMonitor(overloaded: boolean): LagMonitor & { recordShed: sinon.Sino
   };
 }
 
-function createApp(monitor: LagMonitor, config: EventLoopLagConfig = CONFIG) {
+function createApp(monitor: LagMonitor, config: unknown = CONFIG) {
   const app = express();
   app.use(eventLoopLag(config, monitor));
   app.all(/.*/, (_req, res) => {
@@ -33,34 +33,56 @@ function createApp(monitor: LagMonitor, config: EventLoopLagConfig = CONFIG) {
 }
 
 describe('Event loop lag middleware', function () {
-  describe('createLagMonitor', function () {
+  describe('parseEventLoopLagConfig', function () {
     it('rejects a low water mark at or above the high water mark', function () {
       assert.throws(
-        () => createLagMonitor({ highWaterMarkMs: 100, lowWaterMarkMs: 100 }),
+        () => parseEventLoopLagConfig({ highWaterMarkMs: 100, lowWaterMarkMs: 100 }),
         /must be below highWaterMarkMs/,
       );
+    });
+
+    it('rejects a missing water mark rather than inventing one', function () {
+      assert.throws(() => parseEventLoopLagConfig({ highWaterMarkMs: 250 }), /lowWaterMarkMs/);
+    });
+
+    it('falls back to shipped defaults for malformed tuning values', function () {
+      // An operator can correct a typo live; it must not take the site down.
+      const config = parseEventLoopLagConfig({
+        ...CONFIG,
+        percentile: 'nope',
+        sampleWindowMs: -1,
+        exemptPathPrefixes: [42],
+      });
+
+      assert.equal(config.percentile, 90);
+      assert.equal(config.sampleWindowMs, 500);
+      assert.deepEqual(config.exemptPathPrefixes, ['/ghost/']);
+    });
+
+    it('does not accept the values z.coerce.number() would let through', function () {
+      // null/true/'' all coerce to 0, which here would mean "shed everything".
+      for (const highWaterMarkMs of [null, true, '', []]) {
+        assert.throws(
+          () => parseEventLoopLagConfig({ ...CONFIG, highWaterMarkMs }),
+          /highWaterMarkMs/,
+          `expected ${JSON.stringify(highWaterMarkMs)} to be rejected`,
+        );
+      }
     });
 
     it('accepts numeric config supplied as strings by argv or env vars', function () {
       // nconf layers JSON files over argv and env vars, so these arrive as
       // strings when set via GHOST_optimization__eventLoopLag__...
-      const monitor = createLagMonitor({
-        highWaterMarkMs: '250',
-        lowWaterMarkMs: '60',
-      } as unknown as EventLoopLagConfig);
+      const config = parseEventLoopLagConfig({ highWaterMarkMs: '250', lowWaterMarkMs: '60' });
 
-      assert.equal(monitor.isOverloaded(), false);
-      monitor.stop();
+      assert.equal(config.highWaterMarkMs, 250);
+      assert.equal(config.lowWaterMarkMs, 60);
     });
 
     it('rejects numeric config that is not a number', function () {
       assert.throws(
-        () =>
-          createLagMonitor({
-            highWaterMarkMs: 250,
-            lowWaterMarkMs: 'soon',
-          } as unknown as EventLoopLagConfig),
-        /lowWaterMarkMs must be a finite number/,
+        () => parseEventLoopLagConfig({ highWaterMarkMs: 250, lowWaterMarkMs: 'soon' }),
+        /lowWaterMarkMs/,
       );
     });
 
@@ -68,13 +90,14 @@ describe('Event loop lag middleware', function () {
       // An idle loop reports ~resolution ms of delay, so such a monitor could
       // never leave the overloaded state.
       assert.throws(
-        () => createLagMonitor({ highWaterMarkMs: 250, lowWaterMarkMs: 20, resolutionMs: 20 }),
+        () =>
+          parseEventLoopLagConfig({ highWaterMarkMs: 250, lowWaterMarkMs: 20, resolutionMs: 20 }),
         /must exceed resolutionMs/,
       );
     });
 
     it('starts healthy and does not hold the process open', function () {
-      const monitor = createLagMonitor(CONFIG);
+      const monitor = createLagMonitor(parseEventLoopLagConfig(CONFIG));
       assert.equal(monitor.isOverloaded(), false);
       assert.equal(monitor.lagMs(), 0);
       monitor.stop();
@@ -161,15 +184,13 @@ describe('Event loop lag middleware', function () {
       await request(app).get('/critical/thing').expect(200);
     });
 
-    it('rejects exempt prefixes that are not strings', function () {
-      assert.throws(
-        () =>
-          eventLoopLag(
-            { ...CONFIG, exemptPathPrefixes: [42] } as unknown as EventLoopLagConfig,
-            fakeMonitor(true),
-          ),
-        /exemptPathPrefixes must be a string or an array of strings/,
-      );
+    it('falls back to the default when exempt prefixes are not strings', async function () {
+      // Unlike the water marks, a malformed prefix list falls back rather than
+      // throwing, so admin stays exempt instead of the site failing to boot.
+      const app = createApp(fakeMonitor(true), { ...CONFIG, exemptPathPrefixes: [42] });
+
+      await request(app).get('/ghost/').expect(200);
+      await request(app).get('/some-post').expect(503);
     });
   });
 });

--- a/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
+++ b/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
@@ -41,8 +41,20 @@ describe('Event loop lag middleware', function () {
       );
     });
 
-    it('rejects a missing water mark rather than inventing one', function () {
-      assert.throws(() => parseEventLoopLagConfig({ highWaterMarkMs: 250 }), /lowWaterMarkMs/);
+    it('resolves to the shipped defaults when nothing is configured', function () {
+      const config = parseEventLoopLagConfig(undefined);
+
+      assert.equal(config.enabled, false, 'ships disabled');
+      assert.equal(config.highWaterMarkMs, 500);
+      assert.equal(config.lowWaterMarkMs, 100);
+      assert.deepEqual(config.exemptPathPrefixes, ['/ghost/']);
+    });
+
+    it('reads the enabled flag, including as a string from an env var', function () {
+      assert.equal(parseEventLoopLagConfig({ enabled: true }).enabled, true);
+      assert.equal(parseEventLoopLagConfig({ enabled: 'true' }).enabled, true);
+      // 'false' is truthy as a bare string, so it must be parsed, not coerced.
+      assert.equal(parseEventLoopLagConfig({ enabled: 'false' }).enabled, false);
     });
 
     it('falls back to shipped defaults for malformed tuning values', function () {
@@ -59,13 +71,21 @@ describe('Event loop lag middleware', function () {
       assert.deepEqual(config.exemptPathPrefixes, ['/ghost/']);
     });
 
-    it('does not accept the values z.coerce.number() would let through', function () {
+    it('throws on water marks that are individually valid but incoherent', function () {
+      // No way to guess which of the two the operator meant.
+      assert.throws(
+        () => parseEventLoopLagConfig({ highWaterMarkMs: 100, lowWaterMarkMs: 250 }),
+        /must be below highWaterMarkMs/,
+      );
+    });
+
+    it('does not let through the values z.coerce.number() would', function () {
       // null/true/'' all coerce to 0, which here would mean "shed everything".
       for (const highWaterMarkMs of [null, true, '', []]) {
-        assert.throws(
-          () => parseEventLoopLagConfig({ ...CONFIG, highWaterMarkMs }),
-          /highWaterMarkMs/,
-          `expected ${JSON.stringify(highWaterMarkMs)} to be rejected`,
+        assert.equal(
+          parseEventLoopLagConfig({ ...CONFIG, highWaterMarkMs }).highWaterMarkMs,
+          500,
+          `expected ${JSON.stringify(highWaterMarkMs)} to fall back, not become 0`,
         );
       }
     });
@@ -79,11 +99,11 @@ describe('Event loop lag middleware', function () {
       assert.equal(config.lowWaterMarkMs, 60);
     });
 
-    it('rejects numeric config that is not a number', function () {
-      assert.throws(
-        () => parseEventLoopLagConfig({ highWaterMarkMs: 250, lowWaterMarkMs: 'soon' }),
-        /lowWaterMarkMs/,
-      );
+    it('falls back to the shipped value for a malformed water mark', function () {
+      const config = parseEventLoopLagConfig({ highWaterMarkMs: 250, lowWaterMarkMs: 'soon' });
+
+      assert.equal(config.highWaterMarkMs, 250);
+      assert.equal(config.lowWaterMarkMs, 100, 'shipped value');
     });
 
     it('rejects a low water mark below the sampling resolution', function () {

--- a/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
+++ b/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
@@ -41,6 +41,29 @@ describe('Event loop lag middleware', function () {
       );
     });
 
+    it('accepts numeric config supplied as strings by argv or env vars', function () {
+      // nconf layers JSON files over argv and env vars, so these arrive as
+      // strings when set via GHOST_optimization__eventLoopLag__...
+      const monitor = createLagMonitor({
+        highWaterMarkMs: '250',
+        lowWaterMarkMs: '60',
+      } as unknown as EventLoopLagConfig);
+
+      assert.equal(monitor.isOverloaded(), false);
+      monitor.stop();
+    });
+
+    it('rejects numeric config that is not a number', function () {
+      assert.throws(
+        () =>
+          createLagMonitor({
+            highWaterMarkMs: 250,
+            lowWaterMarkMs: 'soon',
+          } as unknown as EventLoopLagConfig),
+        /lowWaterMarkMs must be a finite number/,
+      );
+    });
+
     it('rejects a low water mark below the sampling resolution', function () {
       // An idle loop reports ~resolution ms of delay, so such a monitor could
       // never leave the overloaded state.
@@ -117,12 +140,36 @@ describe('Event loop lag middleware', function () {
         .expect(200);
     });
 
-    it('honours a configured exempt path pattern', async function () {
-      const app = createApp(fakeMonitor(true), { ...CONFIG, exemptPathPattern: /^\/critical\// });
+    it('honours configured exempt path prefixes', async function () {
+      const app = createApp(fakeMonitor(true), {
+        ...CONFIG,
+        exemptPathPrefixes: ['/critical/'],
+      });
 
       await request(app).get('/critical/thing').expect(200);
       // The default admin exemption is replaced, not merged.
       await request(app).get('/ghost/').expect(503);
+    });
+
+    it('accepts a single exempt prefix as a bare string', async function () {
+      // An env var can only ever supply one string, never an array.
+      const app = createApp(fakeMonitor(true), {
+        ...CONFIG,
+        exemptPathPrefixes: '/critical/',
+      });
+
+      await request(app).get('/critical/thing').expect(200);
+    });
+
+    it('rejects exempt prefixes that are not strings', function () {
+      assert.throws(
+        () =>
+          eventLoopLag(
+            { ...CONFIG, exemptPathPrefixes: [42] } as unknown as EventLoopLagConfig,
+            fakeMonitor(true),
+          ),
+        /exemptPathPrefixes must be a string or an array of strings/,
+      );
     });
   });
 });

--- a/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
+++ b/ghost/core/test/unit/server/web/parent/middleware/event-loop-lag.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import request from 'supertest';
+import sinon from 'sinon';
+import {
+  createLagMonitor,
+  eventLoopLag,
+  type EventLoopLagConfig,
+  type LagMonitor,
+} from '../../../../../../core/server/web/parent/middleware/event-loop-lag';
+
+const CONFIG: EventLoopLagConfig = {
+  highWaterMarkMs: 250,
+  lowWaterMarkMs: 60,
+};
+
+function fakeMonitor(overloaded: boolean): LagMonitor & { recordShed: sinon.SinonStub } {
+  return {
+    isOverloaded: () => overloaded,
+    lagMs: () => 0,
+    recordShed: sinon.stub(),
+    stop: () => {},
+  };
+}
+
+function createApp(monitor: LagMonitor, config: EventLoopLagConfig = CONFIG) {
+  const app = express();
+  app.use(eventLoopLag(config, monitor));
+  app.all(/.*/, (_req, res) => {
+    res.status(200).json({ served: true });
+  });
+  return app;
+}
+
+describe('Event loop lag middleware', function () {
+  describe('createLagMonitor', function () {
+    it('rejects a low water mark at or above the high water mark', function () {
+      assert.throws(
+        () => createLagMonitor({ highWaterMarkMs: 100, lowWaterMarkMs: 100 }),
+        /must be below highWaterMarkMs/,
+      );
+    });
+
+    it('rejects a low water mark below the sampling resolution', function () {
+      // An idle loop reports ~resolution ms of delay, so such a monitor could
+      // never leave the overloaded state.
+      assert.throws(
+        () => createLagMonitor({ highWaterMarkMs: 250, lowWaterMarkMs: 20, resolutionMs: 20 }),
+        /must exceed resolutionMs/,
+      );
+    });
+
+    it('starts healthy and does not hold the process open', function () {
+      const monitor = createLagMonitor(CONFIG);
+      assert.equal(monitor.isOverloaded(), false);
+      assert.equal(monitor.lagMs(), 0);
+      monitor.stop();
+    });
+  });
+
+  describe('while the loop is healthy', function () {
+    it('serves requests it would otherwise shed', async function () {
+      await request(createApp(fakeMonitor(false)))
+        .get('/some-post')
+        .expect(200)
+        .expect({ served: true });
+    });
+  });
+
+  describe('while the loop is overloaded', function () {
+    it('sheds a frontend GET with 503, Retry-After and an uncacheable response', async function () {
+      const monitor = fakeMonitor(true);
+
+      await request(createApp(monitor))
+        .get('/some-post')
+        .expect(503)
+        .expect('Retry-After', '5')
+        .expect('Cache-Control', 'no-store, private');
+
+      sinon.assert.calledOnce(monitor.recordShed);
+    });
+
+    it('sheds a HEAD request', async function () {
+      await request(createApp(fakeMonitor(true)))
+        .head('/some-post')
+        .expect(503);
+    });
+
+    it('honours a configured Retry-After', async function () {
+      await request(createApp(fakeMonitor(true), { ...CONFIG, retryAfterSeconds: 30 }))
+        .get('/some-post')
+        .expect('Retry-After', '30');
+    });
+
+    it('does not shed non-idempotent requests', async function () {
+      // A shed GET costs a retry; a shed POST could drop a member signup,
+      // a comment, or a Stripe webhook.
+      const monitor = fakeMonitor(true);
+
+      await request(createApp(monitor)).post('/members/api/send-magic-link/').expect(200);
+
+      sinon.assert.notCalled(monitor.recordShed);
+    });
+
+    it('does not shed static assets', async function () {
+      await request(createApp(fakeMonitor(true)))
+        .get('/assets/built/screen.css')
+        .expect(200);
+    });
+
+    it('does not shed admin, so the owner is not locked out mid-incident', async function () {
+      await request(createApp(fakeMonitor(true)))
+        .get('/ghost/api/admin/site/')
+        .expect(200);
+      await request(createApp(fakeMonitor(true)))
+        .get('/ghost/')
+        .expect(200);
+    });
+
+    it('honours a configured exempt path pattern', async function () {
+      const app = createApp(fakeMonitor(true), { ...CONFIG, exemptPathPattern: /^\/critical\// });
+
+      await request(app).get('/critical/thing').expect(200);
+      // The default admin exemption is replaced, not merged.
+      await request(app).get('/ghost/').expect(503);
+    });
+  });
+});


### PR DESCRIPTION
ref INC-323

## Why are you making it?

In a recent incident an origin sat pegged at 100% CPU for two hours. A homepage `{{#get}}` over 62 featured posts with tags, authors and tier data cost seconds of CPU per render. Because that work is CPU-bound rather than I/O-bound, the event loop was blocked in multi-second chunks, and every other page on the site was starved behind the homepage.

Two existing mechanisms did not help:

- **The request queue is unbounded.** `queue-request.js` sets `queuedLimit: -1`, so requests accumulate until they exceed the timeout of whatever is in front of them.
- **The `{{#get}}` timeout cannot fire.** It races the API call against a `setTimeout`, and a timer callback needs a free event loop to run. While synchronous serialization holds the loop, the timeout is queued behind the very work it is meant to abort. Verified with a 500ms threshold against 3000ms of synchronous work: it returned normally at 3000ms without aborting. It guards against a slow database, not slow serialization.

Note that an `AbortController` would not have helped either, for the same reason — `abort()` still has to be *called* by something, and JavaScript has no preemption. Cancellation only takes effect at yield points.

## What does it do?

Adds optional admission control ahead of the request queue, shipped in `defaults.json` as `optimization.eventLoopLag` with `enabled: false`.

`monitorEventLoopDelay` is sampled by libuv rather than by a JS timer, so it stays accurate precisely when a timer-based check cannot run. When lag for a sampling window crosses the high water mark, the origin returns an immediate 503 with `Retry-After` for idempotent frontend reads, and stops once lag falls back below the low water mark.

Design points worth reviewing:

- **Two water marks, not one.** A single threshold oscillates: shedding lowers lag, which immediately re-admits the traffic that raised it. Flapping every window would make the CDN cache a mix of real pages and 503s.
- **The histogram is cumulative** and must be reset each window. Read without resetting, a site that was briefly busy an hour ago never reads healthy again.
- **An idle loop reports ~`resolution` ms of delay, not zero** (measured: resolution 20ms → p90 idle floor 20.3ms). A low water mark below the resolution can never be reached, so that combination is rejected rather than silently shedding forever.
- **The sampler is itself a timer**, so a fully blocked loop stops it updating and leaves the flag stale. `isOverloaded()` treats a badly overdue sample as overloaded.
- **Only GET and HEAD are shed.** A shed GET costs the client a retry; a shed POST could drop a member signup, a comment, or a Stripe webhook.
- **Static assets and admin are never shed**, so the owner is not locked out of their own site mid-incident.
- **Shed responses are `no-store`**, so a CDN cannot pin a 503 over a good URL for a whole TTL.
- **No per-request logging.** At the rate this fires that would itself be meaningful load; transitions are logged, and the 503 already appears in the access log via `logRequest`.

### Config handling

Config is parsed with zod at the boundary, following `members-custom-fields/config.ts` and `members/import-export/config.ts`. nconf layers an operator's config file, env vars and argv over `defaults.json`, so it can only produce JSON types and numbers arrive as strings when set via env.

- `defaults.json` is the single source of the shipped values, parsed eagerly and strictly — a bad value there is our bug and should fail at boot.
- Each field falls back to its shipped value independently, so one typo doesn't take the site down.
- Water marks that are individually valid but incoherent together throw, since there's no way to guess which of the two was meant.
- `z.coerce.number()` is deliberately avoided: it accepts `null`, `true`, `[]` and `''` and turns each into `0`, which for a water mark would mean "shed everything". Covered by a test.
- `enabled` is parsed rather than read for truthiness — an env var supplies `'false'` as a string, which is truthy.
- Exemptions are path prefixes matched with `startsWith`, not a RegExp: JSON-native, cheaper per request, avoids giving an operator-supplied regex an unbounded backtracking risk on this middleware's hot path, and matches how `max-limit-cap.js` exempts endpoints.

## Why is this something Ghost users or developers need?

It does not make a slow page fast — the underlying cost still needs fixing, and for INC-323 that was public post caching. What it does is stop one expensive page from starving the rest of the site while that happens.

Simulating the incident shape (3s CPU-bound homepage render, 30 req/s, 40% homepage):

| scenario | homepages served | other pages served | shed | peak lag |
|---|---|---|---|---|
| no shedding | 4 | 3 | 0 | – |
| with shedding | 4 | 13 | 38 | 3003ms |

Homepage throughput is unchanged; the loop is saturated either way. The difference is that the rest of the site keeps serving. It converts "the site is down" into "one page is degraded".

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

## Testing notes

20 unit tests covering config resolution (shipped defaults, string-typed numerics and flags as nconf delivers them, per-field fallback, incoherent water marks, and the values `z.coerce.number()` would let through), pass-through when healthy, and the shed/exempt matrix. `test/unit/server/web/` and `test/unit/shared/` pass (38 files, 385 tests). ESLint and `oxfmt --check` clean.

`tsc --noEmit` reports pre-existing `TS2307` errors across unrelated services in this environment, caused by unbuilt workspace packages (`@tryghost/adapter-base-*` etc. have `src` but no `dist`) — none reference the files in this PR. Worth a green CI run to confirm.