### PR TITLE
Fixed flaky membership tier access acceptance test

### DIFF
--- a/apps/admin/src/settings/membership/access.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/access.acceptance.test.tsx
@@ -234,8 +234,13 @@ describe('Access settings', () => {
 
     await choose('default-post-access-select', 'Specific tiers');
     await settingsScreen.access().getByTestId('tiers-select').click();
-    await settingsScreen.selectOption(basic.name).click();
-    await settingsScreen.selectOption(premium.name).click();
+    const basicOption = settingsScreen.tierOption(basic.name);
+    await expect.element(basicOption).toBeVisible();
+    await basicOption.click();
+
+    const premiumOption = settingsScreen.tierOption(premium.name);
+    await expect.element(premiumOption).toBeVisible();
+    await premiumOption.click();
     await settingsScreen.access().getByRole('button', { name: 'Save' }).click();
 
     await expect

--- a/apps/admin/src/settings/settings.screen.ts
+++ b/apps/admin/src/settings/settings.screen.ts
@@ -50,6 +50,8 @@ export const settingsScreen = {
     page.getByRole('option', {
       name: new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\s|$)`),
     }),
+  tierOption: (name: string) =>
+    page.getByRole('listbox').getByRole('option', { name, exact: true }),
   errorToast: toast,
   successToast: toast,
   inviteUserModal: () => page.getByTestId(sel.inviteUserModal),


### PR DESCRIPTION
## Summary

- Scope tier option lookup to the open command listbox.
- Wait for each tier option to become visible before clicking it.
- Match tier names exactly to avoid unrelated option matches.

This removes the race between the asynchronous mocked tiers request and the React Query result rendering in the combobox. The same timeout occurred in multiple CI runs, including the linked failure.

## Testing

- `CI=1 pnpm --filter @tryghost/admin exec vitest run -c vitest.acceptance.config.ts src/settings/membership/access.acceptance.test.tsx`
- `pnpm nx run @tryghost/admin:typecheck`
- `pnpm nx run @tryghost/admin:lint`

No changeset is required because this is an internal acceptance-test fix.