### PR TITLE
Added typechecking as a first-class CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -747,16 +747,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1000
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - name: Typecheck projects
         run: pnpm nx run-many -t test:types -p "${{ needs.job_setup.outputs.typecheck_projects_str }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
           if [[ "${{ env.IS_TAG }}" != 'true' && "${{ steps.changed.outputs.any-code }}" != 'true' ]]; then
             echo 'affected_projects=[]' >> "$GITHUB_OUTPUT"
             echo 'affected_projects_str=' >> "$GITHUB_OUTPUT"
+            echo 'typecheck_projects_str=' >> "$GITHUB_OUTPUT"
             echo 'unit_test_projects_str=' >> "$GITHUB_OUTPUT"
             echo 'affected_i18n_projects=' >> "$GITHUB_OUTPUT"
             echo 'affected_playwright_projects=[]' >> "$GITHUB_OUTPUT"
@@ -258,6 +259,9 @@ jobs:
           # string list for use in run-many commands
           AFFECTED_PROJECTS_STR=$(pnpm nx show projects ${AFFECTED_ARG} --sep=, | tr -d '\n')
           echo "affected_projects_str=$AFFECTED_PROJECTS_STR" >> "$GITHUB_OUTPUT"
+
+          TYPECHECK_PROJECTS_STR=$(pnpm -s nx show projects ${AFFECTED_ARG} --withTarget test:types --sep=, | tr -d '\n')
+          echo "typecheck_projects_str=$TYPECHECK_PROJECTS_STR" >> "$GITHUB_OUTPUT"
 
           UNIT_TEST_AFFECTED_ARG="$AFFECTED_ARG"
           if [[ "${{ steps.changed.outputs.unit-test-globals }}" == 'true' ]]; then
@@ -294,6 +298,7 @@ jobs:
     outputs:
       affected_projects: ${{ steps.affected.outputs.affected_projects }}
       affected_projects_str: ${{ steps.affected.outputs.affected_projects_str }}
+      typecheck_projects_str: ${{ steps.affected.outputs.typecheck_projects_str }}
       unit_test_projects_str: ${{ steps.affected.outputs.unit_test_projects_str }}
       affected_playwright_projects: ${{ steps.affected.outputs.affected_playwright_projects }}
       publish_public_apps_matrix: ${{ steps.affected.outputs.publish_public_apps_matrix }}
@@ -725,6 +730,39 @@ jobs:
             git diff
             exit 1
           fi
+
+      - uses: tryghost/actions/actions/slack-build@12da0671df2e249a65c467340262e6c4251d9565 # main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  job_typecheck:
+    runs-on: ubuntu-latest
+    needs: [job_setup]
+    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.typecheck_projects_str != ''
+    name: Typecheck
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1000
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck projects
+        run: pnpm nx run-many -t test:types -p "${{ needs.job_setup.outputs.typecheck_projects_str }}"
+        env:
+          FORCE_COLOR: 0
+          NX_SKIP_LOG_GROUPING: true
 
       - uses: tryghost/actions/actions/slack-build@12da0671df2e249a65c467340262e6c4251d9565 # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -2259,6 +2297,7 @@ jobs:
         job_docker,
         job_ghost-cli,
         job_admin-tests,
+        job_typecheck,
         job_unit-tests,
         job_acceptance-tests,
         job_legacy-tests,
@@ -2282,7 +2321,7 @@ jobs:
   # Runs only on push-to-main — never on pull_request — so the `id-token: write`
   # permission is never exposed to PR-controlled code (ref: ONC-1677).
   publish_public_apps:
-    needs: [job_setup, job_lint, job_unit-tests, job_build_e2e_public_apps]
+    needs: [job_setup, job_lint, job_typecheck, job_unit-tests, job_build_e2e_public_apps]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
     # Serialize per-app publishes so two quick main merges can't both compute the
@@ -2293,11 +2332,13 @@ jobs:
       group: publish-public-app-${{ matrix.package_name }}
       cancel-in-progress: false
     if: |
-      github.event_name != 'pull_request'
+      always()
+      && github.event_name != 'pull_request'
       && github.repository == 'TryGhost/Ghost'
       && needs.job_setup.outputs.is_main == 'true'
       && needs.job_setup.result == 'success'
       && needs.job_lint.result == 'success'
+      && (needs.job_typecheck.result == 'success' || needs.job_typecheck.result == 'skipped')
       && needs.job_unit-tests.result == 'success'
       && needs.job_build_e2e_public_apps.result == 'success'
       && needs.job_setup.outputs.publish_public_apps_matrix != '[]'

--- a/apps/shade/README.md
+++ b/apps/shade/README.md
@@ -73,7 +73,7 @@ Local docs with Storybook:
 ## Test
 
 - `pnpm test` — type-checks and runs Vitest with coverage
-- `pnpm test:unit` — type-checks and runs Vitest
+- `pnpm test:unit` — runs Vitest
 - `pnpm test:types` — TypeScript only
 - `pnpm lint` — ESLint for `src/` and `test/`
 

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -67,7 +67,7 @@
     "dev": "vite build --watch",
     "build": "tsc -p tsconfig.declaration.json && tsc-alias -p tsconfig.declaration.json && vite build",
     "test": "pnpm test:types && vitest run --coverage",
-    "test:unit": "pnpm test:types && vitest run",
+    "test:unit": "vitest run",
     "test:types": "tsc --noEmit",
     "lint:code": "eslint src/ scripts/ --cache",
     "lint": "pnpm run '/^lint:/'",

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -55,9 +55,13 @@ Nx can run a target for one workspace from the repository root:
 
 ```bash
 pnpm nx test <project-name>
+pnpm nx test:types <project-name>
 pnpm nx test:unit <project-name>
 pnpm nx test:acceptance <project-name>
 ```
+
+Run all package typechecks with `pnpm test:types`. CI runs this as a dedicated
+affected-project task, separately from unit tests.
 
 Check the workspace's `package.json` or list its Nx targets when you are unsure
 which targets it provides:

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -68,12 +68,13 @@
     "test:int:slow": "pnpm test:integration",
     "test:e2e:slow": "vitest run -c vitest.config.db.ts --project e2e --project e2e-api --reporter=verbose",
     "test:leg:slow": "vitest run -c vitest.config.db.ts --project legacy --reporter=verbose",
+    "test:types": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
     "lint:server": "eslint 'core/server/**/*.js' 'core/*.js' '*.js' --cache",
     "lint:shared": "eslint 'core/shared/**/*.js' --cache",
     "lint:frontend": "eslint 'core/frontend/**/*.js' --cache",
     "lint:test": "eslint 'test/**/*.js' --cache",
     "lint:code": "pnpm run '/^lint:(server|shared|frontend)$/'",
-    "lint:types": "eslint '**/*.ts' --cache && tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
+    "lint:types": "eslint '**/*.ts' --cache",
     "lint": "pnpm run '/^lint:(server|shared|frontend|test|types)$/'"
   },
   "dependencies": {

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -57,7 +57,7 @@
     "test": "pnpm test:unit",
     "test:watch": "vitest --reporter=default",
     "test:single": "f() { case \"$1\" in test/unit/*) vitest run \"$1\" ;; test/*) vitest run -c vitest.config.db.ts \"$1\" ;; *) vitest run \"$1\" || vitest run -c vitest.config.db.ts \"$1\" ;; esac; }; f",
-    "test:all": "pnpm test:unit && pnpm test:integration && pnpm test:e2e && pnpm lint",
+    "test:all": "pnpm test:unit && pnpm test:integration && pnpm test:e2e && pnpm test:types && pnpm lint",
     "test:debug": "DEBUG=ghost:test* pnpm test",
     "test:unit": "vitest run",
     "test:integration": "vitest run -c vitest.config.db.ts --project integration",
@@ -69,13 +69,12 @@
     "test:e2e:slow": "vitest run -c vitest.config.db.ts --project e2e --project e2e-api --reporter=verbose",
     "test:leg:slow": "vitest run -c vitest.config.db.ts --project legacy --reporter=verbose",
     "test:types": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
-    "lint:server": "eslint 'core/server/**/*.js' 'core/*.js' '*.js' --cache",
-    "lint:shared": "eslint 'core/shared/**/*.js' --cache",
-    "lint:frontend": "eslint 'core/frontend/**/*.js' --cache",
-    "lint:test": "eslint 'test/**/*.js' --cache",
+    "lint:server": "eslint 'core/server/**/*.{js,ts}' 'core/*.{js,ts}' '*.{js,ts}' 'bin/**/*.{js,ts}' 'scripts/**/*.{js,ts}' 'types/**/*.ts' --cache",
+    "lint:shared": "eslint 'core/shared/**/*.{js,ts}' --cache",
+    "lint:frontend": "eslint 'core/frontend/**/*.{js,ts}' --cache",
+    "lint:test": "eslint 'test/**/*.{js,ts}' --cache",
     "lint:code": "pnpm run '/^lint:(server|shared|frontend)$/'",
-    "lint:types": "eslint '**/*.ts' --cache",
-    "lint": "pnpm run '/^lint:(server|shared|frontend|test|types)$/'"
+    "lint": "pnpm run '/^lint:(server|shared|frontend|test)$/'"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1079.0",

--- a/nx.json
+++ b/nx.json
@@ -41,6 +41,10 @@
       "cache": true,
       "dependsOn": ["build"]
     },
+    "test:types": {
+      "cache": true,
+      "dependsOn": ["^build"]
+    },
     "test:ci:*": {
       "cache": true,
       "inputs": ["default", "^default"]

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "format:check": "oxfmt --check",
     "check": "pnpm format:check && pnpm lint && pnpm test",
     "test": "pnpm nx run-many -t test --exclude @tryghost/e2e --exclude ghost-admin",
+    "test:types": "pnpm nx run-many -t test:types",
     "test:unit": "pnpm nx run-many -t test:unit",
     "test:watch": "vitest",
     "test:e2e": "pnpm --filter @tryghost/e2e test",


### PR DESCRIPTION
no refs

## Context

Many TypeScript workspaces already expose a `test:types` target, but CI currently selects only affected `test:unit` targets. That leaves standalone typechecks unprotected and makes their dependency on built workspace packages implicit. The [recent Admin-X typecheck regression fixed in #30291](https://github.com/TryGhost/Ghost/pull/30291) demonstrated that these failures can land on `main` while unit-test CI remains green.

## Summary

- Added a root `pnpm test:types` command and a cached Nx `test:types` target that builds dependency projects first.
- Added an affected-project `Typecheck` job with its own required CI signal and main-branch failure notification.
- Included typechecking in the public-app publishing prerequisites while allowing the job to be skipped when no typed project is affected.
- Removed Shade typechecking from `test:unit` so unit tests and typechecks are reported independently.
- Documented how to run repository-wide and project-specific typechecks.
- Separated `ghost/core`'s `lint:types` script into `test:types` (for typechecks) and `lint:code` (for linting .ts files)