### PR TITLE
Removed unused options from labs Handlebars helper

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -107,13 +107,9 @@ module.exports.isSet = function isSet(flag) {
  * @param {string} options.flagKey the internal lookup key of the flag e.g. labs.isSet(matchHelper)
  * @param {string} options.flagName the user-facing name of the flag e.g. Match helper
  * @param {string} options.helperName Name of the helper to be enabled/disabled
- * @param {string} [options.errorMessage] Optional replacement error message
- * @param {string} [options.errorContext] Optional replacement context message
- * @param {string} [options.errorHelp] Optional replacement help message
  * @param {string} [options.helpUrl] Url to show in the help message
- * @param {string} [options.async] is the helper async?
  * @param {function} callback
- * @returns {Promise<Handlebars.SafeString>|Handlebars.SafeString}
+ * @returns {Handlebars.SafeString}
  */
 module.exports.enabledHelper = function enabledHelper(options, callback) {
   const errDetails = {};
@@ -125,14 +121,14 @@ module.exports.enabledHelper = function enabledHelper(options, callback) {
   }
 
   // Else, the helper is not active and we need to handle this as an error
-  errDetails.message = tpl(options.errorMessage || messages.errorMessage, {
+  errDetails.message = tpl(messages.errorMessage, {
     helperName: options.helperName,
   });
-  errDetails.context = tpl(options.errorContext || messages.errorContext, {
+  errDetails.context = tpl(messages.errorContext, {
     helperName: options.helperName,
     flagName: options.flagName,
   });
-  errDetails.help = tpl(options.errorHelp || messages.errorHelp, { url: options.helpUrl });
+  errDetails.help = tpl(messages.errorHelp, { url: options.helpUrl });
 
   logging.error(
     new errors.DisabledFeatureError({
@@ -146,10 +142,6 @@ module.exports.enabledHelper = function enabledHelper(options, callback) {
   errString = new SafeString(
     `<script>console.error("${_.values(errDetails).join(' ')}");</script>`,
   );
-
-  if (options.async) {
-    return Promise.resolve(errString);
-  }
 
   return errString;
 };


### PR DESCRIPTION
no ref

This change should have no user impact.

Four options were never used: `errorMessage`, `errorContext`, `errorHelp`, and `async`. We can remove them and simplify the function a bit.
