### PR TITLE
Fixed the format-number skill's import example

### DIFF
--- a/.agents/skills/format-number/SKILL.md
+++ b/.agents/skills/format-number/SKILL.md
@@ -7,12 +7,12 @@ autoTrigger:
 
 # Format Numbers
 
-When editing `.tsx` files, ensure all user-facing numbers are formatted using the `formatNumber` utility from `@tryghost/shade`.
+When editing `.tsx` files, ensure all user-facing numbers are formatted using the `formatNumber` utility from `@tryghost/shade/utils`.
 
 ## Import
 
 ```typescript
-import {formatNumber} from '@tryghost/shade';
+import { formatNumber } from '@tryghost/shade/utils';
 ```
 
 ## When to use formatNumber
@@ -58,4 +58,4 @@ Do NOT use any of these patterns for formatting numbers in TSX files:
 - `abbreviateNumber()` - for compact notation (e.g., 1.2M, 50k)
 - `centsToDollars()` - convert cents to dollars before passing to `formatNumber`
 
-All are imported from `@tryghost/shade`.
+All are imported from `@tryghost/shade/utils`.


### PR DESCRIPTION
The skill's example imported `formatNumber` from the Shade root barrel, which the admin ESLint config bans (`shadeRestricted` — root-barrel imports are lint errors). The real import used by ~80 files is the `/utils` subpath; the example now shows it. `pnpm lint:agent-skills` passes.