### PR TITLE
Changed members custom field and import failures to be traceable

### DIFF
--- a/ghost/core/core/server/services/members-custom-fields/actions.ts
+++ b/ghost/core/core/server/services/members-custom-fields/actions.ts
@@ -100,6 +100,16 @@ export async function recordCustomFieldAction({
       { autoRefresh: false },
     );
   } catch (err) {
-    logging.error(err);
+    logging.error(
+      {
+        event: { name: 'members.custom_fields.action_log_failed' },
+        err,
+        verb,
+        subject,
+        actorType: context.actor.type,
+        actorId: context.actor.id,
+      },
+      'Failed to record a member custom field action',
+    );
   }
 }

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -107,7 +107,13 @@ export class CustomFieldValuesService {
         leaves.push(DbCustomFieldLeaf.parse(row));
       } catch (err) {
         logging.warn(
-          `Skipping unreadable custom field value (field '${row.key}', path '${row.path}'): ${err instanceof Error ? err.message : String(err)}`,
+          {
+            event: { name: 'members.custom_fields.value_unreadable' },
+            err,
+            customFieldKey: row.key,
+            path: row.path,
+          },
+          'Skipping an unreadable custom field value',
         );
       }
     }

--- a/ghost/core/core/server/services/members/import-export/export/exporter.ts
+++ b/ghost/core/core/server/services/members/import-export/export/exporter.ts
@@ -154,7 +154,10 @@ export default class MembersCSVExporter {
     const hasFilter = options.limit !== 'all' || options.filter || options.search;
     const ids = hasFilter ? await this._members.findFilteredIds(options) : null;
     if (ids) {
-      logging.info(`[MembersExporter] Found ${ids.length} members matching filter criteria`);
+      logging.info(
+        { event: { name: 'members-export.filtered' }, matched: ids.length },
+        'Found members matching the export filter',
+      );
     }
 
     const reference = await this.fetchReferenceData();
@@ -164,7 +167,10 @@ export default class MembersCSVExporter {
       membersQuery.whereIn('id', ids);
     }
 
-    logging.info('[MembersExporter] Starting streaming export of members');
+    logging.info(
+      { event: { name: 'members-export.started' } },
+      'Starting streaming export of members',
+    );
     const batchingTransform = this.createBatchingTransform();
     const processingTransform = this.createProcessingTransform(reference);
 
@@ -176,9 +182,8 @@ export default class MembersCSVExporter {
         );
       } else {
         logging.info(
-          '[MembersExporter] Total time taken for member export: ' +
-            (Date.now() - start) / 1000 +
-            's',
+          { event: { name: 'members-export.completed' }, durationMs: Date.now() - start },
+          'Members export completed',
         );
       }
     });
@@ -212,7 +217,10 @@ export default class MembersCSVExporter {
         }, {}),
       );
 
-    logging.info('[MembersExporter] Fetched products and labels in ' + (Date.now() - start) + 'ms');
+    logging.info(
+      { event: { name: 'members-export.reference_data_read' }, durationMs: Date.now() - start },
+      'Read the products and labels an export names',
+    );
 
     const activeCustomFields = await this._customFields.activeDefinitions();
 

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -182,6 +182,7 @@ const messages = {
   giftCannotCombineWithImportTier: 'Cannot specify both gift_id and import_tier.',
   giftCannotCombineWithComplimentary: 'Cannot specify both gift_id and complimentary_plan.',
   giftReassignFailed: 'Failed to reassign gift to member.',
+  customFieldWriteFailed: 'Failed to save the custom field values for this member.',
 };
 
 // Columns whose presence makes a row slow to import (they reach out to Stripe), so
@@ -581,7 +582,16 @@ class MembersCSVImporter {
         }
 
         // On the row's transaction, so the values commit or roll back with the member.
-        await this._customFields.applyWrite(member.id, customFieldPlan, trx);
+        try {
+          await this._customFields.applyWrite(member.id, customFieldPlan, trx);
+        } catch (writeError) {
+          // planWrite passed every value before the transaction opened, so a failure
+          // here is ours and not the row's. Operators get the original, which a driver
+          // will have written a query into; the publisher gets a sentence instead, in a
+          // file they open next to a spreadsheet.
+          this._report(writeError);
+          throw new errors.DataImportError({ message: tpl(messages.customFieldWriteFailed) });
+        }
 
         await trx.commit();
         imported += 1;

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -305,7 +305,10 @@ class MembersCSVImporter {
     const emailRecipient: string = requestUserEmail ?? (await this._email.getDefaultRecipient());
     const spooled = await this._spool.write(rows);
 
-    logging.info('[Background Job] members-import queued');
+    logging.info(
+      { event: { name: 'members.import.queued' }, rows: rows.length },
+      'Members import queued',
+    );
     this._addJob({
       job: () =>
         this.runImportJob(spooled, { labelName, extraLabels, emailRecipient }, verificationTrigger),
@@ -326,7 +329,7 @@ class MembersCSVImporter {
     verificationTrigger: VerificationTrigger,
   ): Promise<void> {
     const startedAt = Date.now();
-    logging.info('[Background Job] members-import started');
+    logging.info({ event: { name: 'members.import.started' } }, 'Members import started');
     // Null until the import produces one: parsing and mapping already happened inside
     // the request, so anything failing from here is ours rather than the file's.
     let result: ImportResult | null = null;
@@ -355,10 +358,19 @@ class MembersCSVImporter {
 
     if (result) {
       logging.info(
-        `[Background Job] members-import completed in ${Date.now() - startedAt}ms: imported ${result.imported}, ${result.errors.length} row(s) rejected`,
+        {
+          event: { name: 'members.import.completed' },
+          durationMs: Date.now() - startedAt,
+          imported: result.imported,
+          rejected: result.errors.length,
+        },
+        'Members import completed',
       );
     } else {
-      logging.info(`[Background Job] members-import failed after ${Date.now() - startedAt}ms`);
+      logging.info(
+        { event: { name: 'members.import.failed' }, durationMs: Date.now() - startedAt },
+        'Members import failed',
+      );
     }
   }
 

--- a/ghost/core/core/server/services/members/import-export/import/stripe-utils.js
+++ b/ghost/core/core/server/services/members/import-export/import/stripe-utils.js
@@ -175,7 +175,12 @@ module.exports = class MembersCSVImporterStripeUtils {
           await this.archivePrice(newStripePrice.id);
         } catch (archiveErr) {
           logging.warn(
-            `Failed to archive orphaned Stripe price ${newStripePrice.id} after a failed subscription update: ${archiveErr.message}`,
+            {
+              event: { name: 'members.import.orphaned_price_archive_failed' },
+              err: archiveErr,
+              stripePriceId: newStripePrice.id,
+            },
+            'Failed to archive an orphaned Stripe price after a failed subscription update',
           );
         }
         throw err;

--- a/ghost/core/test/unit/server/services/members/import-export/import/error-handling.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/error-handling.test.ts
@@ -243,6 +243,23 @@ describe('members import error handling', function () {
       assert.deepEqual(h.reported, []);
     });
 
+    // The one row failure whose fault is known: the values were validated before the
+    // transaction opened, so nothing left in them can be what threw here.
+    it('keeps a fault of its own out of the error file and sends it to operators', async function () {
+      const h = harness([row('first@example.com')]);
+      const fault = new Error('ER_LOCK_WAIT_TIMEOUT: update `members_custom_field_values` set ...');
+      h.deps.customFields.applyWrite = async () => {
+        throw fault;
+      };
+
+      await h.run();
+
+      assert.equal(h.onlyReport(), fault);
+      const attached = h.onlyEmail().attachments[0].content;
+      assert.match(attached, /Failed to save the custom field values for this member/);
+      assert.doesNotMatch(attached, /ER_LOCK_WAIT_TIMEOUT|members_custom_field_values/);
+    });
+
     it('reports an import where every row failed as unsuccessful', async function () {
       const h = harness();
       h.deps.members.create = async () => {


### PR DESCRIPTION
## Problem

The logs in the members custom-fields and import/export services glue their context into sentences. A decode regression that drops a stored value on every member read, an import that rejected a large share of a file, an export that has slowed down — each arrives as prose, so none can be counted, grouped or alerted on without parsing English back out of a log line. Two of them say less than that, handing an error straight to the logger with nothing naming what was swallowed, which is the whole difficulty with a best-effort write: it is invisible unless the line that gives it up says what it gave up.

Separately, an import row can fail for a reason that is not the publisher's. Every custom field value is validated before the row's transaction opens, so a failure to write one afterwards is a database fault or a race, not bad data in the file. It was handled as though it were bad data: the publisher received the driver's own message in their error CSV, and nobody was told.

## Solution

Every one of these calls now follows the convention the gifts service already uses: a dotted event name, a static message, the error under `err`, and its context in named fields. Durations and the counts an operator would aggregate — how many rows an import took, wrote and rejected — become fields rather than sentence fragments. Field names are camelCase, because a log is written from domain code about domain objects, and the domain speaks camelCase while storage and the API speak snake_case.

The import fault is now reported where faults go and wrapped in a message written for the person reading the error CSV, so the row still fails and still rolls back, but the publisher is told their values could not be saved rather than shown a query, and an operator learns it happened at all.

Nothing else about behaviour changes. The swallows stay swallows; they just say what they swallowed.

ref https://linear.app/ghost/issue/BER-3872
