### PR TITLE
Added local TrafficAnalytics development command

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -142,6 +142,8 @@ services:
       context: ./docker/dev-gateway
       dockerfile: Dockerfile
     container_name: ghost-dev-gateway
+    environment:
+      ANALYTICS_PROXY_TARGET: ${ANALYTICS_PROXY_TARGET:-analytics:3000}
     ports:
       - '2368:80'
       - '80:80'

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -105,15 +105,20 @@ runs.
 Run one root command at a time. Each variant includes the standard development
 environment and adds the listed tooling:
 
-| Command              | Use it when working on                                                                  |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| `pnpm dev`           | Ghost Core, Admin, or Portal                                                            |
-| `pnpm dev:public`    | Comments UI, Signup Form, Search, Announcement Bar, or Admin Toolbar                    |
-| `pnpm dev:lexical`   | Koenig's Lexical editor inside Ghost Admin                                              |
-| `pnpm dev:analytics` | Tinybird-backed analytics; also exposes Tinybird on port `7181`                         |
-| `pnpm dev:storage`   | S3-compatible storage through MinIO on ports `9000` and `9001`                          |
-| `pnpm dev:stripe`    | Stripe webhooks; requires `STRIPE_SECRET_KEY` in the environment or a local `.env` file |
-| `pnpm dev:full`      | Public app watchers plus analytics, storage, and Stripe                                 |
+| Command                    | Use it when working on                                                                  |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| `pnpm dev`                 | Ghost Core, Admin, or Portal                                                            |
+| `pnpm dev:public`          | Comments UI, Signup Form, Search, Announcement Bar, or Admin Toolbar                    |
+| `pnpm dev:lexical`         | Koenig's Lexical editor inside Ghost Admin                                              |
+| `pnpm dev:analytics`       | Tinybird-backed analytics; also exposes Tinybird on port `7181`                         |
+| `pnpm dev:analytics:local` | Analytics routed to a local TrafficAnalytics checkout on the `ghost_dev` network        |
+| `pnpm dev:storage`         | S3-compatible storage through MinIO on ports `9000` and `9001`                          |
+| `pnpm dev:stripe`          | Stripe webhooks; requires `STRIPE_SECRET_KEY` in the environment or a local `.env` file |
+| `pnpm dev:full`            | Public app watchers plus analytics, storage, and Stripe                                 |
+
+To develop against TrafficAnalytics locally, run `pnpm dev:analytics:local`,
+then run `yarn dev:ghost` from TrafficAnalytics. The local ingest service and
+worker join the Ghost development network and use its Tinybird configuration.
 
 Copy [`.env.example`](../../.env.example) to `.env` only when you need an
 optional integration. Never commit credentials or the local `.env` file.

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -105,20 +105,16 @@ runs.
 Run one root command at a time. Each variant includes the standard development
 environment and adds the listed tooling:
 
-| Command                    | Use it when working on                                                                  |
-| -------------------------- | --------------------------------------------------------------------------------------- |
-| `pnpm dev`                 | Ghost Core, Admin, or Portal                                                            |
-| `pnpm dev:public`          | Comments UI, Signup Form, Search, Announcement Bar, or Admin Toolbar                    |
-| `pnpm dev:lexical`         | Koenig's Lexical editor inside Ghost Admin                                              |
-| `pnpm dev:analytics`       | Tinybird-backed analytics; also exposes Tinybird on port `7181`                         |
-| `pnpm dev:analytics:local` | Analytics routed to a local TrafficAnalytics checkout on the `ghost_dev` network        |
-| `pnpm dev:storage`         | S3-compatible storage through MinIO on ports `9000` and `9001`                          |
-| `pnpm dev:stripe`          | Stripe webhooks; requires `STRIPE_SECRET_KEY` in the environment or a local `.env` file |
-| `pnpm dev:full`            | Public app watchers plus analytics, storage, and Stripe                                 |
-
-To develop against TrafficAnalytics locally, run `pnpm dev:analytics:local`,
-then run `yarn dev:ghost` from TrafficAnalytics. The local ingest service and
-worker join the Ghost development network and use its Tinybird configuration.
+| Command                    | Use it when working on                                                                        |
+| -------------------------- | --------------------------------------------------------------------------------------------- |
+| `pnpm dev`                 | Ghost Core, Admin, or Portal                                                                  |
+| `pnpm dev:public`          | Comments UI, Signup Form, Search, Announcement Bar, or Admin Toolbar                          |
+| `pnpm dev:lexical`         | Koenig's Lexical editor inside Ghost Admin                                                    |
+| `pnpm dev:analytics`       | Tinybird-backed analytics with the latest published version of the Traffic Analytics service  |
+| `pnpm dev:analytics:local` | Tinybird-backed analytics with your locally running instance of the Traffic Analytics service |
+| `pnpm dev:storage`         | S3-compatible storage through MinIO on ports `9000` and `9001`                                |
+| `pnpm dev:stripe`          | Stripe webhooks; requires `STRIPE_SECRET_KEY` in the environment or a local `.env` file       |
+| `pnpm dev:full`            | Public app watchers plus analytics, storage, and Stripe                                       |
 
 Copy [`.env.example`](../../.env.example) to `.env` only when you need an
 optional integration. Never commit credentials or the local `.env` file.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:public": "pnpm nx run ghost-monorepo:docker:dev:public",
     "dev:full": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' ./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev:public",
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' pnpm nx run ghost-monorepo:docker:dev",
+    "dev:analytics:local": "ANALYTICS_PROXY_TARGET=traffic-analytics-local:3000 DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:stripe": "./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' ./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1550/make-it-easier-to-do-development-with-both-ghost-and-traffic-analytics

This is a development only change that should have no user impact.

_Note: this PR depends on [this PR](https://github.com/TryGhost/TrafficAnalytics/pull/859) in the Traffic Analytics repository._

## Summary

- When developing features that touch both Ghost and the Traffic Analytics service, it can be useful to run your local version of both services locally. Currently, `pnpm dev:analytics` runs Ghost against the latest published version of the Traffic Analytics service, but running against your own locally running instance of the service was not possible out of the box — this makes it as simple as running `pnpm dev:analytics:local` in Ghost, and `yarn dev:ghost` in Traffic Analytics