### PR TITLE
✨ Added email-able gift subscriptions and Portal gift sub links

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -27,7 +27,7 @@ const messages = {
 };
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
-const GA_FEATURES = ['automationAnalytics'];
+const GA_FEATURES = ['automationAnalytics', 'giftSubCustomization'];
 
 // These features are considered publicly available and can be enabled/disabled by users
 const PUBLIC_BETA_FEATURES = [
@@ -53,7 +53,6 @@ const PRIVATE_FEATURES = [
   'getHelperDeduplication',
   'membersCustomFields',
   'paywallImprovements',
-  'giftSubCustomization',
   'tagDetailsReact',
   'selfServeArchives',
   'machinePayments',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3900/

- adds links to Portal for purchasing gift subscriptions
  - can be disabled through Settings
- adds 3 and 6 month durations for gift subscriptions
- adds ability to have email subscriptions delivered to recipient via email with a customised message, either immediately or on a scheduled date
