### PR TITLE
Added reusable external media imports

### DIFF
--- a/ghost/core/core/server/services/media-inliner/external-media-inliner.d.ts
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner.d.ts
@@ -1,6 +1,9 @@
+import type { ExternalMediaImportResult } from './types';
+
 declare class ExternalMediaInliner {
   constructor(deps: object);
 
+  importUrl(sourceUrl: string): Promise<ExternalMediaImportResult>;
   inline(domains: string[]): Promise<void>;
 }
 

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner.js
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner.js
@@ -177,6 +177,96 @@ class ExternalMediaInliner {
     }
   }
 
+  /**
+   * Download and store one external media URL without deciding where it came from
+   * or where its replacement belongs. Callers own discovery and replacement.
+   *
+   * @param {string} sourceUrl
+   * @returns {Promise<import('./types').ExternalMediaImportResult>}
+   */
+  async importUrl(sourceUrl) {
+    let response;
+    try {
+      response = await this.getRemoteMedia(sourceUrl);
+    } catch (error) {
+      return {
+        status: 'failed',
+        sourceUrl,
+        stage: 'download',
+        reason: 'The media file could not be downloaded.',
+        error,
+      };
+    }
+
+    if (!response) {
+      return {
+        status: 'failed',
+        sourceUrl,
+        stage: 'download',
+        reason: 'The media file could not be downloaded.',
+      };
+    }
+
+    let media;
+    try {
+      media = await this.extractFileDataFromResponse(sourceUrl, response);
+    } catch (error) {
+      return {
+        status: 'failed',
+        sourceUrl,
+        stage: 'extract',
+        reason: 'The downloaded media file could not be read.',
+        error,
+      };
+    }
+
+    try {
+      const storedUrl = await this.storeMediaLocally(media);
+      if (!storedUrl) {
+        return {
+          status: 'failed',
+          sourceUrl,
+          stage: 'unsupported',
+          reason: 'No configured storage accepts this media file.',
+        };
+      }
+
+      return {
+        status: 'stored',
+        sourceUrl,
+        storedUrl,
+      };
+    } catch (error) {
+      return {
+        status: 'failed',
+        sourceUrl,
+        stage: 'storage',
+        reason: 'The media file could not be stored in Ghost.',
+        error,
+      };
+    }
+  }
+
+  /**
+   * Convert an import result into the replacement URL expected by the existing
+   * content and field processing. Expected download and unsupported-file failures
+   * return null so the original URL remains unchanged. Results containing an
+   * underlying processing error are rethrown so the established per-resource
+   * catch boundary continues to log and isolate them.
+   *
+   * @param {import('./types').ExternalMediaImportResult} result
+   * @returns {string|null}
+   */
+  #replacementUrlFromImportResult(result) {
+    if (result.status === 'stored') {
+      return result.storedUrl;
+    }
+    if ('error' in result) {
+      throw result.error;
+    }
+    return null;
+  }
+
   static findMatches(content, domain) {
     // NOTE: the src could end with a quote, bracket, apostrophe, double-backslash, or encoded quote.
     //     Backlashes are added to content as an escape character
@@ -208,22 +298,14 @@ class ExternalMediaInliner {
       const matches = this.constructor.findMatches(content, domain);
 
       for (const src of matches) {
-        const response = await this.getRemoteMedia(src);
+        const result = await this.importUrl(src);
+        const replacementUrl = this.#replacementUrlFromImportResult(result);
 
-        let media;
-        if (response) {
-          media = await this.extractFileDataFromResponse(src, response);
-        }
-
-        if (media) {
-          const inlinedSrc = await this.storeMediaLocally(media);
-
-          if (inlinedSrc) {
-            // NOTE: does not account for duplicate images in content
-            //       in those cases would be processed twice
-            content = content.replace(src, inlinedSrc);
-            logging.info(`Inlined media: ${src} -> ${inlinedSrc}`);
-          }
+        if (replacementUrl) {
+          // NOTE: does not account for duplicate images in content
+          //       in those cases would be processed twice
+          content = content.replace(src, replacementUrl);
+          logging.info(`Inlined media: ${src} -> ${replacementUrl}`);
         }
       }
     }
@@ -246,20 +328,12 @@ class ExternalMediaInliner {
         const src = resourceModel.get(field);
 
         if (src && src.startsWith(domain)) {
-          const response = await this.getRemoteMedia(src);
+          const result = await this.importUrl(src);
+          const replacementUrl = this.#replacementUrlFromImportResult(result);
 
-          let media;
-          if (response) {
-            media = await this.extractFileDataFromResponse(src, response);
-          }
-
-          if (media) {
-            const inlinedSrc = await this.storeMediaLocally(media);
-
-            if (inlinedSrc) {
-              updatedFields[field] = inlinedSrc;
-              logging.info(`Added media to inline: ${src} -> ${inlinedSrc}`);
-            }
+          if (replacementUrl) {
+            updatedFields[field] = replacementUrl;
+            logging.info(`Added media to inline: ${src} -> ${replacementUrl}`);
           }
         }
       }

--- a/ghost/core/core/server/services/media-inliner/types.ts
+++ b/ghost/core/core/server/services/media-inliner/types.ts
@@ -1,0 +1,21 @@
+export type ExternalMediaFailureStage = 'download' | 'extract' | 'unsupported' | 'storage';
+
+export interface ExternalMediaStored {
+  status: 'stored';
+  sourceUrl: string;
+  storedUrl: string;
+}
+
+export interface ExternalMediaFailed {
+  status: 'failed';
+  sourceUrl: string;
+  stage: ExternalMediaFailureStage;
+  reason: string;
+  error?: unknown;
+}
+
+export type ExternalMediaImportResult = ExternalMediaStored | ExternalMediaFailed;
+
+export interface ExternalMediaImporter {
+  importUrl(sourceUrl: string): Promise<ExternalMediaImportResult>;
+}

--- a/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
+++ b/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
@@ -67,6 +67,160 @@ describe('ExternalMediaInliner', function () {
     assert.ok(new ExternalMediaInliner({}));
   });
 
+  describe('importUrl', function () {
+    function harness() {
+      const response = { body: Buffer.from('media') };
+      const media = { fileBuffer: response.body, filename: 'media.jpg', extension: '.jpg' };
+      const inliner = new ExternalMediaInliner({});
+      const getRemoteMedia = sinon.stub(inliner, 'getRemoteMedia').resolves(response);
+      const extractFileDataFromResponse = sinon
+        .stub(inliner, 'extractFileDataFromResponse')
+        .resolves(media);
+      const storeMediaLocally = sinon
+        .stub(inliner, 'storeMediaLocally')
+        .resolves('__GHOST_URL__/content/images/media.jpg');
+
+      return {
+        inliner,
+        response,
+        media,
+        getRemoteMedia,
+        extractFileDataFromResponse,
+        storeMediaLocally,
+      };
+    }
+
+    it('downloads, extracts, and stores one source URL', async function () {
+      const h = harness();
+      const sourceUrl = 'https://example.com/media.jpg';
+
+      const result = await h.inliner.importUrl(sourceUrl);
+
+      assert.deepEqual(result, {
+        status: 'stored',
+        sourceUrl,
+        storedUrl: '__GHOST_URL__/content/images/media.jpg',
+      });
+      sinon.assert.calledWithExactly(h.getRemoteMedia, sourceUrl);
+      sinon.assert.calledWithExactly(h.extractFileDataFromResponse, sourceUrl, h.response);
+      sinon.assert.calledWithExactly(h.storeMediaLocally, h.media);
+    });
+
+    it('returns a typed download failure when fetching throws', async function () {
+      const h = harness();
+      const error = new Error('network unavailable');
+      h.getRemoteMedia.rejects(error);
+
+      const result = await h.inliner.importUrl('https://example.com/media.jpg');
+
+      assert.deepEqual(result, {
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.jpg',
+        stage: 'download',
+        reason: 'The media file could not be downloaded.',
+        error,
+      });
+      sinon.assert.notCalled(h.extractFileDataFromResponse);
+    });
+
+    it('returns a typed download failure when fetching produces no response', async function () {
+      const h = harness();
+      h.getRemoteMedia.resolves(null);
+
+      const result = await h.inliner.importUrl('https://example.com/media.jpg');
+
+      assert.deepEqual(result, {
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.jpg',
+        stage: 'download',
+        reason: 'The media file could not be downloaded.',
+      });
+      sinon.assert.notCalled(h.extractFileDataFromResponse);
+    });
+
+    it('returns a typed extraction failure', async function () {
+      const h = harness();
+      const error = new Error('invalid media');
+      h.extractFileDataFromResponse.rejects(error);
+
+      const result = await h.inliner.importUrl('https://example.com/media.jpg');
+
+      assert.deepEqual(result, {
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.jpg',
+        stage: 'extract',
+        reason: 'The downloaded media file could not be read.',
+        error,
+      });
+      sinon.assert.notCalled(h.storeMediaLocally);
+    });
+
+    it('returns a typed unsupported-media failure', async function () {
+      const h = harness();
+      h.storeMediaLocally.resolves(null);
+
+      const result = await h.inliner.importUrl('https://example.com/media.exe');
+
+      assert.deepEqual(result, {
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.exe',
+        stage: 'unsupported',
+        reason: 'No configured storage accepts this media file.',
+      });
+    });
+
+    it('returns a typed storage failure', async function () {
+      const h = harness();
+      const error = new Error('storage unavailable');
+      h.storeMediaLocally.rejects(error);
+
+      const result = await h.inliner.importUrl('https://example.com/media.jpg');
+
+      assert.deepEqual(result, {
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.jpg',
+        stage: 'storage',
+        reason: 'The media file could not be stored in Ghost.',
+        error,
+      });
+    });
+
+    it('preserves legacy processing errors at the existing catch boundary', async function () {
+      const inliner = new ExternalMediaInliner({});
+      const error = new Error('could not inspect media');
+      sinon.stub(inliner, 'importUrl').resolves({
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.jpg',
+        stage: 'extract',
+        reason: 'The downloaded media file could not be read.',
+        error,
+      });
+
+      await assert.rejects(
+        inliner.inlineContent('{"src":"https://example.com/media.jpg"}', ['https://example.com']),
+        (thrown) => thrown === error,
+      );
+    });
+
+    it('preserves legacy falsy thrown values at the existing catch boundary', async function () {
+      const inliner = new ExternalMediaInliner({});
+      sinon.stub(inliner, 'importUrl').resolves({
+        status: 'failed',
+        sourceUrl: 'https://example.com/media.jpg',
+        stage: 'extract',
+        reason: 'The downloaded media file could not be read.',
+        error: null,
+      });
+
+      await inliner
+        .inlineContent('{"src":"https://example.com/media.jpg"}', ['https://example.com'])
+        .then(
+          () => assert.fail('Expected inlineContent to reject'),
+          (error) => assert.equal(error, null),
+        );
+    });
+  });
+
   describe('inline', function () {
     it("inlines image in the post's mobiledoc content", async function () {
       const imageURL = 'https://img.stockfresh.com/files/f/image.jpg';


### PR DESCRIPTION
no ref

CSV imports need to store one discovered media URL at a time without inheriting the existing batch service's content-matching rules. Expose a typed per-URL result directly from the existing CommonJS service while preserving the batch importer's failure boundaries and established module contract, allowing future callers to reuse media downloading and storage without changing existing batch behavior.