### PR TITLE
Fixed MySQL acceptance test connection options

### DIFF
--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -56,10 +56,6 @@ process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_
 // nothing exactly as a fresh name would. mysql keeps a random per-fork name: it
 // has no /tmp to bound (CI databases die with the job) and a random name sidesteps
 // the same stale-reuse hazard without a pre-boot DROP.
-const poolSlot = parseInt(process.env.VITEST_POOL_ID || '', 10);
-const sqliteId = Number.isInteger(poolSlot)
-  ? `pool_${poolSlot}`
-  : crypto.randomBytes(4).toString('hex');
 if (process.env.NODE_ENV.includes('mysql')) {
   const mysqlId = crypto.randomBytes(4).toString('hex');
   const mysqlBase = process.env.database__connection__database;
@@ -67,6 +63,10 @@ if (process.env.NODE_ENV.includes('mysql')) {
     ? `${mysqlBase}_${mysqlId}`
     : `ghost_testing_${mysqlId}`;
 } else {
+  const poolSlot = parseInt(process.env.VITEST_POOL_ID || '', 10);
+  const sqliteId = Number.isInteger(poolSlot)
+    ? `pool_${poolSlot}`
+    : crypto.randomBytes(4).toString('hex');
   const sqliteBase = process.env.database__connection__filename;
   process.env.database__connection__filename = sqliteBase
     ? `${sqliteBase.replace(/\.db$/i, '')}-${sqliteId}.db`

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -60,15 +60,18 @@ const poolSlot = parseInt(process.env.VITEST_POOL_ID || '', 10);
 const sqliteId = Number.isInteger(poolSlot)
   ? `pool_${poolSlot}`
   : crypto.randomBytes(4).toString('hex');
-const sqliteBase = process.env.database__connection__filename;
-process.env.database__connection__filename = sqliteBase
-  ? `${sqliteBase.replace(/\.db$/i, '')}-${sqliteId}.db`
-  : `/tmp/ghost-test-${sqliteId}.db`;
-const mysqlId = crypto.randomBytes(4).toString('hex');
-const mysqlBase = process.env.database__connection__database;
-process.env.database__connection__database = mysqlBase
-  ? `${mysqlBase}_${mysqlId}`
-  : `ghost_testing_${mysqlId}`;
+if (process.env.NODE_ENV.includes('mysql')) {
+  const mysqlId = crypto.randomBytes(4).toString('hex');
+  const mysqlBase = process.env.database__connection__database;
+  process.env.database__connection__database = mysqlBase
+    ? `${mysqlBase}_${mysqlId}`
+    : `ghost_testing_${mysqlId}`;
+} else {
+  const sqliteBase = process.env.database__connection__filename;
+  process.env.database__connection__filename = sqliteBase
+    ? `${sqliteBase.replace(/\.db$/i, '')}-${sqliteId}.db`
+    : `/tmp/ghost-test-${sqliteId}.db`;
+}
 
 // Delete this slot's leftover sqlite file (+ sidecars) before Ghost loads, so a
 // reused pool name boots from a clean slate — see the note above. SQLITE LEG ONLY:


### PR DESCRIPTION
## Summary

- derive a database name only for MySQL acceptance-test workers
- derive a SQLite filename only for SQLite acceptance-test workers
- stop passing the invalid `filename` option to MySQL2 connections

## Why

The shared Vitest database setup populated both identifiers on every worker. Because nconf environment values take precedence over Ghost’s merged-config sanitization, MySQL workers retained the generated SQLite filename and MySQL2 3.22.5 emitted an invalid configuration warning polluting our acceptance test logs with an error for every test:

`Ignoring invalid configuration option passed to Connection: filename. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection`

## Testing

- `pnpm exec oxfmt --check ghost/core/test/utils/vitest-setup-db.ts`
- `pnpm --dir ghost/core exec eslint test/utils/vitest-setup-db.ts`
- pre-commit formatting, ESLint, secrets, submodule, and changeset checks

The broader test TypeScript check could not run cleanly in this worktree because required workspace packages such as `@tryghost/adapter-base-jobs` and `@tryghost/adapter-base-redirects` are not currently built/resolvable.