### PR TITLE
Added a Labs flag for the redesigned members import

### DIFF
--- a/apps/admin/src/members/components/bulk-action-modals/import-members-gate.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-gate.tsx
@@ -1,5 +1,5 @@
 import { ImportMembersModal as BaselineImportMembersModal } from '@/members/components/bulk-action-modals/import-members-modal';
-import { ImportMembersModal as CustomFieldsImportMembersModal } from '@/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal';
+import { ImportMembersModal as RedesignedImportMembersModal } from '@/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import type { ImportResponse } from '@/members/components/bulk-action-modals/import-members/state';
 
@@ -11,8 +11,8 @@ interface ImportMembersGateProps {
 }
 
 /**
- * Serves the members CSV import from the custom fields experience when the `membersCustomFields`
- * Labs flag is on, and from the import as it shipped otherwise.
+ * Serves the redesigned members CSV import when the `membersImportRedesign` Labs flag is on,
+ * and the import as it shipped otherwise.
  *
  * Two whole implementations rather than one with the flag threaded through it. The mapping step
  * diverges in almost every part — what a row offers, what a row means, what the request carries —
@@ -22,12 +22,15 @@ interface ImportMembersGateProps {
  *
  * The cost is real and worth stating: a fix to the import has to be applied to both, or knowingly
  * to one, until the flag goes and the baseline is deleted.
+ *
+ * Custom fields are not this flag's decision. The redesign ships whether or not custom fields
+ * exist, and asks `membersCustomFields` itself for whether to offer them.
  */
 export function ImportMembersGate(props: ImportMembersGateProps) {
-  const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+  const importRedesignEnabled = useFeatureFlag('membersImportRedesign');
 
-  if (customFieldsEnabled) {
-    return <CustomFieldsImportMembersModal {...props} />;
+  if (importRedesignEnabled) {
+    return <RedesignedImportMembersModal {...props} />;
   }
   return <BaselineImportMembersModal {...props} />;
 }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
@@ -27,10 +27,6 @@ import {
   isImportMembersCompleteResponse,
   useImportMembers,
 } from '@tryghost/admin-x-framework/api/members';
-import {
-  memberCustomFieldCsvColumns,
-  useBrowseMemberCustomFields,
-} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import { parseCSV } from './import-members/csv';
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
@@ -54,28 +50,12 @@ export function ImportMembersModal({
   const { mutateAsync: importMembers } = useImportMembers();
   const importMemberTier = useFeatureFlag('importMemberTier');
 
-  // Defined custom fields become mapping targets. Fetched only when the feature is on;
-  // browse returns active fields only, which are the ones the importer writes to.
-  const customFieldsEnabled = useFeatureFlag('membersCustomFields');
-  const { data: customFieldsData } = useBrowseMemberCustomFields({ enabled: customFieldsEnabled });
-  const customFieldColumns = useMemo(
-    () => memberCustomFieldCsvColumns(customFieldsData?.members_custom_fields ?? []),
-    [customFieldsData],
-  );
-  // The file-reader effect waits for this before its first parse: with the feature on,
-  // the custom field definitions must be loaded or auto-detection would miss
-  // custom_fields.* columns on a fast upload. It flips false -> true once and stays true
-  // (a refetch keeps data defined), so readiness never re-triggers the read.
-  const customFieldsReady = !customFieldsEnabled || customFieldsData !== undefined;
   // Detection options are read inside the effect through this ref rather than as deps, so
-  // a later refetch of the options can't re-run the read and overwrite a mapping the user
-  // has begun editing.
-  const detectOptionsRef = useRef({ importMemberTier, customFieldColumns });
-  detectOptionsRef.current = { importMemberTier, customFieldColumns };
-  const fieldMappings = useMemo(
-    () => getFieldMappings({ importMemberTier, customFieldColumns }),
-    [importMemberTier, customFieldColumns],
-  );
+  // a later change to them can't re-run the read and overwrite a mapping the user has
+  // begun editing.
+  const detectOptionsRef = useRef({ importMemberTier });
+  detectOptionsRef.current = { importMemberTier };
+  const fieldMappings = useMemo(() => getFieldMappings({ importMemberTier }), [importMemberTier]);
 
   const labelPicker = useLabelPicker({
     selectedSlugs: state.selectedLabelSlugs,
@@ -119,7 +99,7 @@ export function ImportMembersModal({
   );
 
   useEffect(() => {
-    if (!state.file || !customFieldsReady) {
+    if (!state.file) {
       return;
     }
 
@@ -186,7 +166,7 @@ export function ImportMembersModal({
         reader.abort();
       }
     };
-  }, [state.file, customFieldsReady]);
+  }, [state.file]);
 
   const validateFile = useCallback((file: File): boolean => {
     const match = /(?:\.([^.]+))?$/.exec(file.name);

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Command,
   CommandCheck,
+  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -67,6 +68,9 @@ interface FieldPickerProps {
   disabled?: boolean;
   invalid?: boolean;
   targets: FieldTarget[];
+  // Whether the list ends with an offer to make a custom field. Off, a search that matches
+  // nothing says so instead, which the offer had been standing in for.
+  canCreateField: boolean;
   // Open and search are the caller's, not this component's: creating a composite has to
   // reopen this row's picker filtered to the field it just made, so which picker is open and
   // what it is filtered by have to be sayable from outside.
@@ -86,6 +90,7 @@ export function FieldPicker({
   disabled,
   invalid,
   targets,
+  canCreateField,
   open,
   search,
   onOpenChange,
@@ -266,7 +271,12 @@ export function FieldPicker({
                             and Enter would take whichever the DOM had first. Identity is the
                             target, which is namespaced and so already distinct; the label moves
                             to keywords for scoreByLabel. */}
-            {FIELD_SOURCE_ORDER.map((source) => (
+            {/* Empty sources are dropped rather than left to cmdk: a group with no items
+                            still owns its heading in the DOM, so a site with custom fields off would
+                            be told there is a Custom fields section and then shown nothing under it. */}
+            {FIELD_SOURCE_ORDER.filter((source) =>
+              targets.some((target) => target.source === source),
+            ).map((source) => (
               <CommandGroup key={source} heading={FIELD_SOURCES[source].heading}>
                 {targets
                   .filter((target) => target.source === source)
@@ -284,26 +294,32 @@ export function FieldPicker({
                   ))}
               </CommandGroup>
             ))}
-            {/* Its own group because cmdk hands forceMount down to every item in a
-                            group, so among the fields it would have pinned all of them. Search
-                            finding nothing is the strongest signal the field does not exist yet,
-                            which is why nothing else stands in for an empty state. */}
-            <CommandGroup forceMount>
-              {/* A publisher can name a field "New field", so the colour is what
+            {canCreateField ? (
+              /* Its own group because cmdk hands forceMount down to every item in a group, so
+                                among the fields it would have pinned all of them. Search finding nothing
+                                is the strongest signal the field does not exist yet, which is why
+                                nothing else stands in for an empty state while this is offered. */
+              <CommandGroup forceMount>
+                {/* A publisher can name a field "New field", so the colour is what
                                 sets this apart from one. */}
-              <CommandItem
-                className="font-semibold text-green"
-                value="Add custom field"
-                forceMount
-                onSelect={() => {
-                  openingCreateForm.current = true;
-                  onOpenChange(false);
-                }}
-              >
-                <LucideIcon.Plus />
-                <span>Add custom field</span>
-              </CommandItem>
-            </CommandGroup>
+                <CommandItem
+                  className="font-semibold text-green"
+                  value="Add custom field"
+                  forceMount
+                  onSelect={() => {
+                    openingCreateForm.current = true;
+                    onOpenChange(false);
+                  }}
+                >
+                  <LucideIcon.Plus />
+                  <span>Add custom field</span>
+                </CommandItem>
+              </CommandGroup>
+            ) : (
+              // With the offer gone nothing is force-mounted, so a search matching nothing
+              // would otherwise leave the list blank with no account of why.
+              <CommandEmpty>No fields found.</CommandEmpty>
+            )}
           </CommandList>
         </Command>
       </PopoverContent>

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
@@ -16,9 +16,8 @@ import {
   inputSurfaceClasses,
 } from '@tryghost/shade/components';
 import {
-  FIELD_SOURCES,
-  FIELD_SOURCE_ORDER,
   type FieldTarget,
+  type FieldTargetGroup,
 } from '@/members/components/bulk-action-modals/import-members/custom-fields/field-targets';
 import { LucideIcon, cn } from '@tryghost/shade/utils';
 import { useRef } from 'react';
@@ -67,7 +66,10 @@ interface FieldPickerProps {
   value: string | null;
   disabled?: boolean;
   invalid?: boolean;
-  targets: FieldTarget[];
+  // The list as it is shown: sections in order, each already headed and populated. Everything
+  // about where a target sits and how it is named is settled by fieldTargets, so nothing here
+  // re-derives it.
+  targetGroups: FieldTargetGroup[];
   // Whether the list ends with an offer to make a custom field. Off, a search that matches
   // nothing says so instead, which the offer had been standing in for.
   canCreateField: boolean;
@@ -89,7 +91,7 @@ export function FieldPicker({
   value,
   disabled,
   invalid,
-  targets,
+  targetGroups,
   canCreateField,
   open,
   search,
@@ -106,9 +108,11 @@ export function FieldPicker({
   // its autoFocus pulled straight back inside. Both are dealt with at teardown, below.
   const openingCreateForm = useRef(false);
 
-  const selected = targets.find((target) => target.value === value);
-  const badge = selected?.contested ? FIELD_SOURCES[selected.source].badge : null;
-  const ariaKind = selected ? FIELD_SOURCES[selected.source].ariaKind : null;
+  const selected = targetGroups
+    .flatMap((group) => group.targets)
+    .find((target) => target.value === value);
+  const badge = selected?.badge ?? null;
+  const ariaKind = selected?.ariaKind ?? null;
 
   const choose = (target: string) => {
     onOpenChange(false);
@@ -271,27 +275,20 @@ export function FieldPicker({
                             and Enter would take whichever the DOM had first. Identity is the
                             target, which is namespaced and so already distinct; the label moves
                             to keywords for scoreByLabel. */}
-            {/* Empty sources are dropped rather than left to cmdk: a group with no items
-                            still owns its heading in the DOM, so a site with custom fields off would
-                            be told there is a Custom fields section and then shown nothing under it. */}
-            {FIELD_SOURCE_ORDER.filter((source) =>
-              targets.some((target) => target.source === source),
-            ).map((source) => (
-              <CommandGroup key={source} heading={FIELD_SOURCES[source].heading}>
-                {targets
-                  .filter((target) => target.source === source)
-                  .map((target) => (
-                    <CommandItem
-                      key={target.value}
-                      keywords={[target.label]}
-                      value={target.value}
-                      onSelect={() => choose(target.value)}
-                    >
-                      <TargetIcon target={target} />
-                      <span className="truncate">{target.label}</span>
-                      {value === target.value && <CommandCheck />}
-                    </CommandItem>
-                  ))}
+            {targetGroups.map((group) => (
+              <CommandGroup key={group.source} heading={group.heading}>
+                {group.targets.map((target) => (
+                  <CommandItem
+                    key={target.value}
+                    keywords={[target.label]}
+                    value={target.value}
+                    onSelect={() => choose(target.value)}
+                  >
+                    <TargetIcon target={target} />
+                    <span className="truncate">{target.label}</span>
+                    {value === target.value && <CommandCheck />}
+                  </CommandItem>
+                ))}
               </CommandGroup>
             ))}
             {canCreateField ? (

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.test.ts
@@ -1,4 +1,4 @@
-import { FIELD_SOURCES, FIELD_SOURCE_ORDER, fieldTargets } from './field-targets';
+import { type FieldTargetGroup, fieldTargets } from './field-targets';
 import { type MemberCustomFieldCsvColumn } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 const membershipFields = [
@@ -17,25 +17,31 @@ const customColumn = (
   ...overrides,
 });
 
+/** Every target across every section, for the assertions that are about the list as a whole. */
+const allTargets = (groups: FieldTargetGroup[]) => groups.flatMap((group) => group.targets);
+
 describe('field targets', () => {
   describe('fieldTargets', () => {
-    it('gives a membership field the same two halves every target carries', () => {
-      const [target] = fieldTargets({
+    it('gives a membership field the same halves every target carries', () => {
+      const [group] = fieldTargets({
         membershipFields: [{ label: 'Name', value: 'name' }],
         customFieldColumns: [],
       });
 
-      expect(target).toEqual({
-        value: 'name',
-        source: 'membership',
-        fieldName: 'Name',
-        label: 'Name',
-        contested: false,
-      });
+      expect(group.targets).toEqual([
+        {
+          value: 'name',
+          source: 'membership',
+          fieldName: 'Name',
+          label: 'Name',
+          badge: null,
+          ariaKind: null,
+        },
+      ]);
     });
 
     it("carries a custom field's type, name and part through", () => {
-      const targets = fieldTargets({
+      const groups = fieldTargets({
         membershipFields: [],
         customFieldColumns: [
           customColumn({
@@ -48,7 +54,7 @@ describe('field targets', () => {
         ],
       });
 
-      expect(targets).toEqual([
+      expect(allTargets(groups)).toEqual([
         {
           value: 'custom_fields.shipping_address.city',
           source: 'custom',
@@ -56,54 +62,80 @@ describe('field targets', () => {
           partLabel: 'City',
           label: 'Shipping Address (City)',
           type: 'address',
-          contested: false,
+          badge: null,
+          ariaKind: 'Custom field',
         },
       ]);
     });
 
     it('leaves a one-column field with no part at all', () => {
-      const [target] = fieldTargets({ membershipFields: [], customFieldColumns: [customColumn()] });
+      const [target] = allTargets(
+        fieldTargets({ membershipFields: [], customFieldColumns: [customColumn()] }),
+      );
 
       expect(target).not.toHaveProperty('partLabel');
     });
+  });
 
-    it('offers the sources in the order they are declared in', () => {
-      const targets = fieldTargets({ membershipFields, customFieldColumns: [customColumn()] });
+  describe('sections', () => {
+    it('heads each section with the kind under it, in the order they are declared in', () => {
+      const groups = fieldTargets({ membershipFields, customFieldColumns: [customColumn()] });
 
-      expect([...new Set(targets.map((target) => target.source))]).toEqual([...FIELD_SOURCE_ORDER]);
+      expect(groups.map((group) => [group.source, group.heading])).toEqual([
+        ['membership', 'Membership fields'],
+        ['custom', 'Custom fields'],
+      ]);
+    });
+
+    // A section with nothing under it would still be announced, so a site with custom fields
+    // off must not be offered the heading at all.
+    it('drops a section nothing falls into', () => {
+      const groups = fieldTargets({ membershipFields, customFieldColumns: [] });
+
+      expect(groups.map((group) => group.source)).toEqual(['membership']);
+    });
+
+    it('offers no section at all when there is nothing to offer', () => {
+      expect(fieldTargets({ membershipFields: [], customFieldColumns: [] })).toEqual([]);
     });
   });
 
-  describe('contested', () => {
-    const contestedLabels = (targets: ReturnType<typeof fieldTargets>) =>
-      targets.filter((target) => target.contested).map((target) => target.label);
+  // The badge tells two same-named targets apart. It is a fact about the list rather than the
+  // field, so it is settled here and the picker only shows what it is given.
+  describe('badge', () => {
+    const badged = (groups: FieldTargetGroup[]) =>
+      allTargets(groups)
+        .filter((target) => target.badge !== null)
+        .map((target) => [target.label, target.badge]);
 
-    it('finds a custom field a membership field has the name of', () => {
-      const targets = fieldTargets({
+    it('marks a custom field a membership field has the name of', () => {
+      const groups = fieldTargets({
         membershipFields,
         customFieldColumns: [customColumn({ fieldName: 'Name', label: 'Name' })],
       });
 
-      expect(contestedLabels(targets)).toEqual(['Name', 'Name']);
+      // Only the custom one is marked: membership is the kind a reader assumes, so naming it
+      // would mark both halves of the pair and tell them apart no better than marking neither.
+      expect(badged(groups)).toEqual([['Name', 'Custom']]);
     });
 
-    it('leaves a name no other source offers alone', () => {
-      const targets = fieldTargets({ membershipFields, customFieldColumns: [customColumn()] });
+    it('leaves a name no other source offers unmarked', () => {
+      const groups = fieldTargets({ membershipFields, customFieldColumns: [customColumn()] });
 
-      expect(contestedLabels(targets)).toEqual([]);
+      expect(badged(groups)).toEqual([]);
     });
 
     it('counts a name differing only in case or space as the same name', () => {
-      const targets = fieldTargets({
+      const groups = fieldTargets({
         membershipFields,
         customFieldColumns: [customColumn({ fieldName: ' name ', label: ' name ' })],
       });
 
-      expect(contestedLabels(targets)).toEqual(['Name', ' name ']);
+      expect(badged(groups)).toEqual([[' name ', 'Custom']]);
     });
 
-    it('does not contest a composite part that shares only its field name', () => {
-      const targets = fieldTargets({
+    it('does not mark a composite part that shares only its field name', () => {
+      const groups = fieldTargets({
         membershipFields,
         customFieldColumns: [
           customColumn({
@@ -116,41 +148,52 @@ describe('field targets', () => {
         ],
       });
 
-      expect(contestedLabels(targets)).toEqual([]);
+      expect(badged(groups)).toEqual([]);
     });
 
-    it('contests only against the targets in the list it is given', () => {
+    it('marks only against the targets in the list it is given', () => {
       const custom = [
         customColumn({ value: 'custom_fields.tier', fieldName: 'Tier', label: 'Tier' }),
       ];
 
+      expect(badged(fieldTargets({ membershipFields, customFieldColumns: custom }))).toEqual([]);
       expect(
-        contestedLabels(fieldTargets({ membershipFields, customFieldColumns: custom })),
-      ).toEqual([]);
-      expect(
-        contestedLabels(
+        badged(
           fieldTargets({
             membershipFields: [...membershipFields, { label: 'Tier', value: 'import_tier' }],
             customFieldColumns: custom,
           }),
         ),
-      ).toEqual(['Tier', 'Tier']);
+      ).toEqual([['Tier', 'Custom']]);
     });
   });
 
-  describe('FIELD_SOURCES', () => {
-    it('leaves exactly one source unmarked', () => {
-      const unmarked = FIELD_SOURCE_ORDER.filter((source) => FIELD_SOURCES[source].badge === null);
+  // Read out with the selection, so a custom field is not announced as a membership one.
+  describe('accessible kind', () => {
+    it('names a custom field in full, and says nothing for a membership field', () => {
+      const groups = fieldTargets({
+        membershipFields: [{ label: 'Name', value: 'name' }],
+        customFieldColumns: [customColumn()],
+      });
 
-      expect(unmarked).toEqual(['membership']);
+      expect(allTargets(groups).map((target) => [target.label, target.ariaKind])).toEqual([
+        ['Name', null],
+        ['Nickname', 'Custom field'],
+      ]);
     });
 
-    it('names a marked source in full for the accessible name', () => {
-      expect(FIELD_SOURCES.custom).toEqual({
-        heading: 'Custom fields',
-        badge: 'Custom',
-        ariaKind: 'Custom field',
+    // Unlike the badge, which only appears where something else shares the label.
+    it('names the kind whether or not the label is shared', () => {
+      const groups = fieldTargets({
+        membershipFields,
+        customFieldColumns: [customColumn({ fieldName: 'Name', label: 'Name' })],
       });
+
+      expect(
+        allTargets(groups)
+          .filter((target) => target.source === 'custom')
+          .map((target) => target.ariaKind),
+      ).toEqual(['Custom field']);
     });
   });
 });

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-targets.ts
@@ -19,12 +19,25 @@ type FieldOffer =
   | (FieldFacts & { source: 'custom'; type: MemberCustomField['type'] });
 
 /**
- * One thing a CSV column can be imported as.
+ * One thing a CSV column can be imported as, as the picker shows it.
  *
- * `contested` belongs to the list rather than to the field: whether "Tier" needs telling apart
- * depends on whether tiers are on offer at all.
+ * The badge is settled here rather than left to the picker, because it is not a fact about the
+ * field: whether "Tier" needs telling apart depends on whether tiers are on offer at all, which
+ * only the whole list knows.
  */
-export type FieldTarget = FieldOffer & { contested: boolean };
+export type FieldTarget = FieldOffer & {
+  /** The kind, shown beside the label; null where no other source offers this label. */
+  badge: string | null;
+  /** The kind named in full, for the accessible name; null to say nothing. */
+  ariaKind: string | null;
+};
+
+/** One section of the picker's list: what heads it, and what is under it. */
+export interface FieldTargetGroup {
+  source: FieldSource;
+  heading: string;
+  targets: FieldTarget[];
+}
 
 interface FieldSourcePresentation {
   heading: string;
@@ -34,21 +47,28 @@ interface FieldSourcePresentation {
   ariaKind: string | null;
 }
 
-export const FIELD_SOURCES: Record<FieldSource, FieldSourcePresentation> = {
+const FIELD_SOURCES: Record<FieldSource, FieldSourcePresentation> = {
   membership: { heading: 'Membership fields', badge: null, ariaKind: null },
   custom: { heading: 'Custom fields', badge: 'Custom', ariaKind: 'Custom field' },
 };
 
-export const FIELD_SOURCE_ORDER = Object.keys(FIELD_SOURCES) as FieldSource[];
+const FIELD_SOURCE_ORDER = Object.keys(FIELD_SOURCES) as FieldSource[];
 
-/** Everything a column can be imported as, in the order the sections offer it. */
+/**
+ * Everything a column can be imported as, sectioned as the picker offers it: in the order the
+ * sources are declared in, and without a section nothing falls into — a site with custom fields
+ * off is not told there is a Custom fields section and then shown nothing under it.
+ *
+ * The picker is handed this and nothing else, so where a target sits, what heads its section and
+ * how it is named are all answered before it renders.
+ */
 export function fieldTargets({
   membershipFields,
   customFieldColumns,
 }: {
   membershipFields: { label: string; value: string }[];
   customFieldColumns: MemberCustomFieldCsvColumn[];
-}): FieldTarget[] {
+}): FieldTargetGroup[] {
   const offers: FieldOffer[] = [
     ...membershipFields.map((field): FieldOffer => ({
       value: field.value,
@@ -67,7 +87,17 @@ export function fieldTargets({
   ];
 
   const contested = labelsSharedAcrossSources(offers);
-  return offers.map((offer) => ({ ...offer, contested: contested.has(readsAs(offer)) }));
+  const targets = offers.map((offer): FieldTarget => ({
+    ...offer,
+    badge: contested.has(readsAs(offer)) ? FIELD_SOURCES[offer.source].badge : null,
+    ariaKind: FIELD_SOURCES[offer.source].ariaKind,
+  }));
+
+  return FIELD_SOURCE_ORDER.map((source) => ({
+    source,
+    heading: FIELD_SOURCES[source].heading,
+    targets: targets.filter((target) => target.source === source),
+  })).filter((group) => group.targets.length > 0);
 }
 
 function readsAs(offer: { label: string }): string {

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -77,26 +77,36 @@ export function ImportMembersModal({
   const { mutateAsync: importMembers } = useImportMembers();
   const importMemberTier = useFeatureFlag('importMemberTier');
 
+  // Whether custom fields exist at all is their own flag's answer, not this dialog's: the
+  // redesigned import ships on `membersImportRedesign` and has to be a plain column-to-member-field
+  // mapper while custom fields are still an experiment. Off, they are absent from every part of
+  // this file — not fetched, not offered as a target, not creatable.
+  const customFieldsEnabled = useFeatureFlag('membersCustomFields');
   // Defined custom fields become mapping targets. Browse returns active fields only, which
-  // are the ones the importer writes to. No flag check anywhere in this file: the gate does
-  // not render it unless membersCustomFields is on.
-  const { data: customFieldsData, isError: customFieldsFailed } = useBrowseMemberCustomFields();
+  // are the ones the importer writes to.
+  const { data: customFieldsData, isError: customFieldsFailed } = useBrowseMemberCustomFields({
+    enabled: customFieldsEnabled,
+  });
   // A field created from the mapping step is in here the moment it is created: the create
   // mutation puts it into the cached list, so there is no window where a row points at a
   // column the picker cannot name yet.
   const customFieldColumns = useMemo(
-    () => memberCustomFieldCsvColumns(customFieldsData?.members_custom_fields ?? []),
-    [customFieldsData],
+    () =>
+      customFieldsEnabled
+        ? memberCustomFieldCsvColumns(customFieldsData?.members_custom_fields ?? [])
+        : [],
+    [customFieldsEnabled, customFieldsData],
   );
   // The file-reader effect waits for this before its first parse: the custom field
   // definitions must be loaded or auto-detection would miss custom_fields.* columns on a
   // fast upload. It flips false -> true once and stays true (a refetch keeps data defined),
   // so readiness never re-triggers the read.
-  // Ready, or never going to be. A failure has no representation in `data`, so waiting on it
-  // alone leaves the file unparsed and the step on a spinner with nothing said — for a query
-  // whose only job is to add targets to a list. Failing it costs the custom fields; blocking
-  // on it costs the import.
-  const customFieldsReady = customFieldsData !== undefined || customFieldsFailed;
+  // Ready, or never going to be. Neither a failed query nor a disabled one has any
+  // representation in `data`, so waiting on `data` alone leaves the file unparsed and the step
+  // on a spinner with nothing said — for a query whose only job is to add targets to a list.
+  // Failing it costs the custom fields; blocking on it costs the import.
+  const customFieldsReady =
+    !customFieldsEnabled || customFieldsData !== undefined || customFieldsFailed;
   // Detection options are read inside the effect through this ref rather than as deps, so
   // a later refetch of the options can't re-run the read and overwrite a mapping the user
   // has begun editing.
@@ -474,6 +484,7 @@ export function ImportMembersModal({
         {(state.status === 'MAPPING' || state.status === 'UPLOADING') &&
           state.fileData !== null && (
             <MappingStep
+              canCreateCustomFields={customFieldsEnabled}
               dataPreviewIndex={state.dataPreviewIndex}
               fileData={state.fileData}
               labelPicker={labelPicker}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -90,6 +90,9 @@ export function ImportMembersModal({
   // A field created from the mapping step is in here the moment it is created: the create
   // mutation puts it into the cached list, so there is no window where a row points at a
   // column the picker cannot name yet.
+  //
+  // The flag is asked again rather than left to the disabled query above: disabling stops the
+  // fetch, not the read, so a cache another screen had warmed would still be served here.
   const customFieldColumns = useMemo(
     () =>
       customFieldsEnabled
@@ -118,7 +121,7 @@ export function ImportMembersModal({
   }, [importMemberTier, customFieldColumns]);
   // Auto-detection takes customFieldColumns separately, through detectOptionsRef above: it
   // matches on column names rather than on what is offered.
-  const targets = useMemo(
+  const targetGroups = useMemo(
     () =>
       fieldTargets({
         membershipFields: getFieldMappings({ importMemberTier }),
@@ -492,7 +495,7 @@ export function ImportMembersModal({
               mappingError={state.mappingError}
               showMappingErrors={state.showMappingErrors}
               status={state.status}
-              targets={targets}
+              targetGroups={targetGroups}
               onColumnsChanged={() => {
                 hasEditsRef.current = true;
               }}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
@@ -57,6 +57,9 @@ interface MappingStepProps {
   showMappingErrors: boolean;
   dataPreviewIndex: number;
   targets: FieldTarget[];
+  // Whether custom fields exist for this site at all. Off, no row offers to make one and the
+  // create form is unreachable, so the table is a plain mapping of columns onto member fields.
+  canCreateCustomFields: boolean;
   labelPicker: UseLabelPickerResult;
   onUpdateMapping: (from: string, to: string | null) => void;
   onFieldCreated: (columnKey: string, column: string | null) => void;
@@ -107,6 +110,7 @@ export function MappingStep({
   showMappingErrors,
   dataPreviewIndex,
   targets,
+  canCreateCustomFields,
   labelPicker,
   onUpdateMapping,
   onFieldCreated,
@@ -525,6 +529,7 @@ export function MappingStep({
                                                         second mechanism. The mapping is not lost either way —
                                                         it comes back with the row when it is selected again. */}
                               <FieldPicker
+                                canCreateField={canCreateCustomFields}
                                 className={cn(!isImported(row) && 'invisible')}
                                 columnKey={row.key}
                                 disabled={isRowLocked(row)}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
@@ -32,7 +32,7 @@ import {
   columnsOf,
 } from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
 import { Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { type FieldTarget } from '@/members/components/bulk-action-modals/import-members/custom-fields/field-targets';
+import { type FieldTargetGroup } from '@/members/components/bulk-action-modals/import-members/custom-fields/field-targets';
 import { type MemberCustomField } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import { type UseLabelPickerResult } from '@/members/hooks/use-label-picker';
 
@@ -56,7 +56,7 @@ interface MappingStepProps {
   mappingError: string | null;
   showMappingErrors: boolean;
   dataPreviewIndex: number;
-  targets: FieldTarget[];
+  targetGroups: FieldTargetGroup[];
   // Whether custom fields exist for this site at all. Off, no row offers to make one and the
   // create form is unreachable, so the table is a plain mapping of columns onto member fields.
   canCreateCustomFields: boolean;
@@ -109,7 +109,7 @@ export function MappingStep({
   mappingError,
   showMappingErrors,
   dataPreviewIndex,
-  targets,
+  targetGroups,
   canCreateCustomFields,
   labelPicker,
   onUpdateMapping,
@@ -536,7 +536,7 @@ export function MappingStep({
                                 invalid={incomplete?.columns.has(row.key)}
                                 open={openPicker?.columnKey === row.key}
                                 search={openPicker?.columnKey === row.key ? openPicker.search : ''}
-                                targets={targets}
+                                targetGroups={targetGroups}
                                 triggerRef={(node) => {
                                   if (node) {
                                     fieldTriggers.current.set(row.key, node);

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.ts
@@ -1,7 +1,3 @@
-import {
-  FIELD_MAPPINGS,
-  IMPORT_TIER_FIELD_MAPPING,
-} from '@/members/components/bulk-action-modals/import-members/mapping';
 import { isCustomFieldColumn } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 /**
@@ -20,16 +16,9 @@ export {
   columnsOf,
   detectFieldTypes,
   formatImportError,
+  getFieldMappings,
   sampleData,
 } from '@/members/components/bulk-action-modals/import-members/mapping';
-
-// The native targets only. Custom fields are offered from their own list, chosen by kind, so
-// they are not folded in here — auto-detection still sees both, through the shared detection.
-export function getFieldMappings({
-  importMemberTier = false,
-}: { importMemberTier?: boolean } = {}) {
-  return [...FIELD_MAPPINGS, ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : [])];
-}
 
 /**
  * The field name to suggest for a column no defined field matches.

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
@@ -148,20 +148,6 @@ describe('mapping helpers', () => {
     },
   ];
 
-  it('offers the custom field columns as mapping targets', () => {
-    const mappings = getFieldMappings({ customFieldColumns });
-
-    expect(mappings).toContainEqual(
-      expect.objectContaining({ label: 'Nickname', value: 'custom_fields.nickname' }),
-    );
-    expect(mappings).toContainEqual(
-      expect.objectContaining({
-        label: 'Shipping Address (Line 1)',
-        value: 'custom_fields.shipping_address.line1',
-      }),
-    );
-  });
-
   it('auto-detects a custom field column by its namespaced header', () => {
     const mapping = detectFieldTypes(
       [{ email: 'user@example.com', 'custom_fields.nickname': 'Bex' }],

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -4,10 +4,16 @@ import {
   type MemberCustomFieldCsvColumn,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
-type FieldMappingOptions = {
+/**
+ * What auto-detection is allowed to map a column onto.
+ *
+ * `customFieldColumns` is the redesigned import's alone — it is the only one that offers
+ * custom fields, so it is the only one that passes any. Detection is shared with the import
+ * as it shipped, which passes none.
+ */
+type DetectionOptions = {
   importMemberTier?: boolean;
-  // Custom field CSV columns offered as mapping targets (see memberCustomFieldCsvColumns);
-  // empty when the feature is off.
+  // Custom field CSV columns offered as mapping targets (see memberCustomFieldCsvColumns).
   customFieldColumns?: MemberCustomFieldCsvColumn[];
 };
 
@@ -40,7 +46,7 @@ const SUPPORTED_TYPES = [
 function getSupportedTypes({
   importMemberTier = false,
   customFieldColumns = [],
-}: FieldMappingOptions = {}): string[] {
+}: DetectionOptions = {}): string[] {
   return [
     ...SUPPORTED_TYPES,
     ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING.value] : []),
@@ -48,15 +54,15 @@ function getSupportedTypes({
   ];
 }
 
+/**
+ * Everything a column can be imported as. Native targets only, on both sides of the flag: the
+ * import as it shipped has no others, and the redesigned one offers custom fields from a list
+ * of its own rather than folded in here.
+ */
 export function getFieldMappings({
   importMemberTier = false,
-  customFieldColumns = [],
-}: FieldMappingOptions = {}) {
-  return [
-    ...FIELD_MAPPINGS,
-    ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : []),
-    ...customFieldColumns,
-  ];
+}: { importMemberTier?: boolean } = {}) {
+  return [...FIELD_MAPPINGS, ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : [])];
 }
 
 const AUTO_DETECTED_TYPES = ['email'];
@@ -186,7 +192,7 @@ export function sampleData(
  */
 export function detectFieldTypes(
   data: Record<string, string>[],
-  options: FieldMappingOptions = {},
+  options: DetectionOptions = {},
 ): Record<string, string> {
   const sampledData = sampleData(data);
   const mapping: Record<string, string> = {};

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/modal.test.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/modal.test.tsx
@@ -39,19 +39,6 @@ vi.mock('@tryghost/admin-x-framework/api/members', async () => {
   };
 });
 
-// The modal offers defined custom fields as mapping targets. Stub the browse hook
-// (which needs a QueryClient this test does not mount) while keeping the real
-// column-deriving helper, so a mapping built from fields still exercises production logic.
-vi.mock('@tryghost/admin-x-framework/api/member-custom-fields', async () => {
-  const actual = await vi.importActual<
-    typeof import('@tryghost/admin-x-framework/api/member-custom-fields')
-  >('@tryghost/admin-x-framework/api/member-custom-fields');
-  return {
-    ...actual,
-    useBrowseMemberCustomFields: () => ({ data: undefined }),
-  };
-});
-
 vi.mock('@/members/hooks/use-label-picker', () => ({
   useLabelPicker: () => ({
     labels: [],

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -11,7 +11,10 @@ import {
 import { importMembersScreen } from './import-members.screen';
 import { membersScreen } from './members.screen';
 
-const FLAGS = { labs: { membersCustomFields: true } };
+// Both flags: the redesigned dialog is what this file exercises, and custom fields are what it
+// exercises it for. They are separate switches — the redesign ships without custom fields.
+const FLAGS = { labs: { membersImportRedesign: true, membersCustomFields: true } };
+const WITHOUT_CUSTOM_FIELDS = { labs: { membersImportRedesign: true } };
 
 // A `nickname` column no defined field matches, alongside the columns auto-detection claims.
 // `name` is present deliberately: it takes the /name/i heuristic, which would otherwise map
@@ -37,10 +40,10 @@ const EXPORTED_CSV = 'email,custom_fields.nickname\nada@example.com,Countess\n';
  * key from the name the way the service does, and a browse reflecting what has been
  * created, so the picker behaves as it would against a real site.
  */
-function fakeCustomFieldsWorld() {
-  const fields: Array<Record<string, unknown>> = [];
+function fakeCustomFieldsWorld(definedFields: Array<Record<string, unknown>> = []) {
+  const fields: Array<Record<string, unknown>> = [...definedFields];
   fakeMembers([member({ name: 'Ada Lovelace' })]);
-  fakeMemberCustomFields(() => fields);
+  const browseApi = fakeMemberCustomFields(() => fields);
   const uploadApi = fakeAdminEndpoint('POST', '/members/upload/', {
     meta: { stats: { imported: 1, invalid: [] }, import_label: { name: 'Import', slug: 'import' } },
   });
@@ -58,8 +61,18 @@ function fakeCustomFieldsWorld() {
     fields.push(field);
     return { members_custom_fields: [field] };
   });
-  return { createApi, uploadApi };
+  return { browseApi, createApi, uploadApi };
 }
+
+/** A field the site has already defined, for proving what an import does and does not offer. */
+const NICKNAME_FIELD = {
+  key: 'nickname',
+  name: 'Nickname',
+  type: 'text',
+  status: 'active',
+  created_at: '2026-08-05T00:00:00.000Z',
+  updated_at: null,
+};
 
 /**
  * The mapping as it went over the wire: the upload is multipart, carrying one
@@ -746,5 +759,44 @@ describe('Import members custom fields', () => {
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
     await expect.element(importMembersScreen.leaveConfirmationText()).toBeVisible();
+  });
+
+  // The redesigned dialog ships on its own flag, ahead of custom fields. Off, it has to be a
+  // plain mapping of columns onto the member fields Ghost already has, with nothing about
+  // custom fields anywhere in it — including on a site that has some defined.
+  describe('with custom fields off', () => {
+    it('offers no custom field, and no way to make one', async () => {
+      const { browseApi } = fakeCustomFieldsWorld([NICKNAME_FIELD]);
+      await renderAdminApp('/members', WITHOUT_CUSTOM_FIELDS);
+      await openMappingStep();
+
+      await importToggle('nickname').click();
+      await fieldSelect('nickname').click();
+
+      // Exact, or "Email" also matches "Subscribed to emails".
+      await expect.element(importMembersScreen.option('Email', { exact: true })).toBeVisible();
+      await expect.element(importMembersScreen.option('Nickname')).not.toBeInTheDocument();
+      await expect.element(importMembersScreen.addCustomFieldOption()).not.toBeInTheDocument();
+
+      // Not merely unrendered: the definitions are never asked for. That query also gates the
+      // first parse of the file, so leaving it enabled and unanswerable would hold the mapping
+      // step on a spinner — which reaching the table above already rules out.
+      expect(browseApi.requests).toHaveLength(0);
+    });
+
+    it('says no field matches a search rather than offering to make one', async () => {
+      fakeCustomFieldsWorld();
+      await renderAdminApp('/members', WITHOUT_CUSTOM_FIELDS);
+      await openMappingStep();
+
+      await importToggle('nickname').click();
+      await fieldSelect('nickname').click();
+      await userEvent.fill(importMembersScreen.searchFieldsInput(), 'zzzz');
+
+      // The offer to add a field was the list's only force-mounted item, so without it a
+      // fruitless search would leave the list blank with nothing said.
+      await expect.element(importMembersScreen.addCustomFieldOption()).not.toBeInTheDocument();
+      await expect.element(importMembersScreen.messageText('No fields found.')).toBeVisible();
+    });
   });
 });

--- a/apps/admin/src/members/import-members-gate.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-gate.acceptance.test.tsx
@@ -16,7 +16,7 @@ const CSV = 'email,name\nada@example.com,Ada Lovelace\n';
  * The one thing the split can break.
  *
  * Both implementations have their own tests: the import as it shipped is covered by
- * import-members/modal.test.tsx, and the custom fields experience by
+ * import-members/modal.test.tsx, and the redesigned one by
  * import-members-custom-fields.acceptance.test.tsx. Neither can regress from the other's
  * changes, because they share no file. What is left is whether the gate hands over to the
  * right one, which is what this asserts — by a marker only that implementation renders.
@@ -36,11 +36,11 @@ async function openMappingStep(labs: Record<string, boolean>) {
 }
 
 describe('Import members gate', () => {
-  it('serves the custom fields import when the flag is on', async () => {
-    await openMappingStep({ membersCustomFields: true });
+  it('serves the redesigned import when the flag is on', async () => {
+    await openMappingStep({ membersImportRedesign: true });
 
-    // A checkbox per column exists only in the custom fields experience: it is what decides
-    // whether a column is imported there, a job the select does in the import as it shipped.
+    // A checkbox per column exists only in the redesigned dialog: it is what decides whether
+    // a column is imported there, a job the select does in the import as it shipped.
     await expect.element(importMembersScreen.importToggle('name')).toBeVisible();
   });
 
@@ -54,5 +54,14 @@ describe('Import members gate', () => {
     await expect.element(page.getByRole('combobox').first()).toBeVisible();
     await page.getByRole('combobox').first().click();
     await expect.element(importMembersScreen.option('Not imported')).toBeVisible();
+  });
+
+  // Custom fields are no longer what chooses between the two: they are an experiment the
+  // redesign is meant to ship ahead of, so on their own they must move nothing.
+  it('serves the import as it shipped when only custom fields are on', async () => {
+    await openMappingStep({ membersCustomFields: true });
+
+    await expect.element(importMembersScreen.importToggle('name')).not.toBeInTheDocument();
+    await expect.element(page.getByRole('combobox').first()).toBeVisible();
   });
 });

--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -84,6 +84,12 @@ const features: Feature[] = [
     flag: 'membersCustomFields',
   },
   {
+    title: 'Members import redesign',
+    description:
+      'Serves the redesigned members CSV import dialog, which shows every column in the file and lets each one be mapped to a member field',
+    flag: 'membersImportRedesign',
+  },
+  {
     title: 'Paywall improvements',
     description: 'Enables paywall usability, discoverability and email customization improvements',
     flag: 'paywallImprovements',

--- a/e2e/tests/admin/members/import-custom-fields.test.ts
+++ b/e2e/tests/admin/members/import-custom-fields.test.ts
@@ -18,12 +18,13 @@ import { usePerTestIsolation } from '@/helpers/playwright/isolation';
  * two things only the browser exercises -- the export -> import loop end to end, and the
  * mapping step both auto-detecting an exported column and taking a hand-picked target.
  *
- * Behind membersCustomFields, which gates the whole feature.
+ * Behind two flags: membersImportRedesign serves the mapping step this drives, and
+ * membersCustomFields is what puts custom fields into it.
  */
 usePerTestIsolation();
 
 test.describe('Ghost Admin - Members import with custom fields', () => {
-  test.use({ labs: { membersCustomFields: true } });
+  test.use({ labs: { membersImportRedesign: true, membersCustomFields: true } });
 
   test('an exported custom field value round-trips back through import, auto-mapped', async ({
     page,

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -52,6 +52,7 @@ const PRIVATE_FEATURES = [
   'pictureImageFormats',
   'getHelperDeduplication',
   'membersCustomFields',
+  'membersImportRedesign',
   'paywallImprovements',
   'tagDetailsReact',
   'selfServeArchives',


### PR DESCRIPTION
## Problem

Ghost Admin has two versions of the dialog for importing members from a CSV file. The newer one shows every column in the uploaded file at once and lets you pick what each column should be imported as. It is finished and ready for people to use.

The only way to reach it is to switch on Member custom fields, which is a separate, unfinished experiment about letting a site define extra fields on member records. One switch controls both. So the import cannot go out to anyone without also turning on an experiment that is not ready, and the experiment cannot be tried without changing how importing works.

## Solution

The import dialog gets its own switch, so the two can move independently.

With the new dialog on and custom fields off, it is a plain mapping of the columns in your file onto the member fields Ghost already has. Nothing about custom fields appears anywhere in it: none are offered as a destination for a column, and there is no way to create one. Turning custom fields on puts them back.

The older dialog stays as it was. It contained its own handling for custom fields that had never been reachable by anyone, because it was only ever shown to sites with custom fields switched off. Separating the switches would have brought that code to life for the first time, so it has been deleted instead.

A companion change, held in draft, turns the new dialog on for every Ghost(Pro) site. It can go out as soon as Admin is deployed and does not need to wait for a Ghost release.

Linear: https://linear.app/ghost/issue/BER-3897

https://claude.ai/code/session_01WHJ1RdhTX8n6KwvrgSEnRT
