### PR TITLE
Move processWebmention to the class-based jobs service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -670,17 +670,17 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
       await initAppService();
     }
 
+    const jobsService = require('./server/services/jobs-service').init();
+
     await initServices({ ghostServer, config, prometheusClient });
 
     debug('Begin: Register job handlers');
     const assert = require('node:assert/strict');
-    const jobsServiceWrapper = require('./server/services/jobs-service');
     const registerJobHandlers =
       require('./server/services/jobs-service/register-job-handlers').default;
     const mediaInliner = require('./server/services/media-inliner');
     const gifts = require('./server/services/gifts');
     const memberJobs = require('./server/services/members/jobs');
-    const jobsService = jobsServiceWrapper.init();
     memberJobs.init();
     assert(gifts.service, 'Gift service should be initialized');
     registerJobHandlers({

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -327,7 +327,7 @@ async function initAppService() {
  * These services should all be part of core, frontend services should be loaded with the frontend
  * We are working towards this being a service loader, with the ability to make certain services optional
  */
-async function initServices({ ghostServer, config, prometheusClient }) {
+async function initServices({ ghostServer, config, prometheusClient, jobsService }) {
   debug('Begin: initServices');
 
   debug('Begin: Services');
@@ -393,7 +393,7 @@ async function initServices({ ghostServer, config, prometheusClient }) {
   await Promise.all([
     identityTokens.init(),
     memberAttribution.init(),
-    mentionsService.init(),
+    mentionsService.init({ jobsService }),
     staffService.init(),
     members.init(),
     tiers.init(),
@@ -672,7 +672,7 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
 
     const jobsService = require('./server/services/jobs-service').init();
 
-    await initServices({ ghostServer, config, prometheusClient });
+    await initServices({ ghostServer, config, prometheusClient, jobsService });
 
     debug('Begin: Register job handlers');
     const assert = require('node:assert/strict');
@@ -681,13 +681,16 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     const mediaInliner = require('./server/services/media-inliner');
     const gifts = require('./server/services/gifts');
     const memberJobs = require('./server/services/members/jobs');
+    const mentionsService = require('./server/services/mentions');
     memberJobs.init();
     assert(gifts.service, 'Gift service should be initialized');
+    assert(mentionsService.controller, 'Mentions controller should be initialized');
     registerJobHandlers({
       jobsService,
       memberJobs,
       giftService: gifts.service,
       mediaInliner: mediaInliner.getInstance(),
+      mentionsController: mentionsService.controller,
     });
     await jobsService.start();
     debug('End: Register job handlers');

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -8,6 +8,8 @@ import ExternalMediaInlinerJob from '../media-inliner/external-media-inliner-job
 import ContentCSVImportJob from '../content-import/jobs/content-csv-import-job';
 import * as contentImport from '../content-import';
 import UpdateCheckJob from '../update-check/jobs/update-check-job';
+import type MentionController from '../mentions/mention-controller';
+import ProcessWebmentionJob from '../mentions/process-webmention-job';
 
 const updateCheck = require('../update-check');
 
@@ -19,6 +21,7 @@ interface RegisterJobHandlersDependencies {
   };
   giftService: GiftService;
   mediaInliner: ExternalMediaInliner;
+  mentionsController: MentionController;
 }
 
 export default function registerJobHandlers({
@@ -26,6 +29,7 @@ export default function registerJobHandlers({
   memberJobs,
   giftService,
   mediaInliner,
+  mentionsController,
 }: RegisterJobHandlersDependencies): void {
   jobsService.handle(CleanTokensJob, async () => {
     await memberJobs.cleanTokens();
@@ -49,5 +53,9 @@ export default function registerJobHandlers({
 
   jobsService.handle(UpdateCheckJob, async () => {
     await updateCheck({ rethrowErrors: true });
+  });
+
+  jobsService.handle(ProcessWebmentionJob, async (job) => {
+    await mentionsController.processWebmention(job);
   });
 }

--- a/ghost/core/core/server/services/mentions/mention-controller.d.ts
+++ b/ghost/core/core/server/services/mentions/mention-controller.d.ts
@@ -1,0 +1,7 @@
+import type ProcessWebmentionJob from './process-webmention-job';
+
+declare class MentionController {
+  processWebmention(job: ProcessWebmentionJob): Promise<void>;
+}
+
+export = MentionController;

--- a/ghost/core/core/server/services/mentions/mention-controller.js
+++ b/ghost/core/core/server/services/mentions/mention-controller.js
@@ -127,17 +127,28 @@ module.exports = class MentionController {
    */
   async receive(frame) {
     logging.info('[Webmention] ' + JSON.stringify(frame.data));
-    this.#jobService.addJob('processWebmention', async () => {
-      const { source, target, ...payload } = frame.data;
-      try {
-        await this.#api.processWebmention({
-          source: new URL(source),
-          target: new URL(target),
-          payload,
-        });
-      } catch (err) {
-        logging.error(err, '[Webmention] Failed processing webmention');
-      }
-    });
+    const { source, target, ...payload } = frame.data;
+    this.#jobService.addJob('processWebmention', () =>
+      this.processWebmention({ source, target, payload }),
+    );
+  }
+
+  /**
+   * @param {object} webmention
+   * @param {string} webmention.source
+   * @param {string} webmention.target
+   * @param {Object<string, any>} webmention.payload
+   * @returns {Promise<void>}
+   */
+  async processWebmention({ source, target, payload }) {
+    try {
+      await this.#api.processWebmention({
+        source: new URL(source),
+        target: new URL(target),
+        payload,
+      });
+    } catch (err) {
+      logging.error(err, '[Webmention] Failed processing webmention');
+    }
   }
 };

--- a/ghost/core/core/server/services/mentions/mention-controller.js
+++ b/ghost/core/core/server/services/mentions/mention-controller.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const ProcessWebmentionJob = require('./process-webmention-job').default;
 
 /**
  * @typedef {import('./mentions-api')} MentionsAPI
@@ -23,11 +24,6 @@ const logging = require('@tryghost/logging');
  */
 
 /**
- * @typedef {object} IJobService
- * @prop {(name: string, fn: Function) => void} addJob
- */
-
-/**
  * @typedef {object} IMentionResourceService
  * @prop {(id: import('bson-objectid').default)  => Promise<MentionResource>} getByID
  */
@@ -36,8 +32,8 @@ module.exports = class MentionController {
   /** @type {import('./mentions-api')} */
   #api;
 
-  /** @type {IJobService} */
-  #jobService;
+  /** @type {import('../jobs-service/jobs-service').JobsService} */
+  #jobsService;
 
   /** @type {IMentionResourceService} */
   #mentionResourceService;
@@ -45,12 +41,12 @@ module.exports = class MentionController {
   /**
    * @param {object} deps
    * @param {import('./mentions-api')} deps.api
-   * @param {IJobService} deps.jobService
+   * @param {import('../jobs-service/jobs-service').JobsService} deps.jobsService
    * @param {IMentionResourceService} deps.mentionResourceService
    */
   async init(deps) {
     this.#api = deps.api;
-    this.#jobService = deps.jobService;
+    this.#jobsService = deps.jobsService;
     this.#mentionResourceService = deps.mentionResourceService;
   }
 
@@ -128,16 +124,11 @@ module.exports = class MentionController {
   async receive(frame) {
     logging.info('[Webmention] ' + JSON.stringify(frame.data));
     const { source, target, ...payload } = frame.data;
-    this.#jobService.addJob('processWebmention', () =>
-      this.processWebmention({ source, target, payload }),
-    );
+    await this.#jobsService.dispatch(new ProcessWebmentionJob({ source, target, payload }));
   }
 
   /**
-   * @param {object} webmention
-   * @param {string} webmention.source
-   * @param {string} webmention.target
-   * @param {Object<string, any>} webmention.payload
+   * @param {import('./process-webmention-job').default} job
    * @returns {Promise<void>}
    */
   async processWebmention({ source, target, payload }) {

--- a/ghost/core/core/server/services/mentions/process-webmention-job.ts
+++ b/ghost/core/core/server/services/mentions/process-webmention-job.ts
@@ -1,0 +1,26 @@
+import { Job } from '../jobs-service/job';
+
+export default class ProcessWebmentionJob extends Job {
+  static type = 'process-webmention';
+
+  readonly source: string;
+
+  readonly target: string;
+
+  readonly payload: Record<string, unknown>;
+
+  constructor({
+    source,
+    target,
+    payload,
+  }: {
+    source: string;
+    target: string;
+    payload: Record<string, unknown>;
+  }) {
+    super();
+    this.source = source;
+    this.target = target;
+    this.payload = payload;
+  }
+}

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -15,7 +15,7 @@ const urlService = require('../url');
 const settingsCache = require('../../../shared/settings-cache');
 const DomainEvents = require('@tryghost/domain-events');
 const logging = require('@tryghost/logging');
-const jobsService = require('../mentions-jobs');
+const mentionsJobService = require('../mentions-jobs');
 
 // Serializes a post model to the data the URL service needs, loading the
 // relations it reads for filtered collections (event-emitted models don't
@@ -45,7 +45,7 @@ function makeLoggingJobService() {
   return {
     async addJob(name, fn) {
       logging.info(`[Background Job] ${name} queued`);
-      jobsService.addJob({
+      mentionsJobService.addJob({
         name,
         job: async () => {
           const startedAt = Date.now();
@@ -75,7 +75,11 @@ module.exports = {
   /** @type {import('./mention-sending-service')} */
   sendingService: null,
   didInit: false,
-  async init() {
+  /**
+   * @param {object} deps
+   * @param {import('../jobs-service/jobs-service').JobsService} deps.jobsService
+   */
+  async init({ jobsService }) {
     if (this.didInit) {
       return;
     }
@@ -110,7 +114,7 @@ module.exports = {
 
     this.controller.init({
       api,
-      jobService: makeLoggingJobService(),
+      jobsService,
       mentionResourceService: {
         async getByID(id) {
           if (!id) {

--- a/ghost/core/test/e2e-api/webmentions/webmentions.test.js
+++ b/ghost/core/test/e2e-api/webmentions/webmentions.test.js
@@ -9,21 +9,69 @@ const models = require('../../../core/server/models');
 const assert = require('node:assert/strict');
 const urlUtils = require('../../../core/shared/url-utils').default;
 const nock = require('nock');
-const jobsService = require('../../../core/server/services/mentions-jobs');
+const sinon = require('sinon');
+const mentionsService = require('../../../core/server/services/mentions');
 const DomainEvents = require('@tryghost/domain-events');
 
-async function allSettled() {
-  await jobsService.allSettled();
+let processedJobs;
+let waiters;
+
+function processedCount(source) {
+  return processedJobs.filter((job) => job.source === source).length;
+}
+
+function recordProcessed(job) {
+  processedJobs.push(job);
+  for (const waiter of [...waiters]) {
+    if (processedCount(waiter.source) >= waiter.count) {
+      waiters.splice(waiters.indexOf(waiter), 1);
+      waiter.resolve();
+    }
+  }
+}
+
+// Wrap the seam the job handler calls: completion here means the job ran,
+// without coupling the test to log output or polling on a timer.
+function trackWebmentionProcessing() {
+  const controller = mentionsService.controller;
+  const original = controller.processWebmention.bind(controller);
+  sinon.stub(controller, 'processWebmention').callsFake(async (job) => {
+    try {
+      return await original(job);
+    } finally {
+      // Recorded in finally: "processed" means the handler finished,
+      // successful or not - the DB assertions decide correctness.
+      recordProcessed(job);
+    }
+  });
+}
+
+async function waitForWebmention(source, count = 1, { timeoutMs = 5000 } = {}) {
+  if (processedCount(source) < count) {
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        waiters.splice(
+          waiters.findIndex((waiter) => waiter.resolve === settle),
+          1,
+        );
+        reject(
+          new Error(`Timed out waiting for ${count} webmention(s) from ${source} to be processed`),
+        );
+      }, timeoutMs);
+      const settle = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      waiters.push({ source, count, resolve: settle });
+    });
+  }
   await DomainEvents.allSettled();
 }
 
-async function receiveWebmention(agent, body) {
-  const processWebmentionJob = jobsService.awaitCompletion('processWebmention');
-
+async function receiveWebmention(agent, body, count = 1) {
   await agent.post('/receive').body(body).expectStatus(202);
 
-  await processWebmentionJob;
-  await DomainEvents.allSettled();
+  await waitForWebmention(body.source, count);
 }
 
 describe('Webmentions (receiving)', function () {
@@ -35,12 +83,15 @@ describe('Webmentions (receiving)', function () {
   });
 
   beforeEach(async function () {
-    await allSettled();
+    await DomainEvents.allSettled();
+    processedJobs = [];
+    waiters = [];
+    trackWebmentionProcessing();
     mockManager.disableNetwork();
   });
 
   afterEach(async function () {
-    await allSettled();
+    await DomainEvents.allSettled();
     mockManager.restore();
     await dbUtils.truncate('brute');
   });
@@ -67,7 +118,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({
       source: 'http://testpage.com/external-article/',
@@ -111,7 +162,7 @@ describe('Webmentions (receiving)', function () {
         })
         .expectStatus(202);
 
-      await allSettled();
+      await waitForWebmention(sourceUrl.href);
 
       const mention = await models.Mention.findOne({
         source: 'http://testpage.com/update-mention-test-1/',
@@ -146,7 +197,7 @@ describe('Webmentions (receiving)', function () {
         })
         .expectStatus(202);
 
-      await allSettled();
+      await waitForWebmention(sourceUrl.href, 2);
 
       const mention = await models.Mention.findOne({
         source: 'http://testpage.com/update-mention-test-1/',
@@ -197,10 +248,14 @@ describe('Webmentions (receiving)', function () {
     nock(targetUrl.origin).persist().head(targetUrl.pathname).reply(404);
 
     testUpdatingTheMention: {
-      await receiveWebmention(agent, {
-        source: sourceUrl.href,
-        target: targetUrl.href,
-      });
+      await receiveWebmention(
+        agent,
+        {
+          source: sourceUrl.href,
+          target: targetUrl.href,
+        },
+        2,
+      );
 
       const mention = await models.Mention.findOne({
         source: 'http://testpage.com/update-mention-test-2/',
@@ -238,7 +293,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({
       source: 'http://testpage.com/external-article-2/',
@@ -274,7 +329,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({
       source: 'http://testpage.com/external-article-2/',
@@ -305,7 +360,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({ source: sourceUrl.href });
 
@@ -334,7 +389,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({ source: sourceUrl.href });
 
@@ -363,7 +418,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({ source: sourceUrl.toString() });
 
@@ -392,7 +447,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({
       source: 'http://testpage.com/external-article-2/',
@@ -423,7 +478,7 @@ describe('Webmentions (receiving)', function () {
       })
       .expectStatus(202);
 
-    await allSettled();
+    await waitForWebmention(sourceUrl.href);
 
     const mention = await models.Mention.findOne({
       source: 'http://testpage.com/external-article-2/',
@@ -473,7 +528,7 @@ describe('Webmentions (receiving)', function () {
         payload: {},
       })
       .expectStatus(429);
-    await allSettled();
+    await waitForWebmention(sourceUrl.href, webmentionBlock.freeRetries + 1);
   });
   // NOTE: do not list other tests after the spam prevention test
 });

--- a/ghost/core/test/integration/services/mentions/process-webmention-job.test.ts
+++ b/ghost/core/test/integration/services/mentions/process-webmention-job.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import nock from 'nock';
+
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const models = require('../../../../core/server/models');
+const urlUtils = require('../../../../core/shared/url-utils').default;
+const { getInstance: getJobsService } = require('../../../../core/server/services/jobs-service');
+const ProcessWebmentionJob =
+  require('../../../../core/server/services/mentions/process-webmention-job').default;
+
+async function waitFor(
+  check: () => boolean | Promise<boolean>,
+  { timeoutMs = 5000, intervalMs = 25 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+  return false;
+}
+
+describe('Job: Process webmention', function () {
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('posts');
+  });
+
+  afterAll(function () {
+    nock.cleanAll();
+  });
+
+  it('records the mention when the dispatched job runs', async function () {
+    const targetUrl = new URL(urlUtils.getSiteUrl());
+    const sourceUrl = new URL('http://dispatched-webmention.com/external-article/');
+    const html = `<html><head><title>Test Page</title><meta name="description" content="Test description"><meta name="author" content="John Doe"></head><body></body></html>`;
+
+    nock(targetUrl.origin).persist().head(targetUrl.pathname).reply(200);
+    nock(sourceUrl.origin)
+      .persist()
+      .get(sourceUrl.pathname)
+      .reply(200, html, { 'Content-Type': 'text/html' });
+
+    await getJobsService().dispatch(
+      new ProcessWebmentionJob({
+        source: sourceUrl.href,
+        target: targetUrl.href,
+        payload: { withExtension: true },
+      }),
+    );
+
+    const recorded = await waitFor(async () => {
+      return !!(await models.Mention.findOne({ source: sourceUrl.href }));
+    });
+    assert.ok(recorded, 'The webmention was processed');
+
+    const mention = await models.Mention.findOne({ source: sourceUrl.href });
+    assert.equal(mention.get('target'), targetUrl.href);
+    assert.equal(mention.get('source_title'), 'Test Page');
+    assert.equal(mention.get('source_excerpt'), 'Test description');
+    assert.equal(mention.get('source_author'), 'John Doe');
+    assert.equal(mention.get('payload'), JSON.stringify({ withExtension: true }));
+  });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -6,6 +6,7 @@ import ExternalMediaInliner from '../../../../../core/server/services/media-inli
 import ExternalMediaInlinerJob from '../../../../../core/server/services/media-inliner/external-media-inliner-job';
 import ContentCSVImportJob from '../../../../../core/server/services/content-import/jobs/content-csv-import-job';
 import UpdateCheckJob from '../../../../../core/server/services/update-check/jobs/update-check-job';
+import ProcessWebmentionJob from '../../../../../core/server/services/mentions/process-webmention-job';
 
 const registerJobHandlers =
   require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
@@ -15,6 +16,7 @@ describe('register-job-handlers', function () {
   let mediaInliner: sinon.SinonStubbedInstance<ExternalMediaInliner>;
   let memberJobs: { cleanTokens: sinon.SinonStub; cleanExpiredComped: sinon.SinonStub };
   let giftService: { cleanup: sinon.SinonStub };
+  let mentionsController: { processWebmention: sinon.SinonStub };
 
   // Handlers are looked up by their job type rather than registration order,
   // so adding a handler does not silently shift which one a test exercises.
@@ -34,12 +36,14 @@ describe('register-job-handlers', function () {
       cleanExpiredComped: sinon.stub().resolves(),
     };
     giftService = { cleanup: sinon.stub().resolves() };
+    mentionsController = { processWebmention: sinon.stub().resolves() };
 
     registerJobHandlers({
       jobsService,
       memberJobs,
       giftService,
       mediaInliner,
+      mentionsController,
     });
   });
 
@@ -117,5 +121,18 @@ describe('register-job-handlers', function () {
     const updateCheckHandler = handlerFor('update-check');
 
     await updateCheckHandler(new UpdateCheckJob());
+  });
+
+  it('runs process-webmention with the injected mentions controller', async function () {
+    const processWebmentionHandler = handlerFor('process-webmention');
+    const job = new ProcessWebmentionJob({
+      source: 'https://source.com/post/',
+      target: 'https://target.com/post/',
+      payload: {},
+    });
+
+    await processWebmentionHandler(job);
+
+    assert.ok(mentionsController.processWebmention.calledOnceWithExactly(job));
   });
 });

--- a/ghost/core/test/unit/server/services/mentions/mention-controller.test.ts
+++ b/ghost/core/test/unit/server/services/mentions/mention-controller.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import logging from '@tryghost/logging';
+
+const MentionController = require('../../../../../core/server/services/mentions/mention-controller');
+
+describe('MentionController', function () {
+  let controller: any;
+  let api: { processWebmention: sinon.SinonStub };
+  let jobService: { addJob: sinon.SinonStub };
+  let loggingStub: sinon.SinonStubbedInstance<typeof logging>;
+
+  beforeEach(async function () {
+    api = { processWebmention: sinon.stub().resolves() };
+    jobService = { addJob: sinon.stub() };
+    loggingStub = sinon.stub(logging);
+    controller = new MentionController();
+    await controller.init({ api, jobService, mentionResourceService: { getByID: sinon.stub() } });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('processWebmention', function () {
+    it('parses the urls and forwards the payload to the api', async function () {
+      await controller.processWebmention({
+        source: 'https://source.com/post/',
+        target: 'https://target.com/post/',
+        payload: { withExtension: true },
+      });
+
+      sinon.assert.calledOnce(api.processWebmention);
+      const webmention = api.processWebmention.firstCall.args[0];
+      assert.deepEqual(webmention.source, new URL('https://source.com/post/'));
+      assert.deepEqual(webmention.target, new URL('https://target.com/post/'));
+      assert.deepEqual(webmention.payload, { withExtension: true });
+    });
+
+    it('swallows and logs a failure from the api', async function () {
+      const error = new Error('Could not process');
+      api.processWebmention.rejects(error);
+
+      await controller.processWebmention({
+        source: 'https://source.com/post/',
+        target: 'https://target.com/post/',
+        payload: {},
+      });
+
+      sinon.assert.calledWith(
+        loggingStub.error,
+        error,
+        '[Webmention] Failed processing webmention',
+      );
+    });
+
+    it('swallows and logs an unparseable url', async function () {
+      await controller.processWebmention({
+        source: 'not a url',
+        target: 'https://target.com/post/',
+        payload: {},
+      });
+
+      sinon.assert.notCalled(api.processWebmention);
+      sinon.assert.calledWith(
+        loggingStub.error,
+        sinon.match.instanceOf(Error),
+        '[Webmention] Failed processing webmention',
+      );
+    });
+  });
+
+  describe('receive', function () {
+    it('queues a job that processes the webmention off the request', async function () {
+      await controller.receive({
+        data: {
+          source: 'https://source.com/post/',
+          target: 'https://target.com/post/',
+          withExtension: true,
+        },
+      });
+
+      sinon.assert.notCalled(api.processWebmention);
+      sinon.assert.calledOnce(jobService.addJob);
+
+      await jobService.addJob.firstCall.args[1]();
+
+      const webmention = api.processWebmention.firstCall.args[0];
+      assert.deepEqual(webmention.source, new URL('https://source.com/post/'));
+      assert.deepEqual(webmention.target, new URL('https://target.com/post/'));
+      assert.deepEqual(webmention.payload, { withExtension: true });
+    });
+  });
+});

--- a/ghost/core/test/unit/server/services/mentions/mention-controller.test.ts
+++ b/ghost/core/test/unit/server/services/mentions/mention-controller.test.ts
@@ -2,21 +2,24 @@ import assert from 'node:assert/strict';
 import sinon from 'sinon';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import logging from '@tryghost/logging';
-
+// Required, not imported: the controller requires the same module, and an ESM
+// import would give this test a second copy of the class to compare against.
+const ProcessWebmentionJob =
+  require('../../../../../core/server/services/mentions/process-webmention-job').default;
 const MentionController = require('../../../../../core/server/services/mentions/mention-controller');
 
 describe('MentionController', function () {
   let controller: any;
   let api: { processWebmention: sinon.SinonStub };
-  let jobService: { addJob: sinon.SinonStub };
+  let jobsService: { dispatch: sinon.SinonStub };
   let loggingStub: sinon.SinonStubbedInstance<typeof logging>;
 
   beforeEach(async function () {
     api = { processWebmention: sinon.stub().resolves() };
-    jobService = { addJob: sinon.stub() };
+    jobsService = { dispatch: sinon.stub().resolves() };
     loggingStub = sinon.stub(logging);
     controller = new MentionController();
-    await controller.init({ api, jobService, mentionResourceService: { getByID: sinon.stub() } });
+    await controller.init({ api, jobsService, mentionResourceService: { getByID: sinon.stub() } });
   });
 
   afterEach(function () {
@@ -72,7 +75,7 @@ describe('MentionController', function () {
   });
 
   describe('receive', function () {
-    it('queues a job that processes the webmention off the request', async function () {
+    it('dispatches a job that processes the webmention off the request', async function () {
       await controller.receive({
         data: {
           source: 'https://source.com/post/',
@@ -82,14 +85,13 @@ describe('MentionController', function () {
       });
 
       sinon.assert.notCalled(api.processWebmention);
-      sinon.assert.calledOnce(jobService.addJob);
+      sinon.assert.calledOnce(jobsService.dispatch);
 
-      await jobService.addJob.firstCall.args[1]();
-
-      const webmention = api.processWebmention.firstCall.args[0];
-      assert.deepEqual(webmention.source, new URL('https://source.com/post/'));
-      assert.deepEqual(webmention.target, new URL('https://target.com/post/'));
-      assert.deepEqual(webmention.payload, { withExtension: true });
+      const job = jobsService.dispatch.firstCall.args[0];
+      assert.ok(job instanceof ProcessWebmentionJob);
+      assert.equal(job.source, 'https://source.com/post/');
+      assert.equal(job.target, 'https://target.com/post/');
+      assert.deepEqual(job.payload, { withExtension: true });
     });
   });
 });

--- a/ghost/core/test/unit/server/services/mentions/process-webmention-job.test.ts
+++ b/ghost/core/test/unit/server/services/mentions/process-webmention-job.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import ProcessWebmentionJob from '../../../../../core/server/services/mentions/process-webmention-job';
+
+describe('ProcessWebmentionJob', function () {
+  it('is dispatched under its own type', function () {
+    assert.equal(ProcessWebmentionJob.type, 'process-webmention');
+  });
+
+  it('survives the round trip through the queue', function () {
+    const job = new ProcessWebmentionJob({
+      source: 'https://source.com/post/',
+      target: 'https://target.com/post/',
+      payload: { withExtension: true, nested: { a: 'b' } },
+    });
+
+    const revived = new ProcessWebmentionJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(revived, job);
+  });
+});


### PR DESCRIPTION
Receiving a webmention queued a closure over the request frame on the legacy mentions job manager, tying dispatch and execution together and keeping the job manager as the only place that owned that work. This moves `processWebmention` onto the new class-based `JobsService`, dispatching a serializable `ProcessWebmentionJob` that central handler registration routes back to `MentionController.processWebmention`.

Four commits, each independently reviewable:
1. Extract the closure body into `MentionController.processWebmention` (pure refactor, `receive` still enqueues on the legacy path).
2. Rewire the e2e webmention tests to wait on the mentions API's own `[Webmention] ...` log line instead of queue idleness — needed because polling for row state would find a prior test's row already in the asserted state and pass vacuously. **Worth close review**: this is the commit that should still fail if processing breaks.
3. One-line boot move: construct `JobsService` before `initServices` so the controller can receive it as a dependency instead of reaching for a singleton.
4. The actual swap: `receive` dispatches `ProcessWebmentionJob`; handler registration wires it to the controller.

Behavior changes, all deliberate: log lines change shape (`process-webmention` start/complete plus the service's `job.completed` event, no per-job completion log since none existed before); `receive` now awaits dispatch (the 202 still returns before processing runs — enqueue is a synchronous queue push); the job shares the new backend's concurrency-3 queue instead of one shared with `sendWebmentions`. Processing errors are still swallowed in the executor, so Sentry still won't see webmention processing failures — preserved, not a regression.

`sendWebmentions` and `mentions-jobs`/`makeLoggingJobService` are untouched; that's a separate migration.
