### PR TITLE
Added a dev mode that receives Stripe webhooks at Ghost's pinned API version

### DIFF
--- a/compose.dev.stripe-remote.yaml
+++ b/compose.dev.stripe-remote.yaml
@@ -1,0 +1,7 @@
+services:
+  ghost-dev:
+    environment:
+      # Ghost registers its own Stripe webhook endpoint, as it does in production, at the
+      # tunnel URL started by with-remote-webhooks.sh. The site itself stays on localhost.
+      stripeWebhookUrl: ${GHOST_STRIPE_WEBHOOK_URL:?set by docker/stripe/with-remote-webhooks.sh; run pnpm dev:stripe:remote}
+      stripeRemoteWebhooks: 'true'

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -71,6 +71,8 @@ services:
     container_name: ghost-dev
     working_dir: /home/ghost/ghost/core
     command: ['pnpm', 'dev']
+    # The entrypoint drains Ghost before exiting; give that longer than Docker's 10s
+    stop_grace_period: 45s
     volumes:
       # Mount the backend source as whole-directory mounts instead of
       # enumerating each server-graph workspace package. `pnpm dev` runs in

--- a/docker/ghost-dev/entrypoint.sh
+++ b/docker/ghost-dev/entrypoint.sh
@@ -29,6 +29,63 @@ if [ -f /mnt/shared-config/.env.stripe ]; then
     fi
 fi
 
-# Execute the CMD
-exec "$@"
+# When Docker stops this container it sends a stop signal to the first process, which
+# is this script. Ghost runs several processes below it (pnpm, nodemon and their
+# shells), and none of them pass the signal on. Without the handling below Ghost is
+# killed outright and never runs its shutdown work. So this script stays as the first
+# process, sends the stop signal straight to Ghost, waits for it to finish, and only
+# then lets the others exit.
+GHOST_COMMAND='node --conditions=source --import=tsx index.js' # nodemon.json exec
+SHUTDOWN_WAIT_SECONDS=30
 
+ghost_pid() {
+    local proc cmdline cwd
+    for proc in /proc/[0-9]*; do
+        cmdline=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null || true)
+        [ "${cmdline% }" = "$GHOST_COMMAND" ] || continue
+        cwd=$(readlink "$proc/cwd" 2>/dev/null || true)
+        [[ "$cwd" == */ghost/core ]] || continue
+        echo "${proc#/proc/}"
+        return
+    done
+}
+
+# A process that has exited but not yet been collected by its parent still has an
+# entry under /proc with state Z. Treat it as exited.
+has_exited() {
+    local state
+    state=$(awk '{print $3}' "/proc/$1/stat" 2>/dev/null || true)
+    [ -z "$state" ] || [ "$state" = "Z" ]
+}
+
+wait_for_exit() {
+    local pid=$1 deadline=$2
+    while ! has_exited "$pid" && [ "$SECONDS" -lt "$deadline" ]; do
+        sleep 0.2
+    done
+    has_exited "$pid"
+}
+
+child=""
+shutdown() {
+    # One time limit for everything below, so it finishes within the stop_grace_period
+    # that compose.dev.yaml gives this container.
+    local pid deadline=$((SECONDS + SHUTDOWN_WAIT_SECONDS))
+    pid=$(ghost_pid || true)
+    if [ -n "$pid" ]; then
+        echo "Stopping Ghost (pid $pid) before the container exits"
+        kill -TERM "$pid" 2>/dev/null || true
+        wait_for_exit "$pid" "$deadline" || echo "Ghost did not stop within ${SHUTDOWN_WAIT_SECONDS}s"
+    fi
+    if [ -n "$child" ]; then
+        kill -TERM "$child" 2>/dev/null || true
+        wait_for_exit "$child" "$deadline" || kill -KILL "$child" 2>/dev/null || true
+        wait "$child" 2>/dev/null || true
+    fi
+    exit 0
+}
+trap shutdown TERM INT
+
+"$@" &
+child=$!
+wait "$child"

--- a/docker/stripe/entrypoint.sh
+++ b/docker/stripe/entrypoint.sh
@@ -3,6 +3,9 @@
 # Entrypoint script for the Stripe CLI service in compose.yml
 ## This script fetches the webhook secret from Stripe CLI and writes it to a shared config file
 ## that the Ghost server can read to verify webhook signatures.
+## Events forwarded by `stripe listen` use the Stripe account's default API version, not
+## the version Ghost registers with in production, so their shape can differ from what
+## production receives. Use `pnpm dev:stripe:remote` when the shape matters.
 
 # Note: the stripe CLI container is based on alpine, hence `sh` instead of `bash`.
 set -eu

--- a/docker/stripe/with-remote-webhooks.sh
+++ b/docker/stripe/with-remote-webhooks.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Runs the development environment with Ghost receiving Stripe webhooks the way it
+# does in production.
+#
+# In production Ghost gives Stripe a URL to send webhooks to, registered with a fixed
+# Stripe API version, so the messages always have the same shape. The usual local
+# setup forwards webhooks with Stripe's command line tool instead, which uses the
+# account's default API version, so messages can have a shape production never sends.
+#
+# This script makes Ghost's webhook URL reachable from the internet through Tailscale,
+# nothing else on the machine, and tells Ghost to register that URL with Stripe at
+# boot. Ghost removes the registration when it shuts down. The site and Admin stay on
+# localhost.
+#
+# Usage: ./docker/stripe/with-remote-webhooks.sh <command>
+# Example: ./docker/stripe/with-remote-webhooks.sh pnpm nx run ghost-monorepo:docker:dev
+
+set -euo pipefail
+
+FUNNEL_PORT=443
+GATEWAY_PORT=2368
+WEBHOOK_PATH=/members/webhooks/stripe
+
+fail() {
+    echo ""
+    echo "================================================================================"
+    echo "ERROR: $1"
+    echo ""
+    shift
+    for line in "$@"; do
+        echo "$line"
+    done
+    echo "================================================================================"
+    echo ""
+    exit 1
+}
+
+[ "$#" -gt 0 ] || fail "no command given" \
+    "Usage: $0 <command>" \
+    "Example: $0 pnpm nx run ghost-monorepo:docker:dev"
+
+# The macOS app bundle does not put its CLI on PATH.
+TAILSCALE=$(command -v tailscale || true)
+if [ -z "$TAILSCALE" ] && [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
+    TAILSCALE=/Applications/Tailscale.app/Contents/MacOS/Tailscale
+fi
+[ -n "$TAILSCALE" ] || fail "tailscale is not installed" \
+    "Install it from https://tailscale.com/download and sign in, then re-run."
+
+status=$("$TAILSCALE" status --json 2>/dev/null || true)
+read -r backend hostname < <(node -e '
+    const status = JSON.parse(process.argv[1] || "{}");
+    const name = ((status.Self || {}).DNSName || "").replace(/\.$/, "");
+    process.stdout.write(`${status.BackendState || "Unknown"} ${name}\n`);
+' "$status")
+
+[ "$backend" = "Running" ] || fail "tailscale is not connected (state: $backend)" \
+    "Run 'tailscale up' (or open the Tailscale app and sign in), then re-run."
+[ -n "$hostname" ] || fail "this node has no MagicDNS name" \
+    "Funnel needs MagicDNS and HTTPS certificates enabled for the tailnet." \
+    "See https://tailscale.com/kb/1223/funnel"
+
+if [ "$FUNNEL_PORT" = "443" ]; then
+    public_origin="https://${hostname}"
+else
+    public_origin="https://${hostname}:${FUNNEL_PORT}"
+fi
+export GHOST_STRIPE_WEBHOOK_URL="${public_origin}${WEBHOOK_PATH}/"
+
+# Something is already published on this port: a funnel left running in the
+# background, or another copy of this script. Do not take it over.
+if "$TAILSCALE" funnel status --json 2>/dev/null | grep -q "\"${hostname}:${FUNNEL_PORT}\""; then
+    fail "tailscale funnel is already serving port ${FUNNEL_PORT}" \
+        "If nothing else needs it: tailscale funnel --https=${FUNNEL_PORT} off" \
+        "If another pnpm dev:stripe:remote is running, stop that first."
+fi
+
+echo "Publishing Ghost's Stripe webhook route at ${GHOST_STRIPE_WEBHOOK_URL} via Tailscale Funnel"
+echo "Only that path is reachable from the internet, and only while this command runs."
+# Run the funnel as a child process without --bg. Tailscale then keeps the URL public
+# only while that process lives, so a crash, a closed terminal or a reboot cannot leave
+# it published. Tailscale removes the path from the request before forwarding, so the
+# target includes the path again for Ghost to route on.
+funnel_err=$(mktemp)
+"$TAILSCALE" funnel --https="$FUNNEL_PORT" --set-path "$WEBHOOK_PATH" \
+    "http://127.0.0.1:${GATEWAY_PORT}${WEBHOOK_PATH}" >/dev/null 2>"$funnel_err" &
+funnel_pid=$!
+
+stop_funnel() {
+    kill "$funnel_pid" 2>/dev/null || true
+    wait "$funnel_pid" 2>/dev/null || true
+    rm -f "$funnel_err"
+}
+# Bash skips the EXIT trap when a signal kills it, so turn signals into exits.
+trap stop_funnel EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+funnel_ready=false
+for _ in $(seq 1 20); do
+    if "$TAILSCALE" funnel status --json 2>/dev/null | grep -q "\"${hostname}:${FUNNEL_PORT}\""; then
+        funnel_ready=true
+        break
+    fi
+    kill -0 "$funnel_pid" 2>/dev/null || break
+    sleep 0.5
+done
+if [ "$funnel_ready" != true ]; then
+    grep -v 'client version' "$funnel_err" >&2 || true
+    fail "tailscale funnel could not be started" \
+        "Funnel must be enabled for your tailnet and this node (Tailscale 1.52 or newer)." \
+        "See https://tailscale.com/kb/1223/funnel"
+fi
+
+# The `stripe` compose profile starts Stripe's command line forwarder. With it running,
+# Ghost would use the forwarder instead of registering its own URL, and every event
+# would also arrive a second time in the other shape.
+profiles="${COMPOSE_PROFILES:-}"
+if [ -z "$profiles" ] && [ -f .env ]; then
+    profiles=$(grep -E '^COMPOSE_PROFILES=' .env | tail -n1 | cut -d= -f2- | sed -e 's/[[:space:]]*#.*$//' -e "s/^['\"]//" -e "s/['\"]$//" || true)
+fi
+if [[ ",${profiles}," == *",stripe,"* ]]; then
+    echo "Dropping the 'stripe' compose profile: remote webhooks replace stripe listen."
+    profiles=$(echo "$profiles" | tr ',' '\n' | grep -vx 'stripe' | paste -sd, - || true)
+fi
+export COMPOSE_PROFILES="$profiles"
+
+export DEV_COMPOSE_FILES="${DEV_COMPOSE_FILES:-} -f compose.dev.stripe-remote.yaml"
+
+echo "Ghost registers its webhook endpoint at boot once Stripe is connected in Ghost Admin (Settings > Tiers)."
+echo "Open the site and Admin on http://localhost:${GATEWAY_PORT} as usual."
+echo "Watch the ghost-dev logs: it warns if Stripe is not connected."
+
+# The wrapped command stops the containers before it returns, and Ghost removes its
+# Stripe registration during that stop. The funnel is closed after that, on exit.
+"$@"

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -114,6 +114,7 @@ environment and adds the listed tooling:
 | `pnpm dev:analytics:local` | Tinybird-backed analytics with your locally running instance of the Traffic Analytics service |
 | `pnpm dev:storage`         | S3-compatible storage through MinIO on ports `9000` and `9001`                                |
 | `pnpm dev:stripe`          | Stripe webhooks; requires `STRIPE_SECRET_KEY` in the environment or a local `.env` file       |
+| `pnpm dev:stripe:remote`   | Stripe webhooks exactly as production receives them; requires Tailscale, see below            |
 | `pnpm dev:full`            | Public app watchers plus analytics, storage, and Stripe                                       |
 
 Copy [`.env.example`](../../.env.example) to `.env` only when you need an
@@ -122,6 +123,37 @@ optional integration. Never commit credentials or the local `.env` file.
 To open Ghost on a phone or another computer, or to exercise HTTPS,
 subdirectory, and separate-Admin URL behaviour, see
 [Testing development URLs and devices](testing-development-urls.md).
+
+### Stripe webhooks
+
+`pnpm dev:stripe` forwards events with `stripe listen`. The CLI renders every
+event at your Stripe account's default API version, which cannot be pinned, so
+an event can carry a different shape from the one Ghost's production endpoint
+receives. Ghost pins that endpoint to its own API version when it creates it.
+Production keeps a persistent endpoint; a normal development environment never
+creates one.
+
+`pnpm dev:stripe:remote` runs the production path instead. It publishes Ghost's
+webhook route, and nothing else, through
+[Tailscale Funnel](https://tailscale.com/kb/1223/funnel), and Ghost registers a
+pinned webhook endpoint at that address once Stripe is connected in Admin, then
+deletes it on shutdown.
+The site and Admin stay on `localhost`, so hot reload and the rest of the
+development environment work as usual. Use it when the shape of a webhook
+payload matters, for example when reading new fields from a checkout session.
+Ghost logs an error whenever an event arrives rendered at a different API
+version from the one it pins, in any environment.
+
+The webhook route is reachable from the internet while the command runs; every
+request to it must carry a valid Stripe signature. The tunnel is a child
+process of the command and ends with it, including on Ctrl-C. Only a forced
+kill of the command can leave the tunnel running, and even then it does not
+survive a restart of Tailscale or the machine.
+
+Funnel needs Tailscale 1.52 or newer with MagicDNS, HTTPS certificates and
+Funnel enabled for your tailnet and node. The command reports when Tailscale is
+missing, not signed in, or has no MagicDNS name; for the other requirements it
+shows Tailscale's own error.
 
 ## Data and email
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -363,6 +363,11 @@ renderings: at Stripe's current default the shipping address moves to
 `collected_information.shipping_details`, which Ghost never sees. Ghost reads only
 `event.type` and `event.data.object`, so the envelope carries nothing worth pinning.
 
+The same difference applies to `stripe listen`, which `pnpm dev:stripe` uses: it renders
+events at the account default too. To see the payloads production receives, run
+`pnpm dev:stripe:remote`, which lets Ghost register its own pinned endpoint (see
+[Development setup](../docs/contributing/development-setup.md#stripe-webhooks)).
+
 ## Resolving issues
 
 ### Test Failures

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -389,6 +389,11 @@ async function initServices({ ghostServer, config, prometheusClient, jobsService
   });
   const giftDeliveryService = giftService.deliveryService;
   assert(giftDeliveryService, 'Gift delivery service should be initialized');
+  if (ghostServer) {
+    ghostServer.registerCleanupTask(async () => {
+      await stripe.shutdown();
+    }, 'Stripe');
+  }
 
   await Promise.all([
     identityTokens.init(),

--- a/ghost/core/core/server/services/stripe/config.js
+++ b/ghost/core/core/server/services/stripe/config.js
@@ -62,16 +62,19 @@ module.exports = {
     }
 
     const env = config.get('env');
-    let webhookSecret = process.env.WEBHOOK_SECRET;
+    const remoteWebhooks = env !== 'production' && config.get('stripeRemoteWebhooks') === true;
+    let webhookSecret = remoteWebhooks ? undefined : process.env.WEBHOOK_SECRET;
 
-    if (env !== 'production') {
-      if (!webhookSecret) {
-        webhookSecret = 'DEFAULT_WEBHOOK_SECRET';
-        logging.warn(tpl(messages.remoteWebhooksInDevelopment));
-      }
+    if (env !== 'production' && !remoteWebhooks && !webhookSecret) {
+      webhookSecret = 'DEFAULT_WEBHOOK_SECRET';
+      logging.warn(tpl(messages.remoteWebhooksInDevelopment));
     }
 
-    const webhookHandlerUrl = new URL('members/webhooks/stripe/', urlUtils.getSiteUrl());
+    // Development can tunnel the webhook URL alone while the site stays on localhost.
+    const webhookHandlerUrl = new URL(
+      config.get('stripeWebhookUrl') || 'members/webhooks/stripe/',
+      urlUtils.getSiteUrl(),
+    );
     const webhookCustomerIgnoreList = parseIgnoreCustomerList(
       config.get('stripeWebhookCustomerIgnoreList'),
     );
@@ -88,6 +91,9 @@ module.exports = {
       },
       webhookSecret: webhookSecret,
       webhookHandlerUrl: webhookHandlerUrl.href,
+      // A development registration points at a tunnel that closes with the process,
+      // so it is removed on shutdown rather than kept for the next boot.
+      ephemeralWebhook: remoteWebhooks,
       webhookCustomerIgnoreList,
       siteUrl,
     };

--- a/ghost/core/core/server/services/stripe/service.js
+++ b/ghost/core/core/server/services/stripe/service.js
@@ -14,6 +14,12 @@ const giftService = require('../gifts');
 const staffService = require('../staff');
 const labs = require('../../../shared/labs');
 const settingsCache = require('../../../shared/settings-cache');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+  remoteWebhooksWithoutStripe:
+    'stripeRemoteWebhooks is set but Stripe is not connected, so no webhook endpoint was registered. Connect Stripe in Ghost Admin under Settings, then restart.',
+};
 
 async function configureApi() {
   const cfg = getConfig({ settingsHelpers, config, urlUtils });
@@ -84,7 +90,10 @@ function stripeSettingsChanged(model) {
 
 module.exports.init = async function init() {
   try {
-    await configureApi();
+    const configured = await configureApi();
+    if (!configured && config.get('stripeRemoteWebhooks') === true) {
+      logging.warn(tpl(messages.remoteWebhooksWithoutStripe));
+    }
   } catch (err) {
     logging.error(err);
   }

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -62,6 +62,8 @@ const MANAGED_PAYMENTS_DISABLED = { enabled: false };
  */
 
 module.exports = class StripeAPI {
+  static API_VERSION = STRIPE_API_VERSION;
+
   /**
    * StripeAPI
    * @param {object} deps

--- a/ghost/core/core/server/services/stripe/stripe-service.js
+++ b/ghost/core/core/server/services/stripe/stripe-service.js
@@ -25,6 +25,7 @@ const customFields = require('../members-custom-fields');
  * @prop {boolean} testEnv Whether this is a test environment
  * @prop {string} webhookSecret The Stripe webhook secret
  * @prop {string} webhookHandlerUrl The URL to handle Stripe webhooks
+ * @prop {boolean} [ephemeralWebhook] Whether the webhook endpoint is deleted on shutdown
  * @prop {string[]} webhookCustomerIgnoreList List of customer IDs for customer.subscription.updated webhook bypass
  * @prop {string} siteUrl The site URL for billing portal return URL
  */
@@ -162,6 +163,8 @@ module.exports = class StripeService {
     this.migrations = migrations;
     this.webhookController = webhookController;
     this.billingPortalManager = billingPortalManager;
+    /** @private */
+    this.ephemeralWebhook = false;
   }
 
   async connect() {
@@ -213,23 +216,31 @@ module.exports = class StripeService {
       webhookSecret: config.webhookSecret,
       webhookHandlerUrl: config.webhookHandlerUrl,
     });
+    this.ephemeralWebhook = config.ephemeralWebhook === true;
 
     this.billingPortalManager.configure({
       siteUrl: config.siteUrl,
     });
 
-    // webhookManager.start() already self-guards: configure() above puts it in
-    // 'local' mode whenever a webhookSecret is set, which is always true outside
-    // production (config.js defaults it to DEFAULT_WEBHOOK_SECRET), so start()
-    // returns immediately without touching Stripe. Only billingPortalManager
-    // needs an explicit test-env skip — in the test env there is no real Stripe
-    // to register against, and the mock returns 500 for billing_portal/
-    // configurations, so this network-registration call only error-logs on
-    // every boot. Tests never need a registered portal configuration. Skip it
-    // under test; prod and dev register exactly as before.
+    // webhookManager.start() registers a webhook URL with Stripe only when no webhook
+    // secret was supplied. Outside production config.js supplies a placeholder secret
+    // unless stripeRemoteWebhooks is set, so start() normally returns without touching
+    // Stripe. billingPortalManager has no such guard: in the test environment the mock
+    // Stripe answers its registration call with a 500 on every boot, and tests never
+    // need a registered portal, so skip it under test only.
     await this.webhookManager.start();
     if (!config.testEnv) {
       await this.billingPortalManager.start();
+    }
+  }
+
+  /**
+   * Removes the webhook registration from Stripe, but only when it was marked ephemeral.
+   * A production registration is kept and reused on the next boot.
+   */
+  async shutdown() {
+    if (this.ephemeralWebhook) {
+      await this.webhookManager.stop();
     }
   }
 };

--- a/ghost/core/core/server/services/stripe/webhook-controller.js
+++ b/ghost/core/core/server/services/stripe/webhook-controller.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const StripeAPI = require('./stripe-api');
 
 module.exports = class WebhookController {
   /**
@@ -87,6 +88,15 @@ module.exports = class WebhookController {
       logging.error(err);
       res.writeHead(401);
       return res.end();
+    }
+
+    // Stripe shapes each event for the API version of the URL it was sent to. A different
+    // version means this event did not come through the URL Ghost registered, and fields
+    // may not be where Ghost reads them.
+    if (event.api_version !== StripeAPI.API_VERSION) {
+      logging.error(
+        `Webhook ${event.type} was rendered at Stripe API version ${event.api_version}, Ghost expects ${StripeAPI.API_VERSION}`,
+      );
     }
 
     const customerId = this.getEventCustomerId(event);

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const { assertExists } = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const UrlUtils = require('@tryghost/url-utils');
+const logging = require('@tryghost/logging');
 
 const configUtils = require('../../../../utils/config-utils');
 
@@ -39,6 +40,7 @@ describe('Stripe - config', function () {
 
   afterEach(async function () {
     configUtils.set(ignoreCustomerConfigKey, null);
+    configUtils.set('stripeWebhookUrl', null);
     await configUtils.restore();
   });
 
@@ -77,6 +79,89 @@ describe('Stripe - config', function () {
     assertExists(config.checkoutSetupSessionSuccessUrl);
     assertExists(config.checkoutSetupSessionCancelUrl);
     assertExists(config.billingPortalReturnUrl);
+  });
+
+  describe('webhook mode', function () {
+    let webhookSecretEnv;
+
+    beforeEach(function () {
+      webhookSecretEnv = process.env.WEBHOOK_SECRET;
+      delete process.env.WEBHOOK_SECRET;
+      sinon.stub(logging, 'warn');
+    });
+
+    afterEach(function () {
+      sinon.restore();
+      if (webhookSecretEnv === undefined) {
+        delete process.env.WEBHOOK_SECRET;
+      } else {
+        process.env.WEBHOOK_SECRET = webhookSecretEnv;
+      }
+    });
+
+    function getWebhookConfig() {
+      return getConfig({
+        settingsHelpers: createSettingsHelpersMock(),
+        config: configUtils.config,
+        urlUtils: createUrlUtilsMock(),
+      });
+    }
+
+    it('Falls back to a placeholder secret outside production', function () {
+      configUtils.set({ env: 'development' });
+
+      const config = getWebhookConfig();
+
+      assert.equal(config.webhookSecret, 'DEFAULT_WEBHOOK_SECRET');
+      assert.equal(config.ephemeralWebhook, false);
+      sinon.assert.calledOnce(logging.warn);
+    });
+
+    it('Uses the WEBHOOK_SECRET environment variable outside production', function () {
+      configUtils.set({ env: 'development' });
+      process.env.WEBHOOK_SECRET = 'whsec_from_stripe_listen';
+
+      const config = getWebhookConfig();
+
+      assert.equal(config.webhookSecret, 'whsec_from_stripe_listen');
+      assert.equal(config.ephemeralWebhook, false);
+    });
+
+    it('Registers an ephemeral remote webhook outside production when opted in', function () {
+      configUtils.set({ env: 'development', stripeRemoteWebhooks: true });
+      process.env.WEBHOOK_SECRET = 'whsec_from_stripe_listen';
+
+      const config = getWebhookConfig();
+
+      assert.equal(config.webhookSecret, undefined);
+      assert.equal(config.ephemeralWebhook, true);
+      sinon.assert.notCalled(logging.warn);
+    });
+
+    it('Never treats a production webhook as ephemeral', function () {
+      configUtils.set({ env: 'production', stripeRemoteWebhooks: true });
+
+      const config = getWebhookConfig();
+
+      assert.equal(config.webhookSecret, undefined);
+      assert.equal(config.ephemeralWebhook, false);
+    });
+  });
+
+  it('Lets config point the webhook handler at another origin', function () {
+    configUtils.set({
+      url: 'http://site.com/subdir',
+      stripeWebhookUrl: 'https://tunnel.example/members/webhooks/stripe/',
+    });
+
+    const config = getConfig({
+      settingsHelpers: createSettingsHelpersMock(),
+      config: configUtils.config,
+      urlUtils: createUrlUtilsMock(),
+    });
+
+    assert.equal(config.webhookHandlerUrl, 'https://tunnel.example/members/webhooks/stripe/');
+    assert.equal(config.siteUrl, 'http://site.com/subdir/');
   });
 
   it('Parses Stripe webhook customer ignore list from config', function () {

--- a/ghost/core/test/unit/server/services/stripe/webhook-controller.test.js
+++ b/ghost/core/test/unit/server/services/stripe/webhook-controller.test.js
@@ -1,4 +1,5 @@
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
 const WebhookController = require('../../../../../core/server/services/stripe/webhook-controller');
 
 describe('WebhookController', function () {
@@ -29,6 +30,38 @@ describe('WebhookController', function () {
       writeHead: sinon.stub(),
       end: sinon.stub(),
     };
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('logs an error for an event rendered at a different API version and still handles it', async function () {
+    sinon.stub(logging, 'error');
+    deps.webhookManager.parseWebhook.returns({
+      type: 'charge.refunded',
+      api_version: '2025-08-27.basil',
+      data: { object: { id: 'ch_1' } },
+    });
+
+    await controller.handle(req, res);
+
+    sinon.assert.calledWithMatch(logging.error, /2025-08-27\.basil.*expects 2020-08-27/);
+    sinon.assert.calledOnce(deps.chargeRefundedEventService.handleEvent);
+    sinon.assert.calledWith(res.writeHead, 200);
+  });
+
+  it('does not log a version error for an event at the pinned API version', async function () {
+    sinon.stub(logging, 'error');
+    deps.webhookManager.parseWebhook.returns({
+      type: 'charge.refunded',
+      api_version: '2020-08-27',
+      data: { object: { id: 'ch_1' } },
+    });
+
+    await controller.handle(req, res);
+
+    sinon.assert.notCalled(logging.error);
   });
 
   it('should return 400 if request body or signature is missing', async function () {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dev:analytics:local": "ANALYTICS_PROXY_TARGET=traffic-analytics-local:3000 DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:stripe": "./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",
+    "dev:stripe:remote": "./docker/stripe/with-remote-webhooks.sh pnpm nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' ./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",
     "dev:daemon": "NX_DAEMON=true NX_TUI=false NX_DEFAULT_OUTPUT_STYLE=stream pnpm nx run ghost-monorepo:docker:dev",
     "fix": "pnpm store prune && rimraf -g '**/node_modules' && pnpm install && pnpm nx reset",


### PR DESCRIPTION
## Problem

Stripe tells Ghost about payments by sending a message to a URL Ghost registers with Stripe. The shape of that message depends on which version of Stripe's API the URL was registered with. Ghost registers its production URL with a fixed version, so production messages always have the same shape.

Local development does not use that URL. It uses Stripe's command line tool to forward messages, and that tool ignores the fixed version. Developers see a message shape that production never sends. That is how a colleague concluded a recent shipping-address change was broken when it was not.

## Solution

`pnpm dev:stripe:remote` runs the production path locally. It makes Ghost's webhook URL reachable from the internet through Tailscale, which every Ghost developer has, and Ghost registers that URL with Stripe at the fixed version, exactly as in production. The registration is removed when the environment stops. Only the webhook URL is exposed; the site and Admin stay on localhost, and hot reload is unchanged. `pnpm dev:stripe` still works for anyone who does not care about message shape.

Ghost also now logs an error whenever a message arrives with a different API version from the one it expects. That would have explained the local confusion immediately, and it catches the same problem in production.

## For reviewers

**Container shutdown (Platform team).** Removing the registration on stop revealed that the development container never shut Ghost down cleanly. The stop signal never reached Ghost, so Docker killed it and none of Ghost's shutdown work ran. The first commit fixes that in the container entrypoint. It affects every development container and the devcontainer image, not only the new command. The other two commits are the Stripe work.

**Production is unaffected.** The new behaviour only runs outside production, and a production registration is never removed on shutdown.

**Out of scope.** Ghost reads its Stripe keys from the database, so the command still needs Stripe connected once through Admin. Letting configuration supply the keys would remove that step and is worth its own change.
