### PR TITLE
Added media inlining to CSV imports

### DIFF
--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -11,6 +11,7 @@ import type { PostsRepository, WrittenPost } from './post-repository';
 import type { ImportRequest } from './schema';
 import type { Clock, ImportRunStore, RowOutcome } from './store';
 import type { PreparedImportSource } from './source';
+import type { PostMediaInlining } from './media';
 
 export type { ImportRequest } from './schema';
 
@@ -60,6 +61,7 @@ interface ImporterDeps {
   getHtmlToLexical: () => HtmlToLexical;
   getMarkdownToHtml: () => MarkdownToHtml;
   getCleanHTML: () => CleanHTML;
+  media: PostMediaInlining;
   addJob: (job: { job: () => Promise<void>; offloaded: boolean; name: string }) => void;
   report: FailureReporter;
   store: ImportRunStore;
@@ -83,6 +85,7 @@ class ContentCSVImporter {
   private _getHtmlToLexical: () => HtmlToLexical;
   private _getMarkdownToHtml: () => MarkdownToHtml;
   private _getCleanHTML: () => CleanHTML;
+  private _media: PostMediaInlining;
   private _addJob: ImporterDeps['addJob'];
   private _report: FailureReporter;
   private _store: ImportRunStore;
@@ -98,6 +101,7 @@ class ContentCSVImporter {
     getHtmlToLexical,
     getMarkdownToHtml,
     getCleanHTML,
+    media,
     addJob,
     report,
     store,
@@ -112,6 +116,7 @@ class ContentCSVImporter {
     this._getHtmlToLexical = getHtmlToLexical;
     this._getMarkdownToHtml = getMarkdownToHtml;
     this._getCleanHTML = getCleanHTML;
+    this._media = media;
     this._addJob = addJob;
     this._report = report;
     this._store = store;
@@ -211,6 +216,8 @@ class ContentCSVImporter {
           // failure. Stop the run before misclassifying it as a lost write.
           throw error;
         }
+
+        await this._media.inline(data);
 
         let post: WrittenPost;
         let writeStatus: 'created' | 'updated';

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -11,7 +11,7 @@ import type { PostsRepository, WrittenPost } from './post-repository';
 import type { ImportRequest } from './schema';
 import type { Clock, ImportRunStore, RowOutcome } from './store';
 import type { PreparedImportSource } from './source';
-import type { PostMediaInlining } from './media';
+import { MediaInliningFailure, type PostMediaInlining } from './media';
 
 export type { ImportRequest } from './schema';
 
@@ -193,8 +193,8 @@ class ContentCSVImporter {
       const cleanHTML = this._getCleanHTML();
       const media = this._createMediaInliner();
       let successfulWrites = 0;
-      let failedWrites = 0;
-      let firstWriteFailure: unknown;
+      let failedRows = 0;
+      let firstRowFailure: unknown;
 
       for (const [index, row] of rows.entries()) {
         const line = index + 2;
@@ -218,7 +218,26 @@ class ContentCSVImporter {
           throw error;
         }
 
-        await media.inline(data);
+        try {
+          await media.inline(data);
+        } catch (error) {
+          if (error instanceof MediaInliningFailure) {
+            if (failedRows === 0) {
+              firstRowFailure = error;
+            }
+            failedRows += 1;
+            this._store.record(runId, {
+              line,
+              title: row.title,
+              status: 'failed',
+              reason: messageOf(error),
+              mediaFailures: error.failures,
+            });
+            continue;
+          }
+
+          throw error;
+        }
 
         let post: WrittenPost;
         let writeStatus: 'created' | 'updated';
@@ -259,10 +278,10 @@ class ContentCSVImporter {
           warnings = result.warnings;
           successfulWrites += 1;
         } catch (error) {
-          if (failedWrites === 0) {
-            firstWriteFailure = error;
+          if (failedRows === 0) {
+            firstRowFailure = error;
           }
-          failedWrites += 1;
+          failedRows += 1;
           this._store.record(runId, {
             line,
             title: row.title,
@@ -290,14 +309,14 @@ class ContentCSVImporter {
         this._store.record(runId, outcome);
       }
 
-      if (failedWrites > 0 && successfulWrites === 0) {
+      if (failedRows > 0 && successfulWrites === 0) {
         this._report(
           new errors.InternalServerError({
             message: tpl(messages.allWritesFailed, {
-              count: failedWrites,
-              postNoun: failedWrites === 1 ? 'post' : 'posts',
+              count: failedRows,
+              postNoun: failedRows === 1 ? 'post' : 'posts',
             }),
-            err: firstWriteFailure,
+            err: firstRowFailure,
           }),
         );
       }

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -61,7 +61,7 @@ interface ImporterDeps {
   getHtmlToLexical: () => HtmlToLexical;
   getMarkdownToHtml: () => MarkdownToHtml;
   getCleanHTML: () => CleanHTML;
-  media: PostMediaInlining;
+  createMediaInliner: () => PostMediaInlining;
   addJob: (job: { job: () => Promise<void>; offloaded: boolean; name: string }) => void;
   report: FailureReporter;
   store: ImportRunStore;
@@ -85,7 +85,7 @@ class ContentCSVImporter {
   private _getHtmlToLexical: () => HtmlToLexical;
   private _getMarkdownToHtml: () => MarkdownToHtml;
   private _getCleanHTML: () => CleanHTML;
-  private _media: PostMediaInlining;
+  private _createMediaInliner: () => PostMediaInlining;
   private _addJob: ImporterDeps['addJob'];
   private _report: FailureReporter;
   private _store: ImportRunStore;
@@ -101,7 +101,7 @@ class ContentCSVImporter {
     getHtmlToLexical,
     getMarkdownToHtml,
     getCleanHTML,
-    media,
+    createMediaInliner,
     addJob,
     report,
     store,
@@ -116,7 +116,7 @@ class ContentCSVImporter {
     this._getHtmlToLexical = getHtmlToLexical;
     this._getMarkdownToHtml = getMarkdownToHtml;
     this._getCleanHTML = getCleanHTML;
-    this._media = media;
+    this._createMediaInliner = createMediaInliner;
     this._addJob = addJob;
     this._report = report;
     this._store = store;
@@ -191,6 +191,7 @@ class ContentCSVImporter {
       const htmlToLexical = this._getHtmlToLexical();
       const markdownToHtml = this._getMarkdownToHtml();
       const cleanHTML = this._getCleanHTML();
+      const media = this._createMediaInliner();
       let successfulWrites = 0;
       let failedWrites = 0;
       let firstWriteFailure: unknown;
@@ -217,7 +218,7 @@ class ContentCSVImporter {
           throw error;
         }
 
-        await this._media.inline(data);
+        await media.inline(data);
 
         let post: WrittenPost;
         let writeStatus: 'created' | 'updated';

--- a/ghost/core/core/server/services/content-import/import/local-media-url.ts
+++ b/ghost/core/core/server/services/content-import/import/local-media-url.ts
@@ -1,0 +1,85 @@
+export interface LocalMediaUrlOptions {
+  siteUrl: string;
+  subdir: string;
+  assetBaseUrls: Array<string | null | undefined>;
+}
+
+const CONTENT_PATH_PREFIXES = ['/content/images', '/content/media', '/content/files'];
+
+function normalizedPathPrefix(value: string): string {
+  if (!value.startsWith('/')) {
+    return `/${value}`.replace(/\/+$/, '');
+  }
+
+  return value.replace(/\/+$/, '');
+}
+
+function pathHasPrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function isContentPath(pathname: string, subdirs: string[]): boolean {
+  const normalizedPathname = normalizedPathPrefix(pathname);
+  const prefixes = subdirs.flatMap((subdir) => {
+    const normalizedSubdir = normalizedPathPrefix(subdir);
+    return CONTENT_PATH_PREFIXES.map((prefix) => `${normalizedSubdir}${prefix}`);
+  });
+
+  return [...CONTENT_PATH_PREFIXES, ...prefixes].some((prefix) =>
+    pathHasPrefix(normalizedPathname, prefix),
+  );
+}
+
+function parseUrl(value: string): URL | undefined {
+  try {
+    return new URL(value.startsWith('//') ? `https:${value}` : value);
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesBaseUrl(source: URL, baseUrl: string): boolean {
+  const base = parseUrl(baseUrl.trim());
+  if (!base || source.host !== base.host) {
+    return false;
+  }
+
+  const basePath = normalizedPathPrefix(base.pathname);
+  return basePath === '' || basePath === '/' || pathHasPrefix(source.pathname, basePath);
+}
+
+/**
+ * Returns whether a media reference already belongs to this Ghost site or one
+ * of its configured asset hosts. This only classifies URLs; it never checks
+ * whether the referenced file exists.
+ */
+export function isLocalMediaUrl(sourceUrl: string, options: LocalMediaUrlOptions): boolean {
+  const value = sourceUrl.trim();
+  if (value.startsWith('__GHOST_URL__')) {
+    return true;
+  }
+
+  if (value.startsWith('/') && !value.startsWith('//')) {
+    return isContentPath(value, [options.subdir]);
+  }
+
+  const source = parseUrl(value);
+  if (!source) {
+    return false;
+  }
+
+  if (
+    options.assetBaseUrls.some(
+      (baseUrl) => typeof baseUrl === 'string' && matchesBaseUrl(source, baseUrl),
+    )
+  ) {
+    return true;
+  }
+
+  const site = parseUrl(options.siteUrl);
+  if (!site || source.host !== site.host) {
+    return false;
+  }
+
+  return isContentPath(source.pathname, [options.subdir, site.pathname]);
+}

--- a/ghost/core/core/server/services/content-import/import/media.ts
+++ b/ghost/core/core/server/services/content-import/import/media.ts
@@ -1,0 +1,297 @@
+import type { PostData } from './post-data';
+import type { ExternalMediaImporter } from '../../media-inliner/types';
+
+const cheerio = require('cheerio');
+
+export interface MediaFailure {
+  sourceUrl: string;
+  reason: string;
+}
+
+export class MediaInliningFailure extends Error {
+  readonly failures: MediaFailure[];
+
+  constructor(failures: MediaFailure[]) {
+    const noun = failures.length === 1 ? 'file' : 'files';
+    super(`Could not import ${failures.length} media ${noun}.`);
+    this.name = 'MediaInliningFailure';
+    this.failures = failures;
+  }
+}
+
+type JSONRecord = Record<string, unknown>;
+
+const DIRECT_MEDIA_FIELDS: Record<string, string[]> = {
+  image: ['src'],
+  audio: ['src', 'thumbnailSrc'],
+  video: ['src', 'thumbnailSrc', 'customThumbnailSrc'],
+  file: ['src'],
+  product: ['productImageSrc'],
+  header: ['backgroundImageSrc'],
+  signup: ['backgroundImageSrc'],
+  'call-to-action': ['imageUrl'],
+  bookmark: ['metadata.icon', 'metadata.thumbnail'],
+  embed: ['metadata.thumbnail_url'],
+  'before-after': ['beforeImage.src', 'afterImage.src'],
+};
+
+const HTML_MEDIA_FIELDS: Record<string, string[]> = {
+  html: ['html'],
+  email: ['html'],
+  'email-cta': ['html'],
+  toggle: ['heading', 'content'],
+  image: ['caption'],
+  gallery: ['caption'],
+  video: ['caption'],
+  product: ['productTitle', 'productDescription'],
+  header: ['header', 'subheader'],
+  bookmark: ['caption'],
+  codeblock: ['caption'],
+};
+
+const MARKDOWN_MEDIA_FIELDS: Record<string, string[]> = {
+  markdown: ['markdown'],
+};
+
+function isRecord(value: unknown): value is JSONRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRemoteMediaUrl(value: string): boolean {
+  return /^(?:https?:)?\/\//i.test(value.trim());
+}
+
+function getPath(record: JSONRecord, path: string): unknown {
+  return path.split('.').reduce<unknown>((value, part) => {
+    return isRecord(value) ? value[part] : undefined;
+  }, record);
+}
+
+function setPath(record: JSONRecord, path: string, value: string): void {
+  const parts = path.split('.');
+  const leaf = parts.pop() as string;
+  let target = record;
+
+  for (const part of parts) {
+    target = target[part] as JSONRecord;
+  }
+
+  target[leaf] = value;
+}
+
+async function replaceAsync(
+  input: string,
+  pattern: RegExp,
+  replacer: (match: RegExpMatchArray) => Promise<string>,
+): Promise<string> {
+  let result = '';
+  let lastIndex = 0;
+
+  for (const match of input.matchAll(pattern)) {
+    const index = match.index as number;
+    result += input.slice(lastIndex, index);
+    result += await replacer(match);
+    lastIndex = index + match[0].length;
+  }
+
+  return result + input.slice(lastIndex);
+}
+
+export interface PostMediaInlining {
+  inline(data: PostData): Promise<void>;
+}
+
+export class PostMediaInliner implements PostMediaInlining {
+  private _media: ExternalMediaImporter;
+  private _failures = new Map<string, MediaFailure>();
+
+  constructor({ media }: { media: ExternalMediaImporter }) {
+    this._media = media;
+  }
+
+  async inline(data: PostData): Promise<void> {
+    this._failures = new Map();
+
+    if (data.feature_image) {
+      data.feature_image = await this.inlineUrl(data.feature_image);
+    }
+    if (data.posts_meta?.og_image) {
+      data.posts_meta.og_image = await this.inlineUrl(data.posts_meta.og_image);
+    }
+    if (data.posts_meta?.twitter_image) {
+      data.posts_meta.twitter_image = await this.inlineUrl(data.posts_meta.twitter_image);
+    }
+    if (data.lexical) {
+      data.lexical = await this.inlineLexical(data.lexical);
+    }
+
+    if (this._failures.size > 0) {
+      throw new MediaInliningFailure([...this._failures.values()]);
+    }
+  }
+
+  private async inlineUrl(sourceUrl: string): Promise<string> {
+    if (!isRemoteMediaUrl(sourceUrl)) {
+      return sourceUrl;
+    }
+
+    const result = await this._media.importUrl(sourceUrl);
+    if (result.status === 'failed') {
+      this.recordFailure(sourceUrl, result.reason);
+      return sourceUrl;
+    }
+
+    return result.storedUrl;
+  }
+
+  private recordFailure(sourceUrl: string, reason: string): void {
+    if (!this._failures.has(sourceUrl)) {
+      this._failures.set(sourceUrl, { sourceUrl, reason });
+    }
+  }
+
+  private async inlineLexical(serializedLexical: string): Promise<string> {
+    const lexical: unknown = JSON.parse(serializedLexical);
+    if (!isRecord(lexical) || !isRecord(lexical.root) || !Array.isArray(lexical.root.children)) {
+      return serializedLexical;
+    }
+
+    await this.inlineLexicalChildren(lexical.root.children);
+    return JSON.stringify(lexical);
+  }
+
+  private async inlineLexicalChildren(children: unknown[]): Promise<void> {
+    for (const child of children) {
+      if (!isRecord(child)) {
+        continue;
+      }
+
+      const type = typeof child.type === 'string' ? child.type : '';
+      for (const path of DIRECT_MEDIA_FIELDS[type] ?? []) {
+        const value = getPath(child, path);
+        if (typeof value === 'string' && value) {
+          setPath(child, path, await this.inlineUrl(value));
+        }
+      }
+
+      if (type === 'gallery' && Array.isArray(child.images)) {
+        for (const image of child.images) {
+          if (isRecord(image) && typeof image.src === 'string' && image.src) {
+            image.src = await this.inlineUrl(image.src);
+          }
+        }
+      }
+
+      for (const path of HTML_MEDIA_FIELDS[type] ?? []) {
+        const value = getPath(child, path);
+        if (typeof value === 'string' && value) {
+          setPath(child, path, await this.inlineHtml(value));
+        }
+      }
+
+      for (const path of MARKDOWN_MEDIA_FIELDS[type] ?? []) {
+        const value = getPath(child, path);
+        if (typeof value === 'string' && value) {
+          setPath(child, path, await this.inlineMarkdown(value));
+        }
+      }
+
+      if (Array.isArray(child.children)) {
+        await this.inlineLexicalChildren(child.children);
+      }
+    }
+  }
+
+  private async inlineHtml(html: string): Promise<string> {
+    const $ = cheerio.load(html, { decodeEntities: false }, false);
+    const attributes: Array<[string, string]> = [
+      ['img[src]', 'src'],
+      ['img[data-src]', 'data-src'],
+      ['video[src]', 'src'],
+      ['video[poster]', 'poster'],
+      ['audio[src]', 'src'],
+      ['source[src]', 'src'],
+    ];
+
+    for (const [selector, attribute] of attributes) {
+      for (const element of $(selector).toArray()) {
+        const value = $(element).attr(attribute);
+        if (value) {
+          $(element).attr(attribute, await this.inlineUrl(value));
+        }
+      }
+    }
+
+    for (const element of $('[srcset]').toArray()) {
+      const value = $(element).attr('srcset');
+      if (value) {
+        $(element).attr('srcset', await this.inlineSrcset(value));
+      }
+    }
+
+    for (const element of $('[style]').toArray()) {
+      const value = $(element).attr('style');
+      if (value) {
+        $(element).attr('style', await this.inlineCss(value));
+      }
+    }
+
+    for (const element of $('style').toArray()) {
+      const value = $(element).html();
+      if (value) {
+        $(element).html(await this.inlineCss(value));
+      }
+    }
+
+    return $.root().html() as string;
+  }
+
+  private async inlineSrcset(srcset: string): Promise<string> {
+    if (srcset.trimStart().startsWith('data:')) {
+      return srcset;
+    }
+
+    const candidates = srcset.split(',');
+    const inlined: string[] = [];
+    for (const candidate of candidates) {
+      const match = candidate.match(/^(\s*)(\S+)(.*)$/s);
+      if (!match) {
+        inlined.push(candidate);
+        continue;
+      }
+      const [, leading, sourceUrl, descriptor] = match;
+      inlined.push(`${leading}${await this.inlineUrl(sourceUrl)}${descriptor}`);
+    }
+    return inlined.join(',');
+  }
+
+  private inlineCss(css: string): Promise<string> {
+    return replaceAsync(css, /url\(\s*(?:(["'])(.*?)\1|([^)'"\s][^)]*?))\s*\)/gi, async (match) => {
+      const sourceUrl = ((match[2] ?? match[3]) as string).trim();
+      if (!sourceUrl) {
+        return match[0];
+      }
+      const storedUrl = await this.inlineUrl(sourceUrl);
+      return match[0].replace(sourceUrl, storedUrl);
+    });
+  }
+
+  private async inlineMarkdown(markdown: string): Promise<string> {
+    let result = await replaceAsync(
+      markdown,
+      /!\[[^\]]*]\(\s*(?:<([^>\s]+)>|((?:https?:)?\/\/[^\s)]+))(?=[\s)])/gi,
+      async (match) => {
+        const sourceUrl = (match[1] ?? match[2]) as string;
+        return match[0].replace(sourceUrl, await this.inlineUrl(sourceUrl));
+      },
+    );
+
+    result = await replaceAsync(result, /<(?:img|video|audio|source)\b[^>]*>/gi, async (match) =>
+      this.inlineHtml(match[0]),
+    );
+
+    return replaceAsync(result, /<style\b[^>]*>[\s\S]*?<\/style>/gi, async (match) =>
+      this.inlineHtml(match[0]),
+    );
+  }
+}

--- a/ghost/core/core/server/services/content-import/import/media.ts
+++ b/ghost/core/core/server/services/content-import/import/media.ts
@@ -1,5 +1,5 @@
 import type { PostData } from './post-data';
-import type { ExternalMediaImporter } from '../../media-inliner/types';
+import type { ExternalMediaImporter, ExternalMediaImportResult } from '../../media-inliner/types';
 
 const cheerio = require('cheerio');
 
@@ -103,6 +103,7 @@ export interface PostMediaInlining {
 
 export class PostMediaInliner implements PostMediaInlining {
   private _media: ExternalMediaImporter;
+  private _cache = new Map<string, Promise<ExternalMediaImportResult>>();
   private _failures = new Map<string, MediaFailure>();
 
   constructor({ media }: { media: ExternalMediaImporter }) {
@@ -135,7 +136,13 @@ export class PostMediaInliner implements PostMediaInlining {
       return sourceUrl;
     }
 
-    const result = await this._media.importUrl(sourceUrl);
+    let resultPromise = this._cache.get(sourceUrl);
+    if (!resultPromise) {
+      resultPromise = this._media.importUrl(sourceUrl);
+      this._cache.set(sourceUrl, resultPromise);
+    }
+
+    const result = await resultPromise;
     if (result.status === 'failed') {
       this.recordFailure(sourceUrl, result.reason);
       return sourceUrl;

--- a/ghost/core/core/server/services/content-import/import/media.ts
+++ b/ghost/core/core/server/services/content-import/import/media.ts
@@ -103,11 +103,19 @@ export interface PostMediaInlining {
 
 export class PostMediaInliner implements PostMediaInlining {
   private _media: ExternalMediaImporter;
+  private _isLocalMediaUrl: (sourceUrl: string) => boolean;
   private _cache = new Map<string, Promise<ExternalMediaImportResult>>();
   private _failures = new Map<string, MediaFailure>();
 
-  constructor({ media }: { media: ExternalMediaImporter }) {
+  constructor({
+    media,
+    isLocalMediaUrl,
+  }: {
+    media: ExternalMediaImporter;
+    isLocalMediaUrl: (sourceUrl: string) => boolean;
+  }) {
     this._media = media;
+    this._isLocalMediaUrl = isLocalMediaUrl;
   }
 
   async inline(data: PostData): Promise<void> {
@@ -132,7 +140,7 @@ export class PostMediaInliner implements PostMediaInlining {
   }
 
   private async inlineUrl(sourceUrl: string): Promise<string> {
-    if (!isRemoteMediaUrl(sourceUrl)) {
+    if (!isRemoteMediaUrl(sourceUrl) || this._isLocalMediaUrl(sourceUrl)) {
       return sourceUrl;
     }
 

--- a/ghost/core/core/server/services/content-import/import/media.ts
+++ b/ghost/core/core/server/services/content-import/import/media.ts
@@ -53,12 +53,25 @@ const MARKDOWN_MEDIA_FIELDS: Record<string, string[]> = {
   markdown: ['markdown'],
 };
 
+const BLOCKED_MEDIA_DOMAINS = ['images.unsplash.com', 'gravatar.com'];
+
 function isRecord(value: unknown): value is JSONRecord {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 function isRemoteMediaUrl(value: string): boolean {
   return /^(?:https?:)?\/\//i.test(value.trim());
+}
+
+export function isBlockedMediaUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim().replace(/^\/\//, 'https://'));
+    return BLOCKED_MEDIA_DOMAINS.some(
+      (domain) => url.hostname === domain || url.hostname.endsWith(`.${domain}`),
+    );
+  } catch {
+    return false;
+  }
 }
 
 function getPath(record: JSONRecord, path: string): unknown {
@@ -140,7 +153,11 @@ export class PostMediaInliner implements PostMediaInlining {
   }
 
   private async inlineUrl(sourceUrl: string): Promise<string> {
-    if (!isRemoteMediaUrl(sourceUrl) || this._isLocalMediaUrl(sourceUrl)) {
+    if (
+      !isRemoteMediaUrl(sourceUrl) ||
+      isBlockedMediaUrl(sourceUrl) ||
+      this._isLocalMediaUrl(sourceUrl)
+    ) {
       return sourceUrl;
     }
 

--- a/ghost/core/core/server/services/content-import/import/store.ts
+++ b/ghost/core/core/server/services/content-import/import/store.ts
@@ -3,7 +3,7 @@
 // replaces this.
 
 // skipped = the row was never attempted (the publisher can fix the file);
-// failed = the write was attempted and lost.
+// failed = row processing was attempted but did not produce a post.
 export type Clock = () => Date;
 
 export type RowStatus = 'created' | 'updated' | 'skipped' | 'failed';
@@ -15,6 +15,7 @@ export interface RowOutcome {
   title: string | null;
   status: RowStatus;
   reason?: string;
+  mediaFailures?: Array<{ sourceUrl: string; reason: string }>;
   warnings?: string[];
   postId?: string;
   url?: string;

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -50,7 +50,7 @@ function makeImporter(): ContentCSVImporter {
     getHtmlToLexical: () => lexicalLib.htmlToLexicalConverter,
     getMarkdownToHtml: () => require('@tryghost/kg-markdown-html-renderer').render,
     getCleanHTML: () => require('@tryghost/mg-clean-html').cleanHTML,
-    media: new PostMediaInliner({ media: mediaInlinerService.getInstance() }),
+    createMediaInliner: () => new PostMediaInliner({ media: mediaInlinerService.getInstance() }),
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -6,6 +6,7 @@ import { importRequestSchema, type ImportRequest } from './import/schema';
 import { ImportRunStore } from './import/store';
 import { prepareImportSource } from './import/source';
 import { PostMediaInliner } from './import/media';
+import { isLocalMediaUrl } from './import/local-media-url';
 
 // The request is built from HTTP upload metadata, so it is validated at the
 // service boundary rather than trusted.
@@ -27,6 +28,7 @@ function makeImporter(): ContentCSVImporter {
   const settingsCache = require('../../../shared/settings-cache');
   const urlService = require('../url');
   const mediaInlinerService = require('../media-inliner');
+  const config = require('../../../shared/config');
   const ObjectID = require('bson-objectid').default;
 
   // Inline jobs never reach the job manager's Sentry handler, which is wired to the
@@ -50,7 +52,20 @@ function makeImporter(): ContentCSVImporter {
     getHtmlToLexical: () => lexicalLib.htmlToLexicalConverter,
     getMarkdownToHtml: () => require('@tryghost/kg-markdown-html-renderer').render,
     getCleanHTML: () => require('@tryghost/mg-clean-html').cleanHTML,
-    createMediaInliner: () => new PostMediaInliner({ media: mediaInlinerService.getInstance() }),
+    createMediaInliner: () =>
+      new PostMediaInliner({
+        media: mediaInlinerService.getInstance(),
+        isLocalMediaUrl: (sourceUrl) =>
+          isLocalMediaUrl(sourceUrl, {
+            siteUrl: config.getSiteUrl(),
+            subdir: config.getSubdir(),
+            assetBaseUrls: [
+              config.get('urls:image'),
+              config.get('urls:media'),
+              config.get('urls:files'),
+            ],
+          }),
+      }),
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -5,6 +5,7 @@ import readPostRows from './import/reader';
 import { importRequestSchema, type ImportRequest } from './import/schema';
 import { ImportRunStore } from './import/store';
 import { prepareImportSource } from './import/source';
+import { PostMediaInliner } from './import/media';
 
 // The request is built from HTTP upload metadata, so it is validated at the
 // service boundary rather than trusted.
@@ -25,6 +26,7 @@ function makeImporter(): ContentCSVImporter {
   const jobsService = require('../jobs');
   const settingsCache = require('../../../shared/settings-cache');
   const urlService = require('../url');
+  const mediaInlinerService = require('../media-inliner');
   const ObjectID = require('bson-objectid').default;
 
   // Inline jobs never reach the job manager's Sentry handler, which is wired to the
@@ -48,6 +50,7 @@ function makeImporter(): ContentCSVImporter {
     getHtmlToLexical: () => lexicalLib.htmlToLexicalConverter,
     getMarkdownToHtml: () => require('@tryghost/kg-markdown-html-renderer').render,
     getCleanHTML: () => require('@tryghost/mg-clean-html').cleanHTML,
+    media: new PostMediaInliner({ media: mediaInlinerService.getInstance() }),
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -14,6 +14,7 @@ const path = require('path');
 const nock = require('nock');
 const models = require('../../../core/server/models');
 const jobsService = require('../../../core/server/services/jobs');
+const mediaInlinerService = require('../../../core/server/services/media-inliner');
 const adapterManager = require('../../../core/server/services/adapter-manager').default;
 const urlUtils = require('../../../core/shared/url-utils').default;
 const { compress } = require('@tryghost/zip');
@@ -254,6 +255,26 @@ describe('Posts Importer API', function () {
     assert.ok(continuedPost);
   });
 
+  it('preserves current-site media URLs without fetching or validating them', async function () {
+    await agent.loginAsOwner();
+    const siteUrl = urlUtils.getSiteUrl().replace(/\/$/, '');
+    const imageUrl = `${siteUrl}/content/images/already-stored.jpg`;
+    const importUrl = sinon.spy(mediaInlinerService.getInstance(), 'importUrl');
+    const filePath = await csvFile(
+      'local-media.csv',
+      `title,html,feature_image\nLocal media,"<p><img src=""${imageUrl}"" /></p>",${imageUrl}\n`,
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', filePath).expectStatus(202);
+    await jobsService.allSettled();
+
+    sinon.assert.notCalled(importUrl);
+    const post = await models.Post.findOne({ title: 'Local media', status: 'all' });
+    assert.ok(post);
+    assert.ok(post.get('feature_image').endsWith('/content/images/already-stored.jpg'));
+    assert.match(post.get('html'), /\/content\/images\/already-stored\.jpg/);
+  });
+
   it('Imports the single mapped CSV inside a ZIP', async function () {
     await agent.loginAsOwner();
 
@@ -280,6 +301,7 @@ describe('Posts Importer API', function () {
 
   it('Stores and rewrites wrapped image, media, and file assets before importing posts', async function () {
     await agent.loginAsOwner();
+    const importUrl = sinon.spy(mediaInlinerService.getInstance(), 'importUrl');
 
     const csv =
       'title,html,markdown,feature_image,og_image,twitter_image\n' +
@@ -299,6 +321,8 @@ describe('Posts Importer API', function () {
       .expectStatus(202);
     assert.equal(body.meta.total, 3);
     await jobsService.allSettled();
+
+    sinon.assert.notCalled(importUrl);
 
     for (const filePath of getImportedAssetPaths().slice(0, 3)) {
       assert.equal(await fs.stat(filePath).then(() => true), true, `${filePath} was stored`);

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -229,7 +229,7 @@ describe('Posts Importer API', function () {
     assert.doesNotMatch(markdownPost.get('html'), /csv-import-assets\.example/);
   });
 
-  it('fails the import when no storage adapter accepts referenced media', async function () {
+  it('isolates unsupported referenced media to its CSV row', async function () {
     await agent.loginAsOwner();
     const origin = 'https://csv-import-assets.example';
     const unsupportedFixture = await fs.readFile(
@@ -238,7 +238,7 @@ describe('Posts Importer API', function () {
     const request = nock(origin).get('/unsupported.exe').reply(200, unsupportedFixture);
     const filePath = await csvFile(
       'unsupported-remote-media.csv',
-      `title,feature_image\nUnsupported remote media,${origin}/unsupported.exe\n`,
+      `title,feature_image\nUnsupported remote media,${origin}/unsupported.exe\nContinues after media failure,\n`,
     );
 
     await agent.post('posts/upload/').attach('postsfile', filePath).expectStatus(202);
@@ -247,6 +247,11 @@ describe('Posts Importer API', function () {
     assert.equal(request.isDone(), true, request.pendingMocks().join(', '));
     const post = await models.Post.findOne({ title: 'Unsupported remote media', status: 'all' });
     assert.equal(post, null);
+    const continuedPost = await models.Post.findOne({
+      title: 'Continues after media failure',
+      status: 'all',
+    });
+    assert.ok(continuedPost);
   });
 
   it('Imports the single mapped CSV inside a ZIP', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -15,6 +15,13 @@ const nock = require('nock');
 const models = require('../../../core/server/models');
 const jobsService = require('../../../core/server/services/jobs');
 const mediaInlinerService = require('../../../core/server/services/media-inliner');
+const {
+  PostMediaInliner,
+  isBlockedMediaUrl,
+} = require('../../../core/server/services/content-import/import/media');
+const {
+  isLocalMediaUrl,
+} = require('../../../core/server/services/content-import/import/local-media-url');
 const adapterManager = require('../../../core/server/services/adapter-manager').default;
 const urlUtils = require('../../../core/shared/url-utils').default;
 const { compress } = require('@tryghost/zip');
@@ -259,10 +266,17 @@ describe('Posts Importer API', function () {
     await agent.loginAsOwner();
     const siteUrl = urlUtils.getSiteUrl().replace(/\/$/, '');
     const imageUrl = `${siteUrl}/content/images/already-stored.jpg`;
+    const unsplashUrl = 'https://images.unsplash.com/photo-123?fit=crop&w=1200';
+    const gravatarUrl = 'https://www.gravatar.com/avatar/abc123?s=200';
     const importUrl = sinon.spy(mediaInlinerService.getInstance(), 'importUrl');
     const filePath = await csvFile(
       'local-media.csv',
-      `title,html,feature_image\nLocal media,"<p><img src=""${imageUrl}"" /></p>",${imageUrl}\n`,
+      [
+        'title,html,feature_image',
+        `Local media,"<p><img src=""${imageUrl}"" /></p>",${imageUrl}`,
+        `Unsplash media,"<p><img src=""${unsplashUrl}"" /></p>",${unsplashUrl}`,
+        `Gravatar media,"<p><img src=""${gravatarUrl}"" /></p>",${gravatarUrl}`,
+      ].join('\n'),
     );
 
     await agent.post('posts/upload/').attach('postsfile', filePath).expectStatus(202);
@@ -273,6 +287,131 @@ describe('Posts Importer API', function () {
     assert.ok(post);
     assert.ok(post.get('feature_image').endsWith('/content/images/already-stored.jpg'));
     assert.match(post.get('html'), /\/content\/images\/already-stored\.jpg/);
+
+    for (const [title, sourceUrl] of [
+      ['Unsplash media', unsplashUrl],
+      ['Gravatar media', gravatarUrl],
+    ]) {
+      const blockedPost = await models.Post.findOne({ title, status: 'all' });
+      assert.ok(blockedPost);
+      assert.equal(blockedPost.get('feature_image'), sourceUrl);
+      assert.ok(blockedPost.get('html').includes(new URL(sourceUrl).hostname));
+    }
+  });
+
+  it('classifies local media URL variants used by importer configuration', function () {
+    const options = {
+      siteUrl: 'https://example.com/blog/',
+      subdir: 'blog',
+      assetBaseUrls: [
+        'not a URL',
+        'https://assets.example/c/site/',
+        'https://root-assets.example/',
+        null,
+      ],
+    };
+
+    for (const sourceUrl of [
+      '__GHOST_URL__/content/images/image.jpg',
+      '/content/media/video.mp4',
+      '/blog/content/files/guide.pdf',
+      '//example.com/blog/content/images/image.jpg',
+      'https://assets.example/c/site/content/images/image.jpg',
+      'https://root-assets.example/anything/image.jpg',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), true, sourceUrl);
+    }
+
+    for (const sourceUrl of [
+      '/blogger/content/images/image.jpg',
+      'https://assets.example/c/site-other/image.jpg',
+      'https://example.com/blog/content/images-other/image.jpg',
+      'https://external.example/content/images/image.jpg',
+      'not a URL',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), false, sourceUrl);
+    }
+
+    assert.equal(
+      isLocalMediaUrl('https://example.com/content/images/image.jpg', {
+        ...options,
+        siteUrl: 'not a URL',
+      }),
+      false,
+    );
+  });
+
+  it('rewrites media in raw Lexical HTML and Markdown card content', async function () {
+    const origin = 'https://raw-card-assets.example';
+    const importUrl = sinon.stub().callsFake(async (sourceUrl) => ({
+      status: 'stored',
+      sourceUrl,
+      storedUrl: sourceUrl.replace(origin, '__GHOST_URL__/content/images'),
+    }));
+    const inliner = new PostMediaInliner({
+      media: { importUrl },
+      isLocalMediaUrl: () => false,
+    });
+    const data = {
+      feature_image: 'https://images.unsplash.com/photo-123',
+      lexical: JSON.stringify({
+        root: {
+          children: [
+            {
+              type: 'before-after',
+              beforeImage: { src: `${origin}/before.jpg` },
+              afterImage: { src: `${origin}/after.jpg` },
+            },
+            {
+              type: 'html',
+              html:
+                `<img src="${origin}/image.jpg" srcset="${origin}/small.jpg 1x, ${origin}/large.jpg 2x">` +
+                `<div style="background-image: url('${origin}/background.jpg')"></div>` +
+                `<style>.hero { background: url(${origin}/style.jpg) }</style>`,
+            },
+            {
+              type: 'markdown',
+              markdown: `![Remote](${origin}/markdown.jpg)`,
+            },
+          ],
+        },
+      }),
+    };
+
+    await inliner.inline(data);
+
+    const lexical = JSON.parse(data.lexical);
+    assert.equal(
+      lexical.root.children[0].beforeImage.src,
+      '__GHOST_URL__/content/images/before.jpg',
+    );
+    assert.equal(lexical.root.children[0].afterImage.src, '__GHOST_URL__/content/images/after.jpg');
+    assert.doesNotMatch(lexical.root.children[1].html, /raw-card-assets\.example/);
+    assert.doesNotMatch(lexical.root.children[2].markdown, /raw-card-assets\.example/);
+    assert.equal(data.feature_image, 'https://images.unsplash.com/photo-123');
+    assert.equal(isBlockedMediaUrl('https://gravatar.com/avatar/abc123'), true);
+    assert.equal(isBlockedMediaUrl('https://gravatar.com.evil.example/avatar/abc123'), false);
+    assert.equal(isBlockedMediaUrl('not a URL'), false);
+    assert.equal(importUrl.callCount, 8);
+  });
+
+  it('fails the run when media inlining throws an unexpected error', async function () {
+    await agent.loginAsOwner();
+    const sourceUrl = 'https://unexpected-media-error.example/image.jpg';
+    const importUrl = sinon
+      .stub(mediaInlinerService.getInstance(), 'importUrl')
+      .rejects(new Error('Unexpected media importer failure'));
+    const filePath = await csvFile(
+      'unexpected-media-error.csv',
+      `title,feature_image\nUnexpected media failure,${sourceUrl}\n`,
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', filePath).expectStatus(202);
+    await jobsService.allSettled();
+
+    sinon.assert.calledOnceWithExactly(importUrl, sourceUrl);
+    const post = await models.Post.findOne({ title: 'Unexpected media failure', status: 'all' });
+    assert.equal(post, null);
   });
 
   it('Imports the single mapped CSV inside a ZIP', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -11,9 +11,11 @@ const {
 } = require('../../utils/e2e-framework');
 const { cacheInvalidateHeaderNotSet } = assertions;
 const path = require('path');
+const nock = require('nock');
 const models = require('../../../core/server/models');
 const jobsService = require('../../../core/server/services/jobs');
 const adapterManager = require('../../../core/server/services/adapter-manager').default;
+const urlUtils = require('../../../core/shared/url-utils').default;
 const { compress } = require('@tryghost/zip');
 const sinon = require('sinon');
 
@@ -21,6 +23,7 @@ const csvPath = path.join(__dirname, '../../utils/fixtures/csv/valid-posts-impor
 
 // Test CSVs are written inline to a temp dir rather than committed as fixtures.
 let tmpDir;
+let remoteImportedMediaUrls = [];
 const getImportedAssetPaths = () => [
   path.join(adapterManager.getAdapter('storage:images').storagePath, 'csv-zip-photo.jpg'),
   path.join(adapterManager.getAdapter('storage:media').storagePath, 'csv-zip-movie.mp4'),
@@ -57,6 +60,23 @@ const zipFile = async (name, files) => {
   return zipPath;
 };
 
+const cleanupRemoteImportedMedia = async () => {
+  const storageByDirectory = {
+    images: adapterManager.getAdapter('storage:images'),
+    media: adapterManager.getAdapter('storage:media'),
+    files: adapterManager.getAdapter('storage:files'),
+  };
+  for (const mediaUrl of new Set(remoteImportedMediaUrls)) {
+    const absoluteUrl = urlUtils.transformReadyToAbsolute(mediaUrl);
+    const directory = new URL(absoluteUrl).pathname.match(/\/content\/(images|media|files)\//)?.[1];
+    if (directory) {
+      const storage = storageByDirectory[directory];
+      await storage.delete(storage.urlToPath(absoluteUrl));
+    }
+  }
+  remoteImportedMediaUrls = [];
+};
+
 describe('Posts Importer API', function () {
   let agent;
 
@@ -74,6 +94,7 @@ describe('Posts Importer API', function () {
     // Each test logs in as a different role — reset the login rate limiter
     // so the repeated logins don't trip spam prevention
     await resetRateLimits();
+    remoteImportedMediaUrls = [];
     await Promise.all(getImportedAssetPaths().map((filePath) => fs.rm(filePath, { force: true })));
   });
 
@@ -81,8 +102,10 @@ describe('Posts Importer API', function () {
     // Every accepted upload schedules a background import — drain it so a job
     // doesn't run on into another test (or another file on this fork's DB)
     await jobsService.allSettled();
+    await cleanupRemoteImportedMedia();
     await Promise.all(getImportedAssetPaths().map((filePath) => fs.rm(filePath, { force: true })));
     mockManager.restore();
+    nock.cleanAll();
     sinon.restore();
   });
 
@@ -132,6 +155,98 @@ describe('Posts Importer API', function () {
       .attach('postsfile', csvPath)
       .expectStatus(202)
       .expect(cacheInvalidateHeaderNotSet());
+  });
+
+  it('downloads and stores referenced CSV media before creating the post', async function () {
+    await agent.loginAsOwner();
+    const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
+    const [audioFixture, videoFixture, fileFixture] = await Promise.all([
+      fs.readFile(path.join(__dirname, '../../utils/fixtures/media/sample.mp3')),
+      fs.readFile(path.join(__dirname, '../../utils/fixtures/media/sample_640x360.mp4')),
+      fs.readFile(path.join(__dirname, '../../utils/fixtures/files/test.pdf')),
+    ]);
+    const origin = 'https://csv-import-assets.example';
+    const requests = [
+      nock(origin).get('/body.jpg').reply(200, GIF1x1),
+      nock(origin).get('/feature.jpg').reply(200, GIF1x1),
+      nock(origin).get('/og.jpg').reply(200, GIF1x1),
+      nock(origin).get('/twitter.jpg').reply(200, GIF1x1),
+      nock(origin).get('/markdown.jpg').reply(200, GIF1x1),
+      nock(origin).get('/audio.mp3').reply(200, audioFixture),
+      nock(origin).get('/video.mp4').reply(200, videoFixture),
+      nock(origin).get('/guide.pdf').reply(200, fileFixture),
+    ];
+    const html =
+      `<p><img src="${origin}/body.jpg"></p>` +
+      `<div class="kg-card kg-audio-card"><div class="kg-audio-player-container"><audio src="${origin}/audio.mp3"></audio></div></div>` +
+      `<figure class="kg-card kg-video-card"><div class="kg-video-container"><video src="${origin}/video.mp4"></video></div></figure>` +
+      `<div class="kg-card kg-file-card"><a href="${origin}/guide.pdf"><div class="kg-file-card-title">Guide</div><div class="kg-file-card-filename">guide.pdf</div></a></div>`;
+    const csvValue = (value) => `"${value.replaceAll('"', '""')}"`;
+    const csv = [
+      'title,html,markdown,feature_image,og_image,twitter_image',
+      `Remote CSV media,${csvValue(html)},,${origin}/feature.jpg,${origin}/og.jpg,${origin}/twitter.jpg`,
+      `Remote Markdown media,,${csvValue(`![Remote](${origin}/markdown.jpg)`)},,,`,
+    ].join('\n');
+    const filePath = await csvFile('remote-media.csv', csv);
+
+    await agent.post('posts/upload/').attach('postsfile', filePath).expectStatus(202);
+    await jobsService.allSettled();
+
+    for (const request of requests) {
+      assert.equal(request.isDone(), true, request.pendingMocks().join(', '));
+    }
+    const post = await models.Post.findOne(
+      { title: 'Remote CSV media', status: 'all' },
+      { withRelated: ['posts_meta'] },
+    );
+    assert.ok(post);
+    const lexical = JSON.parse(post.get('lexical'));
+    const nodeByType = (type) => lexical.root.children.find((node) => node.type === type);
+    const storedUrls = [
+      nodeByType('image').src,
+      nodeByType('audio').src,
+      nodeByType('video').src,
+      nodeByType('file').src,
+      post.get('feature_image'),
+      post.related('posts_meta').get('og_image'),
+      post.related('posts_meta').get('twitter_image'),
+    ];
+    const markdownPost = await models.Post.findOne({
+      title: 'Remote Markdown media',
+      status: 'all',
+    });
+    assert.ok(markdownPost);
+    const markdownLexical = JSON.parse(markdownPost.get('lexical'));
+    const markdownImage = markdownLexical.root.children.find((node) => node.type === 'image').src;
+    storedUrls.push(markdownImage);
+    remoteImportedMediaUrls.push(...storedUrls);
+    for (const storedUrl of storedUrls) {
+      const absoluteUrl = new URL(urlUtils.transformReadyToAbsolute(storedUrl));
+      assert.equal(absoluteUrl.origin, new URL(urlUtils.getSiteUrl()).origin);
+      assert.match(absoluteUrl.pathname, /\/content\/(?:images|media|files)\//);
+    }
+    assert.doesNotMatch(post.get('html'), /csv-import-assets\.example/);
+    assert.doesNotMatch(markdownPost.get('html'), /csv-import-assets\.example/);
+  });
+
+  it('fails the import when no storage adapter accepts referenced media', async function () {
+    await agent.loginAsOwner();
+    const origin = 'https://csv-import-assets.example';
+    const unsupportedFixture = await fs.readFile(
+      path.join(__dirname, '../../unit/server/services/media-inliner/test/fixtures/fixture.exe'),
+    );
+    const request = nock(origin).get('/unsupported.exe').reply(200, unsupportedFixture);
+    const filePath = await csvFile(
+      'unsupported-remote-media.csv',
+      `title,feature_image\nUnsupported remote media,${origin}/unsupported.exe\n`,
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', filePath).expectStatus(202);
+    await jobsService.allSettled();
+
+    assert.equal(request.isDone(), true, request.pendingMocks().join(', '));
+    const post = await models.Post.findOne({ title: 'Unsupported remote media', status: 'all' });
+    assert.equal(post, null);
   });
 
   it('Imports the single mapped CSV inside a ZIP', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -168,10 +168,8 @@ describe('Posts Importer API', function () {
     const origin = 'https://csv-import-assets.example';
     const requests = [
       nock(origin).get('/body.jpg').reply(200, GIF1x1),
-      nock(origin).get('/feature.jpg').reply(200, GIF1x1),
       nock(origin).get('/og.jpg').reply(200, GIF1x1),
       nock(origin).get('/twitter.jpg').reply(200, GIF1x1),
-      nock(origin).get('/markdown.jpg').reply(200, GIF1x1),
       nock(origin).get('/audio.mp3').reply(200, audioFixture),
       nock(origin).get('/video.mp4').reply(200, videoFixture),
       nock(origin).get('/guide.pdf').reply(200, fileFixture),
@@ -184,8 +182,8 @@ describe('Posts Importer API', function () {
     const csvValue = (value) => `"${value.replaceAll('"', '""')}"`;
     const csv = [
       'title,html,markdown,feature_image,og_image,twitter_image',
-      `Remote CSV media,${csvValue(html)},,${origin}/feature.jpg,${origin}/og.jpg,${origin}/twitter.jpg`,
-      `Remote Markdown media,,${csvValue(`![Remote](${origin}/markdown.jpg)`)},,,`,
+      `Remote CSV media,${csvValue(html)},,${origin}/body.jpg,${origin}/og.jpg,${origin}/twitter.jpg`,
+      `Remote Markdown media,,${csvValue(`![Remote](${origin}/body.jpg)`)},,,`,
     ].join('\n');
     const filePath = await csvFile('remote-media.csv', csv);
 
@@ -218,6 +216,8 @@ describe('Posts Importer API', function () {
     assert.ok(markdownPost);
     const markdownLexical = JSON.parse(markdownPost.get('lexical'));
     const markdownImage = markdownLexical.root.children.find((node) => node.type === 'image').src;
+    assert.equal(post.get('feature_image'), nodeByType('image').src);
+    assert.equal(markdownImage, nodeByType('image').src);
     storedUrls.push(markdownImage);
     remoteImportedMediaUrls.push(...storedUrls);
     for (const storedUrl of storedUrls) {

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import sinon from 'sinon';
 import logging from '@tryghost/logging';
 import ContentCSVImporter from '../../../../../../core/server/services/content-import/import/importer';
+import { MediaInliningFailure } from '../../../../../../core/server/services/content-import/import/media';
 import { ImportRunStore } from '../../../../../../core/server/services/content-import/import/store';
 import type { PostImportRow } from '../../../../../../core/server/services/content-import/import/row';
 import type { PostData } from '../../../../../../core/server/services/content-import/import/post-data';
@@ -385,9 +386,65 @@ describe('ContentCSVImporter', function () {
     );
   });
 
-  it('stops the run when media preparation fails before row isolation is added', async function () {
-    const h = harness([row('Media failure'), row('Never reached')]);
-    const failure = new Error('Could not import 1 media file.');
+  it('records expected media failures against one row and imports the rest', async function () {
+    const h = harness([row('First'), row('Media failure'), row('Third')]);
+    const failure = new MediaInliningFailure([
+      { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed.' },
+      { sourceUrl: 'https://assets.test/broken.mp4', reason: 'Storage failed.' },
+    ]);
+    h.inlineMedia.callsFake(async (data: PostData) => {
+      if (data.title === 'Media failure') {
+        throw failure;
+      }
+    });
+
+    await h.run();
+
+    assert.deepEqual(
+      h.created.map((call) => call.data.title),
+      ['First', 'Third'],
+    );
+    assert.equal(h.inlineMedia.callCount, 3);
+    assert.deepEqual(h.reported, []);
+    assert.equal(h.store.get('run_test')?.status, 'complete');
+    assert.deepEqual(h.store.get('run_test')?.rows[1], {
+      line: 3,
+      title: 'Media failure',
+      status: 'failed',
+      reason: 'Could not import 2 media files.',
+      mediaFailures: [
+        { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed.' },
+        { sourceUrl: 'https://assets.test/broken.mp4', reason: 'Storage failed.' },
+      ],
+    });
+  });
+
+  it('reports once when media failures prevent every post write', async function () {
+    const h = harness([row('First'), row('Second')]);
+    const failure = new MediaInliningFailure([
+      { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed.' },
+    ]);
+    h.inlineMedia.rejects(failure);
+
+    await h.run();
+
+    assert.equal(h.created.length, 0);
+    assert.equal(h.reported.length, 1);
+    assert.equal(
+      (h.reported[0] as Error).message,
+      'Content import failed to write all 2 attempted posts.',
+    );
+    assert.match((h.reported[0] as Error).stack ?? '', /Could not import 1 media file/);
+    assert.equal(h.store.get('run_test')?.status, 'complete');
+    assert.deepEqual(
+      h.store.get('run_test')?.rows.map((outcome) => outcome.status),
+      ['failed', 'failed'],
+    );
+  });
+
+  it('stops the run when media preparation throws an unexpected error', async function () {
+    const h = harness([row('Media defect'), row('Never reached')]);
+    const failure = new Error('media importer defect');
     h.inlineMedia.rejects(failure);
 
     await h.run();

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -24,6 +24,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const updatedTitles = new Set<string>();
   const warningsByTitle = new Map<string, string[]>();
   const urlFailures = new Map<string, unknown>();
+  const inlineMedia = sinon.stub().resolves();
   const store = new ImportRunStore();
   let converterResolutions = 0;
   let markdownRendererResolutions = 0;
@@ -68,6 +69,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     getHtmlToLexical: () => htmlToLexicalFactory(),
     getMarkdownToHtml: () => markdownToHtmlFactory(),
     getCleanHTML: () => cleanHTMLFactory(),
+    media: { inline: inlineMedia },
     addJob: (job: { name: string; offloaded: boolean; job: () => Promise<void> }) => {
       jobs.push(job);
     },
@@ -125,6 +127,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     updatedTitles,
     warningsByTitle,
     urlFailures,
+    inlineMedia,
     store,
     setHtmlToLexicalFactory,
     setMarkdownToHtmlFactory,
@@ -263,6 +266,10 @@ describe('ContentCSVImporter', function () {
       events.push('convert');
       return (html: string) => ({ converted: html });
     });
+    h.inlineMedia.callsFake(async (data: PostData) => {
+      events.push('inline');
+      assert.match(data.lexical ?? '', /unique\.jpg/);
+    });
     const importer = new ContentCSVImporter({
       ...h.deps,
       prepareSource: async () => ({
@@ -275,7 +282,7 @@ describe('ContentCSVImporter', function () {
     await importer.importCSV({ filePath: '/tmp/posts.zip', fileName: 'posts.zip' });
     await h.jobs[0].job();
 
-    assert.deepEqual(events.slice(0, 3), ['store', 'rewrite', 'convert']);
+    assert.deepEqual(events.slice(0, 4), ['store', 'rewrite', 'convert', 'inline']);
     assert.match(h.created[0].data.lexical ?? '', /unique\.jpg/);
     sinon.assert.calledOnce(cleanup);
   });
@@ -330,6 +337,61 @@ describe('ContentCSVImporter', function () {
         tagNames: undefined,
       });
     }
+  });
+
+  it('inlines built post data before opening the repository write transaction', async function () {
+    const h = harness([row('Inline order')]);
+    const events: string[] = [];
+    h.setHtmlToLexicalFactory(() => (html: string) => {
+      events.push('convert');
+      return { converted: html };
+    });
+    h.inlineMedia.callsFake(async (data: PostData) => {
+      events.push('inline');
+      data.feature_image = '__GHOST_URL__/content/images/inlined.jpg';
+    });
+    const write = h.deps.posts.write;
+    const importer = new ContentCSVImporter({
+      ...h.deps,
+      posts: {
+        write: async (data, options, metadata) => {
+          events.push('write');
+          assert.equal(data.feature_image, '__GHOST_URL__/content/images/inlined.jpg');
+          return write(data, options, metadata);
+        },
+      },
+    });
+
+    await importer.importCSV({ filePath: '/tmp/posts.csv', fileName: 'posts.csv' });
+    await h.jobs[0].job();
+
+    assert.deepEqual(events, ['convert', 'inline', 'write']);
+  });
+
+  it('stops the run when media preparation fails before row isolation is added', async function () {
+    const h = harness([row('Media failure'), row('Never reached')]);
+    const failure = new Error('Could not import 1 media file.');
+    h.inlineMedia.rejects(failure);
+
+    await h.run();
+
+    assert.equal(h.created.length, 0);
+    assert.equal(h.inlineMedia.callCount, 1);
+    assert.deepEqual(h.reported, [failure]);
+    assert.equal(h.store.get('run_test')?.status, 'failed');
+    assert.equal(h.store.get('run_test')?.failureReason, failure.message);
+  });
+
+  it('does not inspect media for a row skipped during post-data validation', async function () {
+    const h = harness([
+      { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
+      row('Valid row'),
+    ]);
+
+    await h.run();
+
+    sinon.assert.calledOnce(h.inlineMedia);
+    assert.equal(h.inlineMedia.firstCall.args[0].title, 'Valid row');
   });
 
   it('forwards author and tag cells to the transactional write seam', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -25,6 +25,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const warningsByTitle = new Map<string, string[]>();
   const urlFailures = new Map<string, unknown>();
   const inlineMedia = sinon.stub().resolves();
+  const createMediaInliner = sinon.stub().callsFake(() => ({ inline: inlineMedia }));
   const store = new ImportRunStore();
   let converterResolutions = 0;
   let markdownRendererResolutions = 0;
@@ -69,7 +70,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     getHtmlToLexical: () => htmlToLexicalFactory(),
     getMarkdownToHtml: () => markdownToHtmlFactory(),
     getCleanHTML: () => cleanHTMLFactory(),
-    media: { inline: inlineMedia },
+    createMediaInliner,
     addJob: (job: { name: string; offloaded: boolean; job: () => Promise<void> }) => {
       jobs.push(job);
     },
@@ -128,6 +129,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     warningsByTitle,
     urlFailures,
     inlineMedia,
+    createMediaInliner,
     store,
     setHtmlToLexicalFactory,
     setMarkdownToHtmlFactory,
@@ -366,6 +368,21 @@ describe('ContentCSVImporter', function () {
     await h.jobs[0].job();
 
     assert.deepEqual(events, ['convert', 'inline', 'write']);
+  });
+
+  it('creates an isolated media inliner for every import run', async function () {
+    const h = harness([row('Cached media')]);
+
+    await h.importer.importCSV({ filePath: '/tmp/first.csv', fileName: 'first.csv' });
+    await h.jobs[0].job();
+    await h.importer.importCSV({ filePath: '/tmp/second.csv', fileName: 'second.csv' });
+    await h.jobs[1].job();
+
+    sinon.assert.calledTwice(h.createMediaInliner);
+    assert.notEqual(
+      h.createMediaInliner.firstCall.returnValue,
+      h.createMediaInliner.secondCall.returnValue,
+    );
   });
 
   it('stops the run when media preparation fails before row isolation is added', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/media.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/media.test.ts
@@ -362,6 +362,38 @@ describe('PostMediaInliner', function () {
     sinon.assert.calledOnceWithExactly(h.importUrl, sourceUrl);
   });
 
+  it('keeps successful cached media when another URL makes the row fail', async function () {
+    const h = harness();
+    const storedSource = 'https://assets.test/stored-before-failure.jpg';
+    const failedSource = 'https://assets.test/failure-after-storage.jpg';
+    h.importUrl.callsFake(async (sourceUrl: string) => {
+      if (sourceUrl === failedSource) {
+        return {
+          status: 'failed',
+          sourceUrl,
+          stage: 'storage',
+          reason: 'The media file could not be stored in Ghost.',
+        };
+      }
+      return {
+        status: 'stored',
+        sourceUrl,
+        storedUrl: '__GHOST_URL__/content/images/stored-before-failure.jpg',
+      };
+    });
+    const failedRow = postData({
+      feature_image: storedSource,
+      posts_meta: { og_image: failedSource },
+    });
+
+    await assert.rejects(h.inliner.inline(failedRow), MediaInliningFailure);
+    const laterRow = postData({ feature_image: storedSource });
+    await h.inliner.inline(laterRow);
+
+    assert.equal(laterRow.feature_image, '__GHOST_URL__/content/images/stored-before-failure.jpg');
+    assert.equal(h.importUrl.getCalls().filter((call) => call.args[0] === storedSource).length, 1);
+  });
+
   it('keeps query strings and fragments in the exact cache key', async function () {
     const h = harness();
     const sourceUrls = [

--- a/ghost/core/test/unit/server/services/content-import/import/media.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/media.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import sinon from 'sinon';
 import {
+  isBlockedMediaUrl,
   MediaInliningFailure,
   PostMediaInliner,
 } from '../../../../../../core/server/services/content-import/import/media';
@@ -268,6 +269,54 @@ describe('PostMediaInliner', function () {
 
     assert.equal(data.lexical, lexical);
     sinon.assert.notCalled(h.importUrl);
+  });
+
+  it('preserves media hosted on blocked domains without importing or caching it', async function () {
+    const h = harness();
+    const unsplashUrl = 'https://images.unsplash.com/photo-123?fit=crop&w=1200';
+    const gravatarUrl = '//www.gravatar.com/avatar/abc123?s=200';
+    const data = postData({
+      feature_image: unsplashUrl,
+      posts_meta: { og_image: gravatarUrl },
+      lexical: JSON.stringify({
+        root: {
+          children: [
+            { type: 'image', src: unsplashUrl },
+            { type: 'image', src: gravatarUrl },
+          ],
+        },
+      }),
+    });
+
+    await h.inliner.inline(data);
+
+    assert.equal(data.feature_image, unsplashUrl);
+    assert.equal(data.posts_meta?.og_image, gravatarUrl);
+    assert.equal(JSON.parse(data.lexical ?? '{}').root.children[0].src, unsplashUrl);
+    assert.equal(JSON.parse(data.lexical ?? '{}').root.children[1].src, gravatarUrl);
+    sinon.assert.notCalled(h.importUrl);
+    sinon.assert.notCalled(h.localUrl);
+  });
+
+  it('matches blocked domains without matching lookalike hostnames', function () {
+    for (const sourceUrl of [
+      'https://images.unsplash.com/image.jpg',
+      'https://gravatar.com/avatar/abc123',
+      '//www.gravatar.com/avatar/abc123',
+      'https://secure.gravatar.com/avatar/abc123',
+      'https://cdn.images.unsplash.com/image.jpg',
+    ]) {
+      assert.equal(isBlockedMediaUrl(sourceUrl), true, sourceUrl);
+    }
+
+    for (const sourceUrl of [
+      'https://images.unsplash.com.evil.example/image.jpg',
+      'https://notgravatar.com/avatar/abc123',
+      'https://gravatar.com.evil.example/avatar/abc123',
+      'not a URL',
+    ]) {
+      assert.equal(isBlockedMediaUrl(sourceUrl), false, sourceUrl);
+    }
   });
 
   it('recognizes Ghost placeholders and root-relative content paths', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/media.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/media.test.ts
@@ -1,0 +1,419 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import {
+  MediaInliningFailure,
+  PostMediaInliner,
+} from '../../../../../../core/server/services/content-import/import/media';
+import type { PostData } from '../../../../../../core/server/services/content-import/import/post-data';
+
+const postData = (overrides: Partial<PostData> = {}): PostData => ({
+  title: 'Media post',
+  slug: 'media-post',
+  status: 'published',
+  type: 'post',
+  visibility: 'public',
+  tags: [],
+  ...overrides,
+});
+
+function harness() {
+  const importUrl = sinon.stub().callsFake(async (sourceUrl: string) => {
+    const fileName = new URL(sourceUrl.replace(/^\/\//, 'https://')).pathname.split('/').at(-1);
+    return {
+      status: 'stored' as const,
+      sourceUrl,
+      storedUrl: `__GHOST_URL__/content/files/${fileName}`,
+    };
+  });
+  const inliner = new PostMediaInliner({
+    media: { importUrl },
+  });
+
+  return { inliner, importUrl };
+}
+
+describe('PostMediaInliner', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('describes a single failed media file', function () {
+    const error = new MediaInliningFailure([
+      { sourceUrl: 'https://assets.test/image.jpg', reason: 'Download failed.' },
+    ]);
+
+    assert.equal(error.message, 'Could not import 1 media file.');
+  });
+
+  it('inlines direct post image fields and every supported Lexical media card field', async function () {
+    const h = harness();
+    const lexical = {
+      root: {
+        children: [
+          { type: 'image', src: 'https://assets.test/image.jpg', href: 'https://example.com/' },
+          {
+            type: 'gallery',
+            images: [
+              { src: 'https://assets.test/gallery-one.jpg' },
+              { src: 'https://assets.test/gallery-two.jpg' },
+            ],
+          },
+          {
+            type: 'audio',
+            src: 'https://assets.test/audio.mp3',
+            thumbnailSrc: 'https://assets.test/audio-cover.jpg',
+          },
+          {
+            type: 'video',
+            src: 'https://assets.test/video.mp4',
+            thumbnailSrc: 'https://assets.test/video-cover.jpg',
+            customThumbnailSrc: 'https://assets.test/video-custom.jpg',
+          },
+          { type: 'file', src: 'https://assets.test/guide.pdf' },
+          {
+            type: 'product',
+            productImageSrc: 'https://assets.test/product.jpg',
+            productUrl: 'https://example.com/product',
+          },
+          {
+            type: 'header',
+            backgroundImageSrc: 'https://assets.test/header.jpg',
+            buttonUrl: 'https://example.com/header-button',
+          },
+          { type: 'signup', backgroundImageSrc: 'https://assets.test/signup.jpg' },
+          {
+            type: 'call-to-action',
+            imageUrl: 'https://assets.test/cta.jpg',
+            buttonUrl: 'https://example.com/cta-button',
+          },
+          {
+            type: 'bookmark',
+            url: 'https://example.com/bookmark',
+            metadata: {
+              icon: 'https://assets.test/bookmark-icon.ico',
+              thumbnail: 'https://assets.test/bookmark.jpg',
+            },
+          },
+          {
+            type: 'embed',
+            url: 'https://example.com/embed',
+            metadata: { thumbnail_url: 'https://assets.test/embed.jpg' },
+          },
+          {
+            type: 'before-after',
+            beforeImage: { src: 'https://assets.test/before.jpg' },
+            afterImage: { src: 'https://assets.test/after.jpg' },
+          },
+          {
+            type: 'paragraph',
+            children: [{ type: 'image', src: 'https://assets.test/nested.jpg' }],
+          },
+        ],
+      },
+    };
+    const data = postData({
+      feature_image: 'https://assets.test/feature.jpg',
+      posts_meta: {
+        og_image: 'https://assets.test/og.jpg',
+        twitter_image: 'https://assets.test/twitter.jpg',
+      },
+      lexical: JSON.stringify(lexical),
+      canonical_url: 'https://example.com/canonical',
+      codeinjection_head: '<script src="https://assets.test/script.js"></script>',
+    });
+
+    await h.inliner.inline(data);
+
+    assert.equal(data.feature_image, '__GHOST_URL__/content/files/feature.jpg');
+    assert.equal(data.posts_meta?.og_image, '__GHOST_URL__/content/files/og.jpg');
+    assert.equal(data.posts_meta?.twitter_image, '__GHOST_URL__/content/files/twitter.jpg');
+    const result = JSON.parse(data.lexical ?? '{}');
+    const children = result.root.children;
+    assert.equal(children[0].src, '__GHOST_URL__/content/files/image.jpg');
+    assert.equal(children[0].href, 'https://example.com/');
+    assert.deepEqual(
+      children[1].images.map((image: { src: string }) => image.src),
+      [
+        '__GHOST_URL__/content/files/gallery-one.jpg',
+        '__GHOST_URL__/content/files/gallery-two.jpg',
+      ],
+    );
+    assert.equal(children[2].src, '__GHOST_URL__/content/files/audio.mp3');
+    assert.equal(children[2].thumbnailSrc, '__GHOST_URL__/content/files/audio-cover.jpg');
+    assert.equal(children[3].src, '__GHOST_URL__/content/files/video.mp4');
+    assert.equal(children[3].thumbnailSrc, '__GHOST_URL__/content/files/video-cover.jpg');
+    assert.equal(children[3].customThumbnailSrc, '__GHOST_URL__/content/files/video-custom.jpg');
+    assert.equal(children[4].src, '__GHOST_URL__/content/files/guide.pdf');
+    assert.equal(children[5].productImageSrc, '__GHOST_URL__/content/files/product.jpg');
+    assert.equal(children[5].productUrl, 'https://example.com/product');
+    assert.equal(children[6].backgroundImageSrc, '__GHOST_URL__/content/files/header.jpg');
+    assert.equal(children[6].buttonUrl, 'https://example.com/header-button');
+    assert.equal(children[7].backgroundImageSrc, '__GHOST_URL__/content/files/signup.jpg');
+    assert.equal(children[8].imageUrl, '__GHOST_URL__/content/files/cta.jpg');
+    assert.equal(children[8].buttonUrl, 'https://example.com/cta-button');
+    assert.equal(children[9].metadata.icon, '__GHOST_URL__/content/files/bookmark-icon.ico');
+    assert.equal(children[9].metadata.thumbnail, '__GHOST_URL__/content/files/bookmark.jpg');
+    assert.equal(children[9].url, 'https://example.com/bookmark');
+    assert.equal(children[10].metadata.thumbnail_url, '__GHOST_URL__/content/files/embed.jpg');
+    assert.equal(children[10].url, 'https://example.com/embed');
+    assert.equal(children[11].beforeImage.src, '__GHOST_URL__/content/files/before.jpg');
+    assert.equal(children[11].afterImage.src, '__GHOST_URL__/content/files/after.jpg');
+    assert.equal(children[12].children[0].src, '__GHOST_URL__/content/files/nested.jpg');
+    assert.equal(data.canonical_url, 'https://example.com/canonical');
+    assert.equal(data.codeinjection_head, '<script src="https://assets.test/script.js"></script>');
+    assert.equal(h.importUrl.callCount, 22);
+  });
+
+  it('inlines media attributes, srcsets, and CSS URLs inside HTML fields', async function () {
+    const h = harness();
+    const data = postData({
+      lexical: JSON.stringify({
+        root: {
+          children: [
+            {
+              type: 'html',
+              html:
+                '<a href="https://example.com/keep"><img src="https://assets.test/image.jpg" data-src="https://assets.test/lazy.jpg" srcset="https://assets.test/small.jpg 1x, https://assets.test/large.jpg 2x"></a>' +
+                '<video src="https://assets.test/video.mp4" poster="https://assets.test/poster.jpg"><source src="https://assets.test/video.webm"></video>' +
+                '<audio src="https://assets.test/audio.mp3"></audio>' +
+                '<div style="background-image: url(\'https://assets.test/background.jpg\')"></div>' +
+                '<style>.hero { background: url("https://assets.test/style.jpg") }</style>',
+            },
+          ],
+        },
+      }),
+    });
+
+    await h.inliner.inline(data);
+
+    const html = JSON.parse(data.lexical ?? '{}').root.children[0].html;
+    for (const file of [
+      'image.jpg',
+      'lazy.jpg',
+      'small.jpg',
+      'large.jpg',
+      'video.mp4',
+      'poster.jpg',
+      'video.webm',
+      'audio.mp3',
+      'background.jpg',
+      'style.jpg',
+    ]) {
+      assert.match(html, new RegExp(`__GHOST_URL__/content/files/${file.replace('.', '\\.')}`));
+    }
+    assert.match(html, /href="https:\/\/example\.com\/keep"/);
+    assert.match(html, /small\.jpg 1x, __GHOST_URL__\/content\/files\/large\.jpg 2x/);
+  });
+
+  it('inlines image syntax and embedded media in Markdown cards without changing links', async function () {
+    const h = harness();
+    const data = postData({
+      lexical: JSON.stringify({
+        root: {
+          children: [
+            {
+              type: 'markdown',
+              markdown:
+                '![Photo](https://assets.test/markdown.jpg "Title")\n' +
+                '![Angle](<https://assets.test/angle.jpg>)\n' +
+                '[Ordinary link](https://example.com/page)\n' +
+                '<img src="https://assets.test/embedded.jpg">\n' +
+                '<style>.photo { background: url(https://assets.test/markdown-style.jpg) }</style>',
+            },
+          ],
+        },
+      }),
+    });
+
+    await h.inliner.inline(data);
+
+    const markdown = JSON.parse(data.lexical ?? '{}').root.children[0].markdown;
+    assert.match(markdown, /__GHOST_URL__\/content\/files\/markdown\.jpg/);
+    assert.match(markdown, /__GHOST_URL__\/content\/files\/angle\.jpg/);
+    assert.match(markdown, /__GHOST_URL__\/content\/files\/embedded\.jpg/);
+    assert.match(markdown, /__GHOST_URL__\/content\/files\/markdown-style\.jpg/);
+    assert.match(markdown, /\[Ordinary link]\(https:\/\/example\.com\/page\)/);
+  });
+
+  it('preserves local, embedded, unsupported, and non-media URLs', async function () {
+    const h = harness();
+    const lexical = JSON.stringify({
+      root: {
+        children: [
+          { type: 'image', src: '__GHOST_URL__/content/images/local.jpg' },
+          { type: 'image', src: '/content/images/root-relative.jpg' },
+          { type: 'image', src: 'data:image/gif;base64,AAAA' },
+          { type: 'image', src: 'ftp://assets.test/legacy.jpg' },
+          { type: 'link', url: 'https://assets.test/ordinary-link' },
+          null,
+        ],
+      },
+    });
+    const data = postData({
+      feature_image: 'data:image/gif;base64,AAAA',
+      posts_meta: {},
+      lexical,
+    });
+
+    await h.inliner.inline(data);
+
+    assert.equal(data.lexical, lexical);
+    sinon.assert.notCalled(h.importUrl);
+  });
+
+  it('processes protocol-relative media URLs', async function () {
+    const h = harness();
+    const data = postData({ feature_image: '//assets.test/protocol-relative.jpg' });
+
+    await h.inliner.inline(data);
+
+    assert.equal(data.feature_image, '__GHOST_URL__/content/files/protocol-relative.jpg');
+    sinon.assert.calledWithExactly(h.importUrl, '//assets.test/protocol-relative.jpg');
+  });
+
+  it('collects every unique expected download, extraction, and storage failure', async function () {
+    const h = harness();
+    h.importUrl.callsFake(async (sourceUrl: string) => {
+      if (sourceUrl.endsWith('/download-throws.jpg') || sourceUrl.endsWith('/download-null.jpg')) {
+        return {
+          status: 'failed',
+          sourceUrl,
+          stage: 'download',
+          reason: 'The media file could not be downloaded.',
+        } as const;
+      }
+      if (sourceUrl.endsWith('/unreadable.jpg')) {
+        return {
+          status: 'failed',
+          sourceUrl,
+          stage: 'extract',
+          reason: 'The downloaded media file could not be read.',
+        } as const;
+      }
+      if (sourceUrl.endsWith('/unsupported.exe')) {
+        return {
+          status: 'failed',
+          sourceUrl,
+          stage: 'unsupported',
+          reason: 'No configured storage accepts this media file.',
+        } as const;
+      }
+      if (sourceUrl.endsWith('/store-throws.jpg')) {
+        return {
+          status: 'failed',
+          sourceUrl,
+          stage: 'storage',
+          reason: 'The media file could not be stored in Ghost.',
+        } as const;
+      }
+      return { status: 'stored', sourceUrl, storedUrl: `local:${sourceUrl}` } as const;
+    });
+    const data = postData({
+      feature_image: 'https://assets.test/download-throws.jpg',
+      posts_meta: {
+        og_image: 'https://assets.test/download-null.jpg',
+        twitter_image: 'https://assets.test/unreadable.jpg',
+      },
+      lexical: JSON.stringify({
+        root: {
+          children: [
+            { type: 'image', src: 'https://assets.test/unsupported.exe' },
+            { type: 'image', src: 'https://assets.test/store-throws.jpg' },
+            { type: 'image', src: 'https://assets.test/download-null.jpg' },
+          ],
+        },
+      }),
+    });
+
+    await assert.rejects(h.inliner.inline(data), (error: unknown) => {
+      assert.ok(error instanceof MediaInliningFailure);
+      assert.equal(error.message, 'Could not import 5 media files.');
+      assert.deepEqual(error.failures, [
+        {
+          sourceUrl: 'https://assets.test/download-throws.jpg',
+          reason: 'The media file could not be downloaded.',
+        },
+        {
+          sourceUrl: 'https://assets.test/download-null.jpg',
+          reason: 'The media file could not be downloaded.',
+        },
+        {
+          sourceUrl: 'https://assets.test/unreadable.jpg',
+          reason: 'The downloaded media file could not be read.',
+        },
+        {
+          sourceUrl: 'https://assets.test/unsupported.exe',
+          reason: 'No configured storage accepts this media file.',
+        },
+        {
+          sourceUrl: 'https://assets.test/store-throws.jpg',
+          reason: 'The media file could not be stored in Ghost.',
+        },
+      ]);
+      return true;
+    });
+    assert.equal(h.importUrl.callCount, 6, 'all references are attempted before failing');
+  });
+
+  it('propagates unexpected errors from the media importer', async function () {
+    const h = harness();
+    const error = new Error('media importer defect');
+    h.importUrl.rejects(error);
+
+    await assert.rejects(
+      h.inliner.inline(
+        postData({ feature_image: 'https://assets.test/unexpected-import-error.jpg' }),
+      ),
+      (thrown) => thrown === error,
+    );
+  });
+
+  it('preserves valid but empty or unrelated Lexical structures', async function () {
+    const h = harness();
+    for (const lexical of ['null', '{}', '{"root":{}}', '{"root":{"children":[]}}']) {
+      const data = postData({ lexical });
+      await h.inliner.inline(data);
+      assert.equal(data.lexical, lexical);
+    }
+    sinon.assert.notCalled(h.importUrl);
+  });
+
+  it('treats malformed Lexical JSON as an unexpected importer error', async function () {
+    const h = harness();
+    const data = postData({ lexical: '{not-json' });
+
+    await assert.rejects(h.inliner.inline(data), SyntaxError);
+  });
+
+  it('preserves data-URI srcsets and empty CSS URLs', async function () {
+    const h = harness();
+    const data = postData({
+      lexical: JSON.stringify({
+        root: {
+          children: [
+            {
+              type: 'html',
+              html:
+                '<img src="" srcset="" style=""><style></style>' +
+                '<img srcset="data:image/svg+xml;base64,AAAA 1x, data:image/svg+xml;base64,BBBB 2x">' +
+                '<source srcset=", https://assets.test/source.jpg 2x"><div style="background:url(\'\')"></div>',
+            },
+            { type: 'image', src: '' },
+            { type: 'gallery', images: [null, {}, { src: '' }] },
+            { type: 'bookmark' },
+            { type: 'markdown', markdown: '' },
+            { type: 42 },
+          ],
+        },
+      }),
+    });
+
+    await h.inliner.inline(data);
+
+    const html = JSON.parse(data.lexical ?? '{}').root.children[0].html;
+    assert.match(html, /data:image\/svg\+xml;base64,AAAA 1x, data:image\/svg\+xml;base64,BBBB 2x/);
+    assert.match(html, /srcset=", __GHOST_URL__\/content\/files\/source\.jpg 2x"/);
+    assert.match(html, /background:url\(''\)/);
+    sinon.assert.calledOnce(h.importUrl);
+  });
+});

--- a/ghost/core/test/unit/server/services/content-import/import/media.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/media.test.ts
@@ -5,6 +5,7 @@ import {
   PostMediaInliner,
 } from '../../../../../../core/server/services/content-import/import/media';
 import type { PostData } from '../../../../../../core/server/services/content-import/import/post-data';
+import type { ExternalMediaImportResult } from '../../../../../../core/server/services/media-inliner/types';
 
 const postData = (overrides: Partial<PostData> = {}): PostData => ({
   title: 'Media post',
@@ -17,14 +18,16 @@ const postData = (overrides: Partial<PostData> = {}): PostData => ({
 });
 
 function harness() {
-  const importUrl = sinon.stub().callsFake(async (sourceUrl: string) => {
-    const fileName = new URL(sourceUrl.replace(/^\/\//, 'https://')).pathname.split('/').at(-1);
-    return {
-      status: 'stored' as const,
-      sourceUrl,
-      storedUrl: `__GHOST_URL__/content/files/${fileName}`,
-    };
-  });
+  const importUrl = sinon
+    .stub<[string], Promise<ExternalMediaImportResult>>()
+    .callsFake(async (sourceUrl: string) => {
+      const fileName = new URL(sourceUrl.replace(/^\/\//, 'https://')).pathname.split('/').at(-1);
+      return {
+        status: 'stored',
+        sourceUrl,
+        storedUrl: `__GHOST_URL__/content/files/${fileName}`,
+      };
+    });
   const inliner = new PostMediaInliner({
     media: { importUrl },
   });
@@ -271,6 +274,125 @@ describe('PostMediaInliner', function () {
     sinon.assert.calledWithExactly(h.importUrl, '//assets.test/protocol-relative.jpg');
   });
 
+  it('reuses the same URL across fields in one row', async function () {
+    const h = harness();
+    const sourceUrl = 'https://assets.test/shared.jpg';
+    const data = postData({
+      feature_image: sourceUrl,
+      posts_meta: { og_image: sourceUrl, twitter_image: sourceUrl },
+      lexical: JSON.stringify({
+        root: { children: [{ type: 'image', src: sourceUrl }] },
+      }),
+    });
+
+    await h.inliner.inline(data);
+
+    sinon.assert.calledOnceWithExactly(h.importUrl, sourceUrl);
+    assert.equal(data.feature_image, '__GHOST_URL__/content/files/shared.jpg');
+    assert.equal(data.posts_meta?.og_image, '__GHOST_URL__/content/files/shared.jpg');
+    assert.equal(data.posts_meta?.twitter_image, '__GHOST_URL__/content/files/shared.jpg');
+    assert.equal(
+      JSON.parse(data.lexical ?? '{}').root.children[0].src,
+      '__GHOST_URL__/content/files/shared.jpg',
+    );
+  });
+
+  it('reuses the same URL in the same field across rows', async function () {
+    const h = harness();
+    const sourceUrl = 'https://assets.test/cross-row.jpg';
+    const first = postData({ feature_image: sourceUrl });
+    const second = postData({ feature_image: sourceUrl });
+
+    await h.inliner.inline(first);
+    await h.inliner.inline(second);
+
+    sinon.assert.calledOnceWithExactly(h.importUrl, sourceUrl);
+    assert.equal(first.feature_image, '__GHOST_URL__/content/files/cross-row.jpg');
+    assert.equal(second.feature_image, '__GHOST_URL__/content/files/cross-row.jpg');
+  });
+
+  it('shares an in-flight import for simultaneous references', async function () {
+    const h = harness();
+    const sourceUrl = 'https://assets.test/simultaneous.jpg';
+    let resolveImport: (result: ExternalMediaImportResult) => void = () => {};
+    const pendingImport = new Promise<ExternalMediaImportResult>((resolve) => {
+      resolveImport = resolve;
+    });
+    h.importUrl.returns(pendingImport);
+    const first = postData({ feature_image: sourceUrl });
+    const second = postData({ feature_image: sourceUrl });
+
+    const firstInlining = h.inliner.inline(first);
+    const secondInlining = h.inliner.inline(second);
+
+    sinon.assert.calledOnceWithExactly(h.importUrl, sourceUrl);
+    resolveImport({
+      status: 'stored',
+      sourceUrl,
+      storedUrl: '__GHOST_URL__/content/files/simultaneous.jpg',
+    });
+    await Promise.all([firstInlining, secondInlining]);
+    assert.equal(first.feature_image, '__GHOST_URL__/content/files/simultaneous.jpg');
+    assert.equal(second.feature_image, '__GHOST_URL__/content/files/simultaneous.jpg');
+  });
+
+  it('caches failed imports while reporting them for every affected row', async function () {
+    const h = harness();
+    const sourceUrl = 'https://assets.test/missing.jpg';
+    h.importUrl.resolves({
+      status: 'failed',
+      sourceUrl,
+      stage: 'download',
+      reason: 'The media file could not be downloaded.',
+    });
+
+    for (const title of ['First affected row', 'Second affected row']) {
+      await assert.rejects(
+        h.inliner.inline(postData({ title, feature_image: sourceUrl })),
+        (error: unknown) => {
+          assert.ok(error instanceof MediaInliningFailure);
+          assert.deepEqual(error.failures, [
+            { sourceUrl, reason: 'The media file could not be downloaded.' },
+          ]);
+          return true;
+        },
+      );
+    }
+
+    sinon.assert.calledOnceWithExactly(h.importUrl, sourceUrl);
+  });
+
+  it('keeps query strings and fragments in the exact cache key', async function () {
+    const h = harness();
+    const sourceUrls = [
+      'https://assets.test/image.jpg',
+      'https://assets.test/image.jpg?size=large',
+      'https://assets.test/image.jpg#preview',
+    ];
+    const data = postData({
+      feature_image: sourceUrls[0],
+      posts_meta: { og_image: sourceUrls[1], twitter_image: sourceUrls[2] },
+    });
+
+    await h.inliner.inline(data);
+
+    assert.deepEqual(
+      h.importUrl.getCalls().map((call) => call.args[0]),
+      sourceUrls,
+    );
+  });
+
+  it('does not share cached URLs across media-inliner instances', async function () {
+    const h = harness();
+    const sourceUrl = 'https://assets.test/separate-imports.jpg';
+    const nextImportInliner = new PostMediaInliner({ media: { importUrl: h.importUrl } });
+
+    await h.inliner.inline(postData({ feature_image: sourceUrl }));
+    await nextImportInliner.inline(postData({ feature_image: sourceUrl }));
+
+    sinon.assert.calledTwice(h.importUrl);
+  });
+
   it('collects every unique expected download, extraction, and storage failure', async function () {
     const h = harness();
     h.importUrl.callsFake(async (sourceUrl: string) => {
@@ -352,7 +474,7 @@ describe('PostMediaInliner', function () {
       ]);
       return true;
     });
-    assert.equal(h.importUrl.callCount, 6, 'all references are attempted before failing');
+    assert.equal(h.importUrl.callCount, 5, 'every unique reference is attempted before failing');
   });
 
   it('propagates unexpected errors from the media importer', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/media.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/media.test.ts
@@ -4,6 +4,7 @@ import {
   MediaInliningFailure,
   PostMediaInliner,
 } from '../../../../../../core/server/services/content-import/import/media';
+import { isLocalMediaUrl } from '../../../../../../core/server/services/content-import/import/local-media-url';
 import type { PostData } from '../../../../../../core/server/services/content-import/import/post-data';
 import type { ExternalMediaImportResult } from '../../../../../../core/server/services/media-inliner/types';
 
@@ -17,7 +18,11 @@ const postData = (overrides: Partial<PostData> = {}): PostData => ({
   ...overrides,
 });
 
-function harness() {
+function harness({
+  localUrl = sinon.stub<[string], boolean>().returns(false),
+}: {
+  localUrl?: sinon.SinonStub<[string], boolean>;
+} = {}) {
   const importUrl = sinon
     .stub<[string], Promise<ExternalMediaImportResult>>()
     .callsFake(async (sourceUrl: string) => {
@@ -30,9 +35,10 @@ function harness() {
     });
   const inliner = new PostMediaInliner({
     media: { importUrl },
+    isLocalMediaUrl: localUrl,
   });
 
-  return { inliner, importUrl };
+  return { inliner, importUrl, localUrl };
 }
 
 describe('PostMediaInliner', function () {
@@ -264,6 +270,103 @@ describe('PostMediaInliner', function () {
     sinon.assert.notCalled(h.importUrl);
   });
 
+  it('recognizes Ghost placeholders and root-relative content paths', function () {
+    const options = {
+      siteUrl: 'https://example.com/blog/',
+      subdir: 'blog',
+      assetBaseUrls: [],
+    };
+
+    for (const sourceUrl of [
+      '__GHOST_URL__/content/images/image.jpg',
+      '__GHOST_URL__/anything',
+      '/content/images/image.jpg',
+      '/content/images',
+      '/content/media/video.mp4',
+      '/content/files/guide.pdf',
+      '/blog/content/images/image.jpg',
+      '/blog/content/media/video.mp4',
+      '/blog/content/files/guide.pdf',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), true, sourceUrl);
+    }
+
+    assert.equal(isLocalMediaUrl('/content/images-other/image.jpg', options), false);
+    assert.equal(isLocalMediaUrl('/blogger/content/images/image.jpg', options), false);
+  });
+
+  it('recognizes current-site content URLs with configured subdirectories', function () {
+    const options = {
+      siteUrl: 'https://example.com/blog/',
+      subdir: '/blog',
+      assetBaseUrls: [],
+    };
+
+    for (const sourceUrl of [
+      'http://example.com/content/images/image.jpg',
+      '//example.com/blog/content/media/video.mp4',
+      'https://example.com/blog/content/files/guide.pdf',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), true, sourceUrl);
+    }
+
+    for (const sourceUrl of [
+      'https://example.com/about/image.jpg',
+      'https://example.com/blog/content/images-other/image.jpg',
+      'https://example.com.evil/content/images/image.jpg',
+      'https://external.example/content/images/image.jpg',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), false, sourceUrl);
+    }
+  });
+
+  it('recognizes configured storage and CDN URL prefixes without near-matching', function () {
+    const options = {
+      siteUrl: 'https://example.com/',
+      subdir: '',
+      assetBaseUrls: [
+        'https://images.example/c/site/content/images/',
+        'https://assets.example/c/site',
+        null,
+        undefined,
+      ],
+    };
+
+    for (const sourceUrl of [
+      'http://images.example/c/site/content/images/image.jpg',
+      '//assets.example/c/site/content/media/video.mp4',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), true, sourceUrl);
+    }
+
+    for (const sourceUrl of [
+      'https://images.example/c/site/content/images-other/image.jpg',
+      'https://assets.example/c/site-other/content/files/guide.pdf',
+      'https://assets.example.evil/c/site/content/files/guide.pdf',
+      'not a URL',
+    ]) {
+      assert.equal(isLocalMediaUrl(sourceUrl, options), false, sourceUrl);
+    }
+  });
+
+  it('does not import or cache URLs classified as local', async function () {
+    const sourceUrl = 'https://example.com/content/images/existing.jpg';
+    const localUrl = sinon.stub<[string], boolean>();
+    localUrl.onFirstCall().returns(true);
+    localUrl.onSecondCall().returns(false);
+    const h = harness({ localUrl });
+    const first = postData({ feature_image: sourceUrl });
+    const second = postData({ feature_image: sourceUrl });
+
+    await h.inliner.inline(first);
+    await h.inliner.inline(second);
+
+    assert.equal(first.feature_image, sourceUrl);
+    assert.equal(second.feature_image, '__GHOST_URL__/content/files/existing.jpg');
+    sinon.assert.calledTwice(localUrl);
+    sinon.assert.calledOnceWithExactly(h.importUrl, sourceUrl);
+  });
+
   it('processes protocol-relative media URLs', async function () {
     const h = harness();
     const data = postData({ feature_image: '//assets.test/protocol-relative.jpg' });
@@ -417,7 +520,10 @@ describe('PostMediaInliner', function () {
   it('does not share cached URLs across media-inliner instances', async function () {
     const h = harness();
     const sourceUrl = 'https://assets.test/separate-imports.jpg';
-    const nextImportInliner = new PostMediaInliner({ media: { importUrl: h.importUrl } });
+    const nextImportInliner = new PostMediaInliner({
+      media: { importUrl: h.importUrl },
+      isLocalMediaUrl: h.localUrl,
+    });
 
     await h.inliner.inline(postData({ feature_image: sourceUrl }));
     await nextImportInliner.inline(postData({ feature_image: sourceUrl }));


### PR DESCRIPTION
ref https://linear.app/ghost/project/4b2edbd66469/ - Milestone 6

Each commit references an individual Linear issue

Downloads remote media referenced by CSV posts into Ghost storage, with import-level caching and per-row failure isolation. Existing Ghost assets, Unsplash images, and Gravatar images remain untouched.