### PR TITLE
🎨 Improved the members import so you can map every column in your file

### DIFF
--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -84,12 +84,6 @@ const features: Feature[] = [
     flag: 'membersCustomFields',
   },
   {
-    title: 'Members import redesign',
-    description:
-      'Serves the redesigned members CSV import dialog, which shows every column in the file and lets each one be mapped to a member field',
-    flag: 'membersImportRedesign',
-  },
-  {
     title: 'Paywall improvements',
     description: 'Enables paywall usability, discoverability and email customization improvements',
     flag: 'paywallImprovements',

--- a/e2e/tests/admin/members/import-custom-fields.test.ts
+++ b/e2e/tests/admin/members/import-custom-fields.test.ts
@@ -18,13 +18,13 @@ import { usePerTestIsolation } from '@/helpers/playwright/isolation';
  * two things only the browser exercises -- the export -> import loop end to end, and the
  * mapping step both auto-detecting an exported column and taking a hand-picked target.
  *
- * Behind two flags: membersImportRedesign serves the mapping step this drives, and
- * membersCustomFields is what puts custom fields into it.
+ * The mapping step this drives is served to every site now, so the only flag left is
+ * membersCustomFields, which is what puts custom fields into it.
  */
 usePerTestIsolation();
 
 test.describe('Ghost Admin - Members import with custom fields', () => {
-  test.use({ labs: { membersImportRedesign: true, membersCustomFields: true } });
+  test.use({ labs: { membersCustomFields: true } });
 
   test('an exported custom field value round-trips back through import, auto-mapped', async ({
     page,

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -27,7 +27,7 @@ const messages = {
 };
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
-const GA_FEATURES = ['automationAnalytics', 'giftSubCustomization'];
+const GA_FEATURES = ['automationAnalytics', 'giftSubCustomization', 'membersImportRedesign'];
 
 // These features are considered publicly available and can be enabled/disabled by users
 const PUBLIC_BETA_FEATURES = [
@@ -52,7 +52,6 @@ const PRIVATE_FEATURES = [
   'pictureImageFormats',
   'getHelperDeduplication',
   'membersCustomFields',
-  'membersImportRedesign',
   'paywallImprovements',
   'tagDetailsReact',
   'selfServeArchives',


### PR DESCRIPTION
Bottom of the remaining stack, now that #30335 is merged. #30343 sits on top of this one.

## Problem

The redesigned dialog for importing members from a CSV file has been switched on for Ghost(Pro) sites and is working. It is still an opt-in experiment, which means self-hosted sites cannot get it at all, and it can still be switched off by accident.

## Solution

It becomes the import dialog everyone gets.

Nothing about the dialog itself changes. It stops being something a site opts into, so its entry disappears from the experiments list and self-hosted sites get it along with everyone else.

The older dialog and the code that picks between the two are still there and are removed in the change stacked on top of this one. That is deliberate: this change is the one that can be undone in a hurry if the new dialog turns out to have a problem, and undoing it is worth nothing if the old dialog has already been deleted.

Linear: https://linear.app/ghost/issue/BER-3907

https://claude.ai/code/session_01WHJ1RdhTX8n6KwvrgSEnRT
