### PR TITLE
Fixed a type error in the active-visitors hook test

### DIFF
--- a/apps/admin-x-framework/test/unit/hooks/use-active-visitors.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-active-visitors.test.ts
@@ -133,7 +133,7 @@ describe('useActiveVisitors', () => {
     const { rerender } = renderHook(
       ({ config }: { config?: typeof statsConfig }) =>
         useActiveVisitors({ statsConfig: config, enabled: true }),
-      { initialProps: { config: statsConfig } },
+      { initialProps: { config: statsConfig as typeof statsConfig | undefined } },
     );
 
     expect(mockUseTinybirdQuery).toHaveBeenLastCalledWith(


### PR DESCRIPTION
`apps/admin-x-framework` failed `test:types` (`tsc --noEmit`): in `use-active-visitors.test.ts`, `renderHook` infers its Props type from `initialProps`, which made `config` non-optional — so the `rerender({config: undefined})` that exercises the empty-`site_uuid` fallback didn't typecheck, and the package's `pnpm test` was red locally.

Widened the `initialProps` value to `typeof statsConfig | undefined` so the inferred Props match the render callback's optional parameter. Test behavior unchanged.

Verification: `npx tsc --noEmit` clean in the package; the hook suite passes 14/14.