### PR TITLE
Changed a tier that delivers everywhere to store no country list

### DIFF
--- a/e2e/scripts/probe-stripe-constraints.ts
+++ b/e2e/scripts/probe-stripe-constraints.ts
@@ -1,14 +1,22 @@
 import { asSessionCreateParams, provision, stripeClient } from './provision-stripe-environment.ts';
 import { readFileSync } from 'node:fs';
+import type Stripe from 'stripe';
 
 /**
  * Measures the checkout constraints the fake Stripe server enforces.
  *
  * The limits in `fake-stripe-server.ts` cannot be taken from Stripe's docs or its
  * published OpenAPI spec, because both disagree with the API: the spec carries no
- * `maxItems` on `custom_fields`, states the `customer_update` rule only in prose,
- * and marks `allowed_countries` required when the API does not. This script is how
- * those limits were established, and how to re-establish them when Stripe moves one.
+ * `maxItems` on `custom_fields`, and states the `customer_update` rule only in prose.
+ * This script is how those limits were established, and how to re-establish them when
+ * Stripe moves one.
+ *
+ * Read what a probe reports, not whether it was accepted. Stripe's form encoding drops an
+ * empty object, so a parameter can disappear on the way out and the session is created
+ * without it — a success that collects nothing. This once produced the wrong conclusion
+ * here, that the API treats `allowed_countries` as optional where the spec marks it
+ * required. It does not: the list is the only key `shipping_address_collection` has, so
+ * leaving it out removes the whole parameter.
  *
  * Run: STRIPE_SECRET_KEY=sk_test_... pnpm --filter @tryghost/e2e stripe:probe
  */
@@ -42,10 +50,34 @@ const field = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+/** What the created session will actually ask a buyer for, which is the thing to read. */
+function collects(session: Stripe.Checkout.Session): string {
+  const asks: string[] = [];
+  const countries = session.shipping_address_collection?.allowed_countries;
+  if (countries) {
+    asks.push(`shipping_address (${countries.length} countries)`);
+  }
+  if (session.phone_number_collection?.enabled) {
+    asks.push('phone_number');
+  }
+  if (session.tax_id_collection?.enabled) {
+    asks.push('tax_id');
+  }
+  // Read through a cast: the API returns `custom_fields` on a session, but the types for
+  // the pinned version predate it and do not declare it. The probe exists to measure the
+  // API rather than the types, so the API is what it reads.
+  const questions = (session as { custom_fields?: unknown[] }).custom_fields;
+  if (questions?.length) {
+    asks.push(`custom_fields (${questions.length})`);
+  }
+  return asks.length ? asks.join(', ') : 'nothing';
+}
+
 async function probe(name: string, params: Record<string, unknown>): Promise<void> {
   try {
-    await stripe.checkout.sessions.create(asSessionCreateParams(params));
+    const session = await stripe.checkout.sessions.create(asSessionCreateParams(params));
     log(`  ACCEPTED  ${name}`);
+    log(`            collects ${collects(session)}`);
   } catch (error) {
     log(`  REJECTED  ${name}`);
     log(`            ${(error as Error).message}`);
@@ -92,9 +124,17 @@ async function main(): Promise<void> {
     ...base,
     customer_update: { address: 'auto' },
   });
+  // Whether a session can ask for an address without naming countries — the shape an
+  // "everywhere" sentinel would need. Both of these are accepted and both collect nothing,
+  // because the empty object never reaches Stripe. There is no sentinel; a caller that
+  // means everywhere has to enumerate every country.
   await probe('shipping_address_collection without allowed_countries', {
     ...base,
     shipping_address_collection: {},
+  });
+  await probe('shipping_address_collection with an empty allowed_countries', {
+    ...base,
+    shipping_address_collection: { allowed_countries: [] },
   });
 
   // Whether the SDK's own `AllowedCountry` union can be trusted as the list Ghost enforces

--- a/ghost/core/core/server/services/stripe/services/checkout/session-options.ts
+++ b/ghost/core/core/server/services/stripe/services/checkout/session-options.ts
@@ -2,6 +2,7 @@ import logging from '@tryghost/logging';
 import {
   MAX_CHECKOUT_CUSTOM_FIELDS,
   MAX_CHECKOUT_LABEL_LENGTH,
+  STRIPE_ALLOWED_COUNTRIES,
   isCheckoutEligible,
   type CheckoutEligibleFieldType,
 } from '@tryghost/checkout';
@@ -118,15 +119,20 @@ export function stripeCheckoutCollectionOptions(
   }
 
   if (checkout.shipping) {
-    // The country list is what makes this reach Stripe at all. An empty
-    // `shipping_address_collection` form-encodes to nothing, so a request built that
-    // way carries no parameter and Stripe accepts it precisely because it was never
-    // asked to collect anything — which reads as success and collects no addresses.
+    // Ghost stores "everywhere" as no list, because the set of countries moves and a
+    // stored copy of it would quietly become a restriction. Stripe has no such sentinel:
+    // `allowed_countries` is the only key `shipping_address_collection` has, so a request
+    // that omits it carries no parameter at all, and Stripe accepts it precisely because
+    // it was never asked to collect anything — a session that succeeds and collects no
+    // address. So everywhere is expanded to every country here, at the one point that
+    // builds the request.
     //
-    // Defended again here rather than trusted from the settings screen: this is the
-    // checkout path, and a malformed configuration must cost the collection rather than
-    // throw inside a session build.
-    if (checkout.shipping.allowedCountries.length === 0) {
+    // An empty list is neither everywhere nor a real restriction, and would encode to the
+    // same absent parameter. Defended here rather than trusted from the settings screen:
+    // this is the checkout path, and a malformed configuration must cost the collection
+    // rather than throw inside a session build.
+    const allowedCountries = checkout.shipping.allowedCountries ?? [...STRIPE_ALLOWED_COUNTRIES];
+    if (allowedCountries.length === 0) {
       logging.warn(
         {
           event: { name: 'stripe.checkout.collection_skipped' },
@@ -136,9 +142,7 @@ export function stripeCheckoutCollectionOptions(
         'Skipping a Stripe checkout collection',
       );
     } else {
-      options.shipping_address_collection = {
-        allowed_countries: checkout.shipping.allowedCountries,
-      };
+      options.shipping_address_collection = { allowed_countries: allowedCountries };
     }
   }
 

--- a/ghost/core/core/server/services/tier-checkout-config/codec.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/codec.ts
@@ -7,20 +7,26 @@ import { CheckoutOptions } from './models';
 const SEPARATOR = ',';
 
 export const optionsCodec = z.codec(DbCheckoutOptions, CheckoutOptions, {
+  // An absent list is everywhere, so the column is null rather than a copy of every
+  // country. An empty list is neither, and stays representable on purpose: nothing writes
+  // one, and the session builder refuses to collect against it rather than asking the
+  // processor for an address form it would never render.
   decode: (columns) => ({
-    shippingAllowedCountries: splitList(columns.shipping_allowed_countries),
+    shippingAllowedCountries:
+      columns.shipping_allowed_countries === null
+        ? null
+        : splitList(columns.shipping_allowed_countries),
     taxNumber: columns.tax_number_collect,
   }),
   encode: (options) => ({
-    shipping_allowed_countries: options.shippingAllowedCountries.length
-      ? joinList(options.shippingAllowedCountries)
-      : null,
+    shipping_allowed_countries:
+      options.shippingAllowedCountries === null ? null : joinList(options.shippingAllowedCountries),
     tax_number_collect: options.taxNumber,
   }),
 });
 
-function splitList(stored: string | null): string[] {
-  return stored ? stored.split(SEPARATOR).filter(Boolean) : [];
+function splitList(stored: string): string[] {
+  return stored.split(SEPARATOR).filter(Boolean);
 }
 
 function joinList(values: string[]): string {

--- a/ghost/core/core/server/services/tier-checkout-config/models.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/models.ts
@@ -13,8 +13,14 @@ export type CheckoutQuestion = z.infer<typeof CheckoutQuestion>;
  * under one parameter, but a publisher keeps a name and an address in different fields.
  */
 export const ShippingCollection = z.object({
-  /** ISO 3166-1 alpha-2. A processor will not render an address form without them. */
-  allowedCountries: z.array(z.string()),
+  /**
+   * ISO 3166-1 alpha-2, or null for everywhere the processor ships.
+   *
+   * Null rather than a stored enumeration of every country, because that list moves: the
+   * day the processor adds one, a saved "everywhere" would silently be a restriction that
+   * excludes it, and nothing would say so.
+   */
+  allowedCountries: z.array(z.string()).nullable(),
   nameCustomFieldKey: z.string(),
   addressCustomFieldKey: z.string(),
 });
@@ -51,7 +57,7 @@ export const emptyCheckoutConfig = (tierId: string): TierCheckoutConfig => ({
 });
 
 export const CheckoutOptions = z.object({
-  shippingAllowedCountries: z.array(z.string()),
+  shippingAllowedCountries: z.array(z.string()).nullable(),
   taxNumber: z.boolean(),
 });
 export type CheckoutOptions = z.infer<typeof CheckoutOptions>;

--- a/ghost/core/core/server/services/tier-checkout-config/serializers.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/serializers.ts
@@ -8,7 +8,7 @@ import { TierCheckoutConfig } from './models';
 
 // Every country Stripe will take, sent at once, was measured as accepted — so the only
 // ceiling is the list itself, and a request naming more than there are countries is naming
-// something twice.
+// something twice. A request that means all of them omits the list instead.
 const MAX_ALLOWED_COUNTRIES = STRIPE_ALLOWED_COUNTRIES.length;
 
 const QuestionInput = z.object({
@@ -60,10 +60,14 @@ export const CheckoutConfigInput = z.strictObject({
       z.strictObject({ collect: z.literal(false) }),
       z.strictObject({
         collect: z.literal(true),
+        // Absent means everywhere the processor ships. Empty is refused rather than
+        // read as everywhere: a publisher who cleared the list said something, and it
+        // was not "deliver worldwide".
         allowed_countries: z
           .array(CountryCode, { error: 'Choose at least one country you deliver to.' })
           .min(1, { error: 'Choose at least one country you deliver to.' })
-          .max(MAX_ALLOWED_COUNTRIES),
+          .max(MAX_ALLOWED_COUNTRIES)
+          .optional(),
         name: Destination,
         address: Destination,
       }),
@@ -94,7 +98,8 @@ const CollectionResource = z.object({
 
 const ShippingResource = z.object({
   collect: z.literal(true),
-  allowed_countries: z.array(z.string()),
+  /** Absent means everywhere, the same way it does on the way in. */
+  allowed_countries: z.array(z.string()).optional(),
   name: z.object({ custom_field_key: z.string() }),
   address: z.object({ custom_field_key: z.string() }),
 });
@@ -124,7 +129,9 @@ export const toCheckoutConfigResponse = z
         ? {
             shipping: {
               collect: true as const,
-              allowed_countries: config.shipping.allowedCountries,
+              ...(config.shipping.allowedCountries
+                ? { allowed_countries: config.shipping.allowedCountries }
+                : {}),
               name: { custom_field_key: config.shipping.nameCustomFieldKey },
               address: { custom_field_key: config.shipping.addressCustomFieldKey },
             },

--- a/ghost/core/core/server/services/tier-checkout-config/service.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/service.ts
@@ -343,7 +343,9 @@ async function writeOptions(
   now: Date,
 ): Promise<void> {
   const all = z.encode(optionsCodec, {
-    shippingAllowedCountries: stated.shipping?.collect ? stated.shipping.allowed_countries : [],
+    shippingAllowedCountries: stated.shipping?.collect
+      ? (stated.shipping.allowed_countries ?? null)
+      : null,
     taxNumber: stated.tax_number?.collect ?? false,
   });
 

--- a/ghost/core/test/e2e-api/admin/tiers-checkout-config.test.ts
+++ b/ghost/core/test/e2e-api/admin/tiers-checkout-config.test.ts
@@ -455,10 +455,11 @@ describe('Tier Checkout Admin API', function () {
       );
     });
 
-    // Turning it on is one decision; where a parcel goes is not something Ghost can guess.
-    it('still refuses to collect an address without a country to deliver to', async function () {
+    // Turning it on is one decision; where the address lands is not something Ghost can
+    // guess. Where the parcel goes it can: no countries means everywhere.
+    it('still refuses to collect an address without saying where it lands', async function () {
       const body = await setCheckout({ shipping: { collect: true } }, 422);
-      assert.match(body.errors[0].context, /at least one country/);
+      assert.match(body.errors[0].context, /which custom field this is collected into/);
     });
 
     // Ghost keeps no convention about where a collected value belongs, so a request that
@@ -483,13 +484,30 @@ describe('Tier Checkout Admin API', function () {
       assert.equal((await readCheckout()).shipping.address.custom_field_key, 'delivery_address');
     });
 
-    // An address form cannot be rendered without a country list. Stripe's reference
-    // calls it optional, but an empty collection object form-encodes to nothing, so a
-    // request built that way never asks Stripe to collect anything at all.
-    it('refuses to collect an address without countries to collect it in', async function () {
+    // Countries are a restriction, so naming none is not an incomplete request — it is a
+    // publisher who delivers everywhere. Stored as the absence of a list rather than a
+    // copy of every country, because that set moves: an enumeration saved today silently
+    // becomes a restriction the day the processor adds one.
+    it('delivers everywhere when the request names no countries', async function () {
       await createField({ name: 'Delivery address', type: 'address' });
 
-      const body = await setCheckout(shipping({ allowed_countries: undefined }), 422);
+      await setCheckout(shipping({ allowed_countries: undefined }));
+
+      const config = await readCheckout();
+      assert.equal(config.shipping.collect, true);
+      assert.equal(
+        'allowed_countries' in config.shipping,
+        false,
+        'everywhere reads back as no list, the same way it was written',
+      );
+    });
+
+    // Naming none and naming an empty list are different statements. A publisher who
+    // cleared the list said something, and it was not "deliver worldwide".
+    it('refuses an empty list of countries', async function () {
+      await createField({ name: 'Delivery address', type: 'address' });
+
+      const body = await setCheckout(shipping({ allowed_countries: [] }), 422);
       assert.match(body.errors[0].context, /at least one country/);
     });
 
@@ -643,17 +661,25 @@ describe('Tier Checkout Admin API', function () {
     });
 
     // Turning collection back on is a fresh statement of where a publisher delivers, not a
-    // resumption of the last one: the countries have to be given again, so a tier cannot
-    // quietly start delivering somewhere the publisher has since stopped.
-    it('stops collecting, and asks where to deliver again before it will resume', async function () {
+    // resumption of the last one. Resuming without countries is therefore everywhere, and
+    // must not quietly inherit the list from before — a tier that once delivered only to
+    // GB would otherwise keep refusing everyone else, with nothing in the request saying so.
+    it('stops collecting, and does not inherit the old countries when it resumes', async function () {
       await createField({ name: 'Delivery address', type: 'address' });
 
       await setCheckout(shipping());
       await setCheckout({ shipping: { collect: false } });
       assert.equal((await readCheckout()).shipping, undefined);
 
-      const body = await setCheckout(shipping({ allowed_countries: undefined }), 422);
-      assert.match(body.errors[0].context, /at least one country/);
+      await setCheckout(shipping({ allowed_countries: undefined }));
+
+      const config = await readCheckout();
+      assert.equal(config.shipping.collect, true);
+      assert.equal(
+        'allowed_countries' in config.shipping,
+        false,
+        'the GB it delivered to before came back with it',
+      );
     });
   });
 

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -7,6 +7,7 @@ const {
   matchers,
 } = require('../../utils/e2e-framework');
 const nock = require('nock');
+const { STRIPE_ALLOWED_COUNTRIES } = require('@tryghost/checkout');
 const models = require('../../../core/server/models');
 const membersService = require('../../../core/server/services/members');
 const urlServiceUtils = require('../../utils/url-service-utils');
@@ -858,6 +859,46 @@ describe('Create Stripe Checkout Session', function () {
       assert.equal(sessionBody['custom_fields[0][type]'], 'text');
       assert.equal(sessionBody['shipping_address_collection[allowed_countries][0]'], 'GB');
       assert.equal(sessionBody['shipping_address_collection[allowed_countries][1]'], 'IE');
+    });
+
+    // Ghost stores "everywhere" as no countries at all, and Stripe has no way to say that:
+    // `allowed_countries` is the only key `shipping_address_collection` has, so a request
+    // that leaves it out carries no parameter, and Stripe creates a session that succeeds
+    // and collects no address. Measured against the live API, not read from the reference,
+    // which calls the list optional. So the expansion has to happen before the request —
+    // and this is what proves it did.
+    it('asks Stripe for every country when a tier delivers everywhere', async function () {
+      const {
+        body: {
+          members_custom_fields: [address],
+        },
+      } = await adminAgent
+        .post('/members/custom_fields/')
+        .body({ members_custom_fields: [{ name: 'Delivery address', type: 'address' }] });
+
+      await adminAgent.put(`/tiers/${paidTier.id}/checkout_config/`).body({
+        tiers_checkout_config: [
+          {
+            shipping: {
+              collect: true,
+              name: { custom_field_key: 'shipping_name' },
+              address: { custom_field_key: address.key },
+            },
+          },
+        ],
+      });
+
+      const sessionBody = await startCheckout();
+
+      const sent = Object.keys(sessionBody).filter((key) =>
+        key.startsWith('shipping_address_collection[allowed_countries]'),
+      );
+      assert.equal(
+        sent.length,
+        STRIPE_ALLOWED_COUNTRIES.length,
+        'a tier that delivers everywhere has to name every country Stripe ships to',
+      );
+      assert.equal(sessionBody['shipping_address_collection[allowed_countries][0]'], 'AC');
     });
 
     // The safety property: a site that configured nothing sends what it always sent.


### PR DESCRIPTION
## Describe the problem you are solving

A tier that delivers everywhere was stored as a copy of every country Stripe ships to, and read back by comparing the saved list against that set. Both break the day the set moves. The moment Stripe adds a country, every tier previously saved as "everywhere" reads back as a restriction that excludes it, and the next save writes that narrowing for real. Nothing tells the publisher, and nothing tells us.

## What this does

Absence now carries the meaning. A request that names no countries delivers everywhere, the column is null rather than an enumeration, and the response omits the list. An empty list is still refused, because a publisher who cleared it said something and it was not "deliver worldwide". The storage column was already nullable and that state was unreachable, so nothing needs migrating.

Stripe has no equivalent sentinel, and this is the part worth knowing. The country list is the only key its shipping collection parameter has, so a request that leaves it out carries no parameter at all — and Stripe accepts that, creating a session that succeeds and collects no address. A publisher would have configured shipping, saved successfully, got a working checkout, and received nothing, with no error at any layer.

So "everywhere" is expanded to the full list at the one place that builds the session, and it never travels. A test asserts that expansion reaches the wire, because nothing else would catch a regression to an omitted parameter.

## Notes

This was measured, not assumed. The probe that establishes Ghost's Stripe constraints reported only whether a request was accepted, which is not the same as whether it does anything: Stripe's form encoding drops an empty object, so a parameter can vanish on the way out and the session is created without it. That had already produced a wrong claim in the probe's own header, that the API treats the country list as optional where the specification marks it required. The probe now reports what each accepted session will actually ask a buyer for, and both candidate sentinel shapes come back collecting nothing.

Stacked on the shared package PR, which is where the country list now lives.
