### PR TITLE
Fixed buyer name requirement for gift subscriptions

### DIFF
--- a/apps/portal/src/components/pages/beta-gift-page.tsx
+++ b/apps/portal/src/components/pages/beta-gift-page.tsx
@@ -262,12 +262,13 @@ const BetaGiftPage = () => {
   };
 
   const handleContinueToDelivery = () => {
-    const fieldsToValidate = !isLoggedIn ? [{ ...emailField, value: email.trim() }] : [];
-    const formErrors = validateInputForm({ fields: fieldsToValidate });
-
-    if (!buyerName.trim()) {
-      formErrors.buyerName = t('Enter your name');
+    const fieldsToValidate: GiftInputField[] = [];
+    if (!isLoggedIn) {
+      fieldsToValidate.push({ ...emailField, value: email.trim() });
     }
+    fieldsToValidate.push({ ...buyerNameField, value: buyerName.trim() });
+
+    const formErrors = validateInputForm({ fields: fieldsToValidate });
 
     const formHasErrors = Object.values(formErrors).some((errorMessage) => !!errorMessage);
 

--- a/apps/portal/src/components/pages/beta-gift-page.tsx
+++ b/apps/portal/src/components/pages/beta-gift-page.tsx
@@ -210,7 +210,7 @@ const BetaGiftPage = () => {
     placeholder: t('Jamie Larson'),
     label: t('Your name'),
     name: 'buyerName',
-    required: false,
+    required: true,
     maxLength: GIFT_NAME_MAX_LENGTH,
     errorMessage: errors.buyerName || '',
   };
@@ -262,17 +262,19 @@ const BetaGiftPage = () => {
   };
 
   const handleContinueToDelivery = () => {
-    if (!isLoggedIn) {
-      const formErrors = validateInputForm({
-        fields: [{ ...emailField, value: email.trim() }],
-      });
-      const formHasErrors = Object.values(formErrors).some((errorMessage) => !!errorMessage);
+    const fieldsToValidate = !isLoggedIn ? [{ ...emailField, value: email.trim() }] : [];
+    const formErrors = validateInputForm({ fields: fieldsToValidate });
 
-      setErrors(formErrors);
+    if (!buyerName.trim()) {
+      formErrors.buyerName = t('Enter your name');
+    }
 
-      if (formHasErrors) {
-        return;
-      }
+    const formHasErrors = Object.values(formErrors).some((errorMessage) => !!errorMessage);
+
+    setErrors(formErrors);
+
+    if (formHasErrors) {
+      return;
     }
     setStep('delivery');
   };
@@ -296,18 +298,11 @@ const BetaGiftPage = () => {
     const isScheduled = isEmailDelivery && effectiveDeliveryDate > minDeliveryDate;
 
     const fieldsToValidate: GiftInputField[] = [];
-    if (!isLoggedIn) {
-      fieldsToValidate.push({ ...emailField, value: customerEmail });
-    }
     if (isEmailDelivery && trimmedRecipientEmail) {
       fieldsToValidate.push({ ...recipientEmailField, value: trimmedRecipientEmail });
     }
 
     const formErrors = validateInputForm({ fields: fieldsToValidate });
-
-    if (isEmailDelivery && !trimmedBuyerName) {
-      formErrors.buyerName = t('Enter your name');
-    }
 
     // No confirm-email field: the buyer gets a confirmation copy, which covers the unlikely
     // mistyped-recipient case.
@@ -330,9 +325,6 @@ const BetaGiftPage = () => {
     setErrors(formErrors);
 
     if (formHasErrors) {
-      if (formErrors.buyerName) {
-        setStep('plan');
-      }
       return;
     }
 
@@ -343,7 +335,7 @@ const BetaGiftPage = () => {
       deliveryMethod,
       ...(isEmailDelivery ? { recipientEmail: trimmedRecipientEmail } : {}),
       ...(isEmailDelivery && trimmedRecipientName ? { recipientName: trimmedRecipientName } : {}),
-      ...(trimmedBuyerName ? { buyerName: trimmedBuyerName } : {}),
+      buyerName: trimmedBuyerName,
       ...(isEmailDelivery && trimmedGiftMessage ? { personalMessage: trimmedGiftMessage } : {}),
       ...(isScheduled ? { deliveryDate: effectiveDeliveryDate } : {}),
     });

--- a/apps/portal/src/utils/form.js
+++ b/apps/portal/src/utils/form.js
@@ -5,6 +5,7 @@ export const FormInputError = ({ field }) => {
   if (field.required && !field.value) {
     switch (field.name) {
       case 'name':
+      case 'buyerName':
         return t(`Enter your name`);
 
       case 'email':

--- a/apps/portal/test/unit/components/pages/beta-gift-page.test.tsx
+++ b/apps/portal/test/unit/components/pages/beta-gift-page.test.tsx
@@ -40,9 +40,10 @@ function setup(site: SiteData, overrideContext: Record<string, unknown> = {}) {
 describe('BetaGiftPage', () => {
   test('preserves focus on the checkout action when moving to delivery', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
-    const { getByRole } = setup(site);
+    const { getByLabelText, getByRole } = setup(site);
     const continueButton = getByRole('button', { name: 'Continue to delivery details' });
 
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     continueButton.focus();
     fireEvent.click(continueButton);
 
@@ -155,27 +156,27 @@ describe('BetaGiftPage', () => {
 
     expect(getByLabelText('Your name')).toHaveAttribute('maxlength', '191');
 
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
 
     expect(getByLabelText("Recipient's email")).toHaveAttribute('maxlength', '191');
     expect(getByLabelText("Recipient's name")).toHaveAttribute('maxlength', '191');
   });
 
-  test('requires a buyer name for email delivery', () => {
+  test('requires a buyer name before continuing to delivery', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
     const { getByLabelText, getByRole, getByText, mockDoActionFn } = setup(site);
 
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
-    fireEvent.change(getByLabelText("Recipient's email"), {
-      target: { value: 'recipient@example.com' },
-    });
-    fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
 
     expect(mockDoActionFn).not.toHaveBeenCalled();
     expect(getByText('Enter your name')).toBeInTheDocument();
 
     fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.change(getByLabelText("Recipient's email"), {
+      target: { value: 'recipient@example.com' },
+    });
     fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
 
     expect(mockDoActionFn).toHaveBeenCalledWith(
@@ -187,20 +188,15 @@ describe('BetaGiftPage', () => {
     );
   });
 
-  test('does not let a hidden recipient error lock the plan step', () => {
+  test('clears the buyer name error as the buyer types', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
     const { getByLabelText, getByRole, getByText } = setup(site);
 
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
-    fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
 
     expect(getByText('Enter your name')).toBeInTheDocument();
     fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     expect(getByRole('button', { name: 'Continue to delivery details' })).not.toBeDisabled();
-
-    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
-    expect(getByText("Enter the recipient's email address")).toBeInTheDocument();
-    expect(getByRole('button', { name: 'Continue to payment' })).toBeDisabled();
   });
 
   test('shows a buyer name field for a whitespace-only member name', () => {
@@ -249,6 +245,7 @@ describe('BetaGiftPage', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
     const { getByLabelText, getByRole, mockDoActionFn } = setup(site);
 
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
     fireEvent.change(getByLabelText("Recipient's name"), { target: { value: 'Taylor' } });
     fireEvent.change(getByLabelText("Recipient's email"), {
@@ -270,6 +267,7 @@ describe('BetaGiftPage', () => {
       tierId: 'tier_123',
       duration: 1,
       deliveryMethod: 'link',
+      buyerName: 'Jamie',
     });
   });
 

--- a/apps/portal/test/unit/components/pages/beta-gift-page.test.tsx
+++ b/apps/portal/test/unit/components/pages/beta-gift-page.test.tsx
@@ -120,13 +120,15 @@ describe('BetaGiftPage', () => {
       },
       portalDefaultPlan: 'yearly',
     });
-    const { container, getByRole } = setup(site);
+    const { container, getByLabelText, getByRole } = setup(site);
 
     expect(getByRole('radio', { name: '1 year' })).toHaveAttribute('aria-checked', 'true');
 
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    expect(getByLabelText("Recipient's email")).toBeInTheDocument();
     expect(container.querySelector('.gh-portal-gift-email-lede')).toHaveTextContent(
-      "You've been gifted a 1-year Premium membership to The Blueprint",
+      'Jamie has gifted you a 1-year Premium membership to The Blueprint',
     );
   });
 
@@ -165,11 +167,11 @@ describe('BetaGiftPage', () => {
 
   test('requires a buyer name before continuing to delivery', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
-    const { getByLabelText, getByRole, getByText, mockDoActionFn } = setup(site);
+    const { getByLabelText, getByRole, getByText, mockDoActionFn, queryByLabelText } = setup(site);
 
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
 
-    expect(mockDoActionFn).not.toHaveBeenCalled();
+    expect(queryByLabelText("Recipient's email")).not.toBeInTheDocument();
     expect(getByText('Enter your name')).toBeInTheDocument();
 
     fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
@@ -188,14 +190,28 @@ describe('BetaGiftPage', () => {
     );
   });
 
+  test('requires a recipient email before continuing to payment', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const { getByLabelText, getByRole, getByText, mockDoActionFn } = setup(site);
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
+
+    expect(mockDoActionFn).not.toHaveBeenCalled();
+    expect(getByText("Enter the recipient's email address")).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Continue to payment' })).toBeDisabled();
+  });
+
   test('clears the buyer name error as the buyer types', () => {
     const site = buildSite({ labs: { giftSubCustomization: true } });
-    const { getByLabelText, getByRole, getByText } = setup(site);
+    const { getByLabelText, getByRole, getByText, queryByText } = setup(site);
 
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
 
     expect(getByText('Enter your name')).toBeInTheDocument();
     fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    expect(queryByText('Enter your name')).not.toBeInTheDocument();
     expect(getByRole('button', { name: 'Continue to delivery details' })).not.toBeDisabled();
   });
 
@@ -210,6 +226,49 @@ describe('BetaGiftPage', () => {
     });
 
     expect(getByLabelText('Your name')).toBeInTheDocument();
+  });
+
+  test('going back clears delivery errors so the plan step is not locked', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const { getByLabelText, getByRole, getByText, queryByText } = setup(site);
+
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
+
+    expect(getByText("Enter the recipient's email address")).toBeInTheDocument();
+
+    fireEvent.click(getByRole('button', { name: /back/i }));
+
+    expect(queryByText("Enter the recipient's email address")).not.toBeInTheDocument();
+    expect(getByRole('button', { name: 'Continue to delivery details' })).not.toBeDisabled();
+
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    expect(getByLabelText("Recipient's email")).toBeInTheDocument();
+  });
+
+  test('continues without a name field for a member with a saved name', () => {
+    const site = buildSite({ labs: { giftSubCustomization: true } });
+    const { getByLabelText, getByRole, mockDoActionFn, queryByLabelText } = setup(site, {
+      member: {
+        email: 'buyer@example.com',
+        name: 'Jamie Larson',
+        status: 'free',
+      },
+    });
+
+    expect(queryByLabelText('Your name')).not.toBeInTheDocument();
+
+    fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
+    fireEvent.change(getByLabelText("Recipient's email"), {
+      target: { value: 'recipient@example.com' },
+    });
+    fireEvent.click(getByRole('button', { name: 'Continue to payment' }));
+
+    expect(mockDoActionFn).toHaveBeenCalledWith(
+      'checkoutGift',
+      expect.objectContaining({ buyerName: 'Jamie Larson' }),
+    );
   });
 
   test('omits the selector when only one duration is available', () => {

--- a/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/gift-redemption-page.test.jsx
@@ -141,6 +141,16 @@ describe('BetaGiftRedemptionPage', () => {
     expect(queryByText(member.free.name)).not.toBeInTheDocument();
   });
 
+  test('shows the anonymous introduction for a gift without a buyer name', () => {
+    const { container } = renderGiftRedemptionPage(BetaGiftRedemptionPage);
+
+    const subtitle = container.querySelector('.gh-portal-gift-checkout-subtitle');
+    expect(subtitle).toHaveTextContent(
+      "You've been gifted a 1-year Premium membership to The Blueprint",
+    );
+    expect(subtitle).toContainHTML('<strong>1-year</strong>');
+  });
+
   test('presents the buyer details and prefills the intended recipient details', async () => {
     const personalizedGift = {
       ...gift,

--- a/apps/portal/test/unit/components/popup-modal.test.jsx
+++ b/apps/portal/test/unit/components/popup-modal.test.jsx
@@ -29,6 +29,7 @@ describe('PopupContent', () => {
       },
     );
 
+    fireEvent.change(getByLabelText('Your name'), { target: { value: 'Jamie' } });
     fireEvent.click(getByRole('button', { name: 'Continue to delivery details' }));
     const message = getByLabelText('Optional message');
     fireEvent.change(message, { target: { value: 'Enjoy!' } });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3875/

- require and validate the buyer name before entering gift delivery details
- always include the validated buyer name for email and self-share checkouts
- keep delivery-step validation scoped to recipient and scheduling fields