### PR TITLE
Fixed E2E runner disk exhaustion

### DIFF
--- a/.github/actions/load-docker-image/action.yml
+++ b/.github/actions/load-docker-image/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'Docker image tags (multi-line string)'
     required: true
   artifact-name:
-    description: 'Name of the artifact to download (fork PRs only)'
+    description: 'Name of the image artifact to download'
     required: false
     default: 'docker-image'
 
@@ -20,15 +20,17 @@ runs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/${{ inputs.artifact-name }}
 
     - name: Load image from artifact (artifact)
       if: inputs.use-artifact == 'true'
       shell: bash
       env:
-        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        ARTIFACT_PATH: ${{ runner.temp }}/${{ inputs.artifact-name }}/${{ inputs.artifact-name }}.tar.gz
       run: |
+        trap 'rm -f -- "$ARTIFACT_PATH"' EXIT
         echo "Loading Docker image from artifact..."
-        gunzip -c "${ARTIFACT_NAME}.tar.gz" | docker load
+        gunzip -c "$ARTIFACT_PATH" | docker load
         echo "Available images after load:"
         docker images
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2074,10 +2074,6 @@ jobs:
             echo "build_required=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Docker Buildx
-        if: matrix.analytics == 'true' && (needs.job_setup.outputs.changed_tb_cli == 'true' || steps.pull_tb_cli.outputs.build_required == 'true')
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
       - name: Build Tinybird CLI image
         if: matrix.analytics == 'true' && (needs.job_setup.outputs.changed_tb_cli == 'true' || steps.pull_tb_cli.outputs.build_required == 'true')
         env:
@@ -2089,8 +2085,8 @@ jobs:
           else
             echo "GHCR image not available, building from source"
           fi
-          docker buildx build --load -t "$COMPOSE_IMAGE" -f docker/tb-cli/Dockerfile .
-          docker buildx prune --all --force
+          docker build --tag "$COMPOSE_IMAGE" --file docker/tb-cli/Dockerfile .
+          docker builder prune --all --force
 
       - name: Load Image
         uses: ./.github/actions/load-docker-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2060,28 +2060,37 @@ jobs:
       - name: Setup Docker Registry Mirrors
         uses: ./.github/actions/setup-docker-registry-mirrors
 
+      - name: Pull Tinybird CLI image
+        id: pull_tb_cli
+        if: matrix.analytics == 'true' && needs.job_setup.outputs.changed_tb_cli != 'true'
+        run: |
+          COMPOSE_IMAGE="${COMPOSE_PROJECT_NAME:-ghost-dev}-tb-cli"
+          if docker pull ghcr.io/tryghost/tb-cli:latest; then
+            docker tag ghcr.io/tryghost/tb-cli:latest "$COMPOSE_IMAGE"
+            echo "Pulled tb-cli from GHCR"
+            echo "build_required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "GHCR image not available, building from source"
+            echo "build_required=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Docker Buildx
+        if: matrix.analytics == 'true' && (needs.job_setup.outputs.changed_tb_cli == 'true' || steps.pull_tb_cli.outputs.build_required == 'true')
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Pull or build Tinybird CLI Image
-        if: matrix.analytics == 'true'
+      - name: Build Tinybird CLI image
+        if: matrix.analytics == 'true' && (needs.job_setup.outputs.changed_tb_cli == 'true' || steps.pull_tb_cli.outputs.build_required == 'true')
         env:
           CHANGED_TB_CLI: ${{ needs.job_setup.outputs.changed_tb_cli }}
         run: |
           COMPOSE_IMAGE="${COMPOSE_PROJECT_NAME:-ghost-dev}-tb-cli"
-          # GHCR's :latest is only republished from main, so it can't reflect a
-          # Dockerfile change under review — build from source when this PR
-          # touches it, otherwise take the prebuilt fast path.
           if [[ "$CHANGED_TB_CLI" == 'true' ]]; then
             echo "docker/tb-cli changed, building from source"
-            docker buildx build --load -t "$COMPOSE_IMAGE" -f docker/tb-cli/Dockerfile .
-          elif docker pull ghcr.io/tryghost/tb-cli:latest 2>/dev/null; then
-            echo "Pulled tb-cli from GHCR"
-            docker tag ghcr.io/tryghost/tb-cli:latest "$COMPOSE_IMAGE"
           else
             echo "GHCR image not available, building from source"
-            docker buildx build --load -t "$COMPOSE_IMAGE" -f docker/tb-cli/Dockerfile .
           fi
+          docker buildx build --load -t "$COMPOSE_IMAGE" -f docker/tb-cli/Dockerfile .
+          docker buildx prune --all --force
 
       - name: Load Image
         uses: ./.github/actions/load-docker-image
@@ -2102,6 +2111,12 @@ jobs:
         # but only needs @tryghost/e2e's dependency subgraph — not the whole monorepo
         # (admin, apps, ghost/core). Scope the install to cut shard setup time.
         run: pnpm install --frozen-lockfile --filter @tryghost/e2e...
+
+      - name: Report Analytics runner disk usage
+        if: matrix.analytics == 'true'
+        run: |
+          df -h /
+          docker system df
 
       - name: Prepare E2E CI job
         env:


### PR DESCRIPTION
## What happened

Artifact-backed Docker image transfers leave the compressed image archive in the workspace after docker load. Analytics E2E shards already pull several large service images, so that retained archive can consume the remaining runner disk and cause ENOSPC failures.

The canonical registry-backed path does not retain this archive, which makes the failure specific to forks, mirrors, and cross-repository pull requests even though they use the same workflow.

Analytics shards also provisioned a separate Buildx builder before knowing whether the prebuilt Tinybird CLI image was available. That added a BuildKit container and image during the disk-critical setup phase, while source-build cache remained until post-job cleanup.

## What changed

- Download image artifacts into runner temporary storage and delete the archive after docker load, including when loading fails.
- Pull the prebuilt Tinybird CLI image before deciding whether a source build is required.
- Build with the runner Docker builder only when the Tinybird CLI Dockerfile changed or the registry pull failed, without provisioning a separate Buildx builder.
- Prune Docker build cache immediately after a source build.
- Report filesystem and Docker usage before starting Analytics infrastructure.

All decisions are based on the image transfer and build paths. There are no repository-specific conditions.

## Testing

- pnpm check
- docker build --check --file docker/tb-cli/Dockerfile .
- Parsed both changed YAML files with js-yaml.
- Verified the changed files with oxfmt and git diff --check.

## Validation note

A same-repository TryGhost/Ghost PR takes the registry-backed path, so canonical PR CI exercises the pull/no-builder path but not the artifact cleanup or forced source-build branches. Those branches should be confirmed in a fork or mirror run before merge.

## Rollout

This only changes CI runner resource management. The existing registry-backed image path and the source-build fallback remain intact.