### PR TITLE
Added CSV import completion reports and emails

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -136,6 +136,7 @@ const controller = {
         filePath: frame.file.path,
         fileName: frame.file.name,
         mapping: frame.data.mapping,
+        requestUserEmail: frame.user ? frame.user.get('email') : null,
       });
       return { meta: { import_id: importId, total } };
     },

--- a/ghost/core/core/server/services/content-import/csv/formula.ts
+++ b/ghost/core/core/server/services/content-import/csv/formula.ts
@@ -1,0 +1,10 @@
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
+
+// Report files prefix formula-shaped cells with an apostrophe. Remove exactly
+// that guard during re-import so repeated fixes do not change publisher data.
+export function stripFormulaGuard(cell: string): string {
+  if (cell.charAt(0) === "'" && FORMULA_TRIGGERS.includes(cell.charAt(1))) {
+    return cell.slice(1);
+  }
+  return cell;
+}

--- a/ghost/core/core/server/services/content-import/csv/index.ts
+++ b/ghost/core/core/server/services/content-import/csv/index.ts
@@ -1,2 +1,9 @@
-export { default as parse, type Row } from './parse';
+export {
+  default as parse,
+  parseWithSource,
+  type ParsedCSV,
+  type ParsedRow,
+  type Row,
+} from './parse';
 export { default as serialize } from './serialize';
+export { stripFormulaGuard } from './formula';

--- a/ghost/core/core/server/services/content-import/csv/index.ts
+++ b/ghost/core/core/server/services/content-import/csv/index.ts
@@ -1,1 +1,2 @@
 export { default as parse, type Row } from './parse';
+export { default as serialize } from './serialize';

--- a/ghost/core/core/server/services/content-import/csv/parse.ts
+++ b/ghost/core/core/server/services/content-import/csv/parse.ts
@@ -1,10 +1,21 @@
 import papaparse from 'papaparse';
 import fs from 'fs-extra';
+import { stripFormulaGuard } from './formula';
 
 const errors = require('@tryghost/errors');
 
 // A parsed CSV row: raw string cells, keyed by (renamed) column.
 export type Row = Record<string, string>;
+
+export interface ParsedRow {
+  data: Row;
+  source: Row;
+}
+
+export interface ParsedCSV {
+  columns: string[];
+  rows: ParsedRow[];
+}
 
 // A column named after an Object.prototype member is unsafe as a key.
 function isSafeColumnName(name: string): boolean {
@@ -24,6 +35,14 @@ export default async function parse(
   path: string,
   headerMapping?: Record<string, string>,
 ): Promise<Row[]> {
+  const parsed = await parseWithSource(path, headerMapping);
+  return parsed.rows.map(({ data }) => data);
+}
+
+export async function parseWithSource(
+  path: string,
+  headerMapping?: Record<string, string>,
+): Promise<ParsedCSV> {
   // Buffered rather than streamed: files are bounded by the interim row cap, and
   // papaparse's stream mode drops results.errors, which is what catches a
   // malformed quoted field before it imports as garbage.
@@ -38,10 +57,11 @@ export default async function parse(
     throw new errors.ValidationError({ message: `${fatal.code}: ${fatal.message}` });
   }
 
-  const rows: Row[] = [];
+  const rows: ParsedRow[] = [];
 
   for (const parsedRow of parsed.data) {
     const row: Row = {};
+    const source: Row = Object.create(null) as Row;
 
     for (const [header, value] of Object.entries(parsedRow)) {
       // non-string values are papaparse's __parsed_extra overflow from ragged rows
@@ -49,14 +69,16 @@ export default async function parse(
         continue;
       }
 
+      source[header] = value;
+
       // hasOwn: a prototype-named header must not match an inherited method on the mapping
       if (headerMapping && Object.hasOwn(headerMapping, header)) {
         if (!headerMapping[header]) {
           continue;
         }
-        row[headerMapping[header]] = value;
+        row[headerMapping[header]] = stripFormulaGuard(value);
       } else if (isSafeColumnName(header)) {
-        row[header] = value;
+        row[header] = stripFormulaGuard(value);
       }
     }
 
@@ -64,8 +86,8 @@ export default async function parse(
       continue;
     }
 
-    rows.push(row);
+    rows.push({ data: row, source });
   }
 
-  return rows;
+  return { columns: parsed.meta.fields ?? [], rows };
 }

--- a/ghost/core/core/server/services/content-import/csv/parse.ts
+++ b/ghost/core/core/server/services/content-import/csv/parse.ts
@@ -49,7 +49,9 @@ export async function parseWithSource(
   const content = (await fs.readFile(path, 'utf8')).replace(/^\ufeff/, '');
   const parsed = papaparse.parse<Record<string, unknown>>(content, {
     header: true,
-    skipEmptyLines: true,
+    // Spreadsheet exports can represent an empty row as delimiters for every
+    // column rather than a literally blank line. Greedy mode drops both forms.
+    skipEmptyLines: 'greedy',
   });
 
   const fatal = parsed.errors.find(isFatal);

--- a/ghost/core/core/server/services/content-import/csv/parse.ts
+++ b/ghost/core/core/server/services/content-import/csv/parse.ts
@@ -10,6 +10,7 @@ export type Row = Record<string, string>;
 export interface ParsedRow {
   data: Row;
   source: Row;
+  line: number;
 }
 
 export interface ParsedCSV {
@@ -27,6 +28,15 @@ function isSafeColumnName(name: string): boolean {
 // stay tolerated: an overflow cell is dropped per row, not per file.
 function isFatal(error: papaparse.ParseError): boolean {
   return error.type === 'Quotes';
+}
+
+function isEmptyRow(row: Record<string, string | string[]>): boolean {
+  return !Object.values(row).some((value) => {
+    if (Array.isArray(value)) {
+      return value.some((cell) => typeof cell === 'string' && cell.trim().length > 0);
+    }
+    return value.trim().length > 0;
+  });
 }
 
 // headerMapping renames headers to the columns they emit under; unmapped columns
@@ -47,11 +57,11 @@ export async function parseWithSource(
   // papaparse's stream mode drops results.errors, which is what catches a
   // malformed quoted field before it imports as garbage.
   const content = (await fs.readFile(path, 'utf8')).replace(/^\ufeff/, '');
-  const parsed = papaparse.parse<Record<string, unknown>>(content, {
+  const parsed = papaparse.parse<Record<string, string | string[]>>(content, {
     header: true,
-    // Spreadsheet exports can represent an empty row as delimiters for every
-    // column rather than a literally blank line. Greedy mode drops both forms.
-    skipEmptyLines: 'greedy',
+    // Empty records stay in the parser output long enough to contribute to the
+    // publisher-visible spreadsheet line number, then are dropped below.
+    skipEmptyLines: false,
   });
 
   const fatal = parsed.errors.find(isFatal);
@@ -61,7 +71,11 @@ export async function parseWithSource(
 
   const rows: ParsedRow[] = [];
 
-  for (const parsedRow of parsed.data) {
+  for (const [index, parsedRow] of parsed.data.entries()) {
+    if (isEmptyRow(parsedRow)) {
+      continue;
+    }
+
     const row: Row = {};
     const source: Row = Object.create(null) as Row;
 
@@ -88,7 +102,7 @@ export async function parseWithSource(
       continue;
     }
 
-    rows.push({ data: row, source });
+    rows.push({ data: row, source, line: index + 2 });
   }
 
   return { columns: parsed.meta.fields ?? [], rows };

--- a/ghost/core/core/server/services/content-import/csv/serialize.ts
+++ b/ghost/core/core/server/services/content-import/csv/serialize.ts
@@ -1,0 +1,16 @@
+import papaparse from 'papaparse';
+
+interface SerializeOptions {
+  columns?: string[];
+  header?: boolean;
+}
+
+// Import reports are opened in spreadsheets, so formula-shaped cells must never
+// be emitted verbatim. Papa Parse prefixes them with an apostrophe when this
+// option is enabled.
+export default function serialize(
+  rows: Array<Record<string, unknown>>,
+  { columns, header = true }: SerializeOptions = {},
+): string {
+  return papaparse.unparse(rows, { columns, header, escapeFormulae: true });
+}

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -1,5 +1,6 @@
 import type { ImportRun, RowStatus } from './store';
 import buildImportReport from './report';
+import buildErrorsFile from './errors-file';
 
 export interface CompletionEmailPayload {
   to: string;
@@ -133,20 +134,29 @@ export default function buildCompletionEmail(
 ): CompletionEmailPayload {
   const counts = countsFor(run);
   const report = buildImportReport(run);
+  const errorsFile = buildErrorsFile(run);
+  const attachments: CompletionEmailPayload['attachments'] = [];
+  if (report) {
+    attachments.push({
+      filename: 'report.csv',
+      content: report,
+      contentType: 'text/csv',
+      contentDisposition: 'attachment',
+    });
+  }
+  if (errorsFile) {
+    attachments.push({
+      filename: 'errors.csv',
+      content: errorsFile,
+      contentType: 'text/csv',
+      contentDisposition: 'attachment',
+    });
+  }
   return {
     to: recipient,
     subject: headingFor(run, counts),
     html: renderCompletionEmail(run, recipient),
     forceTextContent: true,
-    attachments: report
-      ? [
-          {
-            filename: 'report.csv',
-            content: report,
-            contentType: 'text/csv',
-            contentDisposition: 'attachment',
-          },
-        ]
-      : [],
+    attachments,
   };
 }

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -1,4 +1,5 @@
 import type { ImportRun, RowStatus } from './store';
+import buildImportReport from './report';
 
 export interface CompletionEmailPayload {
   to: string;
@@ -131,11 +132,21 @@ export default function buildCompletionEmail(
   recipient: string,
 ): CompletionEmailPayload {
   const counts = countsFor(run);
+  const report = buildImportReport(run);
   return {
     to: recipient,
     subject: headingFor(run, counts),
     html: renderCompletionEmail(run, recipient),
     forceTextContent: true,
-    attachments: [],
+    attachments: report
+      ? [
+          {
+            filename: 'report.csv',
+            content: report,
+            contentType: 'text/csv',
+            contentDisposition: 'attachment',
+          },
+        ]
+      : [],
   };
 }

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -73,6 +73,25 @@ function summaryItems(counts: OutcomeCounts): string {
     .join('');
 }
 
+function importedPostLinks(run: ImportRun): string {
+  const rows = run.rows.filter(
+    (row) => (row.status === 'created' || row.status === 'updated') && row.url,
+  );
+  if (!rows.length) {
+    return '';
+  }
+
+  const links = rows
+    .map((row) => {
+      const title = escapeHTML(row.title || `Row ${row.line}`);
+      return `<li style="margin-bottom: 6px;"><a href="${escapeHTML(row.url as string)}" style="color: #3A464C;">${title}</a></li>`;
+    })
+    .join('');
+
+  return `<h2 style="color: #15212A; font-size: 18px; line-height: 24px; margin: 32px 0 12px;">Imported posts</h2>
+      <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${links}</ul>`;
+}
+
 function renderCompletionEmail(run: ImportRun, recipient: string): string {
   const counts = countsFor(run);
   const heading = headingFor(run, counts);
@@ -100,6 +119,7 @@ function renderCompletionEmail(run: ImportRun, recipient: string): string {
       <p style="font-size: 16px; line-height: 25px; color: #3A464C;">The import processed ${formatNumber(run.total)} ${run.total === 1 ? 'row' : 'rows'}:</p>
       <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${summaryItems(counts)}</ul>
       ${warningCopy}
+      ${importedPostLinks(run)}
       <p style="color: #738A94; font-size: 11px; line-height: 18px; margin-top: 64px;">This email was sent to <a href="mailto:${escapedRecipient}" style="color: #738A94;">${escapedRecipient}</a>.</p>
     </div>
   </body>

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -2,6 +2,10 @@ import type { ImportRun, RowStatus } from './store';
 import buildImportReport from './report';
 import buildErrorsFile from './errors-file';
 
+const { slugify } = require('@tryghost/string');
+
+const IMPORTED_POST_PREVIEW_LIMIT = 10;
+
 export interface CompletionEmailPayload {
   to: string;
   subject: string;
@@ -75,26 +79,46 @@ function summaryItems(counts: OutcomeCounts): string {
     .join('');
 }
 
-function importedPostLinks(run: ImportRun): string {
-  const rows = run.rows.filter(
-    (row) => (row.status === 'created' || row.status === 'updated') && row.url,
+function importTagSlug(runId: string): string {
+  // Internal tag slugs replace the leading # with "hash-" in the model layer.
+  return slugify(`#Import Run ${runId}`.replace(/^#/, 'hash-'));
+}
+
+function importedPostLinks(run: ImportRun, adminUrl: string): string {
+  const importedRows = run.rows.filter(
+    (row) => row.status === 'created' || row.status === 'updated',
   );
-  if (!rows.length) {
+  if (!importedRows.length) {
     return '';
   }
 
-  const links = rows
+  const rows = importedRows.filter((row) => row.url);
+  const previewRows = rows.slice(0, IMPORTED_POST_PREVIEW_LIMIT);
+
+  const links = previewRows
     .map((row) => {
       const title = escapeHTML(row.title || `Row ${row.line}`);
       return `<li style="margin-bottom: 6px;"><a href="${escapeHTML(row.url as string)}" style="color: #3A464C;">${title}</a></li>`;
     })
     .join('');
+  const remaining = importedRows.length - previewRows.length;
+  const remainingCopy = remaining
+    ? `<p style="font-size: 16px; line-height: 25px; color: #3A464C;">Including ${formatNumber(remaining)} more.</p>`
+    : '';
+  const tag = encodeURIComponent(importTagSlug(run.id));
+  const postsUrl = escapeHTML(new URL(`#/posts?tag=${tag}`, adminUrl).href);
+  const pagesUrl = escapeHTML(new URL(`#/pages?tag=${tag}`, adminUrl).href);
+  const preview = links
+    ? `<ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${links}</ul>`
+    : '';
 
-  return `<h2 style="color: #15212A; font-size: 18px; line-height: 24px; margin: 32px 0 12px;">Imported posts</h2>
-      <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${links}</ul>`;
+  return `<h2 style="color: #15212A; font-size: 18px; line-height: 24px; margin: 32px 0 12px;">Imported posts and pages</h2>
+      ${preview}
+      ${remainingCopy}
+      <p style="font-size: 16px; line-height: 25px; color: #3A464C;"><a href="${postsUrl}" style="color: #3A464C;">View imported posts</a> · <a href="${pagesUrl}" style="color: #3A464C;">View imported pages</a></p>`;
 }
 
-function renderCompletionEmail(run: ImportRun, recipient: string): string {
+function renderCompletionEmail(run: ImportRun, recipient: string, adminUrl: string): string {
   const counts = countsFor(run);
   const heading = headingFor(run, counts);
   const warningCopy = counts.warningRows
@@ -121,7 +145,7 @@ function renderCompletionEmail(run: ImportRun, recipient: string): string {
       <p style="font-size: 16px; line-height: 25px; color: #3A464C;">The import processed ${formatNumber(run.total)} ${run.total === 1 ? 'row' : 'rows'}:</p>
       <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${summaryItems(counts)}</ul>
       ${warningCopy}
-      ${importedPostLinks(run)}
+      ${importedPostLinks(run, adminUrl)}
       <p style="color: #738A94; font-size: 11px; line-height: 18px; margin-top: 64px;">This email was sent to <a href="mailto:${escapedRecipient}" style="color: #738A94;">${escapedRecipient}</a>.</p>
     </div>
   </body>
@@ -131,6 +155,7 @@ function renderCompletionEmail(run: ImportRun, recipient: string): string {
 export default function buildCompletionEmail(
   run: ImportRun,
   recipient: string,
+  adminUrl: string,
 ): CompletionEmailPayload {
   const counts = countsFor(run);
   const report = buildImportReport(run);
@@ -155,7 +180,7 @@ export default function buildCompletionEmail(
   return {
     to: recipient,
     subject: headingFor(run, counts),
-    html: renderCompletionEmail(run, recipient),
+    html: renderCompletionEmail(run, recipient, adminUrl),
     forceTextContent: true,
     attachments,
   };

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -1,0 +1,121 @@
+import type { ImportRun, RowStatus } from './store';
+
+export interface CompletionEmailPayload {
+  to: string;
+  subject: string;
+  html: string;
+  forceTextContent: boolean;
+  attachments: Array<{
+    filename: string;
+    content: string;
+    contentType: string;
+    contentDisposition: string;
+  }>;
+}
+
+type OutcomeCounts = Record<RowStatus, number> & { warningRows: number };
+
+function escapeHTML(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function countsFor(run: ImportRun): OutcomeCounts {
+  const counts: OutcomeCounts = {
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    warningRows: 0,
+  };
+
+  for (const row of run.rows) {
+    counts[row.status] += 1;
+    if (row.warnings?.length) {
+      counts.warningRows += 1;
+    }
+  }
+
+  return counts;
+}
+
+function headingFor(run: ImportRun, counts: OutcomeCounts): string {
+  if (run.status === 'failed') {
+    return 'Your content import could not be completed';
+  }
+  if (counts.failed > 0 && counts.created + counts.updated === 0) {
+    return 'Your content import was unsuccessful';
+  }
+  return 'Your content import is complete';
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString();
+}
+
+function summaryItems(counts: OutcomeCounts): string {
+  const items = [
+    ['Created', counts.created],
+    ['Updated', counts.updated],
+    ['Skipped', counts.skipped],
+    ['Failed', counts.failed],
+  ];
+
+  return items
+    .map(
+      ([label, count]) =>
+        `<li style="margin-bottom: 6px;"><strong>${label}:</strong> ${formatNumber(count as number)}</li>`,
+    )
+    .join('');
+}
+
+function renderCompletionEmail(run: ImportRun, recipient: string): string {
+  const counts = countsFor(run);
+  const heading = headingFor(run, counts);
+  const warningCopy = counts.warningRows
+    ? `<p style="font-size: 16px; line-height: 25px; color: #3A464C;"><strong>${formatNumber(counts.warningRows)}</strong> ${counts.warningRows === 1 ? 'post has' : 'posts have'} warnings.</p>`
+    : '';
+  const failureCopy =
+    run.status === 'failed'
+      ? '<p style="font-size: 16px; line-height: 25px; color: #3A464C;">Something went wrong on our end before the import could finish. There is nothing wrong with your file, and it is safe to try again.</p>'
+      : '';
+  const escapedRecipient = escapeHTML(recipient);
+
+  return `<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>${heading}</title>
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; color: #3A464C; margin: 0; padding: 0;">
+    <div style="box-sizing: border-box; margin: 0 auto; max-width: 540px; padding: 40px 20px;">
+      <img src="https://static.ghost.org/v4.0.0/images/ghost-orb-4.png" width="60" height="60" alt="Ghost" style="display: block; margin: 0 auto 40px;" />
+      <h1 style="color: #15212A; font-size: 21px; line-height: 25px; margin: 0 0 24px;">${heading}</h1>
+      ${failureCopy}
+      <p style="font-size: 16px; line-height: 25px; color: #3A464C;">The import processed ${formatNumber(run.total)} ${run.total === 1 ? 'row' : 'rows'}:</p>
+      <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${summaryItems(counts)}</ul>
+      ${warningCopy}
+      <p style="color: #738A94; font-size: 11px; line-height: 18px; margin-top: 64px;">This email was sent to <a href="mailto:${escapedRecipient}" style="color: #738A94;">${escapedRecipient}</a>.</p>
+    </div>
+  </body>
+</html>`;
+}
+
+export default function buildCompletionEmail(
+  run: ImportRun,
+  recipient: string,
+): CompletionEmailPayload {
+  const counts = countsFor(run);
+  return {
+    to: recipient,
+    subject: headingFor(run, counts),
+    html: renderCompletionEmail(run, recipient),
+    forceTextContent: true,
+    attachments: [],
+  };
+}

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -94,6 +94,8 @@ function importedPostLinks(run: ImportRun, adminUrl: string): string {
 
   const rows = importedRows.filter((row) => row.url);
   const previewRows = rows.slice(0, IMPORTED_POST_PREVIEW_LIMIT);
+  const hasPages = importedRows.some((row) => row.postType === 'page');
+  const hasPosts = importedRows.some((row) => row.postType !== 'page');
 
   const links = previewRows
     .map((row) => {
@@ -108,14 +110,24 @@ function importedPostLinks(run: ImportRun, adminUrl: string): string {
   const tag = encodeURIComponent(importTagSlug(run.id));
   const postsUrl = escapeHTML(new URL(`#/posts?tag=${tag}`, adminUrl).href);
   const pagesUrl = escapeHTML(new URL(`#/pages?tag=${tag}`, adminUrl).href);
+  let heading = 'Imported posts';
+  if (hasPages) {
+    heading = hasPosts ? 'Imported posts and pages' : 'Imported pages';
+  }
+  const filteredLinks = [
+    hasPosts ? `<a href="${postsUrl}" style="color: #3A464C;">View imported posts</a>` : '',
+    hasPages ? `<a href="${pagesUrl}" style="color: #3A464C;">View imported pages</a>` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ');
   const preview = links
     ? `<ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${links}</ul>`
     : '';
 
-  return `<h2 style="color: #15212A; font-size: 18px; line-height: 24px; margin: 32px 0 12px;">Imported posts and pages</h2>
+  return `<h2 style="color: #15212A; font-size: 18px; line-height: 24px; margin: 32px 0 12px;">${heading}</h2>
       ${preview}
       ${remainingCopy}
-      <p style="font-size: 16px; line-height: 25px; color: #3A464C;"><a href="${postsUrl}" style="color: #3A464C;">View imported posts</a> · <a href="${pagesUrl}" style="color: #3A464C;">View imported pages</a></p>`;
+      <p style="font-size: 16px; line-height: 25px; color: #3A464C;">${filteredLinks}</p>`;
 }
 
 function renderCompletionEmail(run: ImportRun, recipient: string, adminUrl: string): string {

--- a/ghost/core/core/server/services/content-import/import/errors-file.ts
+++ b/ghost/core/core/server/services/content-import/import/errors-file.ts
@@ -1,16 +1,10 @@
 import { serialize } from '../csv';
 import type { ImportRun, RowOutcome } from './store';
 
-const ANNOTATION_NAMES = [
-  'ghost_import_outcome',
-  'ghost_import_reason',
-  'ghost_import_media_failures',
-] as const;
+const ANNOTATION_NAMES = ['import_status', 'import_reason', 'import_media_failures'] as const;
 
 function isActionable(row: RowOutcome): boolean {
-  return (
-    Boolean(row.source) && (row.status === 'failed' || (row.status === 'skipped' && !row.duplicate))
-  );
+  return Boolean(row.source) && row.status === 'failed';
 }
 
 function uniqueColumnName(preferred: string, used: Set<string>): string {
@@ -34,7 +28,7 @@ export default function buildErrorsFile(run: ImportRun): string | undefined {
   const [outcomeColumn, reasonColumn, mediaFailuresColumn] = ANNOTATION_NAMES.map((name) =>
     uniqueColumnName(name, usedColumns),
   );
-  const columns = [...run.sourceColumns, outcomeColumn, reasonColumn, mediaFailuresColumn];
+  const columns = [outcomeColumn, ...run.sourceColumns, reasonColumn, mediaFailuresColumn];
 
   return serialize(
     rows.map((row) => {

--- a/ghost/core/core/server/services/content-import/import/errors-file.ts
+++ b/ghost/core/core/server/services/content-import/import/errors-file.ts
@@ -1,0 +1,53 @@
+import { serialize } from '../csv';
+import type { ImportRun, RowOutcome } from './store';
+
+const ANNOTATION_NAMES = [
+  'ghost_import_outcome',
+  'ghost_import_reason',
+  'ghost_import_media_failures',
+] as const;
+
+function isActionable(row: RowOutcome): boolean {
+  return (
+    Boolean(row.source) && (row.status === 'failed' || (row.status === 'skipped' && !row.duplicate))
+  );
+}
+
+function uniqueColumnName(preferred: string, used: Set<string>): string {
+  let candidate = preferred;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    candidate = `${preferred}_${suffix}`;
+    suffix += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+export default function buildErrorsFile(run: ImportRun): string | undefined {
+  const rows = run.rows.filter(isActionable);
+  if (!rows.length) {
+    return undefined;
+  }
+
+  const usedColumns = new Set(run.sourceColumns);
+  const [outcomeColumn, reasonColumn, mediaFailuresColumn] = ANNOTATION_NAMES.map((name) =>
+    uniqueColumnName(name, usedColumns),
+  );
+  const columns = [...run.sourceColumns, outcomeColumn, reasonColumn, mediaFailuresColumn];
+
+  return serialize(
+    rows.map((row) => {
+      const sourceCells = Object.fromEntries(
+        run.sourceColumns.map((column) => [column, row.source?.[column] ?? '']),
+      );
+      return {
+        ...sourceCells,
+        [outcomeColumn]: row.status,
+        [reasonColumn]: row.reason ?? '',
+        [mediaFailuresColumn]: row.mediaFailures?.length ? JSON.stringify(row.mediaFailures) : '',
+      };
+    }),
+    { columns },
+  );
+}

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -269,6 +269,7 @@ class ContentCSVImporter {
             },
             {
               sourceUpdatedAt: row.updated_at,
+              runTagName: importTagNames[1],
               authorNames: row.authors,
               authorEmails: row.author_emails,
               tagNames: row.tags,
@@ -281,6 +282,7 @@ class ContentCSVImporter {
               title: row.title,
               status: 'skipped',
               reason: result.reason,
+              duplicate: result.duplicate,
             });
             continue;
           }

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -9,7 +9,7 @@ import buildPostData, {
 import type { PostImportRow } from './row';
 import type { PostsRepository, WrittenPost } from './post-repository';
 import type { ImportRequest } from './schema';
-import type { Clock, ImportRunStore, RowOutcome } from './store';
+import type { Clock, ImportRun, ImportRunStore, RowOutcome } from './store';
 import type { PreparedImportSource } from './source';
 import { MediaInliningFailure, type PostMediaInlining } from './media';
 
@@ -31,6 +31,11 @@ export interface ImportAccepted {
 
 // Must not throw: it is called from catch blocks that exist to stop an error escaping.
 export type FailureReporter = (error: unknown) => void;
+
+export interface EmailNotifications {
+  send(run: ImportRun, recipient: string): Promise<unknown>;
+  getDefaultRecipient(): Promise<string>;
+}
 
 type ReadRows = (path: string, mapping?: Record<string, string>) => Promise<PostImportRow[]>;
 type PrepareSource = (request: ImportRequest) => Promise<PreparedImportSource>;
@@ -62,6 +67,7 @@ interface ImporterDeps {
   getMarkdownToHtml: () => MarkdownToHtml;
   getCleanHTML: () => CleanHTML;
   createMediaInliner: () => PostMediaInlining;
+  email: EmailNotifications;
   addJob: (job: { job: () => Promise<void>; offloaded: boolean; name: string }) => void;
   report: FailureReporter;
   store: ImportRunStore;
@@ -86,6 +92,7 @@ class ContentCSVImporter {
   private _getMarkdownToHtml: () => MarkdownToHtml;
   private _getCleanHTML: () => CleanHTML;
   private _createMediaInliner: () => PostMediaInlining;
+  private _email: EmailNotifications;
   private _addJob: ImporterDeps['addJob'];
   private _report: FailureReporter;
   private _store: ImportRunStore;
@@ -102,6 +109,7 @@ class ContentCSVImporter {
     getMarkdownToHtml,
     getCleanHTML,
     createMediaInliner,
+    email,
     addJob,
     report,
     store,
@@ -117,6 +125,7 @@ class ContentCSVImporter {
     this._getMarkdownToHtml = getMarkdownToHtml;
     this._getCleanHTML = getCleanHTML;
     this._createMediaInliner = createMediaInliner;
+    this._email = email;
     this._addJob = addJob;
     this._report = report;
     this._store = store;
@@ -127,6 +136,7 @@ class ContentCSVImporter {
   }
 
   async importCSV(request: ImportRequest): Promise<ImportAccepted> {
+    const emailRecipient = request.requestUserEmail ?? (await this._email.getDefaultRecipient());
     const source = await this._prepareSource(request);
     let rows: PostImportRow[];
     try {
@@ -155,13 +165,14 @@ class ContentCSVImporter {
     logLifecycle('queued');
     try {
       this._addJob({
-        job: () => this.runImportJob(runId, importTagNames, rows, source),
+        job: () => this.runImportJob(runId, importTagNames, rows, source, emailRecipient),
         offloaded: false,
         name: 'content-import',
       });
     } catch (error) {
       this._store.fail(runId, messageOf(error));
       await this.cleanupSource(source.cleanup);
+      this._store.release(runId);
       throw error;
     }
 
@@ -175,6 +186,7 @@ class ContentCSVImporter {
     importTagNames: string[],
     rows: PostImportRow[],
     source: PreparedImportSource,
+    emailRecipient: string,
   ): Promise<void> {
     const startedAt = Date.now();
     logLifecycle('started');
@@ -330,6 +342,11 @@ class ContentCSVImporter {
       this._store.fail(runId, messageOf(error));
     } finally {
       await this.cleanupSource(source.cleanup);
+      const run = this._store.get(runId);
+      if (run) {
+        await this.settle(() => this._email.send(run, emailRecipient));
+      }
+      this._store.release(runId);
       const outcome = failed ? 'failed after' : 'completed in';
       logLifecycle(`${outcome} ${Date.now() - startedAt}ms`);
     }
@@ -352,6 +369,14 @@ class ContentCSVImporter {
   private async cleanupSource(cleanup: () => Promise<void>): Promise<void> {
     try {
       await cleanup();
+    } catch (error) {
+      this._report(error);
+    }
+  }
+
+  private async settle(operation: () => Promise<unknown>): Promise<void> {
+    try {
+      await operation();
     } catch (error) {
       this._report(error);
     }

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -11,6 +11,7 @@ import type { PostsRepository, WrittenPost } from './post-repository';
 import type { ImportRequest } from './schema';
 import type { Clock, ImportRun, ImportRunStore, RowOutcome } from './store';
 import type { PreparedImportSource } from './source';
+import type { PreparedPostRow, PreparedPostRows } from './reader';
 import { MediaInliningFailure, type PostMediaInlining } from './media';
 
 export type { ImportRequest } from './schema';
@@ -37,7 +38,10 @@ export interface EmailNotifications {
   getDefaultRecipient(): Promise<string>;
 }
 
-type ReadRows = (path: string, mapping?: Record<string, string>) => Promise<PostImportRow[]>;
+type ReadRows = (
+  path: string,
+  mapping?: Record<string, string>,
+) => Promise<PreparedPostRows | PostImportRow[]>;
 type PrepareSource = (request: ImportRequest) => Promise<PreparedImportSource>;
 
 const messages = {
@@ -138,9 +142,12 @@ class ContentCSVImporter {
   async importCSV(request: ImportRequest): Promise<ImportAccepted> {
     const emailRecipient = request.requestUserEmail ?? (await this._email.getDefaultRecipient());
     const source = await this._prepareSource(request);
-    let rows: PostImportRow[];
+    let preparedRows: PreparedPostRows;
     try {
-      rows = await this._readRows(source.filePath, request.mapping);
+      const result = await this._readRows(source.filePath, request.mapping);
+      preparedRows = Array.isArray(result)
+        ? { columns: [], rows: result.map((data) => ({ data })) }
+        : result;
     } catch (error) {
       await this.cleanupSource(source.cleanup);
       throw new errors.ValidationError({
@@ -151,7 +158,7 @@ class ContentCSVImporter {
 
     // Temporary while import state is held in memory: the durable job
     // system milestone removes the cap.
-    if (rows.length > MAX_POSTS) {
+    if (preparedRows.rows.length > MAX_POSTS) {
       await this.cleanupSource(source.cleanup);
       throw new errors.ValidationError({
         message: tpl(messages.tooManyPosts, { max: MAX_POSTS }),
@@ -160,12 +167,13 @@ class ContentCSVImporter {
 
     const runId = this._newRunId();
     const importTagNames = buildImportTagNames(runId, this._getTimezone(), this._now());
-    this._store.create(runId, rows.length);
+    this._store.create(runId, preparedRows.rows.length, preparedRows.columns);
 
     logLifecycle('queued');
     try {
       this._addJob({
-        job: () => this.runImportJob(runId, importTagNames, rows, source, emailRecipient),
+        job: () =>
+          this.runImportJob(runId, importTagNames, preparedRows.rows, source, emailRecipient),
         offloaded: false,
         name: 'content-import',
       });
@@ -176,7 +184,7 @@ class ContentCSVImporter {
       throw error;
     }
 
-    return { importId: runId, total: rows.length };
+    return { importId: runId, total: preparedRows.rows.length };
   }
 
   // Must resolve in every case: the job manager reads a rejected inline job as a
@@ -184,7 +192,7 @@ class ContentCSVImporter {
   private async runImportJob(
     runId: string,
     importTagNames: string[],
-    rows: PostImportRow[],
+    rows: PreparedPostRow[],
     source: PreparedImportSource,
     emailRecipient: string,
   ): Promise<void> {
@@ -197,7 +205,7 @@ class ContentCSVImporter {
     try {
       if (source.assets) {
         await source.assets.store();
-        source.assets.rewriteRows(rows);
+        source.assets.rewriteRows(rows.map(({ data }) => data));
       }
 
       const htmlToLexical = this._getHtmlToLexical();
@@ -208,15 +216,16 @@ class ContentCSVImporter {
       let failedRows = 0;
       let firstRowFailure: unknown;
 
-      for (const [index, row] of rows.entries()) {
+      for (const [index, preparedRow] of rows.entries()) {
         const line = index + 2;
+        const { data: row, source: sourceCells } = preparedRow;
         let data: PostData;
 
         try {
           data = buildPostData(row, htmlToLexical, importTagNames, markdownToHtml, cleanHTML);
         } catch (error) {
           if (error instanceof RowSkipped) {
-            this._store.record(runId, {
+            this.recordOutcome(runId, sourceCells, {
               line,
               title: row.title || null,
               status: 'skipped',
@@ -238,7 +247,7 @@ class ContentCSVImporter {
               firstRowFailure = error;
             }
             failedRows += 1;
-            this._store.record(runId, {
+            this.recordOutcome(runId, sourceCells, {
               line,
               title: row.title,
               status: 'failed',
@@ -277,7 +286,7 @@ class ContentCSVImporter {
           );
 
           if (result.status === 'skipped') {
-            this._store.record(runId, {
+            this.recordOutcome(runId, sourceCells, {
               line,
               title: row.title,
               status: 'skipped',
@@ -296,7 +305,7 @@ class ContentCSVImporter {
             firstRowFailure = error;
           }
           failedRows += 1;
-          this._store.record(runId, {
+          this.recordOutcome(runId, sourceCells, {
             line,
             title: row.title,
             status: 'failed',
@@ -320,7 +329,7 @@ class ContentCSVImporter {
           }
           urlFailureCount += 1;
         }
-        this._store.record(runId, outcome);
+        this.recordOutcome(runId, sourceCells, outcome);
       }
 
       if (failedRows > 0 && successfulWrites === 0) {
@@ -352,6 +361,14 @@ class ContentCSVImporter {
       const outcome = failed ? 'failed after' : 'completed in';
       logLifecycle(`${outcome} ${Date.now() - startedAt}ms`);
     }
+  }
+
+  private recordOutcome(
+    runId: string,
+    source: Record<string, string> | undefined,
+    outcome: RowOutcome,
+  ): void {
+    this._store.record(runId, source ? { ...outcome, source } : outcome);
   }
 
   private reportUrlFailures(count: number, firstFailure: unknown): void {

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -319,6 +319,7 @@ class ContentCSVImporter {
           title: row.title,
           status: writeStatus,
           postId: post.id,
+          postType: data.type,
           ...(warnings.length > 0 ? { warnings } : {}),
         };
         try {

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -146,7 +146,7 @@ class ContentCSVImporter {
     try {
       const result = await this._readRows(source.filePath, request.mapping);
       preparedRows = Array.isArray(result)
-        ? { columns: [], rows: result.map((data) => ({ data })) }
+        ? { columns: [], rows: result.map((data, index) => ({ data, line: index + 2 })) }
         : result;
     } catch (error) {
       await this.cleanupSource(source.cleanup);
@@ -216,9 +216,8 @@ class ContentCSVImporter {
       let failedRows = 0;
       let firstRowFailure: unknown;
 
-      for (const [index, preparedRow] of rows.entries()) {
-        const line = index + 2;
-        const { data: row, source: sourceCells } = preparedRow;
+      for (const preparedRow of rows) {
+        const { data: row, source: sourceCells, line } = preparedRow;
         let data: PostData;
 
         try {

--- a/ghost/core/core/server/services/content-import/import/importer.ts
+++ b/ghost/core/core/server/services/content-import/import/importer.ts
@@ -228,7 +228,7 @@ class ContentCSVImporter {
             this.recordOutcome(runId, sourceCells, {
               line,
               title: row.title || null,
-              status: 'skipped',
+              status: 'failed',
               reason: messageOf(error),
             });
             continue;

--- a/ghost/core/core/server/services/content-import/import/post-link.ts
+++ b/ghost/core/core/server/services/content-import/import/post-link.ts
@@ -1,0 +1,16 @@
+import type { WrittenPost } from './post-repository';
+
+interface PostLinkOptions {
+  adminUrl: string;
+  publishedUrl(post: WrittenPost): string;
+}
+
+export function urlForImportedPost(post: WrittenPost, options: PostLinkOptions): string {
+  const data = post.toJSON();
+  if (data.status === 'draft') {
+    const editorType = data.type === 'page' ? 'page' : 'post';
+    return new URL(`#/editor/${editorType}/${post.id}`, options.adminUrl).href;
+  }
+
+  return options.publishedUrl(post);
+}

--- a/ghost/core/core/server/services/content-import/import/post-repository.ts
+++ b/ghost/core/core/server/services/content-import/import/post-repository.ts
@@ -1,4 +1,5 @@
 import type { PostData } from './post-data';
+import type { DuplicateMetadata } from './store';
 import {
   BookshelfPostRelationsResolver,
   type PostRelationSource,
@@ -14,10 +15,11 @@ export interface WrittenPost {
 export type PostWriteResult =
   | { status: 'created'; post: WrittenPost; warnings: string[] }
   | { status: 'updated'; post: WrittenPost; warnings: string[] }
-  | { status: 'skipped'; reason: string };
+  | { status: 'skipped'; reason: string; duplicate: DuplicateMetadata };
 
 export interface PostWriteMetadata extends PostRelationSource {
   sourceUpdatedAt?: string;
+  runTagName?: string;
 }
 
 export interface PostsRepository {
@@ -54,8 +56,18 @@ export class BookshelfPostsRepository implements PostsRepository {
   ): Promise<PostWriteResult> {
     return this._models.Base.transaction(async (transacting) => {
       const writeOptions = { ...options, transacting };
-      const lookupOptions = { ...writeOptions, forUpdate: true };
-      let existingMatch: { post: WrittenPost; duplicateReason: string } | undefined;
+      const lookupOptions = {
+        ...writeOptions,
+        forUpdate: true,
+        ...(metadata.runTagName ? { withRelated: ['tags'] } : {}),
+      };
+      let existingMatch:
+        | {
+            post: WrittenPost;
+            duplicateReason: string;
+            matchedBy: DuplicateMetadata['matchedBy'];
+          }
+        | undefined;
 
       if (data.comment_id) {
         const existing = await this._models.Post.findOne(
@@ -67,6 +79,7 @@ export class BookshelfPostsRepository implements PostsRepository {
           existingMatch = {
             post: existing,
             duplicateReason: `A post with the source ID "${data.comment_id}" already exists.`,
+            matchedBy: 'source_id',
           };
         }
       }
@@ -81,14 +94,19 @@ export class BookshelfPostsRepository implements PostsRepository {
           existingMatch = {
             post: existing,
             duplicateReason: `A post with the slug "${data.slug}" already exists.`,
+            matchedBy: 'slug',
           };
         }
       }
 
       if (existingMatch) {
-        const { post: existing, duplicateReason } = existingMatch;
+        const { post: existing, duplicateReason, matchedBy } = existingMatch;
+        const duplicate: DuplicateMetadata = {
+          origin: hasRunTag(existing, metadata.runTagName) ? 'this_import' : 'pre_existing',
+          matchedBy,
+        };
         if (!metadata.sourceUpdatedAt) {
-          return { status: 'skipped', reason: duplicateReason };
+          return { status: 'skipped', reason: duplicateReason, duplicate };
         }
 
         const incomingInstant = new Date(metadata.sourceUpdatedAt).getTime();
@@ -104,6 +122,7 @@ export class BookshelfPostsRepository implements PostsRepository {
           return {
             status: 'skipped',
             reason: 'The existing post is newer than or as recent as the imported row.',
+            duplicate,
           };
         }
 
@@ -135,4 +154,22 @@ export class BookshelfPostsRepository implements PostsRepository {
       return { status: 'created', post, warnings: resolved.warnings };
     });
   }
+}
+
+function hasRunTag(post: WrittenPost, runTagName?: string): boolean {
+  if (!runTagName) {
+    return false;
+  }
+
+  const tags = post.toJSON().tags;
+  return (
+    Array.isArray(tags) &&
+    tags.some(
+      (tag) =>
+        typeof tag === 'object' &&
+        tag !== null &&
+        'name' in tag &&
+        (tag as { name?: unknown }).name === runTagName,
+    )
+  );
 }

--- a/ghost/core/core/server/services/content-import/import/reader.ts
+++ b/ghost/core/core/server/services/content-import/import/reader.ts
@@ -1,14 +1,30 @@
-import { parse as parseCSV } from '../csv';
+import { parseWithSource, type Row } from '../csv';
 import { EDITORIAL_POST_FIELDS, postImportRowSchema, type PostImportRow } from './row';
 
 const FIELD_BY_HEADER: Record<string, string> = Object.fromEntries(
   EDITORIAL_POST_FIELDS.map((field) => [field, field]),
 );
 
+export interface PreparedPostRow {
+  data: PostImportRow;
+  source?: Row;
+}
+
+export interface PreparedPostRows {
+  columns: string[];
+  rows: PreparedPostRow[];
+}
+
 export default async function readPostRows(
   path: string,
   mapping?: Record<string, string>,
-): Promise<PostImportRow[]> {
-  const rows = await parseCSV(path, mapping ?? FIELD_BY_HEADER);
-  return rows.map((row) => postImportRowSchema.parse(row));
+): Promise<PreparedPostRows> {
+  const parsed = await parseWithSource(path, mapping ?? FIELD_BY_HEADER);
+  return {
+    columns: parsed.columns,
+    rows: parsed.rows.map(({ data, source }) => ({
+      data: postImportRowSchema.parse(data),
+      source,
+    })),
+  };
 }

--- a/ghost/core/core/server/services/content-import/import/reader.ts
+++ b/ghost/core/core/server/services/content-import/import/reader.ts
@@ -8,6 +8,7 @@ const FIELD_BY_HEADER: Record<string, string> = Object.fromEntries(
 export interface PreparedPostRow {
   data: PostImportRow;
   source?: Row;
+  line: number;
 }
 
 export interface PreparedPostRows {
@@ -22,9 +23,10 @@ export default async function readPostRows(
   const parsed = await parseWithSource(path, mapping ?? FIELD_BY_HEADER);
   return {
     columns: parsed.columns,
-    rows: parsed.rows.map(({ data, source }) => ({
+    rows: parsed.rows.map(({ data, source, line }) => ({
       data: postImportRowSchema.parse(data),
       source,
+      line,
     })),
   };
 }

--- a/ghost/core/core/server/services/content-import/import/report.ts
+++ b/ghost/core/core/server/services/content-import/import/report.ts
@@ -13,10 +13,6 @@ const REPORT_COLUMNS = [
   'post_url',
 ];
 
-function includedInReport(row: RowOutcome): boolean {
-  return row.status === 'skipped' || row.status === 'failed' || Boolean(row.warnings?.length);
-}
-
 function formatMediaFailures(row: RowOutcome): string {
   return (
     row.mediaFailures?.map(({ sourceUrl, reason }) => `${sourceUrl}: ${reason}`).join('\n') ?? ''
@@ -24,13 +20,12 @@ function formatMediaFailures(row: RowOutcome): string {
 }
 
 export default function buildImportReport(run: ImportRun): string | undefined {
-  const rows = run.rows.filter(includedInReport);
-  if (!rows.length) {
+  if (!run.rows.length) {
     return undefined;
   }
 
   return serialize(
-    rows.map((row) => ({
+    run.rows.map((row) => ({
       line: row.line,
       title: row.title ?? '',
       outcome: row.duplicate ? 'duplicate' : row.status,

--- a/ghost/core/core/server/services/content-import/import/report.ts
+++ b/ghost/core/core/server/services/content-import/import/report.ts
@@ -1,0 +1,46 @@
+import { serialize } from '../csv';
+import type { ImportRun, RowOutcome } from './store';
+
+const REPORT_COLUMNS = [
+  'line',
+  'title',
+  'outcome',
+  'reason',
+  'duplicate_origin',
+  'matched_by',
+  'warnings',
+  'media_failures',
+  'post_url',
+];
+
+function includedInReport(row: RowOutcome): boolean {
+  return row.status === 'skipped' || row.status === 'failed' || Boolean(row.warnings?.length);
+}
+
+function formatMediaFailures(row: RowOutcome): string {
+  return (
+    row.mediaFailures?.map(({ sourceUrl, reason }) => `${sourceUrl}: ${reason}`).join('\n') ?? ''
+  );
+}
+
+export default function buildImportReport(run: ImportRun): string | undefined {
+  const rows = run.rows.filter(includedInReport);
+  if (!rows.length) {
+    return undefined;
+  }
+
+  return serialize(
+    rows.map((row) => ({
+      line: row.line,
+      title: row.title ?? '',
+      outcome: row.duplicate ? 'duplicate' : row.status,
+      reason: row.reason ?? '',
+      duplicate_origin: row.duplicate?.origin ?? '',
+      matched_by: row.duplicate?.matchedBy ?? '',
+      warnings: row.warnings?.join('\n') ?? '',
+      media_failures: formatMediaFailures(row),
+      post_url: row.url ?? '',
+    })),
+    { columns: REPORT_COLUMNS },
+  );
+}

--- a/ghost/core/core/server/services/content-import/import/schema.ts
+++ b/ghost/core/core/server/services/content-import/import/schema.ts
@@ -26,6 +26,7 @@ export const importRequestSchema = z.object({
   filePath: z.string().min(1),
   fileName: z.string().min(1),
   mapping: mappingSchema.optional(),
+  requestUserEmail: z.string().email().nullable().optional(),
 });
 
 export type ImportRequest = z.infer<typeof importRequestSchema>;

--- a/ghost/core/core/server/services/content-import/import/store.ts
+++ b/ghost/core/core/server/services/content-import/import/store.ts
@@ -24,6 +24,7 @@ export interface RowOutcome {
   mediaFailures?: Array<{ sourceUrl: string; reason: string }>;
   warnings?: string[];
   postId?: string;
+  postType?: 'post' | 'page';
   url?: string;
   source?: Record<string, string>;
 }

--- a/ghost/core/core/server/services/content-import/import/store.ts
+++ b/ghost/core/core/server/services/content-import/import/store.ts
@@ -25,6 +25,7 @@ export interface RowOutcome {
   warnings?: string[];
   postId?: string;
   url?: string;
+  source?: Record<string, string>;
 }
 
 export interface ImportRun {
@@ -34,6 +35,7 @@ export interface ImportRun {
   finishedAt?: Date;
   failureReason?: string;
   total: number;
+  sourceColumns: string[];
   rows: RowOutcome[];
 }
 
@@ -50,7 +52,7 @@ export class ImportRunStore {
     this._now = now;
   }
 
-  create(id: string, total: number): ImportRun {
+  create(id: string, total: number, sourceColumns: string[] = []): ImportRun {
     this.evict();
 
     const run: ImportRun = {
@@ -58,6 +60,7 @@ export class ImportRunStore {
       status: 'running',
       startedAt: this._now(),
       total,
+      sourceColumns,
       rows: [],
     };
     this._runs.set(id, run);

--- a/ghost/core/core/server/services/content-import/import/store.ts
+++ b/ghost/core/core/server/services/content-import/import/store.ts
@@ -83,6 +83,10 @@ export class ImportRunStore {
     return this._runs.get(id);
   }
 
+  release(id: string): void {
+    this._runs.delete(id);
+  }
+
   // A running run is never evicted, whatever its age: the job holds only the runId,
   // so evicting mid-import would silently turn its record()/finish() calls into
   // no-ops and lose the report. The count cap can briefly overshoot while several

--- a/ghost/core/core/server/services/content-import/import/store.ts
+++ b/ghost/core/core/server/services/content-import/import/store.ts
@@ -8,6 +8,11 @@ export type Clock = () => Date;
 
 export type RowStatus = 'created' | 'updated' | 'skipped' | 'failed';
 
+export interface DuplicateMetadata {
+  origin: 'this_import' | 'pre_existing';
+  matchedBy: 'source_id' | 'slug';
+}
+
 export interface RowOutcome {
   // Source line number as a publisher sees it in a spreadsheet: the header is
   // line 1, so the first data row is line 2.
@@ -15,6 +20,7 @@ export interface RowOutcome {
   title: string | null;
   status: RowStatus;
   reason?: string;
+  duplicate?: DuplicateMetadata;
   mediaFailures?: Array<{ sourceUrl: string; reason: string }>;
   warnings?: string[];
   postId?: string;

--- a/ghost/core/core/server/services/content-import/import/store.ts
+++ b/ghost/core/core/server/services/content-import/import/store.ts
@@ -2,8 +2,8 @@
 // outcome per row. Nothing is persisted; the durable job system milestone
 // replaces this.
 
-// skipped = the row was never attempted (the publisher can fix the file);
-// failed = row processing was attempted but did not produce a post.
+// skipped = an otherwise valid row required no write (for example a duplicate);
+// failed = the row could not produce a post, including source validation errors.
 export type Clock = () => Date;
 
 export type RowStatus = 'created' | 'updated' | 'skipped' | 'failed';

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -12,6 +12,7 @@ import { ImportRunStore } from './import/store';
 import { prepareImportSource } from './import/source';
 import { PostMediaInliner } from './import/media';
 import { isLocalMediaUrl } from './import/local-media-url';
+import { urlForImportedPost } from './import/post-link';
 
 // The request is built from HTTP upload metadata, so it is validated at the
 // service boundary rather than trusted.
@@ -32,6 +33,7 @@ function makeImporter(): ContentCSVImporter {
   const jobsService = require('../jobs');
   const settingsCache = require('../../../shared/settings-cache');
   const urlService = require('../url');
+  const urlUtils = require('../../../shared/url-utils').default;
   const mediaInlinerService = require('../media-inliner');
   const config = require('../../../shared/config');
   const ObjectID = require('bson-objectid').default;
@@ -82,9 +84,15 @@ function makeImporter(): ContentCSVImporter {
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),
-    // Degrades to the 404 URL for a post the URL service cannot route yet (e.g. a draft).
     urlForPost: (post) =>
-      urlService.getUrlForResource({ ...post.toJSON(), type: 'posts' }, { absolute: true }),
+      urlForImportedPost(post, {
+        adminUrl: urlUtils.urlFor('admin', true),
+        publishedUrl: (publishedPost) =>
+          urlService.getUrlForResource(
+            { ...publishedPost.toJSON(), type: 'posts' },
+            { absolute: true },
+          ),
+      }),
     newRunId: () => new ObjectID().toHexString(),
     getTimezone: () => timezoneSchema.parse(settingsCache.get('timezone')),
   });

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -55,7 +55,8 @@ function makeImporter(): ContentCSVImporter {
   };
 
   const email: EmailNotifications = {
-    send: (run, recipient) => ghostMailer.send(buildCompletionEmail(run, recipient)),
+    send: (run, recipient) =>
+      ghostMailer.send(buildCompletionEmail(run, recipient, urlUtils.urlFor('admin', true))),
     getDefaultRecipient: async () => (await models.User.getOwnerUser()).get('email'),
   };
 

--- a/ghost/core/core/server/services/content-import/index.ts
+++ b/ghost/core/core/server/services/content-import/index.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import ContentCSVImporter, { type ImportAccepted, type FailureReporter } from './import/importer';
+import ContentCSVImporter, {
+  type ImportAccepted,
+  type FailureReporter,
+  type EmailNotifications,
+} from './import/importer';
+import buildCompletionEmail from './import/completion-email';
 import { BookshelfPostsRepository } from './import/post-repository';
 import readPostRows from './import/reader';
 import { importRequestSchema, type ImportRequest } from './import/schema';
@@ -30,6 +35,8 @@ function makeImporter(): ContentCSVImporter {
   const mediaInlinerService = require('../media-inliner');
   const config = require('../../../shared/config');
   const ObjectID = require('bson-objectid').default;
+  const { GhostMailer } = require('../mail');
+  const ghostMailer = new GhostMailer();
 
   // Inline jobs never reach the job manager's Sentry handler, which is wired to the
   // offloaded worker path only, so a throw here would be seen by nobody.
@@ -43,6 +50,11 @@ function makeImporter(): ContentCSVImporter {
     } catch {
       // Callers report from catch blocks, so this must not throw.
     }
+  };
+
+  const email: EmailNotifications = {
+    send: (run, recipient) => ghostMailer.send(buildCompletionEmail(run, recipient)),
+    getDefaultRecipient: async () => (await models.User.getOwnerUser()).get('email'),
   };
 
   return new ContentCSVImporter({
@@ -66,6 +78,7 @@ function makeImporter(): ContentCSVImporter {
             ],
           }),
       }),
+    email,
     addJob: jobsService.addJob.bind(jobsService),
     report,
     store: new ImportRunStore(),

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -204,7 +204,7 @@ describe('Posts Importer API', function () {
     const { data: rows } = papaparse.parse(report.content.trim(), {
       header: true,
     });
-    assert.equal(rows.length, 5);
+    assert.equal(rows.length, 6);
     const sameRun = rows.find((row) => row.title === 'Duplicate in this run');
     assert.equal(sameRun.outcome, 'duplicate');
     assert.equal(sameRun.duplicate_origin, 'this_import');
@@ -216,15 +216,13 @@ describe('Posts Importer API', function () {
     assert.equal(rows.find((row) => row.title === 'Invalid status').outcome, 'failed');
     assert.equal(rows.find((row) => row.title === 'Write failure').outcome, 'failed');
     assert.match(rows.find((row) => row.title === 'Warning success').warnings, /assigned Owner/);
-    assert.equal(
-      rows.some((row) => row.title === 'First in this run'),
-      false,
-    );
+    assert.equal(rows.find((row) => row.title === 'First in this run').outcome, 'created');
 
     const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
     assert.ok(errorsFile);
     const { data: errorRows, meta } = papaparse.parse(errorsFile.content.trim(), { header: true });
-    assert.deepEqual(meta.fields.slice(0, 6), [
+    assert.deepEqual(meta.fields.slice(0, 7), [
+      'import_status',
       'title',
       'slug',
       'status',
@@ -250,13 +248,13 @@ describe('Posts Importer API', function () {
     await agent.loginAsOwner();
     const zipPath = await zipFile('posts-import-errors-source.zip', {
       'wrapper/posts.csv':
-        'Body,Headline,State,ghost_import_outcome\n<p>Keep source cells</p>,ZIP invalid,scheduled,publisher value\n',
+        'Body,Headline,State,import_status\n<p>Keep source cells</p>,ZIP invalid,scheduled,publisher value\n',
     });
     const form = new FormData();
     form.append('mapping[Body]', 'html');
     form.append('mapping[Headline]', 'title');
     form.append('mapping[State]', 'status');
-    form.append('mapping[ghost_import_outcome]', '');
+    form.append('mapping[import_status]', '');
     form.append('postsfile', await fs.readFile(zipPath), {
       filename: path.basename(zipPath),
       contentType: 'application/zip',
@@ -274,19 +272,19 @@ describe('Posts Importer API', function () {
     assert.ok(errorsFile);
     const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });
     assert.deepEqual(parsed.meta.fields, [
+      'import_status_2',
       'Body',
       'Headline',
       'State',
-      'ghost_import_outcome',
-      'ghost_import_outcome_2',
-      'ghost_import_reason',
-      'ghost_import_media_failures',
+      'import_status',
+      'import_reason',
+      'import_media_failures',
     ]);
     assert.equal(parsed.data[0].Body, '<p>Keep source cells</p>');
     assert.equal(parsed.data[0].Headline, 'ZIP invalid');
     assert.equal(parsed.data[0].State, 'scheduled');
-    assert.equal(parsed.data[0].ghost_import_outcome, 'publisher value');
-    assert.equal(parsed.data[0].ghost_import_outcome_2, 'failed');
+    assert.equal(parsed.data[0].import_status, 'publisher value');
+    assert.equal(parsed.data[0].import_status_2, 'failed');
 
     const retryForm = new FormData();
     retryForm.append('mapping[Body]', 'html');
@@ -441,7 +439,7 @@ describe('Posts Importer API', function () {
     const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });
     assert.equal(parsed.data.length, 1);
     assert.equal(parsed.data[0].title, 'Unsupported remote media');
-    assert.deepEqual(JSON.parse(parsed.data[0].ghost_import_media_failures), [
+    assert.deepEqual(JSON.parse(parsed.data[0].import_media_failures), [
       {
         sourceUrl: `${origin}/unsupported.exe`,
         reason: 'No configured storage accepts this media file.',

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -158,12 +158,18 @@ describe('Posts Importer API', function () {
     assert.ok(draft);
     assert.match(email.html, /Completion email created/);
     assert.match(email.html, /\/completion-email-created\//);
+    assert.match(email.html, /Imported posts/);
+    assert.doesNotMatch(email.html, /Imported posts and pages/);
     assert.ok(
       email.html.includes(`/#/editor/post/${draft.id}`),
       'the draft links to its Admin editor',
     );
     assert.match(email.html, new RegExp(`/#/posts\\?tag=hash-import-run-${body.meta.import_id}`));
-    assert.match(email.html, new RegExp(`/#/pages\\?tag=hash-import-run-${body.meta.import_id}`));
+    assert.doesNotMatch(email.html, /View imported pages/);
+    assert.doesNotMatch(
+      email.html,
+      new RegExp(`/#/pages\\?tag=hash-import-run-${body.meta.import_id}`),
+    );
   });
 
   it('attaches a report that classifies same-run and pre-existing duplicates', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -138,7 +138,10 @@ describe('Posts Importer API', function () {
         'Completion email draft,<p>Draft</p>,draft\n',
     );
 
-    await agent.post('posts/upload/').attach('postsfile', completionCsvPath).expectStatus(202);
+    const { body } = await agent
+      .post('posts/upload/')
+      .attach('postsfile', completionCsvPath)
+      .expectStatus(202);
     await jobsService.allSettled();
 
     const email = mockManager.assert.sentEmail({
@@ -159,6 +162,8 @@ describe('Posts Importer API', function () {
       email.html.includes(`/#/editor/post/${draft.id}`),
       'the draft links to its Admin editor',
     );
+    assert.match(email.html, new RegExp(`/#/posts\\?tag=hash-import-run-${body.meta.import_id}`));
+    assert.match(email.html, new RegExp(`/#/pages\\?tag=hash-import-run-${body.meta.import_id}`));
   });
 
   it('attaches a report that classifies same-run and pre-existing duplicates', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -102,6 +102,7 @@ describe('Posts Importer API', function () {
     // Each test logs in as a different role — reset the login rate limiter
     // so the repeated logins don't trip spam prevention
     await resetRateLimits();
+    mockManager.mockMail();
     remoteImportedMediaUrls = [];
     await Promise.all(getImportedAssetPaths().map((filePath) => fs.rm(filePath, { force: true })));
   });
@@ -125,6 +126,29 @@ describe('Posts Importer API', function () {
       .attach('postsfile', csvPath)
       .expectStatus(202)
       .expect(cacheInvalidateHeaderNotSet());
+  });
+
+  it('emails the requesting user when an accepted CSV import finishes', async function () {
+    await agent.loginAsOwner();
+    const completionCsvPath = await csvFile(
+      'posts-import-completion-email.csv',
+      'title,html,status\n' +
+        'Completion email created,<p>Created</p>,published\n' +
+        'Completion email draft,<p>Draft</p>,draft\n',
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', completionCsvPath).expectStatus(202);
+    await jobsService.allSettled();
+
+    const email = mockManager.assert.sentEmail({
+      subject: 'Your content import is complete',
+      to: 'jbloggs@example.com',
+    });
+    assert.match(email.html, /processed 2 rows/);
+    assert.match(email.html, /Created:<\/strong> 2/);
+    assert.match(email.html, /Updated:<\/strong> 0/);
+    assert.match(email.html, /Skipped:<\/strong> 0/);
+    assert.match(email.html, /Failed:<\/strong> 0/);
   });
 
   it('Keeps content import initialization idempotent and rejects invalid service requests', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -12,6 +12,7 @@ const {
 const { cacheInvalidateHeaderNotSet } = assertions;
 const path = require('path');
 const nock = require('nock');
+const papaparse = require('papaparse');
 const models = require('../../../core/server/models');
 const jobsService = require('../../../core/server/services/jobs');
 const mediaInlinerService = require('../../../core/server/services/media-inliner');
@@ -157,6 +158,59 @@ describe('Posts Importer API', function () {
     assert.ok(
       email.html.includes(`/#/editor/post/${draft.id}`),
       'the draft links to its Admin editor',
+    );
+  });
+
+  it('attaches a report that classifies same-run and pre-existing duplicates', async function () {
+    await agent.loginAsOwner();
+    const preExistingPath = await csvFile(
+      'posts-import-report-pre-existing.csv',
+      'title,slug\nPre-existing report post,report-pre-existing\n',
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', preExistingPath).expectStatus(202);
+    await jobsService.allSettled();
+    mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+
+    const reportPath = await csvFile(
+      'posts-import-report.csv',
+      [
+        'title,slug,status,custom_excerpt,authors,author_emails',
+        'First in this run,report-same-run,draft,,,',
+        'Duplicate in this run,report-same-run,draft,,,',
+        'Pre-existing duplicate,report-pre-existing,draft,,,',
+        'Invalid status,report-invalid-status,scheduled,,,',
+        `Write failure,report-write-failure,draft,${'x'.repeat(301)},,`,
+        'Warning success,report-warning,draft,,Warning Author,not-an-email',
+      ].join('\n'),
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', reportPath).expectStatus(202);
+    await jobsService.allSettled();
+
+    const email = mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    assert.equal(email.attachments.length, 1);
+    assert.equal(email.attachments[0].filename, 'report.csv');
+    assert.equal(email.attachments[0].contentType, 'text/csv');
+
+    const { data: rows } = papaparse.parse(email.attachments[0].content.trim(), {
+      header: true,
+    });
+    assert.equal(rows.length, 5);
+    const sameRun = rows.find((row) => row.title === 'Duplicate in this run');
+    assert.equal(sameRun.outcome, 'duplicate');
+    assert.equal(sameRun.duplicate_origin, 'this_import');
+    assert.equal(sameRun.matched_by, 'slug');
+    const preExisting = rows.find((row) => row.title === 'Pre-existing duplicate');
+    assert.equal(preExisting.outcome, 'duplicate');
+    assert.equal(preExisting.duplicate_origin, 'pre_existing');
+    assert.equal(preExisting.matched_by, 'slug');
+    assert.equal(rows.find((row) => row.title === 'Invalid status').outcome, 'skipped');
+    assert.equal(rows.find((row) => row.title === 'Write failure').outcome, 'failed');
+    assert.match(rows.find((row) => row.title === 'Warning success').warnings, /assigned Owner/);
+    assert.equal(
+      rows.some((row) => row.title === 'First in this run'),
+      false,
     );
   });
 

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -189,11 +189,12 @@ describe('Posts Importer API', function () {
     await jobsService.allSettled();
 
     const email = mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
-    assert.equal(email.attachments.length, 1);
-    assert.equal(email.attachments[0].filename, 'report.csv');
-    assert.equal(email.attachments[0].contentType, 'text/csv');
+    assert.equal(email.attachments.length, 2);
+    const report = email.attachments.find(({ filename }) => filename === 'report.csv');
+    assert.ok(report);
+    assert.equal(report.contentType, 'text/csv');
 
-    const { data: rows } = papaparse.parse(email.attachments[0].content.trim(), {
+    const { data: rows } = papaparse.parse(report.content.trim(), {
       header: true,
     });
     assert.equal(rows.length, 5);
@@ -212,6 +213,81 @@ describe('Posts Importer API', function () {
       rows.some((row) => row.title === 'First in this run'),
       false,
     );
+
+    const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
+    assert.ok(errorsFile);
+    const { data: errorRows, meta } = papaparse.parse(errorsFile.content.trim(), { header: true });
+    assert.deepEqual(meta.fields.slice(0, 6), [
+      'title',
+      'slug',
+      'status',
+      'custom_excerpt',
+      'authors',
+      'author_emails',
+    ]);
+    assert.deepEqual(
+      errorRows.map(({ title }) => title),
+      ['Invalid status', 'Write failure'],
+    );
+    assert.equal(
+      errorRows.some(({ title }) => title === 'Duplicate in this run'),
+      false,
+    );
+    assert.equal(
+      errorRows.some(({ title }) => title === 'Warning success'),
+      false,
+    );
+  });
+
+  it('preserves mapped ZIP source columns and avoids annotation collisions', async function () {
+    await agent.loginAsOwner();
+    const zipPath = await zipFile('posts-import-errors-source.zip', {
+      'wrapper/posts.csv':
+        'Body,Headline,State,ghost_import_outcome\n<p>Keep source cells</p>,ZIP invalid,scheduled,publisher value\n',
+    });
+    const form = new FormData();
+    form.append('mapping[Body]', 'html');
+    form.append('mapping[Headline]', 'title');
+    form.append('mapping[State]', 'status');
+    form.append('mapping[ghost_import_outcome]', '');
+    form.append('postsfile', await fs.readFile(zipPath), {
+      filename: path.basename(zipPath),
+      contentType: 'application/zip',
+    });
+
+    await agent.post('posts/upload/').body(form).expectStatus(202);
+    await jobsService.allSettled();
+
+    const email = mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
+    assert.ok(errorsFile);
+    const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });
+    assert.deepEqual(parsed.meta.fields, [
+      'Body',
+      'Headline',
+      'State',
+      'ghost_import_outcome',
+      'ghost_import_outcome_2',
+      'ghost_import_reason',
+      'ghost_import_media_failures',
+    ]);
+    assert.equal(parsed.data[0].Body, '<p>Keep source cells</p>');
+    assert.equal(parsed.data[0].Headline, 'ZIP invalid');
+    assert.equal(parsed.data[0].State, 'scheduled');
+    assert.equal(parsed.data[0].ghost_import_outcome, 'publisher value');
+    assert.equal(parsed.data[0].ghost_import_outcome_2, 'skipped');
+
+    const retryForm = new FormData();
+    retryForm.append('mapping[Body]', 'html');
+    retryForm.append('mapping[Headline]', 'title');
+    retryForm.append('mapping[State]', 'status');
+    retryForm.append('postsfile', Buffer.from(errorsFile.content), {
+      filename: 'errors.csv',
+      contentType: 'text/csv',
+    });
+    await agent.post('posts/upload/').body(retryForm).expectStatus(202);
+    await jobsService.allSettled();
+    mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
   });
 
   it('Keeps content import initialization idempotent and rejects invalid service requests', async function () {
@@ -347,6 +423,19 @@ describe('Posts Importer API', function () {
       status: 'all',
     });
     assert.ok(continuedPost);
+
+    const email = mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
+    assert.ok(errorsFile);
+    const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });
+    assert.equal(parsed.data.length, 1);
+    assert.equal(parsed.data[0].title, 'Unsupported remote media');
+    assert.deepEqual(JSON.parse(parsed.data[0].ghost_import_media_failures), [
+      {
+        sourceUrl: `${origin}/unsupported.exe`,
+        reason: 'No configured storage accepts this media file.',
+      },
+    ]);
   });
 
   it('preserves current-site media URLs without fetching or validating them', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -190,6 +190,7 @@ describe('Posts Importer API', function () {
         'First in this run,report-same-run,draft,,,',
         'Duplicate in this run,report-same-run,draft,,,',
         'Pre-existing duplicate,report-pre-existing,draft,,,',
+        ',,,,,',
         'Invalid status,report-invalid-status,scheduled,,,',
         `Write failure,report-write-failure,draft,${'x'.repeat(301)},,`,
         'Warning success,report-warning,draft,,Warning Author,not-an-email',
@@ -225,7 +226,9 @@ describe('Posts Importer API', function () {
     assert.equal(preExisting.duplicate_origin, 'pre_existing');
     assert.equal(preExisting.matched_by, 'slug');
     assert.equal(rows.find((row) => row.title === 'Invalid status').outcome, 'failed');
+    assert.equal(rows.find((row) => row.title === 'Invalid status').line, '6');
     assert.equal(rows.find((row) => row.title === 'Write failure').outcome, 'failed');
+    assert.equal(rows.find((row) => row.title === 'Write failure').line, '7');
     assert.match(rows.find((row) => row.title === 'Warning success').warnings, /assigned Owner/);
     assert.equal(rows.find((row) => row.title === 'First in this run').outcome, 'created');
 

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -149,6 +149,15 @@ describe('Posts Importer API', function () {
     assert.match(email.html, /Updated:<\/strong> 0/);
     assert.match(email.html, /Skipped:<\/strong> 0/);
     assert.match(email.html, /Failed:<\/strong> 0/);
+
+    const draft = await models.Post.findOne({ title: 'Completion email draft', status: 'all' });
+    assert.ok(draft);
+    assert.match(email.html, /Completion email created/);
+    assert.match(email.html, /\/completion-email-created\//);
+    assert.ok(
+      email.html.includes(`/#/editor/post/${draft.id}`),
+      'the draft links to its Admin editor',
+    );
   });
 
   it('Keeps content import initialization idempotent and rejects invalid service requests', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -182,6 +182,8 @@ describe('Posts Importer API', function () {
         'Invalid status,report-invalid-status,scheduled,,,',
         `Write failure,report-write-failure,draft,${'x'.repeat(301)},,`,
         'Warning success,report-warning,draft,,Warning Author,not-an-email',
+        ',,,,,',
+        '  ,  ,  ,  ,  ,  ',
       ].join('\n'),
     );
 
@@ -189,6 +191,11 @@ describe('Posts Importer API', function () {
     await jobsService.allSettled();
 
     const email = mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    assert.match(email.html, /processed 6 rows/);
+    assert.match(email.html, /Created:<\/strong> 2/);
+    assert.match(email.html, /Updated:<\/strong> 0/);
+    assert.match(email.html, /Skipped:<\/strong> 2/);
+    assert.match(email.html, /Failed:<\/strong> 2/);
     assert.equal(email.attachments.length, 2);
     const report = email.attachments.find(({ filename }) => filename === 'report.csv');
     assert.ok(report);
@@ -206,7 +213,7 @@ describe('Posts Importer API', function () {
     assert.equal(preExisting.outcome, 'duplicate');
     assert.equal(preExisting.duplicate_origin, 'pre_existing');
     assert.equal(preExisting.matched_by, 'slug');
-    assert.equal(rows.find((row) => row.title === 'Invalid status').outcome, 'skipped');
+    assert.equal(rows.find((row) => row.title === 'Invalid status').outcome, 'failed');
     assert.equal(rows.find((row) => row.title === 'Write failure').outcome, 'failed');
     assert.match(rows.find((row) => row.title === 'Warning success').warnings, /assigned Owner/);
     assert.equal(
@@ -258,7 +265,11 @@ describe('Posts Importer API', function () {
     await agent.post('posts/upload/').body(form).expectStatus(202);
     await jobsService.allSettled();
 
-    const email = mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    const email = mockManager.assert.sentEmail({
+      subject: 'Your content import was unsuccessful',
+    });
+    assert.match(email.html, /Skipped:<\/strong> 0/);
+    assert.match(email.html, /Failed:<\/strong> 1/);
     const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
     assert.ok(errorsFile);
     const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });
@@ -275,7 +286,7 @@ describe('Posts Importer API', function () {
     assert.equal(parsed.data[0].Headline, 'ZIP invalid');
     assert.equal(parsed.data[0].State, 'scheduled');
     assert.equal(parsed.data[0].ghost_import_outcome, 'publisher value');
-    assert.equal(parsed.data[0].ghost_import_outcome_2, 'skipped');
+    assert.equal(parsed.data[0].ghost_import_outcome_2, 'failed');
 
     const retryForm = new FormData();
     retryForm.append('mapping[Body]', 'html');
@@ -287,7 +298,7 @@ describe('Posts Importer API', function () {
     });
     await agent.post('posts/upload/').body(retryForm).expectStatus(202);
     await jobsService.allSettled();
-    mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    mockManager.assert.sentEmail({ subject: 'Your content import was unsuccessful' });
   });
 
   it('Keeps content import initialization idempotent and rejects invalid service requests', async function () {

--- a/ghost/core/test/e2e-webhooks/posts-importer.test.ts
+++ b/ghost/core/test/e2e-webhooks/posts-importer.test.ts
@@ -133,8 +133,11 @@ describe('CSV content import side-effects', function () {
     // Zero webhooks: the receiver never recorded a request
     assert.equal(webhookMockReceiver.body, undefined, 'no webhook fired for the imported posts');
 
-    // Zero transactional mail
-    mockManager.assert.sentEmailCount(0);
+    // The only mail side effects are the completion emails for the two
+    // accepted import runs. No per-post or newsletter mail is sent.
+    mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    mockManager.assert.sentEmail({ subject: 'Your content import is complete' });
+    mockManager.assert.sentEmailCount(2);
 
     // Zero newsletters: a newsletter can only be attached via the API layer, which
     // the importer never touches.

--- a/ghost/core/test/unit/server/services/content-import/csv/parse.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/csv/parse.test.ts
@@ -72,7 +72,7 @@ describe('content import csv parse', function () {
   });
 
   it('drops a blank line rather than emitting an empty row', async function () {
-    const result = await parse(
+    const result = await parseWithSource(
       await csvFile(
         'title,html,published_at\n' +
           'Before blank,<p>a</p>,2025-01-01T00:00:00.000Z\n' +
@@ -82,9 +82,13 @@ describe('content import csv parse', function () {
       HEADER_MAPPING,
     );
 
-    assert.equal(result.length, 2);
-    assert.equal(result[0].title, 'Before blank');
-    assert.equal(result[1].title, 'After blank');
+    assert.equal(result.rows.length, 2);
+    assert.equal(result.rows[0].data.title, 'Before blank');
+    assert.equal(result.rows[1].data.title, 'After blank');
+    assert.deepEqual(
+      result.rows.map(({ line }) => line),
+      [2, 4],
+    );
   });
 
   it('drops delimiter-only rows emitted by spreadsheet applications', async function () {
@@ -123,6 +127,17 @@ describe('content import csv parse', function () {
       html: '<p>Hi</p>',
       published_at: '2025-01-01T00:00:00.000Z',
     });
+  });
+
+  it('keeps a row with content only in overflow cells', async function () {
+    const result = await parseWithSource(
+      await csvFile('title,html\n' + ',,overflow\n'),
+      HEADER_MAPPING,
+    );
+
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0].line, 2);
+    assert.deepEqual(result.rows[0].data, { title: '', html: '' });
   });
 
   it('rejects a file with an unterminated quoted field instead of importing garbage', async function () {
@@ -169,6 +184,7 @@ describe('content import csv parse', function () {
     );
 
     assert.deepEqual(result.columns, ['Body', 'Ignore me', 'Headline']);
+    assert.equal(result.rows[0].line, 2);
     assert.deepEqual(result.rows[0].data, { html: '<p>World</p>', title: 'Hello' });
     assert.deepEqual(
       { ...result.rows[0].source },

--- a/ghost/core/test/unit/server/services/content-import/csv/parse.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/csv/parse.test.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import assert from 'node:assert/strict';
-import { parse } from '../../../../../../core/server/services/content-import/csv';
+import papaparse from 'papaparse';
+import sinon from 'sinon';
+import { parse, parseWithSource } from '../../../../../../core/server/services/content-import/csv';
 
 // The CSVs live inline: each case writes its content to a temp file, so the
 // fixture sits next to the assertions that read it.
@@ -137,5 +139,56 @@ describe('content import csv parse', function () {
 
     assert.equal(result.length, 1);
     assert.equal(result[0].custom_thing, 'kept');
+  });
+
+  it('preserves original cells and source-column order before mapping', async function () {
+    const result = await parseWithSource(
+      await csvFile('Body,Ignore me,Headline\n<p>World</p>,unused,Hello\n'),
+      { Body: 'html', 'Ignore me': '', Headline: 'title' },
+    );
+
+    assert.deepEqual(result.columns, ['Body', 'Ignore me', 'Headline']);
+    assert.deepEqual(result.rows[0].data, { html: '<p>World</p>', title: 'Hello' });
+    assert.deepEqual(
+      { ...result.rows[0].source },
+      {
+        Body: '<p>World</p>',
+        'Ignore me': 'unused',
+        Headline: 'Hello',
+      },
+    );
+  });
+
+  it('drops a row when every source column is explicitly ignored', async function () {
+    const result = await parseWithSource(await csvFile('Ignore me\nunmapped value\n'), {
+      'Ignore me': '',
+    });
+
+    assert.deepEqual(result.columns, ['Ignore me']);
+    assert.deepEqual(result.rows, []);
+  });
+
+  it('uses an empty source-column list when the parser has no header metadata', async function () {
+    const parseStub = sinon
+      .stub(papaparse, 'parse')
+      .returns({ data: [], errors: [], meta: {} } as never);
+
+    try {
+      const result = await parseWithSource(await csvFile(''));
+      assert.deepEqual(result, { columns: [], rows: [] });
+    } finally {
+      parseStub.restore();
+    }
+  });
+
+  it('strips a report formula guard from imported data but preserves the source cell', async function () {
+    const result = await parseWithSource(
+      await csvFile("title,html\n'=SUM(A1:A2),'ordinary apostrophe\n"),
+      HEADER_MAPPING,
+    );
+
+    assert.equal(result.rows[0].data.title, '=SUM(A1:A2)');
+    assert.equal(result.rows[0].data.html, "'ordinary apostrophe");
+    assert.equal(result.rows[0].source.title, "'=SUM(A1:A2)");
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/csv/parse.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/csv/parse.test.ts
@@ -87,6 +87,27 @@ describe('content import csv parse', function () {
     assert.equal(result[1].title, 'After blank');
   });
 
+  it('drops delimiter-only rows emitted by spreadsheet applications', async function () {
+    const result = await parse(
+      await csvFile(
+        'title,html,published_at\n' +
+          'Actual post,<p>Body</p>,2025-01-01T00:00:00.000Z\n' +
+          ',,\n' +
+          '  ,  ,  \n' +
+          ',,\n',
+      ),
+      HEADER_MAPPING,
+    );
+
+    assert.deepEqual(result, [
+      {
+        title: 'Actual post',
+        html: '<p>Body</p>',
+        published_at: '2025-01-01T00:00:00.000Z',
+      },
+    ]);
+  });
+
   it('ignores the overflow cells of a ragged row', async function () {
     const result = await parse(
       await csvFile(

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -32,7 +32,11 @@ describe('content import completion email', function () {
     assert.equal(email.to, 'requester@example.com');
     assert.equal(email.subject, 'Your content import is complete');
     assert.equal(email.forceTextContent, true);
-    assert.deepEqual(email.attachments, []);
+    assert.equal(email.attachments.length, 1);
+    assert.equal(email.attachments[0].filename, 'report.csv');
+    assert.equal(email.attachments[0].contentType, 'text/csv');
+    assert.equal(email.attachments[0].contentDisposition, 'attachment');
+    assert.match(email.attachments[0].content, /Skipped/);
     assert.match(email.html, /Created:<\/strong> 2/);
     assert.match(email.html, /Updated:<\/strong> 1/);
     assert.match(email.html, /Skipped:<\/strong> 1/);
@@ -51,6 +55,21 @@ describe('content import completion email', function () {
 
     assert.equal(email.subject, 'Your content import was unsuccessful');
     assert.match(email.html, /processed 1 row:/);
+  });
+
+  it('omits the report attachment for a completely clean run', function () {
+    const email = buildCompletionEmail(
+      run({
+        total: 2,
+        rows: [
+          { line: 2, title: 'Created', status: 'created' },
+          { line: 3, title: 'Updated', status: 'updated' },
+        ],
+      }),
+      'owner@example.com',
+    );
+
+    assert.deepEqual(email.attachments, []);
   });
 
   it('uses plural warning copy for multiple warning-bearing posts', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -9,6 +9,7 @@ function run(overrides: Partial<ImportRun> = {}): ImportRun {
     startedAt: new Date('2026-01-01T10:00:00.000Z'),
     finishedAt: new Date('2026-01-01T10:01:00.000Z'),
     total: 5,
+    sourceColumns: [],
     rows: [
       { line: 2, title: 'Created', status: 'created' },
       { line: 3, title: 'Updated', status: 'updated' },
@@ -70,6 +71,30 @@ describe('content import completion email', function () {
     );
 
     assert.deepEqual(email.attachments, []);
+  });
+
+  it('attaches both the report and actionable errors file in stable order', function () {
+    const email = buildCompletionEmail(
+      run({
+        total: 1,
+        sourceColumns: ['Title', 'State'],
+        rows: [
+          {
+            line: 2,
+            title: 'Invalid',
+            status: 'skipped',
+            reason: 'status is invalid',
+            source: { Title: 'Invalid', State: 'scheduled' },
+          },
+        ],
+      }),
+      'owner@example.com',
+    );
+
+    assert.deepEqual(
+      email.attachments.map(({ filename }) => filename),
+      ['report.csv', 'errors.csv'],
+    );
   });
 
   it('uses plural warning copy for multiple warning-bearing posts', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -58,7 +58,7 @@ describe('content import completion email', function () {
     assert.match(email.html, /processed 1 row:/);
   });
 
-  it('omits the report attachment for a completely clean run', function () {
+  it('attaches a report for a completely clean run', function () {
     const email = buildCompletionEmail(
       run({
         total: 2,
@@ -70,7 +70,10 @@ describe('content import completion email', function () {
       'owner@example.com',
     );
 
-    assert.deepEqual(email.attachments, []);
+    assert.deepEqual(
+      email.attachments.map(({ filename }) => filename),
+      ['report.csv'],
+    );
   });
 
   it('attaches both the report and actionable errors file in stable order', function () {
@@ -82,7 +85,7 @@ describe('content import completion email', function () {
           {
             line: 2,
             title: 'Invalid',
-            status: 'skipped',
+            status: 'failed',
             reason: 'status is invalid',
             source: { Title: 'Invalid', State: 'scheduled' },
           },

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -179,7 +179,10 @@ describe('content import completion email', function () {
       ADMIN_URL,
     );
 
-    assert.match(email.html, /Imported posts and pages/);
+    assert.match(email.html, /Imported posts/);
+    assert.match(email.html, /View imported posts/);
+    assert.doesNotMatch(email.html, /Imported posts and pages/);
+    assert.doesNotMatch(email.html, /View imported pages/);
     assert.match(email.html, /Published &amp; linked/);
     assert.match(email.html, /published\/\?one=1&amp;two=2/);
     assert.match(email.html, /&lt;Draft&gt;/);
@@ -187,7 +190,31 @@ describe('content import completion email', function () {
     assert.doesNotMatch(email.html, /No URL/);
     assert.doesNotMatch(email.html, /must-not-render/);
     assert.match(email.html, /#\/posts\?tag=hash-import-run-run_test/);
+  });
+
+  it('shows only the pages heading and filter link for page-only imports', function () {
+    const email = buildCompletionEmail(
+      run({
+        rows: [
+          {
+            line: 2,
+            title: 'Imported page',
+            status: 'created',
+            postType: 'page',
+            url: 'https://example.com/imported-page/',
+          },
+        ],
+      }),
+      'owner@example.com',
+      ADMIN_URL,
+    );
+
+    assert.match(email.html, /Imported pages/);
+    assert.match(email.html, /View imported pages/);
+    assert.doesNotMatch(email.html, /Imported posts and pages/);
+    assert.doesNotMatch(email.html, /View imported posts/);
     assert.match(email.html, /#\/pages\?tag=hash-import-run-run_test/);
+    assert.doesNotMatch(email.html, /#\/posts\?tag=hash-import-run-run_test/);
   });
 
   it('uses the row number when a linked outcome has no title', function () {
@@ -214,6 +241,7 @@ describe('content import completion email', function () {
       line: index + 2,
       title: `Imported ${index + 1}`,
       status: 'created',
+      postType: index % 2 === 0 ? ('post' as const) : ('page' as const),
       url: `https://example.com/imported-${index + 1}/`,
     }));
     const email = buildCompletionEmail(
@@ -225,6 +253,7 @@ describe('content import completion email', function () {
     assert.match(email.html, /Imported 10/);
     assert.doesNotMatch(email.html, /Imported 11/);
     assert.match(email.html, /Including 25 more\./);
+    assert.match(email.html, /Imported posts and pages/);
     assert.match(
       email.html,
       /https:\/\/example\.com\/blog\/ghost\/#\/posts\?tag=hash-import-run-6a9072a2e385e56d77b83c15/,

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import buildCompletionEmail from '../../../../../../core/server/services/content-import/import/completion-email';
+import type { ImportRun } from '../../../../../../core/server/services/content-import/import/store';
+
+function run(overrides: Partial<ImportRun> = {}): ImportRun {
+  return {
+    id: 'run_test',
+    status: 'complete',
+    startedAt: new Date('2026-01-01T10:00:00.000Z'),
+    finishedAt: new Date('2026-01-01T10:01:00.000Z'),
+    total: 5,
+    rows: [
+      { line: 2, title: 'Created', status: 'created' },
+      { line: 3, title: 'Updated', status: 'updated' },
+      { line: 4, title: 'Skipped', status: 'skipped', reason: 'Invalid' },
+      { line: 5, title: 'Failed', status: 'failed', reason: 'Write failed' },
+      {
+        line: 6,
+        title: 'Warning',
+        status: 'created',
+        warnings: ['Assigned Owner'],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('content import completion email', function () {
+  it('summarises every row outcome and warning-bearing post', function () {
+    const email = buildCompletionEmail(run(), 'requester@example.com');
+
+    assert.equal(email.to, 'requester@example.com');
+    assert.equal(email.subject, 'Your content import is complete');
+    assert.equal(email.forceTextContent, true);
+    assert.deepEqual(email.attachments, []);
+    assert.match(email.html, /Created:<\/strong> 2/);
+    assert.match(email.html, /Updated:<\/strong> 1/);
+    assert.match(email.html, /Skipped:<\/strong> 1/);
+    assert.match(email.html, /Failed:<\/strong> 1/);
+    assert.match(email.html, /1<\/strong> post has warnings/);
+  });
+
+  it('uses an unsuccessful subject when every attempted write failed', function () {
+    const email = buildCompletionEmail(
+      run({
+        total: 1,
+        rows: [{ line: 2, title: 'Failed', status: 'failed', reason: 'Write failed' }],
+      }),
+      'owner@example.com',
+    );
+
+    assert.equal(email.subject, 'Your content import was unsuccessful');
+    assert.match(email.html, /processed 1 row:/);
+  });
+
+  it('uses plural warning copy for multiple warning-bearing posts', function () {
+    const email = buildCompletionEmail(
+      run({
+        total: 2,
+        rows: [
+          { line: 2, title: 'First', status: 'created', warnings: ['First warning'] },
+          { line: 3, title: 'Second', status: 'updated', warnings: ['Second warning'] },
+        ],
+      }),
+      'owner@example.com',
+    );
+
+    assert.match(email.html, /2<\/strong> posts have warnings/);
+  });
+
+  it('uses a generic failure message for a fatal run', function () {
+    const email = buildCompletionEmail(
+      run({ status: 'failed', failureReason: 'database password leaked here' }),
+      'owner@example.com',
+    );
+
+    assert.equal(email.subject, 'Your content import could not be completed');
+    assert.match(email.html, /Something went wrong on our end/);
+    assert.doesNotMatch(email.html, /database password/);
+  });
+
+  it('escapes the recipient in the HTML footer', function () {
+    const email = buildCompletionEmail(run(), 'unsafe<email@example.com');
+
+    assert.match(email.html, /unsafe&lt;email@example\.com/);
+    assert.doesNotMatch(email.html, /unsafe<email@example\.com/);
+  });
+});

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -85,4 +85,59 @@ describe('content import completion email', function () {
     assert.match(email.html, /unsafe&lt;email@example\.com/);
     assert.doesNotMatch(email.html, /unsafe<email@example\.com/);
   });
+
+  it('links every created and updated post with a resolved URL', function () {
+    const email = buildCompletionEmail(
+      run({
+        rows: [
+          {
+            line: 2,
+            title: 'Published & linked',
+            status: 'created',
+            url: 'https://example.com/published/?one=1&two=2',
+          },
+          {
+            line: 3,
+            title: '<Draft>',
+            status: 'updated',
+            url: 'https://example.com/ghost/#/editor/post/draft-id',
+          },
+          { line: 4, title: 'No URL', status: 'created' },
+          {
+            line: 5,
+            title: 'Skipped URL',
+            status: 'skipped',
+            url: 'https://example.com/must-not-render/',
+          },
+        ],
+      }),
+      'owner@example.com',
+    );
+
+    assert.match(email.html, /Imported posts/);
+    assert.match(email.html, /Published &amp; linked/);
+    assert.match(email.html, /published\/\?one=1&amp;two=2/);
+    assert.match(email.html, /&lt;Draft&gt;/);
+    assert.match(email.html, /#\/editor\/post\/draft-id/);
+    assert.doesNotMatch(email.html, /No URL/);
+    assert.doesNotMatch(email.html, /must-not-render/);
+  });
+
+  it('uses the row number when a linked outcome has no title', function () {
+    const email = buildCompletionEmail(
+      run({
+        rows: [
+          {
+            line: 7,
+            title: null,
+            status: 'created',
+            url: 'https://example.com/untitled/',
+          },
+        ],
+      }),
+      'owner@example.com',
+    );
+
+    assert.match(email.html, />Row 7<\/a>/);
+  });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import buildCompletionEmail from '../../../../../../core/server/services/content-import/import/completion-email';
 import type { ImportRun } from '../../../../../../core/server/services/content-import/import/store';
 
+const ADMIN_URL = 'https://example.com/ghost/';
+
 function run(overrides: Partial<ImportRun> = {}): ImportRun {
   return {
     id: 'run_test',
@@ -28,7 +30,7 @@ function run(overrides: Partial<ImportRun> = {}): ImportRun {
 
 describe('content import completion email', function () {
   it('summarises every row outcome and warning-bearing post', function () {
-    const email = buildCompletionEmail(run(), 'requester@example.com');
+    const email = buildCompletionEmail(run(), 'requester@example.com', ADMIN_URL);
 
     assert.equal(email.to, 'requester@example.com');
     assert.equal(email.subject, 'Your content import is complete');
@@ -52,6 +54,7 @@ describe('content import completion email', function () {
         rows: [{ line: 2, title: 'Failed', status: 'failed', reason: 'Write failed' }],
       }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
     assert.equal(email.subject, 'Your content import was unsuccessful');
@@ -68,6 +71,7 @@ describe('content import completion email', function () {
         ],
       }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
     assert.deepEqual(
@@ -92,6 +96,7 @@ describe('content import completion email', function () {
         ],
       }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
     assert.deepEqual(
@@ -110,6 +115,7 @@ describe('content import completion email', function () {
         ],
       }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
     assert.match(email.html, /2<\/strong> posts have warnings/);
@@ -119,6 +125,7 @@ describe('content import completion email', function () {
     const email = buildCompletionEmail(
       run({ status: 'failed', failureReason: 'database password leaked here' }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
     assert.equal(email.subject, 'Your content import could not be completed');
@@ -126,8 +133,18 @@ describe('content import completion email', function () {
     assert.doesNotMatch(email.html, /database password/);
   });
 
+  it('omits attachments when a fatal run stopped before processing a row', function () {
+    const email = buildCompletionEmail(
+      run({ status: 'failed', total: 0, rows: [] }),
+      'owner@example.com',
+      ADMIN_URL,
+    );
+
+    assert.deepEqual(email.attachments, []);
+  });
+
   it('escapes the recipient in the HTML footer', function () {
-    const email = buildCompletionEmail(run(), 'unsafe<email@example.com');
+    const email = buildCompletionEmail(run(), 'unsafe<email@example.com', ADMIN_URL);
 
     assert.match(email.html, /unsafe&lt;email@example\.com/);
     assert.doesNotMatch(email.html, /unsafe<email@example\.com/);
@@ -159,15 +176,18 @@ describe('content import completion email', function () {
         ],
       }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
-    assert.match(email.html, /Imported posts/);
+    assert.match(email.html, /Imported posts and pages/);
     assert.match(email.html, /Published &amp; linked/);
     assert.match(email.html, /published\/\?one=1&amp;two=2/);
     assert.match(email.html, /&lt;Draft&gt;/);
     assert.match(email.html, /#\/editor\/post\/draft-id/);
     assert.doesNotMatch(email.html, /No URL/);
     assert.doesNotMatch(email.html, /must-not-render/);
+    assert.match(email.html, /#\/posts\?tag=hash-import-run-run_test/);
+    assert.match(email.html, /#\/pages\?tag=hash-import-run-run_test/);
   });
 
   it('uses the row number when a linked outcome has no title', function () {
@@ -183,8 +203,35 @@ describe('content import completion email', function () {
         ],
       }),
       'owner@example.com',
+      ADMIN_URL,
     );
 
     assert.match(email.html, />Row 7<\/a>/);
+  });
+
+  it('limits the imported post preview and links to the complete filtered run', function () {
+    const rows: ImportRun['rows'] = Array.from({ length: 35 }, (_, index) => ({
+      line: index + 2,
+      title: `Imported ${index + 1}`,
+      status: 'created',
+      url: `https://example.com/imported-${index + 1}/`,
+    }));
+    const email = buildCompletionEmail(
+      run({ id: '6a9072a2e385e56d77b83c15', total: rows.length, rows }),
+      'owner@example.com',
+      'https://example.com/blog/ghost/',
+    );
+
+    assert.match(email.html, /Imported 10/);
+    assert.doesNotMatch(email.html, /Imported 11/);
+    assert.match(email.html, /Including 25 more\./);
+    assert.match(
+      email.html,
+      /https:\/\/example\.com\/blog\/ghost\/#\/posts\?tag=hash-import-run-6a9072a2e385e56d77b83c15/,
+    );
+    assert.match(
+      email.html,
+      /https:\/\/example\.com\/blog\/ghost\/#\/pages\?tag=hash-import-run-6a9072a2e385e56d77b83c15/,
+    );
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/errors-file.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/errors-file.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import papaparse from 'papaparse';
+import buildErrorsFile from '../../../../../../core/server/services/content-import/import/errors-file';
+import type { ImportRun } from '../../../../../../core/server/services/content-import/import/store';
+
+function run(overrides: Partial<ImportRun> = {}): ImportRun {
+  return {
+    id: 'run_test',
+    status: 'complete',
+    startedAt: new Date('2026-01-01T10:00:00.000Z'),
+    finishedAt: new Date('2026-01-01T10:01:00.000Z'),
+    total: 0,
+    sourceColumns: ['Headline', 'Body'],
+    rows: [],
+    ...overrides,
+  };
+}
+
+describe('content import errors file', function () {
+  it('omits the file without failed or fixable skipped rows', function () {
+    assert.equal(
+      buildErrorsFile(
+        run({
+          rows: [
+            {
+              line: 2,
+              title: 'Created warning',
+              status: 'created',
+              warnings: ['Assigned Owner'],
+              source: { Headline: 'Created warning', Body: '' },
+            },
+            {
+              line: 3,
+              title: 'Duplicate',
+              status: 'skipped',
+              duplicate: { origin: 'pre_existing', matchedBy: 'slug' },
+              source: { Headline: 'Duplicate', Body: '' },
+            },
+            { line: 4, title: 'No source', status: 'failed', reason: 'Internal harness row' },
+          ],
+        }),
+      ),
+      undefined,
+    );
+  });
+
+  it('preserves source columns, annotates actionable rows, and defuses formulas', function () {
+    const csv = buildErrorsFile(
+      run({
+        sourceColumns: ['Body', 'Headline', 'ghost_import_outcome'],
+        rows: [
+          {
+            line: 2,
+            title: '=Skipped()',
+            status: 'skipped',
+            reason: '+invalid source value',
+            source: {
+              Body: '<p>Body</p>',
+              Headline: '=Skipped()',
+              ghost_import_outcome: 'publisher value',
+            },
+          },
+          {
+            line: 3,
+            title: 'Failed media',
+            status: 'failed',
+            reason: 'Could not import 1 media file.',
+            mediaFailures: [
+              { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed.' },
+            ],
+            source: {
+              Body: '<p>Media</p>',
+              Headline: 'Failed media',
+              ghost_import_outcome: 'keep this',
+            },
+          },
+        ],
+      }),
+    );
+
+    assert.ok(csv);
+    const parsed = papaparse.parse<Record<string, string>>(csv, { header: true });
+    assert.deepEqual(parsed.meta.fields, [
+      'Body',
+      'Headline',
+      'ghost_import_outcome',
+      'ghost_import_outcome_2',
+      'ghost_import_reason',
+      'ghost_import_media_failures',
+    ]);
+    assert.equal(parsed.data[0].Headline, "'=Skipped()");
+    assert.equal(parsed.data[0].ghost_import_outcome, 'publisher value');
+    assert.equal(parsed.data[0].ghost_import_outcome_2, 'skipped');
+    assert.equal(parsed.data[0].ghost_import_reason, "'+invalid source value");
+    assert.deepEqual(JSON.parse(parsed.data[1].ghost_import_media_failures), [
+      { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed.' },
+    ]);
+  });
+
+  it('increments annotation suffixes until every generated heading is unique', function () {
+    const csv = buildErrorsFile(
+      run({
+        sourceColumns: [
+          'Headline',
+          'ghost_import_outcome',
+          'ghost_import_outcome_2',
+          'ghost_import_reason',
+          'ghost_import_media_failures',
+        ],
+        rows: [
+          {
+            line: 2,
+            title: 'Invalid',
+            status: 'skipped',
+            source: { Headline: 'Invalid' },
+          },
+        ],
+      }),
+    );
+
+    assert.ok(csv);
+    const parsed = papaparse.parse(csv, { header: true });
+    assert.ok(parsed.meta.fields?.includes('ghost_import_outcome_3'));
+    assert.ok(parsed.meta.fields?.includes('ghost_import_reason_2'));
+    assert.ok(parsed.meta.fields?.includes('ghost_import_media_failures_2'));
+  });
+});

--- a/ghost/core/test/unit/server/services/content-import/import/errors-file.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/errors-file.test.ts
@@ -17,7 +17,7 @@ function run(overrides: Partial<ImportRun> = {}): ImportRun {
 }
 
 describe('content import errors file', function () {
-  it('omits the file without failed or fixable skipped rows', function () {
+  it('omits the file without failed rows containing source cells', function () {
     assert.equal(
       buildErrorsFile(
         run({
@@ -31,10 +31,9 @@ describe('content import errors file', function () {
             },
             {
               line: 3,
-              title: 'Duplicate',
+              title: 'Skipped validation',
               status: 'skipped',
-              duplicate: { origin: 'pre_existing', matchedBy: 'slug' },
-              source: { Headline: 'Duplicate', Body: '' },
+              source: { Headline: 'Skipped validation', Body: '' },
             },
             { line: 4, title: 'No source', status: 'failed', reason: 'Internal harness row' },
           ],
@@ -47,17 +46,17 @@ describe('content import errors file', function () {
   it('preserves source columns, annotates actionable rows, and defuses formulas', function () {
     const csv = buildErrorsFile(
       run({
-        sourceColumns: ['Body', 'Headline', 'ghost_import_outcome'],
+        sourceColumns: ['Body', 'Headline', 'import_status'],
         rows: [
           {
             line: 2,
-            title: '=Skipped()',
-            status: 'skipped',
+            title: '=Failed()',
+            status: 'failed',
             reason: '+invalid source value',
             source: {
               Body: '<p>Body</p>',
-              Headline: '=Skipped()',
-              ghost_import_outcome: 'publisher value',
+              Headline: '=Failed()',
+              import_status: 'publisher value',
             },
           },
           {
@@ -71,7 +70,7 @@ describe('content import errors file', function () {
             source: {
               Body: '<p>Media</p>',
               Headline: 'Failed media',
-              ghost_import_outcome: 'keep this',
+              import_status: 'keep this',
             },
           },
         ],
@@ -81,18 +80,18 @@ describe('content import errors file', function () {
     assert.ok(csv);
     const parsed = papaparse.parse<Record<string, string>>(csv, { header: true });
     assert.deepEqual(parsed.meta.fields, [
+      'import_status_2',
       'Body',
       'Headline',
-      'ghost_import_outcome',
-      'ghost_import_outcome_2',
-      'ghost_import_reason',
-      'ghost_import_media_failures',
+      'import_status',
+      'import_reason',
+      'import_media_failures',
     ]);
-    assert.equal(parsed.data[0].Headline, "'=Skipped()");
-    assert.equal(parsed.data[0].ghost_import_outcome, 'publisher value');
-    assert.equal(parsed.data[0].ghost_import_outcome_2, 'skipped');
-    assert.equal(parsed.data[0].ghost_import_reason, "'+invalid source value");
-    assert.deepEqual(JSON.parse(parsed.data[1].ghost_import_media_failures), [
+    assert.equal(parsed.data[0].Headline, "'=Failed()");
+    assert.equal(parsed.data[0].import_status, 'publisher value');
+    assert.equal(parsed.data[0].import_status_2, 'failed');
+    assert.equal(parsed.data[0].import_reason, "'+invalid source value");
+    assert.deepEqual(JSON.parse(parsed.data[1].import_media_failures), [
       { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed.' },
     ]);
   });
@@ -102,16 +101,16 @@ describe('content import errors file', function () {
       run({
         sourceColumns: [
           'Headline',
-          'ghost_import_outcome',
-          'ghost_import_outcome_2',
-          'ghost_import_reason',
-          'ghost_import_media_failures',
+          'import_status',
+          'import_status_2',
+          'import_reason',
+          'import_media_failures',
         ],
         rows: [
           {
             line: 2,
             title: 'Invalid',
-            status: 'skipped',
+            status: 'failed',
             source: { Headline: 'Invalid' },
           },
         ],
@@ -120,8 +119,8 @@ describe('content import errors file', function () {
 
     assert.ok(csv);
     const parsed = papaparse.parse(csv, { header: true });
-    assert.ok(parsed.meta.fields?.includes('ghost_import_outcome_3'));
-    assert.ok(parsed.meta.fields?.includes('ghost_import_reason_2'));
-    assert.ok(parsed.meta.fields?.includes('ghost_import_media_failures_2'));
+    assert.equal(parsed.meta.fields?.[0], 'import_status_3');
+    assert.ok(parsed.meta.fields?.includes('import_reason_2'));
+    assert.ok(parsed.meta.fields?.includes('import_media_failures_2'));
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -582,7 +582,7 @@ describe('ContentCSVImporter', function () {
     assert.equal(h.store.get('run_test')?.failureReason, failure.message);
   });
 
-  it('does not inspect media for a row skipped during post-data validation', async function () {
+  it('does not inspect media for a row failed during post-data validation', async function () {
     const h = harness([
       { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
       row('Valid row'),
@@ -917,7 +917,7 @@ describe('ContentCSVImporter', function () {
     );
   });
 
-  it('skips a malformed row on its own and imports the rest', async function () {
+  it('fails a malformed row on its own and imports the rest', async function () {
     const h = harness([
       row('First'),
       { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
@@ -936,12 +936,12 @@ describe('ContentCSVImporter', function () {
     assert.deepEqual(run?.rows[1], {
       line: 3,
       title: null,
-      status: 'skipped',
+      status: 'failed',
       reason: 'title is required',
     });
     assert.deepEqual(
       run?.rows.map((r) => r.status),
-      ['created', 'skipped', 'created'],
+      ['created', 'failed', 'created'],
     );
   });
 
@@ -964,7 +964,7 @@ describe('ContentCSVImporter', function () {
     assert.deepEqual(h.store.get('run_test')?.rows[1], {
       line: 3,
       title: 'Bad markdown',
-      status: 'skipped',
+      status: 'failed',
       reason: 'markdown could not be converted',
     });
   });
@@ -987,12 +987,12 @@ describe('ContentCSVImporter', function () {
     assert.deepEqual(h.store.get('run_test')?.rows[1], {
       line: 3,
       title: 'Bad clean',
-      status: 'skipped',
+      status: 'failed',
       reason: 'html could not be cleaned',
     });
   });
 
-  it('completes without reporting when every row is skipped before a write', async function () {
+  it('completes without an internal error when every row fails validation before a write', async function () {
     const h = harness([
       { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
       { title: '', html: '<p>Still no title</p>', markdown: '', published_at: undefined },
@@ -1004,7 +1004,7 @@ describe('ContentCSVImporter', function () {
     assert.equal(h.store.get('run_test')?.status, 'complete');
     assert.deepEqual(
       h.store.get('run_test')?.rows.map((outcome) => outcome.status),
-      ['skipped', 'skipped'],
+      ['failed', 'failed'],
     );
   });
 

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -17,7 +17,10 @@ const row = (title: string, html = `<p>${title}</p>`): PostImportRow => ({
 });
 
 // Collaborators are handed back as `deps` so a test can repoint the seam it is breaking.
-function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
+function harness(
+  rows: PostImportRow[] = [row('First'), row('Second')],
+  source?: { columns: string[]; rows: Array<Record<string, string>> },
+) {
   const created: Array<{ data: PostData; options: object; metadata?: PostWriteMetadata }> = [];
   const reported: unknown[] = [];
   const jobs: Array<{ name: string; offloaded: boolean; job: () => Promise<void> }> = [];
@@ -55,7 +58,13 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   };
 
   const deps = {
-    readRows: async () => rows,
+    readRows: async () =>
+      source
+        ? {
+            columns: source.columns,
+            rows: rows.map((data, index) => ({ data, source: source.rows[index] })),
+          }
+        : rows,
     posts: {
       write: async (data: PostData, options: object, metadata?: PostWriteMetadata) => {
         const failure = createFailures.get(data.title);
@@ -199,6 +208,22 @@ describe('ContentCSVImporter', function () {
     sinon.assert.calledWithExactly(infoLog, '[Background Job] content-import queued');
     sinon.assert.calledWithExactly(infoLog, '[Background Job] content-import started');
     sinon.assert.calledWithMatch(infoLog, /^\[Background Job\] content-import completed in \d+ms$/);
+  });
+
+  it('carries original source columns and cells into the completed run', async function () {
+    const h = harness([row('Mapped title')], {
+      columns: ['Headline', 'Body', 'Ignored'],
+      rows: [{ Headline: 'Mapped title', Body: '<p>Source body</p>', Ignored: 'kept' }],
+    });
+
+    await h.run();
+
+    assert.deepEqual(h.sentRuns[0].sourceColumns, ['Headline', 'Body', 'Ignored']);
+    assert.deepEqual(h.sentRuns[0].rows[0].source, {
+      Headline: 'Mapped title',
+      Body: '<p>Source body</p>',
+      Ignored: 'kept',
+    });
   });
 
   it('emails the requesting user once after completing and releases the run', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -7,6 +7,7 @@ import { ImportRunStore } from '../../../../../../core/server/services/content-i
 import type { PostImportRow } from '../../../../../../core/server/services/content-import/import/row';
 import type { PostData } from '../../../../../../core/server/services/content-import/import/post-data';
 import type { PostWriteMetadata } from '../../../../../../core/server/services/content-import/import/post-repository';
+import type { ImportRun } from '../../../../../../core/server/services/content-import/import/store';
 
 const row = (title: string, html = `<p>${title}</p>`): PostImportRow => ({
   title,
@@ -28,6 +29,14 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
   const inlineMedia = sinon.stub().resolves();
   const createMediaInliner = sinon.stub().callsFake(() => ({ inline: inlineMedia }));
   const store = new ImportRunStore();
+  const releaseRun = sinon.stub(store, 'release');
+  const sentRuns: ImportRun[] = [];
+  const sentRecipients: string[] = [];
+  const sendEmail = sinon.stub().callsFake(async (run: ImportRun, recipient: string) => {
+    sentRuns.push(run);
+    sentRecipients.push(recipient);
+  });
+  const getDefaultRecipient = sinon.stub().resolves('owner@example.com');
   let converterResolutions = 0;
   let markdownRendererResolutions = 0;
   let cleanerResolutions = 0;
@@ -72,6 +81,10 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     getMarkdownToHtml: () => markdownToHtmlFactory(),
     getCleanHTML: () => cleanHTMLFactory(),
     createMediaInliner,
+    email: {
+      send: sendEmail,
+      getDefaultRecipient,
+    },
     addJob: (job: { name: string; offloaded: boolean; job: () => Promise<void> }) => {
       jobs.push(job);
     },
@@ -131,6 +144,11 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
     urlFailures,
     inlineMedia,
     createMediaInliner,
+    sendEmail,
+    getDefaultRecipient,
+    sentRuns,
+    sentRecipients,
+    releaseRun,
     store,
     setHtmlToLexicalFactory,
     setMarkdownToHtmlFactory,
@@ -180,6 +198,87 @@ describe('ContentCSVImporter', function () {
     sinon.assert.calledWithExactly(infoLog, '[Background Job] content-import queued');
     sinon.assert.calledWithExactly(infoLog, '[Background Job] content-import started');
     sinon.assert.calledWithMatch(infoLog, /^\[Background Job\] content-import completed in \d+ms$/);
+  });
+
+  it('emails the requesting user once after completing and releases the run', async function () {
+    const h = harness();
+
+    await h.importer.importCSV({
+      filePath: '/tmp/posts.csv',
+      fileName: 'posts.csv',
+      requestUserEmail: 'requester@example.com',
+    });
+    await h.jobs[0].job();
+
+    sinon.assert.notCalled(h.getDefaultRecipient);
+    sinon.assert.calledOnce(h.sendEmail);
+    assert.deepEqual(h.sentRecipients, ['requester@example.com']);
+    assert.equal(h.sentRuns[0].status, 'complete');
+    sinon.assert.calledOnceWithExactly(h.releaseRun, 'run_test');
+  });
+
+  it('falls back to Owner and reports email delivery failures without failing the run', async function () {
+    const h = harness();
+    const failure = new Error('mail unavailable');
+    h.sendEmail.rejects(failure);
+
+    await h.run();
+
+    sinon.assert.calledOnce(h.getDefaultRecipient);
+    sinon.assert.calledOnceWithExactly(
+      h.sendEmail,
+      sinon.match({ status: 'complete' }),
+      'owner@example.com',
+    );
+    assert.equal(h.reported.at(-1), failure);
+    sinon.assert.calledOnceWithExactly(h.releaseRun, 'run_test');
+  });
+
+  it('does not prepare or schedule an import when the Owner recipient cannot be resolved', async function () {
+    const h = harness();
+    const failure = new Error('Owner unavailable');
+    const prepareSource = sinon.stub().resolves({
+      filePath: '/tmp/posts.csv',
+      cleanup: sinon.stub().resolves(),
+    });
+    h.getDefaultRecipient.rejects(failure);
+    const importer = new ContentCSVImporter({ ...h.deps, prepareSource });
+
+    await assert.rejects(
+      importer.importCSV({ filePath: '/tmp/posts.csv', fileName: 'posts.csv' }),
+      failure,
+    );
+
+    sinon.assert.notCalled(prepareSource);
+    assert.equal(h.jobs.length, 0);
+    sinon.assert.notCalled(h.sendEmail);
+  });
+
+  it('emails a failed accepted run before releasing it', async function () {
+    const h = harness();
+    const failure = new Error('converter unavailable');
+    h.setHtmlToLexicalFactory(() => {
+      throw failure;
+    });
+
+    await h.run();
+
+    sinon.assert.calledOnce(h.sendEmail);
+    assert.equal(h.sentRuns[0].status, 'failed');
+    assert.equal(h.sentRuns[0].failureReason, 'converter unavailable');
+    sinon.assert.calledOnceWithExactly(h.releaseRun, 'run_test');
+  });
+
+  it('finishes safely if an injected store loses the run before the job settles', async function () {
+    const h = harness();
+    h.releaseRun.restore();
+
+    await h.importer.importCSV({ filePath: '/tmp/posts.csv', fileName: 'posts.csv' });
+    h.store.release('run_test');
+    await h.jobs[0].job();
+
+    sinon.assert.notCalled(h.sendEmail);
+    assert.equal(h.created.length, 2);
   });
 
   it('uses the current time by default when one is not injected', async function () {
@@ -603,6 +702,8 @@ describe('ContentCSVImporter', function () {
     assert.equal(h.store.get('run_test')?.status, 'failed');
     assert.equal(h.store.get('run_test')?.failureReason, 'queue unavailable');
     sinon.assert.calledOnce(cleanup);
+    sinon.assert.notCalled(h.sendEmail);
+    sinon.assert.calledOnceWithExactly(h.releaseRun, 'run_test');
   });
 
   it('reports cleanup failures without rejecting the completed job', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -66,6 +66,7 @@ function harness(rows: PostImportRow[] = [row('First'), row('Second')]) {
           return {
             status: 'skipped' as const,
             reason: `A post with the slug "${data.slug}" already exists.`,
+            duplicate: { origin: 'pre_existing' as const, matchedBy: 'slug' as const },
           };
         }
         created.push({ data, options, metadata });
@@ -434,6 +435,7 @@ describe('ContentCSVImporter', function () {
       assert.deepEqual(call.options, { importing: true, context: { internal: true } });
       assert.deepEqual(call.metadata, {
         sourceUpdatedAt: undefined,
+        runTagName: '#Import Run run_test',
         authorNames: undefined,
         authorEmails: undefined,
         tagNames: undefined,
@@ -581,6 +583,7 @@ describe('ContentCSVImporter', function () {
 
     assert.deepEqual(h.created[0].metadata, {
       sourceUpdatedAt: undefined,
+      runTagName: '#Import Run run_test',
       authorNames: 'Alice, Bob',
       authorEmails: 'alice@example.com, bob@example.com',
       tagNames: 'News, Features',
@@ -778,6 +781,7 @@ describe('ContentCSVImporter', function () {
         title: 'Duplicate',
         status: 'skipped',
         reason: 'A post with the slug "duplicate" already exists.',
+        duplicate: { origin: 'pre_existing', matchedBy: 'slug' },
       },
       {
         line: 3,
@@ -798,6 +802,7 @@ describe('ContentCSVImporter', function () {
 
     assert.deepEqual(h.created[0].metadata, {
       sourceUpdatedAt: '2025-02-01T00:00:00.000Z',
+      runTagName: '#Import Run run_test',
       authorNames: undefined,
       authorEmails: undefined,
       tagNames: undefined,

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -813,6 +813,7 @@ describe('ContentCSVImporter', function () {
         title: 'Created',
         status: 'created',
         postId: 'post_1',
+        postType: 'post',
         url: 'https://example.com/post_1/',
       },
     ]);
@@ -838,6 +839,7 @@ describe('ContentCSVImporter', function () {
         title: 'Updated',
         status: 'updated',
         postId: 'post_1',
+        postType: 'post',
         url: 'https://example.com/post_1/',
       },
     ]);
@@ -1068,6 +1070,7 @@ describe('ContentCSVImporter', function () {
       title: 'Owner fallback',
       status: 'created',
       postId: 'post_1',
+      postType: 'post',
       url: 'https://example.com/post_1/',
       warnings: ['Author "Missing Author" has no email; assigned Owner instead.'],
     });
@@ -1082,12 +1085,19 @@ describe('ContentCSVImporter', function () {
 
     assert.equal(h.created.length, 2);
     assert.deepEqual(h.store.get('run_test')?.rows, [
-      { line: 2, title: 'First', status: 'updated', postId: 'post_1' },
+      {
+        line: 2,
+        title: 'First',
+        status: 'updated',
+        postId: 'post_1',
+        postType: 'post',
+      },
       {
         line: 3,
         title: 'Second',
         status: 'created',
         postId: 'post_2',
+        postType: 'post',
         url: 'https://example.com/post_2/',
       },
     ]);
@@ -1122,8 +1132,8 @@ describe('ContentCSVImporter', function () {
     );
   });
 
-  it('records a created outcome per row, 1-based, with the post id and URL', async function () {
-    const h = harness();
+  it('records a created outcome per row with its id, type and URL', async function () {
+    const h = harness([row('First'), { ...row('Second'), type: 'page' }]);
 
     await h.run();
 
@@ -1137,6 +1147,7 @@ describe('ContentCSVImporter', function () {
         title: 'First',
         status: 'created',
         postId: 'post_1',
+        postType: 'post',
         url: 'https://example.com/post_1/',
       },
       {
@@ -1144,6 +1155,7 @@ describe('ContentCSVImporter', function () {
         title: 'Second',
         status: 'created',
         postId: 'post_2',
+        postType: 'page',
         url: 'https://example.com/post_2/',
       },
     ]);

--- a/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/importer.test.ts
@@ -19,7 +19,7 @@ const row = (title: string, html = `<p>${title}</p>`): PostImportRow => ({
 // Collaborators are handed back as `deps` so a test can repoint the seam it is breaking.
 function harness(
   rows: PostImportRow[] = [row('First'), row('Second')],
-  source?: { columns: string[]; rows: Array<Record<string, string>> },
+  source?: { columns: string[]; rows: Array<Record<string, string>>; lines?: number[] },
 ) {
   const created: Array<{ data: PostData; options: object; metadata?: PostWriteMetadata }> = [];
   const reported: unknown[] = [];
@@ -62,7 +62,11 @@ function harness(
       source
         ? {
             columns: source.columns,
-            rows: rows.map((data, index) => ({ data, source: source.rows[index] })),
+            rows: rows.map((data, index) => ({
+              data,
+              source: source.rows[index],
+              line: source.lines?.[index] ?? index + 2,
+            })),
           }
         : rows,
     posts: {
@@ -224,6 +228,30 @@ describe('ContentCSVImporter', function () {
       Body: '<p>Source body</p>',
       Ignored: 'kept',
     });
+  });
+
+  it('records the original spreadsheet line after an ignored empty row', async function () {
+    const h = harness(
+      [
+        row('Before blank'),
+        { title: '', html: '<p>No title</p>', markdown: '', published_at: undefined },
+      ],
+      {
+        columns: ['title', 'html'],
+        rows: [
+          { title: 'Before blank', html: '<p>First</p>' },
+          { title: '', html: '<p>No title</p>' },
+        ],
+        lines: [2, 4],
+      },
+    );
+
+    await h.run();
+
+    assert.deepEqual(
+      h.store.get('run_test')?.rows.map(({ line }) => line),
+      [2, 4],
+    );
   });
 
   it('emails the requesting user once after completing and releases the run', async function () {

--- a/ghost/core/test/unit/server/services/content-import/import/post-link.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/post-link.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { urlForImportedPost } from '../../../../../../core/server/services/content-import/import/post-link';
+
+function post(id: string, status: string, type: string) {
+  return { id, toJSON: () => ({ id, status, type }) };
+}
+
+describe('content import post links', function () {
+  it('uses the resolved absolute URL for a published post', function () {
+    const publishedUrl = sinon.stub().returns('https://example.com/published/');
+    const model = post('published-id', 'published', 'post');
+
+    assert.equal(
+      urlForImportedPost(model, {
+        adminUrl: 'https://example.com/ghost/',
+        publishedUrl,
+      }),
+      'https://example.com/published/',
+    );
+    sinon.assert.calledOnceWithExactly(publishedUrl, model);
+  });
+
+  it('uses the Admin post editor for a draft post', function () {
+    const publishedUrl = sinon.stub();
+
+    assert.equal(
+      urlForImportedPost(post('draft-post-id', 'draft', 'post'), {
+        adminUrl: 'https://example.com/blog/ghost/',
+        publishedUrl,
+      }),
+      'https://example.com/blog/ghost/#/editor/post/draft-post-id',
+    );
+    sinon.assert.notCalled(publishedUrl);
+  });
+
+  it('uses the Admin page editor for a draft page', function () {
+    assert.equal(
+      urlForImportedPost(post('draft-page-id', 'draft', 'page'), {
+        adminUrl: 'https://example.com/ghost/',
+        publishedUrl: sinon.stub(),
+      }),
+      'https://example.com/ghost/#/editor/page/draft-page-id',
+    );
+  });
+});

--- a/ghost/core/test/unit/server/services/content-import/import/post-repository.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/post-repository.test.ts
@@ -82,31 +82,47 @@ describe('BookshelfPostsRepository', function () {
     const h = harness();
     h.findOne.resolves(h.existing);
 
-    const result = await h.repository.write(data, {
-      importing: true,
-      context: { internal: true },
-    });
+    const options = { importing: true, context: { internal: true } };
+    const result = await h.repository.write(data, options, { runTagName: '#Import Run current' });
 
     assert.deepEqual(result, {
       status: 'skipped',
       reason: 'A post with the slug "imported-post" already exists.',
+      duplicate: { origin: 'pre_existing', matchedBy: 'slug' },
     });
+    sinon.assert.calledWithExactly(
+      h.findOne,
+      { slug: 'imported-post', status: 'all' },
+      {
+        ...options,
+        transacting: h.transacting,
+        forUpdate: true,
+        withRelated: ['tags'],
+      },
+    );
     sinon.assert.notCalled(h.add);
     sinon.assert.notCalled(h.edit);
   });
 
   it('matches an explicit source ID before considering the slug', async function () {
     const h = harness();
+    h.existing.toJSON.returns({
+      id: 'existing',
+      updated_at: new Date('2025-01-01T00:00:00Z'),
+      tags: [{ name: '#Import Run current' }],
+    });
     h.findOne.resolves(h.existing);
 
     const result = await h.repository.write(
       { ...data, comment_id: 'source-123', slug: 'a-different-slug' },
       { importing: true, context: { internal: true } },
+      { runTagName: '#Import Run current' },
     );
 
     assert.deepEqual(result, {
       status: 'skipped',
       reason: 'A post with the source ID "source-123" already exists.',
+      duplicate: { origin: 'this_import', matchedBy: 'source_id' },
     });
     sinon.assert.calledOnce(h.findOne);
     sinon.assert.calledWithMatch(h.findOne, {
@@ -130,6 +146,7 @@ describe('BookshelfPostsRepository', function () {
     assert.deepEqual(result, {
       status: 'skipped',
       reason: 'A post with the slug "imported-post" already exists.',
+      duplicate: { origin: 'pre_existing', matchedBy: 'slug' },
     });
     assert.deepEqual(h.findOne.firstCall.args[0], {
       comment_id: 'new-source',
@@ -307,6 +324,7 @@ describe('BookshelfPostsRepository', function () {
     assert.deepEqual(result, {
       status: 'skipped',
       reason: 'The existing post is newer than or as recent as the imported row.',
+      duplicate: { origin: 'pre_existing', matchedBy: 'slug' },
     });
     sinon.assert.notCalled(h.edit);
   });

--- a/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
@@ -53,6 +53,21 @@ describe('content import reader', function () {
     );
   });
 
+  it('preserves spreadsheet line numbers after ignored empty rows', async function () {
+    const file = path.join(directory, 'posts-with-empty-row.csv');
+    await fs.writeFile(
+      file,
+      'title,html\nBefore blank,<p>First</p>\n\nAfter blank,<p>Second</p>\n',
+    );
+
+    const result = await readPostRows(file);
+
+    assert.deepEqual(
+      result.rows.map(({ line }) => line),
+      [2, 4],
+    );
+  });
+
   it('keeps full editorial identity headers for direct API clients', async function () {
     const file = path.join(directory, 'full-post.csv');
     await fs.writeFile(

--- a/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/reader.test.ts
@@ -19,24 +19,38 @@ describe('content import reader', function () {
     const file = path.join(directory, 'posts.csv');
     await fs.writeFile(file, 'Headline,Body,Ignore me\nHello,<p>World</p>,unused\n');
 
-    const rows = await readPostRows(file, {
+    const result = await readPostRows(file, {
       Headline: 'title',
       Body: 'html',
       'Ignore me': '',
     });
 
-    assert.deepEqual(rows, [{ title: 'Hello', html: '<p>World</p>', markdown: '' }]);
+    assert.deepEqual(result.columns, ['Headline', 'Body', 'Ignore me']);
+    assert.deepEqual(result.rows[0].data, {
+      title: 'Hello',
+      html: '<p>World</p>',
+      markdown: '',
+    });
+    assert.deepEqual(
+      { ...result.rows[0].source },
+      {
+        Headline: 'Hello',
+        Body: '<p>World</p>',
+        'Ignore me': 'unused',
+      },
+    );
   });
 
   it('keeps the existing identity headers when no mapping is supplied', async function () {
     const file = path.join(directory, 'posts.csv');
     await fs.writeFile(file, 'title,html,published_at\nHello,<p>World</p>,2025-01-01\n');
 
-    const rows = await readPostRows(file);
+    const result = await readPostRows(file);
 
-    assert.deepEqual(rows, [
-      { title: 'Hello', html: '<p>World</p>', markdown: '', published_at: '2025-01-01' },
-    ]);
+    assert.deepEqual(
+      result.rows.map(({ data }) => data),
+      [{ title: 'Hello', html: '<p>World</p>', markdown: '', published_at: '2025-01-01' }],
+    );
   });
 
   it('keeps full editorial identity headers for direct API clients', async function () {
@@ -46,21 +60,24 @@ describe('content import reader', function () {
       'title,slug,featured,meta_title,comment_id,authors,author_emails,tags\nHello,custom,1,Search title,source-123,"Alice, Bob","alice@example.com, bob@example.com","News, Features"\n',
     );
 
-    const rows = await readPostRows(file);
+    const result = await readPostRows(file);
 
-    assert.deepEqual(rows, [
-      {
-        title: 'Hello',
-        slug: 'custom',
-        featured: '1',
-        meta_title: 'Search title',
-        comment_id: 'source-123',
-        authors: 'Alice, Bob',
-        author_emails: 'alice@example.com, bob@example.com',
-        tags: 'News, Features',
-        html: '',
-        markdown: '',
-      },
-    ]);
+    assert.deepEqual(
+      result.rows.map(({ data }) => data),
+      [
+        {
+          title: 'Hello',
+          slug: 'custom',
+          featured: '1',
+          meta_title: 'Search title',
+          comment_id: 'source-123',
+          authors: 'Alice, Bob',
+          author_emails: 'alice@example.com, bob@example.com',
+          tags: 'News, Features',
+          html: '',
+          markdown: '',
+        },
+      ],
+    );
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/report.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/report.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import papaparse from 'papaparse';
+import buildImportReport from '../../../../../../core/server/services/content-import/import/report';
+import type { ImportRun } from '../../../../../../core/server/services/content-import/import/store';
+
+function run(rows: ImportRun['rows']): ImportRun {
+  return {
+    id: 'run_test',
+    status: 'complete',
+    startedAt: new Date('2026-01-01T10:00:00.000Z'),
+    finishedAt: new Date('2026-01-01T10:01:00.000Z'),
+    total: rows.length,
+    rows,
+  };
+}
+
+describe('content import report', function () {
+  it('omits the report when every row completed without warnings', function () {
+    assert.equal(
+      buildImportReport(
+        run([
+          { line: 2, title: 'Created', status: 'created', url: 'https://example.com/created/' },
+          { line: 3, title: 'Updated', status: 'updated' },
+        ]),
+      ),
+      undefined,
+    );
+  });
+
+  it('serializes duplicates, failures, skips, and warning-bearing successes', function () {
+    const csv = buildImportReport(
+      run([
+        {
+          line: 2,
+          title: 'Same run duplicate',
+          status: 'skipped',
+          reason: 'Already exists',
+          duplicate: { origin: 'this_import', matchedBy: 'slug' },
+        },
+        {
+          line: 3,
+          title: 'Pre-existing source',
+          status: 'skipped',
+          reason: 'Source exists',
+          duplicate: { origin: 'pre_existing', matchedBy: 'source_id' },
+        },
+        { line: 4, title: null, status: 'skipped', reason: 'title is required' },
+        {
+          line: 5,
+          title: '=FAILED()',
+          status: 'failed',
+          reason: '+write failed',
+          mediaFailures: [
+            { sourceUrl: 'https://assets.test/missing.jpg', reason: 'Download failed' },
+            { sourceUrl: 'https://assets.test/broken.mp4', reason: 'Storage failed' },
+          ],
+        },
+        {
+          line: 6,
+          title: 'Created with warning',
+          status: 'created',
+          warnings: ['First warning', 'Second warning'],
+          url: 'https://example.com/warning/',
+        },
+        { line: 7, title: 'Clean', status: 'created' },
+      ]),
+    );
+
+    assert.ok(csv);
+    const parsed = papaparse.parse<Record<string, string>>(csv, { header: true });
+    assert.deepEqual(parsed.meta.fields, [
+      'line',
+      'title',
+      'outcome',
+      'reason',
+      'duplicate_origin',
+      'matched_by',
+      'warnings',
+      'media_failures',
+      'post_url',
+    ]);
+    assert.equal(parsed.data.length, 5);
+    assert.deepEqual(parsed.data[0], {
+      line: '2',
+      title: 'Same run duplicate',
+      outcome: 'duplicate',
+      reason: 'Already exists',
+      duplicate_origin: 'this_import',
+      matched_by: 'slug',
+      warnings: '',
+      media_failures: '',
+      post_url: '',
+    });
+    assert.equal(parsed.data[1].duplicate_origin, 'pre_existing');
+    assert.equal(parsed.data[1].matched_by, 'source_id');
+    assert.equal(parsed.data[2].title, '');
+    assert.equal(parsed.data[2].outcome, 'skipped');
+    assert.equal(parsed.data[3].title, "'=FAILED()");
+    assert.equal(parsed.data[3].reason, "'+write failed");
+    assert.equal(
+      parsed.data[3].media_failures,
+      'https://assets.test/missing.jpg: Download failed\nhttps://assets.test/broken.mp4: Storage failed',
+    );
+    assert.equal(parsed.data[4].warnings, 'First warning\nSecond warning');
+    assert.equal(parsed.data[4].post_url, 'https://example.com/warning/');
+  });
+});

--- a/ghost/core/test/unit/server/services/content-import/import/report.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/report.test.ts
@@ -16,16 +16,24 @@ function run(rows: ImportRun['rows']): ImportRun {
 }
 
 describe('content import report', function () {
-  it('omits the report when every row completed without warnings', function () {
-    assert.equal(
-      buildImportReport(
-        run([
-          { line: 2, title: 'Created', status: 'created', url: 'https://example.com/created/' },
-          { line: 3, title: 'Updated', status: 'updated' },
-        ]),
-      ),
-      undefined,
+  it('omits the report when no rows were processed', function () {
+    assert.equal(buildImportReport(run([])), undefined);
+  });
+
+  it('serializes every processed row', function () {
+    const csv = buildImportReport(
+      run([
+        { line: 2, title: 'Created', status: 'created', url: 'https://example.com/created/' },
+        { line: 3, title: 'Updated', status: 'updated' },
+      ]),
     );
+
+    assert.ok(csv);
+    const parsed = papaparse.parse<Record<string, string>>(csv, { header: true });
+    assert.equal(parsed.data.length, 2);
+    assert.equal(parsed.data[0].outcome, 'created');
+    assert.equal(parsed.data[0].post_url, 'https://example.com/created/');
+    assert.equal(parsed.data[1].outcome, 'updated');
   });
 
   it('serializes duplicates, failures, skips, and warning-bearing successes', function () {
@@ -80,7 +88,7 @@ describe('content import report', function () {
       'media_failures',
       'post_url',
     ]);
-    assert.equal(parsed.data.length, 5);
+    assert.equal(parsed.data.length, 6);
     assert.deepEqual(parsed.data[0], {
       line: '2',
       title: 'Same run duplicate',
@@ -104,5 +112,7 @@ describe('content import report', function () {
     );
     assert.equal(parsed.data[4].warnings, 'First warning\nSecond warning');
     assert.equal(parsed.data[4].post_url, 'https://example.com/warning/');
+    assert.equal(parsed.data[5].title, 'Clean');
+    assert.equal(parsed.data[5].outcome, 'created');
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/report.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/report.test.ts
@@ -10,6 +10,7 @@ function run(rows: ImportRun['rows']): ImportRun {
     startedAt: new Date('2026-01-01T10:00:00.000Z'),
     finishedAt: new Date('2026-01-01T10:01:00.000Z'),
     total: rows.length,
+    sourceColumns: [],
     rows,
   };
 }

--- a/ghost/core/test/unit/server/services/content-import/import/schema.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/schema.test.ts
@@ -18,6 +18,7 @@ describe('content import schema', function () {
       importRequestSchema.parse({
         filePath: '/tmp/posts.zip',
         fileName: 'posts.zip',
+        requestUserEmail: 'requester@example.com',
         mapping: {
           Headline: 'title',
           Body: 'html',
@@ -31,6 +32,7 @@ describe('content import schema', function () {
       {
         filePath: '/tmp/posts.zip',
         fileName: 'posts.zip',
+        requestUserEmail: 'requester@example.com',
         mapping: {
           Headline: 'title',
           Body: 'html',
@@ -48,6 +50,30 @@ describe('content import schema', function () {
     assert.deepEqual(
       importRequestSchema.parse({ filePath: '/tmp/posts.csv', fileName: 'posts.csv' }),
       { filePath: '/tmp/posts.csv', fileName: 'posts.csv' },
+    );
+  });
+
+  it('accepts a null request user and rejects an invalid email address', function () {
+    assert.deepEqual(
+      importRequestSchema.parse({
+        filePath: '/tmp/posts.csv',
+        fileName: 'posts.csv',
+        requestUserEmail: null,
+      }),
+      {
+        filePath: '/tmp/posts.csv',
+        fileName: 'posts.csv',
+        requestUserEmail: null,
+      },
+    );
+
+    assert.equal(
+      importRequestSchema.safeParse({
+        filePath: '/tmp/posts.csv',
+        fileName: 'posts.csv',
+        requestUserEmail: 'not-an-email',
+      }).success,
+      false,
     );
   });
 

--- a/ghost/core/test/unit/server/services/content-import/import/store.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/store.test.ts
@@ -16,13 +16,14 @@ describe('ImportRunStore', function () {
   it('tracks a run from created to complete, in order', function () {
     const store = new ImportRunStore();
 
-    store.create('run_1', 2);
+    store.create('run_1', 2, ['Headline', 'Body']);
     store.record('run_1', outcome(1));
     store.record('run_1', outcome(2));
 
     const running = store.get('run_1');
     assert.equal(running?.status, 'running');
     assert.equal(running?.total, 2);
+    assert.deepEqual(running?.sourceColumns, ['Headline', 'Body']);
     assert.deepEqual(
       running?.rows.map((r) => r.line),
       [1, 2],
@@ -48,6 +49,14 @@ describe('ImportRunStore', function () {
     });
 
     assert.equal(store.get('run_updated')?.rows[0].status, 'updated');
+  });
+
+  it('defaults source columns for internal callers without source data', function () {
+    const store = new ImportRunStore();
+
+    store.create('run_no_source', 0);
+
+    assert.deepEqual(store.get('run_no_source')?.sourceColumns, []);
   });
 
   it('ignores writes against an unknown run rather than throwing', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/store.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/store.test.ts
@@ -60,6 +60,17 @@ describe('ImportRunStore', function () {
     assert.equal(store.get('nope'), undefined);
   });
 
+  it('releases a finished run idempotently', function () {
+    const store = new ImportRunStore();
+    store.create('run_release', 1);
+    store.finish('run_release');
+
+    store.release('run_release');
+    store.release('run_release');
+
+    assert.equal(store.get('run_release'), undefined);
+  });
+
   it('tracks a run-level failure as a finished terminal state', function () {
     const finishedAt = new Date('2026-01-01T11:00:00.000Z');
     const store = new ImportRunStore({ now: () => finishedAt });


### PR DESCRIPTION
ref https://linear.app/ghost/project/4b2edbd66469/ - Milestone 7

Each commit references an individual Linear issue

Adds completion emails for CSV imports with outcome totals, imported-content links, and context-aware Admin filters. Emails include a complete report.csv and a re-uploadable errors.csv for actionable failures. JSON imports remain unchanged.