### PR TITLE
Removed impossible code path from support email address code

### DIFF
--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -133,8 +133,6 @@ class SettingsHelpers {
       return EmailAddressParser.stringify(this.getDefaultEmail());
     }
 
-    supportAddress = supportAddress || 'noreply';
-
     // Any fromAddress without domain uses site domain, like default setting `noreply`
     if (supportAddress.indexOf('@') < 0) {
       return `${supportAddress}@${this.getDefaultEmailDomain()}`;


### PR DESCRIPTION
no ref

This change should have no user impact.

The previous conditional meant that this line did nothing. Let's remove it.
