### PR TITLE
Fixed two flaky admin acceptance races

### DIFF
--- a/apps/admin/src/settings/membership/access.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/access.acceptance.test.tsx
@@ -30,6 +30,12 @@ function configWithPublicSiteAccessLimit() {
 async function choose(selectTestId: string, option: string) {
   await settingsScreen.access().getByTestId(selectTestId).click();
   await settingsScreen.selectOptionExact(option).click();
+  // Choosing an option starts the dropdown's close, it does not finish it: the
+  // list stays mounted and the body keeps `pointer-events: none` until the
+  // teardown completes. Anything clicked inside that window races it — the
+  // click is either refused or opens a layer the teardown then dismisses — so
+  // wait the dropdown out before the caller touches the next control.
+  await expect(settingsScreen.selectOptionExact(option)).toHaveCount(0);
 }
 
 describe('Access settings', () => {

--- a/apps/admin/src/settings/membership/tiers-checkout.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/tiers-checkout.acceptance.test.tsx
@@ -354,6 +354,9 @@ describe('Tier checkout collection', () => {
     await expect.element(modal.getByRole('button', { name: 'Saved' })).toBeVisible();
 
     expect(createApi.lastRequest?.body).toMatchObject({ tiers: [{ name: createdTier.name }] });
+    // The checkout write is chained after the tier's, so "Saved" — which the tier's own
+    // save flips — is reached before it lands. Wait for the write itself.
+    await expect.poll(() => putApi.requests.length).toBe(1);
     const sent = (
       putApi.lastRequest?.body as { tiers_checkout_config: [{ shipping: { collect: boolean } }] }
     ).tiers_checkout_config[0];
@@ -380,7 +383,8 @@ describe('Tier checkout collection', () => {
     await modal.getByLabelText('Collect business tax ID').click();
     await modal.getByRole('button', { name: 'Save' }).click();
     await expect.element(modal.getByRole('button', { name: 'Saved' })).toBeVisible();
-    expect(putApi.requests).toHaveLength(1);
+    // "Saved" is the tier save's signal; the checkout write is chained after it.
+    await expect.poll(() => putApi.requests.length).toBe(1);
 
     await modal.getByRole('button', { name: 'Close' }).click();
     await expect(settingsScreen.tierDetailModal()).toHaveCount(0);


### PR DESCRIPTION
no ref

Two independent races in the admin acceptance suite, both of which made CI red
on main. Each was reproduced before fixing, and the full suite (70 files, 676
tests) passes locally with both changes.

## Tier checkout: asserting on a chained write

The tier detail modal's Save commits two resources in sequence: the tier
itself, then the checkout configuration. `handleSave` flips the button to
"Saved" as soon as the tier write resolves, and only then does `onOk` call the
checkout section's save. Two specs waited on "Saved" and read the checkout
capture synchronously on the next line, so they asserted against a request that
had not necessarily been issued yet.

This accounted for every admin acceptance failure sampled on main over two
days, surfacing as either `Cannot read properties of undefined (reading
'tiers_checkout_config')` or `expected [] to have a length of 1`. Both specs
now poll the capture, matching the sibling spec in the same file that already
does.

Reproduced by delaying the checkout write, which fails both specs with the
exact CI errors and passes with this change.

## Access settings: interacting during a dropdown's teardown

`choose()` clicked a select trigger, clicked an option, and returned. Choosing
an option starts Radix's close but does not finish it. Measured at the instant
the helper returned, the option list was still mounted (4 options) and the body
still carried `pointer-events: none`.

Losing that race fails in two ways, both silent at the point of the mistake: a
click is refused outright — Playwright waits for pointer events the body is
suppressing, which reproduces as a `locator.click` timeout — or it opens a
layer the teardown then dismisses, so the next dropdown never opens and the
failure only surfaces at the assertion waiting for its options. The second is
what CI hit, which is why it failed at the tier-option assertion rather than at
the click before it.

`choose()` now waits for the dropdown to unmount, which also restores the
body's pointer events (re-measured: 0 options, `pointerEvents: ""`).

## Follow-up, deliberately not in this PR

The same shape — pick an option, immediately touch the next control — exists at
roughly twenty other call sites across eleven files. It is not a mechanical
sweep: not all of those dropdowns are single-select, and the bulk-actions label
picker stays open by design, so waiting for unmount there would hang. Each site
needs classifying, ideally behind a shared harness gesture documented as
single-select only.

Also still open: one observed flake at `navigation-history.acceptance.test.tsx`
line 78, where `flushEffects()` waits a fixed number of frames for the dirty
flag to reach the history blocker. It could not be reproduced locally, and the
obvious readiness probe is unusable because MSW's browser worker tears itself
down on `beforeunload`.
