### PR TITLE
Tested member count rounding at each range boundary

### DIFF
--- a/ghost/core/test/unit/frontend/utils/member-count.test.js
+++ b/ghost/core/test/unit/frontend/utils/member-count.test.js
@@ -52,4 +52,24 @@ describe('Member Count', function () {
       return assert.equal(result, mock.expected);
     });
   });
+
+  it('should round correctly at each range boundary', function () {
+    const boundaries = [
+      { members: 50, expected: '50' },
+      { members: 51, expected: '50+' },
+      { members: 100, expected: '100+' },
+      { members: 101, expected: '100+' },
+      { members: 1000, expected: '1,000+' },
+      { members: 1001, expected: '1,000+' },
+      { members: 10000, expected: '10,000+' },
+      { members: 10001, expected: '10,000+' },
+      { members: 100000, expected: '100,000+' },
+      { members: 100001, expected: '100k+' },
+      { members: 1000000, expected: '1m+' },
+      { members: 1000001, expected: '1m+' },
+    ];
+    boundaries.forEach(({ members, expected }) => {
+      assert.equal(memberCountRounding(members), expected, `memberCountRounding(${members})`);
+    });
+  });
 });


### PR DESCRIPTION
### Why are you making it?

The existing `memberCountRounding` test only uses mid-range values (55, 580, 5555...), so the threshold constants themselves are unpinned. A one-character typo in a boundary can slip through with every test green: change `10000` to `9999` in the second range guard and `memberCountRounding(10000)` returns `undefined`, change `1000000` to `999999` and `memberCountRounding(1000000)` does the same. A site's member count would silently render wrong or not at all, and no test would notice.

I posted a summary of this to the forum's Contributing category first, since that seems to be the preferred flow for non-bug contributions, but the post has been stuck in the moderation queue for a while. Opening the PR anyway since the diff is small and test-only.

### What does it do?

Adds one test case that pins `memberCountRounding` at each range boundary, asserting both sides of every threshold from 50 up through 1,000,001. Test-only change, 20 lines.

I verified it by shifting each threshold constant by one in `member-count.js`: each of those planted defects fails the new test, and the clean source passes.

### Why is this something Ghost users or developers need?

The boundaries are the only part of this function's behavior the suite doesn't currently pin, and they're the part most likely to break in a refactor. Found while mutation-testing this repo, I'm building a tool in this space.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
