### PR TITLE
Cleaned up DI and composition in the class-based jobs wiring

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -673,14 +673,17 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     await initServices({ ghostServer, config, prometheusClient });
 
     debug('Begin: Register job handlers');
+    const assert = require('node:assert/strict');
     const jobsServiceWrapper = require('./server/services/jobs-service');
     const registerJobHandlers =
       require('./server/services/jobs-service/register-job-handlers').default;
     const mediaInliner = require('./server/services/media-inliner');
+    const gifts = require('./server/services/gifts');
     const db = require('./server/data/db');
     const models = require('./server/models');
     const events = require('./server/lib/common/events');
     const jobsService = jobsServiceWrapper.init();
+    assert(gifts.service, 'Gift service should be initialized');
     registerJobHandlers({
       jobsService,
       db,
@@ -688,6 +691,7 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
       models,
       events,
       sentry,
+      giftService: gifts.service,
       mediaInliner: mediaInliner.getInstance(),
     });
     await jobsService.start();

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -502,7 +502,7 @@ async function initBackgroundServices({ config }) {
   // service fails.
   try {
     const memberJobs = require('./server/services/members/jobs');
-    await memberJobs.scheduleTokenCleanupJob();
+    await memberJobs.scheduleTokenCleanupJob(jobsService);
   } catch (err) {
     const logging = require('@tryghost/logging');
     logging.error(err);
@@ -510,7 +510,7 @@ async function initBackgroundServices({ config }) {
 
   try {
     const memberJobs = require('./server/services/members/jobs');
-    await memberJobs.scheduleExpiredCompCleanupJob();
+    await memberJobs.scheduleExpiredCompCleanupJob(jobsService);
   } catch (err) {
     const logging = require('@tryghost/logging');
     logging.error(err);

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -679,18 +679,13 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
       require('./server/services/jobs-service/register-job-handlers').default;
     const mediaInliner = require('./server/services/media-inliner');
     const gifts = require('./server/services/gifts');
-    const db = require('./server/data/db');
-    const models = require('./server/models');
-    const events = require('./server/lib/common/events');
+    const memberJobs = require('./server/services/members/jobs');
     const jobsService = jobsServiceWrapper.init();
+    memberJobs.init();
     assert(gifts.service, 'Gift service should be initialized');
     registerJobHandlers({
       jobsService,
-      db,
-      logging,
-      models,
-      events,
-      sentry,
+      memberJobs,
       giftService: gifts.service,
       mediaInliner: mediaInliner.getInstance(),
     });

--- a/ghost/core/core/server/services/gifts/jobs/index.js
+++ b/ghost/core/core/server/services/gifts/jobs/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const logging = require('@tryghost/logging');
-const jobsService = require('../../jobs');
+const jobManager = require('../../jobs');
 const CleanGiftsJob = require('./clean-gifts-job').default;
 
 let hasScheduled = {
@@ -31,7 +31,7 @@ function scheduleJob(key, name, jobFile) {
   const at = randomOffPeakDailyCron();
 
   logging.info(`[Background Job] ${name} scheduled at ${at}`);
-  jobsService.addJob({
+  jobManager.addJob({
     at,
     job: path.resolve(__dirname, jobFile),
     name,

--- a/ghost/core/core/server/services/gifts/jobs/index.js
+++ b/ghost/core/core/server/services/gifts/jobs/index.js
@@ -43,14 +43,14 @@ function scheduleJob(key, name, jobFile) {
 }
 
 module.exports = {
-  async scheduleGiftCleanupJob(classBasedJobs) {
+  async scheduleGiftCleanupJob(jobsService) {
     if (alreadyScheduledOrTest('cleanup')) {
       return;
     }
 
     const cron = randomOffPeakDailyCron();
     logging.info(`[Background Job] clean-gifts scheduled at ${cron}`);
-    await classBasedJobs.scheduleRecurring(new CleanGiftsJob(), { cron });
+    await jobsService.scheduleRecurring(new CleanGiftsJob(), { cron });
 
     hasScheduled.cleanup = true;
   },

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,9 +1,7 @@
 import { JobsService } from './jobs-service';
 import type { GiftService } from '../gifts/gift-service';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
-import cleanTokens from '../members/jobs/clean-tokens-task';
 import CleanExpiredCompedJob from '../members/jobs/clean-expired-comped-job';
-import cleanExpiredComped from '../members/jobs/clean-expired-comped-task';
 import CleanGiftsJob from '../gifts/jobs/clean-gifts-job';
 import ExternalMediaInliner from '../media-inliner/external-media-inliner';
 import ExternalMediaInlinerJob from '../media-inliner/external-media-inliner-job';
@@ -15,40 +13,26 @@ const updateCheck = require('../update-check');
 
 interface RegisterJobHandlersDependencies {
   jobsService: JobsService;
-  db: typeof import('../../data/db');
-  logging: typeof import('@tryghost/logging');
-  // Structural types: models, lib/common/events and shared/sentry are
-  // untyped CommonJS modules, so name just the surface the handlers consume.
-  models: {
-    Member: {
-      findOne(
-        data: Record<string, unknown>,
-        options: Record<string, unknown>,
-      ): Promise<{ attributes: Record<string, unknown> }>;
-    };
+  memberJobs: {
+    cleanTokens(): Promise<number>;
+    cleanExpiredComped(): Promise<unknown>;
   };
-  events: { emit(name: string, model: unknown, options: Record<string, unknown>): void };
-  sentry: { captureException(err: unknown): void };
   giftService: GiftService;
   mediaInliner: ExternalMediaInliner;
 }
 
 export default function registerJobHandlers({
   jobsService,
-  db,
-  logging,
-  models,
-  events,
-  sentry,
+  memberJobs,
   giftService,
   mediaInliner,
 }: RegisterJobHandlersDependencies): void {
   jobsService.handle(CleanTokensJob, async () => {
-    await cleanTokens({ db, logging });
+    await memberJobs.cleanTokens();
   });
 
   jobsService.handle(CleanExpiredCompedJob, async () => {
-    await cleanExpiredComped({ db, models, events, logging, sentry });
+    await memberJobs.cleanExpiredComped();
   });
 
   jobsService.handle(CleanGiftsJob, async () => {

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,10 +1,9 @@
-import errors from '@tryghost/errors';
 import { JobsService } from './jobs-service';
+import type { GiftService } from '../gifts/gift-service';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import cleanTokens from '../members/jobs/clean-tokens-task';
 import CleanExpiredCompedJob from '../members/jobs/clean-expired-comped-job';
 import cleanExpiredComped from '../members/jobs/clean-expired-comped-task';
-import * as gifts from '../gifts';
 import CleanGiftsJob from '../gifts/jobs/clean-gifts-job';
 import ExternalMediaInliner from '../media-inliner/external-media-inliner';
 import ExternalMediaInlinerJob from '../media-inliner/external-media-inliner-job';
@@ -30,6 +29,7 @@ interface RegisterJobHandlersDependencies {
   };
   events: { emit(name: string, model: unknown, options: Record<string, unknown>): void };
   sentry: { captureException(err: unknown): void };
+  giftService: GiftService;
   mediaInliner: ExternalMediaInliner;
 }
 
@@ -40,6 +40,7 @@ export default function registerJobHandlers({
   models,
   events,
   sentry,
+  giftService,
   mediaInliner,
 }: RegisterJobHandlersDependencies): void {
   jobsService.handle(CleanTokensJob, async () => {
@@ -51,12 +52,7 @@ export default function registerJobHandlers({
   });
 
   jobsService.handle(CleanGiftsJob, async () => {
-    if (!gifts.service) {
-      throw new errors.IncorrectUsageError({
-        message: 'clean-gifts ran before the gifts service was initialised',
-      });
-    }
-    await gifts.service.cleanup();
+    await giftService.cleanup();
   });
 
   jobsService.handle(ExternalMediaInlinerJob, async (job) => {

--- a/ghost/core/core/server/services/members/jobs/index.js
+++ b/ghost/core/core/server/services/members/jobs/index.js
@@ -1,11 +1,16 @@
 const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
 const CleanTokensJob = require('./clean-tokens-job').default;
 const CleanExpiredCompedJob = require('./clean-expired-comped-job').default;
+const cleanTokensTask = require('./clean-tokens-task').default;
+const cleanExpiredCompedTask = require('./clean-expired-comped-task').default;
 
 let hasScheduled = {
   expiredComped: false,
   tokens: false,
 };
+
+let tasks;
 
 function alreadyScheduledOrTest(key) {
   return hasScheduled[key] || process.env.NODE_ENV.startsWith('test');
@@ -18,7 +23,42 @@ function randomDailyCron(maxHour = 24) {
   return `${s} ${m} ${h} * * *`;
 }
 
+function getTasks() {
+  if (!tasks) {
+    throw new errors.IncorrectUsageError({
+      message: 'Member jobs used before init(). Call init() from boot first.',
+    });
+  }
+  return tasks;
+}
+
 module.exports = {
+  // Composition root for the member cleanup tasks. Idempotent because tests
+  // may boot more than once per process.
+  init() {
+    if (tasks) {
+      return;
+    }
+
+    const db = require('../../../data/db');
+    const models = require('../../../models');
+    const events = require('../../../lib/common/events');
+    const sentry = require('../../../../shared/sentry');
+
+    tasks = {
+      cleanTokens: () => cleanTokensTask({ db, logging }),
+      cleanExpiredComped: () => cleanExpiredCompedTask({ db, models, events, logging, sentry }),
+    };
+  },
+
+  cleanTokens() {
+    return getTasks().cleanTokens();
+  },
+
+  cleanExpiredComped() {
+    return getTasks().cleanExpiredComped();
+  },
+
   async scheduleExpiredCompCleanupJob(jobsService) {
     if (alreadyScheduledOrTest('expiredComped')) {
       return;

--- a/ghost/core/core/server/services/members/jobs/index.js
+++ b/ghost/core/core/server/services/members/jobs/index.js
@@ -19,29 +19,27 @@ function randomDailyCron(maxHour = 24) {
 }
 
 module.exports = {
-  async scheduleExpiredCompCleanupJob() {
+  async scheduleExpiredCompCleanupJob(jobsService) {
     if (alreadyScheduledOrTest('expiredComped')) {
       return;
     }
 
-    const classBasedJobs = require('../../jobs-service').getInstance();
     // Keep the legacy off-peak window: a random time between 00:00 and 05:59
     const cron = randomDailyCron(6);
     logging.info(`[Background Job] clean-expired-comped scheduled at ${cron}`);
-    await classBasedJobs.scheduleRecurring(new CleanExpiredCompedJob(), { cron });
+    await jobsService.scheduleRecurring(new CleanExpiredCompedJob(), { cron });
 
     hasScheduled.expiredComped = true;
   },
 
-  async scheduleTokenCleanupJob() {
+  async scheduleTokenCleanupJob(jobsService) {
     if (alreadyScheduledOrTest('tokens')) {
       return;
     }
 
-    const classBasedJobs = require('../../jobs-service').getInstance();
     const cron = randomDailyCron();
     logging.info(`[Background Job] clean-tokens scheduled at ${cron}`);
-    await classBasedJobs.scheduleRecurring(new CleanTokensJob(), { cron });
+    await jobsService.scheduleRecurring(new CleanTokensJob(), { cron });
 
     hasScheduled.tokens = true;
   },

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -19,6 +19,7 @@ describe('register-job-handlers', function () {
   let models: { Member: { findOne: sinon.SinonStub } };
   let events: { emit: sinon.SinonStub };
   let sentry: { captureException: sinon.SinonStub };
+  let giftService: { cleanup: sinon.SinonStub };
 
   // Handlers are looked up by their job type rather than registration order,
   // so adding a handler does not silently shift which one a test exercises.
@@ -38,6 +39,7 @@ describe('register-job-handlers', function () {
     models = { Member: { findOne: sinon.stub() } };
     events = { emit: sinon.stub() };
     sentry = { captureException: sinon.stub() };
+    giftService = { cleanup: sinon.stub().resolves() };
 
     registerJobHandlers({
       jobsService,
@@ -46,6 +48,7 @@ describe('register-job-handlers', function () {
       models,
       events,
       sentry,
+      giftService,
       mediaInliner,
     });
   });
@@ -54,15 +57,12 @@ describe('register-job-handlers', function () {
     sinon.restore();
   });
 
-  // Nothing initialises the gifts service here, which is the state the guard
-  // exists for: a dispatch that lands before boot has built the service must
-  // fail loudly rather than reading undefined off the module.
-  it('fails a clean-gifts delivery when the gift service is not initialised', async function () {
+  it('runs clean-gifts with the injected gift service', async function () {
     const cleanGiftsHandler = handlerFor('clean-gifts');
 
-    await assert.rejects(async () => {
-      await cleanGiftsHandler({});
-    }, /clean-gifts ran before the gifts service was initialised/);
+    await cleanGiftsHandler({});
+
+    assert.ok(giftService.cleanup.calledOnce);
   });
 
   it('runs clean-tokens with the injected database and logger', async function () {

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import sinon from 'sinon';
 import { describe, it, beforeEach, afterEach } from 'vitest';
-import logging from '@tryghost/logging';
 import { JobsService } from '../../../../../core/server/services/jobs-service/jobs-service';
 import ExternalMediaInliner from '../../../../../core/server/services/media-inliner/external-media-inliner';
 import ExternalMediaInlinerJob from '../../../../../core/server/services/media-inliner/external-media-inliner-job';
@@ -13,12 +12,8 @@ const registerJobHandlers =
 
 describe('register-job-handlers', function () {
   let jobsService: sinon.SinonStubbedInstance<JobsService>;
-  let db: { knex: sinon.SinonStub & { transaction?: sinon.SinonStub } };
-  let loggingStub: sinon.SinonStubbedInstance<typeof logging>;
   let mediaInliner: sinon.SinonStubbedInstance<ExternalMediaInliner>;
-  let models: { Member: { findOne: sinon.SinonStub } };
-  let events: { emit: sinon.SinonStub };
-  let sentry: { captureException: sinon.SinonStub };
+  let memberJobs: { cleanTokens: sinon.SinonStub; cleanExpiredComped: sinon.SinonStub };
   let giftService: { cleanup: sinon.SinonStub };
 
   // Handlers are looked up by their job type rather than registration order,
@@ -33,21 +28,16 @@ describe('register-job-handlers', function () {
 
   beforeEach(function () {
     jobsService = sinon.createStubInstance(JobsService);
-    db = { knex: sinon.stub() };
-    loggingStub = sinon.stub(logging);
     mediaInliner = sinon.createStubInstance(ExternalMediaInliner);
-    models = { Member: { findOne: sinon.stub() } };
-    events = { emit: sinon.stub() };
-    sentry = { captureException: sinon.stub() };
+    memberJobs = {
+      cleanTokens: sinon.stub().resolves(0),
+      cleanExpiredComped: sinon.stub().resolves(),
+    };
     giftService = { cleanup: sinon.stub().resolves() };
 
     registerJobHandlers({
       jobsService,
-      db,
-      logging: loggingStub,
-      models,
-      events,
-      sentry,
+      memberJobs,
       giftService,
       mediaInliner,
     });
@@ -65,38 +55,20 @@ describe('register-job-handlers', function () {
     assert.ok(giftService.cleanup.calledOnce);
   });
 
-  it('runs clean-tokens with the injected database and logger', async function () {
-    const deleteStub = sinon.stub().resolves(2);
-    const whereStub = sinon.stub().returns({ delete: deleteStub });
-    db.knex.withArgs('tokens').returns({ where: whereStub });
+  it('runs clean-tokens with the injected member jobs module', async function () {
     const cleanTokensHandler = handlerFor('clean-tokens');
 
     await cleanTokensHandler({});
 
-    assert.ok(db.knex.calledOnceWithExactly('tokens'));
-    assert.ok(loggingStub.info.calledOnce);
-    const metadata = loggingStub.info.firstCall.args[0] as {
-      system: { deleted_count: number };
-    };
-    assert.equal(metadata.system.deleted_count, 2);
+    assert.ok(memberJobs.cleanTokens.calledOnce);
   });
 
-  it('runs clean-expired-comped with the injected database, models, events and logger', async function () {
-    db.knex.transaction = sinon.stub().callsFake(async (fn: (trx: unknown) => unknown) => {
-      const trx = () => ({
-        where: () => ({ select: async () => [] }),
-      });
-      return fn(trx);
-    });
+  it('runs clean-expired-comped with the injected member jobs module', async function () {
     const cleanExpiredCompedHandler = handlerFor('clean-expired-comped');
 
     await cleanExpiredCompedHandler({});
 
-    const completionLog = loggingStub.info.getCalls().find((call) => {
-      const metadata = call.args[0] as { system?: { event?: string } };
-      return metadata?.system?.event === 'clean_expired_comped.completed';
-    });
-    assert.ok(completionLog, 'the handler runs the task against the injected dependencies');
+    assert.ok(memberJobs.cleanExpiredComped.calledOnce);
   });
 
   it('runs external-media-inliner with the injected media inliner', async function () {

--- a/ghost/core/test/unit/server/services/members/jobs/cleanup-tasks.test.ts
+++ b/ghost/core/test/unit/server/services/members/jobs/cleanup-tasks.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+
+// require, not import: this must resolve to the same CommonJS module instance
+// the boot layer loads, so the uninitialised state below is the real pre-boot
+// state and not a parallel ESM copy.
+const memberJobs = require('../../../../../../core/server/services/members/jobs');
+
+// Nothing initialises the module here, which is the state the guard exists
+// for: a delivery that lands before boot has wired the tasks must fail loudly
+// rather than reading undefined.
+describe('member jobs: cleanup task guards', function () {
+  it('fails a clean-tokens run before init()', function () {
+    assert.throws(() => memberJobs.cleanTokens(), /Member jobs used before init\(\)/);
+  });
+
+  it('fails a clean-expired-comped run before init()', function () {
+    assert.throws(() => memberJobs.cleanExpiredComped(), /Member jobs used before init\(\)/);
+  });
+});

--- a/ghost/core/test/unit/server/services/members/jobs/schedule-expired-comped-cleanup.test.ts
+++ b/ghost/core/test/unit/server/services/members/jobs/schedule-expired-comped-cleanup.test.ts
@@ -3,32 +3,28 @@ import sinon from 'sinon';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import logging from '@tryghost/logging';
 
-// require, not import: these must resolve to the same CommonJS module
-// instances that core/server/services/members/jobs/index.js loads, so the
-// init() here is the instance scheduleExpiredCompCleanupJob() reads.
-const jobsService = require('../../../../../../core/server/services/jobs-service');
-const adapterManager = require('../../../../../../core/server/services/adapter-manager').default;
+// require, not import: this must resolve to the same CommonJS module instance
+// the boot layer loads, so the module-level "already scheduled" state is shared.
 const memberJobs = require('../../../../../../core/server/services/members/jobs');
+const CleanExpiredCompedJob =
+  require('../../../../../../core/server/services/members/jobs/clean-expired-comped-job').default;
 
 describe('member jobs: expired comped cleanup scheduling', function () {
-  let scheduleStub: sinon.SinonStub;
+  let jobsService: { scheduleRecurring: sinon.SinonStub };
 
   beforeEach(function () {
-    jobsService.init();
-    const backend = adapterManager.getAdapter('jobs');
-    scheduleStub = sinon.stub(backend, 'scheduleRecurring');
+    jobsService = { scheduleRecurring: sinon.stub().resolves() };
   });
 
-  afterEach(async function () {
-    await jobsService.shutdown({ timeoutMs: 100 });
+  afterEach(function () {
     sinon.restore();
   });
 
   it('does not schedule expired comped cleanup under the test environment', async function () {
-    await memberJobs.scheduleExpiredCompCleanupJob();
+    await memberJobs.scheduleExpiredCompCleanupJob(jobsService);
 
     assert.ok(
-      scheduleStub.notCalled,
+      jobsService.scheduleRecurring.notCalled,
       'expired comped cleanup must not be scheduled under NODE_ENV=test*',
     );
   });
@@ -38,18 +34,18 @@ describe('member jobs: expired comped cleanup scheduling', function () {
     sinon.stub(logging, 'info');
     process.env.NODE_ENV = 'production';
     try {
-      await memberJobs.scheduleExpiredCompCleanupJob();
-      await memberJobs.scheduleExpiredCompCleanupJob();
+      await memberJobs.scheduleExpiredCompCleanupJob(jobsService);
+      await memberJobs.scheduleExpiredCompCleanupJob(jobsService);
     } finally {
       process.env.NODE_ENV = originalEnv;
     }
 
     assert.ok(
-      scheduleStub.calledOnce,
+      jobsService.scheduleRecurring.calledOnce,
       'clean-expired-comped is scheduled once, however often scheduling is attempted',
     );
-    const [envelope, schedule] = scheduleStub.firstCall.args;
-    assert.equal(envelope.type, 'clean-expired-comped');
+    const [job, schedule] = jobsService.scheduleRecurring.firstCall.args;
+    assert.ok(job instanceof CleanExpiredCompedJob);
     assert.match(
       schedule.cron,
       /^\d{1,2} \d{1,2} [0-5] \* \* \*$/,

--- a/ghost/core/test/unit/server/services/members/jobs/schedule-token-cleanup.test.ts
+++ b/ghost/core/test/unit/server/services/members/jobs/schedule-token-cleanup.test.ts
@@ -3,31 +3,30 @@ import sinon from 'sinon';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import logging from '@tryghost/logging';
 
-// require, not import: these must resolve to the same CommonJS module
-// instances that core/server/services/members/jobs/index.js loads, so the
-// init() here is the instance scheduleTokenCleanupJob() reads.
-const jobsService = require('../../../../../../core/server/services/jobs-service');
-const adapterManager = require('../../../../../../core/server/services/adapter-manager').default;
+// require, not import: this must resolve to the same CommonJS module instance
+// the boot layer loads, so the module-level "already scheduled" state is shared.
 const memberJobs = require('../../../../../../core/server/services/members/jobs');
+const CleanTokensJob =
+  require('../../../../../../core/server/services/members/jobs/clean-tokens-job').default;
 
 describe('member jobs: token cleanup scheduling', function () {
-  let scheduleStub: sinon.SinonStub;
+  let jobsService: { scheduleRecurring: sinon.SinonStub };
 
   beforeEach(function () {
-    jobsService.init();
-    const backend = adapterManager.getAdapter('jobs');
-    scheduleStub = sinon.stub(backend, 'scheduleRecurring');
+    jobsService = { scheduleRecurring: sinon.stub().resolves() };
   });
 
-  afterEach(async function () {
-    await jobsService.shutdown({ timeoutMs: 100 });
+  afterEach(function () {
     sinon.restore();
   });
 
   it('does not schedule token cleanup under the test environment', async function () {
-    await memberJobs.scheduleTokenCleanupJob();
+    await memberJobs.scheduleTokenCleanupJob(jobsService);
 
-    assert.ok(scheduleStub.notCalled, 'token cleanup must not be scheduled under NODE_ENV=test*');
+    assert.ok(
+      jobsService.scheduleRecurring.notCalled,
+      'token cleanup must not be scheduled under NODE_ENV=test*',
+    );
   });
 
   it('schedules a daily clean-tokens job outside the test environment', async function () {
@@ -35,14 +34,17 @@ describe('member jobs: token cleanup scheduling', function () {
     sinon.stub(logging, 'info');
     process.env.NODE_ENV = 'production';
     try {
-      await memberJobs.scheduleTokenCleanupJob();
+      await memberJobs.scheduleTokenCleanupJob(jobsService);
     } finally {
       process.env.NODE_ENV = originalEnv;
     }
 
-    assert.ok(scheduleStub.calledOnce, 'clean-tokens is scheduled outside the test environment');
-    const [envelope, schedule] = scheduleStub.firstCall.args;
-    assert.equal(envelope.type, 'clean-tokens');
+    assert.ok(
+      jobsService.scheduleRecurring.calledOnce,
+      'clean-tokens is scheduled outside the test environment',
+    );
+    const [job, schedule] = jobsService.scheduleRecurring.firstCall.args;
+    assert.ok(job instanceof CleanTokensJob);
     assert.match(schedule.cron, /^\d+ \d+ \d+ \* \* \*$/, 'a random daily 6-field cron');
   });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/project/durable-background-jobs

The first job migrations left a few inconsistencies in how the class-based jobs service is wired up. This stack aligns everything on one set of conventions, so future migrations have a single reference shape:

- **Boot is the composition root.** The member cleanup scheduling functions now receive the jobs service as a parameter (like gifts and update-check already did) instead of reaching for `getInstance()`, and the `classBasedJobs` name is gone — the legacy service binding is `jobManager`, the class-based service is `jobsService`.
- **Service instances are injected at registration.** The clean-gifts handler previously read the gift service off the module at execution time with an "uninitialised" guard. Registration already runs after `initServices` and nothing executes before `jobsService.start()`, so boot now asserts the gift service exists and injects the instance — the same pattern it already uses for the gift delivery service. A boot-order regression now fails at wire-up rather than at the first delivery.
- **`register-job-handlers` is wiring only.** It previously assembled `db`/`models`/`events`/`logging`/`sentry` for the two member cleanup tasks, making it a second composition root. That composition moved into the members jobs module behind an `init()` called from boot (the same shape content-import uses), so every handler is a single delegating line and the dependency interface shrinks to the jobs service plus service instances.

No behavior changes intended; commits are small and reviewable independently.