### PR TITLE
Changed email analytics ingestion to use transactional counters

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.62/2026-08-31-08-44-17-add-email-tracked-count-to-members.js
+++ b/ghost/core/core/server/data/migrations/versions/6.62/2026-08-31-08-44-17-add-email-tracked-count-to-members.js
@@ -1,0 +1,7 @@
+const { createAddColumnMigration } = require('../../utils');
+
+module.exports = createAddColumnMigration('members', 'email_tracked_count', {
+  type: 'integer',
+  nullable: true,
+  unsigned: true,
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -674,6 +674,7 @@ module.exports = {
     enable_comment_notifications: { type: 'boolean', nullable: false, defaultTo: true },
     enable_updates_and_announcements: { type: 'boolean', nullable: true },
     email_count: { type: 'integer', unsigned: true, nullable: false, defaultTo: 0 },
+    email_tracked_count: { type: 'integer', unsigned: true, nullable: true },
     email_opened_count: { type: 'integer', unsigned: true, nullable: false, defaultTo: 0 },
     email_open_rate: { type: 'integer', unsigned: true, nullable: true, index: true },
     email_disabled: { type: 'boolean', nullable: false, defaultTo: false },

--- a/ghost/core/core/server/services/email-analytics/event-processing-result.ts
+++ b/ghost/core/core/server/services/email-analytics/event-processing-result.ts
@@ -1,6 +1,9 @@
 type EventProcessingResultInput = Partial<Omit<EventProcessingResult, 'merge'>>;
 
 export class EventProcessingResult {
+  #emailIdSet = new Set<string>();
+  #memberIdSet = new Set<string>();
+
   // counts
   delivered: number = 0;
   opened: number = 0;
@@ -34,6 +37,8 @@ export class EventProcessingResult {
     this.processingFailures = 0;
     this.emailIds = [];
     this.memberIds = [];
+    this.#emailIdSet.clear();
+    this.#memberIdSet.clear();
   }
 
   merge(other: EventProcessingResultInput = {}): void {
@@ -48,12 +53,17 @@ export class EventProcessingResult {
 
     this.processingFailures += other.processingFailures || 0;
 
-    // TODO: come up with a cleaner way to merge these without churning through Array and Set
-    this.emailIds = Array.from(new Set([...this.emailIds, ...(other.emailIds || [])])).filter(
-      Boolean,
-    );
-    this.memberIds = Array.from(new Set([...this.memberIds, ...(other.memberIds || [])])).filter(
-      Boolean,
-    );
+    for (const emailId of other.emailIds || []) {
+      if (emailId && !this.#emailIdSet.has(emailId)) {
+        this.#emailIdSet.add(emailId);
+        this.emailIds.push(emailId);
+      }
+    }
+    for (const memberId of other.memberIds || []) {
+      if (memberId && !this.#memberIdSet.has(memberId)) {
+        this.#memberIdSet.add(memberId);
+        this.memberIds.push(memberId);
+      }
+    }
   }
 }

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -91,6 +91,7 @@ export const init = ({
       },
       emailSuppressionList,
       prometheusClient,
+      settingsCache,
     }),
     prometheusClient,
   });

--- a/ghost/core/core/server/services/email-analytics/lib/queries.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.ts
@@ -8,6 +8,7 @@ import type { JsonObject } from 'type-fest';
 const debug = debugFactory('services:email-analytics');
 
 const MIN_EMAIL_COUNT_FOR_OPEN_RATE = 5;
+const MEMBER_RECONCILIATION_JOB_NAME = 'email-analytics-member-reconciliation';
 
 type EmailAnalyticsJobName = string;
 type EmailAnalyticsEvent = 'delivered' | 'opened' | 'failed';
@@ -282,54 +283,43 @@ export class Queries {
   }
 
   async aggregateEmailStats(emailId: string, updateOpenedCount: boolean): Promise<void> {
-    const [deliveredCount] = await this.#knex('email_recipients')
-      .count('id as count')
-      .whereRaw('email_id = ? AND delivered_at IS NOT NULL', [emailId]);
-    const [failedCount] = await this.#knex('email_recipients')
-      .count('id as count')
-      .whereRaw('email_id = ? AND failed_at IS NOT NULL', [emailId]);
+    const counts = await this.#knex('email_recipients')
+      .select(
+        this.#knex.raw(
+          'SUM(CASE WHEN delivered_at IS NOT NULL THEN 1 ELSE 0 END) as delivered_count',
+        ),
+        this.#knex.raw('SUM(CASE WHEN failed_at IS NOT NULL THEN 1 ELSE 0 END) as failed_count'),
+        this.#knex.raw('SUM(CASE WHEN opened_at IS NOT NULL THEN 1 ELSE 0 END) as opened_count'),
+      )
+      .where('email_id', emailId)
+      .first();
 
     const updateData: Record<string, string | number> = {
-      delivered_count: deliveredCount.count,
-      failed_count: failedCount.count,
+      delivered_count: Number(counts?.delivered_count || 0),
+      failed_count: Number(counts?.failed_count || 0),
     };
 
     if (updateOpenedCount) {
-      const [openedCount] = await this.#knex('email_recipients')
-        .count('id as count')
-        .whereRaw('email_id = ? AND opened_at IS NOT NULL', [emailId]);
-      updateData.opened_count = openedCount.count;
+      updateData.opened_count = Number(counts?.opened_count || 0);
     }
 
     await this.#knex('emails').update(updateData).where('id', emailId);
   }
 
   async aggregateMemberStats(memberId: string): Promise<void> {
-    const { trackedEmailCount } =
-      (await this.#knex('email_recipients')
-        .select(this.#knex.raw('COUNT(email_recipients.id) as trackedEmailCount'))
-        .leftJoin('emails', 'email_recipients.email_id', 'emails.id')
-        .where('email_recipients.member_id', memberId)
-        .where('emails.track_opens', true)
-        .first()) || {};
-    const emailCountResult = await this.#knex('email_recipients')
-      .count('id as count')
-      .whereRaw('member_id = ?', [memberId])
-      .first();
-    const emailOpenedCountResult = await this.#knex('email_recipients')
-      .count('id as count')
-      .whereRaw('member_id = ? AND opened_at IS NOT NULL', [memberId])
-      .first();
-    const emailCount = Number(emailCountResult?.count || 0);
-    const emailOpenedCount = Number(emailOpenedCountResult?.count || 0);
+    const stats = await this.#memberStatsQuery([memberId]).first();
+    const emailCount = Number(stats?.email_count || 0);
+    const emailTrackedCount = Number(stats?.tracked_count || 0);
+    const emailOpenedCount = Number(stats?.email_opened_count || 0);
 
-    const updateQuery: Record<string, string | number> = {
+    const updateQuery: Record<string, string | number | null> = {
       email_count: emailCount,
+      email_tracked_count: emailTrackedCount,
       email_opened_count: emailOpenedCount,
     };
 
-    if (trackedEmailCount >= MIN_EMAIL_COUNT_FOR_OPEN_RATE) {
-      updateQuery.email_open_rate = Math.round((emailOpenedCount / trackedEmailCount) * 100);
+    if (emailTrackedCount >= MIN_EMAIL_COUNT_FOR_OPEN_RATE) {
+      updateQuery.email_open_rate = Math.round((emailOpenedCount / emailTrackedCount) * 100);
     }
 
     await this.#knex('members').update(updateQuery).where('id', memberId);
@@ -340,55 +330,57 @@ export class Queries {
       return;
     }
 
-    // Batch query to get stats for all members at once
-    const stats = await this.#knex('email_recipients')
-      .leftJoin('emails', 'emails.id', 'email_recipients.email_id')
-      .select(
-        'email_recipients.member_id',
-        this.#knex.raw('COUNT(email_recipients.id) as email_count'),
-        this.#knex.raw(
-          'SUM(CASE WHEN email_recipients.opened_at IS NOT NULL THEN 1 ELSE 0 END) as email_opened_count',
-        ),
-        this.#knex.raw('SUM(CASE WHEN emails.track_opens = 1 THEN 1 ELSE 0 END) as tracked_count'),
-      )
-      .whereIn('email_recipients.member_id', memberIds)
-      .groupBy('email_recipients.member_id');
+    const stats = await this.#memberStatsQuery(memberIds);
 
     // Build update data for each member
     const memberStatsMap = new Map<
       string,
-      { email_count: number; email_opened_count: number; email_open_rate: number | null }
+      {
+        email_count: number;
+        email_tracked_count: number;
+        email_opened_count: number;
+        email_open_rate: number | null;
+      }
     >();
     for (const stat of stats) {
+      const trackedCount = Number(stat.tracked_count || 0);
+      const openedCount = Number(stat.email_opened_count || 0);
       const emailOpenRate =
-        stat.tracked_count >= MIN_EMAIL_COUNT_FOR_OPEN_RATE
-          ? Math.round((stat.email_opened_count / stat.tracked_count) * 100)
+        trackedCount >= MIN_EMAIL_COUNT_FOR_OPEN_RATE
+          ? Math.round((openedCount / trackedCount) * 100)
           : null;
 
       memberStatsMap.set(stat.member_id, {
-        email_count: stat.email_count,
-        email_opened_count: stat.email_opened_count,
+        email_count: Number(stat.email_count || 0),
+        email_tracked_count: trackedCount,
+        email_opened_count: openedCount,
         email_open_rate: emailOpenRate,
       });
     }
 
     // Build CASE statements for batch update
     const emailCountCases: string[] = [];
+    const emailTrackedCountCases: string[] = [];
     const emailOpenedCountCases: string[] = [];
     const emailOpenRateCases: string[] = [];
     const emailCountBindings: (string | number)[] = [];
+    const emailTrackedCountBindings: (string | number)[] = [];
     const emailOpenedCountBindings: (string | number)[] = [];
     const emailOpenRateBindings: (string | number)[] = [];
 
     for (const memberId of memberIds) {
       const memberStats = memberStatsMap.get(memberId) || {
         email_count: 0,
+        email_tracked_count: 0,
         email_opened_count: 0,
         email_open_rate: null,
       };
 
       emailCountCases.push(`WHEN ? THEN ?`);
       emailCountBindings.push(memberId, memberStats.email_count);
+
+      emailTrackedCountCases.push(`WHEN ? THEN ?`);
+      emailTrackedCountBindings.push(memberId, memberStats.email_tracked_count);
 
       emailOpenedCountCases.push(`WHEN ? THEN ?`);
       emailOpenedCountBindings.push(memberId, memberStats.email_opened_count);
@@ -409,6 +401,7 @@ export class Queries {
     // 4. Member IDs for the WHERE IN clause
     const bindings = [
       ...emailCountBindings,
+      ...emailTrackedCountBindings,
       ...emailOpenedCountBindings,
       ...emailOpenRateBindings,
       ...memberIds,
@@ -420,11 +413,77 @@ export class Queries {
             UPDATE members
             SET
                 email_count = CASE id ${emailCountCases.join(' ')} END,
+                email_tracked_count = CASE id ${emailTrackedCountCases.join(' ')} END,
                 email_opened_count = CASE id ${emailOpenedCountCases.join(' ')} END,
                 email_open_rate = CASE id ${emailOpenRateCases.join(' ')} END
             WHERE id IN (${memberIds.map(() => '?').join(',')})
         `,
       bindings,
     );
+  }
+
+  async reconcileMemberStats(batchSize: number): Promise<number> {
+    const job = await this.#knex('jobs')
+      .select('metadata')
+      .where('name', MEMBER_RECONCILIATION_JOB_NAME)
+      .first();
+    const metadata = parseJsonObject(job?.metadata) || {};
+    const cursor = getStringValue(metadata, 'memberCursor');
+
+    const getMemberIds = async (afterId: string | null) => {
+      const query = this.#knex('members').select('id').orderBy('id').limit(batchSize);
+      if (afterId) {
+        query.where('id', '>', afterId);
+      }
+      return (await query).map(({ id }) => id as string);
+    };
+
+    let memberIds = await getMemberIds(cursor);
+    if (memberIds.length === 0 && cursor) {
+      memberIds = await getMemberIds(null);
+    }
+    if (memberIds.length === 0) {
+      return 0;
+    }
+
+    for (let index = 0; index < memberIds.length; index += 100) {
+      await this.aggregateMemberStatsBatch(memberIds.slice(index, index + 100));
+    }
+
+    const nextMetadata = JSON.stringify({ memberCursor: memberIds.at(-1) });
+    const now = new Date();
+    await this.#knex.transaction(async (transaction) => {
+      const updated = await transaction('jobs')
+        .where('name', MEMBER_RECONCILIATION_JOB_NAME)
+        .update({ metadata: nextMetadata, status: 'finished', finished_at: now, updated_at: now });
+      if (updated === 0) {
+        await transaction('jobs').insert({
+          id: new ObjectID().toHexString(),
+          name: MEMBER_RECONCILIATION_JOB_NAME,
+          metadata: nextMetadata,
+          status: 'finished',
+          finished_at: now,
+          created_at: now,
+        });
+      }
+    });
+
+    return memberIds.length;
+  }
+
+  #memberStatsQuery(memberIds: string[]) {
+    return this.#knex('email_recipients')
+      .select(
+        'email_recipients.member_id',
+        this.#knex.raw('COUNT(email_recipients.id) as email_count'),
+        this.#knex.raw(
+          'SUM(CASE WHEN email_recipients.opened_at IS NOT NULL THEN 1 ELSE 0 END) as email_opened_count',
+        ),
+        this.#knex.raw(
+          'SUM(CASE WHEN email_recipients.email_id IN (SELECT id FROM emails WHERE track_opens = 1) THEN 1 ELSE 0 END) as tracked_count',
+        ),
+      )
+      .whereIn('email_recipients.member_id', memberIds)
+      .groupBy('email_recipients.member_id');
   }
 }

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -4,6 +4,7 @@ const logging = require('@tryghost/logging');
 /** @import {FetchData} from './email-analytics-service' */
 
 const AGGREGATE_MEMBER_STATS_METRIC_NAME = 'email_analytics_aggregate_member_stats_count';
+const MEMBER_RECONCILIATION_BATCH_SIZE = 100;
 exports.AGGREGATE_MEMBER_STATS_METRIC_NAME = AGGREGATE_MEMBER_STATS_METRIC_NAME;
 
 /**
@@ -14,6 +15,7 @@ class NewsletterEmailAnalyticsBatchProcessor {
   #emailEventProcessor;
   #prometheusClient;
   #queries;
+  #emailIdsForReconciliation = new Set();
 
   #lastAggregation = Date.now();
 
@@ -61,6 +63,9 @@ class NewsletterEmailAnalyticsBatchProcessor {
 
       // Flush all batched updates to the database
       await this.#emailEventProcessor.flushBatchedUpdates();
+      for (const emailId of result.emailIds) {
+        this.#emailIdsForReconciliation.add(emailId);
+      }
     } else {
       // Sequential mode: process events one by one (original behavior)
       for (const event of events) {
@@ -90,6 +95,50 @@ class NewsletterEmailAnalyticsBatchProcessor {
    * }>}
    */
   async aggregate({ includeOpenedEvents, processingResult, isFinal }) {
+    const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
+    if (useBatchProcessing) {
+      for (const emailId of processingResult.emailIds) {
+        this.#emailIdsForReconciliation.add(emailId);
+      }
+      const shouldReset =
+        Date.now() - this.#lastAggregation > 5 * 60 * 1000 ||
+        processingResult.memberIds.length > 5000;
+
+      if (!isFinal) {
+        if (shouldReset) {
+          processingResult.reset();
+          this.#lastAggregation = Date.now();
+          return { emailAggregationTimeMs: 0, memberAggregationTimeMs: 0 };
+        }
+        return null;
+      }
+
+      if (this.#emailIdsForReconciliation.size === 0) {
+        return null;
+      }
+
+      const emailAggregationStart = Date.now();
+      for (const emailId of this.#emailIdsForReconciliation) {
+        await this.#aggregateEmailStats(emailId, includeOpenedEvents);
+      }
+      const emailAggregationTimeMs = Date.now() - emailAggregationStart;
+
+      const memberAggregationStart = Date.now();
+      const reconciledMemberCount = await this.#queries.reconcileMemberStats(
+        MEMBER_RECONCILIATION_BATCH_SIZE,
+      );
+      const memberAggregationTimeMs = Date.now() - memberAggregationStart;
+      this.#prometheusClient
+        ?.getMetric(AGGREGATE_MEMBER_STATS_METRIC_NAME)
+        ?.inc(reconciledMemberCount);
+
+      this.#emailIdsForReconciliation.clear();
+      processingResult.reset();
+      this.#lastAggregation = Date.now();
+
+      return { emailAggregationTimeMs, memberAggregationTimeMs };
+    }
+
     /** @type {boolean} */ let shouldAggregate;
     if (isFinal) {
       shouldAggregate = Boolean(
@@ -237,8 +286,6 @@ class NewsletterEmailAnalyticsBatchProcessor {
    * @returns {Promise<{emailAggregationTimeMs: number, memberAggregationTimeMs: number}>}
    */
   async #aggregateStats({ emailIds = [], memberIds = [] }, includeOpenedEvents = true) {
-    const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
-
     const emailAggregationStart = Date.now();
     for (const emailId of emailIds) {
       await this.#aggregateEmailStats(emailId, includeOpenedEvents);
@@ -248,26 +295,12 @@ class NewsletterEmailAnalyticsBatchProcessor {
     const memberMetric = this.#prometheusClient?.getMetric(AGGREGATE_MEMBER_STATS_METRIC_NAME);
 
     const memberAggregationStart = Date.now();
-    if (useBatchProcessing) {
-      // Batched mode: process 100 members at a time
-      logging.info(
-        `[EmailAnalytics] Aggregating stats for ${memberIds.length} members using BATCHED mode (batch size: 100)`,
-      );
-      const BATCH_SIZE = 100;
-      for (let i = 0; i < memberIds.length; i += BATCH_SIZE) {
-        const batch = memberIds.slice(i, i + BATCH_SIZE);
-        await this.#aggregateMemberStatsBatch(batch);
-        memberMetric?.inc(batch.length);
-      }
-    } else {
-      // Sequential mode: process one member at a time
-      logging.info(
-        `[EmailAnalytics] Aggregating stats for ${memberIds.length} members using SEQUENTIAL mode`,
-      );
-      for (const memberId of memberIds) {
-        await this.#aggregateMemberStats(memberId);
-        memberMetric?.inc();
-      }
+    logging.info(
+      `[EmailAnalytics] Aggregating stats for ${memberIds.length} members using SEQUENTIAL mode`,
+    );
+    for (const memberId of memberIds) {
+      await this.#aggregateMemberStats(memberId);
+      memberMetric?.inc();
     }
     const memberAggregationTimeMs = Date.now() - memberAggregationStart;
 
@@ -291,15 +324,6 @@ class NewsletterEmailAnalyticsBatchProcessor {
    */
   async #aggregateMemberStats(memberId) {
     return this.#queries.aggregateMemberStats(memberId);
-  }
-
-  /**
-   * Aggregate member stats for multiple members in a batch.
-   * @param {string[]} memberIds - Array of member IDs to aggregate stats for.
-   * @returns {Promise<void>}
-   */
-  async #aggregateMemberStatsBatch(memberIds) {
-    return this.#queries.aggregateMemberStatsBatch(memberIds);
   }
 }
 

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -34,6 +34,7 @@ class BatchSendingService {
   #db;
   #sentry;
   #getRequiredUrlRelations;
+  #createBatchStageHook;
   #shuttingDown = false;
   #inFlight = new Set();
 
@@ -67,6 +68,7 @@ class BatchSendingService {
    * @param {object} [dependencies.BEFORE_RETRY_CONFIG]
    * @param {object} [dependencies.AFTER_RETRY_CONFIG]
    * @param {object} [dependencies.MAILGUN_API_RETRY_CONFIG]
+   * @param {(stage: string) => Promise<void>|void} [dependencies.createBatchStageHook]
    */
   constructor({
     emailRenderer,
@@ -81,6 +83,7 @@ class BatchSendingService {
     BEFORE_RETRY_CONFIG,
     AFTER_RETRY_CONFIG,
     MAILGUN_API_RETRY_CONFIG,
+    createBatchStageHook,
   }) {
     this.#emailRenderer = emailRenderer;
     this.#sendingService = sendingService;
@@ -91,6 +94,7 @@ class BatchSendingService {
     this.#db = db;
     this.#sentry = sentry;
     this.#getRequiredUrlRelations = getRequiredUrlRelations;
+    this.#createBatchStageHook = createBatchStageHook;
 
     if (BEFORE_RETRY_CONFIG) {
       this.#BEFORE_RETRY_CONFIG = BEFORE_RETRY_CONFIG;
@@ -679,6 +683,49 @@ class BatchSendingService {
       `Inserting ${recipientData.length} recipients for email ${email.id} batch ${batch.id}`,
     );
     await insertQuery;
+    await this.#createBatchStageHook?.('after-recipient-insert');
+
+    const memberIdsByRecipientCount = new Map();
+    const recipientCountByMember = new Map();
+    for (const recipient of recipientData) {
+      recipientCountByMember.set(
+        recipient.member_id,
+        (recipientCountByMember.get(recipient.member_id) || 0) + 1,
+      );
+    }
+    for (const [memberId, recipientCount] of recipientCountByMember) {
+      const memberIds = memberIdsByRecipientCount.get(recipientCount) || [];
+      memberIds.push(memberId);
+      memberIdsByRecipientCount.set(recipientCount, memberIds);
+    }
+
+    for (const [recipientCount, memberIds] of memberIdsByRecipientCount) {
+      const increments = { email_count: recipientCount };
+      if (email.get('track_opens')) {
+        increments.email_tracked_count = recipientCount;
+      }
+
+      const memberUpdate = this.#db.knex('members').whereIn('id', memberIds).increment(increments);
+      if (options.transacting) {
+        memberUpdate.transacting(options.transacting);
+      }
+      await memberUpdate;
+
+      if (email.get('track_opens')) {
+        const rateUpdate = this.#db.knex('members').whereIn('id', memberIds);
+        if (options.transacting) {
+          rateUpdate.transacting(options.transacting);
+        }
+        await rateUpdate.update({
+          email_open_rate: this.#db.knex.raw(
+            'CASE WHEN email_tracked_count IS NULL THEN email_open_rate WHEN email_tracked_count >= ? THEN ROUND(email_opened_count * 100.0 / email_tracked_count) ELSE NULL END',
+            [5],
+          ),
+        });
+      }
+    }
+    await this.#createBatchStageHook?.('after-member-counter-update');
+
     return batch;
   }
 

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -9,21 +9,36 @@ class NewsletterEmailEventStorage {
   #models;
   #emailSuppressionList;
   #prometheusClient;
+  #settingsCache;
   #pendingUpdates;
+  #flushStageHook;
+  #recipientIdCollation;
 
-  constructor({ config, db, models, membersRepository, emailSuppressionList, prometheusClient }) {
+  constructor({
+    config,
+    db,
+    models,
+    membersRepository,
+    emailSuppressionList,
+    prometheusClient,
+    settingsCache,
+    flushStageHook,
+  }) {
     this.#config = config;
     this.#db = db;
     this.#models = models;
     this.#membersRepository = membersRepository;
     this.#emailSuppressionList = emailSuppressionList;
     this.#prometheusClient = prometheusClient;
+    this.#settingsCache = settingsCache;
+    this.#flushStageHook = flushStageHook;
 
     // Initialize pending updates for batched processing
     this.#pendingUpdates = {
       delivered: new Map(), // recipientId -> timestamp
       opened: new Map(), // recipientId -> timestamp
       failed: new Map(), // recipientId -> timestamp
+      lastSeen: new Map(), // memberId -> latest opened timestamp
     };
 
     if (this.#prometheusClient) {
@@ -73,6 +88,10 @@ class NewsletterEmailEventStorage {
       // Keep the earliest timestamp (out-of-order protection)
       if (!existing || timestamp < existing) {
         this.#pendingUpdates.opened.set(event.emailRecipientId, timestamp);
+      }
+      const existingLastSeen = this.#pendingUpdates.lastSeen.get(event.memberId);
+      if (!existingLastSeen || timestamp > existingLastSeen) {
+        this.#pendingUpdates.lastSeen.set(event.memberId, timestamp);
       }
     } else {
       // Sequential mode: immediate update
@@ -306,111 +325,233 @@ class NewsletterEmailEventStorage {
       return; // Nothing to flush
     }
 
-    // Flush delivered events
-    if (deliveredCount > 0) {
-      await this.#flushDeliveredUpdates();
-    }
+    const pending = {
+      delivered: new Map(this.#pendingUpdates.delivered),
+      opened: new Map(this.#pendingUpdates.opened),
+      failed: new Map(this.#pendingUpdates.failed),
+      lastSeen: new Map(this.#pendingUpdates.lastSeen),
+    };
+    const recipientIds = Array.from(
+      new Set([...pending.delivered.keys(), ...pending.opened.keys(), ...pending.failed.keys()]),
+    ).sort();
 
-    // Flush opened events
-    if (openedCount > 0) {
-      await this.#flushOpenedUpdates();
-    }
+    const transitions = await this.#db.knex.transaction(async (transaction) => {
+      const recipients = await transaction('email_recipients')
+        .select('id', 'email_id', 'member_id', 'delivered_at', 'opened_at', 'failed_at')
+        .whereIn('id', recipientIds)
+        .orderBy('id')
+        .forUpdate();
 
-    // Flush failed events
-    if (failedCount > 0) {
-      await this.#flushFailedUpdates();
-    }
+      await this.#onFlushStage('after-lock');
+
+      const transitioned = recipients
+        .map((recipient) => ({
+          id: recipient.id,
+          emailId: recipient.email_id,
+          memberId: recipient.member_id,
+          deliveredAt:
+            recipient.delivered_at === null ? pending.delivered.get(recipient.id) : undefined,
+          openedAt: recipient.opened_at === null ? pending.opened.get(recipient.id) : undefined,
+          failedAt: recipient.failed_at === null ? pending.failed.get(recipient.id) : undefined,
+        }))
+        .filter(({ deliveredAt, openedAt, failedAt }) => deliveredAt || openedAt || failedAt);
+
+      if (transitioned.length > 0) {
+        await this.#applyRecipientTransitions(transaction, transitioned);
+      }
+      await this.#onFlushStage('after-recipient-update');
+
+      if (transitioned.length > 0) {
+        await this.#incrementEmailCounters(transaction, transitioned);
+      }
+      await this.#onFlushStage('after-email-update');
+
+      await this.#updateMemberState(transaction, transitioned, pending.lastSeen);
+      await this.#onFlushStage('after-member-update');
+      await this.#onFlushStage('before-commit');
+
+      return transitioned;
+    });
+
+    await this.#onFlushStage('after-commit');
 
     // Clear the pending updates
     this.#pendingUpdates.delivered.clear();
     this.#pendingUpdates.opened.clear();
     this.#pendingUpdates.failed.clear();
+    this.#pendingUpdates.lastSeen.clear();
+
+    this.recordEventStored(
+      'delivered',
+      transitions.filter(({ deliveredAt }) => deliveredAt).length,
+    );
+    this.recordEventStored('opened', transitions.filter(({ openedAt }) => openedAt).length);
+    this.recordEventStored('failed', transitions.filter(({ failedAt }) => failedAt).length);
   }
 
-  /**
-   * @private
-   */
-  async #flushDeliveredUpdates() {
-    const updates = Array.from(this.#pendingUpdates.delivered.entries());
-    if (updates.length === 0) {
+  async #onFlushStage(stage) {
+    await this.#flushStageHook?.(stage);
+  }
+
+  async #getRecipientIdCollation(connection) {
+    if (this.#recipientIdCollation) {
+      return this.#recipientIdCollation;
+    }
+
+    const column = await connection('information_schema.columns')
+      .select('COLLATION_NAME as collation_name')
+      .whereRaw('TABLE_SCHEMA = DATABASE()')
+      .where({ TABLE_NAME: 'email_recipients', COLUMN_NAME: 'id' })
+      .first();
+    if (!column?.collation_name || !/^[a-z0-9_]+$/.test(column.collation_name)) {
+      throw new errors.InternalServerError({
+        message: 'Could not determine a safe collation for email_recipients.id',
+      });
+    }
+    this.#recipientIdCollation = column.collation_name;
+    return this.#recipientIdCollation;
+  }
+
+  async #applyRecipientTransitions(transaction, transitions) {
+    if (transaction.client.config.client.includes('mysql')) {
+      const collation = await this.#getRecipientIdCollation(transaction);
+      const payload = JSON.stringify(
+        transitions.map(({ id, deliveredAt, openedAt, failedAt }) => ({
+          id,
+          delivered_at: deliveredAt || null,
+          opened_at: openedAt || null,
+          failed_at: failedAt || null,
+        })),
+      );
+      await transaction.raw(
+        `
+          UPDATE email_recipients AS recipient
+          JOIN JSON_TABLE(
+            ?,
+            '$[*]' COLUMNS (
+              id CHAR(24) CHARACTER SET utf8mb4 COLLATE ${collation} PATH '$.id',
+              delivered_at DATETIME PATH '$.delivered_at',
+              opened_at DATETIME PATH '$.opened_at',
+              failed_at DATETIME PATH '$.failed_at'
+            )
+          ) AS pending ON pending.id = recipient.id
+          SET
+            recipient.delivered_at = COALESCE(pending.delivered_at, recipient.delivered_at),
+            recipient.opened_at = COALESCE(pending.opened_at, recipient.opened_at),
+            recipient.failed_at = COALESCE(pending.failed_at, recipient.failed_at)
+        `,
+        [payload],
+      );
       return;
     }
 
-    // Build CASE statement for batched update
-    const recipientIds = updates.map(([id]) => id);
-    const caseClauses = updates
-      .map(([id, timestamp]) => {
-        return `WHEN '${id}' THEN '${timestamp}'`;
-      })
-      .join(' ');
-
-    const sql = `
-            UPDATE email_recipients
-            SET delivered_at = CASE id ${caseClauses} END
-            WHERE id IN (${recipientIds.map(() => '?').join(',')})
-            AND delivered_at IS NULL
-        `;
-
-    const rowCount = await this.#db.knex.raw(sql, recipientIds);
-    this.recordEventStored('delivered', updates.length);
-    return rowCount;
+    for (const [column, property] of [
+      ['delivered_at', 'deliveredAt'],
+      ['opened_at', 'openedAt'],
+      ['failed_at', 'failedAt'],
+    ]) {
+      const updates = transitions.filter((transition) => transition[property]);
+      if (updates.length === 0) {
+        continue;
+      }
+      const cases = updates.map(() => 'WHEN ? THEN ?').join(' ');
+      const bindings = updates.flatMap((transition) => [transition.id, transition[property]]);
+      const ids = updates.map(({ id }) => id);
+      await transaction.raw(
+        `UPDATE email_recipients SET ${column} = CASE id ${cases} ELSE ${column} END WHERE id IN (${ids.map(() => '?').join(',')})`,
+        [...bindings, ...ids],
+      );
+    }
   }
 
-  /**
-   * @private
-   */
-  async #flushOpenedUpdates() {
-    const updates = Array.from(this.#pendingUpdates.opened.entries());
-    if (updates.length === 0) {
-      return;
+  async #incrementEmailCounters(transaction, transitions) {
+    const incrementsByEmail = new Map();
+    for (const transition of transitions) {
+      const increments = incrementsByEmail.get(transition.emailId) || {
+        delivered: 0,
+        opened: 0,
+        failed: 0,
+      };
+      increments.delivered += transition.deliveredAt ? 1 : 0;
+      increments.opened += transition.openedAt ? 1 : 0;
+      increments.failed += transition.failedAt ? 1 : 0;
+      incrementsByEmail.set(transition.emailId, increments);
     }
 
-    // Build CASE statement for batched update
-    const recipientIds = updates.map(([id]) => id);
-    const caseClauses = updates
-      .map(([id, timestamp]) => {
-        return `WHEN '${id}' THEN '${timestamp}'`;
-      })
-      .join(' ');
-
-    const sql = `
-            UPDATE email_recipients
-            SET opened_at = CASE id ${caseClauses} END
-            WHERE id IN (${recipientIds.map(() => '?').join(',')})
-            AND opened_at IS NULL
-        `;
-
-    const rowCount = await this.#db.knex.raw(sql, recipientIds);
-    this.recordEventStored('opened', updates.length);
-    return rowCount;
+    const emailIds = Array.from(incrementsByEmail.keys());
+    const counterSql = [];
+    const bindings = [];
+    for (const [column, property] of [
+      ['delivered_count', 'delivered'],
+      ['opened_count', 'opened'],
+      ['failed_count', 'failed'],
+    ]) {
+      const cases = emailIds.map(() => 'WHEN ? THEN ?').join(' ');
+      counterSql.push(`${column} = ${column} + CASE id ${cases} ELSE 0 END`);
+      for (const emailId of emailIds) {
+        bindings.push(emailId, incrementsByEmail.get(emailId)[property]);
+      }
+    }
+    await transaction.raw(
+      `UPDATE emails SET ${counterSql.join(', ')} WHERE id IN (${emailIds.map(() => '?').join(',')})`,
+      [...bindings, ...emailIds],
+    );
   }
 
-  /**
-   * @private
-   */
-  async #flushFailedUpdates() {
-    const updates = Array.from(this.#pendingUpdates.failed.entries());
-    if (updates.length === 0) {
-      return;
+  async #updateMemberState(transaction, transitions, lastSeenUpdates) {
+    const incrementsByMember = new Map();
+    for (const transition of transitions) {
+      if (transition.openedAt) {
+        incrementsByMember.set(
+          transition.memberId,
+          (incrementsByMember.get(transition.memberId) || 0) + 1,
+        );
+      }
+    }
+    if (incrementsByMember.size > 0) {
+      const memberIds = Array.from(incrementsByMember.keys());
+      const cases = memberIds.map(() => 'WHEN ? THEN ?').join(' ');
+      const bindings = memberIds.flatMap((memberId) => [
+        memberId,
+        incrementsByMember.get(memberId),
+      ]);
+      await transaction.raw(
+        `UPDATE members SET email_opened_count = email_opened_count + CASE id ${cases} ELSE 0 END WHERE id IN (${memberIds.map(() => '?').join(',')})`,
+        [...bindings, ...memberIds],
+      );
+      await transaction('members')
+        .whereIn('id', memberIds)
+        .update({
+          email_open_rate: transaction.raw(
+            'CASE WHEN email_tracked_count IS NULL THEN email_open_rate WHEN email_tracked_count >= ? THEN ROUND(email_opened_count * 100.0 / email_tracked_count) ELSE NULL END',
+            [5],
+          ),
+        });
     }
 
-    // Build CASE statement for batched update
-    const recipientIds = updates.map(([id]) => id);
-    const caseClauses = updates
-      .map(([id, timestamp]) => {
-        return `WHEN '${id}' THEN '${timestamp}'`;
-      })
-      .join(' ');
-
-    const sql = `
-            UPDATE email_recipients
-            SET failed_at = CASE id ${caseClauses} END
-            WHERE id IN (${recipientIds.map(() => '?').join(',')})
-            AND failed_at IS NULL
-        `;
-
-    const rowCount = await this.#db.knex.raw(sql, recipientIds);
-    return rowCount;
+    if (lastSeenUpdates.size > 0) {
+      const timezone = this.#settingsCache?.get('timezone') || 'Etc/UTC';
+      const memberIds = Array.from(lastSeenUpdates.keys());
+      const cases = [];
+      const bindings = [];
+      for (const memberId of memberIds) {
+        const timestamp = lastSeenUpdates.get(memberId);
+        const startOfDay = moment
+          .utc(timestamp)
+          .tz(timezone)
+          .startOf('day')
+          .utc()
+          .format('YYYY-MM-DD HH:mm:ss');
+        cases.push(
+          'WHEN ? THEN CASE WHEN last_seen_at IS NULL OR last_seen_at < ? THEN ? ELSE last_seen_at END',
+        );
+        bindings.push(memberId, startOfDay, timestamp);
+      }
+      await transaction.raw(
+        `UPDATE members SET last_seen_at = CASE id ${cases.join(' ')} ELSE last_seen_at END WHERE id IN (${memberIds.map(() => '?').join(',')})`,
+        [...bindings, ...memberIds],
+      );
+    }
   }
 }
 

--- a/ghost/core/core/server/services/members-events/last-seen-at-updater.js
+++ b/ghost/core/core/server/services/members-events/last-seen-at-updater.js
@@ -89,6 +89,9 @@ class LastSeenAtUpdater {
 
     domainEvents.subscribe(EmailOpenedEvent, async (event) => {
       try {
+        if (this._config?.get('emailAnalytics:batchProcessing')) {
+          return;
+        }
         await this.updateLastSeenAtWithoutKnownLastSeen(event.memberId, event.timestamp);
       } catch (err) {
         logging.error(

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.61.1-rc.0",
+  "version": "6.62.0-rc.0",
   "description": "The professional publishing platform",
   "keywords": [
     "blog",

--- a/ghost/core/test/integration/services/email-analytics/email-analytics.synthetic-benchmark.test.js
+++ b/ghost/core/test/integration/services/email-analytics/email-analytics.synthetic-benchmark.test.js
@@ -1,0 +1,1114 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs/promises');
+const inspector = require('node:inspector');
+const os = require('node:os');
+const path = require('node:path');
+const { monitorEventLoopDelay, performance } = require('node:perf_hooks');
+
+const ObjectId = require('bson-objectid').default;
+const DomainEvents = require('@tryghost/domain-events');
+const moment = require('moment-timezone');
+const sinon = require('sinon');
+
+const { agentProvider, configUtils, fixtureManager } = require('../../../utils/e2e-framework');
+const db = require('../../../../core/server/data/db');
+const emailAnalytics = require('../../../../core/server/services/email-analytics');
+const EmailEventProcessor = require('../../../../core/server/services/email-service/email-event-processor');
+const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
+const LastSeenAtUpdater = require('../../../../core/server/services/members-events/last-seen-at-updater');
+const MailgunClient = require('../../../../core/server/services/lib/mailgun-client');
+const { Queries } = require('../../../../core/server/services/email-analytics/lib/queries');
+const {
+  EventProcessingResult,
+} = require('../../../../core/server/services/email-analytics/event-processing-result');
+
+const BENCHMARK_ENABLED = process.env.EMAIL_ANALYTICS_BENCHMARK === '1';
+const SCENARIO = process.env.EMAIL_ANALYTICS_BENCHMARK_SCENARIO || 'current';
+const UNIQUE_RECIPIENTS = Number(process.env.EMAIL_ANALYTICS_BENCHMARK_RECIPIENTS || 5001);
+const ACTIVE_SEND_RECIPIENTS = Number(
+  process.env.EMAIL_ANALYTICS_BENCHMARK_SEND_RECIPIENTS || UNIQUE_RECIPIENTS,
+);
+const DUPLICATE_RATE = Number(process.env.EMAIL_ANALYTICS_BENCHMARK_DUPLICATE_RATE || 0.31);
+const PAGE_SIZE = Number(process.env.EMAIL_ANALYTICS_BENCHMARK_PAGE_SIZE || 300);
+const PAGE_SIZES = (process.env.EMAIL_ANALYTICS_BENCHMARK_PAGE_SIZES || String(PAGE_SIZE))
+  .split(',')
+  .map((value) => Number(value.trim()));
+const WRITE_BUFFER_SIZE_MATRIX_ENABLED = Boolean(
+  process.env.EMAIL_ANALYTICS_BENCHMARK_WRITE_BUFFER_SIZES,
+);
+const FETCH_PAGE_SIZE = Number(process.env.EMAIL_ANALYTICS_BENCHMARK_FETCH_PAGE_SIZE || PAGE_SIZE);
+const WRITE_BUFFER_SIZES = (
+  process.env.EMAIL_ANALYTICS_BENCHMARK_WRITE_BUFFER_SIZES || String(FETCH_PAGE_SIZE)
+)
+  .split(',')
+  .map((value) => Number(value.trim()));
+const WRITE_SHAPE_MATRIX_ENABLED = Boolean(process.env.EMAIL_ANALYTICS_BENCHMARK_WRITE_SHAPES);
+const WRITE_SHAPES = (process.env.EMAIL_ANALYTICS_BENCHMARK_WRITE_SHAPES || 'native-case')
+  .split(',')
+  .map((value) => value.trim());
+const PAGE_LATENCY_MS = Number(process.env.EMAIL_ANALYTICS_BENCHMARK_PAGE_LATENCY_MS || 0);
+const HISTORY_RECIPIENTS_PER_MEMBER = Number(
+  process.env.EMAIL_ANALYTICS_BENCHMARK_HISTORY_PER_MEMBER || 0,
+);
+const HISTORY_OPEN_RATE = Number(process.env.EMAIL_ANALYTICS_BENCHMARK_HISTORY_OPEN_RATE || 0.48);
+const PROFILE_DIR =
+  process.env.EMAIL_ANALYTICS_BENCHMARK_OUTPUT ||
+  path.join(os.tmpdir(), 'ghost-email-analytics-benchmark');
+
+function inspectorPost(session, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    session.post(method, params, (error, result) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+async function startCpuProfile() {
+  const session = new inspector.Session();
+  session.connect();
+  await inspectorPost(session, 'Profiler.enable');
+  await inspectorPost(session, 'Profiler.setSamplingInterval', { interval: 1000 });
+  await inspectorPost(session, 'Profiler.start');
+  return session;
+}
+
+async function stopCpuProfile(session) {
+  const { profile } = await inspectorPost(session, 'Profiler.stop');
+  session.disconnect();
+  return profile;
+}
+
+function summarizeCpuProfile(profile, limit = 25) {
+  const nodesById = new Map(profile.nodes.map((node) => [node.id, node]));
+  const selfTimeByFrame = new Map();
+  let sampledMicros = 0;
+
+  for (let index = 0; index < profile.samples.length; index += 1) {
+    const node = nodesById.get(profile.samples[index]);
+    const timeDelta = profile.timeDeltas[index] || 0;
+    if (!node) {
+      continue;
+    }
+
+    const { functionName, url, lineNumber } = node.callFrame;
+    const key = `${functionName || '(anonymous)'}\t${url || '(native)'}\t${lineNumber + 1}`;
+    selfTimeByFrame.set(key, (selfTimeByFrame.get(key) || 0) + timeDelta);
+    sampledMicros += timeDelta;
+  }
+
+  const rawFrames = Array.from(selfTimeByFrame.entries()).map(([key, selfMicros]) => {
+    const [functionName, url, line] = key.split('\t');
+    return {
+      functionName,
+      url,
+      line: Number(line),
+      selfMicros,
+    };
+  });
+  const profilerOverheadMicros = rawFrames
+    .filter(({ url }) => url === 'node:inspector')
+    .reduce((total, { selfMicros }) => total + selfMicros, 0);
+  const workloadSampledMicros = sampledMicros - profilerOverheadMicros;
+  const frames = rawFrames
+    .filter(({ url }) => url !== 'node:inspector')
+    .map(({ functionName, url, line, selfMicros }) => {
+      return {
+        functionName,
+        url,
+        line,
+        selfMs: Number((selfMicros / 1000).toFixed(1)),
+        selfPercent: Number(((selfMicros / workloadSampledMicros) * 100).toFixed(1)),
+      };
+    })
+    .sort((left, right) => right.selfMs - left.selfMs);
+
+  return {
+    sampledMs: Number((workloadSampledMicros / 1000).toFixed(1)),
+    profilerOverheadMs: Number((profilerOverheadMicros / 1000).toFixed(1)),
+    topSelfTime: frames.slice(0, limit),
+    topGhostSelfTime: frames
+      .filter(({ url }) => url.includes('/ghost/core/core/server/'))
+      .slice(0, limit),
+  };
+}
+
+function classifySql(sql) {
+  const normalized = sql.replaceAll('`', '').replace(/\s+/g, ' ').trim().toLowerCase();
+
+  if (normalized.includes('email_analytics_benchmark_open_updates')) {
+    if (normalized.startsWith('update email_recipients')) {
+      return 'recipient opened update';
+    }
+    return 'recipient update staging';
+  }
+  if (normalized.startsWith('update members set last_seen_at')) {
+    return 'member last_seen update';
+  }
+  if (normalized.startsWith('update members set email_opened_count')) {
+    return 'member opened counter update';
+  }
+  if (normalized.startsWith('update members set email_count')) {
+    return 'member aggregate update';
+  }
+  if (
+    normalized.startsWith('select id, member_id, email_id from email_recipients') &&
+    normalized.includes('opened_at is null')
+  ) {
+    return 'recipient transition preselect';
+  }
+  if (
+    normalized.startsWith('select email_recipients.member_id') &&
+    normalized.includes('group by email_recipients.member_id')
+  ) {
+    return 'member aggregate scan';
+  }
+  if (normalized.startsWith('update email_recipients') && normalized.includes('opened_at')) {
+    return 'recipient opened update';
+  }
+  if (normalized.startsWith('select id, member_id, email_id, member_email from email_recipients')) {
+    return 'recipient batch lookup';
+  }
+  if (normalized.includes('count(id) as count from email_recipients')) {
+    return 'email aggregate scan';
+  }
+  if (normalized.startsWith('update emails set') && normalized.includes('opened_count')) {
+    return 'email opened counter update';
+  }
+  if (normalized.startsWith('update emails set')) {
+    return 'email aggregate update';
+  }
+  if (normalized.includes(' jobs ')) {
+    return 'job cursor';
+  }
+  return 'other';
+}
+
+function instrumentDatabase(knex) {
+  const started = new Map();
+  const stats = new Map();
+
+  const onQuery = (query) => {
+    started.set(query.__knexQueryUid, {
+      category: classifySql(query.sql),
+      startedAt: performance.now(),
+    });
+  };
+  const onResponse = (_response, query) => {
+    const pending = started.get(query.__knexQueryUid);
+    if (!pending) {
+      return;
+    }
+    const current = stats.get(pending.category) || { count: 0, elapsedMs: 0 };
+    current.count += 1;
+    current.elapsedMs += performance.now() - pending.startedAt;
+    stats.set(pending.category, current);
+    started.delete(query.__knexQueryUid);
+  };
+  const onError = (_error, query) => onResponse(null, query);
+
+  knex.on('query', onQuery);
+  knex.on('query-response', onResponse);
+  knex.on('query-error', onError);
+
+  return {
+    stop() {
+      knex.off('query', onQuery);
+      knex.off('query-response', onResponse);
+      knex.off('query-error', onError);
+
+      return Object.fromEntries(
+        Array.from(stats.entries())
+          .sort((left, right) => right[1].elapsedMs - left[1].elapsedMs)
+          .map(([category, value]) => [
+            category,
+            {
+              count: value.count,
+              elapsedMs: Number(value.elapsedMs.toFixed(1)),
+            },
+          ]),
+      );
+    },
+  };
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+function buildEvents({ recipients, emailId, providerId }) {
+  const totalEvents = Math.ceil(UNIQUE_RECIPIENTS / (1 - DUPLICATE_RATE));
+  const duplicateEvents = totalEvents - UNIQUE_RECIPIENTS;
+  const openedAt = Date.now() - 10 * 60 * 1000;
+  const eventRecipients = [
+    ...recipients,
+    ...Array.from({ length: duplicateEvents }, (_, index) => recipients[index % recipients.length]),
+  ];
+
+  return eventRecipients.map((recipient, index) => ({
+    event: 'opened',
+    recipient: recipient.member_email,
+    'user-variables': {
+      'email-id': emailId,
+    },
+    message: {
+      headers: {
+        'message-id': providerId,
+      },
+    },
+    timestamp: (openedAt + index) / 1000,
+  }));
+}
+
+async function seedRecipients({ emailId, batchId }) {
+  const now = new Date();
+  const members = [];
+  const recipients = [];
+
+  for (let index = 0; index < UNIQUE_RECIPIENTS; index += 1) {
+    const memberId = ObjectId().toHexString();
+    const memberUuid = crypto.randomUUID();
+    const memberEmail = `analytics-benchmark-${index}@example.com`;
+
+    members.push({
+      id: memberId,
+      uuid: memberUuid,
+      transient_id: crypto.randomUUID(),
+      email: memberEmail,
+      name: `Analytics benchmark ${index}`,
+      status: 'free',
+      email_disabled: false,
+      enable_comment_notifications: true,
+      email_count: 0,
+      email_opened_count: 0,
+      created_at: now,
+      updated_at: now,
+    });
+    recipients.push({
+      id: ObjectId().toHexString(),
+      email_id: emailId,
+      member_id: memberId,
+      batch_id: batchId,
+      member_uuid: memberUuid,
+      member_email: memberEmail,
+      member_name: `Analytics benchmark ${index}`,
+      processed_at: now,
+    });
+  }
+
+  await db.knex.batchInsert('members', members, 250);
+  await db.knex.batchInsert('email_recipients', recipients, 250);
+  return recipients;
+}
+
+function syntheticId(prefix, index) {
+  return `${prefix}${index.toString(16).padStart(16, '0')}`;
+}
+
+function syntheticUuid(index) {
+  return `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`;
+}
+
+async function seedUntouchedActiveRecipients({ emailId, batchId, currentRecipientCount }) {
+  const untouchedRecipientCount = ACTIVE_SEND_RECIPIENTS - currentRecipientCount;
+  assert.ok(
+    untouchedRecipientCount >= 0,
+    'active send recipient count must include touched and pre-existing fixture recipients',
+  );
+  if (untouchedRecipientCount === 0) {
+    return 0;
+  }
+
+  const now = new Date();
+  const members = [];
+  const recipients = [];
+
+  const flush = async () => {
+    if (members.length === 0) {
+      return;
+    }
+    await db.knex.batchInsert('members', members.splice(0), 500);
+    await db.knex.batchInsert('email_recipients', recipients.splice(0), 500);
+  };
+
+  for (let index = 0; index < untouchedRecipientCount; index += 1) {
+    const sequence = UNIQUE_RECIPIENTS + index;
+    const memberId = syntheticId('eb000000', sequence);
+    const memberUuid = syntheticUuid(sequence);
+    const memberEmail = `analytics-benchmark-${sequence}@example.com`;
+
+    members.push({
+      id: memberId,
+      uuid: memberUuid,
+      transient_id: syntheticUuid(sequence + ACTIVE_SEND_RECIPIENTS),
+      email: memberEmail,
+      name: `Analytics benchmark ${sequence}`,
+      status: 'free',
+      email_disabled: false,
+      enable_comment_notifications: true,
+      email_count: 0,
+      email_opened_count: 0,
+      created_at: now,
+      updated_at: now,
+    });
+    recipients.push({
+      id: syntheticId('ec000000', sequence),
+      email_id: emailId,
+      member_id: memberId,
+      batch_id: batchId,
+      member_uuid: memberUuid,
+      member_email: memberEmail,
+      member_name: `Analytics benchmark ${sequence}`,
+      processed_at: now,
+      delivered_at: now,
+    });
+
+    if (members.length >= 5000) {
+      await flush();
+    }
+  }
+  await flush();
+  return untouchedRecipientCount;
+}
+
+function historyRecipientId(index) {
+  return `ea000000${index.toString(16).padStart(16, '0')}`;
+}
+
+async function seedHistoricalRecipients({ recipients, emailId, batchId }) {
+  if (HISTORY_RECIPIENTS_PER_MEMBER === 0) {
+    return 0;
+  }
+
+  const now = Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const rows = [];
+  let rowIndex = 0;
+
+  const flush = async () => {
+    if (rows.length === 0) {
+      return;
+    }
+    await db.knex.batchInsert('email_recipients', rows.splice(0), 500);
+  };
+
+  for (let historyIndex = 0; historyIndex < HISTORY_RECIPIENTS_PER_MEMBER; historyIndex += 1) {
+    const deliveredAt = new Date(now - (historyIndex + 1) * dayMs);
+    for (let memberIndex = 0; memberIndex < recipients.length; memberIndex += 1) {
+      const recipient = recipients[memberIndex];
+      rowIndex += 1;
+      const opened = ((memberIndex * 31 + historyIndex) % 100) / 100 < HISTORY_OPEN_RATE;
+      rows.push({
+        id: historyRecipientId(rowIndex),
+        email_id: emailId,
+        member_id: recipient.member_id,
+        batch_id: batchId,
+        member_uuid: recipient.member_uuid,
+        member_email: recipient.member_email,
+        member_name: recipient.member_name,
+        processed_at: deliveredAt,
+        delivered_at: deliveredAt,
+        opened_at: opened ? deliveredAt : null,
+      });
+
+      if (rows.length >= 5000) {
+        await flush();
+      }
+    }
+  }
+  await flush();
+  return rowIndex;
+}
+
+async function batchGetRecipientsGroupedByEmail(emailIdentifications) {
+  const emailsByEmailId = new Map();
+  for (const identification of emailIdentifications) {
+    if (!identification.emailId || !identification.email) {
+      continue;
+    }
+    const emails = emailsByEmailId.get(identification.emailId) || new Set();
+    emails.add(identification.email);
+    emailsByEmailId.set(identification.emailId, emails);
+  }
+
+  const recipientCache = new Map();
+  if (emailsByEmailId.size === 0) {
+    return recipientCache;
+  }
+
+  const query = db
+    .knex('email_recipients')
+    .select('id', 'member_id', 'email_id', 'member_email')
+    .where(function () {
+      for (const [emailId, emails] of emailsByEmailId) {
+        this.orWhere(function () {
+          this.where('email_id', emailId).whereIn('member_email', Array.from(emails));
+        });
+      }
+    });
+  const recipients = await query;
+
+  for (const recipient of recipients) {
+    recipientCache.set(`${recipient.member_email}:${recipient.email_id}`, {
+      emailRecipientId: recipient.id,
+      memberId: recipient.member_id,
+      emailId: recipient.email_id,
+    });
+  }
+  return recipientCache;
+}
+
+const pendingOpenedUpdates = new WeakMap();
+let currentWriteShape = 'native-case';
+let currentWriteBufferSize = PAGE_SIZE;
+let pageFlushCalls = 0;
+let expectedPageFlushCalls = 0;
+let writeBufferStats;
+let recipientIdCollation;
+
+function collectOpenedUpdate(storage, event) {
+  let updates = pendingOpenedUpdates.get(storage);
+  if (!updates) {
+    updates = new Map();
+    pendingOpenedUpdates.set(storage, updates);
+  }
+
+  const timestamp = moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss');
+  const existing = updates.get(event.emailRecipientId);
+  if (!existing || timestamp < existing) {
+    updates.set(event.emailRecipientId, timestamp);
+  }
+}
+
+async function flushOpenedUpdatesCase(updates, connection = db.knex) {
+  const recipientIds = updates.map(([id]) => id);
+  const caseClauses = updates
+    .map(([id, timestamp]) => `WHEN '${id}' THEN '${timestamp}'`)
+    .join(' ');
+  const sql = `
+    UPDATE email_recipients
+    SET opened_at = CASE id ${caseClauses} END
+    WHERE id IN (${recipientIds.map(() => '?').join(',')})
+    AND opened_at IS NULL
+  `;
+  await connection.raw(sql, recipientIds);
+}
+
+async function flushOpenedUpdatesGroupedIn(updates, connection = db.knex) {
+  const idsByTimestamp = new Map();
+  for (const [id, timestamp] of updates) {
+    const ids = idsByTimestamp.get(timestamp) || [];
+    ids.push(id);
+    idsByTimestamp.set(timestamp, ids);
+  }
+
+  for (const [timestamp, recipientIds] of idsByTimestamp) {
+    await connection('email_recipients')
+      .whereIn('id', recipientIds)
+      .whereNull('opened_at')
+      .update({ opened_at: timestamp });
+  }
+}
+
+async function flushOpenedUpdatesJsonTable(updates, connection = db.knex) {
+  const payload = JSON.stringify(updates.map(([id, openedAt]) => ({ id, opened_at: openedAt })));
+  const sql = `
+    UPDATE email_recipients AS recipient
+    JOIN JSON_TABLE(
+      ?,
+      '$[*]' COLUMNS (
+        id CHAR(24) CHARACTER SET utf8mb4 COLLATE ${recipientIdCollation} PATH '$.id',
+        opened_at DATETIME PATH '$.opened_at'
+      )
+    ) AS pending ON pending.id = recipient.id
+    SET recipient.opened_at = pending.opened_at
+    WHERE recipient.opened_at IS NULL
+  `;
+  await connection.raw(sql, [payload]);
+}
+
+async function flushOpenedUpdatesTemporaryTable(updates, connection = db.knex) {
+  const tableName = `email_analytics_benchmark_open_updates_${process.pid}`;
+  await connection.raw(`
+      CREATE TEMPORARY TABLE ${tableName} (
+        id CHAR(24) CHARACTER SET utf8mb4 COLLATE ${recipientIdCollation} NOT NULL PRIMARY KEY,
+        opened_at DATETIME NOT NULL
+      ) ENGINE=MEMORY
+    `);
+  try {
+    await connection.batchInsert(
+      tableName,
+      updates.map(([id, openedAt]) => ({ id, opened_at: openedAt })),
+      1000,
+    );
+    await connection.raw(`
+        UPDATE email_recipients AS recipient
+        JOIN ${tableName} AS pending
+          ON pending.id = recipient.id
+        SET recipient.opened_at = pending.opened_at
+        WHERE recipient.opened_at IS NULL
+      `);
+  } finally {
+    await connection.raw(`DROP TEMPORARY TABLE IF EXISTS ${tableName}`);
+  }
+}
+
+async function applyOpenedUpdatesByShape(updates, connection) {
+  if (currentWriteShape === 'case' || currentWriteShape === 'native-case') {
+    await flushOpenedUpdatesCase(updates, connection);
+  } else if (currentWriteShape === 'grouped-in') {
+    await flushOpenedUpdatesGroupedIn(updates, connection);
+  } else if (currentWriteShape === 'json-table') {
+    await flushOpenedUpdatesJsonTable(updates, connection);
+  } else if (currentWriteShape === 'temporary-table') {
+    await flushOpenedUpdatesTemporaryTable(updates, connection);
+  } else {
+    throw new Error(`Unknown write shape: ${currentWriteShape}`);
+  }
+}
+
+async function flushOpenedUpdatesByShape(storage) {
+  const pending = pendingOpenedUpdates.get(storage);
+  const updates = Array.from(pending?.entries() || []);
+  if (updates.length === 0) {
+    return;
+  }
+
+  let transitionedCount = updates.length;
+  if (WRITE_BUFFER_SIZE_MATRIX_ENABLED) {
+    transitionedCount = await db.knex.transaction(async (transaction) => {
+      const recipientIds = updates.map(([id]) => id);
+      const recipients = await transaction('email_recipients')
+        .select('id', 'member_id', 'email_id')
+        .whereIn('id', recipientIds)
+        .whereNull('opened_at')
+        .orderBy('id')
+        .forUpdate();
+      const transitionedIds = new Set(recipients.map(({ id }) => id));
+      const transitionedUpdates = updates.filter(([id]) => transitionedIds.has(id));
+
+      if (transitionedUpdates.length === 0) {
+        return 0;
+      }
+
+      await applyOpenedUpdatesByShape(transitionedUpdates, transaction);
+
+      const recipientIdsByEmail = new Map();
+      const memberIdsByIncrement = new Map();
+      const incrementsByMember = new Map();
+      for (const recipient of recipients) {
+        recipientIdsByEmail.set(
+          recipient.email_id,
+          (recipientIdsByEmail.get(recipient.email_id) || 0) + 1,
+        );
+        incrementsByMember.set(
+          recipient.member_id,
+          (incrementsByMember.get(recipient.member_id) || 0) + 1,
+        );
+      }
+
+      for (const [emailId, increment] of recipientIdsByEmail) {
+        await transaction('emails').where('id', emailId).increment('opened_count', increment);
+      }
+      for (const [memberId, increment] of incrementsByMember) {
+        const memberIds = memberIdsByIncrement.get(increment) || [];
+        memberIds.push(memberId);
+        memberIdsByIncrement.set(increment, memberIds);
+      }
+      for (const [increment, memberIds] of memberIdsByIncrement) {
+        await transaction('members')
+          .whereIn('id', memberIds)
+          .increment('email_opened_count', increment);
+      }
+
+      return transitionedUpdates.length;
+    });
+  } else {
+    await applyOpenedUpdatesByShape(updates, db.knex);
+  }
+
+  pending.clear();
+  writeBufferStats.transactionCount += 1;
+  writeBufferStats.transitionedRecipients += transitionedCount;
+  writeBufferStats.maxPendingRecipients = Math.max(
+    writeBufferStats.maxPendingRecipients,
+    updates.length,
+  );
+  storage.recordEventStored('opened', transitionedCount);
+}
+
+async function maybeFlushOpenedUpdatesByShape(storage) {
+  pageFlushCalls += 1;
+  const pendingCount = pendingOpenedUpdates.get(storage)?.size || 0;
+  const isFinalPage = pageFlushCalls >= expectedPageFlushCalls;
+  if (pendingCount < currentWriteBufferSize && !isFinalPage) {
+    return;
+  }
+  await flushOpenedUpdatesByShape(storage);
+}
+
+const emailIdSets = new WeakMap();
+const memberIdSets = new WeakMap();
+
+function mergeEventProcessingResultLinear(other = {}) {
+  this.delivered += other.delivered || 0;
+  this.opened += other.opened || 0;
+  this.temporaryFailed += other.temporaryFailed || 0;
+  this.permanentFailed += other.permanentFailed || 0;
+  this.unsubscribed += other.unsubscribed || 0;
+  this.complained += other.complained || 0;
+  this.unhandled += other.unhandled || 0;
+  this.unprocessable += other.unprocessable || 0;
+  this.processingFailures += other.processingFailures || 0;
+
+  let emailIds = emailIdSets.get(this);
+  if (!emailIds || (this.emailIds.length === 0 && emailIds.size > 0)) {
+    emailIds = new Set(this.emailIds);
+    emailIdSets.set(this, emailIds);
+  }
+  for (const emailId of other.emailIds || []) {
+    if (emailId && !emailIds.has(emailId)) {
+      emailIds.add(emailId);
+      this.emailIds.push(emailId);
+    }
+  }
+
+  let memberIds = memberIdSets.get(this);
+  if (!memberIds || (this.memberIds.length === 0 && memberIds.size > 0)) {
+    memberIds = new Set(this.memberIds);
+    memberIdSets.set(this, memberIds);
+  }
+  for (const memberId of other.memberIds || []) {
+    if (memberId && !memberIds.has(memberId)) {
+      memberIds.add(memberId);
+      this.memberIds.push(memberId);
+    }
+  }
+}
+
+const describeBenchmark = BENCHMARK_ENABLED ? describe : describe.skip;
+
+describeBenchmark('Email analytics synthetic E2E benchmark', function () {
+  let events;
+  let pages = [];
+  let syntheticRecipients;
+  let emailId;
+  let pageFetches = 0;
+  let historicalRecipientRows = 0;
+  let historySeedMs = 0;
+  let preexistingActiveRecipientRows = 0;
+  let untouchedActiveRecipientRows = 0;
+  let activeSendSeedMs = 0;
+
+  beforeAll(async function () {
+    assert.ok(
+      [
+        'current',
+        'incremental-production',
+        'aggregation-disabled',
+        'aggregation-disabled-grouped-lookup',
+        'aggregation-disabled-grouped-lookup-linear-merge',
+        'aggregation-disabled-grouped-lookup-linear-merge-last-seen-disabled',
+        'grouped-lookup-linear-merge-last-seen-disabled',
+      ].includes(SCENARIO),
+      `Unknown EMAIL_ANALYTICS_BENCHMARK_SCENARIO: ${SCENARIO}`,
+    );
+    assert.ok(UNIQUE_RECIPIENTS > 0, 'recipient count must be positive');
+    assert.ok(
+      Number.isInteger(ACTIVE_SEND_RECIPIENTS) && ACTIVE_SEND_RECIPIENTS >= UNIQUE_RECIPIENTS,
+      'active send recipient count must be an integer greater than or equal to touched recipients',
+    );
+    assert.ok(DUPLICATE_RATE >= 0 && DUPLICATE_RATE < 1, 'duplicate rate must be in [0, 1)');
+    assert.ok(
+      PAGE_SIZES.length > 0 &&
+        PAGE_SIZES.every((pageSize) => Number.isInteger(pageSize) && pageSize > 0),
+      'page sizes must be positive integers',
+    );
+    assert.ok(
+      Number.isInteger(FETCH_PAGE_SIZE) && FETCH_PAGE_SIZE > 0,
+      'fetch page size must be a positive integer',
+    );
+    assert.ok(
+      WRITE_BUFFER_SIZES.length > 0 &&
+        WRITE_BUFFER_SIZES.every(
+          (writeBufferSize) => Number.isInteger(writeBufferSize) && writeBufferSize > 0,
+        ),
+      'write buffer sizes must be positive integers',
+    );
+    assert.ok(
+      WRITE_SHAPES.length > 0 &&
+        WRITE_SHAPES.every((shape) =>
+          ['native-case', 'case', 'grouped-in', 'json-table', 'temporary-table'].includes(shape),
+        ),
+      'write shapes must be supported',
+    );
+    assert.ok(
+      Number.isInteger(HISTORY_RECIPIENTS_PER_MEMBER) && HISTORY_RECIPIENTS_PER_MEMBER >= 0,
+      'history rows per member must be a non-negative integer',
+    );
+    assert.ok(
+      HISTORY_OPEN_RATE >= 0 && HISTORY_OPEN_RATE <= 1,
+      'history open rate must be in [0, 1]',
+    );
+
+    configUtils.set('emailAnalytics:batchProcessing', true);
+    configUtils.set('bulkEmail:mailgun', {
+      apiKey: 'benchmark-key',
+      domain: 'benchmark.example.com',
+      baseUrl: 'https://api.mailgun.net',
+    });
+
+    sinon.stub(Queries.prototype, 'getLastEventTimestamp').resolves(new Date(2000, 0, 1));
+    if (SCENARIO.includes('aggregation-disabled')) {
+      sinon.stub(Queries.prototype, 'aggregateEmailStats').resolves();
+      sinon.stub(Queries.prototype, 'aggregateMemberStatsBatch').resolves();
+      sinon.stub(Queries.prototype, 'aggregateMemberStats').resolves();
+      sinon.stub(Queries.prototype, 'reconcileMemberStats').resolves(0);
+    }
+    if (SCENARIO.includes('grouped-lookup')) {
+      sinon
+        .stub(EmailEventProcessor.prototype, 'batchGetRecipients')
+        .callsFake(batchGetRecipientsGroupedByEmail);
+    }
+    if (SCENARIO.includes('linear-merge')) {
+      sinon
+        .stub(EventProcessingResult.prototype, 'merge')
+        .callsFake(mergeEventProcessingResultLinear);
+    }
+    if (SCENARIO.endsWith('last-seen-disabled')) {
+      sinon.stub(LastSeenAtUpdater.prototype, 'updateLastSeenAtWithoutKnownLastSeen').resolves();
+    }
+    if (WRITE_SHAPE_MATRIX_ENABLED) {
+      sinon.stub(NewsletterEmailEventStorage.prototype, 'handleOpened').callsFake(function (event) {
+        collectOpenedUpdate(this, event);
+      });
+      sinon
+        .stub(NewsletterEmailEventStorage.prototype, 'flushBatchedUpdates')
+        .callsFake(function () {
+          return maybeFlushOpenedUpdatesByShape(this);
+        });
+    }
+
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
+
+    if (WRITE_SHAPE_MATRIX_ENABLED) {
+      const recipientIdColumn = await db
+        .knex('information_schema.columns')
+        .select('COLLATION_NAME as collation_name')
+        .whereRaw('TABLE_SCHEMA = DATABASE()')
+        .where({ TABLE_NAME: 'email_recipients', COLUMN_NAME: 'id' })
+        .first();
+      recipientIdCollation = recipientIdColumn?.collation_name;
+      assert.match(
+        recipientIdCollation || '',
+        /^[a-z0-9_]+$/,
+        'email_recipients.id must have a safe, known collation',
+      );
+    }
+
+    const emailBatch = fixtureManager.get('email_batches', 0);
+    emailId = emailBatch.email_id;
+    await db.knex('emails').where({ id: emailId }).update({ track_opens: true });
+
+    syntheticRecipients = await seedRecipients({
+      emailId,
+      batchId: emailBatch.id,
+    });
+    const activeRecipientsBeforePadding = await db
+      .knex('email_recipients')
+      .where('email_id', emailId)
+      .count('id as count')
+      .first();
+    const currentActiveRecipientCount = Number(activeRecipientsBeforePadding.count);
+    preexistingActiveRecipientRows = currentActiveRecipientCount - UNIQUE_RECIPIENTS;
+    const activeSendSeedStartedAt = performance.now();
+    untouchedActiveRecipientRows = await seedUntouchedActiveRecipients({
+      emailId,
+      batchId: emailBatch.id,
+      currentRecipientCount: currentActiveRecipientCount,
+    });
+    activeSendSeedMs = performance.now() - activeSendSeedStartedAt;
+    if (HISTORY_RECIPIENTS_PER_MEMBER > 0) {
+      const historyEmail = fixtureManager.get('emails', 1);
+      const historyBatchId = ObjectId().toHexString();
+      const now = new Date();
+      await db.knex('emails').where({ id: historyEmail.id }).update({ track_opens: true });
+      await db.knex('email_batches').insert({
+        id: historyBatchId,
+        email_id: historyEmail.id,
+        status: 'submitted',
+        fallback_sending_domain: false,
+        created_at: now,
+        updated_at: now,
+      });
+      const historySeedStartedAt = performance.now();
+      historicalRecipientRows = await seedHistoricalRecipients({
+        recipients: syntheticRecipients,
+        emailId: historyEmail.id,
+        batchId: historyBatchId,
+      });
+      historySeedMs = performance.now() - historySeedStartedAt;
+    }
+    events = buildEvents({
+      recipients: syntheticRecipients,
+      emailId,
+      providerId: emailBatch.mailgun_message_id,
+    });
+
+    sinon.stub(MailgunClient.prototype, 'getInstance').returns({});
+    sinon
+      .stub(MailgunClient.prototype, 'getEventsFromMailgun')
+      .callsFake(async function (_instance, _domain, options) {
+        if (PAGE_LATENCY_MS > 0) {
+          await sleep(PAGE_LATENCY_MS);
+        }
+        const pageIndex = options.page === undefined ? 0 : Number(options.page);
+        pageFetches += 1;
+        return {
+          items: pages[pageIndex] || [],
+          pages: {
+            next: {
+              page: String(pageIndex + 1),
+            },
+          },
+        };
+      });
+  }, 600_000);
+
+  afterAll(async function () {
+    sinon.restore();
+    await configUtils.restore();
+  });
+
+  async function runBenchmark(pageSize, writeShape, writeBufferSize = pageSize) {
+    await fs.mkdir(PROFILE_DIR, { recursive: true });
+    currentWriteShape = writeShape;
+    currentWriteBufferSize = writeBufferSize;
+    await db
+      .knex('email_recipients')
+      .whereIn(
+        'id',
+        syntheticRecipients.map(({ id }) => id),
+      )
+      .update({ opened_at: null });
+    await db
+      .knex('members')
+      .whereIn(
+        'id',
+        syntheticRecipients.map(({ member_id: memberId }) => memberId),
+      )
+      .update({ email_opened_count: 0 });
+    await db.knex('emails').where('id', emailId).update({ opened_count: 0 });
+
+    const analyticsQueries = new Queries(db.knex);
+    const syntheticMemberIds = syntheticRecipients.map(({ member_id: memberId }) => memberId);
+    for (let index = 0; index < syntheticMemberIds.length; index += 100) {
+      await analyticsQueries.aggregateMemberStatsBatch(
+        syntheticMemberIds.slice(index, index + 100),
+      );
+    }
+    const memberCountersBefore = await db
+      .knex('members')
+      .whereIn('id', syntheticMemberIds)
+      .sum('email_opened_count as opened_count')
+      .first();
+
+    pages = [];
+    for (let index = 0; index < events.length; index += pageSize) {
+      pages.push(events.slice(index, index + pageSize));
+    }
+    pageFetches = 0;
+    pageFlushCalls = 0;
+    expectedPageFlushCalls = pages.length;
+    writeBufferStats = {
+      transactionCount: 0,
+      transitionedRecipients: 0,
+      maxPendingRecipients: 0,
+    };
+
+    const databaseInstrumentation = instrumentDatabase(db.knex);
+    const eventLoopDelay = monitorEventLoopDelay({ resolution: 10 });
+    eventLoopDelay.enable();
+    const cpuStart = process.cpuUsage();
+    const memoryStart = process.memoryUsage();
+    const eventLoopStart = performance.eventLoopUtilization();
+    const session = await startCpuProfile();
+    const startedAt = performance.now();
+
+    const fetchResult = await emailAnalytics.newsletters.service.fetchLatestOpenedEvents({
+      maxEvents: Infinity,
+    });
+    const serviceReturnedAt = performance.now();
+    await DomainEvents.allSettled();
+    const completedAt = performance.now();
+
+    const profile = await stopCpuProfile(session);
+    eventLoopDelay.disable();
+    const sql = databaseInstrumentation.stop();
+    const cpu = process.cpuUsage(cpuStart);
+    const memoryEnd = process.memoryUsage();
+    const eventLoop = performance.eventLoopUtilization(eventLoopStart);
+
+    const timestamp = new Date().toISOString().replaceAll(':', '-');
+    const basename = `email-analytics-${SCENARIO}-${UNIQUE_RECIPIENTS}-send-${ACTIVE_SEND_RECIPIENTS}-fetch-${pageSize}-buffer-${writeBufferSize}-write-${writeShape}-history-${HISTORY_RECIPIENTS_PER_MEMBER}-${process.pid}-${timestamp}`;
+    const profilePath = path.join(PROFILE_DIR, `${basename}.cpuprofile`);
+    const summaryPath = path.join(PROFILE_DIR, `${basename}.json`);
+    const cpuProfileSummary = summarizeCpuProfile(profile);
+    const summary = {
+      scenario: SCENARIO,
+      database: process.env.NODE_ENV,
+      inputs: {
+        uniqueRecipients: UNIQUE_RECIPIENTS,
+        activeSendRecipients: ACTIVE_SEND_RECIPIENTS,
+        preexistingActiveRecipientRows,
+        untouchedActiveRecipientRows,
+        activeSendSeedMs: Number(activeSendSeedMs.toFixed(1)),
+        duplicateEvents: events.length - UNIQUE_RECIPIENTS,
+        totalEvents: events.length,
+        duplicateRate: Number(((events.length - UNIQUE_RECIPIENTS) / events.length).toFixed(4)),
+        pageSize,
+        fetchPageSize: pageSize,
+        writeBufferSize,
+        writeTransactions: writeBufferStats.transactionCount,
+        transitionedRecipients: writeBufferStats.transitionedRecipients,
+        maxPendingRecipients: writeBufferStats.maxPendingRecipients,
+        writeShape,
+        pageLatencyMs: PAGE_LATENCY_MS,
+        pageFetches,
+        historyRecipientsPerMember: HISTORY_RECIPIENTS_PER_MEMBER,
+        lifetimeRecipientsPerMember: HISTORY_RECIPIENTS_PER_MEMBER + 1,
+        historyOpenRate: HISTORY_OPEN_RATE,
+        historicalRecipientRows,
+        historySeedMs: Number(historySeedMs.toFixed(1)),
+      },
+      timings: {
+        serviceReturnMs: Number((serviceReturnedAt - startedAt).toFixed(1)),
+        domainEventDrainMs: Number((completedAt - serviceReturnedAt).toFixed(1)),
+        fullStackMs: Number((completedAt - startedAt).toFixed(1)),
+        ...fetchResult,
+        result: {
+          opened: fetchResult.result.opened,
+          unprocessable: fetchResult.result.unprocessable,
+          emailIds: fetchResult.result.emailIds.length,
+          memberIds: fetchResult.result.memberIds.length,
+        },
+      },
+      process: {
+        cpuUserMs: Number((cpu.user / 1000).toFixed(1)),
+        cpuSystemMs: Number((cpu.system / 1000).toFixed(1)),
+        eventLoopUtilization: Number(eventLoop.utilization.toFixed(4)),
+        eventLoopDelayMeanMs: Number((eventLoopDelay.mean / 1e6).toFixed(2)),
+        eventLoopDelayMaxMs: Number((eventLoopDelay.max / 1e6).toFixed(2)),
+        heapUsedDeltaMb: Number(
+          ((memoryEnd.heapUsed - memoryStart.heapUsed) / 1024 / 1024).toFixed(1),
+        ),
+        rssDeltaMb: Number(((memoryEnd.rss - memoryStart.rss) / 1024 / 1024).toFixed(1)),
+      },
+      sql,
+      cpuProfile: cpuProfileSummary,
+      artifacts: {
+        profilePath,
+        summaryPath,
+      },
+    };
+
+    await fs.writeFile(profilePath, JSON.stringify(profile));
+    await fs.writeFile(summaryPath, JSON.stringify(summary, null, 2));
+
+    const openedRecipients = await db
+      .knex('email_recipients')
+      .whereIn(
+        'id',
+        syntheticRecipients.map(({ id }) => id),
+      )
+      .whereNotNull('opened_at')
+      .count('id as count')
+      .first();
+    const activeSendRecipientCount = await db
+      .knex('email_recipients')
+      .where('email_id', emailId)
+      .count('id as count')
+      .first();
+    const activeSendOpenedCount = await db
+      .knex('email_recipients')
+      .where('email_id', emailId)
+      .whereNotNull('opened_at')
+      .count('id as count')
+      .first();
+    const openedRecipientRows = await db
+      .knex('email_recipients')
+      .select('member_email', 'opened_at')
+      .whereIn(
+        'id',
+        syntheticRecipients.map(({ id }) => id),
+      );
+    const emailCounters = await db
+      .knex('emails')
+      .select('opened_count')
+      .where('id', emailId)
+      .first();
+    const memberCounters = await db
+      .knex('members')
+      .whereIn(
+        'id',
+        syntheticRecipients.map(({ member_id: memberId }) => memberId),
+      )
+      .sum('email_opened_count as opened_count')
+      .first();
+    const expectedOpenedAtByEmail = new Map();
+    for (const event of events) {
+      const expectedTimestamp = moment.utc(event.timestamp * 1000).format('YYYY-MM-DD HH:mm:ss');
+      const existing = expectedOpenedAtByEmail.get(event.recipient);
+      if (!existing || expectedTimestamp < existing) {
+        expectedOpenedAtByEmail.set(event.recipient, expectedTimestamp);
+      }
+    }
+
+    assert.equal(fetchResult.eventCount, events.length);
+    assert.equal(fetchResult.result.opened, events.length);
+    assert.equal(Number(openedRecipients.count), UNIQUE_RECIPIENTS);
+    assert.equal(Number(activeSendRecipientCount.count), ACTIVE_SEND_RECIPIENTS);
+    assert.equal(Number(emailCounters.opened_count), Number(activeSendOpenedCount.count));
+    assert.equal(
+      Number(memberCounters.opened_count),
+      Number(memberCountersBefore.opened_count) + UNIQUE_RECIPIENTS,
+    );
+    if (WRITE_BUFFER_SIZE_MATRIX_ENABLED) {
+      assert.equal(writeBufferStats.transitionedRecipients, UNIQUE_RECIPIENTS);
+    }
+    assert.equal(openedRecipientRows.length, UNIQUE_RECIPIENTS);
+    for (const recipient of openedRecipientRows) {
+      assert.equal(
+        moment.utc(recipient.opened_at).format('YYYY-MM-DD HH:mm:ss'),
+        expectedOpenedAtByEmail.get(recipient.member_email),
+      );
+    }
+
+    // eslint-disable-next-line no-console -- machine-readable output for the opt-in benchmark
+    console.log(`EMAIL_ANALYTICS_BENCHMARK_RESULT ${JSON.stringify(summary)}`);
+  }
+
+  it('profiles paginated event ingestion through the full Ghost stack', async function () {
+    if (WRITE_BUFFER_SIZE_MATRIX_ENABLED) {
+      for (const writeBufferSize of WRITE_BUFFER_SIZES) {
+        for (const writeShape of WRITE_SHAPES) {
+          await runBenchmark(FETCH_PAGE_SIZE, writeShape, writeBufferSize);
+        }
+      }
+      return;
+    }
+
+    for (const pageSize of PAGE_SIZES) {
+      for (const writeShape of WRITE_SHAPES) {
+        await runBenchmark(pageSize, writeShape);
+      }
+    }
+  }, 600_000);
+});

--- a/ghost/core/test/integration/services/email-service/newsletter-email-event-storage-crash.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-event-storage-crash.test.js
@@ -1,0 +1,292 @@
+const assert = require('node:assert/strict');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const db = require('../../../../core/server/data/db');
+const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
+const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
+const {
+  EmailDeliveredEvent,
+} = require('../../../../core/server/services/email-service/events/email-delivered-event');
+const {
+  EmailOpenedEvent,
+} = require('../../../../core/server/services/email-service/events/email-opened-event');
+const {
+  EmailBouncedEvent,
+} = require('../../../../core/server/services/email-service/events/email-bounced-event');
+
+describe('NewsletterEmailEventStorage transaction crash recovery', function () {
+  let models;
+  let recipient;
+  let emailId;
+  let memberId;
+
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
+    models = require('../../../../core/server/models');
+    recipient = fixtureManager.get('email_recipients', 0);
+    emailId = recipient.email_id;
+    memberId = recipient.member_id;
+  });
+
+  beforeEach(async function () {
+    await db.knex('email_recipient_failures').where({ email_recipient_id: recipient.id }).delete();
+    await db.knex('email_recipients').where({ id: recipient.id }).update({
+      delivered_at: null,
+      opened_at: null,
+      failed_at: null,
+    });
+    await db.knex('emails').where({ id: emailId }).update({
+      delivered_count: 0,
+      opened_count: 0,
+      failed_count: 0,
+    });
+    await db.knex('members').where({ id: memberId }).update({
+      email_tracked_count: 5,
+      email_opened_count: 0,
+      email_open_rate: 0,
+      last_seen_at: null,
+    });
+  });
+
+  function createStorage(flushStageHook) {
+    return new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db,
+      models: {
+        EmailRecipientFailure: models.EmailRecipientFailure,
+      },
+      flushStageHook,
+    });
+  }
+
+  async function queueAllTransitions(storage) {
+    const eventData = {
+      email: recipient.member_email,
+      memberId,
+      emailId,
+      emailRecipientId: recipient.id,
+      timestamp: new Date('2026-08-31T08:00:00.000Z'),
+    };
+    await storage.handleDelivered(EmailDeliveredEvent.create(eventData));
+    await storage.handleOpened(EmailOpenedEvent.create(eventData));
+    await storage.handlePermanentFailed(
+      EmailBouncedEvent.create({
+        ...eventData,
+        id: 'forced-crash-event',
+        error: { code: 550, enhancedCode: '5.1.1', message: 'Synthetic failure' },
+      }),
+    );
+  }
+
+  async function readState() {
+    const storedRecipient = await db.knex('email_recipients').where({ id: recipient.id }).first();
+    const email = await db.knex('emails').where({ id: emailId }).first();
+    const member = await db.knex('members').where({ id: memberId }).first();
+    return {
+      recipient: storedRecipient,
+      email,
+      member,
+    };
+  }
+
+  function assertUnchanged(state) {
+    assert.equal(state.recipient.delivered_at, null);
+    assert.equal(state.recipient.opened_at, null);
+    assert.equal(state.recipient.failed_at, null);
+    assert.equal(state.email.delivered_count, 0);
+    assert.equal(state.email.opened_count, 0);
+    assert.equal(state.email.failed_count, 0);
+    assert.equal(state.member.email_opened_count, 0);
+    assert.equal(state.member.email_open_rate, 0);
+    assert.equal(state.member.last_seen_at, null);
+  }
+
+  function assertCommittedOnce(state) {
+    assert.notEqual(state.recipient.delivered_at, null);
+    assert.notEqual(state.recipient.opened_at, null);
+    assert.notEqual(state.recipient.failed_at, null);
+    assert.equal(state.email.delivered_count, 1);
+    assert.equal(state.email.opened_count, 1);
+    assert.equal(state.email.failed_count, 1);
+    assert.equal(state.member.email_opened_count, 1);
+    assert.equal(state.member.email_open_rate, 20);
+    assert.notEqual(state.member.last_seen_at, null);
+  }
+
+  for (const crashStage of [
+    'after-lock',
+    'after-recipient-update',
+    'after-email-update',
+    'after-member-update',
+    'before-commit',
+    'after-commit',
+  ]) {
+    it(`replays safely after a crash ${crashStage}`, async function () {
+      let crashed = false;
+      const storage = createStorage((stage) => {
+        if (!crashed && stage === crashStage) {
+          crashed = true;
+          throw new Error(`Forced crash ${stage}`);
+        }
+      });
+      await queueAllTransitions(storage);
+
+      await assert.rejects(storage.flushBatchedUpdates(), /Forced crash/);
+      const stateAfterCrash = await readState();
+      if (crashStage === 'after-commit') {
+        assertCommittedOnce(stateAfterCrash);
+      } else {
+        assertUnchanged(stateAfterCrash);
+      }
+
+      await storage.flushBatchedUpdates();
+      assertCommittedOnce(await readState());
+    });
+  }
+
+  it('counts duplicate opens once and keeps the earliest timestamp', async function () {
+    const storage = createStorage();
+    const baseEvent = {
+      email: recipient.member_email,
+      memberId,
+      emailId,
+      emailRecipientId: recipient.id,
+    };
+    await storage.handleOpened(
+      EmailOpenedEvent.create({ ...baseEvent, timestamp: new Date('2026-08-31T09:00:00.000Z') }),
+    );
+    await storage.handleOpened(
+      EmailOpenedEvent.create({ ...baseEvent, timestamp: new Date('2026-08-31T08:00:00.000Z') }),
+    );
+    await storage.flushBatchedUpdates();
+
+    await storage.handleOpened(
+      EmailOpenedEvent.create({ ...baseEvent, timestamp: new Date('2026-09-01T10:00:00.000Z') }),
+    );
+    await storage.flushBatchedUpdates();
+
+    const state = await readState();
+    if (state.recipient.opened_at instanceof Date) {
+      assert.equal(state.recipient.opened_at.toISOString(), '2026-08-31T08:00:00.000Z');
+    } else {
+      assert.match(String(state.recipient.opened_at), /2026-08-31 08:00:00/);
+    }
+    assert.equal(state.email.opened_count, 1);
+    assert.equal(state.member.email_opened_count, 1);
+    assert.equal(state.member.email_open_rate, 20);
+    if (state.member.last_seen_at instanceof Date) {
+      assert.equal(state.member.last_seen_at.toISOString(), '2026-09-01T10:00:00.000Z');
+    } else {
+      assert.match(String(state.member.last_seen_at), /2026-09-01 10:00:00/);
+    }
+  });
+});
+
+describe('BatchSendingService recipient counter crash recovery', function () {
+  let models;
+  let email;
+  let member;
+
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
+    models = require('../../../../core/server/models');
+    const fixtureEmail = fixtureManager.get('emails', 0);
+    email = await models.Email.findOne({ id: fixtureEmail.id }, { require: true });
+    await email.save({ track_opens: true }, { patch: true });
+    const fixtureMember = fixtureManager.get('members', 0);
+    member = await models.Member.findOne({ id: fixtureMember.id }, { require: true });
+  });
+
+  beforeEach(async function () {
+    await db.knex('members').where({ id: member.id }).update({
+      email_count: 10,
+      email_tracked_count: 5,
+      email_opened_count: 2,
+      email_open_rate: 40,
+    });
+  });
+
+  for (const crashStage of ['after-recipient-insert', 'after-member-counter-update']) {
+    it(`rolls back recipient creation after a crash ${crashStage}`, async function () {
+      let crashed = false;
+      const service = new BatchSendingService({
+        models: { EmailBatch: models.EmailBatch },
+        db,
+        createBatchStageHook(stage) {
+          if (!crashed && stage === crashStage) {
+            crashed = true;
+            throw new Error(`Forced crash ${stage}`);
+          }
+        },
+      });
+      const batchesBefore = await db
+        .knex('email_batches')
+        .where({ email_id: email.id })
+        .count('* as count')
+        .first();
+      const recipientsBefore = await db
+        .knex('email_recipients')
+        .where({ email_id: email.id })
+        .count('* as count')
+        .first();
+
+      await assert.rejects(service.createBatch(email, null, [member.toJSON()], {}), /Forced crash/);
+
+      const memberAfterCrash = await db.knex('members').where({ id: member.id }).first();
+      assert.equal(memberAfterCrash.email_count, 10);
+      assert.equal(memberAfterCrash.email_tracked_count, 5);
+      assert.equal(memberAfterCrash.email_open_rate, 40);
+      assert.equal(
+        Number(
+          (await db.knex('email_batches').where({ email_id: email.id }).count('* as count').first())
+            .count,
+        ),
+        Number(batchesBefore.count),
+      );
+      assert.equal(
+        Number(
+          (
+            await db
+              .knex('email_recipients')
+              .where({ email_id: email.id })
+              .count('* as count')
+              .first()
+          ).count,
+        ),
+        Number(recipientsBefore.count),
+      );
+
+      const batch = await service.createBatch(email, null, [member.toJSON()], {});
+      const memberAfterRetry = await db.knex('members').where({ id: member.id }).first();
+      assert.equal(memberAfterRetry.email_count, 11);
+      assert.equal(memberAfterRetry.email_tracked_count, 6);
+      assert.equal(memberAfterRetry.email_open_rate, 33);
+
+      await db.knex('email_recipients').where({ batch_id: batch.id }).delete();
+      await models.EmailBatch.destroy({ id: batch.id });
+    });
+  }
+
+  it('preserves the visible rate until the tracked denominator is reconciled', async function () {
+    await db.knex('members').where({ id: member.id }).update({
+      email_count: 10,
+      email_tracked_count: null,
+      email_opened_count: 2,
+      email_open_rate: 40,
+    });
+    const service = new BatchSendingService({
+      models: { EmailBatch: models.EmailBatch },
+      db,
+    });
+
+    const batch = await service.createBatch(email, null, [member.toJSON()], {});
+    const updatedMember = await db.knex('members').where({ id: member.id }).first();
+    assert.equal(updatedMember.email_count, 11);
+    assert.equal(updatedMember.email_tracked_count, null);
+    assert.equal(updatedMember.email_open_rate, 40);
+
+    await db.knex('email_recipients').where({ batch_id: batch.id }).delete();
+    await models.EmailBatch.destroy({ id: batch.id });
+  });
+});

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = '0d83dfdf9142d606e0660871c5adcf1a';
+  const currentSchemaHash = '18b1d7ce93d95779b05d3dbd2c628855';
   const currentFixturesHash = '1727a789194847da33d68dd95301b416';
   const currentSettingsHash = '6ea42a00cca61a1ba87f66eb6e25a78a';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
@@ -655,6 +655,7 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
         aggregateEmailStats: sinon.stub().resolves(),
         aggregateMemberStats: sinon.stub().resolves(),
         aggregateMemberStatsBatch: sinon.stub().resolves(),
+        reconcileMemberStats: sinon.stub().resolves(100),
       };
     });
 
@@ -935,7 +936,7 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
     });
 
     describe('member stats batching', function () {
-      it('calls batched query for member stats when batching is enabled', async function () {
+      it('reconciles emails once and advances the bounded member sweep', async function () {
         configUtils.set('emailAnalytics:batchProcessing', true);
         const processor = createProcessor();
         const processingResult = new EventProcessingResult({
@@ -953,19 +954,17 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
         sinon.assert.calledWith(queries.aggregateEmailStats, 'e-1');
         sinon.assert.calledWith(queries.aggregateEmailStats, 'e-2');
 
-        // In batched mode, aggregateMemberStatsBatch should be called
-        sinon.assert.calledOnce(queries.aggregateMemberStatsBatch);
-        sinon.assert.calledWith(queries.aggregateMemberStatsBatch, ['m-1', 'm-2']);
+        sinon.assert.calledOnceWithExactly(queries.reconcileMemberStats, 100);
 
-        // Sequential method should not be called
+        sinon.assert.notCalled(queries.aggregateMemberStatsBatch);
         sinon.assert.notCalled(queries.aggregateMemberStats);
       });
 
-      it('chunks member ids into batches of 100', async function () {
+      it('does not recompute every touched member at job completion', async function () {
         configUtils.set('emailAnalytics:batchProcessing', true);
         const processor = createProcessor();
         const memberIds = Array.from({ length: 250 }, (_, i) => `m-${i}`);
-        const processingResult = new EventProcessingResult({ memberIds });
+        const processingResult = new EventProcessingResult({ emailIds: ['e-1'], memberIds });
 
         await processor.aggregate({
           includeOpenedEvents: true,
@@ -973,10 +972,8 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
           isFinal: true,
         });
 
-        assert.equal(queries.aggregateMemberStatsBatch.callCount, 3);
-        assert.equal(queries.aggregateMemberStatsBatch.getCall(0).args[0].length, 100);
-        assert.equal(queries.aggregateMemberStatsBatch.getCall(1).args[0].length, 100);
-        assert.equal(queries.aggregateMemberStatsBatch.getCall(2).args[0].length, 50);
+        sinon.assert.calledOnceWithExactly(queries.reconcileMemberStats, 100);
+        sinon.assert.notCalled(queries.aggregateMemberStatsBatch);
       });
 
       it('calls sequential query for member stats when batching is disabled', async function () {

--- a/ghost/core/test/unit/server/services/email-analytics/queries.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/queries.test.ts
@@ -39,6 +39,7 @@ const createDatabase = async (): Promise<Knex> => {
   await database.schema.createTable('members', (table) => {
     table.text('id').primary();
     table.integer('email_count').notNullable().defaultTo(0);
+    table.integer('email_tracked_count').unsigned();
     table.integer('email_opened_count').notNullable().defaultTo(0);
     table.integer('email_open_rate');
   });
@@ -454,6 +455,7 @@ describe('Email analytics queries', function () {
 
       const member = await knex('members').where('id', 'member-1').first();
       assert.equal(member.email_count, 5);
+      assert.equal(member.email_tracked_count, 5);
       assert.equal(member.email_opened_count, 2);
       assert.equal(member.email_open_rate, 40);
     });
@@ -473,6 +475,7 @@ describe('Email analytics queries', function () {
 
       const member = await knex('members').where('id', 'member-1').first();
       assert.equal(member.email_count, 2);
+      assert.equal(member.email_tracked_count, 1);
       assert.equal(member.email_opened_count, 1);
       assert.equal(member.email_open_rate, 75);
     });
@@ -488,6 +491,7 @@ describe('Email analytics queries', function () {
 
       const member = await knex('members').where('id', 'member-1').first();
       assert.equal(member.email_count, 0);
+      assert.equal(member.email_tracked_count, 0);
       assert.equal(member.email_opened_count, 0);
       assert.equal(member.email_open_rate, 40);
     });
@@ -533,24 +537,28 @@ describe('Email analytics queries', function () {
         {
           id: 'member-1',
           email_count: 5,
+          email_tracked_count: 5,
           email_opened_count: 2,
           email_open_rate: 40,
         },
         {
           id: 'member-2',
           email_count: 1,
+          email_tracked_count: 1,
           email_opened_count: 1,
           email_open_rate: null,
         },
         {
           id: 'member-3',
           email_count: 0,
+          email_tracked_count: 0,
           email_opened_count: 0,
           email_open_rate: null,
         },
         {
           id: 'untouched-member',
           email_count: 9,
+          email_tracked_count: null,
           email_opened_count: 8,
           email_open_rate: 89,
         },
@@ -565,6 +573,39 @@ describe('Email analytics queries', function () {
 
     it('ignores missing member IDs', async function () {
       await assert.doesNotReject(queries.aggregateMemberStatsBatch(['missing-member']));
+    });
+  });
+
+  describe('reconcileMemberStats', function () {
+    it('walks members in bounded batches and persists its cursor', async function () {
+      await insertEmail('tracked-email', true);
+      for (const memberId of ['member-1', 'member-2', 'member-3']) {
+        await insertMember(memberId);
+        await insertRecipient({
+          email_id: 'tracked-email',
+          member_id: memberId,
+          opened_at: '2026-08-11T10:00:00.000Z',
+        });
+      }
+
+      assert.equal(await queries.reconcileMemberStats(2), 2);
+      assert.deepEqual(await knex('members').select('id', 'email_tracked_count').orderBy('id'), [
+        { id: 'member-1', email_tracked_count: 1 },
+        { id: 'member-2', email_tracked_count: 1 },
+        { id: 'member-3', email_tracked_count: null },
+      ]);
+
+      assert.equal(await queries.reconcileMemberStats(2), 1);
+      assert.equal((await knex('members').where('id', 'member-3').first()).email_tracked_count, 1);
+
+      const job = await knex('jobs').where('name', 'email-analytics-member-reconciliation').first();
+      assert.deepEqual(JSON.parse(job.metadata), { memberCursor: 'member-3' });
+
+      assert.equal(await queries.reconcileMemberStats(2), 2);
+      const wrappedJob = await knex('jobs')
+        .where('name', 'email-analytics-member-reconciliation')
+        .first();
+      assert.deepEqual(JSON.parse(wrappedJob.metadata), { memberCursor: 'member-2' });
     });
   });
 });

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -1129,6 +1129,30 @@ describe('Batch Sending Service', function () {
 
       const insertedRecipients = calls.flatMap((call) => call.args[0]);
       assert.equal(insertedRecipients.length, 1);
+      sinon.assert.calledWithExactly(db.increment, { email_count: 1 });
+    });
+
+    it('increments total and tracked member counters in the recipient transaction', async function () {
+      const EmailBatch = createModelClass({});
+      const db = createDb({});
+      const service = new BatchSendingService({ models: { EmailBatch }, db });
+      const email = createModel({ track_opens: true });
+      const members = [
+        createModel({ email: 'one@example.com', uuid: 'member-1' }).toJSON(),
+        createModel({ email: 'two@example.com', uuid: 'member-2' }).toJSON(),
+      ];
+
+      await service.createBatch(email, null, members, {});
+
+      sinon.assert.calledOnceWithExactly(db.increment, {
+        email_count: 1,
+        email_tracked_count: 1,
+      });
+      assert.equal(
+        db.transacting.callCount,
+        3,
+        'recipient, counter, and rate writes share a transaction',
+      );
     });
   });
 

--- a/ghost/core/test/unit/server/services/email-service/utils/index.ts
+++ b/ghost/core/test/unit/server/services/email-service/utils/index.ts
@@ -157,6 +157,9 @@ const createDb = ({ first, all }: DbOptions = {}) => {
     whereNull: function () {
       return this;
     },
+    whereIn: function () {
+      return this;
+    },
     join: function () {
       return this;
     },
@@ -177,6 +180,9 @@ const createDb = ({ first, all }: DbOptions = {}) => {
       return this;
     },
     update: sinon.stub().resolves(),
+    increment: sinon.spy(function (this: any) {
+      return this;
+    }),
     orderByRaw: function () {
       return this;
     },
@@ -189,9 +195,9 @@ const createDb = ({ first, all }: DbOptions = {}) => {
     then: function (resolve: (value: any) => void) {
       resolve(a);
     },
-    transacting: function () {
+    transacting: sinon.spy(function (this: any) {
       return this;
-    },
+    }),
   };
   db.knex.raw = function () {
     return this;

--- a/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
+++ b/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
@@ -215,6 +215,35 @@ describe('LastSeenAtUpdater', function () {
       sinon.assert.calledOnce(db.update);
     });
 
+    it('leaves batched EmailOpenedEvents to the page transaction', async function () {
+      const now = moment('2022-02-28T18:00:00Z').utc();
+      const updater = new LastSeenAtUpdater({
+        services: { settingsCache: { get: sinon.stub().returns('Etc/UTC') } },
+        getMembersApi() {
+          return {};
+        },
+        db: {},
+        events,
+        config: {
+          get: sinon.stub().withArgs('emailAnalytics:batchProcessing').returns(true),
+        },
+      });
+      updater.subscribe(DomainEvents);
+      sinon.spy(updater, 'updateLastSeenAtWithoutKnownLastSeen');
+
+      DomainEvents.dispatch(
+        EmailOpenedEvent.create({
+          memberId: '1',
+          emailRecipientId: '1',
+          emailId: '1',
+          timestamp: now.toDate(),
+        }),
+      );
+      await DomainEvents.allSettled();
+
+      sinon.assert.notCalled(updater.updateLastSeenAtWithoutKnownLastSeen);
+    });
+
     it('Catches errors in updateLastSeenAtWithoutKnownLastSeen on EmailOpenedEvents', async function () {
       const now = moment('2022-02-28T18:00:00Z').utc();
       const settingsCache = sinon.stub().returns('Etc/UTC');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3915/optimize-mailgun-event-ingestion-pipeline

## Why

Email analytics ingestion repeatedly rebuilds aggregate counts from recipient history. In batched mode this happens inside the ingestion loop, so a large send repeatedly scans each touched member's lifetime history and the active send's recipient rows even when most incoming events are duplicate opens.

The production queries and plans are reasonable; the expensive part is how often we ask the database to repeat the same work.

## What changed

- Recipient timestamp transitions and their dependent email/member counters are now written transactionally once per Mailgun page.
- Only rows whose timestamp moves from `NULL` contribute a counter delta. Replayed and duplicate provider events become no-ops.
- Recipient creation increments each member's total and tracked-email denominators in the same transaction as the recipient insert.
- Member open rates are derived from `email_opened_count / email_tracked_count` once the existing five-email privacy threshold is met.
- Batched ingestion no longer recomputes every touched member after each 5k events. Touched emails are reconciled once at job completion and a persistent cursor repairs 100 members per completed active job.
- Reconciliation remains authoritative, but uses one conditional email scan and a join-free member aggregate.
- `EventProcessingResult` identifier merging is linear rather than rebuilding cumulative sets after every page.
- The missing-events path now updates visible email counters through the same transaction.

Sequential mode is unchanged. The new path remains controlled by the existing `emailAnalytics:batchProcessing` site override so it can be enabled for Tangle first.

## Transaction and crash model

The transaction covers one fetched Mailgun page, normally 300 events:

1. Lock touched recipient rows in primary-key order.
2. Determine exact `NULL -> timestamp` transitions.
3. Update recipient timestamps.
4. Apply grouped email counter deltas.
5. Apply grouped member counter/rate and last-seen updates.
6. Commit, then clear the in-memory pending maps.

A crash before commit rolls the whole page back and leaves the pending maps available for retry. A crash after commit can replay the page, but the timestamps are no longer null, so no counters move twice. Recipient creation and member denominator updates use the same rollback/retry model.

Integration tests force failures after the recipient lock, recipient update, email update, member update, immediately before commit, and immediately after commit. They also cover duplicate opens, earliest-open timestamps, later-day `last_seen_at`, and both crash boundaries in recipient creation.

## Schema and rollout

This promotes Core to `6.62.0-rc.0` and adds nullable `members.email_tracked_count` in the `6.62` migration folder, with no bulk backfill. Existing members retain their current visible rate while the denominator is null. The bounded reconciliation cursor initializes and repairs members gradually; new recipient rows maintain the value once initialized.

The custom Tangle covering index is deliberately not removed here. That needs a separate usage audit after the new path has production evidence.

## Full-stack benchmark

The new opt-in integration benchmark drives synthetic Mailgun pages through the real fetch service, event processor, domain events, storage transaction, and final reconciliation while collecting SQL timings and a Node DevTools CPU profile.

Representative MySQL 8 shape:

- 490k-recipient active send
- 5k unique touched recipients / 7,247 events
- 31% duplicate opens
- 412 historical recipients per touched member
- 300-event Mailgun pages
- 5ms simulated page latency
- one worker

Repeated runs of the final shape completed in 2.27–2.93s locally. The timed ingestion phase was 1.19–1.56s, the one final 490k-recipient email reconciliation was 0.79–1.09s, and the 100-member rolling repair was 107–109ms.

This full-stack benchmark corrected an assumption from the initial microbenchmark: reconciling 5k members with realistic lifetime history is not a 34ms operation. It took roughly 11.9s locally, so the inline repair batch is intentionally 100 members. This PR therefore does not claim the original ~200x end-to-end projection.

The remaining hot costs are recipient lookup and database waiting, not Node CPU. Serial Mailgun fetching is still a separate throughput ceiling.

## Verification

- Repository formatting passed.
- Ghost Core lint and TypeScript checks passed.
- 211 focused schema and email-analytics unit tests passed.
- 46 migration, storage, and crash tests passed on SQLite.
- The same 46 tests passed on MySQL, including the production `JSON_TABLE` update path.
- The profiled representative benchmark passed all timestamp and counter truth assertions.

The repository-wide `pnpm check` reached the Ghost unit suite with every other workspace target passing, then reported seven unrelated local failures: a day-of-week assertion, three Fontconfig-dependent gift-preview tests, a hard-coded rendered date, and an expired reset-token fixture. None of those files are touched here.

## Known follow-ups

- Exercise contention before enabling more than the current single production worker.
- Audit and potentially remove Tangle's `(member_id, opened_at, email_id)` covering index after rollout evidence.
- Profile and parallelize the serial Mailgun fetch loop separately.

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written automated tests to prove the change works
