### PR TITLE
🐛 Fixed recommendations allowing free signups on sites that hide them

### DIFF
--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -27,8 +27,20 @@ class SettingsHelpers {
     return this.settingsCache.get('members_signup_access') === 'invite';
   }
 
+  /**
+   * Whether the site actively offers free signup, not just whether the API permits it.
+   * Hiding "Free" in Portal on a paid site removes free signup from the UI without changing
+   * members_signup_access, so this must stay false in that case — it feeds the public
+   * allow_self_signup / allow_external_signup flags that other sites use to decide whether
+   * to show a one-click subscribe option for recommendations. API-level signup enforcement
+   * lives in members-config-provider getAllowSelfSignup, which only checks signup access.
+   */
   allowSelfSignup() {
-    return this.settingsCache.get('members_signup_access') === 'all';
+    return (
+      this.settingsCache.get('members_signup_access') === 'all' &&
+      ((this.settingsCache.get('portal_plans') ?? []).includes('free') ||
+        !this.arePaidMembersEnabled())
+    );
   }
 
   /**

--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -28,18 +28,17 @@ class SettingsHelpers {
   }
 
   /**
-   * Whether the site actively offers free signup, not just whether the API permits it.
-   * Hiding "Free" in Portal on a paid site removes free signup from the UI without changing
-   * members_signup_access, so this must stay false in that case — it feeds the public
-   * allow_self_signup / allow_external_signup flags that other sites use to decide whether
-   * to show a one-click subscribe option for recommendations. API-level signup enforcement
-   * lives in members-config-provider getAllowSelfSignup, which only checks signup access.
+   * Whether the site offers free signup, based on both of the following settings:
+   * - Membership → Access → "Who should be able to subscribe to your site?" is set to "Public"
+   * - Membership → Portal settings → Signup options has the "Free" tier checked
+   *
+   * @returns {boolean}
    */
   allowSelfSignup() {
+    const portalPlans = this.settingsCache.get('portal_plans') ?? [];
+
     return (
-      this.settingsCache.get('members_signup_access') === 'all' &&
-      ((this.settingsCache.get('portal_plans') ?? []).includes('free') ||
-        !this.arePaidMembersEnabled())
+      this.settingsCache.get('members_signup_access') === 'all' && portalPlans.includes('free')
     );
   }
 

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -200,7 +200,7 @@ module.exports = {
         type: 'boolean',
         group: 'members',
         fn: settingsHelpers.allowSelfSignup.bind(settingsHelpers),
-        dependents: ['members_signup_access'],
+        dependents: ['members_signup_access', 'portal_plans'],
       }),
     );
     fields.push(

--- a/ghost/core/test/e2e-api/members/__snapshots__/site.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/site.test.js.snap
@@ -96,7 +96,7 @@ Object {
 }
 `;
 
-exports[`Site Public Settings Sets allow_external_signup to false when the free plan is hidden in Portal on a paid site 1: [body] 1`] = `
+exports[`Site Public Settings Sets allow_external_signup to false when the free plan is hidden in Portal 1: [body] 1`] = `
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
@@ -115,7 +115,7 @@ Object {
 }
 `;
 
-exports[`Site Public Settings Sets allow_external_signup to false when the free plan is hidden in Portal on a paid site 2: [headers] 1`] = `
+exports[`Site Public Settings Sets allow_external_signup to false when the free plan is hidden in Portal 2: [headers] 1`] = `
 Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",

--- a/ghost/core/test/e2e-api/members/__snapshots__/site.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/site.test.js.snap
@@ -96,6 +96,38 @@ Object {
 }
 `;
 
+exports[`Site Public Settings Sets allow_external_signup to false when the free plan is hidden in Portal on a paid site 1: [body] 1`] = `
+Object {
+  "site": Object {
+    "accent_color": "#FF1A75",
+    "allow_external_signup": false,
+    "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
+    "description": "Thoughts, stories and ideas",
+    "icon": null,
+    "locale": "en",
+    "logo": null,
+    "site_uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    "timezone": "Etc/UTC",
+    "title": "Ghost",
+    "url": "http://127.0.0.1:2369/",
+    "version": StringMatching /\\\\d\\+\\\\\\.\\\\d\\+/,
+  },
+}
+`;
+
+exports[`Site Public Settings Sets allow_external_signup to false when the free plan is hidden in Portal on a paid site 2: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Site Public Settings Sets allow_self_signup to false when members are invite only 1: [body] 1`] = `
 Object {
   "site": Object {

--- a/ghost/core/test/e2e-api/members/site.test.js
+++ b/ghost/core/test/e2e-api/members/site.test.js
@@ -1,4 +1,9 @@
-const { agentProvider, fixtureManager, matchers } = require('../../utils/e2e-framework');
+const {
+  agentProvider,
+  fixtureManager,
+  matchers,
+  mockManager,
+} = require('../../utils/e2e-framework');
 const { anyEtag, stringMatching, anyContentLength, anyUuid } = matchers;
 const assert = require('node:assert/strict');
 const models = require('../../../core/server/models');
@@ -20,12 +25,27 @@ describe('Site Public Settings', function () {
 
   afterEach(async function () {
     await models.Settings.edit(
-      {
-        key: 'members_signup_access',
-        value: 'all',
-      },
+      [
+        {
+          key: 'members_signup_access',
+          value: 'all',
+        },
+        {
+          key: 'portal_plans',
+          value: JSON.stringify(['free']),
+        },
+        {
+          key: 'stripe_secret_key',
+          value: null,
+        },
+        {
+          key: 'stripe_publishable_key',
+          value: null,
+        },
+      ],
       { context: { internal: true } },
     );
+    mockManager.restore();
   });
 
   it('Can retrieve site pubic config', async function () {
@@ -45,6 +65,37 @@ describe('Site Public Settings', function () {
         key: 'members_signup_access',
         value: 'invite',
       },
+      { context: { internal: true } },
+    );
+
+    const { body } = await membersAgent
+      .get('/api/site')
+      .matchBodySnapshot(siteMatcherObject)
+      .matchHeaderSnapshot({
+        etag: anyEtag,
+        'content-length': anyContentLength,
+      });
+    assert.equal(body.site.allow_external_signup, false);
+  });
+
+  it('Sets allow_external_signup to false when the free plan is hidden in Portal on a paid site', async function () {
+    mockManager.mockStripe();
+
+    await models.Settings.edit(
+      [
+        {
+          key: 'stripe_secret_key',
+          value: 'sk_test_blah',
+        },
+        {
+          key: 'stripe_publishable_key',
+          value: 'pk_test_blah',
+        },
+        {
+          key: 'portal_plans',
+          value: JSON.stringify(['monthly', 'yearly']),
+        },
+      ],
       { context: { internal: true } },
     );
 

--- a/ghost/core/test/e2e-api/members/site.test.js
+++ b/ghost/core/test/e2e-api/members/site.test.js
@@ -1,9 +1,4 @@
-const {
-  agentProvider,
-  fixtureManager,
-  matchers,
-  mockManager,
-} = require('../../utils/e2e-framework');
+const { agentProvider, fixtureManager, matchers } = require('../../utils/e2e-framework');
 const { anyEtag, stringMatching, anyContentLength, anyUuid } = matchers;
 const assert = require('node:assert/strict');
 const models = require('../../../core/server/models');
@@ -34,18 +29,9 @@ describe('Site Public Settings', function () {
           key: 'portal_plans',
           value: JSON.stringify(['free']),
         },
-        {
-          key: 'stripe_secret_key',
-          value: null,
-        },
-        {
-          key: 'stripe_publishable_key',
-          value: null,
-        },
       ],
       { context: { internal: true } },
     );
-    mockManager.restore();
   });
 
   it('Can retrieve site pubic config', async function () {
@@ -78,19 +64,9 @@ describe('Site Public Settings', function () {
     assert.equal(body.site.allow_external_signup, false);
   });
 
-  it('Sets allow_external_signup to false when the free plan is hidden in Portal on a paid site', async function () {
-    mockManager.mockStripe();
-
+  it('Sets allow_external_signup to false when the free plan is hidden in Portal', async function () {
     await models.Settings.edit(
       [
-        {
-          key: 'stripe_secret_key',
-          value: 'sk_test_blah',
-        },
-        {
-          key: 'stripe_publishable_key',
-          value: 'pk_test_blah',
-        },
         {
           key: 'portal_plans',
           value: JSON.stringify(['monthly', 'yearly']),

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -167,10 +167,19 @@ describe('Settings Helpers', function () {
       assert.equal(settingsHelpers.allowSelfSignup(), false);
     });
 
-    it('returns true when the free plan is hidden in Portal but paid members are disabled', function () {
+    it('returns false when the free plan is hidden in Portal even without paid members', function () {
       const settingsHelpers = createSettingsHelpers({
         signupAccess: 'all',
         portalPlans: [],
+        stripeConnected: false,
+      });
+      assert.equal(settingsHelpers.allowSelfSignup(), false);
+    });
+
+    it('returns true when the free plan is visible in Portal without paid members', function () {
+      const settingsHelpers = createSettingsHelpers({
+        signupAccess: 'all',
+        portalPlans: ['free'],
         stripeConnected: false,
       });
       assert.equal(settingsHelpers.allowSelfSignup(), true);

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -131,6 +131,63 @@ describe('Settings Helpers', function () {
     });
   });
 
+  describe('allowSelfSignup', function () {
+    function createSettingsHelpers({ signupAccess, portalPlans, stripeConnected }) {
+      const fakeSettings = createSettingsMock({
+        setDirect: stripeConnected,
+        setConnect: stripeConnected,
+      });
+      fakeSettings.get.withArgs('members_signup_access').returns(signupAccess);
+      fakeSettings.get.withArgs('portal_plans').returns(portalPlans);
+
+      return new SettingsHelpers({
+        settingsCache: fakeSettings,
+        config: configUtils.config,
+        urlUtils: {},
+        labs: {},
+        limitService,
+      });
+    }
+
+    it('returns true when signup access is "all" and the free plan is visible in Portal', function () {
+      const settingsHelpers = createSettingsHelpers({
+        signupAccess: 'all',
+        portalPlans: ['free', 'monthly', 'yearly'],
+        stripeConnected: true,
+      });
+      assert.equal(settingsHelpers.allowSelfSignup(), true);
+    });
+
+    it('returns false when the free plan is hidden in Portal on a paid site', function () {
+      const settingsHelpers = createSettingsHelpers({
+        signupAccess: 'all',
+        portalPlans: ['monthly', 'yearly'],
+        stripeConnected: true,
+      });
+      assert.equal(settingsHelpers.allowSelfSignup(), false);
+    });
+
+    it('returns true when the free plan is hidden in Portal but paid members are disabled', function () {
+      const settingsHelpers = createSettingsHelpers({
+        signupAccess: 'all',
+        portalPlans: [],
+        stripeConnected: false,
+      });
+      assert.equal(settingsHelpers.allowSelfSignup(), true);
+    });
+
+    it('returns false when signup access is not "all"', function () {
+      for (const signupAccess of ['invite', 'paid', 'none']) {
+        const settingsHelpers = createSettingsHelpers({
+          signupAccess,
+          portalPlans: ['free'],
+          stripeConnected: true,
+        });
+        assert.equal(settingsHelpers.allowSelfSignup(), false);
+      }
+    });
+  });
+
   describe('getMembersValidationKey', function () {
     it('returns a key that can be used to validate members', function () {
       const fakeSettings = createSettingsMock({ setDirect: true, setConnect: true });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1969

Publishers who hide the free tier in Portal (while keeping signup access on "Anyone can sign up") were receiving unwanted free members through other sites' recommendations. The public site config still advertised `allow_external_signup: true`, so recommending sites showed a one-click Subscribe button that signed readers up as free members — a signup path the publisher had deliberately removed from their own site.

```mermaid
flowchart LR
    subgraph Recommended site
        A[members_signup_access: all<br>portal_plans without free] --> B[allowSelfSignup]
        B --> C[public site config<br>allow_external_signup]
    end
    subgraph Recommending site
        C -->|fetched on create/edit<br>and after every boot| D[one_click_subscribe<br>snapshot]
        D -->|true| E[One-click Subscribe button<br>→ unwanted free members]
        D -->|false| F[Plain link to the site<br>→ reader can buy a paid plan]
    end
```

The advertised flag and the API-level signup gate are intentionally different signals: hiding Free in Portal is a visibility choice that doesn't block API signups (that's what "Paid members only" access is for). But the advertisement must be the stricter of the two, otherwise other sites act on a capability the publisher never surfaced. `SettingsHelpers.allowSelfSignup()` now requires both settings that together mean "free signup is offered": signup access is "Public" and the free tier is visible in Portal.

With this, recommending sites fall back to linking out instead of showing one-click Subscribe, and readers can buy a paid subscription on the recommended site itself. No migration is needed: recommendation metadata is re-fetched a few minutes after every boot, so stored `one_click_subscribe` snapshots correct themselves as sites restart. The private-site landing page also stops rendering its free subscribe form for these sites, closing the same gap there.
