### PR TITLE
🐛 Fixed unsubscribe links affecting the wrong member when logged in

### DIFF
--- a/apps/portal/src/components/pages/unsubscribe-page.jsx
+++ b/apps/portal/src/components/pages/unsubscribe-page.jsx
@@ -30,6 +30,33 @@ function AccountHeader() {
   );
 }
 
+function UnsubscribeErrorPage({ message }) {
+  const { doAction } = useContext(AppContext);
+  return (
+    <div className="gh-portal-content gh-portal-feedback with-footer">
+      <CloseButton />
+      <div className="gh-feedback-icon gh-feedback-icon-error">
+        <WarningIcon />
+      </div>
+      <h1 className="gh-portal-main-title">{t("That didn't go to plan")}</h1>
+      <div>
+        <p className="gh-portal-text-center">{message}</p>
+      </div>
+      <ActionButton
+        style={{ width: '100%' }}
+        retry={false}
+        onClick={() => doAction('closePopup')}
+        disabled={false}
+        brandColor="#000000"
+        label={t('Close')}
+        isRunning={false}
+        tabIndex={3}
+        classes={'sticky bottom'}
+      />
+    </div>
+  );
+}
+
 async function updateMemberNewsletters({
   api,
   memberUuid,
@@ -57,6 +84,7 @@ export default function UnsubscribePage() {
   const { site, api, pageData, member: loggedInMember, doAction } = useContext(AppContext);
   // member is the member data fetched from the API based on the uuid and its state is limited to just this modal, not all of Portal
   const [member, setMember] = useState();
+  const loggedInAsDifferentMember = !!loggedInMember && loggedInMember.uuid !== pageData.uuid;
   const [loading, setLoading] = useState(true);
   const siteNewsletters = getSiteNewsletters({ site });
   const defaultNewsletters = siteNewsletters.filter((d) => {
@@ -170,6 +198,10 @@ export default function UnsubscribePage() {
   // This handles the url query param actions that ultimately launch this component/modal
   useEffect(() => {
     (async () => {
+      if (loggedInAsDifferentMember) {
+        // the error render below doesn't stop this effect from running, so bail explicitly
+        return;
+      }
       let memberData;
       try {
         memberData = await api.member.newsletters({ uuid: pageData.uuid, key: pageData.key });
@@ -210,6 +242,7 @@ export default function UnsubscribePage() {
   }, [
     commentsEnabled,
     canChangeUpdatesAndAnnouncements,
+    loggedInAsDifferentMember,
     pageData.uuid,
     pageData.newsletterUuid,
     pageData.comments,
@@ -217,6 +250,16 @@ export default function UnsubscribePage() {
     site.url,
     siteNewsletters?.length,
   ]);
+
+  if (loggedInAsDifferentMember) {
+    return (
+      <UnsubscribeErrorPage
+        message={t(
+          'This unsubscribe link belongs to a different email address than the one you are signed in with.',
+        )}
+      />
+    );
+  }
 
   if (loading) {
     // Loading member data from the API based on the uuid
@@ -226,31 +269,11 @@ export default function UnsubscribePage() {
   // Case: invalid uuid passed
   if (!member) {
     return (
-      <div className="gh-portal-content gh-portal-feedback with-footer">
-        <CloseButton />
-        <div className="gh-feedback-icon gh-feedback-icon-error">
-          <WarningIcon />
-        </div>
-        <h1 className="gh-portal-main-title">{t("That didn't go to plan")}</h1>
-        <div>
-          <p className="gh-portal-text-center">
-            {t(
-              "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.",
-            )}
-          </p>
-        </div>
-        <ActionButton
-          style={{ width: '100%' }}
-          retry={false}
-          onClick={() => doAction('closePopup')}
-          disabled={false}
-          brandColor="#000000"
-          label={t('Close')}
-          isRunning={false}
-          tabIndex={3}
-          classes={'sticky bottom'}
-        />
-      </div>
+      <UnsubscribeErrorPage
+        message={t(
+          "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.",
+        )}
+      />
     );
   }
 

--- a/apps/portal/test/email-subscriptions-flow.test.jsx
+++ b/apps/portal/test/email-subscriptions-flow.test.jsx
@@ -20,6 +20,7 @@ const setup = async ({ site, member = null, newsletters }, loggedOut = false) =>
 
   ghostApi.member.update = vi.fn(({ newsletters: newNewsletters }) => {
     return Promise.resolve({
+      uuid: member?.uuid,
       newsletters: newNewsletters,
       enable_comment_notifications: false,
     });
@@ -265,6 +266,12 @@ describe('Newsletter Subscriptions', () => {
         uuid: FixtureMember.subbedToNewsletter.uuid,
         key: 'hashedMemberUuid',
       });
+      await waitFor(() => {
+        expect(ghostApi.member.update).toHaveBeenCalledWith({
+          newsletters: Newsletters.filter((n) => n.uuid !== Newsletters[0].uuid),
+        });
+      });
+      expect(ghostApi.member.updateNewsletters).not.toHaveBeenCalled();
       // Verify the local state shows the newsletter as unsubscribed
       let checkboxes = popupIframeDocument.querySelectorAll('input[type="checkbox"]');
       let newsletter1Checkbox = checkboxes[0];
@@ -299,6 +306,37 @@ describe('Newsletter Subscriptions', () => {
       newsletter2Checkbox = checkboxes[1];
       expect(newsletter1Checkbox).not.toBeChecked();
       expect(newsletter2Checkbox).toBeChecked();
+    });
+
+    test("unsubscribe via another member's email link while logged in", async () => {
+      const linkMemberUuid = 'link-member-uuid';
+      // Mock window.location: the link belongs to a member other than the logged-in one
+      Object.defineProperty(window, 'location', {
+        value: new URL(
+          `https://portal.localhost/?action=unsubscribe&uuid=${linkMemberUuid}&newsletter=${Newsletters[0].uuid}&key=hashedLinkMemberUuid`,
+        ),
+        writable: true,
+      });
+
+      const { ghostApi, popupIframeDocument } = await setup({
+        site: FixtureSite.singleTier.onlyFreePlanWithoutStripe,
+        member: FixtureMember.subbedToNewsletter,
+        newsletters: Newsletters,
+      });
+
+      // The request is rejected outright: the link belongs to a different member than
+      // the session, so nobody's preferences are touched
+      await waitFor(() => {
+        expect(
+          within(popupIframeDocument).getByText(/belongs to a different email address/),
+        ).toBeInTheDocument();
+      });
+      expect(within(popupIframeDocument).queryByText(/will no longer receive/)).toBeNull();
+
+      // No reads of the link member's data and no writes against anyone
+      expect(ghostApi.member.newsletters).not.toHaveBeenCalled();
+      expect(ghostApi.member.updateNewsletters).not.toHaveBeenCalled();
+      expect(ghostApi.member.update).not.toHaveBeenCalled();
     });
 
     test('unsubscribe link without a key param', async () => {

--- a/packages/i18n/locales/af/portal.json
+++ b/packages/i18n/locales/af/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ar/portal.json
+++ b/packages/i18n/locales/ar/portal.json
@@ -278,6 +278,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "هذا الموقع لا يقبل المدفوعات في الوقت الحالي",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/bg/portal.json
+++ b/packages/i18n/locales/bg/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "В момента сайтът не приема дарения.",
     "This site is not accepting payments at the moment.": "В момента сайтът не приема плащания.",
     "This site only accepts paid members.": "Този сайт приема само плащащи потребители.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "План",
     "To": "",

--- a/packages/i18n/locales/bn/portal.json
+++ b/packages/i18n/locales/bn/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/bs/portal.json
+++ b/packages/i18n/locales/bs/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ca/portal.json
+++ b/packages/i18n/locales/ca/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Aquest lloc web no està acceptant pagaments en aquests moments.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/context.json
+++ b/packages/i18n/locales/context.json
@@ -391,6 +391,7 @@
     "This site is not accepting donations at the moment.": "Error message in Portal when a user visits the donations page but donations are disabled",
     "This site is not accepting payments at the moment.": "An error message shown when a tips or donations link is opened but the site has donations disabled",
     "This site only accepts paid members.": "error message for sign-up",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "Error shown in Portal when an email unsubscribe link is opened in a browser that is signed in as a different member; the request is rejected and nobody is unsubscribed",
     "Threads": "Share option in Portal share modal overflow menu",
     "Tier": "Label for a membership tier",
     "To": "Label for the intended recipient on a gift card or gift email preview",

--- a/packages/i18n/locales/cs/portal.json
+++ b/packages/i18n/locales/cs/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Tento web momentálně nepřijímá platby.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/da/portal.json
+++ b/packages/i18n/locales/da/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Denne side accepterer ikke betalinger i øjeblikket.",
     "This site only accepts paid members.": "Denne side er kun tilgængelig for betalende medlemmer.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/de-CH/portal.json
+++ b/packages/i18n/locales/de-CH/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Diese Website nimmt derzeit keine Spenden entgegen.",
     "This site is not accepting payments at the moment.": "Diese Seite nimmt momentan keine Zahlungen entgegen.",
     "This site only accepts paid members.": "Diese Seite ist exklusiv für zahlende Mitglieder.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Tarif",
     "To": "",

--- a/packages/i18n/locales/de/portal.json
+++ b/packages/i18n/locales/de/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Diese Website nimmt derzeit keine Spenden entgegen.",
     "This site is not accepting payments at the moment.": "Diese Website nimmt zur Zeit keine Zahlungen entgegen.",
     "This site only accepts paid members.": "Diese Seite ist exklusiv für zahlende Mitglieder.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/el/portal.json
+++ b/packages/i18n/locales/el/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Αυτός ο ιστότοπος δεν δέχεται δωρεές αυτή τη στιγμή.",
     "This site is not accepting payments at the moment.": "Αυτός ο ιστότοπος δεν δέχεται πληρωμές αυτή τη στιγμή.",
     "This site only accepts paid members.": "Αυτός ο ιστότοπος δέχεται μόνο συνδρομητικά μέλη.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Επίπεδο",
     "To": "",

--- a/packages/i18n/locales/en/portal.json
+++ b/packages/i18n/locales/en/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/eo/portal.json
+++ b/packages/i18n/locales/eo/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/es/portal.json
+++ b/packages/i18n/locales/es/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "Este sitio no acepta donaciones en este momento.",
     "This site is not accepting payments at the moment.": "Este sitio no acepta pagos en este momento.",
     "This site only accepts paid members.": "Este sitio es sólo para miembros de pago.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/et/portal.json
+++ b/packages/i18n/locales/et/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/eu/portal.json
+++ b/packages/i18n/locales/eu/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Gune honek ez du une honetan dohaintzarik onartzen.",
     "This site is not accepting payments at the moment.": "Gune honek ez du une honetan ordainketarik onartzen.",
     "This site only accepts paid members.": "Gune honek ordainpeko kideak bakarrik onartzen ditu.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/fa/portal.json
+++ b/packages/i18n/locales/fa/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "این سایت در حال حاضر کمک\u200cهای مالی را نمی\u200cپذیرد.",
     "This site is not accepting payments at the moment.": "این سایت در حال حاضر پرداخت\u200cها را نمی\u200cپذیرد.",
     "This site only accepts paid members.": "این سایت فقط اعضای ویژه را می\u200cپذیرد.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "رشته\u200cها",
     "Tier": "سطح",
     "To": "",

--- a/packages/i18n/locales/fi/portal.json
+++ b/packages/i18n/locales/fi/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Tämä sivu ei vastaanota lahjoituksia juuri nyt.",
     "This site is not accepting payments at the moment.": "Tämä sivu ei vastaanota maksuja juuri nyt.",
     "This site only accepts paid members.": "Tämä sivu on vain maksaville jäsenille.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/fr/portal.json
+++ b/packages/i18n/locales/fr/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "Ce site n'accepte pas les dons pour le moment.",
     "This site is not accepting payments at the moment.": "Ce site n'accepte pas les paiements pour le moment.",
     "This site only accepts paid members.": "Ce site n'accepte que les abonnés payants.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Abonnement",
     "To": "",

--- a/packages/i18n/locales/gd/portal.json
+++ b/packages/i18n/locales/gd/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Chan eil an làrach seo a' gabhail ri phàighidhean an-dràsta.",
     "This site only accepts paid members.": "Chan fhaighear don làrach seo ach buill a tha air pàigheadh.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/he/portal.json
+++ b/packages/i18n/locales/he/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "אתר זה לא מקבל תשלומים כרגע.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/hi/portal.json
+++ b/packages/i18n/locales/hi/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "यह साइट इस समय दान स्वीकार नहीं कर रही है।",
     "This site is not accepting payments at the moment.": "यह साइट इस समय भुगतान स्वीकार नहीं कर रही है।",
     "This site only accepts paid members.": "यह साइट केवल भुगतान करने वाले सदस्यों को स्वीकार करती है।",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/hr/portal.json
+++ b/packages/i18n/locales/hr/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ova stranica trenutno ne prihvaća uplate.",
     "This site only accepts paid members.": "Ova stranica je dostupna samo korisnicima sa plaćenom pretplatom.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/hu/portal.json
+++ b/packages/i18n/locales/hu/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Ez az oldal jelenleg nem fogad adományokat.",
     "This site is not accepting payments at the moment.": "A weboldal jelenleg nem fogad el fizetést.",
     "This site only accepts paid members.": "Ez az oldal csak fizetős tagokat fogad.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/id/portal.json
+++ b/packages/i18n/locales/id/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Situs ini tidak menerima pembayaran saat ini.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/is/portal.json
+++ b/packages/i18n/locales/is/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/it/portal.json
+++ b/packages/i18n/locales/it/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "Questo sito non accetta donazioni al momento.",
     "This site is not accepting payments at the moment.": "Questo sito non accetta pagamenti al momento.",
     "This site only accepts paid members.": "Questo sito è accessibile solo con abbonamento.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Livello",
     "To": "",

--- a/packages/i18n/locales/ja/portal.json
+++ b/packages/i18n/locales/ja/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ko/portal.json
+++ b/packages/i18n/locales/ko/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "현재 이 사이트는 후원을 받지 않고 있어요.",
     "This site is not accepting payments at the moment.": "현재 이 사이트는 결제를 받지 않고 있어요.",
     "This site only accepts paid members.": "이 사이트는 유료 회원만 받고 있어요.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "등급",
     "To": "",

--- a/packages/i18n/locales/kz/portal.json
+++ b/packages/i18n/locales/kz/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/lt/portal.json
+++ b/packages/i18n/locales/lt/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/lv/portal.json
+++ b/packages/i18n/locales/lv/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Šī vietne pašlaik nepieņem maksājumus.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/mk/portal.json
+++ b/packages/i18n/locales/mk/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/mn/portal.json
+++ b/packages/i18n/locales/mn/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Энэхүү сайт одоогоор төлбөр хүлээн авахгүй байна.",
     "This site only accepts paid members.": "Энэхүү сайт зөвхөн төлбөртэй гишүүдийг хүлээн авдаг.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ms/portal.json
+++ b/packages/i18n/locales/ms/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/nb/portal.json
+++ b/packages/i18n/locales/nb/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Denne nettsiden godtar ikke betalinger for øyeblikket.",
     "This site only accepts paid members.": "Denne nettsiden er kun for betalende medlemmer.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ne/portal.json
+++ b/packages/i18n/locales/ne/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/nl/portal.json
+++ b/packages/i18n/locales/nl/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Deze site accepteert momenteel geen betalingen.",
     "This site only accepts paid members.": "Deze site accepteert alleen betalende leden.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/nn/portal.json
+++ b/packages/i18n/locales/nn/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/pa/portal.json
+++ b/packages/i18n/locales/pa/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "ਇਹ ਸਾਈਟ ਇਸ ਵੇਲੇ ਦਾਨ ਨਹੀਂ ਲੈ ਰਹੀ ਹੈ।",
     "This site is not accepting payments at the moment.": "ਇਹ ਸਾਈਟ ਇਸ ਸਮੇਂ ਭੁਗਤਾਨ ਸਵੀਕਾਰ ਨਹੀਂ ਕਰ ਰਹੀ ਹੈ।",
     "This site only accepts paid members.": "ਇਹ ਸਾਈਟ ਸਿਰਫ਼ ਭੁਗਤਾਨਸ਼ੁਦਾ ਮੈਂਬਰਾਂ ਨੂੰ ਸਵੀਕਾਰ ਕਰਦੀ ਹੈ।",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/pl/portal.json
+++ b/packages/i18n/locales/pl/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ta strona nie przyjmuje obecnie płatności.",
     "This site only accepts paid members.": "Ta strona akceptuje tylko płatne członkostwa.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/pt-BR/portal.json
+++ b/packages/i18n/locales/pt-BR/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "Este site não está aceitando doações no momento.",
     "This site is not accepting payments at the moment.": "Este site não está aceitando pagamentos no momento.",
     "This site only accepts paid members.": "Este site aceita apenas membros pagos.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Plano",
     "To": "",

--- a/packages/i18n/locales/pt/portal.json
+++ b/packages/i18n/locales/pt/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Este site não está a aceitar pagamentos de momento",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ro/portal.json
+++ b/packages/i18n/locales/ro/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ru/portal.json
+++ b/packages/i18n/locales/ru/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "В данный момент сайт не принимает пожертвования.",
     "This site is not accepting payments at the moment.": "В данный момент сайт не принимает платежи.",
     "This site only accepts paid members.": "Этот сайт доступен только для платных участников.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/si/portal.json
+++ b/packages/i18n/locales/si/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/sk/portal.json
+++ b/packages/i18n/locales/sk/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Táto stránka momentálne neprijíma platby.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/sl/portal.json
+++ b/packages/i18n/locales/sl/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "To spletno mesto trenutno ne sprejema plačil.",
     "This site only accepts paid members.": "To spletno mesto sprejema samo plačljive člane.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/sq/portal.json
+++ b/packages/i18n/locales/sq/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/sr-Cyrl/portal.json
+++ b/packages/i18n/locales/sr-Cyrl/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "Овај сајт тренутно не прима донације.",
     "This site is not accepting payments at the moment.": "Овај сајт тренутно не прихвата уплате.",
     "This site only accepts paid members.": "Овај сајт прихвата само плаћене чланове.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/sr/portal.json
+++ b/packages/i18n/locales/sr/portal.json
@@ -275,6 +275,7 @@
     "This site is not accepting donations at the moment.": "Ovaj sajt trenutno ne prima donacije.",
     "This site is not accepting payments at the moment.": "Ovaj sajt trenutno ne prihvata uplate.",
     "This site only accepts paid members.": "Ovaj sajt prihvata samo plaćene članove.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Paket",
     "To": "",

--- a/packages/i18n/locales/sv/portal.json
+++ b/packages/i18n/locales/sv/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Den här webbsidan tar för närvarande inte emot donationer.",
     "This site is not accepting payments at the moment.": "Den här webbsidan accepterar inte betalningar för tillfället.",
     "This site only accepts paid members.": "Den här webbsidan accepterar endast betalande medlemmar.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Nivå",
     "To": "",

--- a/packages/i18n/locales/sw/portal.json
+++ b/packages/i18n/locales/sw/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ta/portal.json
+++ b/packages/i18n/locales/ta/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "இந்த தளம் தற்போது கட்டணங்களை ஏற்கவில்லை.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/th/portal.json
+++ b/packages/i18n/locales/th/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/tr/portal.json
+++ b/packages/i18n/locales/tr/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "Bu site şu anda bağış kabul etmemektedir.",
     "This site is not accepting payments at the moment.": "Bu site şu anda ödeme kabul etmemektedir.",
     "This site only accepts paid members.": "Bu site sadece ücretli üye kabul etmektedir.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "Plan",
     "To": "",

--- a/packages/i18n/locales/uk/portal.json
+++ b/packages/i18n/locales/uk/portal.json
@@ -276,6 +276,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Цей сайт на даний момент не приймає платежі.",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/ur/portal.json
+++ b/packages/i18n/locales/ur/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/uz/portal.json
+++ b/packages/i18n/locales/uz/portal.json
@@ -274,6 +274,7 @@
     "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "",
     "To": "",

--- a/packages/i18n/locales/vi/portal.json
+++ b/packages/i18n/locales/vi/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "Trang web này hiện chưa nhận quyên góp.",
     "This site is not accepting payments at the moment.": "Trang web này hiện chưa chấp nhận thanh toán.",
     "This site only accepts paid members.": "Trang web này chỉ dành cho thành viên trả phí.",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "Threads",
     "Tier": "Gói",
     "To": "",

--- a/packages/i18n/locales/zh-Hant/portal.json
+++ b/packages/i18n/locales/zh-Hant/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "本網站目前不接受捐贈。",
     "This site is not accepting payments at the moment.": "本網站目前暫不接受付款。",
     "This site only accepts paid members.": "本網站僅允許付費會員。",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "方案",
     "To": "",

--- a/packages/i18n/locales/zh/portal.json
+++ b/packages/i18n/locales/zh/portal.json
@@ -273,6 +273,7 @@
     "This site is not accepting donations at the moment.": "本网站目前不接受捐赠。",
     "This site is not accepting payments at the moment.": "本网站目前暂不接受付款。",
     "This site only accepts paid members.": "本网站仅允许付费会员。",
+    "This unsubscribe link belongs to a different email address than the one you are signed in with.": "",
     "Threads": "",
     "Tier": "方案",
     "To": "",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1962

An email unsubscribe link carries a `uuid` and `key` identifying whose subscription it manages, but Portal's unsubscribe page routed the actual update through the browser's member session whenever one existed. If the link belonged to a different member — a forwarded email, a shared device, or staff opening a reader's link — the logged-in member was silently unsubscribed instead of the link's owner, and their newsletter selection was overwritten with the other member's list. The unsubscribe flow auto-executes on page load, so a single open of someone else's link was enough.

```mermaid
flowchart LR
    A["Open /unsubscribe/?uuid=A&key=…"] --> C{Browser session?}
    C -- "none" --> E["uuid+key-scoped update<br>→ member A modified ✅"]
    C -- "signed in as A" --> D["Session update<br>→ member A modified,<br>Portal context stays in sync ✅"]
    C -- "signed in as B (before)" --> F["Session update<br>→ member B modified ❌"]
    C -- "signed in as B (after)" --> G["Rejected with an error<br>→ nobody modified ✅"]
```

A mismatched session almost always signals a mistake, and because the page auto-executes with no confirmation, proceeding against either member risks a change nobody intended. Rejection is the only outcome with no wrong victim: the page now shows an error explaining the link belongs to a different email address than the one the browser is signed in with. The rejection happens before the page fetches the link member's data or auto-runs anything, and the error screen replaces the preferences UI entirely — so nothing is read or written for either member, and nothing about the other subscriber is exposed to the session. The logged-out flow and the same-member flow are unchanged: without a session the link works as before, and the member's own link still updates via the session so the Portal member context stays in sync.

The page is only reachable when both `uuid` and `key` are present (enforced in `app.jsx`), so the guard never strands a legitimate flow without a write path.

Tests: added a regression test covering opening another member's link while logged in — it asserts the error is shown and that no member data is read or written. The existing logged-in test now also pins that the member's own link updates via the session endpoint. The new error string is extracted for translation with the standard i18n extraction, including translator context.
