### PR TITLE
✨ Released the React tag details screen

### DIFF
--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -73,12 +73,6 @@ const features: Feature[] = [
     flag: 'getHelperDeduplication',
   },
   {
-    title: 'React tag details',
-    description:
-      'Renders the tag detail screen (/tags/:slug) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
-    flag: 'tagDetailsReact',
-  },
-  {
     title: 'Member custom fields',
     description: 'Let admins create and manage custom field definitions for members',
     flag: 'membersCustomFields',

--- a/e2e/helpers/pages/admin/tags/tag-details-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-details-page.ts
@@ -1,7 +1,6 @@
 import { AdminPage } from '@/admin-pages';
 import { Locator, Page } from '@playwright/test';
 import {
-  deleteTagMenuItem,
   descriptionFieldLabel,
   nameFieldLabel,
   slugFieldLabel,
@@ -14,7 +13,6 @@ export class TagDetailsPage extends AdminPage {
   readonly descriptionInput: Locator;
   readonly saveButton: Locator;
   readonly saveButtonSuccess: Locator;
-  readonly deleteButton: Locator;
   readonly backLink: Locator;
 
   constructor(page: Page) {
@@ -25,7 +23,6 @@ export class TagDetailsPage extends AdminPage {
     this.descriptionInput = page.getByRole('textbox', { name: descriptionFieldLabel });
     this.saveButton = page.getByRole('button', { name: 'Save' });
     this.saveButtonSuccess = page.getByRole('button', { name: 'Saved' });
-    this.deleteButton = page.getByRole('button', { name: deleteTagMenuItem });
 
     this.backLink = page.locator(`[data-test-link="${tagsBackLink}"]`);
   }

--- a/e2e/helpers/pages/admin/tags/tag-editor-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-editor-page.ts
@@ -46,13 +46,8 @@ export class TagEditorPage extends TagDetailsPage {
   }
 
   async deleteTag() {
-    if (await this.tagActionsButton.isVisible()) {
-      await this.tagActionsButton.click();
-      await this.deleteMenuItem.click();
-      return;
-    }
-
-    await this.deleteButton.click();
+    await this.tagActionsButton.click();
+    await this.deleteMenuItem.click();
   }
 
   async confirmDelete() {

--- a/e2e/tests/admin/tags/tag-detail.test.ts
+++ b/e2e/tests/admin/tags/tag-detail.test.ts
@@ -4,85 +4,78 @@ import { expect, test } from '@/helpers/playwright';
 import { usePerTestIsolation } from '@/helpers/playwright/isolation';
 
 /**
- * The tag detail screen exists twice while the Ember-to-React migration is in
- * flight, behind the `tagDetailsReact` Labs flag. The same journeys run
- * against both implementations — a test may not branch on the implementation;
- * a failure under only one flag state is a real user-facing difference.
+ * Behaviour contract for `/tags/:slug` and `/tags/new`. The React screen is
+ * generally available (`tagDetailsReact` sits in GA_FEATURES), so every site
+ * serves it; the assertions describe what the screen does rather than how it
+ * is built.
  */
 
 usePerTestIsolation();
 
-for (const { implementation, tagDetailsReact } of [
-  { implementation: 'Ember', tagDetailsReact: false },
-  { implementation: 'React', tagDetailsReact: true },
-] as const) {
-  test.describe(`Ghost Admin - Tag Detail (${implementation})`, () => {
-    test.use({ labs: { tagDetailsReact } });
+test.describe('Ghost Admin - Tag Detail', () => {
+  let tagFactory: TagFactory;
 
-    let tagFactory: TagFactory;
-
-    test.beforeEach(({ page }) => {
-      tagFactory = createTagFactory(page.request);
-    });
-
-    test('opening a tag from the list and editing it - changes are saved', async ({ page }) => {
-      const tag = await tagFactory.create({
-        name: 'Getting Started',
-        slug: 'getting-started',
-        feature_image: null,
-      });
-      const tagsPage = new TagsPage(page);
-      const tagEditor = new TagEditorPage(page);
-
-      await tagsPage.goto();
-      await tagsPage.waitForPageToFullyLoad();
-      await tagsPage.getTagLinkByName(tag.name).click();
-      await expect(tagEditor.nameInput).toHaveValue('Getting Started');
-      await expect(tagEditor.slugInput).toHaveValue('getting-started');
-
-      await tagEditor.updateTag('Getting Started Updated', 'getting-started-updated');
-      await tagEditor.goBackToTagsList();
-      await tagsPage.waitForPageToFullyLoad();
-
-      await expect(tagsPage.getTagLinkByName('Getting Started Updated')).toBeVisible();
-      await expect(tagsPage.getTagLinkByName('Getting Started Updated')).toContainText(
-        'getting-started-updated',
-      );
-    });
-
-    test('creating a tag via the new tag screen - appears in the tags list', async ({ page }) => {
-      const newTagsPage = new NewTagsPage(page);
-      const tagsPage = new TagsPage(page);
-
-      await newTagsPage.goto();
-      await newTagsPage.createTag('Fresh Tag', 'fresh-tag');
-      await newTagsPage.goBackToTagsList();
-      await tagsPage.waitForPageToFullyLoad();
-
-      await expect(tagsPage.getTagLinkByName('Fresh Tag')).toBeVisible();
-      await expect(tagsPage.getTagLinkByName('Fresh Tag')).toContainText('fresh-tag');
-    });
-
-    test('deleting a tag from the detail screen - removed from the tags list', async ({ page }) => {
-      const tag = await tagFactory.create({
-        name: 'Disposable',
-        slug: 'disposable',
-        feature_image: null,
-      });
-      const tagsPage = new TagsPage(page);
-      const tagEditor = new TagEditorPage(page);
-
-      await tagEditor.gotoTagBySlug(tag.slug);
-      await expect(tagEditor.nameInput).toHaveValue('Disposable');
-
-      await tagEditor.deleteTag();
-      await expect(tagEditor.deleteModal).toBeVisible();
-      await tagEditor.confirmDelete();
-
-      await expect(tagEditor.deleteModal).toBeHidden();
-      await expect(page).toHaveURL(tagsPage.pageUrl);
-      await tagsPage.waitForPageToFullyLoad();
-      await expect(tagsPage.getTagLinkByName('Disposable')).toBeHidden();
-    });
+  test.beforeEach(({ page }) => {
+    tagFactory = createTagFactory(page.request);
   });
-}
+
+  test('opening a tag from the list and editing it - changes are saved', async ({ page }) => {
+    const tag = await tagFactory.create({
+      name: 'Getting Started',
+      slug: 'getting-started',
+      feature_image: null,
+    });
+    const tagsPage = new TagsPage(page);
+    const tagEditor = new TagEditorPage(page);
+
+    await tagsPage.goto();
+    await tagsPage.waitForPageToFullyLoad();
+    await tagsPage.getTagLinkByName(tag.name).click();
+    await expect(tagEditor.nameInput).toHaveValue('Getting Started');
+    await expect(tagEditor.slugInput).toHaveValue('getting-started');
+
+    await tagEditor.updateTag('Getting Started Updated', 'getting-started-updated');
+    await tagEditor.goBackToTagsList();
+    await tagsPage.waitForPageToFullyLoad();
+
+    await expect(tagsPage.getTagLinkByName('Getting Started Updated')).toBeVisible();
+    await expect(tagsPage.getTagLinkByName('Getting Started Updated')).toContainText(
+      'getting-started-updated',
+    );
+  });
+
+  test('creating a tag via the new tag screen - appears in the tags list', async ({ page }) => {
+    const newTagsPage = new NewTagsPage(page);
+    const tagsPage = new TagsPage(page);
+
+    await newTagsPage.goto();
+    await newTagsPage.createTag('Fresh Tag', 'fresh-tag');
+    await newTagsPage.goBackToTagsList();
+    await tagsPage.waitForPageToFullyLoad();
+
+    await expect(tagsPage.getTagLinkByName('Fresh Tag')).toBeVisible();
+    await expect(tagsPage.getTagLinkByName('Fresh Tag')).toContainText('fresh-tag');
+  });
+
+  test('deleting a tag from the detail screen - removed from the tags list', async ({ page }) => {
+    const tag = await tagFactory.create({
+      name: 'Disposable',
+      slug: 'disposable',
+      feature_image: null,
+    });
+    const tagsPage = new TagsPage(page);
+    const tagEditor = new TagEditorPage(page);
+
+    await tagEditor.gotoTagBySlug(tag.slug);
+    await expect(tagEditor.nameInput).toHaveValue('Disposable');
+
+    await tagEditor.deleteTag();
+    await expect(tagEditor.deleteModal).toBeVisible();
+    await tagEditor.confirmDelete();
+
+    await expect(tagEditor.deleteModal).toBeHidden();
+    await expect(page).toHaveURL(tagsPage.pageUrl);
+    await tagsPage.waitForPageToFullyLoad();
+    await expect(tagsPage.getTagLinkByName('Disposable')).toBeHidden();
+  });
+});

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -27,7 +27,7 @@ const messages = {
 };
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
-const GA_FEATURES = ['automationAnalytics', 'giftSubCustomization'];
+const GA_FEATURES = ['automationAnalytics', 'giftSubCustomization', 'tagDetailsReact'];
 
 // These features are considered publicly available and can be enabled/disabled by users
 const PUBLIC_BETA_FEATURES = [
@@ -54,7 +54,6 @@ const PRIVATE_FEATURES = [
   'membersCustomFields',
   'membersImportRedesign',
   'paywallImprovements',
-  'tagDetailsReact',
   'selfServeArchives',
   'machinePayments',
   'postsListReact',


### PR DESCRIPTION
## Summary

Promotes the `tagDetailsReact` Labs flag to generally available, so every site serves `/tags/:slug` and `/tags/new` from the React tag detail screen.

- `tagDetailsReact` moves from `PRIVATE_FEATURES` to `GA_FEATURES` in `ghost/core/core/shared/labs.js`. Self-hosted sites never read the remote flag manifest, so this is what actually puts them on the React screen; Ghost(Pro) keeps a kill switch because remote overrides still sit above the GA list.
- The private Labs toggle is removed from the settings UI, since the flag can no longer be turned off from there.
- The tag detail e2e suite ran every journey against both implementations behind the flag; with the Ember branch unreachable, the dual-implementation loop is removed and the file states the behaviour contract once.
- The page object's `deleteTag()` checked for the React actions menu with an immediate `isVisible()` and fell back to Ember's inline delete button. On client-side navigation that check raced the screen's tag fetch and the helper then hung waiting on a button React never renders. It now drives the React actions menu directly, with Playwright's auto-waiting.

Flag cleanup (removing `tagDetailsReact` from the gate components and deleting the Ember tag screen) is intentionally left for a follow-up, matching how previous screen releases were sequenced.

## Verification

- `ghost/core`: labs unit tests pass.
- `apps/admin`: typecheck, `tag-detail-gate` unit tests, and the tag detail acceptance suite (33 tests) pass.
- `e2e`: lint and typecheck pass; `tests/admin/tags/` passes against a dev-mode Ghost with CI retry settings. The remaining first-attempt flakes in `editor.test.ts` are pre-existing shared-state order dependence (reproduced identically with the flag forced off) and are unrelated to this change.