### PR TITLE
Removed stale dependents from allow_self_signup

### DIFF
--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -200,14 +200,7 @@ module.exports = {
         type: 'boolean',
         group: 'members',
         fn: settingsHelpers.allowSelfSignup.bind(settingsHelpers),
-        dependents: [
-          'members_signup_access',
-          'portal_plans',
-          'stripe_secret_key',
-          'stripe_publishable_key',
-          'stripe_connect_secret_key',
-          'stripe_connect_publishable_key',
-        ],
+        dependents: ['members_signup_access'],
       }),
     );
     fields.push(


### PR DESCRIPTION
no ref

This change should not change behaviour.

The calculated `allow_self_signup` setting has only read `members_signup_access` since its formula was simplified in e67e2411f2 (Dec 2024), but `portal_plans` and the Stripe keys were left in the `dependents` list. Dependents only control when the field is recalculated, so edits to any of those settings have been triggering a pointless recalculation that always produced the identical value.
