### PR TITLE
Fixed automation list timestamp formatting

### DIFF
--- a/apps/admin/src/automations/components/automations-list.test.tsx
+++ b/apps/admin/src/automations/components/automations-list.test.tsx
@@ -74,7 +74,7 @@ describe('AutomationsList', () => {
     expect(screen.getByRole('columnheader', { name: 'In progress' })).toBeInTheDocument();
     expect(screen.getByText('1,432')).toBeInTheDocument();
     expect(screen.getByText('118')).toBeInTheDocument();
-    expect(screen.getByText('14 days ago')).toHaveAttribute('datetime', '2026-07-21T07:12:00.000Z');
+    expect(screen.getByText('Jul 21')).toHaveAttribute('datetime', '2026-07-21T07:12:00.000Z');
   });
 
   it('renders Never when an automation has no last entry', () => {

--- a/apps/admin/src/automations/components/automations-list.tsx
+++ b/apps/admin/src/automations/components/automations-list.tsx
@@ -11,8 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@tryghost/shade/components';
-import { cn, formatNumber } from '@tryghost/shade/utils';
-import moment from 'moment';
+import { cn, formatNumber, formatTimestamp } from '@tryghost/shade/utils';
 
 const AUTOMATION_DESCRIPTIONS: Record<string, string> = {
   'member-welcome-email-free': 'Welcome new free members after they sign up.',
@@ -145,7 +144,7 @@ const AutomationsList: React.FC<AutomationsListProps> = ({
           const statCells = {
             lastEntry: {
               content: lastEntry ? (
-                <time dateTime={lastEntry}>{moment(lastEntry).fromNow()}</time>
+                <time dateTime={lastEntry}>{formatTimestamp(lastEntry)}</time>
               ) : (
                 'Never'
               ),


### PR DESCRIPTION
no ref

Used the shared Shade timestamp formatter so older entries follow the common date format.

<img width="1191" height="272" alt="Screenshot 2026-08-31 at 9 41 59 AM" src="https://github.com/user-attachments/assets/fa8c71b0-2fd6-4dba-9d72-c2d3c92f6ef4" />
