### PR TITLE
Changed the acceptance harness labs option to compose with boot overrides

### DIFF
--- a/apps/admin/src/render-admin-app-labs.acceptance.test.tsx
+++ b/apps/admin/src/render-admin-app-labs.acceptance.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  configResponse,
+  fakePages,
+  fakePosts,
+  fakePostsListScreen,
+  renderAdminApp,
+  settingsResponse,
+} from '@test-utils/acceptance';
+import { composeLabsBootOverrides, type BootOverrides } from '@test-utils/acceptance/boot';
+import { postsListScreen } from '@/posts/list/posts-list.screen';
+
+/** Resolve an override's response the way the boot table serves it. */
+async function bodyOf(override: BootOverrides[keyof BootOverrides]): Promise<unknown> {
+  const response = override?.response;
+  return typeof response === 'function'
+    ? await (response as (request: Request) => unknown)(new Request('https://ghost.test'))
+    : response;
+}
+
+function labsOf(configBody: unknown): Record<string, boolean> {
+  return (configBody as { config: { labs: Record<string, boolean> } }).config.labs;
+}
+
+function labsSettingOf(settingsBody: unknown): Record<string, boolean> {
+  const { settings } = settingsBody as { settings: Array<{ key: string; value: string }> };
+  const entry = settings.find(({ key }) => key === 'labs');
+  expect(entry).toBeDefined();
+  return JSON.parse(entry!.value) as Record<string, boolean>;
+}
+
+describe('labs/boot composition', () => {
+  it('merges labs into a browseConfig object override without mutating it', async () => {
+    const config = configResponse();
+    config.config.hostSettings = { marker: true };
+    const snapshot = JSON.stringify(config);
+
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseConfig: { response: config } },
+    );
+    const body = await bodyOf(composed.browseConfig);
+
+    expect(labsOf(body).automations).toBe(true);
+    expect((body as { config: { hostSettings: unknown } }).config.hostSettings).toEqual({
+      marker: true,
+    });
+    expect(JSON.stringify(config)).toBe(snapshot);
+  });
+
+  it('wins over the same flag inside the override response', async () => {
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      {
+        browseConfig: { response: configResponse({ labs: { automations: false } }) },
+        browseSettings: { response: settingsResponse({ labs: { automations: false } }) },
+      },
+    );
+
+    expect(labsOf(await bodyOf(composed.browseConfig)).automations).toBe(true);
+    expect(labsSettingOf(await bodyOf(composed.browseSettings)).automations).toBe(true);
+  });
+
+  it('merges labs into a browseSettings override, adding the labs entry when missing', async () => {
+    const settings = settingsResponse();
+    settings.settings = settings.settings.filter(({ key }) => key !== 'labs');
+
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseSettings: { response: settings } },
+    );
+
+    expect(labsSettingOf(await bodyOf(composed.browseSettings)).automations).toBe(true);
+  });
+
+  it('merges labs into a function response', async () => {
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseSettings: { response: () => Promise.resolve(settingsResponse()) } },
+    );
+
+    expect(labsSettingOf(await bodyOf(composed.browseSettings)).automations).toBe(true);
+  });
+
+  it('leaves unrecognized bodies untouched and keeps responseStatus', async () => {
+    const errors = { errors: [{ message: 'nope' }] };
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseConfig: { response: errors, responseStatus: 422 } },
+    );
+
+    expect(await bodyOf(composed.browseConfig)).toBe(errors);
+    expect(composed.browseConfig?.responseStatus).toBe(422);
+  });
+
+  it('compiles the canned responses when boot has no override for the entry', async () => {
+    const composed = composeLabsBootOverrides({ automations: true });
+
+    expect(await bodyOf(composed.browseConfig)).toEqual(
+      configResponse({ labs: { automations: true } }),
+    );
+    expect(await bodyOf(composed.browseSettings)).toEqual(
+      settingsResponse({ labs: { automations: true } }),
+    );
+  });
+});
+
+describe('renderAdminApp labs + boot', () => {
+  // postsListReact gates which implementation serves /posts, so the React
+  // screen appearing proves the flag survived the boot overrides.
+  it('applies labs flags alongside browseConfig and browseSettings overrides', async () => {
+    fakePostsListScreen();
+    fakePosts([]);
+    fakePages([]);
+    await renderAdminApp('/posts', {
+      labs: { postsListReact: true },
+      boot: {
+        browseConfig: { response: configResponse() },
+        browseSettings: { response: settingsResponse() },
+      },
+    });
+
+    await expect.element(postsListScreen.page('posts')).toBeVisible();
+  });
+});

--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -46,7 +46,8 @@ When your area calls a new external origin, add it to `EXTERNAL_URL_BLOCKLIST` i
 The shell requests handled by default (`boot.ts`): `browseSettings`, `browseConfig`, `browseSite`, `browseMe`, `browseMembersCount`, `browseActiveTheme`, `editUserPreferences`. A **boot override** replaces the response of one named entry for one test (the entry's method/path stay fixed):
 
 ```ts
-// Labs flags (sugar for lockstep settings + config overrides):
+// Labs flags (sugar for lockstep settings + config overrides; merges into
+// any browseSettings/browseConfig boot override, named flags winning):
 await renderAdminApp("/tags", {labs: {someFlag: true}});
 
 // Persisted user state, e.g. what's-new preferences:

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -85,6 +85,94 @@ export function defaultBootRoutes(): string[] {
   return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
 }
 
+type LabsFlags = Record<string, boolean>;
+type BootOverride = NonNullable<BootOverrides[BootRequestName]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseLabsSettingValue(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'string') {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+// Unrecognized bodies (error envelopes, non-objects) pass through untouched;
+// recognized ones are clone-and-merged — never mutate a test-owned object.
+function mergeLabsIntoConfigBody(body: unknown, labs: LabsFlags): unknown {
+  if (!isRecord(body) || !isRecord(body.config)) {
+    return body;
+  }
+  const existing = isRecord(body.config.labs) ? body.config.labs : {};
+  return { ...body, config: { ...body.config, labs: { ...existing, ...labs } } };
+}
+
+function mergeLabsIntoSettingsBody(body: unknown, labs: LabsFlags): unknown {
+  if (!isRecord(body) || !Array.isArray(body.settings)) {
+    return body;
+  }
+  let found = false;
+  const settings = body.settings.map((entry: unknown) => {
+    if (!isRecord(entry) || entry.key !== 'labs') {
+      return entry;
+    }
+    found = true;
+    return { ...entry, value: JSON.stringify({ ...parseLabsSettingValue(entry.value), ...labs }) };
+  });
+  if (!found) {
+    settings.push(...settingsResponse({ labs }).settings.filter(({ key }) => key === 'labs'));
+  }
+  return { ...body, settings };
+}
+
+function withMergedLabs(
+  override: BootOverride,
+  merge: (body: unknown) => unknown,
+  fallback: () => unknown,
+): BootOverride {
+  const { response } = override;
+  if (response === undefined) {
+    return { ...override, response: fallback() };
+  }
+  if (typeof response === 'function') {
+    return {
+      ...override,
+      response: async (request: Request) =>
+        merge(await (response as (request: Request) => unknown)(request)),
+    };
+  }
+  return { ...override, response: merge(response) };
+}
+
+/**
+ * The `labs` render option compiled onto the boot overrides: `browseConfig`/
+ * `browseSettings` overrides get the flags merged into their responses
+ * (flags named in `labs` win); absent entries get the canned test-data
+ * responses with the flags applied.
+ */
+export function composeLabsBootOverrides(labs: LabsFlags, boot: BootOverrides = {}): BootOverrides {
+  return {
+    ...boot,
+    browseConfig: withMergedLabs(
+      boot.browseConfig ?? {},
+      (body) => mergeLabsIntoConfigBody(body, labs),
+      () => configResponse({ labs }),
+    ),
+    browseSettings: withMergedLabs(
+      boot.browseSettings ?? {},
+      (body) => mergeLabsIntoSettingsBody(body, labs),
+      () => settingsResponse({ labs }),
+    ),
+  };
+}
+
 function matches(config: BootRequestConfig, method: string, apiPath: string): boolean {
   if (config.method !== method) {
     return false;

--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -1,20 +1,23 @@
 import { QueryClient } from '@tanstack/react-query';
 import { render } from 'vitest-browser-react';
-import { configResponse, settingsResponse } from '@tryghost/test-data';
 import { defaultUnsplashConfig, type TopLevelFrameworkProps } from '@tryghost/admin-x-framework';
 
 import '@/index.css';
 import { AdminAppRoot } from '@/app-root';
 
-import { installBootOverrides, type BootOverrides } from './boot';
+import { composeLabsBootOverrides, installBootOverrides, type BootOverrides } from './boot';
 
 export interface RenderAdminAppOptions {
   /**
    * Labs flags for this test; compiles to lockstep settings + config boot
-   * overrides (the admin client reads labs from both).
+   * overrides (the admin client reads labs from both). Merges into any
+   * `boot` override for those entries; flags named here win.
    */
   labs?: Record<string, boolean>;
-  /** Boot-table overrides keyed by entry name (see boot.ts); wins over `labs`. */
+  /**
+   * Boot-table overrides keyed by entry name (see boot.ts); `labs` flags
+   * merge into `browseConfig`/`browseSettings` override responses.
+   */
   boot?: BootOverrides;
 }
 
@@ -36,13 +39,7 @@ export async function renderAdminApp(
   route: string = '/',
   { labs, boot }: RenderAdminAppOptions = {},
 ): Promise<Awaited<ReturnType<typeof render>>> {
-  const overrides: BootOverrides = {
-    ...(labs && {
-      browseSettings: { response: settingsResponse({ labs }) },
-      browseConfig: { response: configResponse({ labs }) },
-    }),
-    ...boot,
-  };
+  const overrides: BootOverrides = labs ? composeLabsBootOverrides(labs, boot) : { ...boot };
 
   if (Object.keys(overrides).length > 0) {
     installBootOverrides(overrides);


### PR DESCRIPTION
## Problem

In the admin acceptance harness, the `labs` render option compiled into full canned `browseSettings`/`browseConfig` boot overrides, and `boot` was spread after it — so any test passing a `boot` override for either of those entries silently lost its labs flags. Tests that needed both had to hand-mutate the boot response object (build a `configResponse({labs})`, tweak it, pass it as the override) instead of just naming the flags.

## Change

`labs` now composes with `boot` in `test-utils/acceptance` (`composeLabsBootOverrides` in `boot.ts`):

- No override for an entry: unchanged — the canned `settingsResponse({labs})` / `configResponse({labs})` from `@tryghost/test-data`, exactly as before.
- Object response: clone-and-merge, never mutating the test-owned object. Config merges into `config.labs`; settings merges into the JSON-string `labs` settings entry (adding one shaped like test-data's when missing).
- Function response: wrapped in an async function that awaits the original and merges into the resolved body.
- Unrecognized bodies (error envelopes, non-objects): passed through untouched. `responseStatus` and method/path handling are unchanged.
- Precedence: flags named in `labs` win over the same flag inside the override's response.

Doc comments on `RenderAdminAppOptions` and the README's boot-table note are updated to match.

## Verification

- New spec `src/render-admin-app-labs.acceptance.test.tsx` covers the composition semantics directly (object merge without mutation, precedence, missing labs entry, function response, error envelope untouched, labs-only fallback) plus a full-render regression test: `postsListReact` + flagless `browseConfig`/`browseSettings` overrides serves the React posts list. That render test fails against the previous clobbering behavior.
- `pnpm test:unit` (2084 passed) and `pnpm test:acceptance` (683 tests; one unrelated comments-spec flake passed on rerun) in `apps/admin`; `tsc -b` and eslint clean on touched files.
- Existing specs passing both `labs` and a config/settings `boot` override (migration-tools-export, email-settings, tiers, portal) re-run green — they all bake the flag into their override already, so the merge is a no-op for them.