### PR TITLE
🐛 Fixed duplicate requests for image dimensions of the same URL

### DIFF
--- a/ghost/core/core/server/lib/image/image-size.js
+++ b/ghost/core/core/server/lib/image/image-size.js
@@ -31,6 +31,12 @@ class ImageSize {
       },
       response_timeout: this.config.get('times:getImageSizeTimeoutInMS') || 10000,
     };
+
+    // Coalesces concurrent getImageSizeFromUrl() calls for the same URL so we only
+    // ever issue one underlying request/read per URL at a time. A single post's
+    // coverImage/ogImage/twitterImage often resolve to the same feature_image URL
+    // and are looked up concurrently, which otherwise fans out into duplicate requests.
+    this.inFlightImageSizeLookups = new Map();
   }
 
   // processes the Buffer result of an image file using image-size
@@ -153,6 +159,24 @@ class ImageSize {
    * @returns {Promise<Object>} imageObject or error
    */
   getImageSizeFromUrl(imagePath) {
+    if (this.inFlightImageSizeLookups.has(imagePath)) {
+      return this.inFlightImageSizeLookups.get(imagePath);
+    }
+
+    const promise = this._getImageSizeFromUrl(imagePath).finally(() => {
+      this.inFlightImageSizeLookups.delete(imagePath);
+    });
+    this.inFlightImageSizeLookups.set(imagePath, promise);
+
+    return promise;
+  }
+
+  /**
+   * @description read image dimensions from URL, without in-flight deduplication
+   * @param {string} imagePath as URL
+   * @returns {Promise<Object>} imageObject or error
+   */
+  _getImageSizeFromUrl(imagePath) {
     if (this.storageUtils.isLocalImage(imagePath)) {
       // don't make a request for a locally stored image
       return this.getImageSizeFromStoragePath(imagePath);

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -575,6 +575,107 @@ describe('lib/image: image size', function () {
       );
       assert.equal(requestMock.isDone(), true);
     });
+
+    describe('concurrent lookups', function () {
+      it('[success] coalesces concurrent lookups for the same URL into a single request', async function () {
+        const url = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg';
+        const expectedImageObject = { height: 1, url, width: 1 };
+
+        // Only one interceptor is registered — if the second/third concurrent call
+        // issued its own request, nock would have no interceptor left to match it
+        // and that call would reject, failing this test.
+        const requestMock = nock('http://img.stockfresh.com')
+          .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+          .reply(200, GIF1x1);
+
+        const imageSize = createImageSize();
+
+        const [res1, res2, res3] = await Promise.all([
+          imageSize.getImageSizeFromUrl(url),
+          imageSize.getImageSizeFromUrl(url),
+          imageSize.getImageSizeFromUrl(url),
+        ]);
+
+        assert.equal(requestMock.isDone(), true);
+        assertImageObject(res1, expectedImageObject);
+        assertImageObject(res2, expectedImageObject);
+        assertImageObject(res3, expectedImageObject);
+      });
+
+      it('[success] does not coalesce concurrent lookups for different URLs', async function () {
+        const url1 = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg';
+        const url2 = 'http://img.stockfresh.com/files/f/feedough/x/12/1540353_20925116.jpg';
+
+        const requestMock1 = nock('http://img.stockfresh.com')
+          .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+          .reply(200, GIF1x1);
+        const requestMock2 = nock('http://img.stockfresh.com')
+          .get('/files/f/feedough/x/12/1540353_20925116.jpg')
+          .reply(200, GIF1x1);
+
+        const imageSize = createImageSize();
+
+        const [res1, res2] = await Promise.all([
+          imageSize.getImageSizeFromUrl(url1),
+          imageSize.getImageSizeFromUrl(url2),
+        ]);
+
+        assert.equal(requestMock1.isDone(), true);
+        assert.equal(requestMock2.isDone(), true);
+        assertImageObject(res1, { height: 1, url: url1, width: 1 });
+        assertImageObject(res2, { height: 1, url: url2, width: 1 });
+      });
+
+      it('[success] issues a fresh request for a later, non-concurrent lookup of the same URL', async function () {
+        const url = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg';
+        const imageSize = createImageSize();
+
+        const requestMock1 = nock('http://img.stockfresh.com')
+          .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+          .reply(200, GIF1x1);
+        await imageSize.getImageSizeFromUrl(url);
+        assert.equal(requestMock1.isDone(), true);
+
+        // The in-flight entry should have been cleaned up after the first lookup
+        // resolved, so this second, non-overlapping call issues its own request
+        // rather than reusing a stale settled promise.
+        const requestMock2 = nock('http://img.stockfresh.com')
+          .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+          .reply(200, GIF1x1);
+        await imageSize.getImageSizeFromUrl(url);
+        assert.equal(requestMock2.isDone(), true);
+      });
+
+      it('[failure] rejects every concurrent caller when the shared lookup fails, then allows a retry', async function () {
+        const url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
+
+        const requestMock1 = nock('http://noimagehere.com')
+          .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+          .reply(404);
+
+        const imageSize = createImageSize();
+
+        const results = await Promise.allSettled([
+          imageSize.getImageSizeFromUrl(url),
+          imageSize.getImageSizeFromUrl(url),
+        ]);
+
+        assert.equal(requestMock1.isDone(), true);
+        assert.equal(results[0].status, 'rejected');
+        assert.equal(results[1].status, 'rejected');
+        assert.equal(results[0].reason.errorType, 'NotFoundError');
+        assert.equal(results[1].reason.errorType, 'NotFoundError');
+
+        // In-flight entry must be cleared even on failure, so a later retry
+        // gets a real second chance instead of reusing the rejected promise.
+        const requestMock2 = nock('http://noimagehere.com')
+          .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+          .reply(200, GIF1x1);
+        const retryResult = await imageSize.getImageSizeFromUrl(url);
+        assert.equal(requestMock2.isDone(), true);
+        assertImageObject(retryResult, { height: 1, url, width: 1 });
+      });
+    });
   });
 
   describe('getImageSizeFromStoragePath', function () {


### PR DESCRIPTION
no ref

A post's `coverImage`, `ogImage`, and `twitterImage` frequently resolve to the same `feature_image` URL, and `getImageDimensions()` looks all three up concurrently via `Promise.all`. Since `ImageSize.getImageSizeFromUrl()` had no in-flight deduplication, a single cold pageview could fire off multiple simultaneous origin requests (HTTP probe or storage read) for the exact same image. This causes slow page loads when `imageSize` cache is not filled for an external image url (including S3Storage setups).

This PR coalesces concurrent lookups for the same URL into one underlying request, regardless of which cache adapter (or none) is configured, since the dedup lives below the caching layer. The fix is applied before the internal/external url decision intentionally, so same optimization will be used to avoid re-reading same image multiple times at the same time from the storage.

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:

- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
