### PR TITLE
CSV import UX improvements

### DIFF
--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.test.ts
@@ -33,6 +33,7 @@ describe('ContentFieldMapping', () => {
       'authors',
       'author_emails',
       'tags',
+      'frontmatter',
       'Something else',
     ]);
 
@@ -45,6 +46,7 @@ describe('ContentFieldMapping', () => {
       authors: 'authors',
       author_emails: 'author_emails',
       tags: 'tags',
+      frontmatter: '',
       'Something else': '',
     });
   });
@@ -106,10 +108,9 @@ describe('ContentFieldMapping', () => {
       'custom_template',
       'codeinjection_head',
       'codeinjection_foot',
-      'frontmatter',
     ]);
     expect(CONTENT_FIELD_MAPPINGS.map((field) => field.value)).not.toEqual(
-      expect.arrayContaining(['newsletter_id', 'email', 'tiers', 'id', 'lexical']),
+      expect.arrayContaining(['frontmatter', 'newsletter_id', 'email', 'tiers', 'id', 'lexical']),
     );
   });
 });

--- a/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
+++ b/apps/admin/src/settings/advanced/migration-tools/content-import/mapping.ts
@@ -79,7 +79,6 @@ export const CONTENT_FIELD_GROUPS: readonly ContentFieldGroup[] = [
       { label: 'Custom template', value: 'custom_template', required: false },
       { label: 'Code injection head', value: 'codeinjection_head', required: false },
       { label: 'Code injection foot', value: 'codeinjection_foot', required: false },
-      { label: 'Frontmatter', value: 'frontmatter', required: false },
     ],
   },
 ] as const;

--- a/ghost/core/core/server/services/content-import/import/completion-email.ts
+++ b/ghost/core/core/server/services/content-import/import/completion-email.ts
@@ -63,8 +63,8 @@ function formatNumber(value: number): string {
   return value.toLocaleString();
 }
 
-function summaryItems(counts: OutcomeCounts): string {
-  const items = [
+function summaryItems(counts: OutcomeCounts, hasErrorsFile: boolean): string {
+  const items: Array<[string, number]> = [
     ['Created', counts.created],
     ['Updated', counts.updated],
     ['Skipped', counts.skipped],
@@ -72,10 +72,11 @@ function summaryItems(counts: OutcomeCounts): string {
   ];
 
   return items
-    .map(
-      ([label, count]) =>
-        `<li style="margin-bottom: 6px;"><strong>${label}:</strong> ${formatNumber(count as number)}</li>`,
-    )
+    .map(([label, count]) => {
+      const attachmentCopy =
+        label === 'Failed' && hasErrorsFile ? ' (see attached errors.csv)' : '';
+      return `<li style="margin-bottom: 6px;"><strong>${label}:</strong> ${formatNumber(count)}${attachmentCopy}</li>`;
+    })
     .join('');
 }
 
@@ -130,7 +131,12 @@ function importedPostLinks(run: ImportRun, adminUrl: string): string {
       <p style="font-size: 16px; line-height: 25px; color: #3A464C;">${filteredLinks}</p>`;
 }
 
-function renderCompletionEmail(run: ImportRun, recipient: string, adminUrl: string): string {
+function renderCompletionEmail(
+  run: ImportRun,
+  recipient: string,
+  adminUrl: string,
+  hasErrorsFile: boolean,
+): string {
   const counts = countsFor(run);
   const heading = headingFor(run, counts);
   const warningCopy = counts.warningRows
@@ -155,7 +161,7 @@ function renderCompletionEmail(run: ImportRun, recipient: string, adminUrl: stri
       <h1 style="color: #15212A; font-size: 21px; line-height: 25px; margin: 0 0 24px;">${heading}</h1>
       ${failureCopy}
       <p style="font-size: 16px; line-height: 25px; color: #3A464C;">The import processed ${formatNumber(run.total)} ${run.total === 1 ? 'row' : 'rows'}:</p>
-      <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${summaryItems(counts)}</ul>
+      <ul style="font-size: 16px; line-height: 25px; color: #3A464C; padding-left: 24px;">${summaryItems(counts, hasErrorsFile)}</ul>
       ${warningCopy}
       ${importedPostLinks(run, adminUrl)}
       <p style="color: #738A94; font-size: 11px; line-height: 18px; margin-top: 64px;">This email was sent to <a href="mailto:${escapedRecipient}" style="color: #738A94;">${escapedRecipient}</a>.</p>
@@ -192,7 +198,7 @@ export default function buildCompletionEmail(
   return {
     to: recipient,
     subject: headingFor(run, counts),
-    html: renderCompletionEmail(run, recipient, adminUrl),
+    html: renderCompletionEmail(run, recipient, adminUrl, Boolean(errorsFile)),
     forceTextContent: true,
     attachments,
   };

--- a/ghost/core/core/server/services/content-import/import/errors-file.ts
+++ b/ghost/core/core/server/services/content-import/import/errors-file.ts
@@ -28,7 +28,7 @@ export default function buildErrorsFile(run: ImportRun): string | undefined {
   const [outcomeColumn, reasonColumn, mediaFailuresColumn] = ANNOTATION_NAMES.map((name) =>
     uniqueColumnName(name, usedColumns),
   );
-  const columns = [outcomeColumn, ...run.sourceColumns, reasonColumn, mediaFailuresColumn];
+  const columns = [outcomeColumn, reasonColumn, mediaFailuresColumn, ...run.sourceColumns];
 
   return serialize(
     rows.map((row) => {

--- a/ghost/core/core/server/services/content-import/import/post-data.ts
+++ b/ghost/core/core/server/services/content-import/import/post-data.ts
@@ -26,7 +26,6 @@ export interface PostsMetaData {
   twitter_image?: string;
   twitter_title?: string;
   twitter_description?: string;
-  frontmatter?: string;
 }
 
 // The values handed to models.Post.add. Content is lexical only: under
@@ -78,7 +77,6 @@ const META_FIELDS = [
   'twitter_image',
   'twitter_title',
   'twitter_description',
-  'frontmatter',
 ] as const;
 
 export default function buildPostData(

--- a/ghost/core/core/server/services/content-import/import/row.ts
+++ b/ghost/core/core/server/services/content-import/import/row.ts
@@ -34,7 +34,6 @@ export const EDITORIAL_POST_FIELDS = [
   'custom_template',
   'codeinjection_head',
   'codeinjection_foot',
-  'frontmatter',
 ] as const;
 
 // An empty cell (or the literal 'undefined') reads as absent, not as a value.
@@ -82,7 +81,6 @@ export const postImportRowSchema = z
     custom_template: optionalCell,
     codeinjection_head: optionalCell,
     codeinjection_foot: optionalCell,
-    frontmatter: optionalCell,
   })
   .loose();
 

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -1026,6 +1026,10 @@ describe('Posts Importer API', function () {
         reason: /Unknown post field mapping: "newsletter_id"/,
       },
       {
+        mapping: { First: 'title', Second: 'frontmatter' },
+        reason: /Unknown post field mapping: "frontmatter"/,
+      },
+      {
         mapping: { First: 'title', Second: 'title' },
         reason: /Post field is mapped more than once: "title"/,
       },
@@ -1044,6 +1048,25 @@ describe('Posts Importer API', function () {
       const { body } = await agent.post('posts/upload/').body(form).expectStatus(422);
       assert.match(body.errors[0].message, reason);
     }
+  });
+
+  it('Ignores an unmapped frontmatter identity header', async function () {
+    await agent.loginAsOwner();
+
+    const frontmatterCsvPath = await csvFile(
+      'posts-import-frontmatter.csv',
+      'title,frontmatter\nFrontmatter source column,key: value\n',
+    );
+
+    await agent.post('posts/upload/').attach('postsfile', frontmatterCsvPath).expectStatus(202);
+    await contentImportService.allSettled();
+
+    const post = await models.Post.findOne(
+      { title: 'Frontmatter source column' },
+      { withRelated: ['posts_meta'] },
+    );
+    assert.ok(post);
+    assert.equal(post.related('posts_meta').get('frontmatter'), undefined);
   });
 
   it('Imports each CSV row as a post with its content and publish date', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -235,8 +235,10 @@ describe('Posts Importer API', function () {
     const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
     assert.ok(errorsFile);
     const { data: errorRows, meta } = papaparse.parse(errorsFile.content.trim(), { header: true });
-    assert.deepEqual(meta.fields.slice(0, 7), [
+    assert.deepEqual(meta.fields.slice(0, 9), [
       'import_status',
+      'import_reason',
+      'import_media_failures',
       'title',
       'slug',
       'status',
@@ -287,12 +289,12 @@ describe('Posts Importer API', function () {
     const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });
     assert.deepEqual(parsed.meta.fields, [
       'import_status_2',
+      'import_reason',
+      'import_media_failures',
       'Body',
       'Headline',
       'State',
       'import_status',
-      'import_reason',
-      'import_media_failures',
     ]);
     assert.equal(parsed.data[0].Body, '<p>Keep source cells</p>');
     assert.equal(parsed.data[0].Headline, 'ZIP invalid');

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -207,7 +207,7 @@ describe('Posts Importer API', function () {
     assert.match(email.html, /Created:<\/strong> 2/);
     assert.match(email.html, /Updated:<\/strong> 0/);
     assert.match(email.html, /Skipped:<\/strong> 2/);
-    assert.match(email.html, /Failed:<\/strong> 2/);
+    assert.match(email.html, /Failed:<\/strong> 2 \(see attached errors\.csv\)/);
     assert.equal(email.attachments.length, 2);
     const report = email.attachments.find(({ filename }) => filename === 'report.csv');
     assert.ok(report);
@@ -283,7 +283,7 @@ describe('Posts Importer API', function () {
       subject: 'Your content import was unsuccessful',
     });
     assert.match(email.html, /Skipped:<\/strong> 0/);
-    assert.match(email.html, /Failed:<\/strong> 1/);
+    assert.match(email.html, /Failed:<\/strong> 1 \(see attached errors\.csv\)/);
     const errorsFile = email.attachments.find(({ filename }) => filename === 'errors.csv');
     assert.ok(errorsFile);
     const parsed = papaparse.parse(errorsFile.content.trim(), { header: true });

--- a/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/completion-email.test.ts
@@ -44,6 +44,7 @@ describe('content import completion email', function () {
     assert.match(email.html, /Updated:<\/strong> 1/);
     assert.match(email.html, /Skipped:<\/strong> 1/);
     assert.match(email.html, /Failed:<\/strong> 1/);
+    assert.doesNotMatch(email.html, /see attached errors\.csv/);
     assert.match(email.html, /1<\/strong> post has warnings/);
   });
 
@@ -51,7 +52,16 @@ describe('content import completion email', function () {
     const email = buildCompletionEmail(
       run({
         total: 1,
-        rows: [{ line: 2, title: 'Failed', status: 'failed', reason: 'Write failed' }],
+        sourceColumns: ['title'],
+        rows: [
+          {
+            line: 2,
+            title: 'Failed',
+            status: 'failed',
+            reason: 'Write failed',
+            source: { title: 'Failed' },
+          },
+        ],
       }),
       'owner@example.com',
       ADMIN_URL,
@@ -59,6 +69,7 @@ describe('content import completion email', function () {
 
     assert.equal(email.subject, 'Your content import was unsuccessful');
     assert.match(email.html, /processed 1 row:/);
+    assert.match(email.html, /Failed:<\/strong> 1 \(see attached errors\.csv\)/);
   });
 
   it('attaches a report for a completely clean run', function () {
@@ -78,6 +89,7 @@ describe('content import completion email', function () {
       email.attachments.map(({ filename }) => filename),
       ['report.csv'],
     );
+    assert.doesNotMatch(email.html, /see attached errors\.csv/);
   });
 
   it('attaches both the report and actionable errors file in stable order', function () {
@@ -103,6 +115,7 @@ describe('content import completion email', function () {
       email.attachments.map(({ filename }) => filename),
       ['report.csv', 'errors.csv'],
     );
+    assert.match(email.html, /Failed:<\/strong> 1 \(see attached errors\.csv\)/);
   });
 
   it('uses plural warning copy for multiple warning-bearing posts', function () {
@@ -131,6 +144,7 @@ describe('content import completion email', function () {
     assert.equal(email.subject, 'Your content import could not be completed');
     assert.match(email.html, /Something went wrong on our end/);
     assert.doesNotMatch(email.html, /database password/);
+    assert.doesNotMatch(email.html, /see attached errors\.csv/);
   });
 
   it('omits attachments when a fatal run stopped before processing a row', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/errors-file.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/errors-file.test.ts
@@ -81,11 +81,11 @@ describe('content import errors file', function () {
     const parsed = papaparse.parse<Record<string, string>>(csv, { header: true });
     assert.deepEqual(parsed.meta.fields, [
       'import_status_2',
+      'import_reason',
+      'import_media_failures',
       'Body',
       'Headline',
       'import_status',
-      'import_reason',
-      'import_media_failures',
     ]);
     assert.equal(parsed.data[0].Headline, "'=Failed()");
     assert.equal(parsed.data[0].import_status, 'publisher value');
@@ -119,8 +119,10 @@ describe('content import errors file', function () {
 
     assert.ok(csv);
     const parsed = papaparse.parse(csv, { header: true });
-    assert.equal(parsed.meta.fields?.[0], 'import_status_3');
-    assert.ok(parsed.meta.fields?.includes('import_reason_2'));
-    assert.ok(parsed.meta.fields?.includes('import_media_failures_2'));
+    assert.deepEqual(parsed.meta.fields?.slice(0, 3), [
+      'import_status_3',
+      'import_reason_2',
+      'import_media_failures_2',
+    ]);
   });
 });

--- a/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/post-data.test.ts
@@ -210,7 +210,7 @@ describe('buildPostData', function () {
     assert.equal(data.comment_id, 'legacy-source-123');
   });
 
-  it('puts feature metadata, SEO, social fields, and frontmatter in posts_meta', function () {
+  it('puts feature metadata, SEO, and social fields in posts_meta', function () {
     const data = buildPostData(
       row({
         title: 'Metadata post',
@@ -224,7 +224,6 @@ describe('buildPostData', function () {
         twitter_image: 'https://example.com/twitter.jpg',
         twitter_title: 'Twitter title',
         twitter_description: 'Twitter description',
-        frontmatter: 'key: value',
       }),
       htmlToLexical,
       TAGS,
@@ -241,8 +240,18 @@ describe('buildPostData', function () {
       twitter_image: 'https://example.com/twitter.jpg',
       twitter_title: 'Twitter title',
       twitter_description: 'Twitter description',
-      frontmatter: 'key: value',
     });
+  });
+
+  it('ignores an unmapped frontmatter source column', function () {
+    const data = buildPostData(
+      row({ title: 'Unsupported metadata', frontmatter: 'key: value' }),
+      htmlToLexical,
+      TAGS,
+    );
+
+    assert.equal(data.posts_meta, undefined);
+    assert.equal('frontmatter' in data, false);
   });
 
   it('omits every date when the cell is absent, leaving the model to stamp now', function () {

--- a/ghost/core/test/unit/server/services/content-import/import/row.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/row.test.ts
@@ -38,7 +38,6 @@ describe('post import row schema', function () {
       slug: '',
       feature_image: 'undefined',
       meta_title: '',
-      frontmatter: '',
       comment_id: '',
       authors: '',
       author_emails: 'undefined',
@@ -48,7 +47,6 @@ describe('post import row schema', function () {
     assert.equal(parsed.slug, undefined);
     assert.equal(parsed.feature_image, undefined);
     assert.equal(parsed.meta_title, undefined);
-    assert.equal(parsed.frontmatter, undefined);
     assert.equal(parsed.comment_id, undefined);
     assert.equal(parsed.authors, undefined);
     assert.equal(parsed.author_emails, undefined);

--- a/ghost/core/test/unit/server/services/content-import/import/schema.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/schema.test.ts
@@ -88,6 +88,9 @@ describe('content import schema', function () {
     assert.deepEqual(issuesFor({ Headline: 'title', Body: 'not_a_field' }), [
       'Unknown post field mapping: "not_a_field"',
     ]);
+    assert.deepEqual(issuesFor({ Headline: 'title', Metadata: 'frontmatter' }), [
+      'Unknown post field mapping: "frontmatter"',
+    ]);
     assert.deepEqual(issuesFor({ Headline: 'title', Duplicate: 'title' }), [
       'Post field is mapped more than once: "title"',
     ]);


### PR DESCRIPTION
ref https://linear.app/ghost/project/4b2edbd66469/

- Reordered CSV import error annotations so that failure reasons sit next to the import status column
- Added CSV error attachment guidance to completion emails
- Removed frontmatter from CSV content imports