### PR TITLE
Improved Admin acceptance fixture construction

### DIFF
--- a/apps/admin/src/admin-scenario.acceptance.test.tsx
+++ b/apps/admin/src/admin-scenario.acceptance.test.tsx
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { configureAdminScenario } from '@test-utils/acceptance/boot';
+import {
+  connectedStripeSettings,
+  currentUserResponse,
+  fakeEditSettings,
+  fakeSettingsScreens,
+  renderAdminApp,
+  settingsResponse,
+  type SettingsResponse,
+  type CurrentUserResponse,
+} from '@test-utils/acceptance';
+import { verifyNoUnhandledRequests } from '@test-utils/acceptance/worker';
+import { settingsScreen } from '@/settings/settings.screen';
+
+const settingsPath = '/settings/?group=site,labs';
+async function api<T>(path: string, body?: object): Promise<T> {
+  const response = await fetch(
+    `/ghost/api/admin${path}`,
+    body === undefined
+      ? {}
+      : {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+  );
+  return (await response.json()) as T;
+}
+const valuesOf = (body: SettingsResponse) =>
+  Object.fromEntries(body.settings.map(({ key, value }) => [key, value]));
+
+describe('Admin scenario API', () => {
+  it('serves settings/config together and retains settings through successive PUTs and refetches', async () => {
+    const capture = fakeEditSettings();
+    configureAdminScenario({
+      settings: connectedStripeSettings(),
+      labs: { machinePayments: true },
+      omitSettings: ['machine_payments_enabled'],
+      config: { stats: { id: 'analytics-site' } },
+      limits: { staff: { max: 4 } },
+    });
+    await api(settingsPath.replace('?group=site,labs', ''), {
+      settings: [{ key: 'title', value: 'Edited' }],
+    });
+    await api('/settings/', { settings: [{ key: 'description', value: 'Second save' }] });
+    const settings = valuesOf(await api<SettingsResponse>(settingsPath));
+    expect(settings).toMatchObject({
+      ...connectedStripeSettings(),
+      title: 'Edited',
+      description: 'Second save',
+    });
+    expect(settings).not.toHaveProperty('machine_payments_enabled');
+    expect(JSON.parse(String(settings.labs))).toMatchObject({ machinePayments: true });
+    expect(await api('/config/')).toMatchObject({
+      config: {
+        stats: { id: 'analytics-site' },
+        labs: { machinePayments: true },
+        hostSettings: { limits: { staff: { max: 4 } } },
+      },
+    });
+    expect(capture.requests).toHaveLength(2);
+  });
+
+  it('keeps the seeded current user after a write and refuses writes to another user', async () => {
+    configureAdminScenario({ user: { id: 'editor-id', roles: ['Editor'] } });
+    await api('/users/editor-id/?include=roles', {
+      users: [{ id: 'wrong-id', accessibility: '{"darkMode":true}' }],
+    });
+    expect(await api('/users/me/?include=roles')).toMatchObject({
+      users: [{ id: 'editor-id', roles: [{ name: 'Editor' }], accessibility: '{"darkMode":true}' }],
+    });
+    const response = await fetch('/ghost/api/admin/users/other/?include=roles', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ users: [{ name: 'Another user' }] }),
+    });
+    expect(response.status).toBe(418);
+    expect(() => verifyNoUnhandledRequests()).toThrow('/users/other/');
+    expect(await api('/users/me/?include=roles')).toMatchObject({
+      users: [{ id: 'editor-id', name: 'Owner User' }],
+    });
+  });
+
+  it.each([false, true])(
+    'does not commit a failed preference write (raw response: %s)',
+    async (raw) => {
+      configureAdminScenario({
+        user: { roles: ['Editor'] },
+        boot: {
+          editUserPreferences: {
+            responseStatus: 422,
+            ...(raw ? { response: { errors: [{ message: 'Save failed' }] } } : {}),
+          },
+        },
+      });
+      const response = await fetch('/ghost/api/admin/users/1/?include=roles', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ users: [{ name: 'Must not save' }] }),
+      });
+      expect(response.status).toBe(422);
+      expect(await api('/users/me/?include=roles')).toMatchObject({
+        users: [{ name: 'Owner User', roles: [{ name: 'Editor' }] }],
+      });
+    },
+  );
+
+  it('preserves raw settings callbacks and their legacy echo behavior', async () => {
+    fakeEditSettings();
+    const raw = settingsResponse({ settings: { title: 'Raw settings' } });
+    configureAdminScenario({
+      labs: { automations: true },
+      boot: { browseSettings: { response: () => Promise.resolve(raw) } },
+    });
+    const initial = valuesOf(await api<SettingsResponse>(settingsPath));
+    expect(initial.title).toBe('Raw settings');
+    expect(JSON.parse(String(initial.labs))).toMatchObject({ automations: true });
+    const saved = valuesOf(
+      await api<SettingsResponse>('/settings/', {
+        settings: [{ key: 'description', value: 'Edited' }],
+      }),
+    );
+    expect(saved.title).toBe('Test Site');
+    expect(valuesOf(await api<SettingsResponse>(settingsPath)).title).toBe('Raw settings');
+    expect(valuesOf(raw).title).toBe('Raw settings');
+  });
+
+  it('keeps a raw current-user read outside managed state', async () => {
+    const raw = currentUserResponse();
+    raw.users[0].id = 'legacy-user';
+    configureAdminScenario({ boot: { browseMe: { response: raw } } });
+    const saved = await api<CurrentUserResponse>('/users/legacy-user/?include=roles', {
+      users: [{ name: 'Legacy edit' }],
+    });
+    expect(saved.users[0].name).toBe('Legacy edit');
+    expect(await api('/users/me/?include=roles')).toEqual(raw);
+  });
+
+  it('keeps successful raw staff writes out of managed current-user state', async () => {
+    const saved = currentUserResponse();
+    saved.users[0].id = 'another-user';
+    saved.users[0].name = 'Another user';
+    configureAdminScenario({
+      user: { roles: ['Editor'] },
+      boot: { editUserPreferences: { response: saved } },
+    });
+    expect(
+      await api('/users/another-user/?include=roles', { users: [{ name: 'Another user' }] }),
+    ).toEqual(saved);
+    expect(await api('/users/me/?include=roles')).toMatchObject({
+      users: [{ id: '1', name: 'Owner User', roles: [{ name: 'Editor' }] }],
+    });
+  });
+
+  it('rejects competing read seeds but accepts status-only overrides', async () => {
+    expect(() =>
+      configureAdminScenario({
+        settings: {},
+        boot: { browseSettings: { response: { settings: [] } } },
+      }),
+    ).toThrow('browseSettings.response');
+    expect(() =>
+      configureAdminScenario({ config: {}, boot: { browseConfig: { response: { config: {} } } } }),
+    ).toThrow('browseConfig.response');
+    expect(() =>
+      configureAdminScenario({ user: {}, boot: { browseMe: { response: { users: [] } } } }),
+    ).toThrow('browseMe.response');
+    configureAdminScenario({
+      settings: { title: 'Seeded' },
+      boot: { browseSettings: { responseStatus: 200, response: undefined } },
+    });
+    expect(valuesOf(await api<SettingsResponse>(settingsPath)).title).toBe('Seeded');
+  });
+
+  it('preserves the scenario after saving through the actual settings UI', async () => {
+    fakeSettingsScreens();
+    const capture = fakeEditSettings();
+    await renderAdminApp('/settings', {
+      settings: connectedStripeSettings(),
+      labs: { machinePayments: true },
+      omitSettings: ['machine_payments_enabled'],
+    });
+    const section = settingsScreen.titleAndDescription();
+    await section.getByRole('button', { name: 'Edit' }).click();
+    await section.getByLabelText('Site title').fill('Updated publication');
+    await section.getByRole('button', { name: 'Save' }).click();
+    await expect.element(section.getByText('Updated publication', { exact: true })).toBeVisible();
+    const saved = valuesOf(await api<SettingsResponse>(settingsPath));
+    expect(saved).toMatchObject({ ...connectedStripeSettings(), title: 'Updated publication' });
+    expect(saved).not.toHaveProperty('machine_payments_enabled');
+    expect(capture.requests).toHaveLength(1);
+  });
+});

--- a/apps/admin/src/admin-scenario.test.ts
+++ b/apps/admin/src/admin-scenario.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { connectedStripeSettings } from '@tryghost/test-data';
+import { createAdminState } from '@test-utils/acceptance/state';
+
+describe('Admin scenario state', () => {
+  it('preserves seeded settings, omissions, and earlier writes', () => {
+    const state = createAdminState({
+      labs: { machinePayments: true },
+      settings: connectedStripeSettings(),
+      omitSettings: ['machine_payments_enabled'],
+    });
+    state.editSettings([{ key: 'title', value: 'First edit' }]);
+    state.editSettings([
+      { key: 'description', value: 'Second edit' },
+      { key: 'logo', value: null },
+    ]);
+
+    const values = Object.fromEntries(
+      state.readSettings().settings.map(({ key, value }) => [key, value]),
+    );
+    expect(values).toMatchObject({
+      ...connectedStripeSettings(),
+      title: 'First edit',
+      description: 'Second edit',
+      logo: null,
+    });
+    expect(values).not.toHaveProperty('machine_payments_enabled');
+    expect(JSON.parse(String(values.labs))).toMatchObject({ machinePayments: true });
+    expect(state.readConfig().config.labs).toMatchObject({ machinePayments: true });
+  });
+
+  it('updates config when the settings labs value changes and rejects malformed labs atomically', () => {
+    const state = createAdminState({ labs: { automations: true } });
+    state.editSettings([{ key: 'labs', value: JSON.stringify({ automations: false }) }]);
+    expect(state.readConfig().config.labs).toEqual({ automations: false });
+    const before = state.readSettings();
+    expect(() =>
+      state.editSettings([
+        { key: 'title', value: 'Must not save' },
+        { key: 'labs', value: '[' },
+      ]),
+    ).toThrow();
+    expect(state.readSettings()).toEqual(before);
+  });
+
+  it('merges named limits without losing other host settings and isolates caller data', () => {
+    const options = {
+      config: {
+        hostSettings: { billing: { enabled: true, url: '/billing' } },
+        stats: { id: 'site', endpoint: 'https://tinybird.test' },
+      },
+      limits: { customThemes: { allowlist: ['casper'] }, staff: { max: 3 } },
+    };
+    const state = createAdminState(options);
+    options.limits.customThemes.allowlist.push('source');
+    options.config.hostSettings.billing.url = '/changed';
+    expect(state.readConfig().config).toMatchObject({
+      hostSettings: {
+        billing: { enabled: true, url: '/billing' },
+        limits: { customThemes: { allowlist: ['casper'] }, staff: { max: 3 } },
+      },
+      stats: { id: 'site', endpoint: 'https://tinybird.test' },
+    });
+  });
+
+  it('retains role and identity through preference edits without leaking snapshots', () => {
+    const state = createAdminState({
+      user: {
+        id: 'editor-id',
+        roles: ['Editor'],
+        accessibility: { whatsNew: { lastSeenDate: '2026-01-01' } },
+      },
+    });
+    const before = state.readUser();
+    expect(JSON.parse(String(before.users[0].accessibility))).toEqual({
+      whatsNew: { lastSeenDate: '2026-01-01' },
+    });
+    state.editUser({ id: 'another-user', accessibility: JSON.stringify({ darkMode: true }) });
+    state.editUser({ name: 'Updated name' });
+    const after = state.readUser();
+    expect(after.users[0]).toMatchObject({
+      id: 'editor-id',
+      name: 'Updated name',
+      roles: [{ name: 'Editor' }],
+      accessibility: '{"darkMode":true}',
+    });
+    after.users[0].name = 'Mutated response';
+    expect(state.readUser().users[0].name).toBe('Updated name');
+    expect(before.users[0].name).toBe('Owner User');
+    expect(createAdminState().readUser().users[0]).toMatchObject({ id: '1', name: 'Owner User' });
+  });
+
+  it.each([
+    [{ settings: { labs: '{}' } }, 'settings.labs'],
+    [{ omitSettings: ['labs'] }, 'omitSettings'],
+    [
+      { settings: { title: 'Conflict' }, omitSettings: ['title'] },
+      'both settings and omitSettings',
+    ],
+    [
+      {
+        config: { hostSettings: { limits: { staff: { max: 1 } } } },
+        limits: { staff: { max: 2 } },
+      },
+      'not both',
+    ],
+  ] as const)('rejects ambiguous seed inputs: %j', (options, message) => {
+    expect(() => createAdminState(options)).toThrow(message);
+  });
+});

--- a/apps/admin/src/home.acceptance.test.tsx
+++ b/apps/admin/src/home.acceptance.test.tsx
@@ -3,22 +3,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   allowUnhandledRequests,
   currentRoute,
-  currentUserResponse,
   fakeAdminEndpoint,
   renderAdminApp,
-  staffRole,
   type CapturedEndpointRequest,
   type EndpointCapture,
-  type RenderAdminAppOptions,
 } from '@test-utils/acceptance';
-import type { StaffRoleName } from '@tryghost/test-data';
 import { onboardingScreen } from '@/onboarding/onboarding.screen';
-
-function asRole(name: StaffRoleName): RenderAdminAppOptions {
-  const me = currentUserResponse();
-  me.users[0].roles = [staffRole({ name })];
-  return { boot: { browseMe: { response: me } } };
-}
 
 const homeHandoff = (): unknown => JSON.parse(document.body.dataset.externalNavigate ?? 'null');
 
@@ -45,13 +35,13 @@ describe('Home route', () => {
   it('sends admins to Analytics', async () => {
     // The analytics screens own their request graph; these specs assert only the dispatch.
     allowUnhandledRequests();
-    await renderAdminApp('/', asRole('Administrator'));
+    await renderAdminApp('/', { user: { roles: ['Administrator'] } });
 
     await expect.poll(currentRoute).toBe('/analytics');
   });
 
   it('sends contributors to Posts', async () => {
-    await renderAdminApp('/', asRole('Contributor'));
+    await renderAdminApp('/', { user: { roles: ['Contributor'] } });
 
     await expect
       .poll(homeHandoff)
@@ -59,7 +49,7 @@ describe('Home route', () => {
   });
 
   it('sends other staff roles to Site', async () => {
-    await renderAdminApp('/', asRole('Author'));
+    await renderAdminApp('/', { user: { roles: ['Author'] } });
 
     await expect
       .poll(homeHandoff)
@@ -84,7 +74,7 @@ describe('Home route', () => {
   it('continues admins to Analytics without starting the checklist on firstStart', async () => {
     allowUnhandledRequests();
     const preferencesApi = fakePreferenceEdits();
-    await renderAdminApp('/?firstStart=true', asRole('Administrator'));
+    await renderAdminApp('/?firstStart=true', { user: { roles: ['Administrator'] } });
 
     await expect.poll(currentRoute).toBe('/analytics');
     // Unrelated preference writes (e.g. the what's-new init) may happen,

--- a/apps/admin/src/posts/list/posts-list.acceptance.test.tsx
+++ b/apps/admin/src/posts/list/posts-list.acceptance.test.tsx
@@ -3,13 +3,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   fakePages,
   fakePosts,
-  fakePostsListScreen,
+  renderPostsListScreen,
   renderAdminApp,
   type ResourceCapture,
 } from '@test-utils/acceptance';
 import { postsListScreen } from './posts-list.screen';
 
-const FLAG_ON = { labs: { postsListReact: true } };
 const FLAG_OFF = { labs: { postsListReact: false } };
 
 /**
@@ -30,7 +29,6 @@ describe('Posts and pages list flag', () => {
   // content is irrelevant here, this file is only about which implementation
   // serves the route.
   beforeEach(() => {
-    fakePostsListScreen();
     postsApi = fakePosts([]);
     pagesApi = fakePages([]);
   });
@@ -40,14 +38,14 @@ describe('Posts and pages list flag', () => {
     { resource: 'pages', route: '/pages', title: 'Pages', newLabel: 'New page' },
   ] as const)('$route', ({ resource, route, title, newLabel }) => {
     it('renders the React screen when the flag is on', async () => {
-      await renderAdminApp(route, FLAG_ON);
+      await renderPostsListScreen(route);
 
       await expect.element(postsListScreen.page(resource)).toBeVisible();
       await expect.element(postsListScreen.title(resource, title)).toBeVisible();
     });
 
     it('offers the primary create action', async () => {
-      await renderAdminApp(route, FLAG_ON);
+      await renderPostsListScreen(route);
 
       await expect.element(postsListScreen.newLink(resource, newLabel)).toBeVisible();
     });
@@ -57,7 +55,7 @@ describe('Posts and pages list flag', () => {
     // there is no Ember app in this harness, so it can't be checked here.
 
     it('defers to Ember when the flag is off', async () => {
-      await renderAdminApp(route, FLAG_OFF);
+      await renderPostsListScreen(route, FLAG_OFF);
 
       await expect(postsListScreen.page(resource)).toHaveCount(0);
     });
@@ -72,7 +70,7 @@ describe('Posts and pages list flag', () => {
   // The two routes share one gate implementation, so a copy-paste slip would
   // silently serve the wrong screen.
   it('serves each route its own resource', async () => {
-    await renderAdminApp('/pages', FLAG_ON);
+    await renderPostsListScreen('/pages');
 
     await expect.element(postsListScreen.page('pages')).toBeVisible();
     await expect(postsListScreen.page('posts')).toHaveCount(0);

--- a/apps/admin/src/render-admin-app-labs.acceptance.test.tsx
+++ b/apps/admin/src/render-admin-app-labs.acceptance.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  configResponse,
+  fakePages,
+  fakePosts,
+  fakePostsListScreen,
+  renderAdminApp,
+  settingsResponse,
+} from '@test-utils/acceptance';
+import { composeLabsBootOverrides, type BootOverrides } from '@test-utils/acceptance/boot';
+import { postsListScreen } from '@/posts/list/posts-list.screen';
+
+/** Resolve an override's response the way the boot table serves it. */
+async function bodyOf(override: BootOverrides[keyof BootOverrides]): Promise<unknown> {
+  const response = override?.response;
+  return typeof response === 'function'
+    ? await (response as (request: Request) => unknown)(new Request('https://ghost.test'))
+    : response;
+}
+
+function labsOf(configBody: unknown): Record<string, boolean> {
+  return (configBody as { config: { labs: Record<string, boolean> } }).config.labs;
+}
+
+function labsSettingOf(settingsBody: unknown): Record<string, boolean> {
+  const { settings } = settingsBody as { settings: Array<{ key: string; value: string }> };
+  const entry = settings.find(({ key }) => key === 'labs');
+  expect(entry).toBeDefined();
+  return JSON.parse(entry!.value) as Record<string, boolean>;
+}
+
+describe('labs/boot composition', () => {
+  it('merges labs into a browseConfig object override without mutating it', async () => {
+    const config = configResponse();
+    config.config.hostSettings = { marker: true };
+    const snapshot = JSON.stringify(config);
+
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseConfig: { response: config } },
+    );
+    const body = await bodyOf(composed.browseConfig);
+
+    expect(labsOf(body).automations).toBe(true);
+    expect((body as { config: { hostSettings: unknown } }).config.hostSettings).toEqual({
+      marker: true,
+    });
+    expect(JSON.stringify(config)).toBe(snapshot);
+  });
+
+  it('wins over the same flag inside the override response', async () => {
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      {
+        browseConfig: { response: configResponse({ labs: { automations: false } }) },
+        browseSettings: { response: settingsResponse({ labs: { automations: false } }) },
+      },
+    );
+
+    expect(labsOf(await bodyOf(composed.browseConfig)).automations).toBe(true);
+    expect(labsSettingOf(await bodyOf(composed.browseSettings)).automations).toBe(true);
+  });
+
+  it('merges labs into a browseSettings override, adding the labs entry when missing', async () => {
+    const settings = settingsResponse();
+    settings.settings = settings.settings.filter(({ key }) => key !== 'labs');
+
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseSettings: { response: settings } },
+    );
+
+    expect(labsSettingOf(await bodyOf(composed.browseSettings)).automations).toBe(true);
+  });
+
+  it('merges labs into a function response', async () => {
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseSettings: { response: () => Promise.resolve(settingsResponse()) } },
+    );
+
+    expect(labsSettingOf(await bodyOf(composed.browseSettings)).automations).toBe(true);
+  });
+
+  it('leaves unrecognized bodies untouched and keeps responseStatus', async () => {
+    const errors = { errors: [{ message: 'nope' }] };
+    const composed = composeLabsBootOverrides(
+      { automations: true },
+      { browseConfig: { response: errors, responseStatus: 422 } },
+    );
+
+    expect(await bodyOf(composed.browseConfig)).toBe(errors);
+    expect(composed.browseConfig?.responseStatus).toBe(422);
+  });
+
+  it('compiles the canned responses when boot has no override for the entry', async () => {
+    const composed = composeLabsBootOverrides({ automations: true });
+
+    expect(await bodyOf(composed.browseConfig)).toEqual(
+      configResponse({ labs: { automations: true } }),
+    );
+    expect(await bodyOf(composed.browseSettings)).toEqual(
+      settingsResponse({ labs: { automations: true } }),
+    );
+  });
+});
+
+describe('renderAdminApp labs + boot', () => {
+  // postsListReact gates which implementation serves /posts, so the React
+  // screen appearing proves the flag survived the boot overrides.
+  it('applies labs flags alongside browseConfig and browseSettings overrides', async () => {
+    fakePostsListScreen();
+    fakePosts([]);
+    fakePages([]);
+    await renderAdminApp('/posts', {
+      labs: { postsListReact: true },
+      boot: {
+        browseConfig: { response: configResponse() },
+        browseSettings: { response: settingsResponse() },
+      },
+    });
+
+    await expect.element(postsListScreen.page('posts')).toBeVisible();
+  });
+});

--- a/apps/admin/src/resource-fakes.acceptance.test.tsx
+++ b/apps/admin/src/resource-fakes.acceptance.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fakeAdminEndpoint,
+  fakeMemberCustomFields,
+  fakeSettingsScreens,
+  fakeTags,
+  fakeTiers,
+  memberCustomField,
+  renderSettingsScreen,
+  tag,
+  tier,
+} from '@test-utils/acceptance';
+import { configureAdminScenario } from '@test-utils/acceptance/boot';
+import { verifyNoUnhandledRequests, withScreenDefaults } from '@test-utils/acceptance/worker';
+
+async function request(path: string, method = 'GET', body?: object) {
+  return await fetch(`/ghost/api/admin${path}`, {
+    method,
+    ...(body === undefined
+      ? {}
+      : { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }),
+  });
+}
+
+describe('screen defaults', () => {
+  it('preserves explicit data registered before the defaults and captures its requests', async () => {
+    const supporter = tier({ name: 'Supporter' });
+    const tiers = fakeTiers([supporter]);
+    withScreenDefaults(fakeSettingsScreens);
+    const response = await request('/tiers/');
+    expect(await response.json()).toMatchObject({ tiers: [{ name: 'Supporter' }] });
+    expect(tiers.requests).toHaveLength(1);
+  });
+
+  it('keeps explicit failure and recovery ordering, regardless of when defaults register', async () => {
+    fakeAdminEndpoint('GET', '/tiers/', { errors: [{ message: 'Not yet' }] }, { status: 400 });
+    withScreenDefaults(fakeSettingsScreens);
+    expect((await request('/tiers/')).status).toBe(400);
+    fakeTiers([tier({ name: 'Recovered' })]);
+    const response = await request('/tiers/');
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ tiers: [{ name: 'Recovered' }] });
+  });
+
+  it('reads the current user after the scenario is composed', async () => {
+    withScreenDefaults(fakeSettingsScreens);
+    configureAdminScenario({ user: { id: 'editor', roles: ['Editor'] } });
+    expect(await (await request('/users/')).json()).toMatchObject({
+      users: [{ id: 'editor', roles: [{ name: 'Editor' }] }],
+    });
+  });
+
+  it('does not silently enable settings saves when rendering a settings screen', async () => {
+    await renderSettingsScreen();
+    expect(
+      (await request('/settings/', 'PUT', { settings: [{ key: 'title', value: 'Unexpected' }] }))
+        .status,
+    ).toBe(418);
+    expect(() => verifyNoUnhandledRequests()).toThrow('PUT /settings/');
+  });
+});
+
+describe('tag resource state', () => {
+  it('uses current identity for reads after a rename and does not change the seed', async () => {
+    const news = tag({ id: 'news-id', slug: 'news', name: 'News' });
+    const operations = { read: true, update: true };
+    const tags = fakeTags([news], operations);
+    expect(await (await request('/tags/slug/news/')).json()).toMatchObject({
+      tags: [{ name: 'News' }],
+    });
+    const body = { tags: [{ id: 'cannot-change-id', name: 'Latest', slug: 'latest' }] };
+    expect((await request('/tags/news-id/', 'PUT', body)).status).toBe(200);
+    expect(await (await request('/tags/news-id/')).json()).toMatchObject({
+      tags: [{ id: 'news-id', name: 'Latest', slug: 'latest' }],
+    });
+    expect(await (await request('/tags/slug/latest/')).json()).toMatchObject({
+      tags: [{ id: 'news-id', name: 'Latest' }],
+    });
+    expect((await request('/tags/slug/news/')).status).toBe(404);
+    expect(await (await request('/tags/')).json()).toMatchObject({ tags: [{ name: 'Latest' }] });
+    expect(tags.update?.lastRequest?.body).toEqual(body);
+    expect(tags.read?.requests).toHaveLength(4);
+    expect(tags.requests).toHaveLength(1);
+    expect(news).toMatchObject({ id: 'news-id', name: 'News', slug: 'news' });
+  });
+
+  it('leaves state unchanged when a later explicit handler rejects a write', async () => {
+    const news = tag({ id: 'news-id', name: 'News' });
+    const tags = fakeTags([news], { read: true, update: true });
+    const failed = fakeAdminEndpoint(
+      'PUT',
+      '/tags/news-id/',
+      { errors: [{ message: 'Rejected' }] },
+      { status: 422 },
+    );
+    expect((await request('/tags/news-id/', 'PUT', { tags: [{ name: 'Wrong' }] })).status).toBe(
+      422,
+    );
+    expect(await (await request('/tags/news-id/')).json()).toMatchObject({
+      tags: [{ name: 'News' }],
+    });
+    expect(tags.update.requests).toHaveLength(0);
+    expect(failed.requests).toHaveLength(1);
+  });
+
+  it('does not enable writes for a browse-only declaration', async () => {
+    fakeTags([tag({ id: 'news-id' })]);
+    expect(
+      (await request('/tags/news-id/', 'PUT', { tags: [{ name: 'Unexpected' }] })).status,
+    ).toBe(418);
+    expect(() => verifyNoUnhandledRequests()).toThrow('PUT /tags/news-id/');
+  });
+
+  it('captures a write to a missing tag without adding it to the collection', async () => {
+    const tags = fakeTags([], { update: true });
+    const body = { tags: [{ name: 'Missing' }] };
+    expect((await request('/tags/missing/', 'PUT', body)).status).toBe(404);
+    expect(tags.update.lastRequest?.body).toEqual(body);
+    expect(await (await request('/tags/')).json()).toMatchObject({ tags: [] });
+  });
+
+  it('rejects callback data with automatic mutations', () => {
+    // @ts-expect-error Mutable resources require an array, checked at runtime for JS callers too.
+    expect(() => fakeTags(() => [], { update: true })).toThrow('declared array');
+  });
+});
+
+describe('custom-field creation', () => {
+  it('appends exactly one declared result, captures the input, and preserves the caller data', async () => {
+    const initial = [memberCustomField({ key: 'company', name: 'Company' })];
+    const created = memberCustomField({ key: 'newest', name: 'Newest' });
+    const fields = fakeMemberCustomFields(initial, { create: { response: created } });
+    created.name = 'Mutated fixture';
+    const body = { members_custom_fields: [{ name: 'Newest', type: 'short_text' }] };
+    expect((await request('/members/custom_fields/', 'POST', body)).status).toBe(200);
+    expect(await (await request('/members/custom_fields/')).json()).toMatchObject({
+      members_custom_fields: [
+        { key: 'company', name: 'Company' },
+        { key: 'newest', name: 'Newest' },
+      ],
+    });
+    expect(fields.create.lastRequest?.body).toEqual(body);
+    expect(initial).toHaveLength(1);
+    expect((await request('/members/custom_fields/', 'POST', body)).status).toBe(418);
+    expect(() => verifyNoUnhandledRequests()).toThrow('already consumed');
+    expect(await (await request('/members/custom_fields/')).json()).toMatchObject({
+      meta: { pagination: { total: 2 } },
+    });
+  });
+
+  it('does not append when the create request is overridden by an error', async () => {
+    const fields = fakeMemberCustomFields([], {
+      create: { response: memberCustomField({ key: 'newest', name: 'Newest' }) },
+    });
+    fakeAdminEndpoint(
+      'POST',
+      '/members/custom_fields/',
+      { errors: [{ message: 'Rejected' }] },
+      { status: 422 },
+    );
+    expect(
+      (
+        await request('/members/custom_fields/', 'POST', {
+          members_custom_fields: [{ name: 'Newest', type: 'short_text' }],
+        })
+      ).status,
+    ).toBe(422);
+    expect(await (await request('/members/custom_fields/')).json()).toMatchObject({
+      members_custom_fields: [],
+    });
+    expect(fields.create.requests).toHaveLength(0);
+  });
+});

--- a/apps/admin/src/route-access.acceptance.test.tsx
+++ b/apps/admin/src/route-access.acceptance.test.tsx
@@ -7,16 +7,7 @@ import {
   currentUserResponse,
   fakeTags,
   renderAdminApp,
-  staffRole,
-  type RenderAdminAppOptions,
 } from '@test-utils/acceptance';
-import type { StaffRoleName } from '@tryghost/test-data';
-
-function asRole(name: StaffRoleName): RenderAdminAppOptions {
-  const me = currentUserResponse();
-  me.users[0].roles = [staffRole({ name })];
-  return { boot: { browseMe: { response: me } } };
-}
 
 // Denied routes redirect to the home route through the router; only the home
 // dispatch itself may then hand off cross-app (asserted in home.acceptance).
@@ -31,7 +22,7 @@ describe('Route access', () => {
   });
 
   it('redirects a contributor away from settings', async () => {
-    await renderAdminApp('/settings/design', asRole('Contributor'));
+    await renderAdminApp('/settings/design', { user: { roles: ['Contributor'] } });
 
     await expect.poll(currentRoute).toBe('/');
   });
@@ -39,26 +30,26 @@ describe('Route access', () => {
   it('keeps a contributor on their own profile settings', async () => {
     // The settings app owns its request graph; this spec asserts only the shell routing.
     allowUnhandledRequests();
-    await renderAdminApp(`/settings/staff/${OWNER_SLUG}`, asRole('Contributor'));
+    await renderAdminApp(`/settings/staff/${OWNER_SLUG}`, { user: { roles: ['Contributor'] } });
 
     await expect.poll(currentRoute).toBe(`/settings/staff/${OWNER_SLUG}`);
     expect(homeHandoff()).toBe(null);
   });
 
   it("redirects an author away from another staff member's profile settings", async () => {
-    await renderAdminApp('/settings/staff/someone-else', asRole('Author'));
+    await renderAdminApp('/settings/staff/someone-else', { user: { roles: ['Author'] } });
 
     await expect.poll(currentRoute).toBe('/');
   });
 
   it('redirects a contributor away from tags', async () => {
-    await renderAdminApp('/tags', asRole('Contributor'));
+    await renderAdminApp('/tags', { user: { roles: ['Contributor'] } });
 
     await expect.poll(currentRoute).toBe('/');
   });
 
   it('redirects an editor away from members', async () => {
-    await renderAdminApp('/members', asRole('Editor'));
+    await renderAdminApp('/members', { user: { roles: ['Editor'] } });
 
     await expect.poll(currentRoute).toBe('/');
   });

--- a/apps/admin/src/settings/email/default-recipients.acceptance.test.tsx
+++ b/apps/admin/src/settings/email/default-recipients.acceptance.test.tsx
@@ -6,11 +6,10 @@ import {
   fakeAdminEndpoint,
   fakeLabels,
   fakeOffers,
-  fakeSettingsScreens,
   fakeTiers,
   label,
   offer,
-  renderAdminApp,
+  renderSettingsScreen,
   settingsResponse,
   tier,
 } from '@test-utils/acceptance';
@@ -27,9 +26,8 @@ describe('Default recipient settings', () => {
     { choice: 'Usually nobody', filter: null },
     { choice: 'Paid-members only', filter: 'status:-free' },
   ])('saves the standard recipient choice: $choice', async ({ choice, filter }) => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings/newsletters');
+    await renderSettingsScreen('/settings/newsletters');
 
     const section = settingsScreen.defaultRecipients();
     await expect
@@ -51,12 +49,11 @@ describe('Default recipient settings', () => {
     const supporter = tier({ id: '645453f4d254799990dd0e22', name: 'Basic Supporter' });
     const firstLabel = label({ name: 'first-label', slug: 'first-label' });
     const firstOffer = offer({ id: '6487ea6464fca78ec2fff5fe', name: 'First offer' });
-    fakeSettingsScreens();
     fakeTiers([supporter]);
     fakeLabels([firstLabel]);
     fakeOffers([firstOffer]);
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings/newsletters');
+    await renderSettingsScreen('/settings/newsletters');
 
     const section = settingsScreen.defaultRecipients();
     await selectDefaultRecipients('Specific people');
@@ -84,7 +81,6 @@ describe('Default recipient settings', () => {
     const supporter = tier({ id: '645453f4d254799990dd0e22', name: 'Basic Supporter' });
     const firstLabel = label({ name: 'first-label', slug: 'first-label' });
     const firstOffer = offer({ id: '6487ea6464fca78ec2fff5fe', name: 'First offer' });
-    fakeSettingsScreens();
     fakeTiers([supporter]);
     fakeLabels([firstLabel]);
     fakeOffers([firstOffer]);
@@ -94,7 +90,7 @@ describe('Default recipient settings', () => {
         editor_default_email_recipients_filter: `${supporter.id},label:${firstLabel.slug},offer_redemptions:${firstOffer.id}`,
       },
     });
-    await renderAdminApp('/settings/newsletters', {
+    await renderSettingsScreen('/settings/newsletters', {
       boot: { browseSettings: { response: settings } },
     });
 
@@ -108,7 +104,6 @@ describe('Default recipient settings', () => {
   it('restores the saved segment when cancelling changes', async () => {
     const savedTier = tier({ id: '645453f4d254799990dd0e22', name: 'Basic Supporter' });
     const addedTier = tier({ id: '645453f4d254799990dd0e23', name: 'Premium Supporter' });
-    fakeSettingsScreens();
     fakeTiers([savedTier, addedTier]);
     fakeLabels([]);
     fakeOffers([]);
@@ -118,7 +113,7 @@ describe('Default recipient settings', () => {
         editor_default_email_recipients_filter: savedTier.id,
       },
     });
-    await renderAdminApp('/settings/newsletters', {
+    await renderSettingsScreen('/settings/newsletters', {
       boot: { browseSettings: { response: settings } },
     });
 
@@ -137,7 +132,6 @@ describe('Default recipient settings', () => {
   it('retries failed segment hydration without dropping the saved filter', async () => {
     const savedTier = tier({ id: '645453f4d254799990dd0e22', name: 'Basic Supporter' });
     const addedTier = tier({ id: '645453f4d254799990dd0e23', name: 'Premium Supporter' });
-    fakeSettingsScreens();
     fakeLabels([]);
     fakeOffers([]);
     fakeAdminEndpoint(
@@ -153,7 +147,7 @@ describe('Default recipient settings', () => {
         editor_default_email_recipients_filter: savedTier.id,
       },
     });
-    await renderAdminApp('/settings/newsletters', {
+    await renderSettingsScreen('/settings/newsletters', {
       boot: { browseSettings: { response: settings } },
     });
 

--- a/apps/admin/src/settings/general/social-accounts.acceptance.test.tsx
+++ b/apps/admin/src/settings/general/social-accounts.acceptance.test.tsx
@@ -1,13 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
-import {
-  fakeEditSettings,
-  fakeSettingsScreens,
-  renderAdminApp,
-  settingsResponse,
-  type SettingsResponse,
-} from '@test-utils/acceptance';
+import { fakeEditSettings, renderSettingsScreen, settingsResponse } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
 
 const newPlatformKeys = [
@@ -78,17 +72,10 @@ const editedSocialSettings = [
   },
 ] as const;
 
-function withoutSettings(keys: string[]): SettingsResponse {
-  const response = settingsResponse();
-  response.settings = response.settings.filter(({ key }) => !keys.includes(key));
-  return response;
-}
-
 describe('Social account settings', () => {
   it('edits all publication social URLs', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.socialAccounts();
     await expect
@@ -110,9 +97,8 @@ describe('Social account settings', () => {
   });
 
   it('hides new platforms when the backend has not deployed them', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings', {
-      boot: { browseSettings: { response: withoutSettings(newPlatformKeys) } },
+    await renderSettingsScreen('/settings', {
+      omitSettings: newPlatformKeys,
     });
 
     const section = settingsScreen.socialAccounts();
@@ -124,13 +110,8 @@ describe('Social account settings', () => {
   });
 
   it('shows all new platforms when any migrated key is present', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings', {
-      boot: {
-        browseSettings: {
-          response: withoutSettings(newPlatformKeys.filter((key) => key !== 'threads')),
-        },
-      },
+    await renderSettingsScreen('/settings', {
+      omitSettings: newPlatformKeys.filter((key) => key !== 'threads'),
     });
 
     for (const label of platformLabels) {
@@ -139,8 +120,7 @@ describe('Social account settings', () => {
   });
 
   it('restores values on cancel', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.socialAccounts();
     const linkedin = section.getByLabelText('LinkedIn');
@@ -154,8 +134,7 @@ describe('Social account settings', () => {
   });
 
   it('normalizes and validates social URLs', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.socialAccounts();
     const cases = [
@@ -230,8 +209,7 @@ describe('Social account settings', () => {
   });
 
   it('keeps invalid input after a valid value', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.socialAccounts();
     const instagram = section.getByLabelText('Instagram');
@@ -247,8 +225,7 @@ describe('Social account settings', () => {
   });
 
   it('does not rewrite a Mastodon handle while typing', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const mastodon = settingsScreen.socialAccounts().getByLabelText('Mastodon');
     await mastodon.click();
@@ -259,8 +236,7 @@ describe('Social account settings', () => {
   });
 
   it('allows a federated Mastodon URL', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.socialAccounts();
     const mastodon = section.getByLabelText('Mastodon');
@@ -273,9 +249,8 @@ describe('Social account settings', () => {
   });
 
   it('does not block unrelated saves on a stale stored value', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings', {
+    await renderSettingsScreen('/settings', {
       boot: {
         browseSettings: { response: settingsResponse({ settings: { threads: '@ghost.tld.' } }) },
       },
@@ -295,9 +270,8 @@ describe('Social account settings', () => {
   });
 
   it('blocks a first invalid edit when another field is dirty', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.socialAccounts();
     await section.getByLabelText('Facebook').fill('fb');

--- a/apps/admin/src/settings/general/title-and-description.acceptance.test.tsx
+++ b/apps/admin/src/settings/general/title-and-description.acceptance.test.tsx
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { fakeEditSettings, fakeSettingsScreens, renderAdminApp } from '@test-utils/acceptance';
+import { fakeEditSettings, renderSettingsScreen } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
 
 describe('Title and description settings', () => {
   it('edits the title and description', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.titleAndDescription();
     await expect.element(section.getByText('Test Site', { exact: true })).toBeVisible();
@@ -30,9 +29,8 @@ describe('Title and description settings', () => {
   });
 
   it('validates the title without saving', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.titleAndDescription();
     await section.getByRole('button', { name: 'Edit' }).click();
@@ -50,8 +48,7 @@ describe('Title and description settings', () => {
   });
 
   it('restores the title and description on cancel', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     const section = settingsScreen.titleAndDescription();
     await section.getByRole('button', { name: 'Edit' }).click();

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -2,40 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
-  configResponse,
+  memberCustomField,
   fakeAdminEndpoint,
   fakeMemberCustomFields,
-  fakeSettingsScreens,
-  renderAdminApp,
-  settingsResponse,
+  renderSettingsScreen,
 } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
 
-const companyField = {
-  key: 'company',
-  name: 'Company',
-  type: 'short_text',
-  status: 'active',
-  created_at: '2026-07-13T00:00:00.000Z',
-  updated_at: null as string | null,
-};
-
-const archivedField = {
+const companyField = memberCustomField({ key: 'company', name: 'Company' });
+const archivedField = memberCustomField({
   key: 'old_hobby',
   name: 'Old hobby',
-  type: 'short_text',
   status: 'archived',
-  created_at: '2026-07-12T00:00:00.000Z',
-  updated_at: '2026-07-13T00:00:00.000Z',
-};
-
-function customFieldsBoot() {
-  const labs = { membersCustomFields: true };
-  return {
-    browseConfig: { response: configResponse({ labs }) },
-    browseSettings: { response: settingsResponse({ labs }) },
-  };
-}
+});
 
 type CustomField = typeof companyField;
 
@@ -43,37 +22,18 @@ function fakeCustomFields(fields: CustomField[] = [companyField]) {
   return fakeMemberCustomFields(fields);
 }
 
-/**
- * Mutations invalidate and refetch the list, so a spec observing the list
- * after a create serves it from state that grows when the POST lands; the
- * created entity is declared by the spec, the fake invents nothing.
- * Post-mutation outcomes of edits and deletes are server behavior, owned by
- * the API suite (ghost/core e2e-api member-custom-fields) — those specs
- * assert the outgoing request and the refetch instead.
- */
-function fakeCustomFieldsWithCreate(initial: CustomField[], created: CustomField) {
-  let fields = initial;
-  fakeMemberCustomFields(() => fields);
-  return fakeAdminEndpoint('POST', '/members/custom_fields/', () => {
-    fields = [...fields, created];
-    return { members_custom_fields: [created] };
-  });
-}
-
 describe('Custom fields', () => {
   it('stays hidden and does not query the closed endpoint while the flag is off', async () => {
-    fakeSettingsScreens();
     const customFieldsApi = fakeCustomFields();
-    await renderAdminApp('/settings');
+    await renderSettingsScreen('/settings');
 
     await expect(settingsScreen.customFields()).toHaveCount(0);
     expect(customFieldsApi.requests).toHaveLength(0);
   });
 
   it('lists each field with its user-facing type, opting into archived fields', async () => {
-    fakeSettingsScreens();
     const customFieldsApi = fakeCustomFields();
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     // Browse hides archived by default; Settings asks for both statuses.
     await expect
@@ -87,12 +47,11 @@ describe('Custom fields', () => {
   });
 
   it('validates and creates a short-text field without sending a key', async () => {
-    fakeSettingsScreens();
     fakeCustomFields();
     const createApi = fakeAdminEndpoint('POST', '/members/custom_fields/', {
       members_custom_fields: [{ ...companyField, key: 'job_title', name: 'Job Title' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByRole('button', { name: 'Add custom field' }).click();
     const modal = settingsScreen.customFieldModal();
@@ -109,12 +68,11 @@ describe('Custom fields', () => {
   });
 
   it('creates the selected long-text field type', async () => {
-    fakeSettingsScreens();
     fakeCustomFields();
     const createApi = fakeAdminEndpoint('POST', '/members/custom_fields/', {
       members_custom_fields: [{ ...companyField, key: 'bio', name: 'Bio', type: 'long_text' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByRole('button', { name: 'Add custom field' }).click();
     const modal = settingsScreen.customFieldModal();
@@ -130,7 +88,6 @@ describe('Custom fields', () => {
   });
 
   it('shows an API duplicate-name error on the name field without leaking the envelope message', async () => {
-    fakeSettingsScreens();
     fakeCustomFields();
     const createApi = fakeAdminEndpoint(
       'POST',
@@ -147,7 +104,7 @@ describe('Custom fields', () => {
       },
       { status: 422 },
     );
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByRole('button', { name: 'Add custom field' }).click();
     const modal = settingsScreen.customFieldModal();
@@ -162,12 +119,11 @@ describe('Custom fields', () => {
   });
 
   it('renames a field without allowing its type to change', async () => {
-    fakeSettingsScreens();
     fakeCustomFields();
     const editApi = fakeAdminEndpoint('PUT', '/members/custom_fields/company/', {
       members_custom_fields: [{ ...companyField, name: 'Employer' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();
     const modal = settingsScreen.customFieldModal();
@@ -181,12 +137,11 @@ describe('Custom fields', () => {
   });
 
   it('archives a field only after destructive confirmation', async () => {
-    fakeSettingsScreens();
     fakeCustomFields();
     const editApi = fakeAdminEndpoint('PUT', '/members/custom_fields/company/', {
       members_custom_fields: [{ ...companyField, status: 'archived' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();
     await settingsScreen.customFieldModal().getByRole('button', { name: 'Archive' }).click();
@@ -207,9 +162,8 @@ describe('Custom fields', () => {
   });
 
   it('splits fields into Active and Archived tabs', async () => {
-    fakeSettingsScreens();
     fakeCustomFields([companyField, archivedField]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     // Active tab is the default and shows only active fields.
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
@@ -222,14 +176,13 @@ describe('Custom fields', () => {
   });
 
   it('collapses long lists behind Show all, five at a time like recommendations', async () => {
-    fakeSettingsScreens();
     const manyFields = Array.from({ length: 7 }, (_, index) => ({
       ...companyField,
       key: `field_${index}`,
       name: `Field ${index}`,
     }));
     fakeCustomFields(manyFields);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(5);
@@ -248,14 +201,15 @@ describe('Custom fields', () => {
   });
 
   it('reveals a just-created field even when the list is collapsed', async () => {
-    fakeSettingsScreens();
     const initialFields = Array.from({ length: 6 }, (_, index) => ({
       ...companyField,
       key: `field_${index}`,
       name: `Field ${index}`,
     }));
-    fakeCustomFieldsWithCreate(initialFields, { ...companyField, key: 'newest', name: 'Newest' });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    const fieldsApi = fakeMemberCustomFields(initialFields, {
+      create: { response: memberCustomField({ key: 'newest', name: 'Newest' }) },
+    });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(5);
@@ -269,6 +223,9 @@ describe('Custom fields', () => {
 
     await expect(rows).toHaveCount(7);
     await expect.element(rows.last()).toHaveTextContent('Newest');
+    expect(fieldsApi.create.lastRequest?.body).toEqual({
+      members_custom_fields: [{ name: 'Newest', type: 'short_text' }],
+    });
 
     // Save holds the modal open for its ~500ms saving state. Verify the
     // async save has completed and the parent-controlled modal unmounts.
@@ -276,7 +233,6 @@ describe('Custom fields', () => {
   });
 
   it('reorders a field by dragging it, sending the whole list in its new order', async () => {
-    fakeSettingsScreens();
     const shirtField = { ...companyField, key: 'shirt_size', name: 'Shirt size' };
     const nicknameField = { ...companyField, key: 'nickname', name: 'Nickname' };
     let currentFields = [companyField, shirtField, nicknameField];
@@ -287,7 +243,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(3);
@@ -321,7 +277,6 @@ describe('Custom fields', () => {
   });
 
   it('leaves the dragged field where it was dropped while the request is in flight', async () => {
-    fakeSettingsScreens();
     const nicknameField = { ...companyField, key: 'nickname', name: 'Nickname' };
     let currentFields = [companyField, nicknameField];
     fakeMemberCustomFields(() => currentFields);
@@ -340,7 +295,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(2);
@@ -359,7 +314,6 @@ describe('Custom fields', () => {
   });
 
   it('puts the list back and says why when the order is refused', async () => {
-    fakeSettingsScreens();
     const nicknameField = { ...companyField, key: 'nickname', name: 'Nickname' };
     // What the server has, and what this screen does not know about yet: a third
     // field a colleague added since the page loaded.
@@ -388,7 +342,7 @@ describe('Custom fields', () => {
       },
       { status: 422 },
     );
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(2);
@@ -406,7 +360,6 @@ describe('Custom fields', () => {
   });
 
   it('sends the archived fields too, keeping their places in the order', async () => {
-    fakeSettingsScreens();
     const shirtField = { ...companyField, key: 'shirt_size', name: 'Shirt size' };
     // Archived between the two active fields, which is the arrangement that catches a
     // move applied to the visible tab instead of the whole list.
@@ -418,7 +371,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(2);
@@ -438,7 +391,6 @@ describe('Custom fields', () => {
   });
 
   it('reorders from a collapsed list without disturbing the fields behind Show all', async () => {
-    fakeSettingsScreens();
     let currentFields = Array.from({ length: 7 }, (_, index) => ({
       ...companyField,
       key: `field_${index}`,
@@ -451,7 +403,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(5);
@@ -478,9 +430,8 @@ describe('Custom fields', () => {
   });
 
   it('does not offer dragging on the archived tab', async () => {
-    fakeSettingsScreens();
     fakeCustomFields([companyField, archivedField]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     // An archived field holds its place in the order, but there is nowhere to see
     // it, so there is nothing to drag it through.
@@ -493,10 +444,9 @@ describe('Custom fields', () => {
   });
 
   it('permanently deletes an archived field from the header menu, after a heavy warning', async () => {
-    fakeSettingsScreens();
     const customFieldsApi = fakeCustomFields([companyField, archivedField]);
     const deleteApi = fakeAdminEndpoint('DELETE', '/members/custom_fields/old_hobby/', {});
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByRole('tab', { name: 'Archived' }).click();
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();
@@ -524,9 +474,8 @@ describe('Custom fields', () => {
   });
 
   it('does not expose permanent deletion for an active field', async () => {
-    fakeSettingsScreens();
     fakeCustomFields([companyField]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     // Deletion lives behind the header menu, and an active field has none —
     // the UI can't reach delete, matching the API's archived-only rule.
@@ -536,21 +485,19 @@ describe('Custom fields', () => {
   });
 
   it('shows no tabs at all while no fields exist', async () => {
-    fakeSettingsScreens();
     fakeCustomFields([]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await expect.element(settingsScreen.customFields()).toBeVisible();
     await expect(settingsScreen.customFields().getByRole('tab')).toHaveCount(0);
   });
 
   it('reactivates an archived field after confirmation, as a status edit', async () => {
-    fakeSettingsScreens();
     const customFieldsApi = fakeCustomFields([companyField, archivedField]);
     const editApi = fakeAdminEndpoint('PUT', '/members/custom_fields/old_hobby/', {
       members_custom_fields: [{ ...archivedField, status: 'active' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderSettingsScreen('/settings', { labs: { membersCustomFields: true } });
 
     await settingsScreen.customFields().getByRole('tab', { name: 'Archived' }).click();
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();

--- a/apps/admin/src/settings/membership/tiers-checkout.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/tiers-checkout.acceptance.test.tsx
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
-  configResponse,
+  connectedStripeSettings,
+  memberCustomField,
   fakeAdminEndpoint,
   fakeMemberCustomFields,
-  fakeSettingsScreens,
   fakeTiers,
-  renderAdminApp,
-  settingsResponse,
+  renderSettingsScreen,
   tier,
 } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
@@ -20,41 +19,12 @@ const supporterTier = tier({
   slug: 'basic-supporter',
 });
 
-const addressField = {
+const addressField = memberCustomField({
   key: 'shipping_address',
   name: 'Shipping Address',
   type: 'address',
-  status: 'active',
-  created_at: '2026-07-13T00:00:00.000Z',
-  updated_at: null as string | null,
-};
-
-const nameField = {
-  ...addressField,
-  key: 'recipient_name',
-  name: 'Recipient Name',
-  type: 'short_text',
-};
-
-function stripeSettings(overrides: Parameters<typeof settingsResponse>[0] = {}) {
-  return settingsResponse({
-    ...overrides,
-    settings: {
-      stripe_connect_display_name: 'Dummy',
-      stripe_connect_livemode: false,
-      stripe_connect_account_id: 'acct_123',
-      stripe_connect_publishable_key: 'pk_test_123',
-      stripe_connect_secret_key: 'sk_test_123',
-      ...overrides.settings,
-    },
-  });
-}
-
-// The flag lives in settings and config in lockstep, and Stripe rides along in settings.
-const flagOnBoot = {
-  browseConfig: { response: configResponse({ labs: { membersCustomFields: true } }) },
-  browseSettings: { response: stripeSettings({ labs: { membersCustomFields: true } }) },
-};
+});
+const nameField = memberCustomField({ key: 'recipient_name', name: 'Recipient Name' });
 
 const supporterConfig = {
   tier_id: supporterTier.id,
@@ -70,7 +40,6 @@ const supporterConfig = {
 
 /** The world most specs share: both tiers, both fields, and a declared configuration. */
 function checkoutWorld(configs: object[] = []) {
-  fakeSettingsScreens();
   fakeTiers([freeTier, supporterTier]);
   fakeMemberCustomFields([addressField, nameField]);
   fakeAdminEndpoint('GET', '/tiers/checkout_config/', { tiers_checkout_config: configs });
@@ -89,12 +58,11 @@ async function openSupporterModal() {
 
 describe('Tier checkout collection', () => {
   it('keeps the tier modal untouched and the endpoint unqueried while the flag is off', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
     const configApi = fakeAdminEndpoint('GET', '/tiers/checkout_config/', {
       tiers_checkout_config: [],
     });
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     const modal = await openSupporterModal();
     await expect(modal.getByText('Checkout', { exact: true })).toHaveCount(0);
@@ -104,7 +72,6 @@ describe('Tier checkout collection', () => {
   // The deploy-compatibility rule in apps/admin/README.md: an Admin deployed ahead of a
   // Core without this endpoint must keep existing tier editing intact.
   it('renders the tier modal without the section against a Core without the endpoint', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
     // The flag also shows the Custom fields settings group, which browses the fields.
     fakeMemberCustomFields([]);
@@ -114,7 +81,10 @@ describe('Tier checkout collection', () => {
       { errors: [{ type: 'NotFoundError', message: 'Resource not found error.' }] },
       { status: 404 },
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await expect(modal.getByText('Checkout', { exact: true })).toHaveCount(0);
@@ -122,7 +92,6 @@ describe('Tier checkout collection', () => {
   });
 
   it("holds the section's place with an explanation when the configuration read fails", async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
     fakeMemberCustomFields([]);
     fakeAdminEndpoint(
@@ -131,7 +100,10 @@ describe('Tier checkout collection', () => {
       { errors: [{ type: 'InternalServerError', message: 'Something went wrong.' }] },
       { status: 500 },
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await expect.element(modal.getByText(/could not be loaded/)).toBeVisible();
@@ -140,7 +112,10 @@ describe('Tier checkout collection', () => {
 
   it('shows no checkout section on the free tier', async () => {
     checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     await settingsScreen.tiers().getByText(freeTier.name, { exact: true }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -150,7 +125,10 @@ describe('Tier checkout collection', () => {
 
   it('reflects the saved configuration and writes nothing when untouched', async () => {
     const putApi = checkoutWorld([supporterConfig]);
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await expect.element(modal.getByLabelText('Collect shipping address')).toBeChecked();
@@ -182,7 +160,10 @@ describe('Tier checkout collection', () => {
     const everywhere = { ...supporterConfig.shipping };
     delete (everywhere as { allowed_countries?: string[] }).allowed_countries;
     checkoutWorld([{ ...supporterConfig, shipping: everywhere }]);
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await expect.element(modal.getByLabelText('Collect shipping address')).toBeChecked();
@@ -192,7 +173,10 @@ describe('Tier checkout collection', () => {
 
   it('validates destinations inline before anything is written', async () => {
     const putApi = checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -204,7 +188,10 @@ describe('Tier checkout collection', () => {
 
   it('saves the chosen collections, stating every block explicitly', async () => {
     const putApi = checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -240,7 +227,6 @@ describe('Tier checkout collection', () => {
   // picker it names, carrying the server's own words rather than a guess restated here.
   it('shows a refused destination against the picker that named it', async () => {
     const refusal = 'An archived custom field cannot receive collected data. Restore it first.';
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
     fakeMemberCustomFields([addressField, nameField]);
     fakeAdminEndpoint('GET', '/tiers/checkout_config/', { tiers_checkout_config: [] });
@@ -259,7 +245,10 @@ describe('Tier checkout collection', () => {
       },
       { status: 422 },
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -280,17 +269,16 @@ describe('Tier checkout collection', () => {
   });
 
   it('creates a destination field from inside the picker', async () => {
-    let fields = [addressField];
     const created = { ...nameField, key: 'gift_recipient', name: 'Gift Recipient' };
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
-    fakeMemberCustomFields(() => fields);
-    fakeAdminEndpoint('GET', '/tiers/checkout_config/', { tiers_checkout_config: [] });
-    const createApi = fakeAdminEndpoint('POST', '/members/custom_fields/', () => {
-      fields = [...fields, created];
-      return { members_custom_fields: [created] };
+    const { create: createApi } = fakeMemberCustomFields([addressField], {
+      create: { response: created },
     });
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    fakeAdminEndpoint('GET', '/tiers/checkout_config/', { tiers_checkout_config: [] });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -318,7 +306,6 @@ describe('Tier checkout collection', () => {
       yearly_price: 8000,
     });
     let saved = false;
-    fakeSettingsScreens();
     fakeTiers(() => (saved ? [freeTier, supporterTier, createdTier] : [freeTier, supporterTier]));
     fakeMemberCustomFields([addressField, nameField]);
     fakeAdminEndpoint('GET', '/tiers/checkout_config/', { tiers_checkout_config: [] });
@@ -335,7 +322,10 @@ describe('Tier checkout collection', () => {
         ],
       }),
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     await settingsScreen.tiers().getByRole('button', { name: 'Add tier' }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -377,7 +367,10 @@ describe('Tier checkout collection', () => {
 
   it('closes without confirmation after saving checkout edits', async () => {
     const putApi = checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect business tax ID').click();
@@ -392,7 +385,10 @@ describe('Tier checkout collection', () => {
 
   it('asks before discarding unsaved checkout edits', async () => {
     checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderSettingsScreen('/settings', {
+      labs: { membersCustomFields: true },
+      settings: connectedStripeSettings(),
+    });
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect phone number').click();

--- a/apps/admin/src/settings/membership/tiers.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/tiers.acceptance.test.tsx
@@ -2,13 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
 import {
-  configResponse,
+  connectedStripeSettings,
   fakeAdminEndpoint,
   fakeEditSettings,
-  fakeSettingsScreens,
   fakeTiers,
-  renderAdminApp,
-  settingsResponse,
+  renderSettingsScreen,
   tier,
 } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
@@ -21,39 +19,6 @@ const supporterTier = tier({
   benefits: ['Simple benefit'],
 });
 
-function stripeSettings(overrides: Parameters<typeof settingsResponse>[0] = {}) {
-  return settingsResponse({
-    ...overrides,
-    settings: {
-      stripe_connect_display_name: 'Dummy',
-      stripe_connect_livemode: false,
-      stripe_connect_account_id: 'acct_123',
-      stripe_connect_publishable_key: 'pk_test_123',
-      stripe_connect_secret_key: 'sk_test_123',
-      ...overrides.settings,
-    },
-  });
-}
-
-function withoutSettings(keys: string[]) {
-  const response = stripeSettings({ labs: { machinePayments: true } });
-  response.settings = response.settings.filter(({ key }) => !keys.includes(key));
-  return response;
-}
-
-function stripeLimitConfig() {
-  const config = configResponse();
-  config.config.hostSettings = {
-    limits: {
-      limitStripeConnect: {
-        disabled: true,
-        error: "Your current plan doesn't support Stripe Connect.",
-      },
-    },
-  };
-  return config;
-}
-
 describe('Tier settings', () => {
   it('validates and creates a paid tier in the visible list', async () => {
     const created = tier({
@@ -64,13 +29,12 @@ describe('Tier settings', () => {
       yearly_price: 8000,
     });
     let saved = false;
-    fakeSettingsScreens();
     fakeTiers(() => (saved ? [freeTier, supporterTier, created] : [freeTier, supporterTier]));
     const createApi = fakeAdminEndpoint('POST', '/tiers/', () => {
       saved = true;
       return { tiers: [created] };
     });
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     await settingsScreen.tiers().getByRole('button', { name: 'Add tier' }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -103,10 +67,9 @@ describe('Tier settings', () => {
       trial_days: 7,
       benefits: ['Simple benefit', 'New benefit'],
     };
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
     const editApi = fakeAdminEndpoint('PUT', `/tiers/${supporterTier.id}/`, { tiers: [updated] });
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     await settingsScreen.tiers().getByText(supporterTier.name, { exact: true }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -147,10 +110,9 @@ describe('Tier settings', () => {
       welcome_page_url: '/welcome-page/',
       benefits: ['First benefit', 'Second benefit'],
     };
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
     const editApi = fakeAdminEndpoint('PUT', `/tiers/${freeTier.id}/`, { tiers: [updated] });
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     await settingsScreen.tiers().getByText(freeTier.name, { exact: true }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -179,9 +141,8 @@ describe('Tier settings', () => {
       ...supporterTier,
       benefits: Array.from({ length: 12 }, (_, index) => `Benefit ${index + 1}`),
     };
-    fakeSettingsScreens();
     fakeTiers([freeTier, scrollingTier]);
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     await settingsScreen.tiers().getByText(scrollingTier.name, { exact: true }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -229,13 +190,12 @@ describe('Tier settings', () => {
 
   it('moves a tier between the Active and Archived tabs when archived and reactivated', async () => {
     let currentSupporter = supporterTier;
-    fakeSettingsScreens();
     fakeTiers(() => [freeTier, currentSupporter]);
     const editApi = fakeAdminEndpoint('PUT', `/tiers/${supporterTier.id}/`, ({ body }) => {
       currentSupporter = (body as { tiers: [typeof supporterTier] }).tiers[0];
       return { tiers: [currentSupporter] };
     });
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     const section = settingsScreen.tiers();
     const tierName = section.getByText(supporterTier.name, { exact: true });
@@ -281,11 +241,10 @@ describe('Tier settings', () => {
 
   it('shows a hidden paid tier as unchecked in portal signup options and saves enabling it', async () => {
     const hidden = { ...supporterTier, visibility: 'none' as const };
-    fakeSettingsScreens();
     fakeTiers([freeTier, hidden]);
     fakeEditSettings();
     const tierApi = fakeAdminEndpoint('PUT', `/tiers/${hidden.id}/`, ({ body }) => body);
-    await renderAdminApp('/settings', { boot: { browseSettings: { response: stripeSettings() } } });
+    await renderSettingsScreen('/settings', { settings: connectedStripeSettings() });
 
     await settingsScreen.portal().getByRole('button', { name: 'Customize' }).click();
     const modal = settingsScreen.portalModal();
@@ -302,10 +261,14 @@ describe('Tier settings', () => {
   });
 
   it('blocks Stripe connection when the plan limit applies', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
-    await renderAdminApp('/settings', {
-      boot: { browseConfig: { response: stripeLimitConfig() } },
+    await renderSettingsScreen('/settings', {
+      limits: {
+        limitStripeConnect: {
+          disabled: true,
+          error: "Your current plan doesn't support Stripe Connect.",
+        },
+      },
     });
 
     await settingsScreen.tiers().getByRole('button', { name: 'Connect with Stripe' }).click();
@@ -318,13 +281,15 @@ describe('Tier settings', () => {
   });
 
   it('allows an already-connected site to manage Stripe despite the plan limit', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
-    await renderAdminApp('/settings', {
-      boot: {
-        browseConfig: { response: stripeLimitConfig() },
-        browseSettings: { response: stripeSettings() },
+    await renderSettingsScreen('/settings', {
+      limits: {
+        limitStripeConnect: {
+          disabled: true,
+          error: "Your current plan doesn't support Stripe Connect.",
+        },
       },
+      settings: connectedStripeSettings(),
     });
 
     await settingsScreen
@@ -337,11 +302,10 @@ describe('Tier settings', () => {
   });
 
   it('shows agent payment controls when the lab is on and the backend has deployed them', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
-    await renderAdminApp('/settings', {
+    await renderSettingsScreen('/settings', {
       labs: { machinePayments: true },
-      boot: { browseSettings: { response: stripeSettings({ labs: { machinePayments: true } }) } },
+      settings: connectedStripeSettings(),
     });
 
     await expect
@@ -353,11 +317,11 @@ describe('Tier settings', () => {
   });
 
   it('hides agent payment controls when the backend has not deployed them', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
-    await renderAdminApp('/settings', {
+    await renderSettingsScreen('/settings', {
       labs: { machinePayments: true },
-      boot: { browseSettings: { response: withoutSettings(['machine_payments_enabled']) } },
+      settings: connectedStripeSettings(),
+      omitSettings: ['machine_payments_enabled'],
     });
 
     await expect(settingsScreen.tiers().getByText('Accept payments from AI agents')).toHaveCount(0);
@@ -365,10 +329,14 @@ describe('Tier settings', () => {
   });
 
   it('blocks direct access to Stripe connection when the plan limit applies', async () => {
-    fakeSettingsScreens();
     fakeTiers([freeTier, supporterTier]);
-    await renderAdminApp('/settings/stripe-connect', {
-      boot: { browseConfig: { response: stripeLimitConfig() } },
+    await renderSettingsScreen('/settings/stripe-connect', {
+      limits: {
+        limitStripeConnect: {
+          disabled: true,
+          error: "Your current plan doesn't support Stripe Connect.",
+        },
+      },
     });
 
     await expect

--- a/apps/admin/src/settings/site/navigation.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/navigation.acceptance.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
-import { fakeEditSettings, fakeSettingsScreens, renderAdminApp } from '@test-utils/acceptance';
+import { fakeEditSettings, renderSettingsScreen } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
 
 const primaryNavigation = settingsScreen.navigationPrimaryPanel;
@@ -10,9 +10,8 @@ const newItem = () => primaryNavigation().newItem();
 
 describe('Navigation settings', () => {
   it('edits primary and secondary navigation', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings/navigation/edit');
+    await renderSettingsScreen('/settings/navigation/edit');
 
     const modal = settingsScreen.navigationModal();
     const primaryTab = modal.getByRole('tab', { name: 'Primary' });
@@ -56,8 +55,7 @@ describe('Navigation settings', () => {
   });
 
   it('validates existing items and clears errors while editing', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings/navigation/edit');
+    await renderSettingsScreen('/settings/navigation/edit');
 
     const item = existingItem();
     await item.getByLabelText('Label').fill('');
@@ -77,8 +75,7 @@ describe('Navigation settings', () => {
   });
 
   it('validates and adds a new item', async () => {
-    fakeSettingsScreens();
-    await renderAdminApp('/settings/navigation/edit');
+    await renderSettingsScreen('/settings/navigation/edit');
 
     await expect(primaryNavigation().itemEditors()).toHaveCount(2);
     const item = newItem();
@@ -106,9 +103,8 @@ describe('Navigation settings', () => {
   });
 
   it('confirms before discarding unsaved changes', async () => {
-    fakeSettingsScreens();
     const settingsApi = fakeEditSettings();
-    await renderAdminApp('/settings/navigation/edit');
+    await renderSettingsScreen('/settings/navigation/edit');
 
     await newItem().getByLabelText('Label').fill('Label');
     await newItem().getByLabelText('URL').fill('https://google.com');

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -18,25 +18,10 @@ import { tagDetailScreen } from './tag-detail.screen';
 
 const FLAGS = { labs: { tagDetailsReact: true } };
 
-/**
- * A working single-tag fake: the slug read serves the latest state and writes
- * update it, so the post-save refetch reflects what was saved — the shape a
- * real server has, which the screen's dirty tracking depends on.
- */
-function fakeTagWorld(t: Tag) {
-  let current = t;
-  fakeAdminEndpoint('GET', new RegExp(`^/tags/slug/${t.slug}/`), () => ({ tags: [current] }));
-  const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/tags/${t.id}/`), ({ body }) => {
-    current = { ...current, ...(body as { tags: Partial<Tag>[] }).tags[0] };
-    return { tags: [current] };
-  });
-  return saveApi;
-}
-
 describe('Tag detail (tagDetailsReact on)', () => {
   it('renders the seeded tag', async () => {
     const t = tag({ name: 'News', slug: 'news', description: 'All the news', count: { posts: 3 } });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await expect.element(tagDetailScreen.title()).toHaveTextContent('News');
@@ -62,7 +47,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('shows an internal badge after the name for internal tags', async () => {
     const t = tag({ name: '#News', slug: 'hash-news', visibility: 'internal' });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await expect.element(tagDetailScreen.title()).toHaveTextContent('#News');
@@ -71,7 +56,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('shows metadata in Search, X card, and Facebook card tabs', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     const metadataCard = tagDetailScreen.metadataCard();
@@ -148,7 +133,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
       codeinjection_head: head,
       codeinjection_foot: foot,
     });
-    const saveApi = fakeTagWorld(t);
+    const { update: saveApi } = fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await expect
@@ -183,14 +168,14 @@ describe('Tag detail (tagDetailsReact on)', () => {
     await tagDetailScreen.saveButton().click();
 
     await expect.element(tagDetailScreen.savedButton()).toBeVisible();
-    const saved = (saveApi.lastRequest?.body as { tags: Array<Record<string, unknown>> }).tags[0];
+    const saved = saveApi.lastRequest!.body.tags[0];
     expect(saved.codeinjection_head).toBe(updatedHead);
     expect(saved.codeinjection_foot).toBe(updatedFoot);
   });
 
   it('opens code injection when only the footer contains code', async () => {
     const t = tag({ name: 'News', slug: 'news', codeinjection_foot: '<script>footer();</script>' });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await expect
@@ -201,7 +186,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('keeps CodeMirror autocomplete visible in the code injection accordion', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.codeInjectionTrigger().click();
@@ -238,7 +223,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('offers Unsplash for an empty tag image', async () => {
     const t = tag({ name: 'News', slug: 'news', feature_image: null });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     fakeEndpoint('GET', 'https://api.unsplash.com/photos', []);
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
@@ -249,8 +234,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('does not treat an open image picker as a dirty tag', async () => {
     const t = tag({ name: 'News', slug: 'news', feature_image: null });
-    fakeTags([t]);
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     fakeEndpoint('GET', 'https://api.unsplash.com/photos', []);
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
@@ -267,19 +251,21 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('saves edits and reports the saved state', async () => {
     const t = tag({ name: 'News', slug: 'news', visibility: 'public' });
-    const saveApi = fakeTagWorld(t);
+    const { read: reads, update: saveApi } = fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.nameInput().fill('Renamed');
     await tagDetailScreen.saveButton().click();
 
     await expect.element(tagDetailScreen.savedButton()).toBeVisible();
-    const saved = (saveApi.lastRequest?.body as { tags: Array<Record<string, unknown>> }).tags[0];
+    const saved = saveApi.lastRequest!.body.tags[0];
     expect(saved.name).toBe('Renamed');
     expect(saved.slug).toBe('news');
     // The name changed, so the payload re-derives visibility (Ember
     // `models/tag.js` recomputes it in `save()` whenever the name changed).
     expect(saved.visibility).toBe('public');
+    await expect.poll(() => reads.requests.length).toBeGreaterThan(1);
+    await expect.element(tagDetailScreen.nameInput()).toHaveValue('Renamed');
   });
 
   it('preserves whitespace in untouched fields on a clean save', async () => {
@@ -289,21 +275,20 @@ describe('Tag detail (tagDetailsReact on)', () => {
       description: '\nImportant\n',
       meta_title: ' Meta title ',
     });
-    const saveApi = fakeTagWorld(t);
+    const { update: saveApi } = fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.saveButton().click();
 
     await expect.element(tagDetailScreen.savedButton()).toBeVisible();
-    const saved = (saveApi.lastRequest?.body as { tags: Array<Record<string, unknown>> }).tags[0];
+    const saved = saveApi.lastRequest!.body.tags[0];
     expect(saved.description).toBe('\nImportant\n');
     expect(saved.meta_title).toBe(' Meta title ');
   });
 
   it('guards edits made after a same-slug save', async () => {
     const t = tag({ name: 'News', slug: 'news', visibility: 'public' });
-    fakeTags([t]);
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.nameInput().fill('Renamed');
@@ -319,7 +304,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
   it('creates a tag from /tags/new, generating the slug from the name', async () => {
     const created = tag({ name: 'Weekly News', slug: 'weekly-news' });
     const createApi = fakeAdminEndpoint('POST', new RegExp('^/tags/'), { tags: [created] });
-    fakeTagWorld(created);
+    fakeTags([created], { read: true, update: true });
     await renderAdminApp('/tags/new', FLAGS);
 
     await expect.element(tagDetailScreen.title()).toHaveTextContent('New tag');
@@ -340,7 +325,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('shows validation errors instead of saving an invalid tag', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    const saveApi = fakeTagWorld(t);
+    const { update: saveApi } = fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.nameInput().fill('');
@@ -355,7 +340,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('waits for an image upload before allowing the tag to save', async () => {
     const t = tag({ name: 'News', slug: 'news', feature_image: null });
-    const saveApi = fakeTagWorld(t);
+    const { update: saveApi } = fakeTags([t], { read: true, update: true });
     const pendingUpload = deferred<{ images: { url: string; ref: null }[] }>();
     const uploadApi = fakeAdminEndpoint('POST', '/images/upload/', () => pendingUpload.promise);
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
@@ -378,13 +363,13 @@ describe('Tag detail (tagDetailsReact on)', () => {
     await tagDetailScreen.saveButton().click();
 
     await expect.element(tagDetailScreen.savedButton()).toBeVisible();
-    const saved = (saveApi.lastRequest?.body as { tags: Array<Record<string, unknown>> }).tags[0];
+    const saved = saveApi.lastRequest!.body.tags[0];
     expect(saved.feature_image).toBe('https://example.com/tag.png');
   });
 
   it('rejects image formats that the legacy uploader does not support', async () => {
     const t = tag({ name: 'News', slug: 'news', feature_image: null });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen
@@ -398,7 +383,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('shows the legacy message when an image exceeds the server limit', async () => {
     const t = tag({ name: 'News', slug: 'news', feature_image: null });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     fakeAdminEndpoint('POST', '/images/upload/', null, { status: 413 });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
@@ -418,9 +403,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
   it('clears save state when navigating to another tag', async () => {
     const first = tag({ name: 'First', slug: 'first' });
     const second = tag({ name: 'Second', slug: 'second' });
-    fakeTags([first, second]);
-    fakeTagWorld(first);
-    fakeTagWorld(second);
+    fakeTags([first, second], { read: true, update: true });
     await renderAdminApp(`/tags/${first.slug}`, FLAGS);
 
     await tagDetailScreen.saveButton().click();
@@ -586,8 +569,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('deletes the tag after confirming, reporting the posts it is used on', async () => {
     const t = tag({ name: 'News', slug: 'news', count: { posts: 3 } });
-    fakeTags([t]);
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     const deleteApi = fakeAdminEndpoint('DELETE', new RegExp(`^/tags/${t.id}/`), null, {
       status: 204,
     });
@@ -607,7 +589,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('uses the current draft name in the delete confirmation', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.nameInput().fill('Draft name');
@@ -641,8 +623,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('keeps the Tags nav item active while editing a tag from the list', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    fakeTags([t]);
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp('/tags', FLAGS);
 
     await tagsScreen.tagRows().getByRole('link', { name: 'News' }).click();
@@ -653,8 +634,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
   it('guards leaving with unsaved edits via the breadcrumb', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    fakeTags([t]);
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.nameInput().fill('Renamed');
@@ -674,8 +654,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 describe('Tag detail history guard', () => {
   it('confirms before the back button leaves a dirty tag opened from the list', async () => {
     const t = tag({ name: 'News', slug: 'news' });
-    fakeTags([t]);
-    fakeTagWorld(t);
+    fakeTags([t], { read: true, update: true });
     await renderAdminApp('/site', FLAGS);
 
     await sidebarScreen.navLink('Tags').click();

--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -25,7 +25,7 @@ await expect.poll(currentRoute).toBe("/members");   // URL assertions
 await expect.poll(() => document.documentElement.classList.contains("dark")).toBe(true);   // DOM state no locator reaches
 ```
 
-**One render per test.** Each `renderAdminApp` gets a fresh QueryClient and the fake API resets between tests — there is no reload. State that would be persisted on a real server (user preferences, settings) is _represented_ by boot overrides; a journey that genuinely needs persistence across reloads belongs in `e2e/`.
+**One render per test.** Each `renderAdminApp` gets a fresh QueryClient. The fake API retains managed settings and current-user edits through refetches within the test, then resets after pending requests drain. There is no reload; a journey that needs persistence across reloads belongs in `e2e/`.
 
 **Host page.** `renderAdminApp` mounts into a stand-in of the production host page (the `react-admin` body class + `#root` from index.html), so the shell's viewport-bounded grid applies and scroll-driven behaviors — virtualized lists, infinite paging — work like production.
 
@@ -41,22 +41,97 @@ When your area calls a new external origin, add it to `EXTERNAL_URL_BLOCKLIST` i
 
 **THE RULE:** fakes never implement NQL — declare the response and assert the outgoing filter string instead (see the doc comment in `resources.ts`).
 
-## The boot table
+## Constructing a scenario
 
-The shell requests handled by default (`boot.ts`): `browseSettings`, `browseConfig`, `browseSite`, `browseMe`, `browseMembersCount`, `browseActiveTheme`, `editUserPreferences`. A **boot override** replaces the response of one named entry for one test (the entry's method/path stay fixed):
+Import builders, fakes, and render helpers from `@test-utils/acceptance`. Builders come from `@tryghost/test-data`, shared with e2e. Render options describe the settings, config, and current user without editing API envelopes:
 
 ```ts
-// Labs flags (sugar for lockstep settings + config overrides; merges into
-// any browseSettings/browseConfig boot override, named flags winning):
-await renderAdminApp("/tags", {labs: {someFlag: true}});
+await renderSettingsScreen('/settings', {
+  settings: {...connectedStripeSettings(), title: 'My publication'},
+  labs: {machinePayments: true},
+  omitSettings: ['machine_payments_enabled'], // An older backend lacks this setting
+  limits: {staff: {max: 4}},
+});
 
-// Persisted user state, e.g. what's-new preferences:
-const me = currentUserResponse();
-me.users[0].accessibility = JSON.stringify({whatsNew: {lastSeenDate: "2025-01-01T00:00:00.000Z"}});
-await renderAdminApp("/tags", {boot: {browseMe: {response: me}}});
+fakeTags([]);
+await renderAdminApp('/tags', {
+  config: {stats: {id: 'analytics-site'}},
+  user: {
+    roles: ['Editor'],
+    accessibility: {whatsNew: {lastSeenDate: '2025-01-01T00:00:00.000Z'}},
+  },
+});
 ```
 
-Boot responses are STATELESS — a canned reply per request, nothing is stored — with one exception: `editUserPreferences` echoes the PUT's user fields back, because the framework replaces its cached current user with that response (a canned reply would silently wipe every preferences write).
+These are separate tests: use one render per test.
+
+| Option         | Behavior                                                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `settings`     | Overrides values by key; other defaults remain. `null` is a value.                                                        |
+| `omitSettings` | Removes keys entirely. Unrelated saves leave them absent. Supplying and omitting the same key is an error.                |
+| `labs`         | Sets flags in both settings and config, including explicit `false`. Use this instead of `settings.labs` or `config.labs`. |
+| `config`       | Overrides top-level fields. Nested objects replace; there is no general deep merge.                                       |
+| `limits`       | Replaces named limits while retaining other limits and host settings. Cannot accompany `config.hostSettings.limits`.      |
+| `user`         | Overrides the current user. Role names expand to role objects; accessibility is serialized to the API string.             |
+
+Settings writes remain opt-in. Register `fakeEditSettings()` when the test saves: successful edits merge into the scenario, so later writes and refetches retain unrelated settings, omissions, and Stripe credentials. A labs save also updates managed config. Current-user preferences writes are handled by default, preserve the seeded identity, and are visible on subsequent reads. Writes to another user require an explicit fake; otherwise they 418.
+
+### Screen presets
+
+`renderSettingsScreen(route?, options?)` installs the incidental settings-screen reads. `renderPostsListScreen(route?, options?)` installs the posts-list defaults and enables `postsListReact`; an explicit `labs: {postsListReact: false}` still wins. Both return the same result as `renderAdminApp`.
+
+```ts
+fakeTiers([tier({name: 'Supporter'})]);
+const settingsApi = fakeEditSettings(); // The preset does not enable saves
+await renderSettingsScreen('/settings', {settings: connectedStripeSettings()});
+// Interact with the settings UI, then assert settingsApi's captured writes.
+```
+
+Presets supply defaults below explicit fakes, even if the explicit fake was registered first. Among explicit fakes, the latest matching registration still wins: register an error after a resource fake to reject a request, or register a replacement after an error to recover. Presets do not enable tag updates or custom-field creates either. The lower-level `fakeSettingsScreens()` and `fakePostsListScreen()` remain available with their existing explicit registration behavior.
+
+### Raw boot overrides
+
+The shell requests handled by default (`boot.ts`): `browseSettings`, `browseConfig`, `browseSite`, `browseMe`, `browseMembersCount`, `browseActiveTheme`, `editUserPreferences`. Use `boot` for response errors, callbacks, and unusual wire shapes:
+
+```ts
+await renderAdminApp('/tags', {
+  boot: {browseConfig: {response: {errors: [{message: 'Unavailable'}]}, responseStatus: 400}},
+});
+```
+
+A raw response replaces the named entry's body; method/path stay fixed, and callbacks run at request time. Status-only overrides retain the managed response. Supplying `settings`/`omitSettings`, `config`/`limits`, or `user` alongside the corresponding raw read response is an error: choose one source for that read. `labs` remains compatible with raw settings/config bodies and callbacks; named flags win when the response has a recognized envelope. Use a raw settings response when the labs key itself must be absent.
+
+Raw reads do not seed managed state. A raw `browseSettings` keeps the legacy stateless settings-write echo; a raw `browseMe` keeps the legacy preferences echo. Their subsequent reads still serve the raw response. A raw preferences-write override can accompany a managed `user` seed, but does not commit edits; a failed status-only preference write does not commit either.
+
+## Opt-in resource operations
+
+Browse-only declarations retain their existing signatures and behavior. Opt into the concrete operations needed by a journey:
+
+```ts
+const news = tag({name: 'News', slug: 'news'});
+const tagsApi = fakeTags([news], {read: true, update: true});
+await renderAdminApp('/tags/news', {labs: {tagDetailsReact: true}});
+// Edit and save through the UI. Reads by ID or the new slug now see the edit.
+await expect.poll(() => tagsApi.update.lastRequest?.body.tags[0].name).toBe('Renamed');
+```
+
+Tag detail reads support ID and slug; updates support ID and preserve it. Declare the full collection once, including every tag the test navigates to. The fake does not transform edited values or simulate creation/deletion. A missing tag returns 404. Browse requests use the existing `.requests`/`.lastRequest` capture; opted-in operations have typed `.read` and `.update` captures. Mutable fakes clone the seed and require arrays, not browse callbacks.
+
+Inline `true` options give required capture properties. With boolean variables, captures are optional because the operation may be disabled; use `tagsApi.update?.lastRequest` or retain literal types with `as const` when extracting fixed options.
+
+```ts
+const fieldsApi = fakeMemberCustomFields(
+  [memberCustomField({key: 'company', name: 'Company'})],
+  {create: {response: memberCustomField({key: 'department', name: 'Department'})}},
+);
+await renderSettingsScreen('/settings', {labs: {membersCustomFields: true}});
+// Create through the UI. The declared result joins subsequent browse responses.
+await expect.poll(() => fieldsApi.create.lastRequest?.body).toEqual({
+  members_custom_fields: [{name: 'Department', type: 'short_text'}],
+});
+```
+
+Custom-field creation consumes exactly one declared response; another POST 418s. The fake does not generate keys or implement server validation. Use an explicit endpoint for reorder/edit/delete or other behavior. An explicit error handler registered after either mutable fake rejects the write without changing its collection.
 
 ## Faking a resource that has no fake yet
 

--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -46,7 +46,8 @@ When your area calls a new external origin, add it to `EXTERNAL_URL_BLOCKLIST` i
 The shell requests handled by default (`boot.ts`): `browseSettings`, `browseConfig`, `browseSite`, `browseMe`, `browseMembersCount`, `browseActiveTheme`, `editUserPreferences`. A **boot override** replaces the response of one named entry for one test (the entry's method/path stay fixed):
 
 ```ts
-// Labs flags (sugar for lockstep settings + config overrides):
+// Labs flags (sugar for lockstep settings + config overrides; merges into
+// any browseSettings/browseConfig boot override, named flags winning):
 await renderAdminApp("/tags", {labs: {someFlag: true}});
 
 // Persisted user state, e.g. what's-new preferences:

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -85,6 +85,94 @@ export function defaultBootRoutes(): string[] {
   return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
 }
 
+type LabsFlags = Record<string, boolean>;
+type BootOverride = NonNullable<BootOverrides[BootRequestName]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseLabsSettingValue(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'string') {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+// Unrecognized bodies (error envelopes, non-objects) pass through untouched;
+// recognized ones are clone-and-merged — never mutate a test-owned object.
+function mergeLabsIntoConfigBody(body: unknown, labs: LabsFlags): unknown {
+  if (!isRecord(body) || !isRecord(body.config)) {
+    return body;
+  }
+  const existing = isRecord(body.config.labs) ? body.config.labs : {};
+  return { ...body, config: { ...body.config, labs: { ...existing, ...labs } } };
+}
+
+function mergeLabsIntoSettingsBody(body: unknown, labs: LabsFlags): unknown {
+  if (!isRecord(body) || !Array.isArray(body.settings)) {
+    return body;
+  }
+  let found = false;
+  const settings = body.settings.map((entry: unknown) => {
+    if (!isRecord(entry) || entry.key !== 'labs') {
+      return entry;
+    }
+    found = true;
+    return { ...entry, value: JSON.stringify({ ...parseLabsSettingValue(entry.value), ...labs }) };
+  });
+  if (!found) {
+    settings.push(...settingsResponse({ labs }).settings.filter(({ key }) => key === 'labs'));
+  }
+  return { ...body, settings };
+}
+
+function withMergedLabs(
+  override: BootOverride,
+  merge: (body: unknown) => unknown,
+  fallback: () => unknown,
+): BootOverride {
+  const { response } = override;
+  if (response === undefined) {
+    return { ...override, response: fallback() };
+  }
+  if (typeof response === 'function') {
+    return {
+      ...override,
+      response: async (request: Request) =>
+        merge(await (response as (request: Request) => unknown)(request)),
+    };
+  }
+  return { ...override, response: merge(response) };
+}
+
+/**
+ * The `labs` render option compiled onto the boot overrides: `browseConfig`/
+ * `browseSettings` overrides get the flags merged into their responses
+ * (flags named in `labs` win); absent entries get the canned test-data
+ * responses with the flags applied.
+ */
+export function composeLabsBootOverrides(labs: LabsFlags, boot: BootOverrides = {}): BootOverrides {
+  return {
+    ...boot,
+    browseConfig: withMergedLabs(
+      boot.browseConfig ?? {},
+      (body) => mergeLabsIntoConfigBody(body, labs),
+      () => configResponse({ labs }),
+    ),
+    browseSettings: withMergedLabs(
+      boot.browseSettings ?? {},
+      (body) => mergeLabsIntoSettingsBody(body, labs),
+      () => settingsResponse({ labs }),
+    ),
+  };
+}
+
 function matches(config: BootRequestConfig, method: string, apiPath: string): boolean {
   if (config.method !== method) {
     return false;

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -6,9 +6,11 @@ import {
   currentUserResponse,
   settingsResponse,
   siteResponse,
+  type Setting,
 } from '@tryghost/test-data';
 
 import { registerAdminApiHandler, registerRoute } from './worker';
+import { createAdminState, type AdminScenarioOptions } from './state';
 
 /**
  * The requests the admin shell fires on boot regardless of route, handled by
@@ -61,7 +63,7 @@ export function defaultBootRequests() {
     },
     editUserPreferences: {
       method: 'PUT',
-      path: /^\/users\/\w+\/\?include=roles/,
+      path: /^\/users\/[^/]+\/\?include=roles/,
       // The framework caches this response as the current user, so a
       // canned reply would wipe the client's write — echo the body.
       response: async (request: Request) => {
@@ -191,30 +193,145 @@ async function respond(config: BootRequestConfig, request: Request): Promise<Res
   });
 }
 
-/** The persistent lowest-priority resolver for the boot table; runtime handlers and overrides win. */
+let state: ReturnType<typeof createAdminState> | undefined;
+let rawSettings = false;
+let rawUser = false;
+
+function currentState() {
+  return (state ??= createAdminState());
+}
+
+/** Reset only after pending requests have drained. */
+export function resetBootState(): void {
+  state = undefined;
+  rawSettings = false;
+  rawUser = false;
+}
+
+/** The composed user for incidental screen chrome, resolved at request time. */
+export function currentBootUser() {
+  return currentState().readUser();
+}
+
+/** Settings writes share the seed unless the test explicitly owns a raw read response. */
+export function editBootSettings(edits: Setting[]) {
+  return rawSettings
+    ? settingsResponse({
+        settings: Object.fromEntries(edits.map(({ key, value }) => [key, value])),
+      })
+    : currentState().editSettings(edits);
+}
+
+function runtimeBootRequests(
+  overrides: BootOverrides = {},
+): Record<BootRequestName, BootRequestConfig> {
+  const defaults: Record<BootRequestName, BootRequestConfig> = defaultBootRequests();
+  defaults.browseSettings.response = () => currentState().readSettings();
+  defaults.browseConfig.response = () => currentState().readConfig();
+  defaults.browseMe.response = () => currentState().readUser();
+  if (!rawUser) {
+    const status = overrides.editUserPreferences?.responseStatus ?? 200;
+    defaults.editUserPreferences.response = async (request: Request) => {
+      const body = (await request.clone().json()) as { users?: Array<Record<string, unknown>> };
+      return currentState().editUser(body.users?.[0] ?? {}, status >= 200 && status < 300);
+    };
+  }
+  return defaults;
+}
+
+function matchesEntry(
+  name: string,
+  config: BootRequestConfig,
+  request: Request,
+  apiPath: string,
+  rawResponse = false,
+): boolean {
+  if (!matches(config, request.method, apiPath)) {
+    return false;
+  }
+  if (name === 'editUserPreferences' && !rawUser && !rawResponse) {
+    const id = apiPath.match(/^\/users\/([^/]+)\//)?.[1];
+    return id !== undefined && currentState().isCurrentUser(decodeURIComponent(id));
+  }
+  return true;
+}
+
+/** The persistent lowest-priority resolver; explicit fakes and presets win. */
 export async function defaultBootResolver(
   request: Request,
   apiPath: string,
 ): Promise<Response | undefined> {
-  const config = Object.values(defaultBootRequests()).find((entry) =>
-    matches(entry, request.method, apiPath),
+  const entry = Object.entries(runtimeBootRequests()).find(([name, config]) =>
+    matchesEntry(name, config, request, apiPath),
   );
-  return config ? await respond(config, request) : undefined;
+  return entry ? await respond(entry[1], request) : undefined;
 }
 
-/** Register per-test boot overrides (higher priority than the defaults). */
+/** Register explicit per-test boot overrides, preserving their registration priority. */
 export function installBootOverrides(overrides: BootOverrides): void {
-  const defaults = defaultBootRequests();
+  const defaults = runtimeBootRequests(overrides);
   const entries = Object.entries(overrides)
     .filter(([, override]) => Boolean(override))
-    .map(([name, override]) => ({ ...defaults[name as BootRequestName], ...override }));
-
-  for (const config of entries) {
+    .map(([name, override]) => ({
+      name,
+      rawResponse: override?.response !== undefined,
+      config: {
+        ...defaults[name as BootRequestName],
+        ...override,
+        response:
+          override?.response === undefined
+            ? defaults[name as BootRequestName].response
+            : override.response,
+      },
+    }));
+  for (const { config } of entries) {
     registerRoute(config.method, config.path);
   }
-
   registerAdminApiHandler(async (request, apiPath) => {
-    const config = entries.find((entry) => matches(entry, request.method, apiPath));
-    return config ? await respond(config, request) : undefined;
+    const entry = entries.find(({ name, config, rawResponse }) =>
+      matchesEntry(name, config, request, apiPath, rawResponse),
+    );
+    return entry ? await respond(entry.config, request) : undefined;
   });
+}
+
+/** Configure once before mounting; callbacks remain raw and are never awaited at setup. */
+export function configureAdminScenario({
+  boot = {},
+  ...options
+}: AdminScenarioOptions & { boot?: BootOverrides } = {}): void {
+  const conflicts: Array<[boolean, BootRequestName, string]> = [
+    [
+      options.settings !== undefined || options.omitSettings !== undefined,
+      'browseSettings',
+      'settings/omitSettings',
+    ],
+    [options.config !== undefined || options.limits !== undefined, 'browseConfig', 'config/limits'],
+    [options.user !== undefined, 'browseMe', 'user'],
+  ];
+  for (const [supplied, name, input] of conflicts) {
+    if (supplied && boot[name]?.response !== undefined) {
+      throw new Error(
+        `${input} conflicts with boot.${name}.response. Declare the read seed with scenario options or a raw response, not both.`,
+      );
+    }
+  }
+  state = createAdminState(options);
+  rawSettings = boot.browseSettings?.response !== undefined;
+  rawUser = boot.browseMe?.response !== undefined;
+
+  const overrides = { ...boot };
+  if (options.labs) {
+    const composed = composeLabsBootOverrides(options.labs, boot);
+    // Only raw bodies need wrapping. Managed reads must remain live after a write.
+    if (rawSettings) {
+      overrides.browseSettings = composed.browseSettings;
+    }
+    if (boot.browseConfig?.response !== undefined) {
+      overrides.browseConfig = composed.browseConfig;
+    }
+  }
+  if (Object.keys(overrides).length > 0) {
+    installBootOverrides(overrides);
+  }
 }

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,6 +1,7 @@
 /** Acceptance-harness public surface — see README.md for the spec anatomy. */
 export { fakeAnalyticsOverview } from './analytics';
 export { currentRoute, renderAdminApp } from './render-admin-app';
+export { renderSettingsScreen, renderPostsListScreen } from './screens';
 export type { RenderAdminAppOptions } from './render-admin-app';
 export {
   defineResource,
@@ -31,6 +32,10 @@ export type {
   BrowseQuery,
   EditSettingsCapture,
   FakeMembersOptions,
+  FakeTagsOptions,
+  TagUpdateBody,
+  FakeMemberCustomFieldsOptions,
+  CustomFieldCreateBody,
   ResourceCapture,
   ResourceOptions,
   ResourceSemantics,
@@ -74,10 +79,12 @@ export {
   comment,
   commentThread,
   configResponse,
+  connectedStripeSettings,
   currentUserResponse,
   defaultThemesResponse,
   label,
   member,
+  memberCustomField,
   memberStatusStat,
   mrrHistoryStat,
   newsletter,
@@ -123,8 +130,10 @@ export type {
   Comment,
   CommentThread,
   CurrentUserResponse,
+  ConnectedStripeSettings,
   Label,
   Member,
+  MemberCustomField,
   MemberStatusStat,
   MrrHistoryStat,
   Newsletter,
@@ -138,6 +147,7 @@ export type {
   PostStats,
   ReplySpec,
   SettingsResponse,
+  SettingValue,
   StaffInvite,
   StaffRole,
   StaffRoleName,

--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -1,20 +1,23 @@
 import { QueryClient } from '@tanstack/react-query';
 import { render } from 'vitest-browser-react';
-import { configResponse, settingsResponse } from '@tryghost/test-data';
 import { defaultUnsplashConfig, type TopLevelFrameworkProps } from '@tryghost/admin-x-framework';
 
 import '@/index.css';
 import { AdminAppRoot } from '@/app-root';
 
-import { installBootOverrides, type BootOverrides } from './boot';
+import { composeLabsBootOverrides, installBootOverrides, type BootOverrides } from './boot';
 
 export interface RenderAdminAppOptions {
   /**
    * Labs flags for this test; compiles to lockstep settings + config boot
-   * overrides (the admin client reads labs from both).
+   * overrides (the admin client reads labs from both). Merges into any
+   * `boot` override for those entries; flags named here win.
    */
   labs?: Record<string, boolean>;
-  /** Boot-table overrides keyed by entry name (see boot.ts); wins over `labs`. */
+  /**
+   * Boot-table overrides keyed by entry name (see boot.ts); `labs` flags
+   * merge into `browseConfig`/`browseSettings` override responses.
+   */
   boot?: BootOverrides;
 }
 
@@ -36,13 +39,7 @@ export async function renderAdminApp(
   route: string = '/',
   { labs, boot }: RenderAdminAppOptions = {},
 ): Promise<Awaited<ReturnType<typeof render>>> {
-  const overrides: BootOverrides = {
-    ...(labs && {
-      browseSettings: { response: settingsResponse({ labs }) },
-      browseConfig: { response: configResponse({ labs }) },
-    }),
-    ...boot,
-  };
+  const overrides: BootOverrides = labs ? composeLabsBootOverrides(labs, boot) : { ...boot };
 
   if (Object.keys(overrides).length > 0) {
     installBootOverrides(overrides);

--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -5,15 +5,10 @@ import { defaultUnsplashConfig, type TopLevelFrameworkProps } from '@tryghost/ad
 import '@/index.css';
 import { AdminAppRoot } from '@/app-root';
 
-import { composeLabsBootOverrides, installBootOverrides, type BootOverrides } from './boot';
+import { configureAdminScenario, type BootOverrides } from './boot';
+import type { AdminScenarioOptions } from './state';
 
-export interface RenderAdminAppOptions {
-  /**
-   * Labs flags for this test; compiles to lockstep settings + config boot
-   * overrides (the admin client reads labs from both). Merges into any
-   * `boot` override for those entries; flags named here win.
-   */
-  labs?: Record<string, boolean>;
+export interface RenderAdminAppOptions extends AdminScenarioOptions {
   /**
    * Boot-table overrides keyed by entry name (see boot.ts); `labs` flags
    * merge into `browseConfig`/`browseSettings` override responses.
@@ -37,13 +32,9 @@ export function currentRoute(): string {
  */
 export async function renderAdminApp(
   route: string = '/',
-  { labs, boot }: RenderAdminAppOptions = {},
+  options: RenderAdminAppOptions = {},
 ): Promise<Awaited<ReturnType<typeof render>>> {
-  const overrides: BootOverrides = labs ? composeLabsBootOverrides(labs, boot) : { ...boot };
-
-  if (Object.keys(overrides).length > 0) {
-    installBootOverrides(overrides);
-  }
+  configureAdminScenario(options);
 
   // Mirror the production host page (index.html): the react-admin body
   // class and the #root mount point drive the shell's grid layout — without

--- a/apps/admin/test-utils/acceptance/resources.ts
+++ b/apps/admin/test-utils/acceptance/resources.ts
@@ -4,16 +4,15 @@ import type { Integration } from '@tryghost/admin-x-framework/api/integrations';
 import {
   activeThemeResponse,
   browseResponse,
-  currentUserResponse,
-  settingsResponse,
   type Automation,
   type Comment,
   type Label,
   type Member,
+  type MemberCustomField,
   type Newsletter,
   type Offer,
   type Post,
-  type SettingsResponse,
+  type Setting,
   type StaffInvite,
   type StaffRole,
   type StaffUser,
@@ -22,8 +21,11 @@ import {
   type Tier,
 } from '@tryghost/test-data';
 
+import { currentBootUser, editBootSettings } from './boot';
+
 import {
   fakeAdminEndpoint,
+  createEndpointCapture,
   record418,
   registerAdminApiHandler,
   registerRoute,
@@ -204,7 +206,7 @@ export function defineResource<TEntity>({
 }
 
 /** Tags list fake: declared-query semantics for the tags tabs and remote tag pickers. */
-export const fakeTags = defineResource<Tag>({
+const tagsResource = defineResource<Tag>({
   resource: 'tags',
   semantics: {
     kind: 'declared-query',
@@ -215,6 +217,88 @@ export const fakeTags = defineResource<Tag>({
     },
   },
 });
+
+export interface FakeTagsOptions {
+  read?: boolean;
+  update?: boolean;
+}
+export type TagUpdateBody = { tags: Partial<Tag>[] };
+type TagCaptures<T extends FakeTagsOptions> = ResourceCapture &
+  Partial<{ read: EndpointCapture<undefined>; update: EndpointCapture<TagUpdateBody> }> &
+  (T extends { read: true } ? { read: EndpointCapture<undefined> } : object) &
+  (T extends { update: true } ? { update: EndpointCapture<TagUpdateBody> } : object);
+
+export function fakeTags(respondWith: RespondWith<Tag>): ResourceCapture;
+export function fakeTags<T extends FakeTagsOptions>(tags: Tag[], options: T): TagCaptures<T>;
+/** Opt into detail reads and/or updates; browse-only callers retain their existing semantics. */
+export function fakeTags(
+  respondWith: RespondWith<Tag>,
+  { read = false, update = false }: FakeTagsOptions = {},
+) {
+  if (!read && !update) {
+    return tagsResource(respondWith);
+  }
+  if (!Array.isArray(respondWith)) {
+    throw new Error('Tag reads/updates need a declared array, not a browse callback.');
+  }
+  const tags = structuredClone(respondWith);
+  const capture = tagsResource(() => tags);
+  const reads = createEndpointCapture<undefined>();
+  const updates = createEndpointCapture<TagUpdateBody>();
+  if (read) {
+    Object.assign(capture, { read: reads });
+    registerRoute('GET', '/tags/<id>/ or /tags/slug/<slug>/');
+  }
+  if (update) {
+    Object.assign(capture, { update: updates });
+    registerRoute('PUT', '/tags/<id>/');
+  }
+  registerAdminApiHandler(async (request, apiPath) => {
+    const match = apiPath.split('?')[0].match(/^\/tags\/(?:slug\/([^/]+)|([^/]+))\/$/);
+    if (!match) {
+      return undefined;
+    }
+    const reading = read && request.method === 'GET';
+    const updating = update && request.method === 'PUT' && match[2] !== undefined;
+    if (!reading && !updating) {
+      return undefined;
+    }
+    const index = tags.findIndex((tag) =>
+      match[1] !== undefined
+        ? tag.slug === decodeURIComponent(match[1])
+        : tag.id === decodeURIComponent(match[2]),
+    );
+    if (reading) {
+      reads.requests.push({ url: request.url, body: undefined });
+    }
+    let body: TagUpdateBody | undefined;
+    if (updating) {
+      body = (await request.json()) as TagUpdateBody;
+      updates.requests.push({ url: request.url, body });
+    }
+    if (index === -1) {
+      return HttpResponse.json(
+        { errors: [{ type: 'NotFoundError', message: 'Tag not found.' }] },
+        { status: 404 },
+      );
+    }
+    if (updating) {
+      if (
+        !body ||
+        !Array.isArray(body.tags) ||
+        body.tags.length !== 1 ||
+        !body.tags[0] ||
+        typeof body.tags[0] !== 'object'
+      ) {
+        record418(`${request.method} ${apiPath} — expected one tag in the update envelope`);
+        return new HttpResponse('Expected one tag in the update envelope.', { status: 418 });
+      }
+      tags[index] = { ...tags[index], ...structuredClone(body.tags[0]), id: tags[index].id };
+    }
+    return HttpResponse.json({ tags: [tags[index]] });
+  });
+  return capture;
+}
 
 /** Automations list fake: the browse request carries no query the fake would need to interpret. */
 export const fakeAutomations = defineResource<Automation>({
@@ -251,15 +335,63 @@ const membersResource = defineResource<Member>({
  * shape) for every browse — the plain read and Settings' archived-inclusive
  * `?filter=status:[active,archived]` variant alike; assert the outgoing
  * filter, not served subsets. Values ride the member read payload, and the
- * create/edit/reorder/delete mutations are one-off endpoints — declare those
- * with `fakeAdminEndpoint`. A spec observing the list grow across a create
- * declares that growth itself via the function form (`() => fields`).
+ * edit/reorder/delete mutations are one-off endpoints. Opt into one declared
+ * create result with `{create: {response: memberCustomField(...)}}` when the
+ * test needs the subsequent browse to reflect it.
  */
-export const fakeMemberCustomFields = defineResource({
+const customFieldsResource = defineResource<unknown>({
   resource: 'members/custom_fields',
   envelopeKey: 'members_custom_fields',
   semantics: { kind: 'passthrough' },
 });
+
+export type CustomFieldCreateBody = {
+  members_custom_fields: Array<Pick<MemberCustomField, 'name' | 'type'>>;
+};
+export interface FakeMemberCustomFieldsOptions {
+  create: { response: MemberCustomField };
+}
+
+export function fakeMemberCustomFields(respondWith: RespondWith<unknown>): ResourceCapture;
+export function fakeMemberCustomFields(
+  fields: MemberCustomField[],
+  options: FakeMemberCustomFieldsOptions,
+): ResourceCapture & { create: EndpointCapture<CustomFieldCreateBody> };
+/** A declared POST result joins the collection; no server-side key generation is simulated. */
+export function fakeMemberCustomFields(
+  respondWith: RespondWith<unknown>,
+  options?: FakeMemberCustomFieldsOptions,
+) {
+  if (!options) {
+    return customFieldsResource(respondWith);
+  }
+  if (!Array.isArray(respondWith)) {
+    throw new Error('Custom-field creation needs a declared array, not a browse callback.');
+  }
+  const fields = structuredClone(respondWith);
+  const created = structuredClone(options.create.response);
+  const capture = customFieldsResource(() => fields);
+  const create = createEndpointCapture<CustomFieldCreateBody>();
+  let consumed = false;
+  registerRoute('POST', '/members/custom_fields/');
+  registerAdminApiHandler(async (request, apiPath) => {
+    if (request.method !== 'POST' || apiPath !== '/members/custom_fields/') {
+      return undefined;
+    }
+    create.requests.push({
+      url: request.url,
+      body: (await request.json()) as CustomFieldCreateBody,
+    });
+    if (consumed) {
+      record418('POST /members/custom_fields/ — declared create response already consumed');
+      return new HttpResponse('Declare another create response for another POST.', { status: 418 });
+    }
+    consumed = true;
+    fields.push(created);
+    return HttpResponse.json({ members_custom_fields: [created] });
+  });
+  return Object.assign(capture, { create });
+}
 
 // Members-page chrome: the filter bar mounts with the page and probes these lookups.
 const labelsResource = defineResource<Label>({
@@ -407,13 +539,13 @@ export const fakeActions = defineResource<Omit<Action, 'context'> & { context: s
  * (themes), membership (tiers/newsletters), growth (recommendations, offers,
  * referrer stats) and advanced (integrations, automated emails).
  *
- * Defaults are the minimal believable world: the boot table's owner as the
+ * Defaults are the minimal believable world: the composed current user as the
  * only staff user, the canned active theme, and empty lists everywhere else.
  * Screen-specific data a spec asserts on is declared in the spec — a fake
  * registered after this one wins (e.g. `fakeOffers([...])`).
  */
 export function fakeSettingsScreens(): void {
-  fakeUsers(currentUserResponse().users as unknown as StaffUser[]);
+  fakeUsers(() => currentBootUser().users as unknown as StaffUser[]);
   fakeInvites([]);
   fakeRoles([]);
   themesResource(activeThemeResponse().themes);
@@ -466,7 +598,7 @@ export function fakePostsListScreen(): void {
   fakeAdminEndpoint('GET', /^\/users\/\?.*slug/, { users: [] });
 }
 
-type SettingsPutBody = { settings: Array<{ key: string; value: string | boolean | null }> };
+type SettingsPutBody = { settings: Setting[] };
 
 export interface EditSettingsCapture {
   /** Every PUT /settings/ body, oldest first. */
@@ -475,9 +607,9 @@ export interface EditSettingsCapture {
 }
 
 /**
- * Handles PUT /settings/ the way Ghost does — echoes back the full settings
- * world with the submitted keys applied — and captures every request body so
- * specs can assert exactly what the UI saved.
+ * Handles PUT /settings/ and captures every request body. Edits merge into the
+ * managed settings seed and survive refetches; a raw browseSettings override
+ * retains the legacy stateless echo instead.
  */
 export function fakeEditSettings(): EditSettingsCapture {
   const requests: SettingsPutBody[] = [];
@@ -491,9 +623,7 @@ export function fakeEditSettings(): EditSettingsCapture {
     const body = (await request.json()) as SettingsPutBody;
     requests.push(body);
 
-    const overrides = Object.fromEntries(body.settings.map(({ key, value }) => [key, value]));
-    const response: SettingsResponse = settingsResponse({ settings: overrides });
-    return HttpResponse.json(response);
+    return HttpResponse.json(editBootSettings(body.settings));
   });
 
   return {

--- a/apps/admin/test-utils/acceptance/screens.ts
+++ b/apps/admin/test-utils/acceptance/screens.ts
@@ -1,0 +1,21 @@
+import { renderAdminApp, type RenderAdminAppOptions } from './render-admin-app';
+import { fakePostsListScreen, fakeSettingsScreens } from './resources';
+import { withScreenDefaults } from './worker';
+
+/** Incidental settings reads only. Declare saves separately with fakeEditSettings(). */
+export async function renderSettingsScreen(
+  route = '/settings',
+  options: RenderAdminAppOptions = {},
+) {
+  withScreenDefaults(fakeSettingsScreens);
+  return await renderAdminApp(route, options);
+}
+
+/** Explicit flags (including false) and resource fakes override these screen defaults. */
+export async function renderPostsListScreen(route = '/posts', options: RenderAdminAppOptions = {}) {
+  withScreenDefaults(fakePostsListScreen);
+  return await renderAdminApp(route, {
+    ...options,
+    labs: { postsListReact: true, ...options.labs },
+  });
+}

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll } from 'vitest';
 import { cleanup } from 'vitest-browser-react';
 
 import './matchers';
-import { defaultBootResolver, defaultBootRoutes } from './boot';
+import { defaultBootResolver, defaultBootRoutes, resetBootState } from './boot';
 import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from './worker';
 
 beforeAll(async () => {
@@ -20,6 +20,7 @@ afterEach(async () => {
     await settleRequests();
   } finally {
     resetFakeApi();
+    resetBootState();
     window.location.hash = '';
     verifyNoUnhandledRequests();
   }

--- a/apps/admin/test-utils/acceptance/state.ts
+++ b/apps/admin/test-utils/acceptance/state.ts
@@ -1,0 +1,112 @@
+import type { Config } from '@tryghost/admin-x-framework/api/config';
+import {
+  configResponse,
+  currentUserResponse,
+  settingsResponse,
+  staffRole,
+  type Setting,
+  type SettingValue,
+  type StaffRoleName,
+  type StaffUser,
+} from '@tryghost/test-data';
+
+export type UserOverrides = Partial<Omit<StaffUser, 'roles' | 'accessibility'>> & {
+  roles?: StaffRoleName[];
+  accessibility?: Record<string, unknown> | null;
+};
+
+export interface AdminScenarioOptions {
+  /** Flags are represented in both settings and config. */
+  labs?: Record<string, boolean>;
+  /** Per-key values; null is a value, not an absent setting. Use omitSettings for absence. */
+  settings?: Record<string, SettingValue>;
+  /** Capabilities missing from an older backend. */
+  omitSettings?: readonly string[];
+  /** Known config fields; nested objects replace rather than deep-merge. */
+  config?: Partial<Config> & { labs?: never };
+  /** Per-limit replacements, preserving other limits and host settings. */
+  limits?: NonNullable<Config['hostSettings']>['limits'];
+  user?: UserOverrides;
+}
+
+/** Pure seed construction, separate from MSW registration and the test lifecycle. */
+export function createAdminState(options: AdminScenarioOptions = {}) {
+  if (options.settings && Object.hasOwn(options.settings, 'labs')) {
+    throw new Error('Use the labs option instead of settings.labs.');
+  }
+  if (options.config && Object.hasOwn(options.config, 'labs')) {
+    throw new Error('Use the labs option instead of config.labs.');
+  }
+  if (options.omitSettings?.includes('labs')) {
+    throw new Error(
+      'Use a raw boot response to omit labs; omitSettings preserves labs composition.',
+    );
+  }
+  for (const key of options.omitSettings ?? []) {
+    if (options.settings && Object.hasOwn(options.settings, key)) {
+      throw new Error(`Setting "${key}" cannot be supplied in both settings and omitSettings.`);
+    }
+  }
+  if (options.limits && options.config?.hostSettings?.limits !== undefined) {
+    throw new Error('Supply limits or config.hostSettings.limits, not both.');
+  }
+
+  const settings = settingsResponse({ labs: options.labs, settings: options.settings });
+  settings.settings = settings.settings.filter(({ key }) => !options.omitSettings?.includes(key));
+
+  const config = configResponse({ labs: options.labs });
+  Object.assign(config.config, structuredClone(options.config ?? {}));
+  if (options.limits) {
+    const hostSettings = config.config.hostSettings as Config['hostSettings'];
+    config.config.hostSettings = {
+      ...hostSettings,
+      limits: { ...hostSettings?.limits, ...structuredClone(options.limits) },
+    };
+  }
+
+  const user = currentUserResponse();
+  const { roles, accessibility, ...fields } = options.user ?? {};
+  Object.assign(user.users[0], structuredClone(fields));
+  if (roles !== undefined) {
+    user.users[0].roles = roles.map((name) =>
+      staffRole({
+        name,
+        description: name === 'Owner' ? 'Blog Owner' : `${name}s`,
+      }),
+    );
+  }
+  if (accessibility !== undefined) {
+    user.users[0].accessibility = accessibility === null ? null : JSON.stringify(accessibility);
+  }
+
+  return {
+    readSettings: () => structuredClone(settings),
+    readConfig: () => structuredClone(config),
+    readUser: () => structuredClone(user),
+    isCurrentUser: (id: string) => id === user.users[0].id,
+    editSettings(edits: Setting[]) {
+      // Parse before committing so a malformed labs write cannot partially update the world.
+      const labsEdit = edits.find(({ key }) => key === 'labs');
+      const labs: unknown = labsEdit ? JSON.parse(String(labsEdit.value)) : undefined;
+      if (labsEdit && (typeof labs !== 'object' || labs === null || Array.isArray(labs))) {
+        throw new Error('A labs setting must contain a JSON object.');
+      }
+      const byKey = new Map(settings.settings.map((setting) => [setting.key, setting]));
+      for (const edit of edits) {
+        byKey.set(edit.key, { ...byKey.get(edit.key), ...structuredClone(edit) });
+      }
+      settings.settings = [...byKey.values()];
+      if (labsEdit) {
+        config.config.labs = labs as Record<string, boolean>;
+      }
+      return structuredClone(settings);
+    },
+    editUser(edits: Record<string, unknown>, commit = true) {
+      const updated = { ...user.users[0], ...structuredClone(edits), id: user.users[0].id };
+      if (commit) {
+        user.users[0] = updated;
+      }
+      return { users: [structuredClone(updated)] };
+    },
+  };
+}

--- a/apps/admin/test-utils/acceptance/worker.ts
+++ b/apps/admin/test-utils/acceptance/worker.ts
@@ -198,12 +198,32 @@ type AdminApiResolver = (
   apiPath: string,
 ) => Promise<Response | undefined> | Response | undefined;
 
+// Screen defaults are resolved below all explicit handlers, even when installed last.
+const screenDefaultResolvers: AdminApiResolver[] = [];
+let installingScreenDefaults = false;
+
+/** Internal synchronous registration scope; legacy fake calls retain explicit priority. */
+export function withScreenDefaults(install: () => void): void {
+  const previous = installingScreenDefaults;
+  installingScreenDefaults = true;
+  try {
+    install();
+  } finally {
+    installingScreenDefaults = previous;
+  }
+}
+
 /**
  * Register a runtime admin-API handler; a resolver returning `undefined`
  * falls through to the boot table, then the 418 catch-all.
  */
 export function registerAdminApiHandler(resolver: AdminApiResolver): void {
-  runningWorker().use(
+  const activeWorker = runningWorker();
+  if (installingScreenDefaults) {
+    screenDefaultResolvers.unshift(resolver);
+    return;
+  }
+  activeWorker.use(
     http.all(ADMIN_API_PATTERN, async ({ request }) => {
       return await resolver(request, toAdminApiPath(request.url));
     }),
@@ -292,16 +312,27 @@ export function fakeEndpoint(
   };
 }
 
-export interface CapturedEndpointRequest {
+export interface CapturedEndpointRequest<TBody = unknown> {
   url: string;
   /** Parsed JSON request body, or undefined when there is none. */
-  body: unknown;
+  body: TBody;
 }
 
-export interface EndpointCapture {
+export interface EndpointCapture<TBody = unknown> {
   /** Every matched request, oldest first. */
-  requests: CapturedEndpointRequest[];
-  readonly lastRequest: CapturedEndpointRequest | undefined;
+  requests: CapturedEndpointRequest<TBody>[];
+  readonly lastRequest: CapturedEndpointRequest<TBody> | undefined;
+}
+
+/** Mutable request ledger shared by concrete resource operations. */
+export function createEndpointCapture<TBody = unknown>(): EndpointCapture<TBody> {
+  const requests: CapturedEndpointRequest<TBody>[] = [];
+  return {
+    requests,
+    get lastRequest() {
+      return requests[requests.length - 1];
+    },
+  };
 }
 
 export interface SitePreviewRequest {
@@ -425,6 +456,15 @@ export async function startFakeApi({
 
   // Initial handlers persist across resetHandlers(); order is priority.
   worker = setupWorker(
+    http.all(ADMIN_API_PATTERN, async ({ request }) => {
+      for (const resolve of screenDefaultResolvers) {
+        const response = await resolve(request, toAdminApiPath(request.url));
+        if (response !== undefined) {
+          return response;
+        }
+      }
+      return undefined;
+    }),
     // Shell boot table.
     http.all(ADMIN_API_PATTERN, async ({ request }) => {
       return await resolver(request, toAdminApiPath(request.url));
@@ -480,6 +520,7 @@ export async function startFakeApi({
 export function resetFakeApi(): void {
   routesDuringLastTest = [...registeredRoutes];
   worker?.resetHandlers();
+  screenDefaultResolvers.length = 0;
   registeredRoutes.length = bootRouteCount;
   trackedSitePreviewUrls.clear();
 }

--- a/packages/testing/test-data/package.json
+++ b/packages/testing/test-data/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint src/ test/ --cache"
   },
   "dependencies": {
-    "@faker-js/faker": "catalog:"
+    "@faker-js/faker": "catalog:",
+    "@tryghost/custom-field-types": "workspace:*"
   },
   "devDependencies": {
     "@internal/cfg-eslint": "workspace:*",

--- a/packages/testing/test-data/src/builders/member-custom-field.ts
+++ b/packages/testing/test-data/src/builders/member-custom-field.ts
@@ -1,0 +1,19 @@
+import type { FieldType } from '@tryghost/custom-field-types';
+import { createRequiredBuilder } from '../factory';
+
+/** Custom-field definitions are addressed by their immutable key, not a database ID. */
+export interface MemberCustomField {
+  key: string;
+  name: string;
+  type: FieldType;
+  status: 'active' | 'archived';
+  created_at: string;
+  updated_at: string | null;
+}
+
+export const memberCustomField = createRequiredBuilder<MemberCustomField, 'key' | 'name'>(() => ({
+  type: 'short_text',
+  status: 'active',
+  created_at: new Date().toISOString(),
+  updated_at: null,
+}));

--- a/packages/testing/test-data/src/builders/stripe-settings.ts
+++ b/packages/testing/test-data/src/builders/stripe-settings.ts
@@ -1,0 +1,21 @@
+/** A connected Stripe account, ready to spread into settingsResponse({settings}). */
+export function connectedStripeSettings(
+  overrides: Partial<ConnectedStripeSettings> = {},
+): ConnectedStripeSettings {
+  return {
+    stripe_connect_display_name: 'Dummy',
+    stripe_connect_livemode: false,
+    stripe_connect_account_id: 'acct_123',
+    stripe_connect_publishable_key: 'pk_test_123',
+    stripe_connect_secret_key: 'sk_test_123',
+    ...overrides,
+  };
+}
+
+export type ConnectedStripeSettings = {
+  stripe_connect_display_name: string | null;
+  stripe_connect_livemode: boolean;
+  stripe_connect_account_id: string | null;
+  stripe_connect_publishable_key: string | null;
+  stripe_connect_secret_key: string | null;
+};

--- a/packages/testing/test-data/src/index.ts
+++ b/packages/testing/test-data/src/index.ts
@@ -4,6 +4,10 @@ export type { Builder, RequiredBuilder, RequiredBuilderInput } from './factory';
 export { tag } from './builders/tag';
 export type { Tag } from './builders/tag';
 export { member } from './builders/member';
+export { memberCustomField } from './builders/member-custom-field';
+export type { MemberCustomField } from './builders/member-custom-field';
+export { connectedStripeSettings } from './builders/stripe-settings';
+export type { ConnectedStripeSettings } from './builders/stripe-settings';
 export type { Member, MemberNewsletter, MemberTier } from './builders/member';
 export { label } from './builders/label';
 export type { Label } from './builders/label';
@@ -112,3 +116,4 @@ export type {
   SettingsResponse,
   SiteResponse,
 } from './fixtures';
+export type { SettingValue } from './fixtures/data/settings';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4225,6 +4225,9 @@ importers:
       '@faker-js/faker':
         specifier: 'catalog:'
         version: 10.5.0
+      '@tryghost/custom-field-types':
+        specifier: workspace:*
+        version: link:../../custom-field-types
     devDependencies:
       '@internal/cfg-eslint':
         specifier: workspace:*


### PR DESCRIPTION
Admin acceptance tests already share entity builders with e2e, but settings/config/labs scenarios still needed response-envelope manipulation and local read/write fakes. This makes those scenarios directly constructable and keeps their seeds consistent through saves and refetches.

For example, the older-backend Stripe scenario now reads:

```ts
fakeTiers([freeTier, supporterTier]);
await renderSettingsScreen('/settings', {
  labs: {machinePayments: true},
  settings: connectedStripeSettings(),
  omitSettings: ['machine_payments_enabled'],
});
```

- Added typed settings, config, limits, current-user, and omission inputs. Labs remain composed across settings/config, and raw response/status overrides remain available.
- Kept settings and current-user state through writes/refetches, including unrelated settings and missing backend capabilities. Failed writes do not commit managed state.
- Added settings/posts screen defaults below explicit fakes. Settings saves and resource mutations remain opt-in, so unexpected writes still fail.
- Shared connected-Stripe and custom-field builders, plus concrete tag read/update and single declared custom-field create support with typed captures.
- Migrated 11 existing acceptance files and documented construction, precedence, persistence, and escape-hatch contracts.

Includes the labs/boot composition prerequisite from #30381, which is still open. This PR targets `main`. No production behavior changes or publishable-package release intent are required.

Validation:

- `pnpm check` (including all 2,092 Admin unit tests)
- Full Admin browser acceptance suite: 703 tests across 73 files
- Admin typecheck
- Shared test-data lint, types, and 22 unit tests
- e2e consumer typechecks
- Commit hooks, including formatting, lint, boundaries, documentation links, and secret scanning

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written automated tests to prove the change works
