### PR TITLE
Cleaned duplicated labs flags out of admin acceptance specs

### DIFF
--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -29,9 +29,8 @@ function fakeExportDownload() {
 }
 
 async function renderWithArchiveHost() {
-  const config = configResponse({ labs: { selfServeArchives: true } });
-  (config.config as { hostSettings?: object }).hostSettings = {
-    ...(config.config as { hostSettings?: object }).hostSettings,
+  const config = configResponse();
+  config.config.hostSettings = {
     export: { webhookUrl: 'https://archives.example.com/generate' },
   };
   await renderAdminApp('/settings/advanced', {

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -2,12 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
-  configResponse,
   fakeAdminEndpoint,
   fakeMemberCustomFields,
   fakeSettingsScreens,
   renderAdminApp,
-  settingsResponse,
 } from '@test-utils/acceptance';
 import { settingsScreen } from '@/settings/settings.screen';
 
@@ -29,13 +27,7 @@ const archivedField = {
   updated_at: '2026-07-13T00:00:00.000Z',
 };
 
-function customFieldsBoot() {
-  const labs = { membersCustomFields: true };
-  return {
-    browseConfig: { response: configResponse({ labs }) },
-    browseSettings: { response: settingsResponse({ labs }) },
-  };
-}
+const flagOn = { labs: { membersCustomFields: true } };
 
 type CustomField = typeof companyField;
 
@@ -73,7 +65,7 @@ describe('Custom fields', () => {
   it('lists each field with its user-facing type, opting into archived fields', async () => {
     fakeSettingsScreens();
     const customFieldsApi = fakeCustomFields();
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     // Browse hides archived by default; Settings asks for both statuses.
     await expect
@@ -92,7 +84,7 @@ describe('Custom fields', () => {
     const createApi = fakeAdminEndpoint('POST', '/members/custom_fields/', {
       members_custom_fields: [{ ...companyField, key: 'job_title', name: 'Job Title' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByRole('button', { name: 'Add custom field' }).click();
     const modal = settingsScreen.customFieldModal();
@@ -114,7 +106,7 @@ describe('Custom fields', () => {
     const createApi = fakeAdminEndpoint('POST', '/members/custom_fields/', {
       members_custom_fields: [{ ...companyField, key: 'bio', name: 'Bio', type: 'long_text' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByRole('button', { name: 'Add custom field' }).click();
     const modal = settingsScreen.customFieldModal();
@@ -147,7 +139,7 @@ describe('Custom fields', () => {
       },
       { status: 422 },
     );
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByRole('button', { name: 'Add custom field' }).click();
     const modal = settingsScreen.customFieldModal();
@@ -167,7 +159,7 @@ describe('Custom fields', () => {
     const editApi = fakeAdminEndpoint('PUT', '/members/custom_fields/company/', {
       members_custom_fields: [{ ...companyField, name: 'Employer' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();
     const modal = settingsScreen.customFieldModal();
@@ -186,7 +178,7 @@ describe('Custom fields', () => {
     const editApi = fakeAdminEndpoint('PUT', '/members/custom_fields/company/', {
       members_custom_fields: [{ ...companyField, status: 'archived' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();
     await settingsScreen.customFieldModal().getByRole('button', { name: 'Archive' }).click();
@@ -209,7 +201,7 @@ describe('Custom fields', () => {
   it('splits fields into Active and Archived tabs', async () => {
     fakeSettingsScreens();
     fakeCustomFields([companyField, archivedField]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     // Active tab is the default and shows only active fields.
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
@@ -229,7 +221,7 @@ describe('Custom fields', () => {
       name: `Field ${index}`,
     }));
     fakeCustomFields(manyFields);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(5);
@@ -255,7 +247,7 @@ describe('Custom fields', () => {
       name: `Field ${index}`,
     }));
     fakeCustomFieldsWithCreate(initialFields, { ...companyField, key: 'newest', name: 'Newest' });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(5);
@@ -287,7 +279,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(3);
@@ -340,7 +332,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(2);
@@ -388,7 +380,7 @@ describe('Custom fields', () => {
       },
       { status: 422 },
     );
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(2);
@@ -418,7 +410,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(2);
@@ -451,7 +443,7 @@ describe('Custom fields', () => {
       currentFields = order.map(({ key }) => currentFields.find((field) => field.key === key)!);
       return { members_custom_fields: currentFields };
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     const rows = settingsScreen.customFields().getByTestId('custom-field-list-item');
     await expect(rows).toHaveCount(5);
@@ -480,7 +472,7 @@ describe('Custom fields', () => {
   it('does not offer dragging on the archived tab', async () => {
     fakeSettingsScreens();
     fakeCustomFields([companyField, archivedField]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     // An archived field holds its place in the order, but there is nowhere to see
     // it, so there is nothing to drag it through.
@@ -496,7 +488,7 @@ describe('Custom fields', () => {
     fakeSettingsScreens();
     const customFieldsApi = fakeCustomFields([companyField, archivedField]);
     const deleteApi = fakeAdminEndpoint('DELETE', '/members/custom_fields/old_hobby/', {});
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByRole('tab', { name: 'Archived' }).click();
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();
@@ -526,7 +518,7 @@ describe('Custom fields', () => {
   it('does not expose permanent deletion for an active field', async () => {
     fakeSettingsScreens();
     fakeCustomFields([companyField]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     // Deletion lives behind the header menu, and an active field has none —
     // the UI can't reach delete, matching the API's archived-only rule.
@@ -538,7 +530,7 @@ describe('Custom fields', () => {
   it('shows no tabs at all while no fields exist', async () => {
     fakeSettingsScreens();
     fakeCustomFields([]);
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await expect.element(settingsScreen.customFields()).toBeVisible();
     await expect(settingsScreen.customFields().getByRole('tab')).toHaveCount(0);
@@ -550,7 +542,7 @@ describe('Custom fields', () => {
     const editApi = fakeAdminEndpoint('PUT', '/members/custom_fields/old_hobby/', {
       members_custom_fields: [{ ...archivedField, status: 'active' }],
     });
-    await renderAdminApp('/settings', { boot: customFieldsBoot() });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.customFields().getByRole('tab', { name: 'Archived' }).click();
     await settingsScreen.customFields().getByTestId('custom-field-list-item').click();

--- a/apps/admin/src/settings/membership/portal.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/portal.acceptance.test.tsx
@@ -108,7 +108,7 @@ describe('Portal settings', () => {
   it('hides gift promotion settings when the backend does not provide them', async () => {
     fakeSettingsScreens();
     fakeTiers([freeTier]);
-    const settings = settingsResponse({ labs: { giftSubCustomization: true } });
+    const settings = settingsResponse();
     settings.settings = settings.settings.filter(
       ({ key }) => !['portal_signup_gift_promotion', 'portal_account_gift_promotion'].includes(key),
     );

--- a/apps/admin/src/settings/membership/tiers-checkout.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/tiers-checkout.acceptance.test.tsx
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
-  configResponse,
   fakeAdminEndpoint,
   fakeMemberCustomFields,
   fakeSettingsScreens,
@@ -36,24 +35,22 @@ const nameField = {
   type: 'short_text',
 };
 
-function stripeSettings(overrides: Parameters<typeof settingsResponse>[0] = {}) {
+function stripeSettings() {
   return settingsResponse({
-    ...overrides,
     settings: {
       stripe_connect_display_name: 'Dummy',
       stripe_connect_livemode: false,
       stripe_connect_account_id: 'acct_123',
       stripe_connect_publishable_key: 'pk_test_123',
       stripe_connect_secret_key: 'sk_test_123',
-      ...overrides.settings,
     },
   });
 }
 
-// The flag lives in settings and config in lockstep, and Stripe rides along in settings.
-const flagOnBoot = {
-  browseConfig: { response: configResponse({ labs: { membersCustomFields: true } }) },
-  browseSettings: { response: stripeSettings({ labs: { membersCustomFields: true } }) },
+// The harness composes the flag into settings and config; Stripe rides along in settings.
+const flagOn = {
+  labs: { membersCustomFields: true },
+  boot: { browseSettings: { response: stripeSettings() } },
 };
 
 const supporterConfig = {
@@ -114,7 +111,7 @@ describe('Tier checkout collection', () => {
       { errors: [{ type: 'NotFoundError', message: 'Resource not found error.' }] },
       { status: 404 },
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await expect(modal.getByText('Checkout', { exact: true })).toHaveCount(0);
@@ -131,7 +128,7 @@ describe('Tier checkout collection', () => {
       { errors: [{ type: 'InternalServerError', message: 'Something went wrong.' }] },
       { status: 500 },
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await expect.element(modal.getByText(/could not be loaded/)).toBeVisible();
@@ -140,7 +137,7 @@ describe('Tier checkout collection', () => {
 
   it('shows no checkout section on the free tier', async () => {
     checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.tiers().getByText(freeTier.name, { exact: true }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -150,7 +147,7 @@ describe('Tier checkout collection', () => {
 
   it('reflects the saved configuration and writes nothing when untouched', async () => {
     const putApi = checkoutWorld([supporterConfig]);
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await expect.element(modal.getByLabelText('Collect shipping address')).toBeChecked();
@@ -182,7 +179,7 @@ describe('Tier checkout collection', () => {
     const everywhere = { ...supporterConfig.shipping };
     delete (everywhere as { allowed_countries?: string[] }).allowed_countries;
     checkoutWorld([{ ...supporterConfig, shipping: everywhere }]);
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await expect.element(modal.getByLabelText('Collect shipping address')).toBeChecked();
@@ -192,7 +189,7 @@ describe('Tier checkout collection', () => {
 
   it('validates destinations inline before anything is written', async () => {
     const putApi = checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -204,7 +201,7 @@ describe('Tier checkout collection', () => {
 
   it('saves the chosen collections, stating every block explicitly', async () => {
     const putApi = checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -259,7 +256,7 @@ describe('Tier checkout collection', () => {
       },
       { status: 422 },
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -290,7 +287,7 @@ describe('Tier checkout collection', () => {
       fields = [...fields, created];
       return { members_custom_fields: [created] };
     });
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect shipping address').click();
@@ -335,7 +332,7 @@ describe('Tier checkout collection', () => {
         ],
       }),
     );
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     await settingsScreen.tiers().getByRole('button', { name: 'Add tier' }).click();
     const modal = settingsScreen.tierDetailModal();
@@ -377,7 +374,7 @@ describe('Tier checkout collection', () => {
 
   it('closes without confirmation after saving checkout edits', async () => {
     const putApi = checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect business tax ID').click();
@@ -392,7 +389,7 @@ describe('Tier checkout collection', () => {
 
   it('asks before discarding unsaved checkout edits', async () => {
     checkoutWorld();
-    await renderAdminApp('/settings', { boot: flagOnBoot });
+    await renderAdminApp('/settings', flagOn);
 
     const modal = await openSupporterModal();
     await modal.getByLabelText('Collect phone number').click();

--- a/apps/admin/src/settings/membership/tiers.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/tiers.acceptance.test.tsx
@@ -21,22 +21,20 @@ const supporterTier = tier({
   benefits: ['Simple benefit'],
 });
 
-function stripeSettings(overrides: Parameters<typeof settingsResponse>[0] = {}) {
+function stripeSettings() {
   return settingsResponse({
-    ...overrides,
     settings: {
       stripe_connect_display_name: 'Dummy',
       stripe_connect_livemode: false,
       stripe_connect_account_id: 'acct_123',
       stripe_connect_publishable_key: 'pk_test_123',
       stripe_connect_secret_key: 'sk_test_123',
-      ...overrides.settings,
     },
   });
 }
 
 function withoutSettings(keys: string[]) {
-  const response = stripeSettings({ labs: { machinePayments: true } });
+  const response = stripeSettings();
   response.settings = response.settings.filter(({ key }) => !keys.includes(key));
   return response;
 }
@@ -341,7 +339,7 @@ describe('Tier settings', () => {
     fakeTiers([freeTier, supporterTier]);
     await renderAdminApp('/settings', {
       labs: { machinePayments: true },
-      boot: { browseSettings: { response: stripeSettings({ labs: { machinePayments: true } }) } },
+      boot: { browseSettings: { response: stripeSettings() } },
     });
 
     await expect


### PR DESCRIPTION
The admin acceptance harness's `labs` render option used to be silently ignored whenever a `boot` override supplied the config or settings response, so any spec that needed both had to bake the flag into a hand-built `configResponse({labs})`/`settingsResponse({labs})` as well as (or instead of) the `labs` option. The harness now composes `labs` flags into boot-provided responses, so each spec can state a flag exactly once.

This is a setup-only cleanup — no assertion changes, and the responses the app sees are identical:

- `migration-tools-export.acceptance.test.tsx`: `renderWithArchiveHost` builds its config override for `hostSettings` only; the `selfServeArchives` flag comes solely from the `labs` option. The now-pointless `hostSettings` spread (the canned config has none) became a plain assignment.
- `portal.acceptance.test.tsx`: the filtered settings response no longer bakes in `giftSubCustomization`; the `labs` option carries it.
- `tiers.acceptance.test.tsx`: `stripeSettings` lost its labs plumbing (its generic `overrides` passthrough existed only for that); `machinePayments` is stated once via the `labs` option in both agent-payment specs.
- `tiers-checkout.acceptance.test.tsx`: the hand-built lockstep `flagOnBoot` pair (config + settings each carrying `membersCustomFields`) became `flagOn` render options — the `labs` option plus a Stripe-only settings response — and `stripeSettings` lost its labs plumbing the same way.
- `custom-fields.acceptance.test.tsx`: `customFieldsBoot()` hand-built exactly the lockstep pair the harness now derives from `labs`, so it reduced to a plain `labs` render option.

Verified by running all five acceptance test files (Vitest Browser Mode): 61 tests pass. ESLint on the touched files passes.