### PR TITLE
🐛 Fixed subscription attribution URLs rendering as clickable links

### DIFF
--- a/apps/admin/src/members/detail/member-subscriptions-section.tsx
+++ b/apps/admin/src/members/detail/member-subscriptions-section.tsx
@@ -2,6 +2,7 @@ import MemberAddCompModal from './member-add-comp-modal';
 import MemberSubscriptionActions from './member-subscription-actions';
 import MemberSubscriptionCompActions from './member-subscription-comp-actions';
 import React from 'react';
+import { isSafeHref } from './is-safe-href';
 import moment from 'moment-timezone';
 import { Badge, Button, Card, CardContent, EmptyIndicator } from '@tryghost/shade/components';
 import { LucideIcon, cn } from '@tryghost/shade/utils';
@@ -78,7 +79,7 @@ const SubscriptionDetails: React.FC<{ sub: MemberSubscription }> = ({ sub }) => 
       {page && (
         <p>
           Page —{' '}
-          {page.url ? (
+          {isSafeHref(page.url) ? (
             <a
               className="text-foreground hover:underline"
               href={page.url}

--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -499,6 +499,63 @@ test.describe('Ghost Admin - Member Detail', () => {
       await expect(page.getByText(/Renews 15 Feb 2026/).first()).toBeVisible();
     });
 
+    test('subscription attribution with an unsafe url - shows the page as text, not a link', async ({
+      page,
+    }) => {
+      // Subscription attribution URLs come from public signup/checkout URL
+      // history, which the server does not scheme-validate, so a member can get
+      // a `javascript:` URL stored as their own subscription attribution. It
+      // should still be shown, but never as a clickable link a staff user could
+      // trigger — the same rule the sidebar and activity feed already apply.
+      const member = await memberFactory.create({
+        name: 'Unsafe Attribution',
+        email: 'unsafe-attribution@ghost.org',
+      });
+      await seedSubscriptions(page, member.id, 'paid', [
+        paidSubscription({
+          attribution: {
+            title: 'Signup page',
+            url: "javascript:localStorage.setItem('attribution_xss', 'executed')",
+            referrer_source: 'Twitter',
+          },
+        }),
+      ]);
+
+      await page.goto(memberPath(member.id));
+      await page.getByTestId('member-subscription-details-toggle').first().click();
+
+      await expect(page.getByText('Signup page')).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Signup page' })).toHaveCount(0);
+    });
+
+    test('subscription attribution with a safe url - shows the page as a working link', async ({
+      page,
+    }) => {
+      // The guard must not swallow legitimate attribution: a site-relative or
+      // http(s) URL still renders as a link the staff user can follow.
+      const member = await memberFactory.create({
+        name: 'Safe Attribution',
+        email: 'safe-attribution@ghost.org',
+      });
+      await seedSubscriptions(page, member.id, 'paid', [
+        paidSubscription({
+          attribution: { title: 'Welcome post', url: '/welcome/', referrer_source: 'Twitter' },
+        }),
+      ]);
+
+      await page.goto(memberPath(member.id));
+      await page.getByTestId('member-subscription-details-toggle').first().click();
+
+      const link = page.getByRole('link', { name: 'Welcome post' });
+      await expect(link).toBeVisible();
+
+      // Following it opens the page in a new tab — proof the affordance is real.
+      const popupPromise = page.context().waitForEvent('page');
+      await link.click();
+      const popup = await popupPromise;
+      await expect(popup).toHaveURL(/\/welcome/);
+    });
+
     test('subscription set to cancel - shows remaining access rather than a renewal', async ({
       page,
     }) => {


### PR DESCRIPTION
A member's subscription attribution records where they signed up from, including a page link. Those links come from the public signup and checkout flow, and the server stores them without checking what kind of link they are, so a member can get a link that runs code instead of opening a page saved as their own attribution.

Everywhere else this data is shown — the member sidebar and the activity feed — an unsafe link is displayed as plain text rather than as something clickable. The subscription section was the one place that still turned it into a clickable link. This change brings it in line with the rest: an unsafe link shows as text, while ordinary page links keep working.

In practice current browsers already refuse to run this kind of link when it opens in a new tab, which is how these links open, so a staff member clicking one runs nothing — an end-to-end test confirms it. The change closes the gap anyway, so the admin never offers a clickable link it hasn't vetted. The tests cover both sides: an unsafe attribution shows as text with nothing to click, and an ordinary attribution still opens its page.
