### PR TITLE
Added tinybird distilled image for less disk space usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1970,6 +1970,20 @@ jobs:
     # Inherits the run_e2e gate transitively via job_docker (which builds the
     # ghost-e2e image).
     if: needs.job_docker.result == 'success'
+    permissions:
+      contents: read
+      packages: read # read the internal tinybird-local-slim package
+    env:
+      # Use the distilled Tinybird image instead of upstream: it needs several GB
+      # less runner disk, which is what keeps the analytics shards inside the disk
+      # budget. See docker/tinybird-local-slim/README.md.
+      #
+      # Its GHCR package is internal (the upstream licence only permits
+      # distribution within our own organization), so it is unreadable from a
+      # cross-repo PR's scoped token — those runs stay on the upstream image.
+      # infra-up.sh falls back on a failed pull regardless, so an unexpected
+      # permission gap degrades rather than breaks.
+      GHOST_E2E_TINYBIRD_SLIM: ${{ github.repository_owner == 'TryGhost' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: true
       matrix:
@@ -2040,6 +2054,16 @@ jobs:
 
       - name: Setup Docker Registry Mirrors
         uses: ./.github/actions/setup-docker-registry-mirrors
+
+      - name: Log in to GitHub Container Registry
+        # Needed to read the internal tinybird-local-slim package.
+        if: matrix.analytics == 'true' && env.GHOST_E2E_TINYBIRD_SLIM == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        continue-on-error: true
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull Tinybird CLI image
         id: pull_tb_cli

--- a/.github/workflows/publish-tinybird-local-slim.yml
+++ b/.github/workflows/publish-tinybird-local-slim.yml
@@ -1,0 +1,100 @@
+name: Publish tinybird-local-slim Image
+
+# Builds a distilled tinybird-local image for use as the Tinybird service in
+# CI/E2E: ~0.7GB pulled and ~2.4GB on disk, against ~2.1GB and ~6.9GB for
+# upstream, which is what keeps the analytics E2E jobs inside the runner disk
+# budget. See docker/tinybird-local-slim/README.md.
+#
+# The upstream image is proprietary (Tinybird License, Self-Managed). It permits
+# derivative works but only allows distributing them within our own organization,
+# so the GHCR package must stay internal — never public.
+
+on:
+  workflow_dispatch: # Manual trigger from GitHub UI or CLI (e.g. after a digest bump)
+  push:
+    branches: [main]
+    paths:
+      - 'docker/tinybird-local-slim/**'
+      - '.github/workflows/publish-tinybird-local-slim.yml'
+      # The upstream digest this image is distilled from lives here.
+      - 'compose.dev.analytics.yaml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push tinybird-local-slim to GHCR
+    runs-on: ubuntu-latest
+    # Publish from main, or from any branch via a manual dispatch (for PR testing).
+    if: github.repository == 'TryGhost/Ghost' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
+    concurrency:
+      group: publish-tinybird-local-slim-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Free up runner disk space
+        # The upstream base image on its own is larger than the free space a stock
+        # runner has left after its preinstalled toolchains.
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          df -h /
+
+      - name: Resolve upstream image
+        id: upstream
+        # compose.dev.analytics.yaml is the single source of truth for the digest,
+        # so the published image can never drift from what local dev runs.
+        run: |
+          ref=$(grep -oE 'tinybirdco/tinybird-local:[^ ]+' compose.dev.analytics.yaml)
+          echo "Upstream image: $ref"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: docker/tinybird-local-slim/Dockerfile
+          build-args: TINYBIRD_LOCAL_REF=${{ steps.upstream.outputs.ref }}
+          platforms: linux/amd64 # E2E CI runners are amd64; upstream also publishes arm64
+          provenance: false # keep a clean single-platform manifest (no attestation entries)
+          load: true
+          tags: tinybird-local-slim:verify
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify runtime config matches upstream
+        # The flatten discards upstream's image config, so the Dockerfile restates
+        # it by hand. Catch an upstream release that changes it before publishing.
+        run: |
+          docker pull --platform linux/amd64 "${{ steps.upstream.outputs.ref }}"
+          bash docker/tinybird-local-slim/verify-config.sh \
+            "${{ steps.upstream.outputs.ref }}" tinybird-local-slim:verify
+
+      - name: Push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: docker/tinybird-local-slim/Dockerfile
+          build-args: TINYBIRD_LOCAL_REF=${{ steps.upstream.outputs.ref }}
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          # Always tag with the immutable commit SHA (PR-test runs reference this);
+          # only move :latest on main. Empty lines are ignored by the action.
+          tags: |
+            ghcr.io/tryghost/tinybird-local-slim:${{ github.sha }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tryghost/tinybird-local-slim:latest' || '' }}
+          cache-from: type=gha

--- a/docker/tinybird-local-slim/Dockerfile
+++ b/docker/tinybird-local-slim/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+#
+# Distilled tinybird-local for Ghost CI. See README.md in this directory.
+#
+# Stage 1 prunes the upstream image (see cleanup.sh); stage 2 flattens the
+# result into a single layer via `COPY --from`. The flatten is where the size
+# reduction comes from: upstream installs ClickHouse twice across separate
+# layers, and a squashed rootfs keeps only the final copy.
+#
+# TINYBIRD_LOCAL_REF has no default on purpose — compose.dev.analytics.yaml is
+# the single source of truth for the upstream digest, and the publish workflow
+# reads it from there. Pass it explicitly for local builds.
+ARG TINYBIRD_LOCAL_REF
+
+FROM ${TINYBIRD_LOCAL_REF} AS pruned
+COPY docker/tinybird-local-slim/cleanup.sh /tmp/cleanup.sh
+RUN /tmp/cleanup.sh && rm /tmp/cleanup.sh
+
+FROM scratch
+COPY --from=pruned / /
+
+# A flatten drops the upstream image's config, so re-declare it here. The publish
+# workflow diffs this against upstream and fails the build when they drift.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    CLICKHOUSE_VERSION=25.3.7.194 \
+    CLICKHOUSE_CLUSTER_HOST=localhost \
+    CLICKHOUSE_CLUSTER_HTTP_PORT=8123 \
+    CLICKHOUSE_CLUSTER_INTERNAL_HOST=localhost \
+    CLICKHOUSE_CLUSTER_INTERNAL_HTTP_PORT=8123 \
+    CLICKHOUSE_INTERNAL_PORT=8123 \
+    USE_GATHERER=False \
+    MINIO_ROOT_USER=admin \
+    MINIO_ROOT_PASSWORD=password
+WORKDIR /app
+EXPOSE 7181 7182
+# Copied verbatim from upstream, notably the licence pointers — the flatten drops
+# them, and they are proprietary notices we are not permitted to strip. Upstream's
+# own `license` label says SSPL and contradicts the LICENSE.md the image ships
+# (and license_url serves); it is reproduced as-is rather than corrected.
+LABEL license="SSPL" \
+      license_url="https://www.tinybird.co/docs/tb-local-license.txt" \
+      org.opencontainers.image.ref.name="ubuntu" \
+      org.opencontainers.image.version="22.04"
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=10 \
+    CMD tb --output json --cloud sql 'SELECT 1 AS healthcheck' | grep '"healthcheck": 1' || exit 1
+CMD ["/usr/bin/supervisord"]

--- a/docker/tinybird-local-slim/README.md
+++ b/docker/tinybird-local-slim/README.md
@@ -1,0 +1,74 @@
+# tinybird-local-slim
+
+A distilled build of `tinybirdco/tinybird-local` for CI. Published to
+`ghcr.io/tryghost/tinybird-local-slim` by
+[`publish-tinybird-local-slim.yml`](../../.github/workflows/publish-tinybird-local-slim.yml)
+and used by the analytics E2E jobs via `GHOST_E2E_TINYBIRD_SLIM=true`.
+
+## Why
+
+The upstream image is ~2.1GB to pull and ~6.9GB once unpacked, which does not
+fit alongside the rest of the E2E infra in a GitHub Actions runner's disk
+budget. The slim build is ~0.7GB to pull and ~2.4GB unpacked, with the same boot
+time (~25s to healthy in both cases).
+
+Most of that comes from flattening, not from deleting things. Upstream installs
+ClickHouse twice and strips the binary in a separate layer, so the image carries
+several gigabytes of superseded content in lower layers. `COPY --from` into a
+`FROM scratch` stage keeps only the final rootfs.
+
+`cleanup.sh` removes the rest: the build toolchain, package installers, VCS and
+transfer tools, docs/man/locale, apt metadata, and the supervisord programs Ghost
+never exercises. It deliberately keeps every Python package and the shipped
+`__pycache__` — the Tinybird server imports its whole feature surface eagerly at
+boot, and dropping the bytecode cache made startup measurably slower.
+
+## Bumping the upstream version
+
+`compose.dev.analytics.yaml` is the single source of truth for the upstream
+digest. Bump it there; the publish workflow reads the digest from that file, so
+no change is needed here.
+
+If the new upstream release changes the image's runtime config (env vars,
+command, ports, healthcheck), the workflow's config-parity check fails — the
+`FROM scratch` flatten discards upstream's config, so the `ENV`/`CMD`/`EXPOSE`
+block in the Dockerfile has to be updated to match. Reproduce locally with
+`verify-config.sh <upstream-ref> <slim-ref>`.
+
+## Building locally
+
+```bash
+docker buildx build --platform linux/amd64 \
+  --build-arg TINYBIRD_LOCAL_REF="$(grep -oE 'tinybirdco/tinybird-local:[^ ]+' compose.dev.analytics.yaml)" \
+  -f docker/tinybird-local-slim/Dockerfile -t tinybird-local-slim:local --load .
+```
+
+Then point E2E at it:
+
+```bash
+GHOST_E2E_TINYBIRD_SLIM=true GHOST_E2E_TINYBIRD_SLIM_IMAGE=tinybird-local-slim:local pnpm test:e2e:analytics
+```
+
+## Licensing
+
+`tinybird-local` is proprietary, under the Tinybird License (Self-Managed) —
+`/LICENSE.md` in the image. Two clauses shape what this directory does:
+
+- **Derivative works are allowed** (§2c), provided they do not circumvent
+  technical limitations or remove license enforcement, auditing, or access
+  control. Distilling the image is fine; `cleanup.sh` touches none of that, and
+  leaves `/LICENSE.md` and the bundled third-party copyright files in place (§3e).
+- **Distribution is limited to within our own organization** (§2d). The GHCR
+  package must therefore stay **internal** — publishing it publicly would be
+  distribution outside the licensee organization. Grant the private forks that
+  need it access through package settings rather than making it public.
+
+An internal package is unreadable from a PR opened from a public fork, whose
+token is scoped to the fork. CI leaves `GHOST_E2E_TINYBIRD_SLIM` off for those
+runs so they use upstream directly, and `e2e/scripts/infra-up.sh` falls back to
+upstream on any failed pull regardless — so a missing access grant, or the
+window before the package is first published, degrades to a slower, fatter run
+rather than a broken one.
+
+Use here is testing, not a Production Environment, so the production usage limits
+in §3a do not apply.

--- a/docker/tinybird-local-slim/cleanup.sh
+++ b/docker/tinybird-local-slim/cleanup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Distills the upstream tinybirdco/tinybird-local image for Ghost CI use.
+#
+# The image is proprietary (Tinybird License, Self-Managed — /LICENSE.md in the
+# image). Derivative works are permitted, so long as they do not remove license
+# enforcement, auditing, or proprietary notices; /LICENSE.md and the third-party
+# copyright files are deliberately left in place.
+#
+# It only removes things Ghost provably does not use. Every Python runtime
+# dependency is kept on purpose: the (closed-source) Tinybird server imports its
+# entire feature surface eagerly at boot (LLM, GCP connectors, scipy, ...), so
+# pruning "unused" packages breaks startup. The shipped __pycache__ is kept for
+# the same reason: deleting it makes every boot recompile the tree. Most of the
+# size win instead comes from flattening the result to a single layer (the
+# `FROM scratch` stage in the Dockerfile), which drops the ClickHouse install the
+# upstream image bakes in twice across separate layers.
+set -euo pipefail
+
+SUPERVISORD=/etc/supervisor/conf.d/supervisord.conf
+
+# Drop the supervisord programs Ghost never exercises (Kafka ingestion + MCP/AI
+# server). Editing the shipped config in-place keeps this robust to upstream
+# version bumps rather than committing a copy that can drift.
+awk 'BEGIN{RS="";ORS="\n\n"} !/\[program:tinybird-kafka\]/ && !/\[program:tinybird-mcp\]/' \
+    "$SUPERVISORD" > "$SUPERVISORD.slim"
+mv "$SUPERVISORD.slim" "$SUPERVISORD"
+
+# Build toolchain / linkers — runtime-unnecessary (the image ships prebuilt wheels).
+rm -rf /usr/lib/gcc /usr/bin/gcc* /usr/bin/g++* /usr/bin/*-gcc* /usr/bin/*-g++* \
+       /usr/bin/cpp* /usr/bin/*-cpp* /usr/bin/x86_64-linux-gnu-lto-dump* \
+       /usr/bin/x86_64-linux-gnu-gcc* /usr/bin/x86_64-linux-gnu-g++*
+
+# Package installers + VCS/transfer tools not used at runtime.
+rm -rf /usr/bin/uv /usr/bin/uvx \
+       /usr/bin/git /usr/lib/git-core /usr/share/git-core \
+       /usr/bin/rsync /usr/bin/ssh /usr/bin/scp
+
+# Apt metadata and caches. /usr/share/doc stays: it is only ~6MB, and it holds
+# the Debian copyright files for the third-party packages the image bundles.
+rm -rf /var/lib/apt/lists/* /var/cache/apt/* /root/.cache
+
+# Clear log *files* but keep the dirs supervisord + services expect to exist.
+find /var/log -type f -delete 2>/dev/null || true
+mkdir -p /var/log/supervisor /var/log/clickhouse-server /var/log/nginx /var/log/redis

--- a/docker/tinybird-local-slim/verify-config.sh
+++ b/docker/tinybird-local-slim/verify-config.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Fails when the slim image's re-declared runtime config has drifted from upstream.
+#
+# The slim build flattens the rootfs into a `FROM scratch` stage, which discards
+# the upstream image config, so the Dockerfile restates it by hand. An upstream
+# release that adds an env var or changes the command would silently ship a
+# broken image without this check.
+#
+# Usage: verify-config.sh <upstream-ref> <slim-ref>
+set -euo pipefail
+
+UPSTREAM="${1:?upstream image ref required}"
+SLIM="${2:?slim image ref required}"
+
+config() {
+    local out
+    out=$(docker image inspect --platform linux/amd64 "$1" --format '{{json .Config}}' | jq -S '{
+        Env: (.Env // []| sort),
+        Cmd, Entrypoint, WorkingDir, User, StopSignal,
+        ExposedPorts: (.ExposedPorts // {} | keys),
+        Volumes: (.Volumes // {} | keys),
+        Labels: (.Labels // {}),
+        Healthcheck: (.Healthcheck // null)
+    }')
+    # An index manifest with no local amd64 child inspects to an empty config —
+    # that is a missing `docker pull --platform linux/amd64`, not real drift.
+    if [[ "$(jq -r '.Env | length' <<<"$out")" == "0" ]]; then
+        echo "No linux/amd64 config for $1 — pull it for that platform first." >&2
+        return 1
+    fi
+    printf '%s\n' "$out"
+}
+
+upstream_config=$(config "$UPSTREAM")
+slim_config=$(config "$SLIM")
+
+if diff -u <(printf '%s\n' "$upstream_config") <(printf '%s\n' "$slim_config"); then
+    echo "Slim image config matches upstream."
+    exit 0
+fi
+
+cat >&2 <<EOF
+
+Slim image runtime config differs from upstream (- upstream, + slim).
+Reconcile docker/tinybird-local-slim/Dockerfile with the pinned upstream image.
+EOF
+exit 1

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -80,6 +80,18 @@ snapshot restore cycles stay fast and isolated from local development data.
 Set `GHOST_E2E_MYSQL_TMPFS=false` to use the normal Docker volume instead, or
 `GHOST_E2E_MYSQL_TMPFS_SIZE=4g` to adjust the tmpfs size.
 
+Set `GHOST_E2E_TINYBIRD_SLIM=true` to swap the Tinybird service for the distilled
+slim image (`ghcr.io/tryghost/tinybird-local-slim`): ~0.7GB pulled and ~2.4GB on
+disk, against ~2.1GB and ~6.9GB for upstream. CI enables it so the analytics jobs
+fit inside the runner disk budget. Override the image/tag with
+`GHOST_E2E_TINYBIRD_SLIM_IMAGE`. Local dev (`compose.dev.analytics.yaml`) always
+uses the upstream image.
+
+The slim image's GHCR package is internal, so a pull can legitimately fail — most
+often on a PR from a public fork, whose token cannot read it. `infra-up.sh` warns
+and falls back to the upstream image rather than failing the run. CI leaves the
+flag off for cross-repo PRs so those runs skip the doomed pull entirely.
+
 For a CI-like local preflight (pulls Playwright + gateway images and starts infra), run:
 
 ```bash

--- a/e2e/compose.e2e.tinybird-slim.yaml
+++ b/e2e/compose.e2e.tinybird-slim.yaml
@@ -1,0 +1,13 @@
+# Swaps the Tinybird service to the distilled slim image (~0.7GB pulled / ~2.4GB
+# on disk, vs ~2.1GB / ~6.9GB upstream) so the analytics E2E jobs fit inside the
+# runner disk budget. Layered on top of compose.dev.analytics.yaml by infra-up.sh
+# when GHOST_E2E_TINYBIRD_SLIM=true. Local dev is unaffected —
+# compose.dev.analytics.yaml keeps the upstream image.
+#
+# See docker/tinybird-local-slim/ for how the image is built and published.
+#
+# infra-up.sh owns the default and exports it, so that there is one source of
+# truth for which image this resolves to.
+services:
+  tinybird-local:
+    image: ${GHOST_E2E_TINYBIRD_SLIM_IMAGE:?set by e2e/scripts/infra-up.sh}

--- a/e2e/scripts/infra-up.sh
+++ b/e2e/scripts/infra-up.sh
@@ -11,6 +11,7 @@ MODE="$(resolve_e2e_mode)"
 export GHOST_E2E_MODE="$MODE"
 ANALYTICS_ENABLED="${GHOST_E2E_ANALYTICS:-true}"
 MYSQL_TMPFS_ENABLED="${GHOST_E2E_MYSQL_TMPFS:-true}"
+TINYBIRD_SLIM_ENABLED="${GHOST_E2E_TINYBIRD_SLIM:-false}"
 
 if [[ "$MODE" != "build" ]]; then
   DEV_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-ghost-dev}"
@@ -33,6 +34,27 @@ fi
 if [[ "$ANALYTICS_ENABLED" == "true" ]]; then
   compose_files+=(-f compose.dev.analytics.yaml)
   services+=(tinybird-local analytics)
+
+  # Opt-in override to the distilled slim Tinybird image, which is a fraction of
+  # upstream's size on disk. Must be layered after compose.dev.analytics.yaml to
+  # override its image.
+  #
+  # The image is licensed for distribution within our organization only, so its
+  # GHCR package is internal and unreadable from a fork PR's scoped token. Fall
+  # back to the upstream image whenever the pull fails, rather than failing the
+  # run: it also covers the window before the package is first published, and a
+  # revoked or not-yet-granted access grant.
+  if [[ "$TINYBIRD_SLIM_ENABLED" == "true" ]]; then
+    export GHOST_E2E_TINYBIRD_SLIM_IMAGE="${GHOST_E2E_TINYBIRD_SLIM_IMAGE:-ghcr.io/tryghost/tinybird-local-slim:latest}"
+
+    if docker image inspect "$GHOST_E2E_TINYBIRD_SLIM_IMAGE" >/dev/null 2>&1 \
+        || docker pull "$GHOST_E2E_TINYBIRD_SLIM_IMAGE"; then
+      compose_files+=(-f e2e/compose.e2e.tinybird-slim.yaml)
+    else
+      echo "WARNING: could not pull ${GHOST_E2E_TINYBIRD_SLIM_IMAGE} — falling back to the upstream Tinybird image."
+      echo "WARNING: the upstream image needs several more GB of runner disk; expect a disk-space failure on a constrained runner."
+    fi
+  fi
 fi
 
 docker compose "${compose_files[@]}" up -d --wait "${services[@]}"

--- a/e2e/scripts/prepare-ci-e2e-build-mode.sh
+++ b/e2e/scripts/prepare-ci-e2e-build-mode.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/load-playwright-container-env.sh"
 GATEWAY_IMAGE="${GHOST_E2E_GATEWAY_IMAGE:-caddy:2-alpine}"
 ANALYTICS_ENABLED="${GHOST_E2E_ANALYTICS:-true}"
+TINYBIRD_SLIM_ENABLED="${GHOST_E2E_TINYBIRD_SLIM:-false}"
 
 echo "Preparing E2E build-mode runtime"
 echo "Playwright image: ${PLAYWRIGHT_IMAGE}"
 echo "Gateway image: ${GATEWAY_IMAGE}"
 echo "Analytics enabled: ${ANALYTICS_ENABLED}"
+echo "Tinybird slim image: ${TINYBIRD_SLIM_ENABLED}"
 
 pids=()
 labels=()
@@ -27,7 +29,7 @@ run_bg() {
 
 run_bg "pull-gateway-image" docker pull "$GATEWAY_IMAGE"
 run_bg "pull-playwright-image" ensure_playwright_image
-run_bg "start-infra" env GHOST_E2E_MODE=build GHOST_E2E_ANALYTICS="$ANALYTICS_ENABLED" bash "$REPO_ROOT/e2e/scripts/infra-up.sh"
+run_bg "start-infra" env GHOST_E2E_MODE=build GHOST_E2E_ANALYTICS="$ANALYTICS_ENABLED" GHOST_E2E_TINYBIRD_SLIM="$TINYBIRD_SLIM_ENABLED" bash "$REPO_ROOT/e2e/scripts/infra-up.sh"
 
 for i in "${!pids[@]}"; do
     if ! wait "${pids[$i]}"; then

--- a/e2e/scripts/sync-tinybird-state.mjs
+++ b/e2e/scripts/sync-tinybird-state.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -9,14 +10,8 @@ const repoRoot = path.resolve(__dirname, '../..');
 const stateDir = path.resolve(repoRoot, 'e2e/data/state');
 const configPath = path.resolve(stateDir, 'tinybird.json');
 
-const composeArgs = [
-  'compose',
-  '-f',
-  path.resolve(repoRoot, 'compose.dev.yaml'),
-  '-f',
-  path.resolve(repoRoot, 'compose.dev.analytics.yaml'),
-];
 const composeProject = process.env.COMPOSE_PROJECT_NAME || 'ghost-dev';
+const tinybirdConfigPath = '/mnt/shared-config/.env.tinybird';
 
 function log(message) {
   process.stdout.write(`${message}\n`);
@@ -49,25 +44,16 @@ function clearConfigIfPresent() {
   }
 }
 
-function runCompose(args) {
-  return execFileSync('docker', [...composeArgs, ...args], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-}
-
-function isTinybirdRunning() {
+function findContainer(service, extraFilters = []) {
   const output = execFileSync(
     'docker',
     [
       'ps',
+      ...extraFilters,
       '--filter',
       `label=com.docker.compose.project=${composeProject}`,
       '--filter',
-      'label=com.docker.compose.service=tinybird-local',
-      '--filter',
-      'status=running',
+      `label=com.docker.compose.service=${service}`,
       '--format',
       '{{.Names}}',
     ],
@@ -78,11 +64,40 @@ function isTinybirdRunning() {
     },
   );
 
-  return Boolean(output.trim());
+  return output.trim().split('\n')[0] || null;
 }
 
+function isTinybirdRunning() {
+  return Boolean(findContainer('tinybird-local', ['--filter', 'status=running']));
+}
+
+// Copied out of the tb-cli container rather than read through `docker compose
+// run`. That would re-run the tb-cli entrypoint (a full datafile deploy), and,
+// worse, compose would recreate any dependency whose config differs from the
+// compose files listed here — silently replacing a tinybird-local started from
+// an override (see e2e/compose.e2e.tinybird-slim.yaml). `docker cp` reads the
+// same file straight from the exited container and cannot diverge.
 function fetchConfigFromTbCli() {
-  return runCompose(['run', '--rm', '-T', 'tb-cli', 'cat', '/mnt/shared-config/.env.tinybird']);
+  const container = findContainer('tb-cli', ['-a']);
+
+  if (!container) {
+    throw new Error(`No tb-cli container found for compose project ${composeProject}`);
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-e2e-tinybird-'));
+  const tmpFile = path.join(tmpDir, '.env.tinybird');
+
+  try {
+    execFileSync('docker', ['cp', `${container}:${tinybirdConfigPath}`, tmpFile], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return fs.readFileSync(tmpFile, 'utf8');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 }
 
 function writeConfig(env) {
@@ -116,7 +131,7 @@ try {
   if (!env.TINYBIRD_WORKSPACE_ID || !env.TINYBIRD_ADMIN_TOKEN) {
     clearConfigIfPresent();
     throw new Error(
-      'Tinybird is running but required config values are missing in /mnt/shared-config/.env.tinybird',
+      `Tinybird is running but required config values are missing in ${tinybirdConfigPath}`,
     );
   }
 


### PR DESCRIPTION
no ref
- tinybird local is a huge docker image, building a distilled one allows us to save on runner disk space
