### PR TITLE
Migrated sendWebmentions to the class-based jobs service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -690,12 +690,14 @@ async function bootGhost({ backend = true, frontend = true, server = true } = {}
     memberJobs.init();
     assert(gifts.service, 'Gift service should be initialized');
     assert(mentionsService.controller, 'Mentions controller should be initialized');
+    assert(mentionsService.sendingService, 'Mentions sending service should be initialized');
     registerJobHandlers({
       jobsService,
       memberJobs,
       giftService: gifts.service,
       mediaInliner: mediaInliner.getInstance(),
       mentionsController: mentionsService.controller,
+      mentionsSendingService: mentionsService.sendingService,
     });
     await jobsService.start();
     debug('End: Register job handlers');

--- a/ghost/core/core/server/services/jobs-service/index.ts
+++ b/ghost/core/core/server/services/jobs-service/index.ts
@@ -5,6 +5,15 @@ import type { JobsShutdownOptions } from '@tryghost/adapter-base-jobs';
 let instance: JobsService | undefined;
 
 export function init(): JobsService {
+  // The instance lives for the whole process: the didInit-guarded mentions
+  // service captures it in MentionController and MentionSendingService, so
+  // an in-process restart (test harness) must revive the same object rather
+  // than strand those references on a stopped queue.
+  if (instance) {
+    instance.clearHandlers();
+    return instance;
+  }
+
   const adapterManager = require('../adapter-manager').default;
   const logging = require('@tryghost/logging');
   const sentry = require('../../../shared/sentry');

--- a/ghost/core/core/server/services/jobs-service/jobs-service.ts
+++ b/ghost/core/core/server/services/jobs-service/jobs-service.ts
@@ -152,6 +152,15 @@ export class JobsService {
     await this.#backend.shutdown(options);
   }
 
+  // An in-process restart (test harness) re-runs handler registration on the
+  // same instance, so all registration state resets - handlers and queue
+  // declarations alike. The duplicate-type guard still holds within a boot.
+  clearHandlers(): void {
+    this.#registry.clear();
+    this.#queueByType.clear();
+    this.#queues.clear();
+  }
+
   #buildEnvelope(job: Job): JobEnvelope {
     return { type: this.#typeOf(job), payload: JSON.stringify(job) };
   }

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -10,7 +10,9 @@ import ContentCSVImportJob from '../content-import/jobs/content-csv-import-job';
 import * as contentImport from '../content-import';
 import UpdateCheckJob from '../update-check/jobs/update-check-job';
 import type MentionController from '../mentions/mention-controller';
+import type MentionSendingService from '../mentions/mention-sending-service';
 import ProcessWebmentionJob from '../mentions/process-webmention-job';
+import SendWebmentionsJob from '../mentions/send-webmentions-job';
 
 const updateCheck = require('../update-check');
 
@@ -31,6 +33,7 @@ interface RegisterJobHandlersDependencies {
   giftService: GiftService;
   mediaInliner: ExternalMediaInliner;
   mentionsController: MentionController;
+  mentionsSendingService: MentionSendingService;
 }
 
 export default function registerJobHandlers({
@@ -39,6 +42,7 @@ export default function registerJobHandlers({
   giftService,
   mediaInliner,
   mentionsController,
+  mentionsSendingService,
 }: RegisterJobHandlersDependencies): void {
   jobsService.handle(CleanTokensJob, async () => {
     await memberJobs.cleanTokens();
@@ -68,6 +72,14 @@ export default function registerJobHandlers({
     ProcessWebmentionJob,
     async (job) => {
       await mentionsController.processWebmention(job);
+    },
+    WEBMENTIONS_QUEUE,
+  );
+
+  jobsService.handle(
+    SendWebmentionsJob,
+    async (job) => {
+      await mentionsSendingService.sendWebmentions(job);
     },
     WEBMENTIONS_QUEUE,
   );

--- a/ghost/core/core/server/services/mentions/mention-sending-service.d.ts
+++ b/ghost/core/core/server/services/mentions/mention-sending-service.d.ts
@@ -1,0 +1,7 @@
+import type SendWebmentionsJob from './send-webmentions-job';
+
+declare class MentionSendingService {
+  sendWebmentions(job: SendWebmentionsJob): Promise<void>;
+}
+
+export = MentionSendingService;

--- a/ghost/core/core/server/services/mentions/mention-sending-service.js
+++ b/ghost/core/core/server/services/mentions/mention-sending-service.js
@@ -158,10 +158,22 @@ module.exports = class MentionSendingService {
   }
 
   /**
+   * Send the webmentions for a delivered job.
+   * @param {import('./send-webmentions-job').default} job
+   */
+  async sendWebmentions(job) {
+    await this.sendForHTMLResource({
+      url: new URL(job.sourceUrl),
+      html: job.html,
+      previousHtml: job.previousHtml,
+    });
+  }
+
+  /**
    * Send a webmention call for the links in a resource.
    * @param {object} resource
    * @param {URL} resource.url
-   * @param {string} resource.html
+   * @param {string|null} resource.html
    * @param {string|null} [resource.previousHtml]
    */
   async sendForHTMLResource(resource) {

--- a/ghost/core/core/server/services/mentions/mention-sending-service.js
+++ b/ghost/core/core/server/services/mentions/mention-sending-service.js
@@ -1,5 +1,6 @@
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const SendWebmentionsJob = require('./send-webmentions-job').default;
 
 module.exports = class MentionSendingService {
   #discoveryService;
@@ -8,8 +9,12 @@ module.exports = class MentionSendingService {
   #getPostData;
   #getPostUrl;
   #isEnabled;
-  #jobService;
+  #jobsService;
 
+  /**
+   * @param {object} deps
+   * @param {import('../jobs-service/jobs-service').JobsService} deps.jobsService
+   */
   constructor({
     discoveryService,
     externalRequest,
@@ -17,7 +22,7 @@ module.exports = class MentionSendingService {
     getPostData,
     getPostUrl,
     isEnabled,
-    jobService,
+    jobsService,
   }) {
     this.#discoveryService = discoveryService;
     this.#externalRequest = externalRequest;
@@ -25,7 +30,7 @@ module.exports = class MentionSendingService {
     this.#getPostData = getPostData;
     this.#getPostUrl = getPostUrl;
     this.#isEnabled = isEnabled;
-    this.#jobService = jobService;
+    this.#jobsService = jobsService;
   }
 
   get siteUrl() {
@@ -82,13 +87,13 @@ module.exports = class MentionSendingService {
         // Capture the source URL now, from the event's data, rather than
         // deferring the model into the job.
         const url = new URL(await this.#resolvePostUrl(post));
-        await this.#jobService.addJob('sendWebmentions', async () => {
-          await this.sendForHTMLResource({
-            url,
+        await this.#jobsService.dispatch(
+          new SendWebmentionsJob({
+            sourceUrl: url.href,
             html: html,
             previousHtml: previousHtml,
-          });
-        });
+          }),
+        );
       }
     } catch (e) {
       logging.error('Error in webmention sending service post update event handler:');

--- a/ghost/core/core/server/services/mentions/send-webmentions-job.ts
+++ b/ghost/core/core/server/services/mentions/send-webmentions-job.ts
@@ -1,0 +1,28 @@
+import { Job } from '../jobs-service/job';
+
+// Carries the post's full html twice - the largest job payload in the system;
+// revisit if a durable backend puts size limits on envelopes.
+export default class SendWebmentionsJob extends Job {
+  static type = 'send-webmentions';
+
+  readonly sourceUrl: string;
+
+  readonly html: string | null;
+
+  readonly previousHtml: string | null;
+
+  constructor({
+    sourceUrl,
+    html,
+    previousHtml,
+  }: {
+    sourceUrl: string;
+    html: string | null;
+    previousHtml: string | null;
+  }) {
+    super();
+    this.sourceUrl = sourceUrl;
+    this.html = html ?? null;
+    this.previousHtml = previousHtml ?? null;
+  }
+}

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -14,8 +14,6 @@ const outputSerializerUrlUtil = require('../../../server/api/endpoints/utils/ser
 const urlService = require('../url');
 const settingsCache = require('../../../shared/settings-cache');
 const DomainEvents = require('@tryghost/domain-events');
-const logging = require('@tryghost/logging');
-const mentionsJobService = require('../mentions-jobs');
 
 // Serializes a post model to the data the URL service needs, loading the
 // relations it reads for filtered collections (event-emitted models don't
@@ -36,33 +34,6 @@ function getPostUrl(id, postData) {
   const type = postData.type === 'page' ? 'pages' : 'posts';
   outputSerializerUrlUtil.forPost(id, jsonModel, { options: {} }, type);
   return jsonModel.url;
-}
-
-// Reports the same queued/started/finished/failed lifecycle for every mentions
-// background job. The wrapped callback's result and errors pass through unchanged,
-// so job manager outcomes and retries are unaffected.
-function makeLoggingJobService() {
-  return {
-    async addJob(name, fn) {
-      logging.info(`[Background Job] ${name} queued`);
-      mentionsJobService.addJob({
-        name,
-        job: async () => {
-          const startedAt = Date.now();
-          logging.info(`[Background Job] ${name} started`);
-          try {
-            const result = await fn();
-            logging.info(`[Background Job] ${name} completed in ${Date.now() - startedAt}ms`);
-            return result;
-          } catch (err) {
-            logging.error(err, `[Background Job] ${name} failed after ${Date.now() - startedAt}ms`);
-            throw err;
-          }
-        },
-        offloaded: false,
-      });
-    },
-  };
 }
 
 module.exports = {
@@ -141,7 +112,7 @@ module.exports = {
       getPostData: (post) => getPostData(post),
       getPostUrl: (id, data) => getPostUrl(id, data),
       isEnabled: () => !settingsCache.get('is_private'),
-      jobService: makeLoggingJobService(),
+      jobsService,
     });
     sendingService.listen(events);
 
@@ -152,4 +123,3 @@ module.exports = {
 // exposed for testing
 module.exports.getPostData = getPostData;
 module.exports.getPostUrl = getPostUrl;
-module.exports.makeLoggingJobService = makeLoggingJobService;

--- a/ghost/core/test/e2e-server/services/mentions.test.js
+++ b/ghost/core/test/e2e-server/services/mentions.test.js
@@ -1,10 +1,12 @@
+/* global vi */
 const { agentProvider, fixtureManager, mockManager } = require('../../utils/e2e-framework');
 const nock = require('nock');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const markdownToLexical = require('../../utils/fixtures/data-generator').markdownToLexical;
-const jobsService = require('../../../core/server/services/mentions-jobs');
+const mentionsService = require('../../../core/server/services/mentions');
 const urlService = require('../../../core/server/services/url');
+const events = require('../../../core/server/lib/common/events');
 
 let agent;
 let mentionUrl = new URL('https://www.otherghostsite.com/');
@@ -18,6 +20,78 @@ let targetHtml2 = `<head><link rel="webmention" href="${endpointUrl2.href}"</hea
 let mentionMock;
 let endpointMock;
 const DomainEvents = require('@tryghost/domain-events');
+
+// sendForPost runs from model events that fire on transaction commit and
+// awaits DB work before dispatching. Track every run so tests can drain them.
+const mentionEvents = [
+  'post.published',
+  'post.published.edited',
+  'post.unpublished',
+  'page.published',
+  'page.published.edited',
+  'page.unpublished',
+];
+const pendingSendForPost = [];
+const wrappedListeners = [];
+
+function trackSendForPost() {
+  for (const eventName of mentionEvents) {
+    const original = events.listeners(eventName).find((l) => l.name === 'bound sendForPost');
+    assert.ok(original, `expected a sendForPost listener on ${eventName}`);
+    const wrapper = (...args) => {
+      const run = original(...args);
+      pendingSendForPost.push(run);
+      return run;
+    };
+    events.removeListener(eventName, original);
+    events.on(eventName, wrapper);
+    wrappedListeners.push({ eventName, original, wrapper });
+  }
+}
+
+function untrackSendForPost() {
+  for (const { eventName, original, wrapper } of wrappedListeners) {
+    events.removeListener(eventName, wrapper);
+    events.on(eventName, original);
+  }
+  wrappedListeners.length = 0;
+}
+
+// Draining the runs proves no job was dispatched - for the cases whose
+// filters return before reaching the queue.
+async function sendForPostSettled() {
+  while (pendingSendForPost.length) {
+    await Promise.all(pendingSendForPost.splice(0));
+  }
+  await DomainEvents.allSettled();
+}
+
+let processedJobs;
+
+function recordProcessed(resource) {
+  processedJobs.push(resource);
+}
+
+// Wrap the seam the job handler calls: completion here means the job ran,
+// without coupling the test to the queue or its backend.
+function trackWebmentionSending() {
+  const sendingService = mentionsService.sendingService;
+  const original = sendingService.sendForHTMLResource.bind(sendingService);
+  sinon.stub(sendingService, 'sendForHTMLResource').callsFake(async (resource) => {
+    try {
+      return await original(resource);
+    } finally {
+      // Recorded in finally: "processed" means the handler finished,
+      // successful or not - the nock assertions decide correctness.
+      recordProcessed(resource);
+    }
+  });
+}
+
+async function waitForSends(count, { timeoutMs = 5000 } = {}) {
+  await vi.waitUntil(() => processedJobs.length >= count, { timeout: timeoutMs });
+  await DomainEvents.allSettled();
+}
 
 const mentionsPost = {
   title: 'testing sending webmentions',
@@ -45,6 +119,11 @@ describe('Mentions Service', function () {
     agent = await agentProvider.getAdminAPIAgent();
     await fixtureManager.init('users');
     await agent.loginAsAdmin();
+    trackSendForPost();
+  });
+
+  afterAll(function () {
+    untrackSendForPost();
   });
 
   beforeEach(async function () {
@@ -54,8 +133,9 @@ describe('Mentions Service', function () {
     // mock response from website mentioned by post to provide endpoint
     addMentionMocks();
 
-    await jobsService.allSettled();
-    await DomainEvents.allSettled();
+    await sendForPostSettled();
+    processedJobs = [];
+    trackWebmentionSending();
   });
 
   afterEach(async function () {
@@ -72,8 +152,7 @@ describe('Mentions Service', function () {
           .body({ posts: [draftPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await sendForPostSettled();
 
         assert.equal(mentionMock.isDone(), false);
         assert.equal(endpointMock.isDone(), false);
@@ -86,8 +165,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await sendForPostSettled();
 
         assert.equal(mentionMock.isDone(), false);
         assert.equal(endpointMock.isDone(), false);
@@ -104,8 +182,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await sendForPostSettled();
 
         assert.equal(mentionMock.isDone(), false);
         assert.equal(endpointMock.isDone(), false);
@@ -118,8 +195,7 @@ describe('Mentions Service', function () {
           .body({ pages: [draftPage] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await sendForPostSettled();
 
         assert.equal(mentionMock.isDone(), false);
         assert.equal(endpointMock.isDone(), false);
@@ -134,8 +210,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         assert.equal(mentionMock.isDone(), true);
         assert.equal(endpointMock.isDone(), true);
@@ -148,8 +223,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -171,8 +245,9 @@ describe('Mentions Service', function () {
           .body({ posts: [editedPost] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        // The edit dispatches a job (the html changed); "does not send" is
+        // the handler's link diff yielding nothing, so wait for processing.
+        await waitForSends(2);
 
         assert.equal(mentionMock.isDone(), false);
         assert.equal(endpointMock.isDone(), false);
@@ -185,8 +260,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -216,8 +290,7 @@ describe('Mentions Service', function () {
           .body({ posts: [editedPost] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         assert.equal(mentionMockTwo.isDone(), true);
         assert.equal(endpointMockTwo.isDone(), true);
@@ -234,8 +307,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -261,8 +333,7 @@ describe('Mentions Service', function () {
           .body({ posts: [unpublishedPost] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         assert.equal(mentionMockTwo.isDone(), true);
         assert.equal(endpointMockTwo.isDone(), true);
@@ -279,8 +350,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
         assert.equal(endpointMock.isDone(), true);
 
         nock.cleanAll();
@@ -296,8 +366,7 @@ describe('Mentions Service', function () {
         const postId = res.body.posts[0].id;
         await agent.delete(`posts/${postId}/`).expectStatus(204);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         // the webmention for the removed content went out...
         assert.equal(endpointMock.isDone(), true);
@@ -317,8 +386,7 @@ describe('Mentions Service', function () {
           .body({ pages: [publishedPage] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         assert.equal(mentionMock.isDone(), true);
         assert.equal(endpointMock.isDone(), true);
@@ -331,8 +399,7 @@ describe('Mentions Service', function () {
           .body({ pages: [publishedPage] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -354,8 +421,9 @@ describe('Mentions Service', function () {
           .body({ pages: [editedPage] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        // The edit dispatches a job (the html changed); "does not send" is
+        // the handler's link diff yielding nothing, so wait for processing.
+        await waitForSends(2);
 
         assert.equal(mentionMock.isDone(), false);
         assert.equal(mentionMock.isDone(), false);
@@ -368,8 +436,7 @@ describe('Mentions Service', function () {
           .body({ pages: [publishedPage] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -399,8 +466,7 @@ describe('Mentions Service', function () {
           .body({ pages: [editedPage] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         assert.equal(mentionMockTwo.isDone(), true);
         assert.equal(endpointMockTwo.isDone(), true);
@@ -417,8 +483,7 @@ describe('Mentions Service', function () {
           .body({ pages: [publishedPage] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -444,8 +509,7 @@ describe('Mentions Service', function () {
           .body({ pages: [unpublishedPage] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         assert.equal(mentionMockTwo.isDone(), true);
         assert.equal(endpointMockTwo.isDone(), true);
@@ -458,8 +522,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -485,8 +548,7 @@ describe('Mentions Service', function () {
           .body({ posts: [editedPost] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         assert.equal(mentionMockTwo.isDone(), true);
         assert.equal(endpointMockTwo.isDone(), true);
@@ -499,8 +561,7 @@ describe('Mentions Service', function () {
           .body({ pages: [publishedPage] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         // while not the point of the test, we should have real links/mentions to start with
         assert.equal(mentionMock.isDone(), true);
@@ -526,8 +587,7 @@ describe('Mentions Service', function () {
           .body({ pages: [editedPage] })
           .expectStatus(200);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(2);
 
         assert.equal(mentionMockTwo.isDone(), true);
         assert.equal(endpointMockTwo.isDone(), true);
@@ -541,8 +601,7 @@ describe('Mentions Service', function () {
           .body({ posts: [publishedPost] })
           .expectStatus(201);
 
-        await jobsService.allSettled();
-        await DomainEvents.allSettled();
+        await waitForSends(1);
 
         assert.equal(mentionMock.isDone(), true);
         assert.equal(endpointMock.isDone(), true);

--- a/ghost/core/test/integration/services/mentions/send-webmentions-job.test.ts
+++ b/ghost/core/test/integration/services/mentions/send-webmentions-job.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import nock from 'nock';
+
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const { getInstance: getJobsService } = require('../../../../core/server/services/jobs-service');
+const SendWebmentionsJob =
+  require('../../../../core/server/services/mentions/send-webmentions-job').default;
+
+async function waitFor(
+  check: () => boolean | Promise<boolean>,
+  { timeoutMs = 5000, intervalMs = 25 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+  return false;
+}
+
+describe('Job: Send webmentions', function () {
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('posts');
+  });
+
+  afterAll(function () {
+    nock.cleanAll();
+  });
+
+  it('sends a webmention to the linked target when the dispatched job runs', async function () {
+    const targetUrl = new URL('https://target-of-outbound-webmention.com/article/');
+    const endpointUrl = new URL('https://target-of-outbound-webmention.com/webmention-endpoint/');
+    const targetHtml = `<html><head><link rel="webmention" href="${endpointUrl.href}"></head><body>Some content</body></html>`;
+
+    nock(targetUrl.origin)
+      .persist()
+      .get(targetUrl.pathname)
+      .reply(200, targetHtml, { 'Content-Type': 'text/html' });
+    let receivedBody: string | null = null;
+    const endpointScope = nock(endpointUrl.origin)
+      .post(endpointUrl.pathname, (body) => {
+        receivedBody = new URLSearchParams(body).toString();
+        return true;
+      })
+      .reply(201);
+
+    await getJobsService().dispatch(
+      new SendWebmentionsJob({
+        sourceUrl: 'http://127.0.0.1:2369/source-post/',
+        html: `<a href="${targetUrl.href}">linked</a>`,
+        previousHtml: null,
+      }),
+    );
+
+    const delivered = await waitFor(() => endpointScope.isDone());
+    assert.ok(delivered, 'The webmention endpoint received the notification');
+
+    const body = new URLSearchParams(receivedBody!);
+    assert.equal(body.get('source'), 'http://127.0.0.1:2369/source-post/');
+    assert.equal(body.get('target'), targetUrl.href);
+  });
+});

--- a/ghost/core/test/unit/server/services/jobs-service/index.test.js
+++ b/ghost/core/test/unit/server/services/jobs-service/index.test.js
@@ -33,15 +33,27 @@ describe('jobs-service wrapper', function () {
     assert.throws(() => jobsService.getInstance(), /used before init/);
   });
 
-  it('init builds the service from the jobs adapter and getInstance returns it', function () {
-    const fakeBackend = {
+  function makeFakeBackend() {
+    return {
       requiredFns: ['start', 'enqueue', 'scheduleRecurring', 'shutdown'],
+      shutdownCalls: 0,
       start() {},
       enqueue() {},
       scheduleRecurring() {},
-      async shutdown() {},
+      async shutdown() {
+        this.shutdownCalls += 1;
+      },
     };
-    sinon.stub(adapterManager, 'getAdapter').withArgs('jobs').returns(fakeBackend);
+  }
+
+  function stubAdapters() {
+    const jobsBackend = makeFakeBackend();
+    sinon.stub(adapterManager, 'getAdapter').withArgs('jobs').returns(jobsBackend);
+    return { jobsBackend };
+  }
+
+  it('init builds the service from the jobs adapter and getInstance returns it', function () {
+    stubAdapters();
 
     const service = jobsService.init();
 
@@ -50,5 +62,34 @@ describe('jobs-service wrapper', function () {
       service,
       'getInstance returns the instance built by init',
     );
+  });
+
+  it('init after a shutdown reuses the same instance, so captured references stay live', async function () {
+    stubAdapters();
+
+    const service = jobsService.init();
+    await jobsService.shutdown({ timeoutMs: 10 });
+
+    assert.equal(jobsService.init(), service, 'the instance survives a reboot');
+  });
+
+  it('re-init clears handlers so a reboot can register the same job types again', function () {
+    stubAdapters();
+
+    class RebootJob {
+      static type = 'reboot-job';
+    }
+    jobsService.init().handle(RebootJob, async () => {});
+
+    jobsService.init().handle(RebootJob, async () => {});
+  });
+
+  it('shutdown after init shuts down the backend', async function () {
+    const { jobsBackend } = stubAdapters();
+
+    jobsService.init();
+    await jobsService.shutdown({ timeoutMs: 10 });
+
+    assert.equal(jobsBackend.shutdownCalls, 1, 'the jobs backend was shut down');
   });
 });

--- a/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
@@ -367,4 +367,24 @@ describe('JobsService', function () {
       assert.deepEqual(backend.shutdownCalls, [{ timeoutMs: 42 }]);
     });
   });
+
+  describe('restart', function () {
+    it('clearHandlers lets a rebooted process register the same job types again', function () {
+      const service = makeService();
+      service.handle(GreetJob, async () => {});
+
+      service.clearHandlers();
+
+      service.handle(GreetJob, async () => {});
+    });
+
+    it('clearHandlers resets queue declarations so a reboot can re-declare them', function () {
+      const service = makeService();
+      service.handle(GreetJob, async () => {}, { queue: 'greetings', concurrency: 1 });
+
+      service.clearHandlers();
+
+      service.handle(GreetJob, async () => {}, { queue: 'greetings', concurrency: 2 });
+    });
+  });
 });

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -7,6 +7,7 @@ import ExternalMediaInlinerJob from '../../../../../core/server/services/media-i
 import ContentCSVImportJob from '../../../../../core/server/services/content-import/jobs/content-csv-import-job';
 import UpdateCheckJob from '../../../../../core/server/services/update-check/jobs/update-check-job';
 import ProcessWebmentionJob from '../../../../../core/server/services/mentions/process-webmention-job';
+import SendWebmentionsJob from '../../../../../core/server/services/mentions/send-webmentions-job';
 
 const registerJobHandlers =
   require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
@@ -17,6 +18,7 @@ describe('register-job-handlers', function () {
   let memberJobs: { cleanTokens: sinon.SinonStub; cleanExpiredComped: sinon.SinonStub };
   let giftService: { cleanup: sinon.SinonStub };
   let mentionsController: { processWebmention: sinon.SinonStub };
+  let mentionsSendingService: { sendWebmentions: sinon.SinonStub };
 
   // Handlers are looked up by their job type rather than registration order,
   // so adding a handler does not silently shift which one a test exercises.
@@ -41,6 +43,7 @@ describe('register-job-handlers', function () {
     };
     giftService = { cleanup: sinon.stub().resolves() };
     mentionsController = { processWebmention: sinon.stub().resolves() };
+    mentionsSendingService = { sendWebmentions: sinon.stub().resolves() };
 
     registerJobHandlers({
       jobsService,
@@ -48,6 +51,7 @@ describe('register-job-handlers', function () {
       giftService,
       mediaInliner,
       mentionsController,
+      mentionsSendingService,
     });
   });
 
@@ -145,6 +149,25 @@ describe('register-job-handlers', function () {
   // every handler-behavior test still passes.
   it('registers process-webmention on the dedicated webmentions queue', function () {
     const registration = registrationFor('process-webmention');
+
+    assert.deepEqual(registration.args[2], { queue: 'webmentions', concurrency: 3 });
+  });
+
+  it('runs send-webmentions with the injected mentions sending service', async function () {
+    const sendWebmentionsHandler = handlerFor('send-webmentions');
+    const job = new SendWebmentionsJob({
+      sourceUrl: 'https://site.com/post/',
+      html: '<a href="https://example.com/">link</a>',
+      previousHtml: null,
+    });
+
+    await sendWebmentionsHandler(job);
+
+    assert.ok(mentionsSendingService.sendWebmentions.calledOnceWithExactly(job));
+  });
+
+  it('registers send-webmentions on the dedicated webmentions queue', function () {
+    const registration = registrationFor('send-webmentions');
 
     assert.deepEqual(registration.args[2], { queue: 'webmentions', concurrency: 3 });
   });

--- a/ghost/core/test/unit/server/services/mentions/mention-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/mention-sending-service.test.js
@@ -8,12 +8,8 @@ const logging = require('@tryghost/logging');
 const dnsPromises = require('node:dns').promises;
 const { createModel } = require('./utils/index.js');
 
-// mock up job service
-let jobService = {
-  async addJob(name, fn) {
-    return fn();
-  },
-};
+const SendWebmentionsJob =
+  require('../../../../../core/server/services/mentions/send-webmentions-job').default;
 
 describe('MentionSendingService', function () {
   let errorLogStub;
@@ -53,39 +49,81 @@ describe('MentionSendingService', function () {
 
   describe('sendForPost', function () {
     it('Ignores if disabled', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => false,
+        getPostData: () => ({}),
+        getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
-      await service.sendForPost({});
-      sinon.assert.notCalled(stub);
+      await service.sendForPost(
+        createModel({
+          status: 'published',
+          html: 'same',
+          previous: {
+            status: 'draft',
+            html: 'same',
+          },
+        }),
+      );
+      sinon.assert.notCalled(jobsService.dispatch);
+      sinon.assert.notCalled(errorLogStub);
     });
 
     it('Ignores if importing data', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
+        getPostData: () => ({}),
+        getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
-      let options = { importing: true };
-      await service.sendForPost({}, options);
-      sinon.assert.notCalled(stub);
+      await service.sendForPost(
+        createModel({
+          status: 'published',
+          html: 'same',
+          previous: {
+            status: 'draft',
+            html: 'same',
+          },
+        }),
+        { importing: true },
+      );
+      sinon.assert.notCalled(jobsService.dispatch);
+      sinon.assert.notCalled(errorLogStub);
     });
 
     it('Ignores if internal context', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
+        getPostData: () => ({}),
+        getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
-      let options = { context: { internal: true } };
-      await service.sendForPost({}, options);
-      sinon.assert.notCalled(stub);
+      await service.sendForPost(
+        createModel({
+          status: 'published',
+          html: 'same',
+          previous: {
+            status: 'draft',
+            html: 'same',
+          },
+        }),
+        { context: { internal: true } },
+      );
+      sinon.assert.notCalled(jobsService.dispatch);
+      sinon.assert.notCalled(errorLogStub);
     });
 
     it('Ignores draft posts', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
+        getPostData: () => ({}),
+        getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'draft',
@@ -96,14 +134,18 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.notCalled(stub);
+      sinon.assert.notCalled(jobsService.dispatch);
+      sinon.assert.notCalled(errorLogStub);
     });
 
     it('Ignores if html was not changed', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
+        getPostData: () => ({}),
+        getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'published',
@@ -114,14 +156,18 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.notCalled(stub);
+      sinon.assert.notCalled(jobsService.dispatch);
+      sinon.assert.notCalled(errorLogStub);
     });
 
     it('Ignores email only posts', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
+        getPostData: () => ({}),
+        getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'send',
@@ -132,17 +178,18 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.notCalled(stub);
+      sinon.assert.notCalled(jobsService.dispatch);
+      sinon.assert.notCalled(errorLogStub);
     });
 
     it('Sends on publish', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
         getPostData: () => ({}),
         getPostUrl: () => 'https://site.com/post/',
-        jobService: jobService,
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'published',
@@ -153,21 +200,22 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.calledOnce(stub);
-      const firstCall = stub.getCall(0).args[0];
-      assert.equal(firstCall.url.toString(), 'https://site.com/post/');
-      assert.equal(firstCall.html, 'same');
-      assert.equal(firstCall.previousHtml, null);
+      sinon.assert.calledOnce(jobsService.dispatch);
+      const job = jobsService.dispatch.getCall(0).args[0];
+      assert.ok(job instanceof SendWebmentionsJob);
+      assert.equal(job.sourceUrl, 'https://site.com/post/');
+      assert.equal(job.html, 'same');
+      assert.equal(job.previousHtml, null);
     });
 
     it('Sends on unpublish', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
         getPostData: () => ({}),
         getPostUrl: () => 'https://site.com/post/',
-        jobService: jobService,
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'draft',
@@ -178,11 +226,12 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.calledOnce(stub);
-      const firstCall = stub.getCall(0).args[0];
-      assert.equal(firstCall.url.toString(), 'https://site.com/post/');
-      assert.equal(firstCall.html, null);
-      assert.equal(firstCall.previousHtml, 'same');
+      sinon.assert.calledOnce(jobsService.dispatch);
+      const job = jobsService.dispatch.getCall(0).args[0];
+      assert.ok(job instanceof SendWebmentionsJob);
+      assert.equal(job.sourceUrl, 'https://site.com/post/');
+      assert.equal(job.html, null);
+      assert.equal(job.previousHtml, 'same');
     });
 
     it('Resolves the url from previous data when the post was destroyed', async function () {
@@ -190,13 +239,13 @@ describe('MentionSendingService', function () {
       // already destroyed: own attributes cleared, previous state kept.
       const getPostData = sinon.stub().resolves({});
       const getPostUrl = sinon.stub().returns('https://site.com/gone/');
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
         getPostData,
         getPostUrl,
-        jobService: jobService,
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
 
       const previous = {
         id: 'post-id',
@@ -215,8 +264,8 @@ describe('MentionSendingService', function () {
 
       await service.sendForPost(destroyedPost);
 
-      sinon.assert.calledOnce(stub);
-      assert.equal(stub.getCall(0).args[0].url.toString(), 'https://site.com/gone/');
+      sinon.assert.calledOnce(jobsService.dispatch);
+      assert.equal(jobsService.dispatch.getCall(0).args[0].sourceUrl, 'https://site.com/gone/');
       // resolved from the destroyed model's previous data, not by loading it
       sinon.assert.notCalled(getPostData);
       assert.equal(getPostUrl.getCall(0).args[0], 'post-id');
@@ -225,13 +274,13 @@ describe('MentionSendingService', function () {
     });
 
     it('Sends on html change', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
         getPostData: () => ({}),
         getPostUrl: () => 'https://site.com/post/',
-        jobService: jobService,
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'published',
@@ -242,20 +291,24 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.calledOnce(stub);
-      const firstCall = stub.getCall(0).args[0];
-      assert.equal(firstCall.url.toString(), 'https://site.com/post/');
-      assert.equal(firstCall.html, 'updated');
-      assert.equal(firstCall.previousHtml, 'same');
+      sinon.assert.calledOnce(jobsService.dispatch);
+      const job = jobsService.dispatch.getCall(0).args[0];
+      assert.ok(job instanceof SendWebmentionsJob);
+      assert.equal(job.sourceUrl, 'https://site.com/post/');
+      assert.equal(job.html, 'updated');
+      assert.equal(job.previousHtml, 'same');
     });
 
     it('Catches and logs errors', async function () {
+      const jobsService = {
+        dispatch: sinon.stub().rejects(new Error('Internal error test')),
+      };
       const service = new MentionSendingService({
         isEnabled: () => true,
         getPostData: () => ({}),
         getPostUrl: () => 'https://site.com/post/',
+        jobsService,
       });
-      sinon.stub(service, 'sendForHTMLResource').rejects(new Error('Internal error test'));
       await service.sendForPost(
         createModel({
           status: 'published',
@@ -270,13 +323,13 @@ describe('MentionSendingService', function () {
     });
 
     it('Sends no mentions for posts without html and previous html', async function () {
+      const jobsService = { dispatch: sinon.stub().resolves() };
       const service = new MentionSendingService({
         isEnabled: () => true,
         getPostData: () => ({}),
         getPostUrl: () => 'https://site.com/post/',
-        jobService: jobService,
+        jobsService,
       });
-      const stub = sinon.stub(service, 'sendForHTMLResource');
       await service.sendForPost(
         createModel({
           status: 'published',
@@ -287,7 +340,28 @@ describe('MentionSendingService', function () {
           },
         }),
       );
-      sinon.assert.notCalled(stub);
+      sinon.assert.notCalled(jobsService.dispatch);
+    });
+  });
+
+  describe('sendWebmentions', function () {
+    it('rehydrates the source url and forwards the html fields', async function () {
+      const service = new MentionSendingService({});
+      const stub = sinon.stub(service, 'sendForHTMLResource').resolves();
+      const job = new SendWebmentionsJob({
+        sourceUrl: 'https://site.com/post/',
+        html: '<a href="https://example.com/">link</a>',
+        previousHtml: null,
+      });
+
+      await service.sendWebmentions(job);
+
+      sinon.assert.calledOnce(stub);
+      const resource = stub.firstCall.args[0];
+      assert.ok(resource.url instanceof URL, 'the source url is rehydrated into a URL');
+      assert.equal(resource.url.href, 'https://site.com/post/');
+      assert.equal(resource.html, job.html);
+      assert.equal(resource.previousHtml, null);
     });
   });
 
@@ -380,7 +454,6 @@ describe('MentionSendingService', function () {
         discoveryService: {
           getEndpoint: async () => new URL('https://example.org/webmentions-test'),
         },
-        jobService: jobService,
       });
       await service.sendForHTMLResource({
         url: new URL('https://site.com'),

--- a/ghost/core/test/unit/server/services/mentions/send-webmentions-job.test.ts
+++ b/ghost/core/test/unit/server/services/mentions/send-webmentions-job.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import SendWebmentionsJob from '../../../../../core/server/services/mentions/send-webmentions-job';
+
+describe('SendWebmentionsJob', function () {
+  it('is dispatched under its own type', function () {
+    assert.equal(SendWebmentionsJob.type, 'send-webmentions');
+  });
+
+  it('survives the round trip through the queue', function () {
+    const job = new SendWebmentionsJob({
+      sourceUrl: 'https://site.com/post/',
+      html: '<a href="https://example.com/">link</a>',
+      previousHtml: '<a href="https://old.example.com/">old link</a>',
+    });
+
+    const revived = new SendWebmentionsJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(revived, job);
+  });
+
+  it('round-trips a first publish, where there is no previous html', function () {
+    const job = new SendWebmentionsJob({
+      sourceUrl: 'https://site.com/post/',
+      html: '<a href="https://example.com/">link</a>',
+      previousHtml: null,
+    });
+
+    const revived = new SendWebmentionsJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(revived, job);
+    assert.equal(revived.previousHtml, null);
+  });
+
+  it('round-trips an unpublish, where there is no current html', function () {
+    const job = new SendWebmentionsJob({
+      sourceUrl: 'https://site.com/post/',
+      html: null,
+      previousHtml: '<a href="https://example.com/">link</a>',
+    });
+
+    const revived = new SendWebmentionsJob(JSON.parse(JSON.stringify(job)));
+
+    assert.deepEqual(revived, job);
+    assert.equal(revived.html, null);
+  });
+});

--- a/ghost/core/test/unit/server/services/mentions/service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/service.test.js
@@ -2,12 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const urlService = require('../../../../../core/server/services/url');
 const outputSerializerUrlUtil = require('../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
-const jobsService = require('../../../../../core/server/services/mentions-jobs');
-const {
-  getPostData,
-  getPostUrl,
-  makeLoggingJobService,
-} = require('../../../../../core/server/services/mentions/service');
+const { getPostData, getPostUrl } = require('../../../../../core/server/services/mentions/service');
 
 describe('Mentions service post url helpers', function () {
   afterEach(function () {
@@ -80,60 +75,5 @@ describe('Mentions service post url helpers', function () {
     await getPostData(post);
 
     sinon.assert.notCalled(post.load);
-  });
-});
-
-// Both mentions jobs are queued through this wrapper, so it has to hand the job
-// manager the same job it was given: same name, same inline flag, same result,
-// same error. The lifecycle logging it adds is deliberately not asserted here:
-// that would mean stubbing the shared logger, which is order-dependent under the
-// unit project's `isolate: false`.
-describe('Mentions service background job wrapper', function () {
-  let addJob;
-
-  // Runs the job the wrapper handed to the job service, the way the job
-  // manager runs an inline job.
-  function runQueuedJob() {
-    return addJob.firstCall.args[0].job();
-  }
-
-  beforeEach(function () {
-    addJob = sinon.stub(jobsService, 'addJob');
-  });
-
-  afterEach(function () {
-    sinon.restore();
-  });
-
-  it('queues the job under its own name without running it', async function () {
-    const fn = sinon.stub().resolves();
-
-    await makeLoggingJobService().addJob('processWebmention', fn);
-
-    sinon.assert.calledOnce(addJob);
-    assert.equal(addJob.firstCall.args[0].name, 'processWebmention');
-    assert.equal(addJob.firstCall.args[0].offloaded, false);
-    assert.notEqual(addJob.firstCall.args[0].job, fn, 'the job is wrapped');
-    assert.ok(fn.notCalled, 'the job is not run at queue time');
-  });
-
-  it('runs the job once and returns its result untouched', async function () {
-    const result = { mentions: 1 };
-    const fn = sinon.stub().resolves(result);
-
-    await makeLoggingJobService().addJob('sendWebmentions', fn);
-    const returned = await runQueuedJob();
-
-    sinon.assert.calledOnce(fn);
-    assert.equal(returned, result, 'the wrapped result is passed through by reference');
-  });
-
-  it('rethrows the original error', async function () {
-    const failure = new Error('Job failed');
-    const fn = sinon.stub().rejects(failure);
-
-    await makeLoggingJobService().addJob('sendWebmentions', fn);
-
-    await assert.rejects(runQueuedJob(), (error) => error === failure);
   });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1979/migrate-sendwebmentions-to-the-durable-jobs-interface

## What

Migrates the outbound `sendWebmentions` job from an inline closure on the legacy mentions
JobManager to the class-based jobs service, following the pattern established by the
`process-webmention` migration (HKG-1977). This phase only moves the job behind the new
interface — the backend stays in-memory and no durable queue is introduced.

- **`SendWebmentionsJob`** (`mentions/send-webmentions-job.ts`): carries a serialisable
  event-time snapshot — `sourceUrl` (string), `html`, `previousHtml` (`string | null`).
  Type string is kebab-case `send-webmentions`, the same deliberate rename HKG-1977 made
  for inbound (`processWebmention` → `process-webmention`); nothing persists type strings yet.
- **Dispatch**: `MentionSendingService.sendForPost` keeps every publication-event filter and
  the event-time URL resolution untouched, and replaces only the closure enqueue with
  `jobsService.dispatch(new SendWebmentionsJob(...))` on the shared class-based service —
  the same instance the inbound controller uses. The surrounding try/catch is unchanged,
  so a dispatch failure is contained exactly like a legacy enqueue failure.
- **Handler**: registered in `register-job-handlers.ts` beside the `process-webmention`
  handler, via the injected `mentionsSendingService` (new boot assert, mirroring the
  controller wiring); it hands the job to the service's new `sendWebmentions`, which
  rehydrates the URL and calls the pre-existing `sendForHTMLResource` — the identical
  argument shape the legacy closure used. Link
  diffing, dedup, own-hostname exclusion, endpoint discovery, HTTP retry/timeout behavior,
  and per-target error containment are untouched code.
- **Legacy path removed in the same commit** (no double delivery): the closure enqueue,
  `makeLoggingJobService`, and the dead `mentions-jobs` require in `mentions/service.js`.
  The `mentions-jobs` service itself stays until HKG-1985 (legacy job services removal).
- **Restart fix**: the jobs service instance is now **process-lifetime** — `init()` is
  idempotent and revives the same `JobsService` object across the test harness's in-process
  Ghost restarts instead of building a fresh one per boot. Services capture the injected
  instance at their own init (`didInit`-guarded), so per-boot instances stranded those
  captured references on stopped queues whose `enqueue()` drops silently. A re-init clears
  the handler registry so boot's registration can re-run (the shutdown cleanup task only
  runs when a `ghostServer` exists, so shutdown cannot own the clearing). This also fixes
  the same latent restart staleness for the inbound `process-webmention` controller wiring
  from HKG-1977. Production boots `init()` exactly once, so nothing changes there.

## Test approach

The tests wait on processing, not the queue — mirroring the inbound suite from HKG-1977 —
so nothing couples to the backend and the approach survives a durable backend unchanged:

- The outbound e2e suite (`test/e2e-server/services/mentions.test.js`) tracks each
  `sendForPost` run at the event listener (the handler runs from transaction-commit events
  and awaits DB work before dispatching, so draining the runs proves whether a job was
  dispatched at all — which is what the "does not send" cases assert for the filters that
  return before reaching the queue), and records handler completions through a
  `sendForHTMLResource` seam wrap, waiting on them with `vi.waitUntil`. Positive phases `waitForSends(n)`; the "edited without url changes"
  negatives also wait on processing, since those edits do dispatch a job whose link diff
  yields nothing. All 16 assertions are unchanged and are the end-to-end parity proof.
- The no-send unit tests in `mention-sending-service.test.js` construct the service with the
  full dispatch path and models that would dispatch if the filter under test broke, asserting
  both that `dispatch` and the error log stay untouched — so a filter regression fails
  deterministically at the unit level.
- New unit tests (job round-trip incl. null html/previousHtml, `sendWebmentions` URL rehydration,
  restart/`clearHandlers` semantics) and an integration test that dispatches through the real
  jobs service to a nock'd Webmention endpoint, mirroring `process-webmention-job.test.ts`.

## Behavior parity

Everything externally visible is preserved: which webmentions are sent, when, to whom, with
what HTTP semantics, dedup, and per-target error containment. At-most-once execution is
unchanged (the in-memory backend runs each job once, no retries — same as the legacy inline
queue); the issue's replay strategy materialises only when a durable backend arrives, and the
payload being a deterministic snapshot means a replay recomputes the same bounded target set.

Known, accepted deltas:

- **Queue placement — the one intentional behavioral change**: outbound sending moves from
  the dedicated legacy mentions JobManager queue (fastq, concurrency 3, sole remaining
  tenant) onto the class-based backend's dedicated `webmentions` lane, declared at handler
  registration with the shared `WEBMENTIONS_QUEUE` options (queue routing from HKG-2001,
  now on main). It shares that lane with inbound `process-webmention` at the same
  concurrency 3 — the exact pairing and sizing the legacy mentions queue had before
  HKG-1977 — and stays isolated from the default lane's cleanups, `update-check`,
  `external-media-inliner`, and `content-csv-import`.
- **Logging**: the wrapper's `[Background Job] sendWebmentions queued/started/completed/failed`
  lines and JobManager's `Adding one-off job to inlineQueue…`/`UnhandledJobError` lines are
  replaced by the JobsService lifecycle logs (`[Background Job] send-webmentions …`), a
  structured `job.completed` event, and the backend's `delivery failed` log. Verified against
  the pro-infra Elastic alert rules: no rule matches any of these strings.
- **Sentry**: send failures now reach Sentry with a `job_type` tag — a net-new destination
  (legacy inline failures never had Sentry wired); strictly additive monitoring.
- **Shutdown**: the new backend drops queued-not-started envelopes and bounds the in-flight
  drain with `server:shutdownTimeout`, where the legacy queue drained without a timeout.
  Webmentions pending at process shutdown are no longer sent — the same delta every migrated
  job accepted; only relevant during restarts/deploys.

## Production verification

Per the issue, the migrated job must be manually verified on staging and then production
(controlled receiver + disposable content) — checklist in HKG-1979.

