### PR TITLE
Fixed collected fields writing onto members that predate the checkout

### DIFF
--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -1,7 +1,10 @@
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
-const { canWelcomeEmailReplaceSignupPaidEmail } = require('../../../lib/member-signup-contexts');
+const {
+  SIGNUP_CONTEXTS,
+  canWelcomeEmailReplaceSignupPaidEmail,
+} = require('../../../lib/member-signup-contexts');
 const { collectedByPort } = require('../checkout/completed-session');
 /** @typedef {import('../../../lib/member-signup-contexts').SignupContext} SignupContext */
 
@@ -335,6 +338,7 @@ module.exports = class CheckoutSessionEventService {
       email: customer.email,
     });
 
+    const memberPreexisted = Boolean(member);
     const checkoutType = _.get(session, 'metadata.checkoutType');
 
     if (!member) {
@@ -426,7 +430,7 @@ module.exports = class CheckoutSessionEventService {
     // After the subscription work, and deliberately not part of it: a value the member
     // gave us for free must never be able to fail the webhook. A throw here would make
     // Stripe retry the event and risk doing the payment work twice.
-    await this.writeCollectedFields(member.id, session);
+    await this.writeCollectedFields(member.id, session, { memberPreexisted });
 
     if (checkoutType !== 'upgrade') {
       const ghostSignupContext = /** @type {SignupContext | undefined} */ (
@@ -457,8 +461,10 @@ module.exports = class CheckoutSessionEventService {
    *
    * @param {string} memberId
    * @param {import('stripe').Stripe.Checkout.Session} session
+   * @param {object} options
+   * @param {boolean} options.memberPreexisted Whether the member's record existed before this event resolved it
    */
-  async writeCollectedFields(memberId, session) {
+  async writeCollectedFields(memberId, session, { memberPreexisted }) {
     // Stamped at create time. A session predating this feature carries none. Read
     // outside the try so a failure below can name the tier whose answers were lost.
     const tierId = session.metadata?.ghostTierId;
@@ -469,6 +475,25 @@ module.exports = class CheckoutSessionEventService {
       }
 
       if (!tierId) {
+        return;
+      }
+
+      // A checkout can be started with nothing but an email address, and typing an
+      // email is not proof of owning it. Values may land on the member this event just
+      // created — that record holds nothing the buyer didn't supply — but a record
+      // that existed before the checkout belongs to whoever verified that email, so it
+      // is only written when the session was created by a signed-in member.
+      const wasAuthenticated =
+        session.metadata?.ghostSignupContext === SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED;
+      if (memberPreexisted && !wasAuthenticated) {
+        logging.warn(
+          {
+            event: { name: 'stripe_checkout.collected_fields.write_skipped' },
+            memberId,
+            tierId,
+          },
+          'Skipped storing the fields an unverified checkout collected for an existing member',
+        );
         return;
       }
 

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -1692,6 +1692,58 @@ describe('Members API', function () {
         assert.equal(member.status, 'paid');
         assert.deepEqual(member.custom_fields, {});
       });
+
+      // A checkout session can be started with nothing but an email address, and typing
+      // an email is not proof of owning it. The tests above all write onto the member
+      // the webhook itself created, which is safe: that record holds nothing the buyer
+      // didn't supply. A record that existed before the checkout is only written when
+      // the session was started by a signed-in member.
+      it('does not write onto a member that existed before an unverified checkout', async function () {
+        const email = 'checkout-collected-preexisting@email.com';
+        const { body: created } = await adminAgent
+          .post('/members/')
+          .body({ members: [{ email }] })
+          .expectStatus(201);
+        await adminAgent
+          .put(`/members/${created.members[0].id}/`)
+          .body({ members: [{ custom_fields: { [fieldKeys.question]: 'Small' } }] })
+          .expectStatus(200);
+
+        const member = await sendCheckoutWebhook(email, {
+          custom_fields: [{ key: fieldKeys.question, type: 'text', text: { value: 'Large' } }],
+          shipping: {
+            name: 'Someone Else',
+            address: { line1: '1 High Street', country: 'GB' },
+          },
+        });
+
+        assert.equal(member.status, 'paid', 'the payment work still happened');
+        assert.equal(
+          member.custom_fields[fieldKeys.question],
+          'Small',
+          'the stored answer was not overwritten',
+        );
+        assert.equal(member.custom_fields[fieldKeys.recipient], undefined);
+        assert.equal(member.custom_fields[fieldKeys.address], undefined);
+      });
+
+      it('writes onto an existing member when the checkout was started signed in', async function () {
+        const email = 'checkout-collected-signed-in@email.com';
+        await adminAgent
+          .post('/members/')
+          .body({ members: [{ email }] })
+          .expectStatus(201);
+
+        const member = await sendCheckoutWebhook(email, {
+          metadata: {
+            ghostTierId: (await getPaidProduct()).id,
+            ghostSignupContext: 'already_authenticated',
+          },
+          custom_fields: [{ key: fieldKeys.question, type: 'text', text: { value: 'Large' } }],
+        });
+
+        assert.equal(member.custom_fields[fieldKeys.question], 'Large');
+      });
     });
 
     it('Will create a member with default newsletter subscriptions', async function () {

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const sinon = require('sinon');
 
 const CheckoutSessionEventService = require('../../../../../../../core/server/services/stripe/services/webhook/checkout-session-event-service');
@@ -1155,6 +1156,104 @@ describe('CheckoutSessionEventService', function () {
         await service.handleSubscriptionEvent(session);
 
         sinon.assert.notCalled(sendSignupEmail);
+      });
+    });
+
+    // A checkout session can be created for any email address without proof the buyer
+    // owns it, so what gates the write is whether the target record predates the
+    // checkout, and whether the session was started by a signed-in member.
+    describe('collected fields writeback', function () {
+      let labsService;
+      let customFieldBindings;
+
+      beforeEach(function () {
+        labsService = { isSet: sinon.stub().returns(true) };
+        customFieldBindings = { writeCollected: sinon.stub().resolves() };
+        service = createService({ labsService, customFieldBindings });
+        session.metadata.ghostTierId = 'tier_123';
+        api.getCustomer.resolves(customer);
+        sinon.stub(logging, 'warn');
+        sinon.stub(logging, 'error');
+      });
+
+      afterEach(function () {
+        sinon.restore();
+      });
+
+      it('writes onto the member this event created, even unverified', async function () {
+        memberRepository.get.resolves(null);
+        session.metadata.ghostSignupContext = 'needs_magic_link_email';
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.calledOnce(customFieldBindings.writeCollected);
+        sinon.assert.calledWith(
+          customFieldBindings.writeCollected,
+          'created_member',
+          'tier_123',
+          sinon.match.array,
+        );
+      });
+
+      it('does not write onto a member that existed before an unverified checkout', async function () {
+        memberRepository.get.resolves(member);
+        session.metadata.ghostSignupContext = 'needs_magic_link_email';
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.notCalled(customFieldBindings.writeCollected);
+      });
+
+      it('treats a session carrying no signup context as unverified', async function () {
+        memberRepository.get.resolves(member);
+        delete session.metadata.ghostSignupContext;
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.notCalled(customFieldBindings.writeCollected);
+      });
+
+      it('writes onto an existing member when the checkout was started signed in', async function () {
+        memberRepository.get.resolves(member);
+        session.metadata.ghostSignupContext = 'already_authenticated';
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.calledOnce(customFieldBindings.writeCollected);
+        sinon.assert.calledWith(
+          customFieldBindings.writeCollected,
+          'member_123',
+          'tier_123',
+          sinon.match.array,
+        );
+      });
+
+      it('does not write when the flag is off', async function () {
+        labsService.isSet.returns(false);
+        memberRepository.get.resolves(null);
+        session.metadata.ghostSignupContext = 'already_authenticated';
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.notCalled(customFieldBindings.writeCollected);
+      });
+
+      it('does not write when the session names no tier', async function () {
+        memberRepository.get.resolves(null);
+        delete session.metadata.ghostTierId;
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.notCalled(customFieldBindings.writeCollected);
+      });
+
+      it('does not fail the webhook when the write is rejected', async function () {
+        memberRepository.get.resolves(null);
+        customFieldBindings.writeCollected.rejects(new Error('storage broke'));
+
+        await service.handleSubscriptionEvent(session);
+
+        sinon.assert.calledOnce(customFieldBindings.writeCollected);
       });
     });
   });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3872

Stripe Checkout can collect extra answers during payment (custom fields and a shipping address), and the webhook that completes the payment stores those answers on the member. The problem is that a checkout session can be started with nothing but an email address, and typing an email is not proof of owning it. If that email belonged to an existing member, whoever started the checkout could overwrite that member's stored answers.

The webhook now stores collected answers on a pre-existing member only when the checkout was started by a signed-in member, using the signup context Ghost already stamps on the session. A member the webhook itself just created still gets the answers, since that record holds nothing the buyer didn't supply. When the write is skipped a warning is logged so the dropped answers are visible, and the payment work is unaffected either way.

This is part of the members custom fields work, which is still behind a private feature flag.