### PR TITLE
Added standardized node/pnpm setup action

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,57 @@
+name: Set up Node and pnpm
+description: Install pnpm and Node, then install workspace dependencies.
+
+inputs:
+  node-version:
+    description: Node version to install.
+    required: true
+  install:
+    description: Run `pnpm install`. Set to 'false' for jobs that only need the toolchain on PATH.
+    default: 'true'
+  install-args:
+    description: >-
+      Extra arguments appended to `pnpm install --frozen-lockfile`, e.g.
+      `--filter @tryghost/e2e...`, `--force`, `--prod`, `--ignore-scripts`.
+      Word-split, so quote nothing here that a shell would have to strip.
+    default: ''
+  trust-lockfile:
+    description: >-
+      Pass `--trust-lockfile`, which skips re-applying the supply-chain policies in
+      pnpm-workspace.yaml (minimumReleaseAge, trustPolicy, tarball-URL binding, tarball
+      integrity) to every lockfile entry. pnpm runs that pass on every install and
+      `--filter` does not narrow it, so it is pure duplicated work — but only once some
+      earlier job in the same run has verified this exact lockfile. Defaults to off so a
+      new workflow verifies unless it opts out.
+    default: 'false'
+  store-cache:
+    description: Let setup-node restore and save the pnpm store.
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      env:
+        FORCE_COLOR: 0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.store-cache == 'true' && 'pnpm' || '' }}
+
+    - name: Install dependencies
+      if: inputs.install == 'true'
+      shell: bash
+      # Args arrive as env rather than ${{ }} so nothing job-controlled
+      # (a matrix value, a job output) is interpolated into the script.
+      env:
+        INSTALL_ARGS: ${{ inputs.install-args }}
+        TRUST_LOCKFILE: ${{ inputs.trust-lockfile }}
+      run: |
+        args=(--frozen-lockfile)
+        if [ "$TRUST_LOCKFILE" = "true" ]; then
+          args+=(--trust-lockfile)
+        fi
+        # shellcheck disable=SC2206 # deliberate word split: install-args is an argument list
+        args+=($INSTALL_ARGS)
+        pnpm install "${args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,17 +78,27 @@ jobs:
           echo "GITHUB_EVENT_NAME: ${{ github.event_name }}"
           echo "GITHUB_CONTEXT: ${{ toJson(github.event) }}"
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Set up Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      # pnpm's cache dir, not the store dir that setup-node's `cache: pnpm`
+      # already handles. On a hit `pnpm install` reuses the cached verdict and
+      # skips verification entirely; on a miss it checks all ~4.4k lockfile
+      # entries (~7s, and ~670MB of registry metadata pulled into the cache
+      # dir) and the post-step saves the new verdict.
+      - name: Restore pnpm lockfile verification cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/pnpm/lockfile-verified.jsonl
+          key: pnpm-lockfile-verified-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
+
+      # The only job that verifies the lockfile against the supply-chain
+      # policies in pnpm-workspace.yaml (minimumReleaseAge, trustPolicy,
+      # tarball-URL binding, tarball integrity). pnpm re-runs that whole pass
+      # on every install and --filter does not narrow it, so every other job —
+      # all of which need this one and install the same lockfile — sets
+      # trust-lockfile to skip the redundant re-verification.
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+          install-args: --ignore-scripts
 
       # Replaced nrwl/nx-set-shas, which verified each candidate commit over the
       # API and hid the errors — see scripts/nx-set-shas.js.
@@ -328,18 +338,13 @@ jobs:
       - name: Fetch main branch
         run: git fetch --no-tags origin main
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      # The script's only runtime dep is semver, so install @internal/scripts
-      # alone rather than the whole workspace — ~0.5s and a single package.
-      - name: Install scripts dependencies
-        run: pnpm install --frozen-lockfile --filter @internal/scripts --prod --ignore-scripts
+          trust-lockfile: 'true'
+          # The script's only runtime dep is semver, so install @internal/scripts
+          # alone rather than the whole workspace — ~0.5s and a single package.
+          install-args: --filter @internal/scripts --prod --ignore-scripts
 
       - name: Check app version bump
         env:
@@ -386,16 +391,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1000
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -447,11 +446,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
+          # Only needs pnpm and node on PATH for the checker scripts.
+          install: 'false'
+          store-cache: 'false'
 
       - name: Check internal package golden path
         run: node scripts/check-internal-packages.js
@@ -468,14 +468,11 @@ jobs:
       || needs.job_setup.outputs.changed_i18n_apps == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --filter @tryghost/i18n... --ignore-scripts
+          trust-lockfile: 'true'
+          install-args: --filter @tryghost/i18n... --ignore-scripts
 
       - name: Run i18n tests
         run: pnpm --filter @tryghost/i18n test
@@ -494,14 +491,10 @@ jobs:
       COVERAGE: ${{ needs.job_setup.outputs.coverage_enabled }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - run: pnpm nx run ghost-admin:test
         env:
@@ -542,18 +535,13 @@ jobs:
           # Boot activates the default theme, which is a submodule
           submodules: true
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # --force for the same reason as job_unit-tests: better-sqlite3 is an
-        # optionalDependency and boot uses it for the development database.
-        run: pnpm install --frozen-lockfile --force
+          trust-lockfile: 'true'
+          # --force for the same reason as job_unit-tests: better-sqlite3 is an
+          # optionalDependency and boot uses it for the development database.
+          install-args: --force
 
       - name: Install hyperfine
         uses: ./.github/actions/install-hyperfine
@@ -685,20 +673,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1000
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # better-sqlite3 is an optionalDependency. Without --force, pnpm may skip
-        # installing/linking it when restoring from a cached store. --force
-        # ensures all optional deps are installed regardless.
-        # (ghost core's test:unit job requires better-sqlite3)
-        run: pnpm install --frozen-lockfile --force
+          trust-lockfile: 'true'
+          # better-sqlite3 is an optionalDependency. Without --force, pnpm may skip
+          # installing/linking it when restoring from a cached store. --force
+          # ensures all optional deps are installed regardless.
+          # (ghost core's test:unit job requires better-sqlite3)
+          install-args: --force
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
@@ -785,16 +768,10 @@ jobs:
     name: Acceptance tests (Node ${{ needs.job_setup.outputs.node_version }}, mysql8)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ needs.job_setup.outputs.node_version }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
@@ -891,16 +868,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: true
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ needs.job_setup.outputs.node_version }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - name: Set env vars (MySQL)
         run: |
@@ -944,20 +915,15 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # Each matrix leg only Playwright-tests one app, so scope the install to that
-        # app's dependency subgraph instead of the whole monorepo (which drags in
-        # ghost/core, ghost-admin and unrelated apps). nx and the app's workspace deps
-        # are still installed; the nx project name matches the package name.
-        run: pnpm install --frozen-lockfile --filter ${{ matrix.app }}...
+          trust-lockfile: 'true'
+          # Each matrix leg only Playwright-tests one app, so scope the install to that
+          # app's dependency subgraph instead of the whole monorepo (which drags in
+          # ghost/core, ghost-admin and unrelated apps). nx and the app's workspace deps
+          # are still installed; the nx project name matches the package name.
+          install-args: --filter ${{ matrix.app }}...
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
@@ -1144,16 +1110,10 @@ jobs:
     name: Stripe fixture checks
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       # Needs no Ghost, no Docker and no browser, so it does not belong in the e2e
       # matrix that waits on the image. Run through nx so the target pulls in the
@@ -1180,19 +1140,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # Admin's nx build fans out across the whole frontend graph (ghost-admin,
-        # admin-x-*, shade, koenig-lexical) via nx dependsOn rather than package
-        # deps, so a filtered install would miss pieces — install the full workspace.
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
+          # Admin's nx build fans out across the whole frontend graph (ghost-admin,
+          # admin-x-*, shade, koenig-lexical) via nx dependsOn rather than package
+          # deps, so a filtered install would miss pieces — install the full workspace.
 
       - name: Build admin
         # IS_SHIPPING enables the Sentry vite plugin in koenig-lexical: it
@@ -1269,18 +1223,13 @@ jobs:
           # archive — without them the tarball ships empty theme dirs.
           submodules: true
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # pack only needs ghost and its dependency subgraph (dev deps included, to
-        # build the prod closure below) — not the whole monorepo.
-        run: pnpm install --frozen-lockfile --filter "ghost..."
+          trust-lockfile: 'true'
+          # pack only needs ghost and its dependency subgraph (dev deps included, to
+          # build the prod closure below) — not the whole monorepo.
+          install-args: --filter ghost...
 
       - name: Verify tag matches package.json
         if: startsWith(github.ref, 'refs/tags/v')
@@ -1930,17 +1879,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - name: Build public apps for E2E
         run: pnpm --filter @tryghost/e2e build:apps
@@ -2101,17 +2043,14 @@ jobs:
           image-tags: ${{ needs.job_docker.outputs.image-e2e-tags }}
           artifact-name: docker-image-e2e
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # The Playwright container runs against the host's bind-mounted node_modules,
-        # but only needs @tryghost/e2e's dependency subgraph — not the whole monorepo
-        # (admin, apps, ghost/core). Scope the install to cut shard setup time.
-        run: pnpm install --frozen-lockfile --filter @tryghost/e2e...
+          trust-lockfile: 'true'
+          # The Playwright container runs against the host's bind-mounted node_modules,
+          # but only needs @tryghost/e2e's dependency subgraph — not the whole monorepo
+          # (admin, apps, ghost/core). Scope the install to cut shard setup time.
+          install-args: --filter @tryghost/e2e...
 
       - name: Report Analytics runner disk usage
         if: matrix.analytics == 'true'
@@ -2184,14 +2123,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -2372,15 +2307,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          trust-lockfile: 'true'
 
       - name: Determine release version
         id: release

--- a/.github/workflows/koenig-demo.yml
+++ b/.github/workflows/koenig-demo.yml
@@ -34,15 +34,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --filter @tryghost/koenig-lexical...
+          install-args: --filter @tryghost/koenig-lexical...
 
       - name: Build demo
         run: pnpm nx run @tryghost/koenig-lexical:build:demo

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -67,15 +67,11 @@ jobs:
           # the token, so don't leave it in .git/config for later steps.
           persist-credentials: false
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-cache: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          # Publishing runs against the public registry with a cold store on purpose.
+          store-cache: 'false'
 
       - name: Configure .npmrc
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,9 @@ jobs:
       # Ghost only and can't authenticate against Casper/Source over SSH
       - run: git submodule update --init
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        env:
-          FORCE_COLOR: 0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
no ref
- skip lockfile trust verification in jobs downstream of setup
- cache lockfile verification file to speed up verification
- reduce duplicate steps across jobs with standardized composite action