### PR TITLE
Removed unnecessary links from the gift delivery email

### DIFF
--- a/ghost/core/core/server/services/gifts/email-templates/gift-delivery.hbs
+++ b/ghost/core/core/server/services/gifts/email-templates/gift-delivery.hbs
@@ -31,9 +31,9 @@
                     <tr>
                       <td align="left" style="padding-bottom: 22px; text-align: left;">
                         {{#if siteIconUrl}}
-                          <a href="{{siteUrl}}"><img src="{{siteIconUrl}}" alt="{{siteTitle}}" border="0" width="48" height="48" style="border-radius: 4px;"></a>
+                          <img src="{{siteIconUrl}}" alt="{{siteTitle}}" border="0" width="48" height="48" style="border-radius: 4px;">
                         {{else}}
-                          <a href="{{siteUrl}}" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 17px; font-weight: 700; color: {{accentColor}}; text-decoration: none;">{{siteTitle}}</a>
+                          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 17px; font-weight: 700; color: {{accentColor}};">{{siteTitle}}</span>
                         {{/if}}
                       </td>
                     </tr>
@@ -92,7 +92,7 @@
                     </tr>
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 40px;">
-                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 16px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0;">{{t 'This message was sent from {siteDomain} to {email} on behalf of {buyerName} ({buyerEmail}).' siteDomain=(linkTag siteUrl siteDomain class="small" style="text-decoration: underline; color: #738A94; font-size: 11px;") email=(linkTag (mailto toEmail) toEmail class="small" style="text-decoration: underline; color: #738A94; font-size: 11px;") buyerName=buyerName buyerEmail=(linkTag (mailto buyerEmail) buyerEmail class="small" style="text-decoration: underline; color: #738A94; font-size: 11px;")}}</p>
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 16px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0;">{{t 'This message was sent from {siteDomain} to {email} on behalf of {buyerName} ({buyerEmail}).' siteDomain=siteDomain email=toEmail buyerName=buyerName buyerEmail=buyerEmail}}</p>
                       </td>
                     </tr>
                   </table>

--- a/ghost/core/core/server/services/gifts/email-templates/gift-delivery.ts
+++ b/ghost/core/core/server/services/gifts/email-templates/gift-delivery.ts
@@ -2,7 +2,6 @@ import type { Translate } from '../gift-email-renderer';
 
 export interface GiftDeliveryEmailData {
   siteTitle: string;
-  siteUrl: string;
   siteIconUrl: string | null;
   siteDomain: string;
   accentColor: string;

--- a/ghost/core/core/server/services/gifts/gift-email-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-email-service.ts
@@ -339,7 +339,6 @@ export class GiftEmailService {
     const giftLink = `${siteUrl.replace(/\/$/, '')}/gift/${token}`;
     const { html, text } = await this.renderer.renderDelivery({
       siteTitle,
-      siteUrl,
       siteIconUrl: this.blogIcon.getIconUrl({ absolute: true, fallbackToDefault: false }),
       siteDomain,
       accentColor: this.accentColor,

--- a/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
+++ b/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
@@ -391,7 +391,9 @@ describe('GiftEmailService', function () {
       );
       sinon.assert.match(
         message.html,
-        sinon.match(/on behalf of Buyer \(<a[^>]+href="mailto:buyer@example\.com"/),
+        sinon.match(
+          'This message was sent from example.com to recipient@example.com on behalf of Buyer (buyer@example.com).',
+        ),
       );
       sinon.assert.match(message.html, sinon.match('background:#fff3ed'));
       sinon.assert.match(message.html, sinon.match('color:#bd460c'));
@@ -424,7 +426,7 @@ describe('GiftEmailService', function () {
       });
 
       const html = bulkMailer.send.firstCall.firstArg.html;
-      assert.match(html, /<a href="https:\/\/example\.com\/"[^>]*>Test Site<\/a>/);
+      assert.match(html, /<span[^>]*>Test Site<\/span>/);
       assert.doesNotMatch(html, /<img /);
     });
 


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3901

The button that redeems the gift is the only link left in the recipient gift subscription email. The publication header and the footer's email addresses are plain text.