### PR TITLE
Fixed theme test slowness and max worker count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,7 +734,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   job_acceptance-tests:
-    runs-on: ubuntu-latest
+    # Private copies of this repo get 2-core runners, where vitest's DB suite
+    # falls to a single worker; the public repo's runner is already 4-core.
+    runs-on: ${{ (github.repository_owner == 'TryGhost' && github.repository != 'TryGhost/Ghost') && 'ubuntu-latest-4-cores' || 'ubuntu-latest' }}
     needs: [job_setup]
     if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.changed_core == 'true'
     services:
@@ -903,7 +905,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   job_apps_acceptance-tests:
-    runs-on: ubuntu-latest
+    # Admin is by far the largest suite here and is CPU-bound; the other apps
+    # are not starved on the default runner. See job_acceptance-tests above.
+    runs-on: ${{ (github.repository_owner == 'TryGhost' && github.repository != 'TryGhost/Ghost' && matrix.app == '@tryghost/admin') && 'ubuntu-latest-4-cores' || 'ubuntu-latest' }}
     needs: [job_setup]
     if: needs.job_setup.outputs.affected_playwright_projects != '[]'
     name: App Playwright Acceptance Tests

--- a/apps/admin/src/settings/site/theme.acceptance.test.tsx
+++ b/apps/admin/src/settings/site/theme.acceptance.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, onTestFinished, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+import { EditorView } from '@uiw/react-codemirror';
 
 import {
   configResponse,
@@ -133,10 +134,24 @@ function problemLists(): HTMLElement[] {
   return [...dialog.querySelectorAll<HTMLElement>(`[data-testid="${THEME_PROBLEM_LIST_TESTID}"]`)];
 }
 
+/**
+ * Replaces the editor's contents through CodeMirror itself. Playwright's
+ * `fill()` costs ~2s per freshly mounted editor here; a transaction drives the
+ * same onChange path in ~50ms.
+ */
 async function editorTextbox() {
   const editor = settingsScreen.themeCodeEditorModal().getByRole('textbox').first();
   await expect.element(editor).toBeVisible();
-  return editor;
+  return Object.assign(editor, {
+    setContent: (text: string) => {
+      const view = EditorView.findFromDOM(editor.element() as HTMLElement);
+      if (!view) {
+        throw new Error('CodeMirror EditorView not found for the theme editor');
+      }
+      view.focus();
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+    },
+  });
 }
 
 describe('Theme settings', () => {
@@ -636,7 +651,7 @@ describe('Theme settings', () => {
     await expect.element(modal).toHaveTextContent(/Edit theme/);
     await expect.element(modal).toHaveTextContent(/json/i);
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
     await expect.element(modal).toHaveTextContent(/1 file modified/);
     await modal.getByRole('button', { name: 'Save' }).click();
     await settingsScreen
@@ -658,7 +673,10 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/edition');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
+    await expect
+      .element(settingsScreen.themeCodeEditorModal())
+      .toHaveTextContent(/1 file modified/);
     window.dispatchEvent(
       new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true }),
     );
@@ -701,7 +719,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/edition');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
     await settingsScreen
       .themeEditorConfirmModal()
@@ -733,7 +751,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/edition');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
     await settingsScreen
       .themeEditorConfirmModal()
@@ -765,7 +783,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/edition');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
     await settingsScreen
       .themeEditorConfirmModal()
@@ -788,7 +806,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/edition');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
     await settingsScreen
       .themeEditorConfirmModal()
@@ -806,7 +824,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/casper');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"casper","version":"1.0.0"}\n');
+    editor.setContent('{"name":"casper","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
     const inputModal = settingsScreen.themeEditorInputModal();
     await inputModal.getByLabelText('Theme name').fill('Foo Bar!');
@@ -830,7 +848,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/casper');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"casper","version":"1.0.0"}\n');
+    editor.setContent('{"name":"casper","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Save' }).click();
     await settingsScreen.themeEditorInputModal().getByLabelText('Theme name').fill('casper-edited');
     await settingsScreen.themeEditorInputModal().getByRole('button', { name: 'Continue' }).click();
@@ -984,7 +1002,7 @@ describe('Theme settings', () => {
     await renderAdminApp('/settings/theme/edit/edition');
 
     const editor = await editorTextbox();
-    await editor.fill('{"name":"edition","version":"1.0.0"}\n');
+    editor.setContent('{"name":"edition","version":"1.0.0"}\n');
     await settingsScreen.themeCodeEditorModal().getByRole('button', { name: 'Close' }).click();
     await expect
       .element(settingsScreen.themeEditorConfirmModal())

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -6,6 +6,19 @@ import { defaultBootResolver, defaultBootRoutes } from './boot';
 import { resetFakeApi, settleRequests, startFakeApi, verifyNoUnhandledRequests } from './worker';
 
 beforeAll(async () => {
+  // Playwright waits for an element to stop moving before it acts on it, so every
+  // click that opens an animated surface pays that animation — Shade's toaster-in
+  // alone is 0.8s, and a modal-opening click costs ~209ms against ~37ms without.
+  // Scoped to elements carrying an `animate-*` utility (Shade's --animate-* tokens
+  // plus Radix's data-[state]:animate-in), so transitions — which one analytics
+  // test asserts on — are untouched.
+  const style = document.createElement('style');
+  style.textContent = `[class*="animate-"] {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }`;
+  document.head.appendChild(style);
+
   await startFakeApi({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
 });
 

--- a/apps/admin/vitest.acceptance.config.ts
+++ b/apps/admin/vitest.acceptance.config.ts
@@ -1,3 +1,5 @@
+import { availableParallelism } from 'node:os';
+
 import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 import type { PluginOption } from 'vite';
@@ -11,6 +13,15 @@ import { sharedDefine, sharedResolve } from './vite.shared';
  * against a fake Ghost Admin API (test-utils/acceptance/). Unit tests stay
  * in vite.config.ts (jsdom).
  */
+
+/*
+ * Each worker drives its own Chromium page, so workers stay ~97% busy right up
+ * to the core count and then fall off a cliff (63% at 18 workers on an 18-core
+ * box, and worse wall-clock than 8). Leave a core for the Vite server and cap
+ * the top end; the floor keeps 2-core runners on their current two workers.
+ */
+const getWorkerCount = () => Math.min(8, Math.max(2, availableParallelism() - 1));
+
 export default defineConfig({
   plugins: [tailwindcss() as PluginOption, react()],
   // Serves the MSW service worker script; scoped to the test config so it
@@ -28,7 +39,7 @@ export default defineConfig({
   test: {
     name: 'acceptance',
     include: ['src/**/*.acceptance.test.tsx'],
-    maxWorkers: process.env.CI ? 2 : undefined,
+    maxWorkers: getWorkerCount(),
     setupFiles: ['./test-utils/acceptance/setup.ts'],
     expect: {
       // Full-app renders are slower than unit renders; the harness's

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { availableParallelism } from 'node:os';
 import { defineConfig } from 'vitest/config';
 
 // DB-backed suite runner (integration / e2e / legacy) — separate from the unit
@@ -45,6 +46,15 @@ const sharedSsrConfig = {
   resolve: { conditions: ['source', 'node'] },
 };
 
+/*
+ * Vitest defaults maxWorkers to availableParallelism() - 1, which is 1 on a
+ * 2-core runner — the whole DB suite then runs serially. Floor it at 2: a
+ * 4-core runner measured 2.08x (e2e) and 1.79x (integration) against a 2-core
+ * one purely on worker count. `legacy` runs on the threads pool, so the
+ * "forks 2 hangs" wedge below is not in play here.
+ */
+const getWorkerCount = () => Math.max(2, availableParallelism() - 1);
+
 // Shared by every DB-backed project — the execution model is identical for all
 // of them; only the include globs and per-suite timeouts differ.
 const sharedDbConfig = {
@@ -57,6 +67,7 @@ const sharedDbConfig = {
   // here except `legacy`, which sets pool: 'threads' (see its note below).
   pool: 'forks' as const,
   isolate: false,
+  maxWorkers: getWorkerCount(),
   sequence: { shuffle: { files: !!process.env.CI } },
   setupFiles: ['./test/utils/vitest-setup-db.ts'],
   resolveSnapshotPath,


### PR DESCRIPTION
no ref
- increase max worker count when possible in github action runners
- speed up theme editor codemirror tests