### PR TITLE
Changed custom field filtering to declare each type's operators once

### DIFF
--- a/apps/admin/src/members/custom-fields/addressing.test.ts
+++ b/apps/admin/src/members/custom-fields/addressing.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { customFieldAddressing } from './addressing';
+import { parseFilterToAst } from '@/shared/filters';
+
+function ast(filter: string) {
+  const node = parseFilterToAst(filter);
+
+  if (!node) {
+    throw new Error(`could not parse: ${filter}`);
+  }
+
+  return node;
+}
+
+describe('customFieldAddressing bound to a key', () => {
+  const bound = customFieldAddressing('shipping');
+
+  it('claims a compound naming its own key', () => {
+    expect(
+      bound.matchCompound?.(ast("(custom_fields.key:'shipping'+custom_fields.value:~'x')")),
+    ).not.toBeNull();
+  });
+
+  it('refuses a compound naming another field', () => {
+    expect(
+      bound.matchCompound?.(ast("(custom_fields.key:'billing'+custom_fields.value:~'x')")),
+    ).toBeNull();
+  });
+
+  it('refuses a lone key clause naming another field', () => {
+    expect(bound.matchCompound?.(ast("custom_fields.key:'billing'"))).toBeNull();
+  });
+
+  it('leaves other fields readable by the unbound template', () => {
+    const template = customFieldAddressing();
+    expect(
+      template.matchCompound?.(ast("(custom_fields.key:'billing'+custom_fields.value:~'x')")),
+    ).not.toBeNull();
+  });
+});

--- a/apps/admin/src/members/custom-fields/addressing.ts
+++ b/apps/admin/src/members/custom-fields/addressing.ts
@@ -81,12 +81,18 @@ export function customFieldAddressing(boundKey?: string): PresenceAddressing {
     },
 
     matchCompound(node): CompoundMatch | null {
+      const ownsKey = (candidate: string) => boundKey === undefined || candidate === boundKey;
+
       const children = getCompoundChildren(node, '$and');
 
       if (!children) {
         const keyValue = node[KEY_ATTRIBUTE];
 
         if (typeof keyValue === 'string') {
+          if (!ownsKey(keyValue)) {
+            return null;
+          }
+
           return {
             kind: 'predicate',
             predicate: {
@@ -100,6 +106,10 @@ export function customFieldAddressing(boundKey?: string): PresenceAddressing {
         const negatedKey = readNegatedString(keyValue);
 
         if (negatedKey !== null) {
+          if (!ownsKey(negatedKey)) {
+            return null;
+          }
+
           return {
             kind: 'predicate',
             predicate: {
@@ -147,7 +157,7 @@ export function customFieldAddressing(boundKey?: string): PresenceAddressing {
         }
       }
 
-      if (!fieldKey) {
+      if (!fieldKey || !ownsKey(fieldKey)) {
         return null;
       }
 

--- a/apps/admin/src/members/custom-fields/filter-fields.test.ts
+++ b/apps/admin/src/members/custom-fields/filter-fields.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { KIND_FILTER_TYPE } from './filter-fields';
+import { MEMBER_CUSTOM_FIELD_KINDS } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type { MemberCustomFieldKind } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type { FilterTypeId } from '@/shared/filters';
+
+// Compile-time assertions: this file is type-checked by `tsc -b`, so each expected
+// error going away fails the build.
+// @ts-expect-error -- must not compile, or KIND_FILTER_TYPE is no longer exhaustive
+const _mappingWithAMissingKindDoesNotCompile: { [K in MemberCustomFieldKind]: FilterTypeId } = {
+  text: 'text',
+  date: 'plain_date',
+  number: 'number',
+};
+const _mappingWithAnUnknownKindDoesNotCompile: { [K in MemberCustomFieldKind]: FilterTypeId } = {
+  ...KIND_FILTER_TYPE,
+  // @ts-expect-error -- must not compile, or KIND_FILTER_TYPE accepts undeclared kinds
+  boolean: 'scalar',
+};
+void _mappingWithAMissingKindDoesNotCompile;
+void _mappingWithAnUnknownKindDoesNotCompile;
+
+describe('KIND_FILTER_TYPE', () => {
+  it('maps every kind the shared catalog declares', () => {
+    expect(Object.keys(KIND_FILTER_TYPE).sort()).toEqual([...MEMBER_CUSTOM_FIELD_KINDS].sort());
+  });
+});

--- a/apps/admin/src/members/custom-fields/filter-fields.ts
+++ b/apps/admin/src/members/custom-fields/filter-fields.ts
@@ -1,5 +1,4 @@
-import { CUSTOM_FIELD_SET_OPERATORS, customFieldAddressing } from './addressing';
-import { filterType } from '@/shared/filters';
+import { customFieldAddressing } from './addressing';
 import { memberCustomFieldKind } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type { FieldDescriptor, FieldProvider, FilterTypeId } from '@/shared/filters';
 import type {
@@ -7,7 +6,7 @@ import type {
   MemberCustomFieldKind,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
-const FILTER_TYPE_FOR_KIND: Record<MemberCustomFieldKind, FilterTypeId> = {
+export const KIND_FILTER_TYPE: { [K in MemberCustomFieldKind]: FilterTypeId } = {
   text: 'text',
   date: 'plain_date',
   number: 'number',
@@ -22,25 +21,18 @@ export interface CustomFieldDefinition {
   type: MemberCustomField['type'];
 }
 
-function filterTypeFor(type: MemberCustomField['type']): FilterTypeId {
-  return FILTER_TYPE_FOR_KIND[memberCustomFieldKind(type)];
-}
-
 export function customFieldDescriptor(definition: CustomFieldDefinition): FieldDescriptor {
-  const type = filterTypeFor(definition.type);
-  const isRecord = memberCustomFieldKind(definition.type) === 'record';
+  const kind = memberCustomFieldKind(definition.type);
 
   return {
     key: `custom_fields.${definition.key}`,
     icon: 'text',
-    type,
+    type: KIND_FILTER_TYPE[kind],
     addressing: customFieldAddressing(definition.key),
     ui: {
       label: definition.name,
       type: 'custom',
-      defaultOperator: isRecord
-        ? CUSTOM_FIELD_SET_OPERATORS[0]
-        : (filterType(type).defaultOperator ?? CUSTOM_FIELD_SET_OPERATORS[0]),
+      ...(kind === 'record' ? { defaultOperator: 'is-set' } : {}),
     },
   } as FieldDescriptor;
 }

--- a/apps/admin/src/members/custom-fields/filter-renderer.test.tsx
+++ b/apps/admin/src/members/custom-fields/filter-renderer.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import CustomFieldFilterRenderer from './filter-renderer';
+import type { FilterFieldConfig } from '@tryghost/shade/patterns';
+
+vi.mock('@/shared/member-custom-fields/use-definitions', () => ({
+  useCustomFieldDefinitionsIncludingArchived: () => ({
+    data: {
+      members_custom_fields: [
+        { key: 'birthday', name: 'Birthday', type: 'short_text', status: 'active' },
+      ],
+    },
+  }),
+}));
+
+const PRESENCE_ONLY = [
+  { value: 'is-set', label: 'is set' },
+  { value: 'is-not-set', label: 'is not set' },
+];
+
+const TEXT_OPERATORS = [
+  { value: 'is', label: 'is' },
+  { value: 'is-not', label: 'is not' },
+  { value: 'contains', label: 'contains' },
+  { value: 'does-not-contain', label: 'does not contain' },
+  { value: 'starts-with', label: 'starts with' },
+  { value: 'ends-with', label: 'ends with' },
+  ...PRESENCE_ONLY,
+];
+
+function renderPill({
+  operators,
+  defaultOperator,
+  operator,
+  onOperatorChange = () => {},
+}: {
+  operators: FilterFieldConfig['operators'];
+  defaultOperator?: string;
+  operator: string;
+  onOperatorChange?: (operator: string) => void;
+}) {
+  return render(
+    <CustomFieldFilterRenderer
+      field={{
+        key: 'custom_fields.birthday',
+        label: 'Birthday',
+        operators,
+        defaultOperator,
+      }}
+      operator={operator}
+      values={['', '']}
+      onChange={() => {}}
+      onOperatorChange={onOperatorChange}
+    />,
+  );
+}
+
+describe('CustomFieldFilterRenderer operators', () => {
+  it('offers only the operators the field declares', async () => {
+    renderPill({ operators: PRESENCE_ONLY, defaultOperator: 'is-set', operator: 'is-set' });
+
+    fireEvent.pointerDown(screen.getByLabelText('Birthday operator'));
+    await screen.findByRole('menu');
+
+    expect(screen.getByRole('menuitem', { name: 'is set' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'contains' })).not.toBeInTheDocument();
+  });
+
+  it('keeps an operator the field declares, even one outside the text vocabulary', () => {
+    const onOperatorChange = vi.fn();
+    renderPill({
+      operators: [{ value: 'is-or-less', label: 'is on or before' }, ...PRESENCE_ONLY],
+      defaultOperator: 'is-or-less',
+      operator: 'is-or-less',
+      onOperatorChange,
+    });
+
+    expect(onOperatorChange).not.toHaveBeenCalled();
+  });
+
+  it('coerces an undeclared operator to the field default', () => {
+    const onOperatorChange = vi.fn();
+    renderPill({
+      operators: PRESENCE_ONLY,
+      defaultOperator: 'is-set',
+      operator: 'contains',
+      onOperatorChange,
+    });
+
+    expect(onOperatorChange).toHaveBeenCalledWith('is-set');
+  });
+
+  it('still offers the full text vocabulary to a text field', async () => {
+    const onOperatorChange = vi.fn();
+    renderPill({
+      operators: TEXT_OPERATORS,
+      defaultOperator: 'contains',
+      operator: 'contains',
+      onOperatorChange,
+    });
+
+    expect(onOperatorChange).not.toHaveBeenCalled();
+    fireEvent.pointerDown(screen.getByLabelText('Birthday operator'));
+    await screen.findByRole('menu');
+    expect(screen.getByRole('menuitem', { name: 'contains' })).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/members/custom-fields/filter-renderer.tsx
+++ b/apps/admin/src/members/custom-fields/filter-renderer.tsx
@@ -1,11 +1,28 @@
 import React, { useEffect } from 'react';
-import { CUSTOM_FIELDS_PREFIX, CUSTOM_FIELD_OPERATORS } from '@/members/member-fields';
+import { CUSTOM_FIELDS_PREFIX } from '@/members/member-fields';
 import { CUSTOM_FIELD_SET_OPERATORS } from './addressing';
 import { FilterSegmentInput, FilterSegmentSelect } from '@tryghost/shade/patterns';
 import { createOperatorOptions, listsOperator } from '@/shared/filters';
 import { memberCustomFieldParts } from '@tryghost/admin-x-framework/api/member-custom-fields';
 import { useCustomFieldDefinitionsIncludingArchived } from '@/shared/member-custom-fields/use-definitions';
-import type { CustomRendererProps } from '@tryghost/shade/patterns';
+import type { CustomRendererProps, FilterFieldConfig } from '@tryghost/shade/patterns';
+
+// "Is set" and "is not set" apply to a field of any value type.
+const PRESENCE_ONLY_OPTIONS = createOperatorOptions(CUSTOM_FIELD_SET_OPERATORS);
+
+function offeredOperators(field: FilterFieldConfig<string>, wholeComposite: boolean) {
+  const declared = field.operators?.length ? field.operators : PRESENCE_ONLY_OPTIONS;
+  const options = wholeComposite
+    ? declared.filter((option) => listsOperator(CUSTOM_FIELD_SET_OPERATORS, option.value))
+    : declared;
+  const ids = options.map((option) => option.value);
+  const fallback =
+    field.defaultOperator && ids.includes(field.defaultOperator)
+      ? field.defaultOperator
+      : (ids[0] ?? 'is-set');
+
+  return { options, ids, fallback };
+}
 
 const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({
   field,
@@ -32,15 +49,18 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({
   const [subfield = '', value = ''] = values;
   const isWholeField = subfield === '';
 
-  const operators =
-    isComposite && isWholeField ? CUSTOM_FIELD_SET_OPERATORS : CUSTOM_FIELD_OPERATORS;
+  const {
+    options: operatorOptions,
+    ids: operators,
+    fallback: fallbackOperator,
+  } = offeredOperators(field, isComposite && isWholeField);
 
   useEffect(() => {
-    if (readOnly || !onOperatorChange || listsOperator(operators, operator)) {
+    if (readOnly || !onOperatorChange || operators.includes(operator)) {
       return;
     }
-    onOperatorChange('is-set');
-  }, [readOnly, operator, operators, onOperatorChange]);
+    onOperatorChange(fallbackOperator);
+  }, [readOnly, operator, operators, fallbackOperator, onOperatorChange]);
 
   const needsValue = !listsOperator(CUSTOM_FIELD_SET_OPERATORS, operator);
   const partOptions = [{ value: '', label: 'Any' }, ...parts];
@@ -61,7 +81,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({
       {onOperatorChange && (
         <FilterSegmentSelect
           ariaLabel={`${fieldLabel} operator`}
-          options={createOperatorOptions(operators)}
+          options={operatorOptions}
           readOnly={readOnly}
           testId="custom-field-filter-operator"
           value={operator}

--- a/apps/admin/src/members/hooks/use-member-filter-sources.test.tsx
+++ b/apps/admin/src/members/hooks/use-member-filter-sources.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMemberFilterSources } from './use-member-filter-sources';
+
+const BIRTHDAY = { key: 'birthday', name: 'Birthday', type: 'short_text', status: 'active' };
+
+const mocks = vi.hoisted(() => ({
+  definitionsFailed: false,
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/newsletters', () => ({
+  useBrowseNewsletters: () => ({ data: undefined, isError: false }),
+}));
+
+vi.mock('@/shared/member-custom-fields/use-definitions', () => ({
+  useCustomFieldDefinitionsIncludingArchived: () => ({
+    data: mocks.definitionsFailed ? undefined : { members_custom_fields: [BIRTHDAY] },
+    isError: mocks.definitionsFailed,
+  }),
+}));
+
+describe('useMemberFilterSources custom fields', () => {
+  it('serves the definitions when no filter names a custom field', () => {
+    mocks.definitionsFailed = false;
+    const { result } = renderHook(() => useMemberFilterSources(undefined));
+
+    expect(result.current.customFields).toEqual([BIRTHDAY]);
+  });
+
+  it('serves an empty list when the definitions cannot be fetched', () => {
+    mocks.definitionsFailed = true;
+    const { result } = renderHook(() => useMemberFilterSources("custom_fields.birthday:'x'"));
+
+    expect(result.current.customFields).toEqual([]);
+  });
+});

--- a/apps/admin/src/members/hooks/use-member-filter-sources.ts
+++ b/apps/admin/src/members/hooks/use-member-filter-sources.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_FIELDS_PREFIX } from '@/members/member-fields';
 import { filterNamesKey } from '@/shared/filters';
 import { useCustomFieldDefinitionsIncludingArchived } from '@/shared/member-custom-fields/use-definitions';
 import { useBrowseNewsletters } from '@tryghost/admin-x-framework/api/newsletters';
@@ -16,32 +15,38 @@ export interface MemberFilterSources {
 }
 
 /**
- * The site's own newsletters and custom fields, for whoever is reading a filter.
+ * The site's newsletters and its custom field definitions. The members page needs both
+ * to read a filter accurately: which newsletters exist decides what a
+ * `newsletters.<slug>` clause means, and a custom field's definition decides how its
+ * values compare.
  *
- * "Not here yet" and "not coming at all" are different answers, and the difference is the whole
- * point of this: the page waits for the first, and must never wait for the second or it waits
- * for good. Undefined is still loading. An empty list means there is nothing to load — the
- * feature is off, the request failed, or this filter never mentioned one.
+ * `undefined` means the answer has not arrived and the caller may wait for it. An empty
+ * array means no answer is coming and the caller must not wait: newsletters are empty
+ * when the request failed or the current filter names none, and custom fields are empty
+ * when the request failed.
  *
- * Not waiting is safe. A filter still reads without these; it is just read less precisely.
+ * Waiting is optional either way. A filter is still readable without these lists, just
+ * with less accurate labels and value types.
  */
 export function useMemberFilterSources(filterParam: string | undefined): MemberFilterSources {
-  const wantsCustomFields = filterNamesKey(filterParam, CUSTOM_FIELDS_PREFIX);
   const wantsNewsletters = filterNamesKey(filterParam, NEWSLETTERS_PREFIX);
 
   const { data: newslettersData, isError: newslettersFailed } = useBrowseNewsletters({
     searchParams: { limit: '100' },
     enabled: wantsNewsletters,
   });
+  // Requested on every members page, not only when the current filter already names a
+  // custom field. Picking a custom field in the filter bar puts it into the URL on the
+  // first keystroke; if the definitions were still unrequested at that moment, the new
+  // filter would be interpreted by the catch-all "any custom field" entry in
+  // member-fields.ts, which treats every value as text. The filter bar's picker requests
+  // the same definitions, so this shares that cached request rather than adding one.
   const { data: customFieldsData, isError: customFieldsFailed } =
-    useCustomFieldDefinitionsIncludingArchived({ enabled: wantsCustomFields });
+    useCustomFieldDefinitionsIncludingArchived();
 
   return {
     newsletters:
       !wantsNewsletters || newslettersFailed ? NO_NEWSLETTERS : newslettersData?.newsletters,
-    customFields:
-      !wantsCustomFields || customFieldsFailed
-        ? NO_CUSTOM_FIELDS
-        : customFieldsData?.members_custom_fields,
+    customFields: customFieldsFailed ? NO_CUSTOM_FIELDS : customFieldsData?.members_custom_fields,
   };
 }

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -11,8 +11,8 @@ import {
 import { registerAdminApiHandler, registerRoute } from './worker';
 
 /**
- * The requests the admin shell fires on boot regardless of route, handled by
- * default so specs never mention them. Override per test keyed by entry
+ * The requests the admin shell fires on boot regardless of route, and the lookups a
+ * page fires on every mount, handled by default so specs never mention them. Override per test keyed by entry
  * name: `renderAdminApp("/", {boot: {browseMe: {response: ...}}})`. Canned
  * responses come from @tryghost/test-data; this harness must not import test
  * data from admin-x-framework.
@@ -53,6 +53,11 @@ export function defaultBootRequests() {
       method: 'GET',
       path: '/members/?limit=1',
       response: browseResponse('members', [], { limit: 1 }),
+    },
+    browseMemberCustomFieldDefinitions: {
+      method: 'GET',
+      path: /^\/members\/custom_fields\/(\?|$)/,
+      response: browseResponse('members_custom_fields', []),
     },
     browseActiveTheme: {
       method: 'GET',


### PR DESCRIPTION
## The problem

We ran an experiment: add a date field type to the shared catalog and see what the build demands. The compiler walked us through the presentation label, the icon and the editor control — and said nothing at all about filtering. The result in the UI was three silent failures. The filter pill offered text comparisons like "contains" on a date, because it carried its own hard-coded operator list instead of reading the field's. A freshly added filter was typed off a generic stand-in that treats every custom field as text, because the site's definitions were only loaded after a filter already named one. And a filter written that way was read back by the stand-in but unwritable by the real field, so reloading the page dropped the condition from a saved segment on the next write.

None of this can happen today, while every field's values are text — which is exactly why nothing caught it.

## The fix

What a comparison means was never the pill's to decide. The shared filter registry already owns the semantics for each kind of value — the same operators, wording and defaults that fields like "created at" use — and the presence pair (is set, is not set) applies to every custom field alike, because every custom field is optionally set on a member. So filtering is now derived: a field's kind picks its registry type, that type's vocabulary plus presence is everything the pill offers, and a new field type of an existing kind — a date field alongside "created at" — inherits everything and costs the filter layer nothing.

The only declaration left is one line per kind, mapping it to a registry type, and it is exhaustive: a genuinely new kind of value, one the registry cannot yet express, fails compilation at that map until someone decides. Type-level canaries make weakening the map itself a build error. That is the guard this PR exists for — a new type is silent exactly when silence is correct, and loud exactly when there is a decision to make.

Alongside the derivation: the pill renders the derived operators instead of its own list, the site's definitions load with the members page rather than after a filter names one — so a freshly added pill is never typed off the stand-in — and a field's addressing no longer answers for other fields' clauses.

We verified the guard end to end by replaying the experiment on top of this change: the date type that previously shipped three silent failures now inherits working date filtering by derivation, and adding a genuinely new kind stops the build at the map.