### PR TITLE
Fixed the delivery date picker opening on the current month

### DIFF
--- a/apps/portal/src/components/common/date-picker.jsx
+++ b/apps/portal/src/components/common/date-picker.jsx
@@ -479,6 +479,7 @@ const DatePicker = ({
             <DayPicker
               classNames={classNames}
               dir={dir}
+              defaultMonth={selected || minDate}
               disabled={[
                 ...(minDate ? [{ before: minDate }] : []),
                 ...(maxDate ? [{ after: maxDate }] : []),

--- a/apps/portal/test/unit/components/common/date-picker.test.tsx
+++ b/apps/portal/test/unit/components/common/date-picker.test.tsx
@@ -53,17 +53,6 @@ const dayButton = ({ getByText }: RenderPickerUtils, day: number) =>
   getByText(String(day), { selector: 'button.gh-portal-datepicker-day-button' });
 
 describe('DatePicker', () => {
-  // The calendar opens on the current month, so these specs depend on the clock as
-  // well as their fixtures. Pin it inside the fixture month or they only pass while
-  // the real month happens to agree.
-  beforeAll(() => {
-    vi.useFakeTimers({ toFake: ['Date'], now: new Date('2026-08-15T12:00:00Z') });
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   it('shows the minLabel while the field sits on the minimum', () => {
     const utils = renderPicker({ minLabel: 'Now' });
 

--- a/apps/portal/test/unit/components/common/date-picker.test.tsx
+++ b/apps/portal/test/unit/components/common/date-picker.test.tsx
@@ -137,6 +137,28 @@ describe('DatePicker', () => {
     expect(dayButton(utils, 12).closest('td')).toHaveClass('gh-portal-datepicker-selected');
   });
 
+  it('opens on the selected month when the value sits in a later month', () => {
+    const toDateValue = (date: Date) =>
+      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+        date.getDate(),
+      ).padStart(2, '0')}`;
+    const today = new Date();
+    const futureDay = new Date(today.getFullYear(), today.getMonth() + 2, 12);
+    const utils = renderPicker({
+      min: toDateValue(today),
+      max: toDateValue(new Date(today.getFullYear(), today.getMonth() + 6, 12)),
+      value: toDateValue(futureDay),
+    });
+    openPicker(utils);
+
+    const caption = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+    expect(utils.getByText(caption.format(futureDay))).toBeInTheDocument();
+    const selectedCell = utils
+      .getByTestId('datepicker-popover')
+      .querySelector('td.gh-portal-datepicker-selected');
+    expect(selectedCell).toHaveTextContent('12');
+  });
+
   it('refuses days before the minimum', () => {
     const utils = renderPicker();
     openPicker(utils);


### PR DESCRIPTION
no issue

The gift delivery date picker passed no `defaultMonth` to react-day-picker, which then falls back to today's month. Two consequences:

- Reopening the picker after choosing a date in another month showed the wrong month instead of the chosen date's month.
- The component's rendering depended on the real-world clock, so the unit tests — which select days around a fixed date — only passed while the current month happened to coincide with the fixture month. They broke on the September 1st month boundary and are currently failing on every branch, including `main`.

The calendar now opens on the selected date's month, falling back to the first selectable month before anything is chosen. That makes the component deterministic from its props, which fixes the UX quirk and makes the existing tests date-independent with no clock faking. All 22 date picker tests pass on a date outside the fixture month.

Before fix:
https://github.com/user-attachments/assets/ed5fbfa2-7dac-41da-9c3c-d0e21275a8a7

After fix:
https://github.com/user-attachments/assets/14f2783a-f6bf-4fd1-af5f-cf59c1dd231b


