### PR TITLE
Fixed the portal date picker tests failing once the real month moved on

### DIFF
--- a/apps/portal/test/unit/components/common/date-picker.test.tsx
+++ b/apps/portal/test/unit/components/common/date-picker.test.tsx
@@ -53,6 +53,17 @@ const dayButton = ({ getByText }: RenderPickerUtils, day: number) =>
   getByText(String(day), { selector: 'button.gh-portal-datepicker-day-button' });
 
 describe('DatePicker', () => {
+  // The calendar opens on the current month, so these specs depend on the clock as
+  // well as their fixtures. Pin it inside the fixture month or they only pass while
+  // the real month happens to agree.
+  beforeAll(() => {
+    vi.useFakeTimers({ toFake: ['Date'], now: new Date('2026-08-15T12:00:00Z') });
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it('shows the minLabel while the field sits on the minimum', () => {
     const utils = renderPicker({ minLabel: 'Now' });
 


### PR DESCRIPTION
## Problem

The portal date picker's unit tests select dates from fixtures fixed in August 2026, but the calendar under test opens on the current month, taken from the real clock. The tests therefore depended on an input nobody declared: they passed all August because the real month and the fixture month agreed, then started failing everywhere on September 1st, when the calendar opened on a month with no August days to click.

Main's own CI still looks green because portal is unchanged there, so Nx replays a cached result from August. Any branch that misses that cache runs the tests for real and fails.

## Solution

Pin the test clock inside the fixture month, so the suite is deterministic whatever the real date is. Only `Date` is faked; timers and rendering are untouched.

Left deliberately alone: the calendar opening on today's month rather than the selected date's month. That is defensible either way as product behaviour, and this change only removes the hidden clock dependency from the tests.