### PR TITLE
Changed composite custom fields to filter by their parts' declared types

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -1,9 +1,11 @@
 import {
   FIELD_TYPES,
   FIELD_TYPE_IDS,
+  partTypesOf,
   subFieldsOf,
   type FieldKind,
   type FieldType,
+  type PartType,
   type PartsOf,
 } from '@tryghost/custom-field-types';
 import { csvColumnsForField } from '@tryghost/custom-field-types/csv';
@@ -161,10 +163,13 @@ export const memberCustomFieldCsvColumns = (
   });
 };
 
-/** One part of a composite field type: the key the value schema declares, and its label. */
+export type { PartType as MemberCustomFieldPartType } from '@tryghost/custom-field-types';
+
+/** One part of a composite field type: the key the value schema declares, its label, and its declared type. */
 export type MemberCustomFieldPart<T extends FieldType = FieldType> = {
   key: PartsOf<T>;
   label: string;
+  type: PartType;
 };
 
 /**
@@ -177,11 +182,12 @@ export const memberCustomFieldParts = <T extends FieldType>(
   type: T,
 ): MemberCustomFieldPart<T>[] | null => {
   const partKeys = subFieldsOf(type);
-  if (!partKeys) {
+  const partTypes = partTypesOf(type);
+  if (!partKeys || !partTypes) {
     return null;
   }
   const labels = partLabelsFor(type);
-  return partKeys.map((key) => ({ key, label: labels[key] }));
+  return partKeys.map((key) => ({ key, label: labels[key], type: partTypes[key] }));
 };
 
 /**

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -186,14 +186,14 @@ describe('member custom fields api helpers', () => {
       expect(memberCustomFieldParts('long_text')).toBeNull();
     });
 
-    it("names a composite type's parts in the order its value schema declares them", () => {
+    it("carries each part's key, label and declared type, in schema order", () => {
       expect(memberCustomFieldParts('address')).toEqual([
-        { key: 'line1', label: 'Address line 1' },
-        { key: 'line2', label: 'Address line 2' },
-        { key: 'city', label: 'City' },
-        { key: 'state', label: 'State' },
-        { key: 'postal_code', label: 'Postal code' },
-        { key: 'country', label: 'Country' },
+        { key: 'line1', label: 'Address line 1', type: 'short_text' },
+        { key: 'line2', label: 'Address line 2', type: 'short_text' },
+        { key: 'city', label: 'City', type: 'short_text' },
+        { key: 'state', label: 'State', type: 'short_text' },
+        { key: 'postal_code', label: 'Postal code', type: 'postal_code' },
+        { key: 'country', label: 'Country', type: 'country_code' },
       ]);
     });
   });

--- a/apps/admin/src/members/custom-fields/filter-fields.test.ts
+++ b/apps/admin/src/members/custom-fields/filter-fields.test.ts
@@ -1,27 +1,60 @@
 import { describe, expect, it } from 'vitest';
-import { KIND_FILTER_TYPE } from './filter-fields';
+import { PART_FILTER_TYPE, SCALAR_KIND_FILTER_TYPE, customFieldDescriptor } from './filter-fields';
 import { MEMBER_CUSTOM_FIELD_KINDS } from '@tryghost/admin-x-framework/api/member-custom-fields';
-import type { MemberCustomFieldKind } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type {
+  MemberCustomFieldKind,
+  MemberCustomFieldPartType,
+} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type { FilterTypeId } from '@/shared/filters';
+
+type ScalarKind = Exclude<MemberCustomFieldKind, 'record'>;
 
 // Compile-time assertions: this file is type-checked by `tsc -b`, so each expected
 // error going away fails the build.
-// @ts-expect-error -- must not compile, or KIND_FILTER_TYPE is no longer exhaustive
-const _mappingWithAMissingKindDoesNotCompile: { [K in MemberCustomFieldKind]: FilterTypeId } = {
+// @ts-expect-error -- must not compile, or SCALAR_KIND_FILTER_TYPE is no longer exhaustive
+const _mappingWithAMissingKindDoesNotCompile: { [K in ScalarKind]: FilterTypeId } = {
   text: 'text',
   date: 'plain_date',
-  number: 'number',
 };
-const _mappingWithAnUnknownKindDoesNotCompile: { [K in MemberCustomFieldKind]: FilterTypeId } = {
-  ...KIND_FILTER_TYPE,
-  // @ts-expect-error -- must not compile, or KIND_FILTER_TYPE accepts undeclared kinds
+const _mappingWithAnUnknownKindDoesNotCompile: { [K in ScalarKind]: FilterTypeId } = {
+  ...SCALAR_KIND_FILTER_TYPE,
+  // @ts-expect-error -- must not compile, or SCALAR_KIND_FILTER_TYPE accepts undeclared kinds
   boolean: 'scalar',
 };
 void _mappingWithAMissingKindDoesNotCompile;
 void _mappingWithAnUnknownKindDoesNotCompile;
 
-describe('KIND_FILTER_TYPE', () => {
-  it('maps every kind the shared catalog declares', () => {
-    expect(Object.keys(KIND_FILTER_TYPE).sort()).toEqual([...MEMBER_CUSTOM_FIELD_KINDS].sort());
+describe('SCALAR_KIND_FILTER_TYPE', () => {
+  it('maps every scalar kind the shared catalog declares', () => {
+    const scalarKinds = MEMBER_CUSTOM_FIELD_KINDS.filter((kind) => kind !== 'record');
+    expect(Object.keys(SCALAR_KIND_FILTER_TYPE).sort()).toEqual([...scalarKinds].sort());
+  });
+});
+
+describe('a composite field descriptor', () => {
+  it('filters parts as text and starts the whole field at presence', () => {
+    const descriptor = customFieldDescriptor({
+      key: 'shipping',
+      name: 'Shipping',
+      type: 'address',
+    });
+
+    expect(descriptor.type).toBe('text');
+    expect(descriptor.ui.defaultOperator).toBe('is-set');
+  });
+});
+
+// @ts-expect-error -- must not compile, or PART_FILTER_TYPE is no longer exhaustive
+const _partMappingWithAMissingTypeDoesNotCompile: {
+  [P in MemberCustomFieldPartType]: FilterTypeId;
+} = {
+  short_text: 'text',
+  postal_code: 'text',
+};
+void _partMappingWithAMissingTypeDoesNotCompile;
+
+describe('PART_FILTER_TYPE', () => {
+  it('filters every part type the same way, because a composite is read with one semantics', () => {
+    expect(new Set(Object.values(PART_FILTER_TYPE)).size).toBe(1);
   });
 });

--- a/apps/admin/src/members/custom-fields/filter-fields.ts
+++ b/apps/admin/src/members/custom-fields/filter-fields.ts
@@ -1,17 +1,44 @@
 import { customFieldAddressing } from './addressing';
-import { memberCustomFieldKind } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {
+  memberCustomFieldKind,
+  memberCustomFieldParts,
+} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type { FieldDescriptor, FieldProvider, FilterTypeId } from '@/shared/filters';
 import type {
   MemberCustomField,
   MemberCustomFieldKind,
+  MemberCustomFieldPartType,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
 
-export const KIND_FILTER_TYPE: { [K in MemberCustomFieldKind]: FilterTypeId } = {
+export const SCALAR_KIND_FILTER_TYPE: {
+  [K in Exclude<MemberCustomFieldKind, 'record'>]: FilterTypeId;
+} = {
   text: 'text',
   date: 'plain_date',
   number: 'number',
-  record: 'text',
 };
+
+export const PART_FILTER_TYPE: { [P in MemberCustomFieldPartType]: FilterTypeId } = {
+  short_text: 'text',
+  postal_code: 'text',
+  country_code: 'text',
+};
+
+function compositeFilterType(type: MemberCustomField['type']): FilterTypeId {
+  const partFilterTypes = [
+    ...new Set((memberCustomFieldParts(type) ?? []).map((p) => PART_FILTER_TYPE[p.type])),
+  ];
+
+  if (partFilterTypes.length > 1) {
+    throw new Error(
+      `The parts of '${type}' filter as different types (${partFilterTypes.join(', ')}), ` +
+        'but the filter engine reads a composite with a single semantics. Build per-part ' +
+        'dispatch into the codec before mapping a part type away from its siblings.',
+    );
+  }
+
+  return partFilterTypes[0] ?? 'text';
+}
 
 export const CUSTOM_FIELD_CLAUSE = 'custom_fields.';
 
@@ -27,7 +54,7 @@ export function customFieldDescriptor(definition: CustomFieldDefinition): FieldD
   return {
     key: `custom_fields.${definition.key}`,
     icon: 'text',
-    type: KIND_FILTER_TYPE[kind],
+    type: kind === 'record' ? compositeFilterType(definition.type) : SCALAR_KIND_FILTER_TYPE[kind],
     addressing: customFieldAddressing(definition.key),
     ui: {
       label: definition.name,

--- a/apps/admin/src/members/custom-fields/filter-renderer.test.tsx
+++ b/apps/admin/src/members/custom-fields/filter-renderer.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/shared/member-custom-fields/use-definitions', () => ({
     data: {
       members_custom_fields: [
         { key: 'birthday', name: 'Birthday', type: 'short_text', status: 'active' },
+        { key: 'shipping', name: 'Shipping', type: 'address', status: 'active' },
       ],
     },
   }),
@@ -33,22 +34,28 @@ function renderPill({
   defaultOperator,
   operator,
   onOperatorChange = () => {},
+  fieldKey = 'custom_fields.birthday',
+  label = 'Birthday',
+  values = ['', ''],
 }: {
   operators: FilterFieldConfig['operators'];
   defaultOperator?: string;
   operator: string;
   onOperatorChange?: (operator: string) => void;
+  fieldKey?: string;
+  label?: string;
+  values?: string[];
 }) {
   return render(
     <CustomFieldFilterRenderer
       field={{
-        key: 'custom_fields.birthday',
-        label: 'Birthday',
+        key: fieldKey,
+        label,
         operators,
         defaultOperator,
       }}
       operator={operator}
-      values={['', '']}
+      values={values}
       onChange={() => {}}
       onOperatorChange={onOperatorChange}
     />,
@@ -101,6 +108,35 @@ describe('CustomFieldFilterRenderer operators', () => {
 
     expect(onOperatorChange).not.toHaveBeenCalled();
     fireEvent.pointerDown(screen.getByLabelText('Birthday operator'));
+    await screen.findByRole('menu');
+    expect(screen.getByRole('menuitem', { name: 'contains' })).toBeInTheDocument();
+  });
+
+  it('narrows a whole composite to presence, and opens up once a part is chosen', async () => {
+    const whole = renderPill({
+      operators: TEXT_OPERATORS,
+      defaultOperator: 'is-set',
+      operator: 'is-set',
+      fieldKey: 'custom_fields.shipping',
+      label: 'Shipping',
+    });
+
+    fireEvent.pointerDown(screen.getByLabelText('Shipping operator'));
+    await screen.findByRole('menu');
+    expect(screen.getByRole('menuitem', { name: 'is set' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'contains' })).not.toBeInTheDocument();
+    whole.unmount();
+
+    renderPill({
+      operators: TEXT_OPERATORS,
+      defaultOperator: 'is-set',
+      operator: 'contains',
+      fieldKey: 'custom_fields.shipping',
+      label: 'Shipping',
+      values: ['city', 'London'],
+    });
+
+    fireEvent.pointerDown(screen.getByLabelText('Shipping operator'));
     await screen.findByRole('menu');
     expect(screen.getByRole('menuitem', { name: 'contains' })).toBeInTheDocument();
   });

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -93,37 +93,10 @@ const byteLength = (value: string): number => new TextEncoder().encode(value).le
  */
 const text = () => z.string({ error: 'Enter text.' }).trim();
 
-const shortText = () => text().max(255, { error: 'Use 255 characters or fewer.' });
-
 const longText = () =>
   text().refine((value) => byteLength(value) <= MAX_LONG_TEXT_BYTES, {
     error: 'This text is too long to save. Shorten it a little.',
   });
-
-/**
- * A postal code, bounded well under a street address because no country's is long. The
- * bound is a sanity limit rather than a format: postal codes vary too much between
- * countries to check the shape of one without knowing which country it is for, and the
- * country is a sibling part rather than something this can see.
- */
-const postalCode = () => text().max(32, { error: 'Use 32 characters or fewer.' });
-
-/**
- * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the list of
- * them. Membership of that list is contested, and a closed list here would make Ghost the
- * arbiter of it for every member of every site. The collection form can offer countries to
- * pick from without this deciding which ones exist.
- *
- * Case is normalized so that `gb` and `GB` are not two values for one place, which a
- * filter for either would silently half-miss.
- *
- * Checked as two ASCII letters on the way in rather than by length on the way out, because
- * uppercasing does not preserve length: `ß` becomes `SS` and `aß` becomes `ASS`.
- */
-const countryCode = () =>
-  text()
-    .regex(/^[A-Za-z]{2}$/, { error: 'Enter a 2-letter country code, like US.' })
-    .toUpperCase();
 
 /**
  * Both ends are pinned to a string because storage keeps one string per leaf: a type
@@ -133,14 +106,54 @@ const countryCode = () =>
 type PartSchema = z.ZodType<string, string>;
 
 /**
+ * The types a composite's parts can declare, each defined once with its rule. A country
+ * code and a postal code both store short text, but they are different things — the
+ * part's type is what a control or a filter dispatches on, the way a field's own type
+ * is for a scalar.
+ */
+export const PART_TYPES = {
+  short_text: text().max(255, { error: 'Use 255 characters or fewer.' }),
+
+  // A postal code, bounded well under a street address because no country's is long. The
+  // bound is a sanity limit rather than a format: postal codes vary too much between
+  // countries to check the shape of one without knowing which country it is for, and the
+  // country is a sibling part rather than something this can see.
+  postal_code: text().max(32, { error: 'Use 32 characters or fewer.' }),
+
+  // The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the list of
+  // them. Membership of that list is contested, and a closed list here would make Ghost
+  // the arbiter of it for every member of every site. The collection form can offer
+  // countries to pick from without this deciding which ones exist.
+  //
+  // Case is normalized so that `gb` and `GB` are not two values for one place, which a
+  // filter for either would silently half-miss.
+  //
+  // Checked as two ASCII letters on the way in rather than by length on the way out,
+  // because uppercasing does not preserve length: `ß` becomes `SS` and `aß` becomes `ASS`.
+  country_code: text()
+    .regex(/^[A-Za-z]{2}$/, { error: 'Enter a 2-letter country code, like US.' })
+    .toUpperCase(),
+} satisfies Record<string, PartSchema>;
+
+export type PartType = keyof typeof PART_TYPES;
+export const PART_TYPE_IDS = Object.keys(PART_TYPES) as PartType[];
+
+interface TypedPart<T extends PartType = PartType> {
+  type: T;
+  schema: (typeof PART_TYPES)[T];
+}
+
+const part = <T extends PartType>(type: T): TypedPart<T> => ({ type, schema: PART_TYPES[type] });
+
+/**
  * A part as a write may name it: absent, empty, or a value of its own kind.
  *
  * A rule that is a bound would admit empty on its own; one that is a format would not,
  * and would leave its part the only one that could be set but never removed.
  */
-const clearable = <T extends PartSchema>(part: T) =>
+const clearable = <T extends PartSchema>(schema: T) =>
   text()
-    .pipe(z.union([z.literal(''), part]))
+    .pipe(z.union([z.literal(''), schema]))
     .optional();
 
 export interface FieldTypeDefinition {
@@ -151,7 +164,7 @@ export interface FieldTypeDefinition {
    * A record type's parts, in declaration order. Each part's own rule, and nothing
    * about how a write may name it: validate against `value`, never against these.
    */
-  fields?: Record<string, PartSchema>;
+  fields?: Record<string, TypedPart>;
 }
 
 /**
@@ -173,24 +186,24 @@ function defineFieldTypes<D extends Record<FieldType, FieldTypeDefinition>>(decl
  * explicitly undefined survives parsing as a key holding undefined, and a bare presence
  * check would let `{line1: undefined}` through as if it named something.
  */
-function record<F extends Record<string, PartSchema>>(fields: F, { error }: { error: string }) {
+function record<F extends Record<string, TypedPart>>(fields: F, { error }: { error: string }) {
   // Restated for the type system, which loses the key-to-schema mapping through
   // `Object.fromEntries`; without it every type built on a record infers as `unknown`.
   const shape = Object.fromEntries(
-    Object.entries(fields).map(([key, part]) => [key, clearable(part)]),
-  ) as { [K in keyof F]: ReturnType<typeof clearable<F[K]>> };
+    Object.entries(fields).map(([key, declared]) => [key, clearable(declared.schema)]),
+  ) as { [K in keyof F]: ReturnType<typeof clearable<F[K]['schema']>> };
 
   // Strict, so a part nobody declared is refused rather than dropped. That refusal keeps
   // zod's wording, which names the offending key.
   const value = z
     .strictObject(shape)
-    .refine((parts) => Object.values(parts).some((part) => typeof part === 'string'), { error });
+    .refine((parts) => Object.values(parts).some((entry) => typeof entry === 'string'), { error });
 
   return { kind: 'record' as const, value, fields };
 }
 
 export const FIELD_TYPES = defineFieldTypes({
-  short_text: { kind: 'text', value: shortText() },
+  short_text: { kind: 'text', value: PART_TYPES.short_text },
   long_text: { kind: 'text', value: longText() },
   // An address is a delivery address, so its bounds are what a courier will accept
   // rather than what the column could hold. Modeled on Stripe's Address object.
@@ -202,12 +215,12 @@ export const FIELD_TYPES = defineFieldTypes({
   // also how Stripe hands it back: beside the address rather than inside it.
   address: record(
     {
-      line1: shortText(),
-      line2: shortText(),
-      city: shortText(),
-      state: shortText(),
-      postal_code: postalCode(),
-      country: countryCode(),
+      line1: part('short_text'),
+      line2: part('short_text'),
+      city: part('short_text'),
+      state: part('short_text'),
+      postal_code: part('postal_code'),
+      country: part('country_code'),
     },
     { error: 'Enter at least one part of the address.' },
   ),
@@ -250,4 +263,17 @@ export function subFieldsOf<T extends FieldType>(type: T): PartsOf<T>[] | null {
   const definition: FieldTypeDefinition | undefined = FIELD_TYPES[type];
   // The keys are `PartsOf<T>` by construction: `fields` is the object it reads `keyof` from.
   return definition?.fields ? (Object.keys(definition.fields) as PartsOf<T>[]) : null;
+}
+
+/** Each part's declared type, keyed by part; null for a type with no parts, and for one this build has never heard of. */
+export function partTypesOf<T extends FieldType>(type: T): Record<PartsOf<T>, PartType> | null {
+  const definition: FieldTypeDefinition | undefined = FIELD_TYPES[type];
+
+  if (!definition?.fields) {
+    return null;
+  }
+
+  return Object.fromEntries(
+    Object.entries(definition.fields).map(([key, declared]) => [key, declared.type]),
+  ) as Record<PartsOf<T>, PartType>;
 }

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -4,6 +4,7 @@ import {
   FIELD_TYPES,
   FIELD_TYPE_IDS,
   MAX_LONG_TEXT_BYTES,
+  partTypesOf,
   subFieldsOf,
   type FieldType,
 } from '../src/index.ts';
@@ -23,6 +24,18 @@ describe('custom-field-types catalog', function () {
       long_text: null,
       address: ['line1', 'line2', 'city', 'state', 'postal_code', 'country'],
     });
+  });
+
+  it("declares each part's own type", function () {
+    assert.deepEqual(partTypesOf('address'), {
+      line1: 'short_text',
+      line2: 'short_text',
+      city: 'short_text',
+      state: 'short_text',
+      postal_code: 'postal_code',
+      country: 'country_code',
+    });
+    assert.equal(partTypesOf('short_text'), null);
   });
 
   it('reads a type it has never heard of as having no parts', function () {


### PR DESCRIPTION
Stacked on #30401.

## The problem

A composite custom field, like an address, was mapped as a text field for filtering. That is true of every part it has today, but it is a claim about the parts made in a place where nothing checks it — and some parts are not text in spirit. An address's country is a two-letter code: the honest filter for it, one day, is a country picker, not a free-text "contains". Nothing could say so, because by the time anything outside the shared catalog saw a part, the part was an anonymous string rule with no identity of its own.

## The change

Each part of a composite now declares a type alongside its rule — short text, postal code, country code — defined once in a catalog keyed by the type itself, so a part cannot carry a tag its rule does not match. The parts listing hands that type to whoever renders or filters a part.

Filtering then derives from the declarations at both levels. Scalar field kinds keep their exhaustive map, where a genuinely new kind of value fails the build until someone decides how it filters. A composite derives its filter treatment from its parts' declared types instead of asserting text about the whole. Everything still filters as text today; what changed is where that fact lives and what happens when it stops being true. Giving one part type its own filter treatment — the country picker — fails a pinned test and a definition-time check that names the remaining work, instead of silently misreading values.