### PR TITLE
Fixed a flaky member detail E2E test failing during teardown

### DIFF
--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -129,6 +129,10 @@ const compSubscription = (overrides: Record<string, unknown> = {}) => ({
 
 type MemberStatus = 'paid' | 'comped' | 'gift';
 
+// Playwright's wording once the page, context or a fetched response is gone.
+const isTeardownError = (err: unknown) =>
+  err instanceof Error && /has been (disposed|closed)/.test(err.message);
+
 /**
  * Rewrites this member on every read, letting a test serve a shape the fixture
  * database can't produce (Stripe subscriptions, engagement counters).
@@ -153,11 +157,12 @@ const interceptMemberRead = async (
       }
       return route.fulfill({ response, body: JSON.stringify(body) });
     } catch (err) {
-      // A post-mutation refetch can land after the test has finished, once
-      // the context is gone; there's nothing left to serve. Anything else
-      // is a real failure, and swallowing it would leave the request
-      // hanging until the test times out with no clue why.
-      if (!page.isClosed()) {
+      // A post-mutation refetch can still be in flight when the test ends;
+      // teardown then disposes the response before `page.isClosed()` flips,
+      // so the error itself is the only reliable signal. Anything else is a
+      // real failure, and swallowing it would leave the request hanging
+      // until the test times out with no clue why.
+      if (!page.isClosed() && !isTeardownError(err)) {
         throw err;
       }
     }


### PR DESCRIPTION
Seen on [Main 2/10 in run 33505744100](https://github.com/TryGhost/Ghost/actions/runs/33505744100/job/99850966326), failing all three attempts:

```
Error: apiResponse.json: Response has been disposed
  > 150 |       const body = await response.json();
```

### What happens

The trace from that job puts the whole thing in a 60ms window:

| t | event |
| --- | --- |
| 9.45s | `captureWrite` fulfils the `PUT .../subscriptions/sub_paid_123` |
| 9.47s | the screen refetches the member; `interceptMemberRead` calls `route.fetch()` |
| 9.52s | `expect.poll` passes, test body ends, After Hooks start |
| 9.53s | `Close context` — and `route.fetch()` resolves into a disposed response |

`interceptMemberRead` already intended to swallow this, but keyed the decision on `page.isClosed()`. At that point in teardown the response is disposed while the page has not yet reported itself closed, so the guard rethrows and the error is attributed to the `pageWithAuthenticatedUser` teardown.

### The fix

Key it on the error instead — `has been disposed` / `has been closed` are the only signals available that early in teardown. `page.isClosed()` is kept as the cheap case, and every other error still throws, so a genuinely broken intercept still fails loudly instead of hanging until the test times out.

### Testing

`pnpm lint` and `pnpm test:types` pass in the `e2e` workspace. The race isn't reproducible on demand locally, so CI on this PR is the real check.