### PR TITLE
Added queue routing to the class-based jobs service

### DIFF
--- a/docs/codebase/jobs.md
+++ b/docs/codebase/jobs.md
@@ -45,7 +45,8 @@ concurrency limit together alongside the handler
 which isolates slow or flood-prone job types from the shared workers; with no
 declaration the job type runs on the shared default lane. The queue only
 affects which workers run the job and how many run at once - delivery always
-routes by job type.
+routes by job type. Webmention processing runs on its own `webmentions` queue
+this way.
 
 ## Testing
 

--- a/docs/codebase/jobs.md
+++ b/docs/codebase/jobs.md
@@ -14,10 +14,14 @@ in-process and share the main process's initialized services.
 
 ## Adding a job
 
-Jobs are registered through the service in
-`ghost/core/core/server/services/jobs/`. The service is a wrapper around
-`@tryghost/job-manager` and provides Ghost's logging, configuration, models, and
-events.
+Class-based jobs are registered through
+`jobsService.handle(JobClass, handler)` in
+`ghost/core/core/server/services/jobs-service/register-job-handlers.ts`, which
+boot wires up before starting the service; the queue options below are part of
+this API. Legacy jobs are registered through the service in
+`ghost/core/core/server/services/jobs/`, a wrapper around
+`@tryghost/job-manager` that provides Ghost's logging, configuration, models,
+and events.
 
 Existing examples include:
 
@@ -32,6 +36,16 @@ When adding a service which registers jobs, give it an explicit `init()` call
 from `ghost/core/core/boot.js`. Keep the wrapper's `init()` idempotent, but let
 boot own service construction and worker setup rather than initializing on the
 first request.
+
+## Queues
+
+Handlers registered through the class-based service can declare a queue and a
+concurrency limit together alongside the handler
+(`jobsService.handle(Job, handler, {queue: 'webmentions', concurrency: 3})`),
+which isolates slow or flood-prone job types from the shared workers; with no
+declaration the job type runs on the shared default lane. The queue only
+affects which workers run the job and how many run at once - delivery always
+routes by job type.
 
 ## Testing
 

--- a/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
+++ b/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
@@ -42,6 +42,11 @@ interface RecurringTimer {
   clear(): void;
 }
 
+// Work only flows between start() and shutdown(): boot starts the service
+// before the web app is mounted or any recurring job is scheduled, so an
+// enqueue or recurring registration before start() is a boot-ordering bug and
+// throws, while an enqueue after shutdown() is a benign shutdown race and is
+// dropped.
 export default class InMemoryJobsBackend extends JobsBackendBase {
   private _processor: JobProcessor | null;
   private _stopped: boolean;
@@ -59,53 +64,58 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
   }
 
   private _createQueue(): queueAsPromised<JobEnvelope> {
-    const queue = fastq.promise(
-      (envelope: JobEnvelope) => this._deliver(envelope),
-      this._concurrency,
-    );
-    // Paused until start() attaches a processor; enqueue buffers meanwhile.
-    queue.pause();
-    return queue;
+    return fastq.promise((envelope: JobEnvelope) => this._deliver(envelope), this._concurrency);
   }
 
   start({ processor }: JobsStartOptions): void {
     this._processor = processor;
     this._stopped = false;
-    this._queue.resume();
   }
 
   enqueue(envelope: JobEnvelope): void {
     if (this._stopped) {
       return;
     }
+    if (!this._processor) {
+      throw new errors.IncorrectUsageError({
+        message: `Cannot enqueue job "${envelope.type}" before the jobs backend is started.`,
+      });
+    }
     this._queue.push(envelope);
   }
 
   private async _deliver(envelope: JobEnvelope): Promise<void> {
-    const processor = this._processor;
-    if (!processor) {
-      throw new errors.IncorrectUsageError({
-        message:
-          'InMemoryJobsBackend attempted a delivery with no processor attached - the backend lifecycle is broken.',
-      });
-    }
     try {
-      await processor(envelope);
+      await this._processor!(envelope);
     } catch (err) {
       logging.error(`Job "${envelope.type}" delivery failed`, err);
     }
   }
 
   scheduleRecurring(envelope: JobEnvelope, { cron }: RecurringSchedule): void {
+    if (this._stopped) {
+      return;
+    }
+    if (!this._processor) {
+      throw new errors.IncorrectUsageError({
+        message: `Cannot schedule recurring job "${envelope.type}" before the jobs backend is started.`,
+      });
+    }
     // First schedule per type wins; a re-registration must not disturb a
     // schedule that is already running (parity with a durable backend).
-    if (this._stopped || this._recurring.has(envelope.type)) {
+    if (this._recurring.has(envelope.type)) {
       return;
     }
 
     const parsed = later.parse.cron(cron, hasSeconds(cron));
     const timer = later.setInterval(() => {
-      this.enqueue(envelope);
+      // A throw inside a later timer callback would be an uncaughtException;
+      // a recurring tick must never take the process down.
+      try {
+        this.enqueue(envelope);
+      } catch (err) {
+        logging.error(`Recurring job "${envelope.type}" tick failed to enqueue`, err);
+      }
     }, parsed);
     this._recurring.set(envelope.type, timer);
   }
@@ -132,8 +142,8 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
       await Promise.race([queue.drained(), delay(timeoutMs)]);
     }
 
-    // Fresh (paused) queue so a re-boot never inherits this lifecycle's
-    // abandoned in-flight deliveries against its concurrency limit.
+    // Fresh queue so a re-boot never inherits this lifecycle's abandoned
+    // in-flight deliveries against its concurrency limit.
     this._queue = this._createQueue();
     this._processor = null;
   }

--- a/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
+++ b/ghost/core/core/server/adapters/jobs/InMemoryJobsBackend.ts
@@ -5,6 +5,7 @@ import { JobsBackendBase } from '@tryghost/adapter-base-jobs';
 import type {
   JobProcessor,
   JobEnvelope,
+  JobRouting,
   JobsStartOptions,
   RecurringSchedule,
   JobsShutdownOptions,
@@ -15,6 +16,9 @@ const logging = require('@tryghost/logging');
 
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10000;
 const DEFAULT_CONCURRENCY = 3;
+// Envelopes with no routing share this lane; routing to "default" by name is
+// the same lane, not a collision.
+const DEFAULT_QUEUE = 'default';
 
 function hasSeconds(cron: string): boolean {
   return cron.trim().split(/\s+/).length >= 6;
@@ -50,29 +54,46 @@ interface RecurringTimer {
 export default class InMemoryJobsBackend extends JobsBackendBase {
   private _processor: JobProcessor | null;
   private _stopped: boolean;
-  private _concurrency: number;
-  private _queue: queueAsPromised<JobEnvelope>;
+  private _defaultConcurrency: number;
+  private _queues: Map<string, queueAsPromised<JobEnvelope>>;
   private _recurring: Map<string, RecurringTimer>;
 
   constructor(config: { concurrency?: unknown } = {}) {
     super();
     this._processor = null;
     this._stopped = false;
-    this._concurrency = resolveConcurrency(config.concurrency);
-    this._queue = this._createQueue();
+    this._defaultConcurrency = resolveConcurrency(config.concurrency);
+    this._queues = new Map();
     this._recurring = new Map();
   }
 
-  private _createQueue(): queueAsPromised<JobEnvelope> {
-    return fastq.promise((envelope: JobEnvelope) => this._deliver(envelope), this._concurrency);
+  private _makeQueue(concurrency: number): queueAsPromised<JobEnvelope> {
+    return fastq.promise((envelope: JobEnvelope) => this._deliver(envelope), concurrency);
   }
 
-  start({ processor }: JobsStartOptions): void {
+  start({ processor, queues }: JobsStartOptions): void {
+    const declared = new Map<string, number>();
+    for (const [name, { concurrency }] of Object.entries(queues ?? {})) {
+      // A declaration the backend cannot satisfy must fail loudly here, never
+      // silently fall back (see the jobs-base README).
+      if (concurrency !== undefined && (!Number.isInteger(concurrency) || concurrency < 1)) {
+        throw new errors.IncorrectUsageError({
+          message: `Invalid concurrency for declared queue "${name}": ${JSON.stringify(concurrency)}. Expected a positive integer.`,
+        });
+      }
+      declared.set(name, concurrency ?? this._defaultConcurrency);
+    }
+
+    // State only changes once every declaration is valid, so a rejected
+    // start() never leaves a partially started backend that accepts work.
     this._processor = processor;
     this._stopped = false;
+    for (const [name, concurrency] of declared) {
+      this._queues.set(name, this._makeQueue(concurrency));
+    }
   }
 
-  enqueue(envelope: JobEnvelope): void {
+  enqueue(envelope: JobEnvelope, routing?: JobRouting): void {
     if (this._stopped) {
       return;
     }
@@ -81,7 +102,15 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
         message: `Cannot enqueue job "${envelope.type}" before the jobs backend is started.`,
       });
     }
-    this._queue.push(envelope);
+    const name = routing?.queue ?? DEFAULT_QUEUE;
+    let queue = this._queues.get(name);
+    if (!queue) {
+      // Lanes are created lazily: the default lane, and any queue name no
+      // handler declared, each get their own lane at the default concurrency.
+      queue = this._makeQueue(this._defaultConcurrency);
+      this._queues.set(name, queue);
+    }
+    queue.push(envelope);
   }
 
   private async _deliver(envelope: JobEnvelope): Promise<void> {
@@ -92,7 +121,11 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
     }
   }
 
-  scheduleRecurring(envelope: JobEnvelope, { cron }: RecurringSchedule): void {
+  scheduleRecurring(
+    envelope: JobEnvelope,
+    { cron }: RecurringSchedule,
+    routing?: JobRouting,
+  ): void {
     if (this._stopped) {
       return;
     }
@@ -112,7 +145,7 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
       // A throw inside a later timer callback would be an uncaughtException;
       // a recurring tick must never take the process down.
       try {
-        this.enqueue(envelope);
+        this.enqueue(envelope, routing);
       } catch (err) {
         logging.error(`Recurring job "${envelope.type}" tick failed to enqueue`, err);
       }
@@ -136,15 +169,18 @@ export default class InMemoryJobsBackend extends JobsBackendBase {
       this._clearRecurring(type);
     }
 
-    const queue = this._queue;
-    queue.kill();
-    if (!queue.idle()) {
-      await Promise.race([queue.drained(), delay(timeoutMs)]);
+    const queues = [...this._queues.values()];
+    for (const queue of queues) {
+      queue.kill();
+    }
+    const draining = queues.filter((queue) => !queue.idle());
+    if (draining.length > 0) {
+      await Promise.race([Promise.all(draining.map((queue) => queue.drained())), delay(timeoutMs)]);
     }
 
-    // Fresh queue so a re-boot never inherits this lifecycle's abandoned
-    // in-flight deliveries against its concurrency limit.
-    this._queue = this._createQueue();
+    // Discard the queues so a re-boot never inherits this lifecycle's
+    // abandoned in-flight deliveries against its concurrency limits.
+    this._queues = new Map();
     this._processor = null;
   }
 }

--- a/ghost/core/core/server/services/jobs-service/jobs-service.ts
+++ b/ghost/core/core/server/services/jobs-service/jobs-service.ts
@@ -3,7 +3,9 @@ import cronValidate from 'cron-validate';
 import type {
   JobsBackendBase,
   JobEnvelope,
+  JobRouting,
   JobsShutdownOptions,
+  QueueDeclaration,
   RecurringSchedule,
 } from '@tryghost/adapter-base-jobs';
 import { Job, JobConstructor, JobHandler } from './job';
@@ -25,11 +27,28 @@ export interface JobsServiceOptions {
 
 type Deliverer = (payload: string) => Promise<void> | void;
 
+// Execution policy for a job type, declared where its handler is registered:
+// either no options (the type runs on the backend's shared default lane) or a
+// queue name and concurrency together. The queue is routing metadata only -
+// delivery always routes by job type - and concurrency is a queue-level
+// declaration the backend enforces as strictly as it can (per process
+// in-memory, globally where a durable backend supports it). A tunable value
+// can be resolved from config at the registration site before declaring it
+// here.
+export interface JobHandlingOptions {
+  /** Named lane; types declaring the same name and concurrency share it. */
+  queue: string;
+  /** Max concurrent deliveries for the queue. */
+  concurrency: number;
+}
+
 export class JobsService {
   readonly #backend: JobsBackendBase;
   readonly #logging: JobsLogger;
   readonly #sentry?: JobsErrorReporter;
   readonly #registry = new Map<string, Deliverer>();
+  readonly #queueByType = new Map<string, string>();
+  readonly #queues = new Map<string, QueueDeclaration>();
 
   constructor({ backend, logging, sentry }: JobsServiceOptions) {
     this.#backend = backend;
@@ -37,7 +56,11 @@ export class JobsService {
     this.#sentry = sentry;
   }
 
-  handle<T extends Job, D>(JobClass: JobConstructor<T, D>, handler: JobHandler<T>): void {
+  handle<T extends Job, D>(
+    JobClass: JobConstructor<T, D>,
+    handler: JobHandler<T>,
+    options?: JobHandlingOptions,
+  ): void {
     const type = JobClass.type;
     if (typeof type !== 'string' || type.length === 0) {
       throw new errors.IncorrectUsageError({
@@ -49,16 +72,57 @@ export class JobsService {
         message: `A handler for job type "${type}" is already registered.`,
       });
     }
+    this.#declareQueue(type, options);
     this.#registry.set(type, (payload) => handler(new JobClass(JSON.parse(payload))));
   }
 
+  #declareQueue(type: string, options?: JobHandlingOptions): void {
+    if (!options) {
+      return;
+    }
+    const { queue, concurrency } = options;
+    if (typeof queue !== 'string' || queue.length === 0) {
+      throw new errors.IncorrectUsageError({
+        message: `Invalid queue for job type "${type}": ${JSON.stringify(queue)}. Expected a non-empty string.`,
+      });
+    }
+    // "default" is the backend's shared lane for types that declare no queue;
+    // declaring it would silently re-size that lane for every unrouted type.
+    if (queue === 'default') {
+      throw new errors.IncorrectUsageError({
+        message: `Queue name "default" is reserved for the shared lane; job type "${type}" must omit options to use it.`,
+      });
+    }
+    if (!Number.isInteger(concurrency) || concurrency < 1) {
+      throw new errors.IncorrectUsageError({
+        message: `Invalid concurrency for job type "${type}": ${JSON.stringify(concurrency)}. Expected a positive integer.`,
+      });
+    }
+
+    const existing = this.#queues.get(queue);
+    if (existing && existing.concurrency !== concurrency) {
+      throw new errors.IncorrectUsageError({
+        message: `Conflicting concurrency for queue "${queue}": ${existing.concurrency} is already declared, job type "${type}" declares ${concurrency}.`,
+      });
+    }
+    this.#queues.set(queue, { concurrency });
+    this.#queueByType.set(type, queue);
+  }
+
+  #routingFor(type: string): JobRouting | undefined {
+    const queue = this.#queueByType.get(type);
+    return queue === undefined ? undefined : { queue };
+  }
+
   async dispatch(job: Job): Promise<void> {
-    await this.#backend.enqueue(this.#buildEnvelope(job));
+    const envelope = this.#buildEnvelope(job);
+    await this.#backend.enqueue(envelope, this.#routingFor(envelope.type));
   }
 
   async scheduleRecurring(job: Job, schedule: RecurringSchedule): Promise<void> {
     this.#assertValidCron(schedule.cron);
-    await this.#backend.scheduleRecurring(this.#buildEnvelope(job), schedule);
+    const envelope = this.#buildEnvelope(job);
+    await this.#backend.scheduleRecurring(envelope, schedule, this.#routingFor(envelope.type));
   }
 
   // later.parse.cron does not strictly validate: it silently coerces a
@@ -80,6 +144,7 @@ export class JobsService {
   async start(): Promise<void> {
     await this.#backend.start({
       processor: (envelope) => this.#process(envelope),
+      queues: Object.fromEntries(this.#queues),
     });
   }
 

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -1,4 +1,5 @@
 import { JobsService } from './jobs-service';
+import type { JobHandlingOptions } from './jobs-service';
 import type { GiftService } from '../gifts/gift-service';
 import CleanTokensJob from '../members/jobs/clean-tokens-job';
 import CleanExpiredCompedJob from '../members/jobs/clean-expired-comped-job';
@@ -12,6 +13,14 @@ import type MentionController from '../mentions/mention-controller';
 import ProcessWebmentionJob from '../mentions/process-webmention-job';
 
 const updateCheck = require('../update-check');
+
+// Webmention processing fetches external pages and is triggered by
+// unauthenticated requests, so webmention jobs run in their own lane where a
+// flood cannot occupy the shared workers. The concurrency matches the old
+// dedicated mentions job queue. Every webmention job type must register with
+// this shared declaration so none can declare the queue with a different
+// concurrency.
+const WEBMENTIONS_QUEUE: JobHandlingOptions = { queue: 'webmentions', concurrency: 3 };
 
 interface RegisterJobHandlersDependencies {
   jobsService: JobsService;
@@ -55,7 +64,11 @@ export default function registerJobHandlers({
     await updateCheck({ rethrowErrors: true });
   });
 
-  jobsService.handle(ProcessWebmentionJob, async (job) => {
-    await mentionsController.processWebmention(job);
-  });
+  jobsService.handle(
+    ProcessWebmentionJob,
+    async (job) => {
+      await mentionsController.processWebmention(job);
+    },
+    WEBMENTIONS_QUEUE,
+  );
 }

--- a/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
+++ b/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
@@ -14,20 +14,26 @@ describe('InMemoryJobsBackend', function () {
     assert.deepEqual(backend.requiredFns, ['start', 'enqueue', 'scheduleRecurring', 'shutdown']);
   });
 
-  it('buffers envelopes enqueued before start, then delivers on start', async function () {
-    const received: JobEnvelope[] = [];
+  // Boot starts the jobs service before the web app is mounted or any
+  // recurring job is scheduled, so a pre-start enqueue or schedule is a
+  // boot-ordering bug.
+  it('throws on an enqueue before start instead of silently losing the job', function () {
     const backend = new InMemoryJobsBackend();
+    assert.throws(
+      () => backend.enqueue({ type: 'early', payload: '{}' }),
+      /before the jobs backend is started/,
+    );
+  });
 
-    backend.enqueue({ type: 'buffered', payload: '{"n":1}' });
-
-    backend.start({
-      processor: async (env) => {
-        received.push(env);
-      },
-    });
-    await backend.shutdown({ timeoutMs: 1000 });
-
-    assert.deepEqual(received, [{ type: 'buffered', payload: '{"n":1}' }]);
+  // A silently accepted pre-start schedule would throw from enqueue inside
+  // the timer callback later - an uncaughtException - so it must fail at the
+  // registration site instead.
+  it('throws on a recurring schedule before start instead of arming a delayed crash', function () {
+    const backend = new InMemoryJobsBackend();
+    assert.throws(
+      () => backend.scheduleRecurring({ type: 'early', payload: '{}' }, { cron: '0 0 3 * * *' }),
+      /before the jobs backend is started/,
+    );
   });
 
   it('caps concurrent deliveries at the default concurrency', async function () {

--- a/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
+++ b/ghost/core/test/unit/server/adapters/jobs/in-memory-jobs-backend.test.ts
@@ -36,6 +36,33 @@ describe('InMemoryJobsBackend', function () {
     );
   });
 
+  it('rejects an invalid declared queue concurrency at start instead of silently ignoring it', function () {
+    const backend = new InMemoryJobsBackend();
+    const processor = async () => {};
+    assert.throws(
+      () => backend.start({ processor, queues: { slow: { concurrency: 0 } } }),
+      /declared queue "slow"/,
+    );
+    assert.throws(
+      () => backend.start({ processor, queues: { slow: { concurrency: NaN } } }),
+      /declared queue "slow"/,
+    );
+  });
+
+  it('stays un-started when start rejects a declaration, so no work is accepted', function () {
+    const backend = new InMemoryJobsBackend();
+    assert.throws(() =>
+      backend.start({
+        processor: async () => {},
+        queues: { ok: { concurrency: 1 }, bad: { concurrency: 0 } },
+      }),
+    );
+    assert.throws(
+      () => backend.enqueue({ type: 'early', payload: '{}' }),
+      /before the jobs backend is started/,
+    );
+  });
+
   it('caps concurrent deliveries at the default concurrency', async function () {
     let running = 0;
     let maxConcurrent = 0;
@@ -227,6 +254,82 @@ describe('InMemoryJobsBackend', function () {
     await backend.shutdown({ timeoutMs: 1000 });
 
     assert.deepEqual(received, ['fresh'], 'a re-boot starts new work despite prior hung handlers');
+  });
+
+  describe('queue routing', function () {
+    // Tracks per-lane concurrency by tagging each envelope with its lane.
+    function makeLaneTracker() {
+      const running = new Map<string, number>();
+      const max = new Map<string, number>();
+      const release: Array<() => void> = [];
+      const processor = async (env: JobEnvelope) => {
+        const lane = JSON.parse(env.payload).lane as string;
+        running.set(lane, (running.get(lane) ?? 0) + 1);
+        max.set(lane, Math.max(max.get(lane) ?? 0, running.get(lane)!));
+        await new Promise<void>((resolve) => {
+          release.push(resolve);
+        });
+        running.set(lane, running.get(lane)! - 1);
+      };
+      return { max, release, processor };
+    }
+
+    async function drainAndShutdown(
+      backend: InMemoryJobsBackend,
+      release: Array<() => void>,
+    ): Promise<void> {
+      release.forEach((resolve) => resolve());
+      const releaser = setInterval(() => release.forEach((resolve) => resolve()), 5);
+      await backend.shutdown({ timeoutMs: 2000 });
+      clearInterval(releaser);
+    }
+
+    it('runs a declared queue at its own concurrency without occupying the default lane', async function () {
+      const { max, release, processor } = makeLaneTracker();
+      const backend = new InMemoryJobsBackend();
+
+      backend.start({ processor, queues: { webmentions: { concurrency: 1 } } });
+
+      for (let i = 0; i < 4; i = i + 1) {
+        backend.enqueue(
+          { type: 'webmention', payload: '{"lane":"webmentions"}' },
+          { queue: 'webmentions' },
+        );
+        backend.enqueue({ type: 'work', payload: '{"lane":"default"}' });
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+
+      assert.equal(max.get('webmentions'), 1, 'the declared queue runs serially');
+      assert.equal(max.get('default'), 3, 'a busy declared queue does not occupy default workers');
+
+      await drainAndShutdown(backend, release);
+    });
+
+    it('drains in-flight work on every lane at shutdown', async function () {
+      const completed: string[] = [];
+      const backend = new InMemoryJobsBackend();
+
+      backend.start({
+        processor: async (env) => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+          });
+          completed.push(env.type);
+        },
+        queues: { webmentions: { concurrency: 1 } },
+      });
+
+      backend.enqueue({ type: 'webmention', payload: '{}' }, { queue: 'webmentions' });
+      backend.enqueue({ type: 'work', payload: '{}' });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 5);
+      });
+      await backend.shutdown({ timeoutMs: 2000 });
+
+      assert.deepEqual(completed.sort(), ['webmention', 'work']);
+    });
   });
 
   describe('recurring schedules', function () {

--- a/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/jobs-service.test.ts
@@ -3,6 +3,7 @@ import { describe, it, beforeEach } from 'vitest';
 import type {
   JobsBackendBase,
   JobEnvelope,
+  JobRouting,
   JobsStartOptions,
   JobProcessor,
   RecurringSchedule,
@@ -12,26 +13,33 @@ import {
   JobsService,
   JobsLogger,
   JobsErrorReporter,
+  JobHandlingOptions,
 } from '../../../../../core/server/services/jobs-service/jobs-service';
 import { Job } from '../../../../../core/server/services/jobs-service/job';
 
 class FakeBackend implements JobsBackendBase {
   readonly requiredFns = ['start', 'enqueue', 'scheduleRecurring', 'shutdown'] as const;
   processor: JobProcessor | null = null;
-  enqueued: JobEnvelope[] = [];
-  recurring: { envelope: JobEnvelope; schedule: RecurringSchedule }[] = [];
+  startOptions: JobsStartOptions | null = null;
+  enqueued: { envelope: JobEnvelope; routing?: JobRouting }[] = [];
+  recurring: { envelope: JobEnvelope; schedule: RecurringSchedule; routing?: JobRouting }[] = [];
   shutdownCalls: (JobsShutdownOptions | undefined)[] = [];
 
   start(options: JobsStartOptions): void {
     this.processor = options.processor;
+    this.startOptions = options;
   }
 
-  enqueue(envelope: JobEnvelope): void {
-    this.enqueued.push(envelope);
+  enqueue(envelope: JobEnvelope, routing?: JobRouting): void {
+    this.enqueued.push({ envelope, routing });
   }
 
-  scheduleRecurring(envelope: JobEnvelope, schedule: RecurringSchedule): void {
-    this.recurring.push({ envelope, schedule });
+  scheduleRecurring(
+    envelope: JobEnvelope,
+    schedule: RecurringSchedule,
+    routing?: JobRouting,
+  ): void {
+    this.recurring.push({ envelope, schedule, routing });
   }
 
   shutdown(options?: JobsShutdownOptions): void {
@@ -40,7 +48,7 @@ class FakeBackend implements JobsBackendBase {
 
   async deliver(index = 0): Promise<void> {
     assert.ok(this.processor, 'processor must be wired via start()');
-    await this.processor!(this.enqueued[index]!);
+    await this.processor!(this.enqueued[index]!.envelope);
   }
 }
 
@@ -106,6 +114,71 @@ describe('JobsService', function () {
       service.handle(GreetJob, async () => {});
       assert.throws(() => service.handle(GreetJob, async () => {}), /already registered/);
     });
+
+    it('rejects an invalid concurrency at registration', function () {
+      const service = makeService();
+      assert.throws(
+        () => service.handle(GreetJob, async () => {}, { queue: 'slow', concurrency: 0 }),
+        /Invalid concurrency/,
+      );
+      assert.throws(
+        () => service.handle(GreetJob, async () => {}, { queue: 'slow', concurrency: 1.5 }),
+        /Invalid concurrency/,
+      );
+      assert.throws(
+        () =>
+          service.handle(GreetJob, async () => {}, {
+            queue: 'slow',
+          } as unknown as JobHandlingOptions),
+        /Invalid concurrency/,
+      );
+    });
+
+    it('rejects an invalid or missing queue name at registration', function () {
+      const service = makeService();
+      assert.throws(
+        () => service.handle(GreetJob, async () => {}, { queue: '', concurrency: 1 }),
+        /Invalid queue/,
+      );
+      assert.throws(
+        () =>
+          service.handle(GreetJob, async () => {}, {
+            concurrency: 1,
+          } as unknown as JobHandlingOptions),
+        /Invalid queue/,
+      );
+    });
+
+    it('reserves the "default" queue name for the shared lane', function () {
+      const service = makeService();
+      assert.throws(
+        () => service.handle(GreetJob, async () => {}, { queue: 'default', concurrency: 1 }),
+        /reserved for the shared lane/,
+      );
+    });
+
+    it('rejects conflicting concurrency declarations for one queue', function () {
+      const service = makeService();
+      class OtherJob extends Job {
+        static type = 'other';
+      }
+      service.handle(GreetJob, async () => {}, { queue: 'slow', concurrency: 1 });
+      assert.throws(
+        () => service.handle(OtherJob, async () => {}, { queue: 'slow', concurrency: 2 }),
+        /Conflicting concurrency for queue "slow"/,
+      );
+    });
+
+    it('lets a second type join a queue by declaring the same concurrency', function () {
+      const service = makeService();
+      class OtherJob extends Job {
+        static type = 'other';
+      }
+      service.handle(GreetJob, async () => {}, { queue: 'slow', concurrency: 1 });
+      assert.doesNotThrow(() =>
+        service.handle(OtherJob, async () => {}, { queue: 'slow', concurrency: 1 }),
+      );
+    });
   });
 
   describe('dispatch', function () {
@@ -114,7 +187,7 @@ describe('JobsService', function () {
       await service.dispatch(new GreetJob({ name: 'Ada' }));
 
       assert.equal(backend.enqueued.length, 1);
-      const envelope = backend.enqueued[0]!;
+      const envelope = backend.enqueued[0]!.envelope;
       assert.equal(envelope.type, 'greet');
       assert.equal(typeof envelope.payload, 'string');
       assert.deepEqual(JSON.parse(envelope.payload), { name: 'Ada' });
@@ -141,6 +214,57 @@ describe('JobsService', function () {
       const service = makeService();
       class Untyped extends Job {}
       await assert.rejects(() => service.dispatch(new Untyped()), /missing a static "type"/);
+    });
+  });
+
+  describe('queue routing', function () {
+    it('routes a dispatched job to its handler-declared queue', async function () {
+      const service = makeService();
+      service.handle(GreetJob, async () => {}, { queue: 'greetings', concurrency: 2 });
+
+      await service.dispatch(new GreetJob({ name: 'Ada' }));
+
+      assert.deepEqual(backend.enqueued[0]!.routing, { queue: 'greetings' });
+    });
+
+    it('routing stays out of the envelope: no extra envelope fields from queue config', async function () {
+      const service = makeService();
+      service.handle(GreetJob, async () => {}, { queue: 'greetings', concurrency: 2 });
+
+      await service.dispatch(new GreetJob({ name: 'Ada' }));
+
+      assert.deepEqual(Object.keys(backend.enqueued[0]!.envelope).sort(), ['payload', 'type']);
+    });
+
+    it('dispatches with no routing when the type declares no queue', async function () {
+      const service = makeService();
+      service.handle(GreetJob, async () => {});
+
+      await service.dispatch(new GreetJob({ name: 'Ada' }));
+
+      assert.equal(backend.enqueued[0]!.routing, undefined);
+    });
+
+    it('hands declared queues to the backend on start', async function () {
+      const service = makeService();
+      class OtherJob extends Job {
+        static type = 'other';
+      }
+      service.handle(GreetJob, async () => {}, { queue: 'webmentions', concurrency: 1 });
+      service.handle(OtherJob, async () => {}, { queue: 'webmentions', concurrency: 1 });
+
+      await service.start();
+
+      assert.deepEqual(backend.startOptions!.queues, { webmentions: { concurrency: 1 } });
+    });
+
+    it('routes recurring schedules through the same queue mapping', async function () {
+      const service = makeService();
+      service.handle(GreetJob, async () => {}, { queue: 'greetings', concurrency: 2 });
+
+      await service.scheduleRecurring(new GreetJob({ name: 'cron' }), { cron: '0 0 3 * * *' });
+
+      assert.deepEqual(backend.recurring[0]!.routing, { queue: 'greetings' });
     });
   });
 

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -20,12 +20,16 @@ describe('register-job-handlers', function () {
 
   // Handlers are looked up by their job type rather than registration order,
   // so adding a handler does not silently shift which one a test exercises.
-  function handlerFor(type: string) {
+  function registrationFor(type: string) {
     const call = jobsService.handle
       .getCalls()
       .find((c) => (c.args[0] as { type?: string }).type === type);
     assert.ok(call, `a handler is registered for ${type}`);
-    return call!.args[1] as (job: unknown) => Promise<void>;
+    return call!;
+  }
+
+  function handlerFor(type: string) {
+    return registrationFor(type).args[1] as (job: unknown) => Promise<void>;
   }
 
   beforeEach(function () {
@@ -134,5 +138,14 @@ describe('register-job-handlers', function () {
     await processWebmentionHandler(job);
 
     assert.ok(mentionsController.processWebmention.calledOnceWithExactly(job));
+  });
+
+  // Guards the webmention isolation itself: dropping the options object in a
+  // refactor would silently move webmentions back onto the shared queue while
+  // every handler-behavior test still passes.
+  it('registers process-webmention on the dedicated webmentions queue', function () {
+    const registration = registrationFor('process-webmention');
+
+    assert.deepEqual(registration.args[2], { queue: 'webmentions', concurrency: 3 });
   });
 });

--- a/packages/adapters/jobs-base/README.md
+++ b/packages/adapters/jobs-base/README.md
@@ -12,10 +12,28 @@ in-memory one with no call-site change.
 
 A backend extends `JobsBackendBase` and implements four methods:
 
-- `start({processor})` - wire the single delivery callback and begin accepting work.
-- `enqueue(envelope)` - accept an envelope for delivery. Resolves on **acceptance**, not completion.
-- `scheduleRecurring(envelope, {cron})` - register the recurring schedule for the envelope's type. The first registration per type wins; a later call for an already-scheduled type is ignored.
+- `start({processor, queues})` - wire the single delivery callback and begin accepting work. `queues` is the desired state declared by registered handlers (`{name: {concurrency}}`).
+- `enqueue(envelope, {queue})` - accept an envelope for delivery. Resolves on **acceptance**, not completion.
+- `scheduleRecurring(envelope, {cron}, {queue})` - register the recurring schedule for the envelope's type. The first registration per type wins; a later call for an already-scheduled type is ignored.
 - `shutdown({timeoutMs})` - stop accepting work and drain in-flight work within a bounded time.
+
+### Queues
+
+A queue is a routing/QoS lane, and routing metadata only - **delivery always
+routes by the envelope's `type`, never by queue**, so a job is processable
+whichever queue it arrives on and a deploy can move a type between queues while
+older work is still in flight. Renaming or removing a queue is therefore a
+parallel change: keep consuming the old name until it has drained, then drop it.
+
+The declared queues are desired state, not a command. A backend enforces a
+queue's `concurrency` as strictly as it can - per process for the in-memory
+backend, globally where a durable backend supports it. Weaker enforcement is
+acceptable; silently ignoring a declaration is not: a backend that cannot
+satisfy a declared queue's constraints - whatever that means for its
+implementation - must fail loudly at `start()`. An envelope routed to a queue
+no handler declared must still be delivered, never dropped. The queue name
+`default` names the shared lane for envelopes with no routing and cannot be
+declared.
 
 ### Delivery outcome
 

--- a/packages/adapters/jobs-base/src/base.ts
+++ b/packages/adapters/jobs-base/src/base.ts
@@ -3,10 +3,30 @@ export interface JobEnvelope {
   payload: string;
 }
 
+// Routing is metadata about where a job runs, never what runs it: delivery
+// must always be keyed on the envelope's type, so a job is processable
+// whichever queue it arrives on (deploys can move types between queues while
+// older envelopes are still in flight).
+export interface JobRouting {
+  queue?: string;
+}
+
+// A queue declared in code (via handler registration) is desired state: the
+// backend enforces its concurrency as strictly as it can - per process for an
+// in-memory backend, globally where a durable backend supports it. Weaker
+// enforcement is acceptable; silently ignoring a declaration is not.
+export interface QueueDeclaration {
+  concurrency?: number;
+}
+
 export type JobProcessor = (envelope: JobEnvelope) => Promise<void>;
 
 export interface JobsStartOptions {
   processor: JobProcessor;
+  // Queues declared by registered handlers. A backend that cannot satisfy a
+  // declared queue's constraints - whatever that means for its implementation -
+  // must fail loudly here rather than silently dropping the declaration.
+  queues?: Record<string, QueueDeclaration>;
 }
 
 export interface RecurringSchedule {
@@ -29,11 +49,12 @@ export abstract class JobsBackendBase {
 
   abstract start(options: JobsStartOptions): void | Promise<void>;
 
-  abstract enqueue(envelope: JobEnvelope): void | Promise<void>;
+  abstract enqueue(envelope: JobEnvelope, routing?: JobRouting): void | Promise<void>;
 
   abstract scheduleRecurring(
     envelope: JobEnvelope,
     schedule: RecurringSchedule,
+    routing?: JobRouting,
   ): void | Promise<void>;
 
   abstract shutdown(options?: JobsShutdownOptions): void | Promise<void>;

--- a/packages/adapters/jobs-base/src/contract-test-suite.ts
+++ b/packages/adapters/jobs-base/src/contract-test-suite.ts
@@ -110,6 +110,40 @@ export function runJobsBackendContractTests(
       assert.equal(raced, 'shutdown');
     });
 
+    // Queue routing is metadata: a backend may isolate queues or run one
+    // lane, but a routed envelope must always be delivered, and unknown
+    // routing must never lose work.
+    it('delivers an envelope enqueued with queue routing', async function () {
+      const received: JobEnvelope[] = [];
+      const backend = makeBackend();
+      await backend.start({
+        processor: async (env) => {
+          received.push(env);
+        },
+        queues: { isolated: { concurrency: 1 } },
+      });
+
+      await backend.enqueue(envelope, { queue: 'isolated' });
+      await backend.shutdown({ timeoutMs: 1000 });
+
+      assert.deepEqual(received, [envelope]);
+    });
+
+    it('delivers an envelope routed to a queue no handler declared', async function () {
+      const received: JobEnvelope[] = [];
+      const backend = makeBackend();
+      await backend.start({
+        processor: async (env) => {
+          received.push(env);
+        },
+      });
+
+      await backend.enqueue(envelope, { queue: 'undeclared' });
+      await backend.shutdown({ timeoutMs: 1000 });
+
+      assert.deepEqual(received, [envelope]);
+    });
+
     it('tolerates start after a prior shutdown', async function () {
       const received: JobEnvelope[] = [];
       const backend = makeBackend();


### PR DESCRIPTION
**Why am I making it?**

Webmention processing fetches external pages and is triggered by unauthenticated public requests. When `ProcessWebmentionJob` moved to the class-based jobs service, it landed on the single shared queue (concurrency 3) alongside every other job type, so a burst of webmentions could occupy all shared workers and delay member cleanup, update checks, and other background jobs. The legacy system isolated this by running an entire second `JobManager` instance (`services/mentions-jobs`); the new jobs contract had no concept of routing or per-type limits. With a durable backend as the next step of the jobs project, the replacement needs to survive a durable, multi-instance world rather than being an in-memory-only fix.

**What does it do?**

Three commits, meant to be read in order:

1. **Removed pre-start job buffering from the in-memory jobs backend.** Boot starts the jobs service before the web app is mounted and before any recurring job is scheduled, so nothing can legitimately enqueue or schedule before `start()`. A pre-start enqueue or recurring schedule now throws (a boot-ordering bug surfaces immediately, rather than a silently accepted schedule crashing inside a timer callback later); an enqueue after `shutdown()` remains a silently dropped benign race.

2. **Added queue routing to the class-based jobs service.** The capability only — no job type is routed yet. Handlers declare execution policy where they are registered: either nothing (the shared default lane, whose name is reserved) or a queue name and concurrency together. The queue is routing metadata resolved at dispatch time (`enqueue(envelope, {queue})`) — delivery always routes by job type, never by queue, and the envelope stays a pure `{type, payload}`. Declared queues are handed to the backend at `start()` as desired state; the in-memory backend runs one fastq lane per queue, and a declaration a backend cannot satisfy fails loudly at `start()` rather than being silently dropped.

3. **Added a dedicated queue for webmention processing.**

   ```ts
   jobsService.handle(ProcessWebmentionJob, handler, {queue: 'webmentions', concurrency: 3});
   ```

   This restores the isolation the old dedicated mentions queue provided; the concurrency matches that legacy queue's inline fastq concurrency of 3 — the isolation comes from the dedicated lane, not from serialising it.

**Why is this something Ghost users or developers need?**

It stops a flood of untrusted, slow webmention work from degrading every other background job's latency, and it gives the imminent durable backend a queue concept to build on — the contract changes (`JobRouting`, `queues` at `start()`, and the invariants documented in the `@tryghost/adapter-base-jobs` README) are written to be backend-agnostic.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMPuKWMmsPWTwXYgK1biZr