### PR TITLE
Trimmed cached c8 coverage artifacts

### DIFF
--- a/ghost/core/.c8rc.e2e.json
+++ b/ghost/core/.c8rc.e2e.json
@@ -1,7 +1,7 @@
 {
   "all": true,
   "check-coverage": true,
-  "reporter": ["html-spa", "text-summary", "cobertura"],
+  "reporter": ["text-summary", "cobertura"],
   "reportsDir": "./coverage-e2e",
   "statements": 54,
   "branches": 75,

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -384,7 +384,7 @@
           "^build"
         ],
         "outputs": [
-          "{projectRoot}/coverage-e2e"
+          "{projectRoot}/coverage-e2e/cobertura-coverage.xml"
         ]
       },
       "test:ci:integration": {
@@ -393,7 +393,7 @@
           "^build"
         ],
         "outputs": [
-          "{projectRoot}/coverage-integration"
+          "{projectRoot}/coverage-integration/cobertura-coverage.xml"
         ]
       }
     }


### PR DESCRIPTION
no ref
- speed up acceptance tests runs by only caching the coverage xml artifact, rather than the full v8 profiles
