### PR TITLE
Fixed PR checks blaming the branch for the base branch's own drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,12 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR base branch
-        run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+        # Through env, never interpolated into the script: a branch name can
+        # carry shell metacharacters, and template expansion happens before the
+        # shell parses the command.
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch --no-tags origin "refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
@@ -376,7 +381,12 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR base branch
-        run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+        # Through env, never interpolated into the script: a branch name can
+        # carry shell metacharacters, and template expansion happens before the
+        # shell parses the command.
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch --no-tags origin "refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
 
       - name: Check migration integrity
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,8 +335,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Fetch main branch
-        run: git fetch --no-tags origin main
+      - name: Fetch PR base branch
+        run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
@@ -349,6 +349,7 @@ jobs:
       - name: Check app version bump
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_COMPARE_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/check-app-version-bump.js
 
@@ -358,6 +359,7 @@ jobs:
       - name: Check for missing changesets
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_COMPARE_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/change-check.js
 
@@ -379,6 +381,7 @@ jobs:
       - name: Check migration integrity
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_COMPARE_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/check-migration-integrity.cjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
         # shell parses the command.
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: git fetch --no-tags origin "refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
+        run: git fetch --no-tags origin "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
@@ -386,7 +386,7 @@ jobs:
         # shell parses the command.
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: git fetch --no-tags origin "refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
+        run: git fetch --no-tags origin "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
 
       - name: Check migration integrity
         env:

--- a/scripts/change-check.js
+++ b/scripts/change-check.js
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
 import camelcaseKeys from 'camelcase-keys';
 
@@ -23,10 +24,25 @@ const { testPattern = [], changedFilesIgnorePattern = [] } = camelcaseKeys(value
 // Positional args win; otherwise fall back to the PR_* env vars the sibling PR
 // checks use (check-app-version-bump.js, check-migration-integrity.cjs), so CI
 // can invoke this bare. Local runs with neither default to main..HEAD.
+// The comparison must be rooted at the PR's fork point, not at a tip of the
+// base branch: a tree-diff from the live tip charges the PR with every base
+// commit it has not rebased onto yet, while the event payload's PR_BASE_SHA
+// freezes at event time and drifts the other way. The merge-base of the base
+// ref and the head is right in both cases. Prefer the live base ref (fetched
+// by CI just before this runs) for finding it; fall back to the payload SHA.
+const liveBase = process.env.PR_BASE_REF && `origin/${process.env.PR_BASE_REF}`;
 const [
-  baseCommit = process.env.PR_BASE_SHA || 'main',
+  requestedBase = liveBase || process.env.PR_BASE_SHA || 'main',
   headCommit = process.env.PR_COMPARE_SHA || process.env.GITHUB_SHA || 'HEAD',
 ] = positionals;
+let baseCommit = requestedBase;
+try {
+  baseCommit = execFileSync('git', ['merge-base', requestedBase, headCommit || 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+} catch {
+  // One of the refs is unknown in this checkout; downstream reports it better.
+}
 // Always applied — the release policy, not a default callers can replace.
 const ignorePatterns = [INTERNAL_DOCS_PATTERN, ...testPattern, ...changedFilesIgnorePattern];
 

--- a/scripts/change-check.js
+++ b/scripts/change-check.js
@@ -1,8 +1,8 @@
-import { execFileSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
 import camelcaseKeys from 'camelcase-keys';
 
 import { findPackagesNeedingChangeset } from './lib/pnpm.js';
+import { resolveBaseCommit, rootAtMergeBase } from './lib/pr-base.js';
 import { INTERNAL_DOCS_PATTERN } from './lib/constants.js';
 
 const { values, positionals } = parseArgs({
@@ -27,22 +27,14 @@ const { testPattern = [], changedFilesIgnorePattern = [] } = camelcaseKeys(value
 // The comparison must be rooted at the PR's fork point, not at a tip of the
 // base branch: a tree-diff from the live tip charges the PR with every base
 // commit it has not rebased onto yet, while the event payload's PR_BASE_SHA
-// freezes at event time and drifts the other way. The merge-base of the base
-// ref and the head is right in both cases. Prefer the live base ref (fetched
-// by CI just before this runs) for finding it; fall back to the payload SHA.
-const liveBase = process.env.PR_BASE_REF && `origin/${process.env.PR_BASE_REF}`;
+// freezes at event time and drifts the other way. resolveBaseCommit picks the
+// freshest base available and rootAtMergeBase confines the diff to what the
+// branch actually changed.
 const [
-  requestedBase = liveBase || process.env.PR_BASE_SHA || 'main',
+  requestedBase = resolveBaseCommit() || 'main',
   headCommit = process.env.PR_COMPARE_SHA || process.env.GITHUB_SHA || 'HEAD',
 ] = positionals;
-let baseCommit = requestedBase;
-try {
-  baseCommit = execFileSync('git', ['merge-base', requestedBase, headCommit || 'HEAD'], {
-    encoding: 'utf8',
-  }).trim();
-} catch {
-  // One of the refs is unknown in this checkout; downstream reports it better.
-}
+const baseCommit = rootAtMergeBase(requestedBase, headCommit || 'HEAD');
 // Always applied — the release policy, not a default callers can replace.
 const ignorePatterns = [INTERNAL_DOCS_PATTERN, ...testPattern, ...changedFilesIgnorePattern];
 

--- a/scripts/check-app-version-bump.js
+++ b/scripts/check-app-version-bump.js
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 
 import { PUBLIC_APPS, DEFAULTS_PATH, DEFAULTS_REPO_PATH, majorMinor } from './lib/public-apps.js';
+import { resolveBaseCommit } from './lib/pr-base.js';
 
 const MONITORED_APP_PATHS = PUBLIC_APPS.map((app) => app.path);
 
@@ -128,25 +129,8 @@ export function checkAppConsistency(app, prVersion, prDefaultsVersion) {
   return null;
 }
 
-// `pull_request.base.sha` in the event payload freezes when the event fires and
-// goes stale as the base branch moves on; a diff rooted there blames the PR for
-// the base branch's own drift. Prefer the live tip of the base ref, which the
-// workflow fetches right before running this; the payload SHA is the fallback
-// for contexts that fetched nothing.
-function resolveBaseSha() {
-  const baseRef = process.env.PR_BASE_REF;
-  if (baseRef) {
-    try {
-      return runGit(['rev-parse', `origin/${baseRef}`]);
-    } catch {
-      // The ref was not fetched in this checkout; the payload SHA still works.
-    }
-  }
-  return process.env.PR_BASE_SHA;
-}
-
 function main() {
-  const baseSha = resolveBaseSha();
+  const baseSha = resolveBaseCommit();
   const compareSha = process.env.PR_COMPARE_SHA || process.env.GITHUB_SHA;
 
   if (!baseSha) {

--- a/scripts/check-app-version-bump.js
+++ b/scripts/check-app-version-bump.js
@@ -128,8 +128,25 @@ export function checkAppConsistency(app, prVersion, prDefaultsVersion) {
   return null;
 }
 
+// `pull_request.base.sha` in the event payload freezes when the event fires and
+// goes stale as the base branch moves on; a diff rooted there blames the PR for
+// the base branch's own drift. Prefer the live tip of the base ref, which the
+// workflow fetches right before running this; the payload SHA is the fallback
+// for contexts that fetched nothing.
+function resolveBaseSha() {
+  const baseRef = process.env.PR_BASE_REF;
+  if (baseRef) {
+    try {
+      return runGit(['rev-parse', `origin/${baseRef}`]);
+    } catch {
+      // The ref was not fetched in this checkout; the payload SHA still works.
+    }
+  }
+  return process.env.PR_BASE_SHA;
+}
+
 function main() {
-  const baseSha = process.env.PR_BASE_SHA;
+  const baseSha = resolveBaseSha();
   const compareSha = process.env.PR_COMPARE_SHA || process.env.GITHUB_SHA;
 
   if (!baseSha) {

--- a/scripts/check-migration-integrity.cjs
+++ b/scripts/check-migration-integrity.cjs
@@ -221,8 +221,19 @@ function main() {
     errors.push(orphanedError);
   }
 
-  // Check 2: Stale placements (needs git context, only on PRs)
-  const baseSha = process.env.PR_BASE_SHA;
+  // Check 2: Stale placements (needs git context, only on PRs).
+  // `pull_request.base.sha` (PR_BASE_SHA) freezes when the event fires and goes
+  // stale as the base branch moves on; prefer the live tip of the base ref,
+  // which this job's workflow fetches right before running.
+  const baseRef = process.env.PR_BASE_REF;
+  let baseSha = process.env.PR_BASE_SHA;
+  if (baseRef) {
+    try {
+      baseSha = runGit(['rev-parse', `origin/${baseRef}`]);
+    } catch {
+      // The ref was not fetched in this checkout; the payload SHA still works.
+    }
+  }
   const compareSha = process.env.PR_COMPARE_SHA || process.env.GITHUB_SHA;
 
   if (baseSha && compareSha) {

--- a/scripts/check-migration-integrity.cjs
+++ b/scripts/check-migration-integrity.cjs
@@ -12,7 +12,12 @@ const PACKAGE_JSON_PATH = 'ghost/core/package.json';
  */
 function runGit(args) {
   try {
-    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+    // stderr piped, not inherited: the fallback below probes a ref that may
+    // not exist, and git's complaint should reach the thrown error, not the log.
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
   } catch (error) {
     const stderr = error.stderr ? error.stderr.toString().trim() : '';
     const stdout = error.stdout ? error.stdout.toString().trim() : '';
@@ -229,7 +234,7 @@ function main() {
   let baseSha = process.env.PR_BASE_SHA;
   if (baseRef) {
     try {
-      baseSha = runGit(['rev-parse', `origin/${baseRef}`]);
+      baseSha = runGit(['rev-parse', '--verify', `origin/${baseRef}^{commit}`]);
     } catch {
       // The ref was not fetched in this checkout; the payload SHA still works.
     }

--- a/scripts/lib/pr-base.js
+++ b/scripts/lib/pr-base.js
@@ -1,0 +1,75 @@
+import { execFileSync } from 'node:child_process';
+
+import { ROOT_DIR } from './constants.js';
+
+// Stays in sync with lib/git.js: git always runs from the repo root, and a
+// child's stderr never leaks into the caller's output — the pre-commit hook
+// runs these checks on every commit.
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: ROOT_DIR,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+/**
+ * The base commit a PR check should compare against.
+ *
+ * `pull_request.base.sha` freezes into the event payload when the event fires
+ * and goes stale as the base branch moves on, while the live tip of the base
+ * ref is fetched by CI immediately before these checks run. Prefer the live
+ * ref; fall back to the payload SHA when the ref was never fetched into this
+ * checkout.
+ *
+ * @param {object} [env=process.env] - Source of PR_BASE_REF / PR_BASE_SHA.
+ * @returns {string|undefined} - A commit SHA, or undefined outside PR context.
+ */
+export function resolveBaseCommit(env = process.env) {
+  if (env.PR_BASE_REF) {
+    try {
+      return git(['rev-parse', '--verify', `origin/${env.PR_BASE_REF}^{commit}`]);
+    } catch {
+      // The ref was not fetched in this checkout; the payload SHA still works.
+    }
+  }
+  return env.PR_BASE_SHA;
+}
+
+/**
+ * The merge-base of `base` and `head`, so a comparison rooted at the result
+ * only ever contains the branch's own changes, never the base branch's drift.
+ *
+ * `head` may be a tree rather than a commit — the pre-commit hook passes `git
+ * write-tree` output to compare the staged index. A tree has no ancestry to
+ * intersect, so the base is returned as given; the hook already passes the
+ * merge-base it computed itself. Any other failure throws: silently falling
+ * back to a tip-rooted diff would reintroduce the drift-blaming this exists
+ * to prevent.
+ *
+ * @param {string} base - A commit-ish to root the comparison at.
+ * @param {string} head - A commit-ish or tree to compare to.
+ * @returns {string} - The merge-base SHA, or `base` for a tree head.
+ */
+export function rootAtMergeBase(base, head) {
+  let headType = null;
+  try {
+    headType = git(['cat-file', '-t', String(head)]);
+  } catch {
+    // An unknown head falls through to merge-base for its clearer error.
+  }
+  if (headType === 'tree') {
+    return base;
+  }
+
+  try {
+    return git(['merge-base', String(base), String(head)]);
+  } catch (error) {
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    throw new Error(
+      `Unable to determine merge-base for ${base} and ${head}. ` +
+        `Ensure the base branch history is available in the checkout.` +
+        (stderr ? `\n${stderr}` : ''),
+    );
+  }
+}

--- a/scripts/test/pr-base.test.js
+++ b/scripts/test/pr-base.test.js
@@ -1,54 +1,99 @@
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { resolveBaseCommit, rootAtMergeBase } from '../lib/pr-base.js';
-import { ROOT_DIR } from '../lib/constants.js';
 
-// These run against the live repo, the same way git.test.js does.
-function git(args) {
-  return execFileSync('git', args, { cwd: ROOT_DIR, encoding: 'utf8' }).trim();
+// A throwaway repository rather than the live one: CI checkouts don't reliably
+// carry `refs/remotes/origin/*` (a pull_request checkout fetches only the merge
+// ref), and fixture commits make the merge-base assertions deterministic.
+//
+// pr-base.js pins its git calls to the repo root, so the fixture is routed to
+// them through GIT_DIR, which git honours over the working directory.
+const FIXTURE = mkdtempSync(join(tmpdir(), 'pr-base-fixture-'));
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Fixture',
+  GIT_AUTHOR_EMAIL: 'fixture@example.com',
+  GIT_COMMITTER_NAME: 'Fixture',
+  GIT_COMMITTER_EMAIL: 'fixture@example.com',
+};
+
+function fixtureGit(args) {
+  return execFileSync('git', args, { cwd: FIXTURE, encoding: 'utf8', env: GIT_ENV }).trim();
 }
 
-const MAIN_TIP = git(['rev-parse', 'origin/main']);
-const HEAD_SHA = git(['rev-parse', 'HEAD']);
+function commit(message) {
+  fixtureGit(['commit', '--allow-empty', '-m', message]);
+  return fixtureGit(['rev-parse', 'HEAD']);
+}
+
+let forkPoint; // the commit both branches share
+let mainTip; // one commit of base-branch drift past the fork point
+let featureTip; // one branch commit past the fork point
+let featureTree; // what the pre-commit hook passes as head
+let orphanTip; // shares no history with anything
+
+before(() => {
+  fixtureGit(['init', '--initial-branch', 'main', '.']);
+  forkPoint = commit('fork point');
+  mainTip = commit('base branch drift');
+  fixtureGit(['update-ref', 'refs/remotes/origin/main', mainTip]);
+  fixtureGit(['checkout', '-q', '-b', 'feature', forkPoint]);
+  featureTip = commit('branch work');
+  featureTree = fixtureGit(['rev-parse', 'HEAD^{tree}']);
+  fixtureGit(['checkout', '-q', '--orphan', 'disjoint']);
+  orphanTip = commit('no shared history');
+
+  process.env.GIT_DIR = join(FIXTURE, '.git');
+});
+
+after(() => {
+  delete process.env.GIT_DIR;
+  rmSync(FIXTURE, { recursive: true, force: true });
+});
 
 describe('resolveBaseCommit', () => {
   it('prefers the live tip of the base ref over the payload SHA', () => {
     const resolved = resolveBaseCommit({ PR_BASE_REF: 'main', PR_BASE_SHA: 'stale-sha' });
-    assert.strictEqual(resolved, MAIN_TIP);
+    assert.strictEqual(resolved, mainTip);
   });
 
   it('falls back to the payload SHA when the ref was never fetched', () => {
     const resolved = resolveBaseCommit({
-      PR_BASE_REF: 'no-such-branch-zzzzzz',
-      PR_BASE_SHA: HEAD_SHA,
+      PR_BASE_REF: 'no-such-branch',
+      PR_BASE_SHA: forkPoint,
     });
-    assert.strictEqual(resolved, HEAD_SHA);
+    assert.strictEqual(resolved, forkPoint);
   });
 
   it('returns the payload SHA alone outside a fetched-ref context', () => {
-    assert.strictEqual(resolveBaseCommit({ PR_BASE_SHA: HEAD_SHA }), HEAD_SHA);
+    assert.strictEqual(resolveBaseCommit({ PR_BASE_SHA: forkPoint }), forkPoint);
     assert.strictEqual(resolveBaseCommit({}), undefined);
   });
 });
 
 describe('rootAtMergeBase', () => {
-  it('roots a commit comparison at the merge-base', () => {
-    const expected = git(['merge-base', 'origin/main', 'HEAD']);
-    assert.strictEqual(rootAtMergeBase('origin/main', 'HEAD'), expected);
+  it('roots a drifted-base comparison at the fork point', () => {
+    assert.strictEqual(rootAtMergeBase(mainTip, featureTip), forkPoint);
   });
 
   it('returns the base untouched for a tree head, as the pre-commit hook passes', () => {
-    // The commit's own tree stands in for `git write-tree` output.
-    const tree = git(['rev-parse', 'HEAD^{tree}']);
-    assert.strictEqual(rootAtMergeBase(MAIN_TIP, tree), MAIN_TIP);
+    assert.strictEqual(rootAtMergeBase(mainTip, featureTree), mainTip);
   });
 
-  it('throws a clear error when no merge-base can be determined', () => {
+  it('throws a clear error for an unknown ref', () => {
     assert.throws(
-      () => rootAtMergeBase('not-a-real-ref-zzzzzz', 'HEAD'),
+      () => rootAtMergeBase('not-a-real-ref', featureTip),
       /Unable to determine merge-base/,
     );
+  });
+
+  it('throws a clear error when the histories share no ancestor', () => {
+    assert.throws(() => rootAtMergeBase(mainTip, orphanTip), /Unable to determine merge-base/);
   });
 });

--- a/scripts/test/pr-base.test.js
+++ b/scripts/test/pr-base.test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+
+import { resolveBaseCommit, rootAtMergeBase } from '../lib/pr-base.js';
+import { ROOT_DIR } from '../lib/constants.js';
+
+// These run against the live repo, the same way git.test.js does.
+function git(args) {
+  return execFileSync('git', args, { cwd: ROOT_DIR, encoding: 'utf8' }).trim();
+}
+
+const MAIN_TIP = git(['rev-parse', 'origin/main']);
+const HEAD_SHA = git(['rev-parse', 'HEAD']);
+
+describe('resolveBaseCommit', () => {
+  it('prefers the live tip of the base ref over the payload SHA', () => {
+    const resolved = resolveBaseCommit({ PR_BASE_REF: 'main', PR_BASE_SHA: 'stale-sha' });
+    assert.strictEqual(resolved, MAIN_TIP);
+  });
+
+  it('falls back to the payload SHA when the ref was never fetched', () => {
+    const resolved = resolveBaseCommit({
+      PR_BASE_REF: 'no-such-branch-zzzzzz',
+      PR_BASE_SHA: HEAD_SHA,
+    });
+    assert.strictEqual(resolved, HEAD_SHA);
+  });
+
+  it('returns the payload SHA alone outside a fetched-ref context', () => {
+    assert.strictEqual(resolveBaseCommit({ PR_BASE_SHA: HEAD_SHA }), HEAD_SHA);
+    assert.strictEqual(resolveBaseCommit({}), undefined);
+  });
+});
+
+describe('rootAtMergeBase', () => {
+  it('roots a commit comparison at the merge-base', () => {
+    const expected = git(['merge-base', 'origin/main', 'HEAD']);
+    assert.strictEqual(rootAtMergeBase('origin/main', 'HEAD'), expected);
+  });
+
+  it('returns the base untouched for a tree head, as the pre-commit hook passes', () => {
+    // The commit's own tree stands in for `git write-tree` output.
+    const tree = git(['rev-parse', 'HEAD^{tree}']);
+    assert.strictEqual(rootAtMergeBase(MAIN_TIP, tree), MAIN_TIP);
+  });
+
+  it('throws a clear error when no merge-base can be determined', () => {
+    assert.throws(
+      () => rootAtMergeBase('not-a-real-ref-zzzzzz', 'HEAD'),
+      /Unable to determine merge-base/,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The "Check for missing changesets" job fails on PRs for packages the PR never touched. It compares the tip of the base branch against the PR head as a plain tree diff, so a PR that has not rebased onto the very newest main is charged with every package main changed in the meantime. Example from today: a members-area PR failed for `@tryghost/koenig-lexical` and `@tryghost/kg-unsplash-selector` because main had merged a colour-token sweep after the PR's last rebase. The only remedy was rebasing and re-running CI, and the check goes red again every time main moves.

The sibling checks (app version bump, migration integrity) already root their diffs at a merge-base, but they compute it from `pull_request.base.sha` out of the event payload — a value that freezes when the event fires and goes stale as the base branch moves on.

## Solution

Root every one of these comparisons at the merge-base of the base branch and the PR head, found from the live base ref rather than the payload snapshot. The changesets check now computes that merge-base before diffing, and all three scripts prefer `origin/<base ref>` — which their CI jobs fetch immediately before running — falling back to the payload SHA where nothing was fetched. The version-bump job also fetches the PR's actual base ref instead of a hard-coded `main`, so PRs against release branches compare against the right base.

Verified against the failing case: with a base tip four commits ahead of the PR's fork point, the changesets check no longer names the drifted packages, and a genuine package change without a changeset still fails the check.