### PR TITLE
Added snippets API hooks to the shared admin framework

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,6 +17,7 @@
     "koenig/kg-lexical-html-renderer/**",
     "koenig/kg-simplemde/debug/**",
     "koenig/koenig-lexical/**",
-    "packages/i18n/locales/**"
+    "packages/i18n/locales/**",
+    ".changeset/ledger.yaml"
   ]
 }

--- a/apps/admin-x-framework/src/api/snippets.ts
+++ b/apps/admin-x-framework/src/api/snippets.ts
@@ -10,7 +10,9 @@ export type Snippet = {
   updated_at: string | null;
 };
 
-export type SnippetEditableData = Partial<Omit<Snippet, 'id' | 'created_at' | 'updated_at'>>;
+// The add and edit schemas require name and mobiledoc on every item
+export type SnippetEditableData = Pick<Snippet, 'name' | 'mobiledoc'> &
+  Partial<Pick<Snippet, 'lexical'>>;
 
 export interface SnippetsResponseType {
   meta?: Meta;
@@ -22,11 +24,21 @@ const dataType = 'SnippetsResponseType';
 // Without `formats` the API strips `lexical` from responses (mobiledoc is the default format)
 const formats = 'mobiledoc,lexical';
 
-export const useBrowseSnippets = createQuery<SnippetsResponseType>({
+const useBrowseSnippetsQuery = createQuery<SnippetsResponseType>({
   dataType,
   path: '/snippets/',
   defaultSearchParams: { limit: 'all', formats },
 });
+
+export const useBrowseSnippets = ({
+  searchParams,
+  ...args
+}: Parameters<typeof useBrowseSnippetsQuery>[0] = {}) =>
+  useBrowseSnippetsQuery({
+    ...args,
+    // caller searchParams replace the defaults wholesale, so re-merge formats
+    searchParams: { limit: 'all', ...searchParams, formats },
+  });
 
 export const useAddSnippet = createMutation<SnippetsResponseType, SnippetEditableData>({
   method: 'POST',

--- a/apps/admin-x-framework/src/api/snippets.ts
+++ b/apps/admin-x-framework/src/api/snippets.ts
@@ -1,0 +1,54 @@
+import { Meta, createMutation, createQuery } from '../utils/api/hooks';
+
+// mobiledoc and lexical travel as JSON strings on the wire; callers parse/stringify
+export type Snippet = {
+  id: string;
+  name: string;
+  mobiledoc: string;
+  lexical: string | null;
+  created_at: string;
+  updated_at: string | null;
+};
+
+export type SnippetEditableData = Partial<Omit<Snippet, 'id' | 'created_at' | 'updated_at'>>;
+
+export interface SnippetsResponseType {
+  meta?: Meta;
+  snippets: Snippet[];
+}
+
+const dataType = 'SnippetsResponseType';
+
+// Without `formats` the API strips `lexical` from responses (mobiledoc is the default format)
+const formats = 'mobiledoc,lexical';
+
+export const useBrowseSnippets = createQuery<SnippetsResponseType>({
+  dataType,
+  path: '/snippets/',
+  defaultSearchParams: { limit: 'all', formats },
+});
+
+export const useAddSnippet = createMutation<SnippetsResponseType, SnippetEditableData>({
+  method: 'POST',
+  path: () => '/snippets/',
+  searchParams: () => ({ formats }),
+  body: (snippet) => ({ snippets: [snippet] }),
+  invalidateQueries: { dataType },
+});
+
+export const useEditSnippet = createMutation<
+  SnippetsResponseType,
+  SnippetEditableData & { id: string }
+>({
+  method: 'PUT',
+  path: ({ id }) => `/snippets/${id}/`,
+  searchParams: () => ({ formats }),
+  body: ({ id, ...rest }) => ({ snippets: [{ id, ...rest }] }),
+  invalidateQueries: { dataType },
+});
+
+export const useDeleteSnippet = createMutation<unknown, string>({
+  method: 'DELETE',
+  path: (id) => `/snippets/${id}/`,
+  invalidateQueries: { dataType },
+});

--- a/apps/admin-x-framework/src/api/snippets.ts
+++ b/apps/admin-x-framework/src/api/snippets.ts
@@ -55,11 +55,11 @@ export const useEditSnippet = createMutation<
   method: 'PUT',
   path: ({ id }) => `/snippets/${id}/`,
   searchParams: () => ({ formats }),
-  body: ({ id, ...rest }) => ({ snippets: [{ id, ...rest }] }),
+  body: ({ id: _id, ...snippet }) => ({ snippets: [snippet] }),
   invalidateQueries: { dataType },
 });
 
-export const useDeleteSnippet = createMutation<unknown, string>({
+export const useDeleteSnippet = createMutation<void, string>({
   method: 'DELETE',
   path: (id) => `/snippets/${id}/`,
   invalidateQueries: { dataType },

--- a/apps/admin-x-framework/test/unit/api/snippets.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/snippets.test.tsx
@@ -1,0 +1,107 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '../../../src/test/test-utils';
+import {
+  useAddSnippet,
+  useBrowseSnippets,
+  useDeleteSnippet,
+  useEditSnippet,
+} from '../../../src/api/snippets';
+import { withMockFetch } from '../../utils/mock-fetch';
+
+const existingSnippet = {
+  id: 'snippet-1',
+  name: 'Existing snippet',
+  mobiledoc: '{}',
+  lexical: '{"nodes":[]}',
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z',
+};
+
+const okResponse = (json: unknown) => ({
+  json,
+  headers: { 'content-type': 'application/json' },
+  ok: true,
+  status: 200,
+});
+
+const findCall = (mock: { calls: unknown[][] }, path: string) =>
+  mock.calls.find((call) => String(call[0]).includes(path));
+
+describe('snippets api', () => {
+  it('browses all snippets in both formats', async () => {
+    await withMockFetch(okResponse({ snippets: [existingSnippet] }), async (mock) => {
+      const { result } = renderHookWithProviders(() => useBrowseSnippets());
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ snippets: [existingSnippet] });
+      });
+
+      const call = findCall(mock, '/snippets/');
+      const url = new URL(String(call![0]));
+      expect(url.pathname).toBe('/ghost/api/admin/snippets/');
+      expect(url.searchParams.get('limit')).toBe('all');
+      expect(url.searchParams.get('formats')).toBe('mobiledoc,lexical');
+    });
+  });
+
+  it('adds a snippet and requests both formats back', async () => {
+    await withMockFetch(okResponse({ snippets: [existingSnippet] }), async (mock) => {
+      const { result } = renderHookWithProviders(() => useAddSnippet());
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          name: 'Existing snippet',
+          lexical: '{"nodes":[]}',
+          mobiledoc: '{}',
+        });
+      });
+
+      const call = findCall(mock, '/snippets/')!;
+      const url = new URL(String(call[0]));
+      expect(url.pathname).toBe('/ghost/api/admin/snippets/');
+      expect(url.searchParams.get('formats')).toBe('mobiledoc,lexical');
+
+      const options = call[1] as RequestInit;
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body as string)).toEqual({
+        snippets: [{ name: 'Existing snippet', lexical: '{"nodes":[]}', mobiledoc: '{}' }],
+      });
+    });
+  });
+
+  it('edits a snippet by id and requests both formats back', async () => {
+    await withMockFetch(okResponse({ snippets: [existingSnippet] }), async (mock) => {
+      const { result } = renderHookWithProviders(() => useEditSnippet());
+
+      await act(async () => {
+        await result.current.mutateAsync({ id: 'snippet-1', lexical: '{"nodes":[]}' });
+      });
+
+      const call = findCall(mock, '/snippets/snippet-1/')!;
+      const url = new URL(String(call[0]));
+      expect(url.pathname).toBe('/ghost/api/admin/snippets/snippet-1/');
+      expect(url.searchParams.get('formats')).toBe('mobiledoc,lexical');
+
+      const options = call[1] as RequestInit;
+      expect(options.method).toBe('PUT');
+      expect(JSON.parse(options.body as string)).toEqual({
+        snippets: [{ id: 'snippet-1', lexical: '{"nodes":[]}' }],
+      });
+    });
+  });
+
+  it('deletes a snippet by id', async () => {
+    await withMockFetch(okResponse({}), async (mock) => {
+      const { result } = renderHookWithProviders(() => useDeleteSnippet());
+
+      await act(async () => {
+        await result.current.mutateAsync('snippet-1');
+      });
+
+      const call = findCall(mock, '/snippets/snippet-1/')!;
+      expect(String(call[0])).toBe('http://localhost:3000/ghost/api/admin/snippets/snippet-1/');
+      expect((call[1] as RequestInit).method).toBe('DELETE');
+    });
+  });
+});

--- a/apps/admin-x-framework/test/unit/api/snippets.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/snippets.test.tsx
@@ -1,5 +1,6 @@
 import { act, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ValidationError } from '../../../src/utils/errors';
 import { renderHookWithProviders } from '../../../src/test/test-utils';
 import {
   useAddSnippet,
@@ -8,6 +9,17 @@ import {
   useEditSnippet,
 } from '../../../src/api/snippets';
 import { withMockFetch } from '../../utils/mock-fetch';
+
+const { mockSonnerError } = vi.hoisted(() => ({
+  mockSonnerError: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockSonnerError,
+    dismiss: vi.fn(),
+  },
+}));
 
 const existingSnippet = {
   id: 'snippet-1',
@@ -25,10 +37,37 @@ const okResponse = (json: unknown) => ({
   status: 200,
 });
 
+const duplicateSnippetResponse = {
+  errors: [
+    {
+      code: 'VALIDATION',
+      context: 'Snippet already exists.',
+      details: null,
+      ghostErrorCode: null,
+      help: null,
+      id: 'snippet-error-id',
+      message: 'Validation error, cannot save snippet.',
+      property: null,
+      type: 'ValidationError',
+    },
+  ],
+};
+
+const mockErrorFetch = {
+  json: duplicateSnippetResponse,
+  headers: { 'content-type': 'application/json' },
+  ok: false,
+  status: 422,
+};
+
 const findCall = (mock: { calls: unknown[][] }, path: string) =>
   mock.calls.find((call) => String(call[0]).includes(path));
 
 describe('snippets api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('browses all snippets in both formats', async () => {
     await withMockFetch(okResponse({ snippets: [existingSnippet] }), async (mock) => {
       const { result } = renderHookWithProviders(() => useBrowseSnippets());
@@ -42,6 +81,36 @@ describe('snippets api', () => {
       expect(url.pathname).toBe('/ghost/api/admin/snippets/');
       expect(url.searchParams.get('limit')).toBe('all');
       expect(url.searchParams.get('formats')).toBe('mobiledoc,lexical');
+    });
+  });
+
+  it('keeps the formats param when a caller passes its own search params', async () => {
+    await withMockFetch(okResponse({ snippets: [existingSnippet] }), async (mock) => {
+      const { result } = renderHookWithProviders(() =>
+        useBrowseSnippets({ searchParams: { filter: 'name:foo' } }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ snippets: [existingSnippet] });
+      });
+
+      const url = new URL(String(findCall(mock, '/snippets/')![0]));
+      expect(url.searchParams.get('filter')).toBe('name:foo');
+      expect(url.searchParams.get('formats')).toBe('mobiledoc,lexical');
+    });
+  });
+
+  it('rejects duplicate creates with a validation error without reporting', async () => {
+    await withMockFetch(mockErrorFetch, async () => {
+      const { result } = renderHookWithProviders(() => useAddSnippet());
+
+      await act(async () => {
+        await expect(
+          result.current.mutateAsync({ name: 'Existing snippet', mobiledoc: '{}' }),
+        ).rejects.toBeInstanceOf(ValidationError);
+      });
+
+      expect(mockSonnerError).not.toHaveBeenCalled();
     });
   });
 
@@ -70,12 +139,18 @@ describe('snippets api', () => {
     });
   });
 
-  it('edits a snippet by id and requests both formats back', async () => {
+  // The edit schema requires name and mobiledoc on every item, so edits send the full record
+  it('edits a snippet with the full record and requests both formats back', async () => {
     await withMockFetch(okResponse({ snippets: [existingSnippet] }), async (mock) => {
       const { result } = renderHookWithProviders(() => useEditSnippet());
 
       await act(async () => {
-        await result.current.mutateAsync({ id: 'snippet-1', lexical: '{"nodes":[]}' });
+        await result.current.mutateAsync({
+          id: 'snippet-1',
+          name: 'Existing snippet',
+          mobiledoc: '{}',
+          lexical: '{"nodes":[]}',
+        });
       });
 
       const call = findCall(mock, '/snippets/snippet-1/')!;
@@ -86,7 +161,9 @@ describe('snippets api', () => {
       const options = call[1] as RequestInit;
       expect(options.method).toBe('PUT');
       expect(JSON.parse(options.body as string)).toEqual({
-        snippets: [{ id: 'snippet-1', lexical: '{"nodes":[]}' }],
+        snippets: [
+          { id: 'snippet-1', name: 'Existing snippet', mobiledoc: '{}', lexical: '{"nodes":[]}' },
+        ],
       });
     });
   });

--- a/apps/admin-x-framework/test/unit/api/snippets.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/snippets.test.tsx
@@ -96,6 +96,7 @@ describe('snippets api', () => {
 
       const url = new URL(String(findCall(mock, '/snippets/')![0]));
       expect(url.searchParams.get('filter')).toBe('name:foo');
+      expect(url.searchParams.get('limit')).toBe('all');
       expect(url.searchParams.get('formats')).toBe('mobiledoc,lexical');
     });
   });
@@ -161,15 +162,13 @@ describe('snippets api', () => {
       const options = call[1] as RequestInit;
       expect(options.method).toBe('PUT');
       expect(JSON.parse(options.body as string)).toEqual({
-        snippets: [
-          { id: 'snippet-1', name: 'Existing snippet', mobiledoc: '{}', lexical: '{"nodes":[]}' },
-        ],
+        snippets: [{ name: 'Existing snippet', mobiledoc: '{}', lexical: '{"nodes":[]}' }],
       });
     });
   });
 
   it('deletes a snippet by id', async () => {
-    await withMockFetch(okResponse({}), async (mock) => {
+    await withMockFetch({ ok: true, status: 204 }, async (mock) => {
       const { result } = renderHookWithProviders(() => useDeleteSnippet());
 
       await act(async () => {

--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -250,6 +250,34 @@ describe('useEmberDataSync', () => {
     });
   });
 
+  queryTest('invalidates snippets when Ember saves one', async ({ queryClient, wrapper }) => {
+    const mock = createMockStateBridge();
+    window.EmberBridge = { state: mock.stateBridge };
+    const snippetsKey = ['SnippetsResponseType', '/snippets'];
+
+    queryClient.setQueryDefaults(snippetsKey, { gcTime: Infinity });
+    queryClient.setQueryData(snippetsKey, { snippets: [] });
+
+    renderHook(() => useEmberDataSync(), { wrapper });
+
+    await waitFor(() => {
+      expect(mock.onSpy).toHaveBeenCalledWith('emberDataChange', expect.any(Function));
+    });
+
+    act(() => {
+      mock.emit('emberDataChange', {
+        operation: 'update',
+        modelName: 'snippet',
+        id: 'snippet-1',
+        data: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(snippetsKey)?.isInvalidated).toBe(true);
+    });
+  });
+
   queryTest(
     'invalidates the sidebar member count query for Ember member changes',
     async ({ queryClient, wrapper }) => {

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -105,6 +105,7 @@ const EMBER_TO_REACT_TYPE_MAPPING: Record<string, string> = {
   member: 'MembersResponseType',
   tag: 'TagsResponseType',
   label: 'LabelsResponseType',
+  snippet: 'SnippetsResponseType',
 };
 
 /**

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -19,6 +19,7 @@ const emberDataTypeMapping = {
     NewslettersResponseType: {type: 'newsletter'},
     RecommendationResponseType: {type: 'recommendation'},
     SettingsResponseType: {type: 'setting', singleton: true},
+    SnippetsResponseType: {type: 'snippet'},
     TagsResponseType: {type: 'tag'},
     ThemesResponseType: {type: 'theme'},
     TiersResponseType: {type: 'tier'},

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -306,6 +306,14 @@ describe('Unit: Service: state-bridge', function () {
             expect(store.unloadAll.calledWith('integration')).to.be.true;
         });
 
+        it('unloads snippets when React snippet queries are invalidated', function () {
+            run(() => {
+                service.onInvalidate('SnippetsResponseType');
+            });
+
+            expect(store.unloadAll.calledOnceWith('snippet')).to.be.true;
+        });
+
         it('unloads all tags when tag queries are invalidated', function () {
             run(() => {
                 service.onInvalidate('TagsResponseType');


### PR DESCRIPTION
The React editor will need the snippet save/insert feature that Ember Data currently serves in the Ember editor. This adds a snippets API module to `apps/admin-x-framework` with `useBrowseSnippets`, `useAddSnippet`, `useEditSnippet`, and `useDeleteSnippet`, following the existing per-resource API module pattern (`labels.ts`/`tags.ts`): a `Snippet` type, a `SnippetsResponseType` envelope with `Meta`, a shared `dataType` for query keys, and `invalidateQueries` on every mutation. No consumers or UI are included.

Three server-contract details are encoded in the hooks:

- The Admin API only returns the `mobiledoc` format by default; `lexical` is stripped from responses unless `?formats=mobiledoc,lexical` is requested. The Ember snippet adapter appends this to every request, so browse, add, and edit all send it here too — and the browse hook re-merges it over caller-supplied search params so it can't be dropped accidentally.
- The snippets add and edit schemas require `name` and `mobiledoc` on every item, so the mutation payload types make both required (the Ember editor always sends the full record, with `mobiledoc: '{}'` for lexical snippets).
- `mobiledoc` and `lexical` travel as JSON strings on the wire (the Ember model parses them client-side via its `json-string` transform), so the `Snippet` type declares them as strings and leaves parsing to callers.

Intentionally out of scope: the Ember editor's `syncMobiledocSnippets` repair pass, which re-saves legacy snippets that were stored with double-encoded lexical JSON early in the lexical beta and back-converts mobiledoc-only snippets. That is one-time data repair, not data access, and does not belong in the hooks layer; the editor migration can decide separately where (or whether) it is still needed.

Verification: `pnpm --filter @tryghost/admin-x-framework lint` and `pnpm --filter @tryghost/admin-x-framework test` (type check + unit tests) pass locally, including new unit tests covering the request shapes of all four hooks, the formats merge, and the 422 validation error path.