### PR TITLE
Fixed a flaky members import E2E test opening a member detail

### DIFF
--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -8,6 +8,9 @@ export interface ExportedFile {
   content: string;
 }
 
+const OPEN_MEMBER_ATTEMPTS = 3;
+const OPEN_MEMBER_TIMEOUT_MS = 5_000;
+
 export class MembersListPage extends AdminPage {
   readonly memberRows: Locator;
   readonly searchInput: Locator;
@@ -20,6 +23,9 @@ export class MembersListPage extends AdminPage {
   readonly importCsvLink: Locator;
   readonly noResults: Locator;
   readonly showAllButton: Locator;
+  // Not part of this screen: openMemberByName reads it to tell a row click that landed
+  // on the detail route from one the list navigated back out of.
+  readonly memberDetailScreen: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -38,6 +44,7 @@ export class MembersListPage extends AdminPage {
     this.importCsvLink = page.getByRole('link', { name: membersSel.importCsvLink });
     this.noResults = page.getByText(membersSel.noResultsText);
     this.showAllButton = page.getByRole('button', { name: membersSel.showAllButton });
+    this.memberDetailScreen = page.getByTestId(membersSel.memberDetail);
   }
 
   getMemberByName(name: string): Locator {
@@ -50,8 +57,33 @@ export class MembersListPage extends AdminPage {
     return this.getMemberByName(name).getByRole('link', { name, exact: true });
   }
 
+  /**
+   * Open a member's detail screen from the list.
+   *
+   * The list writes its own query string back after something changes it — an import
+   * applies its label filter on close — and a write that lands right after the row
+   * click replaces the detail route with the list again, leaving the click with
+   * nothing to show for it. Re-click when that happens instead of waiting out a
+   * timeout on a screen the app navigated away from.
+   */
   async openMemberByName(name: string): Promise<void> {
-    await this.getMemberLinkByName(name).click();
+    const link = this.getMemberLinkByName(name);
+
+    for (let attempt = 1; attempt <= OPEN_MEMBER_ATTEMPTS; attempt++) {
+      await link.click();
+
+      try {
+        await this.memberDetailScreen.waitFor({
+          state: 'visible',
+          timeout: OPEN_MEMBER_TIMEOUT_MS,
+        });
+        return;
+      } catch (error) {
+        if (attempt === OPEN_MEMBER_ATTEMPTS) {
+          throw error;
+        }
+      }
+    }
   }
 
   async openActionsMenu(): Promise<void> {


### PR DESCRIPTION
## Why

[E2E Tests (Main 1/10)](https://github.com/TryGhost/Ghost/actions/runs/33517279400/job/99889272100) went red on `main` at 0b8af54, with `import-custom-fields.test.ts:92` failing all three attempts. It is not new: the same test failed once and passed on retry in 3 of the 12 preceding `main` runs — about a quarter of attempts — and this run simply lost every retry.

From the failing run's Playwright trace, the failure is not about the imported value. After the row click, the `member-detail` chunk loads but `GET /members/<id>/` is never issued, and the URL timeline reads:

```
211714  #/members?filter=label:[import-2026-09-01-14-15]   modal close navigates
211774  #/members                                          test goto strips it
211930  click member row
212012  #/members?filter=label:[import-2026-09-01-14-15]   app rewrites, replacing the detail route
```

The members list mirrors its filter state into the URL from an effect (`use-members-filter-state.ts`), and that write is a navigation of its own. One landing right after the click replaces the detail route with the list again, so the assertion waits out its timeout on the screen it started from.

## What

`openMemberByName` re-clicks the row when the detail screen does not appear, instead of waiting out a timeout on a screen the app navigated away from. Three attempts, 5s each, against a 60s CI test timeout on a test that normally runs in ~13s.

## The app bug stays open

A member opened straight after an import can send the reader back to the list — this only stops the test from being red. Two fixes to the URL sync were tried and rejected:

- Merging the adopt and normalize effects so an externally-changed query is not overwritten. `currentQuery` lags the last-written query by one render after every `setFilters`, so the adopt branch fires on the app's own writes and resets the draft: the composite custom-field filter cascade loses its operator selection and `custom-field-filter-value` never renders. Failed `an address filter matches on the chosen part only` 2/2, which passes 3/3 without the change.
- Guarding the write with `useNavigation().state !== 'idle'`. Needs a data router; every MemoryRouter-based harness in `apps/admin` then throws, failing the members unit suite, and no unit test could be made to fail without the guard.

The real fix looks like making the URL the single source of truth for committed filters and keeping in-progress predicates local, so no background write can preempt a navigation.

## Testing

Locally, against the dev stack:

- `Members import with custom fields` — 4 passed
- `custom-field-filter-*` tests, run individually — pass
- admin unit suite — 512 passed; e2e `lint` 0 errors; e2e `test:types` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)