### PR TITLE
Fixed automation email analytics filtering

### DIFF
--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -96,8 +96,11 @@ export const init = ({
   });
 
   const newsletterMailgunTags = ['bulk-email'];
-  if (config.get('bulkEmail:mailgun:tag')) {
-    newsletterMailgunTags.push(config.get('bulkEmail:mailgun:tag'));
+  const automationMailgunTags = [AUTOMATION_EMAIL_TAG];
+  const mailgunTagFromConfig = config.get('bulkEmail:mailgun:tag');
+  if (mailgunTagFromConfig) {
+    newsletterMailgunTags.push(mailgunTagFromConfig);
+    automationMailgunTags.push(mailgunTagFromConfig);
   }
 
   prometheusClient?.registerCounter({
@@ -141,7 +144,7 @@ export const init = ({
     domainEvents,
     event: StartAutomationEmailAnalyticsJobEvent,
     queries,
-    mailgunTags: [AUTOMATION_EMAIL_TAG],
+    mailgunTags: automationMailgunTags,
     jobNames: {
       latestNonOpened: 'email-analytics-automation-latest-others',
       missing: 'email-analytics-automation-missing',

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -16,7 +16,6 @@ describe('email analytics service', function () {
     trackEmailDeliveredAndOpened: sinon.stub(),
   };
   const config = { get: sinon.stub() };
-  config.get.withArgs('bulkEmail:mailgun:tag').returns('custom-mailgun-tag');
   const domainEvents = { subscribe: sinon.stub() };
   const metrics = { metric: sinon.stub() };
   const settingsCache = { get: sinon.stub() };
@@ -29,6 +28,8 @@ describe('email analytics service', function () {
   let dependencies: Parameters<typeof init>[0];
 
   beforeEach(function () {
+    config.get.reset();
+    config.get.withArgs('bulkEmail:mailgun:tag').returns('custom-mailgun-tag');
     newslettersInit = sinon.stub(newsletters, 'init');
     automationsInit = sinon.stub(automations, 'init');
     giftsInit = sinon.stub(gifts, 'init');
@@ -70,7 +71,7 @@ describe('email analytics service', function () {
     sinon.restore();
   });
 
-  it('initializes newsletter, automation, and gift analytics', function () {
+  it('initializes newsletter, automation, and gift analytics with configured Mailgun tags', function () {
     init(dependencies);
 
     sinon.assert.calledOnceWithExactly(
@@ -110,7 +111,7 @@ describe('email analytics service', function () {
         event: {
           name: 'StartAutomationEmailAnalyticsJobEvent',
         },
-        mailgunTags: [AUTOMATION_EMAIL_TAG],
+        mailgunTags: [AUTOMATION_EMAIL_TAG, 'custom-mailgun-tag'],
         jobNames: {
           latestNonOpened: 'email-analytics-automation-latest-others',
           missing: 'email-analytics-automation-missing',
@@ -155,6 +156,19 @@ describe('email analytics service', function () {
         metrics,
         settingsCache,
         createEventProcessor: sinon.match.func,
+      }),
+    );
+  });
+
+  it('does not add a site tag to automation analytics when none is configured', function () {
+    config.get.withArgs('bulkEmail:mailgun:tag').returns(undefined);
+
+    init(dependencies);
+
+    sinon.assert.calledOnceWithExactly(
+      automationsInit,
+      sinon.match({
+        mailgunTags: [AUTOMATION_EMAIL_TAG],
       }),
     );
   });


### PR DESCRIPTION
closes [NY-1537](https://linear.app/ghost/issue/NY-1537/)
closes [NY-1535](https://linear.app/ghost/issue/NY-1535/)

## Context

Automation emails were switched to the bulk Mailgun domain in [#29728](<https://github.com/TryGhost/Ghost/pull/29728>). As part of that work, responsibility for applying `bulkEmail:mailgun:tag`  (ex: `blog-{site_id}`) moved from the shared
Mailgun client to individual callers. Newsletter sends continued applying the configured site tag, but automation sends bypassed that provider and initially sent only the `automation-email` classification.

Automation analytics had originally been introduced in [#29333](<https://github.com/TryGhost/Ghost/pull/29333>) with a filter containing only `automation-email`.

[#30093](<https://github.com/TryGhost/Ghost/pull/30093>) restored the configured site tag on outgoing automation emails. Automation analytics intentionally continued querying only `automation-email` during the rollout window so events from previously sent emails would not be excluded.

That rollout window has now passed. This change completes the transition by querying automation events using both `automation-email` and the configured site tag, preventing sites on shared Mailgun domains from fetching one another's automation events.

### Relevant commits

* [`58244a1`](<https://github.com/TryGhost/Ghost/commit/58244a1cd499c5c85692d5e2634ea1ba0f2723c3>)   switched automation emails to the bulk Mailgun domain and moved configured tag handling out of the shared Mailgun client.
* [`f84ed756`](<https://github.com/TryGhost/Ghost/commit/f84ed7565b5c7ad8e998f3b7cf69bfef07e3738d>)   introduced automation email analytics using the `automation-email` filter.
* [`d64be44f`](<https://github.com/TryGhost/Ghost/commit/d64be44f83bc3d9c7c0ad33f481bd3d3e48672a7>)   restored the configured site tag on outgoing automation emails while leaving analytics filtering unchanged for the transition period.

## Testing

Manually tested, and confirmed that automation email analytics jobs include the `bulkEmail:mailgun:tag` in the query (via a temporary console log), and confirmed that email opens still populate for automations.