### PR TITLE
Ignore changeset ledger in oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,6 +17,7 @@
     "koenig/kg-lexical-html-renderer/**",
     "koenig/kg-simplemde/debug/**",
     "koenig/koenig-lexical/**",
-    "packages/i18n/locales/**"
+    "packages/i18n/locales/**",
+    ".changeset/ledger.yaml"
   ]
 }


### PR DESCRIPTION
no ref
- changeset is written by pnpm, including it in oxfmt just creates conflict between the two systems