### PR TITLE
Fixed the members page looping when custom field definitions fail to load

### DIFF
--- a/apps/admin/src/members/members-filtering.acceptance.test.tsx
+++ b/apps/admin/src/members/members-filtering.acceptance.test.tsx
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 
 import {
+  currentRoute,
+  fakeAdminEndpoint,
   fakeMemberCustomFields,
   fakeMembers,
   label,
@@ -123,6 +125,42 @@ describe('Members list', () => {
     expect(fieldsApi.requests.map((request) => request.filter)).toEqual(
       fieldsApi.requests.map(() => 'status:[active,archived]'),
     );
+  });
+
+  // The deploy-compatibility rule in apps/admin/README.md: an Admin deployed ahead of a
+  // Core without the definitions endpoint must keep filtering intact. Adding a filter swaps
+  // the filter bar between its two placements, and each one asks for the definitions; the
+  // failed answer has to hold across that, or every swap asks again, the answer flips the
+  // page's field catalog, and the URL is rewritten in a loop that never settles.
+  it('adds a filter against a Core without the definitions endpoint', async () => {
+    const membersApi = fakeMembers(({ filter }) =>
+      filter
+        ? [member({ name: 'Alice Alpha' })]
+        : [member({ name: 'Alice Alpha' }), member({ name: 'Bob Beta' })],
+    );
+    // After fakeMembers, which serves an empty definitions list on behalf of specs that never
+    // mention custom fields: a handler registered later wins.
+    const definitionsApi = fakeAdminEndpoint(
+      'GET',
+      /^\/members\/metafields\/custom\/(\?|$)/,
+      { errors: [{ type: 'NotFoundError', message: 'Resource not found error.' }] },
+      { status: 404 },
+    );
+    await renderAdminApp('/members');
+
+    await expect(membersScreen.memberRows()).toHaveCount(2);
+    const requestsBeforeFilter = definitionsApi.requests.length;
+
+    await membersScreen.addFilter('Name', 'Alice');
+
+    await expect(membersApi).toHaveSentFilter(/name:~'Alice'/);
+    await expect(membersScreen.memberRows()).toHaveCount(1);
+    // The loop asks again roughly every round trip, so a short pause is enough to catch it.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 500);
+    });
+    expect(definitionsApi.requests.length).toBe(requestsBeforeFilter);
+    expect(currentRoute()).toMatch(/^\/members\?filter=/);
   });
 
   it('builds a name filter through the filters UI', async () => {

--- a/apps/admin/src/shared/member-custom-fields/use-definitions.ts
+++ b/apps/admin/src/shared/member-custom-fields/use-definitions.ts
@@ -12,11 +12,18 @@ import {
  * custom fields, the member page shows no custom fields section, a filtered column falls
  * back to an unnamed header, and the import dialog maps onto Ghost's built-in member
  * fields alone. None of that is what the publisher came to the screen to do.
+ *
+ * A failed fetch is held for the life of the cache entry rather than retried whenever
+ * another consumer mounts. A retry in flight reports neither data nor an error, so every
+ * consumer would watch the definitions vanish and return on each mount. On the members
+ * page that swing rebuilt the field catalog, rewrote the URL, remounted the filter bar and
+ * retried again, without end. One attempt per visit settles it.
  */
+const quietlyDegrading = { defaultErrorHandler: false, retryOnMount: false } as const;
+
 export const useCustomFieldDefinitions: typeof useBrowseMemberCustomFields = (options) =>
-  useBrowseMemberCustomFields({ ...options, defaultErrorHandler: false });
+  useBrowseMemberCustomFields({ ...options, ...quietlyDegrading });
 
 /** As above, and also lists fields the publisher has archived. */
 export const useCustomFieldDefinitionsIncludingArchived: typeof useBrowseMemberCustomFieldsIncludingArchived =
-  (options) =>
-    useBrowseMemberCustomFieldsIncludingArchived({ ...options, defaultErrorHandler: false });
+  (options) => useBrowseMemberCustomFieldsIncludingArchived({ ...options, ...quietlyDegrading });


### PR DESCRIPTION
When the request for member custom field definitions fails, the members page gets stuck in a loop: the filter bar disappears, reappears, the URL rewrites itself, and the cycle repeats indefinitely. The page never settles.

The definitions hook already suppresses the default error toast so the page can degrade quietly when the fields cannot be loaded. But the underlying query was still retrying every time a consumer mounted. While a retry is in flight the query reports neither data nor an error, so every consumer sees the definitions vanish and then return. On the members page that swing rebuilt the field catalog, rewrote the URL from the filter state, remounted the filter bar, and the remount kicked off the next retry.

This change holds a failed fetch for the life of the cache entry instead of retrying on mount. One attempt per visit is enough: the page degrades once and stays degraded until the page is reloaded or the cached answer expires, rather than flickering. Both the active-only and the including-archived variants of the hook share the same settings so they cannot drift apart.
