### PR TITLE
Changed the Ghost-CLI job to run each scenario on its own Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1066,16 +1066,29 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   job_ghost-cli:
-    name: Ghost-CLI tests
+    name: Ghost-CLI tests (${{ matrix.scenario }})
     needs: [job_setup, job_pack]
     if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.changed_core == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # This build, installed from the tarball this run produced.
+          - scenario: clean-install
+            node: ${{ needs.job_setup.outputs.node_version }}
+          # Upgrade from the newest Ghost on npm, which is pinned to the Node
+          # version whose `engines` that release declared — it can't be raised
+          # until a release ships supporting the newer line. Move this to
+          # node_version once the published release supports it.
+          - scenario: latest-release
+            node: '22.23.1'
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         env:
           FORCE_COLOR: 0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.node }}
 
       - name: Install Ghost-CLI
         run: npm install -g ghost-cli@latest
@@ -1097,10 +1110,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ghost-cli-debug-logs
+          name: ghost-cli-debug-logs-${{ matrix.scenario }}
           path: /home/runner/.ghost/logs/
 
       - name: Clean Install
+        if: matrix.scenario == 'clean-install'
         run: |
           DIR=$(mktemp -d)
           ghost install local -d "$DIR" --archive "$(pwd)/ghost.tgz"
@@ -1109,6 +1123,7 @@ jobs:
           ghost stop -d "$DIR"
 
       - name: Latest Release
+        if: matrix.scenario == 'latest-release'
         # --force skips Ghost-CLI's version comparison between the archive and
         # the installed release. Without it this step is coupled to how far the
         # branch has drifted from main: a PR branched before the last release


### PR DESCRIPTION
## Why

The Ghost-CLI job runs two scenarios that look similar but test opposite things:

- **Clean Install** — installs the tarball this run produced, i.e. *this branch's* build.
- **Latest Release** — installs the newest Ghost from npm, then updates it to this branch's build.

They currently share one `setup-node`, pinned to `NODE_VERSION`. That's fine while `NODE_VERSION` matches what the published release supports, and breaks the moment it doesn't.

It broke on #30434 (the Node 24 default flip). With `NODE_VERSION: 24.20.0`, Clean Install passed and Latest Release failed:

```
[STARTED] Checking version compatibility
[FAILED] Ghost v6.62.0 is not compatible with the current Node version.
         Your node version is 24.20.0, but Ghost v6.62.0 requires ^22.23.1
```

That's Ghost-CLI reading the *published* release's `engines` and correctly refusing. Ghost-CLI itself is fine on Node 24 (it declares `^22.13.0 || ^24.0.0`). No change on the branch can fix it: every published Ghost says `^22.23.1` until a release ships carrying widened engines, and that release can't happen until the flip merges.

Worth noting `GHOST_NODE_VERSION_CHECK=false` is **not** a way around this. It does skip that gate, but the install then gets further and dies at boot instead — published 6.62.0 pins `@tryghost/request@4.0.3`, whose floating `import('got')` hits `ERR_REQUIRE_ESM_RACE_CONDITION` on Node 24 during `2-create-fixtures.js`. Verified by running `ghost install local` locally on Node 24 with the variable set. 6.62.0 genuinely does not run on Node 24; the version check was telling the truth.

## What

Splits the job across a matrix so each scenario picks its own Node version:

- `clean-install` follows `NODE_VERSION` — it's the leg that proves this build installs and boots on the version we ship.
- `latest-release` stays on the Node version the published release declares, and moves up once a release ships supporting a newer line.

This also matches the real upgrade path: you're on the old Node, you update Ghost, *then* you move Node.

## Notes for reviewers

- **No behaviour change on `main` today.** `NODE_VERSION` is `22.23.1`, so both legs run `22.23.1` — same as now, just two entries on the checks list instead of one. The value is that #30434 gets a green Ghost-CLI job from the rebase alone, with no CI edits of its own.
- **Job id is unchanged**, so `job_required_tests` needs no update — it aggregates via `needs`, which references ids rather than display names.
- **A matrix rather than a second job**, so the shared steps (CLI install, tarball download, `packageManager` verification, debug-log capture) stay written once. The legs never shared state — `Latest Release` always did its own `ghost install local` into a fresh mktemp dir — so separating them is safe, and they now run in parallel instead of sequentially.
- **The `'22.23.1'` literal is the weak point.** It's a second hardcoded Node version in the file and it goes stale silently: if the published release moves to 24 and this stays on 22, nothing fails, the leg just tests less than it could. Deriving it from the published release's `engines` would be self-maintaining; I skipped that rather than add a registry lookup to CI for a value that changes about once a year. Happy to change it.
- No test added — this is CI configuration. `actionlint` is unchanged at 140 pre-existing findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)