### PR TITLE
Added members maintaining their own custom fields

### DIFF
--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -316,6 +316,10 @@ module.exports = {
     return apiFramework.pipeline(require('./members-account'), localUtils, 'members');
   },
 
+  get metafieldsMembers() {
+    return apiFramework.pipeline(require('./metafields-members'), localUtils, 'members');
+  },
+
   get giftsMembers() {
     return apiFramework.pipeline(require('./gifts-members'), localUtils, 'members');
   },

--- a/ghost/core/core/server/api/endpoints/metafields-members.ts
+++ b/ghost/core/core/server/api/endpoints/metafields-members.ts
@@ -1,0 +1,43 @@
+import { definitions } from '../../services/members-custom-fields';
+
+/**
+ * The fields a publisher has defined, as a member's own client reads them.
+ *
+ * The same definitions service Admin reads, answering a different audience. A
+ * member is shown what to fill in: what a field is called and what kind of thing
+ * it holds. What a field made of several parts is made of comes from the catalog
+ * both sides share rather than from here, so the two cannot disagree about what a
+ * valid answer looks like.
+ *
+ * Authenticated as a member but not about any particular member: every member of
+ * a site is offered the same fields. What a given member has answered is on their
+ * own record, not here.
+ */
+
+/** @type {import('@tryghost/api-framework').Controller} */
+interface Frame {
+  options: { namespace: string };
+}
+
+const controller = {
+  // The Admin resource's name, because it is the same resource and the same shape.
+  // Only who may ask differs, and that is the route's business rather than the
+  // response's. A member seeing `status` or when a field was made costs nothing and
+  // saves maintaining a second shape for a distinction that does not exist yet.
+  docName: 'members_metafields',
+
+  browse: {
+    headers: { cacheInvalidate: false },
+    options: ['namespace'],
+    validation: { options: { namespace: { required: true } } },
+    permissions: false,
+    query(frame: Frame) {
+      // No `filter`, which Admin offers: archived fields are a publisher's business,
+      // and a member is only ever shown what they can still fill in.
+      return definitions!.browse({ namespace: frame.options.namespace });
+    },
+  },
+};
+
+export default controller;
+module.exports = controller;

--- a/ghost/core/core/server/services/members-custom-fields/commands.ts
+++ b/ghost/core/core/server/services/members-custom-fields/commands.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { WrittenBy } from './schema';
+
+/**
+ * Setting the values a member holds in the fields a publisher defined.
+ *
+ * Named as one thing because both surfaces that write these — staff editing a
+ * member, and a member editing themselves — are doing the same act and have to say
+ * the same things about it. Carrying it as a command keeps who is writing attached
+ * to what is being written, rather than the two being passed around separately and
+ * paired up correctly by each caller.
+ *
+ * Applying one happens in two steps, which `values-service` owns: what a write
+ * implies is worked out before anything is written, so a value the catalog refuses
+ * fails before the member's record is touched. That matters because the member
+ * write it sits beside is not something a transaction can undo — it reconciles
+ * subscriptions with Stripe and dispatches events — so the only safe place to
+ * refuse is before any of it starts.
+ */
+
+export const UpdateMetafields = z.object({
+  memberId: z.string(),
+  /** As the wire spells it: keyed by namespace, then by field. */
+  values: z.unknown(),
+  /**
+   * Who is making the change. Required and never defaulted: a writer that could be
+   * inferred is one a new caller inherits by accident, and the answer is stored
+   * against every value it writes.
+   */
+  writtenBy: WrittenBy,
+});
+export type UpdateMetafields = z.infer<typeof UpdateMetafields>;

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -10,6 +10,19 @@ export { actingContext } from './actions';
 export type { BoundField } from './bindings-service';
 export type { WrittenBy } from './schema';
 
+// Shared with anything that reads these values as part of its own projection.
+// A value is stored as one row per leaf, so a reader that queries the rows needs
+// the same rule for turning them back into a value — and that rule is pure, so it
+// travels rather than being reimplemented. Reading the rows travels with it: which
+// rows are unusable, and what to say about one, is the same judgement wherever the
+// rows were fetched.
+export { readableLeaves, valuesFromLeaves, type StoredLeaf } from './storage';
+export { activeFields } from './queries';
+
+// What a member's values are being set to, as one command, so the surfaces that
+// write them name the same thing rather than each assembling their own arguments.
+export { UpdateMetafields } from './commands';
+
 // Three services from one module, split along aggregate boundaries rather than
 // technical layers: `definitions` owns the field definitions, which belong to the
 // site's settings, `values` owns the per-member values, which belong to the

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -30,13 +30,18 @@ type CustomFieldRow = z.infer<typeof DbCustomField> & CustomFieldRank;
 /**
  * How a value arrived, not who caused it: who edited a member's fields is already an
  * action, and Stripe is not a person. `type` is the namespace that makes `id` resolvable —
- * `users`, `integrations`, `members_custom_field_bindings` — so the one writer that
- * resolves in no table is the one with no id to give.
+ * `users`, `integrations`, `members`, `members_custom_field_bindings` — so the one writer
+ * that resolves in no table is the one with no id to give.
+ *
+ * A member is a writer because a member can maintain their own answers from their
+ * account. That is also the one writer whose edits leave no action behind: the action log
+ * records what staff did, and no member-initiated change has ever written to it.
  */
 export const WrittenBy = z.discriminatedUnion('type', [
   z.object({ type: z.literal('user'), id: z.string() }),
   z.object({ type: z.literal('integration'), id: z.string() }),
   z.object({ type: z.literal('binding'), id: z.string() }),
+  z.object({ type: z.literal('member'), id: z.string() }),
   z.object({ type: z.literal('import'), id: z.null() }),
 ]);
 export type WrittenBy = z.infer<typeof WrittenBy>;

--- a/ghost/core/core/server/services/members-custom-fields/storage.ts
+++ b/ghost/core/core/server/services/members-custom-fields/storage.ts
@@ -1,4 +1,6 @@
 import errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
+import { DbCustomFieldLeaf } from './schema';
 
 // A value is a tree; the database stores one row per leaf, under the path addressing it.
 // A value with no parts is a single leaf at the root, a part is a leaf under its key, and
@@ -124,4 +126,36 @@ export function valuesFromLeaves(
   }
 
   return byMember;
+}
+
+/**
+ * The rows a member's values can be rebuilt from, skipping any that cannot be read.
+ *
+ * A row stops being readable when its field's type has left the catalog. Failing the
+ * whole read would cost a member every other value they hold over one that can no
+ * longer be shown them, so the row is dropped instead. Never silently: a value that
+ * vanishes without a trace cannot be told apart from one that was never written, and
+ * whoever has to explain the gap needs the field and the path to find it.
+ */
+export function readableLeaves(rows: readonly unknown[]): StoredLeaf[] {
+  const leaves: StoredLeaf[] = [];
+  for (const row of rows) {
+    const parsed = DbCustomFieldLeaf.safeParse(row);
+    if (parsed.success) {
+      leaves.push(parsed.data);
+      continue;
+    }
+
+    const partial = row as { key?: unknown; path?: unknown } | null;
+    logging.warn(
+      {
+        event: { name: 'members.custom_fields.value_unreadable' },
+        err: parsed.error,
+        customFieldKey: partial?.key,
+        path: partial?.path,
+      },
+      'Skipping an unreadable custom field value',
+    );
+  }
+  return leaves;
 }

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -1,6 +1,5 @@
 import ObjectID from 'bson-objectid';
 import errors from '@tryghost/errors';
-import logging from '@tryghost/logging';
 import type { Knex } from 'knex';
 import { z } from 'zod';
 import { FIELD_TYPES, subFieldsOf, type FieldType } from '@tryghost/custom-field-types';
@@ -10,9 +9,10 @@ import {
   formatIdentity,
   parseIdentity,
 } from '@tryghost/custom-field-types/identity';
-import { DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS, type WrittenBy } from './schema';
+import { DbCustomFieldValue, FIELD_STATUS, type WrittenBy } from './schema';
 import { activeFields } from './queries';
-import { leavesToWrite, valuesFromLeaves, type StoredLeaf } from './storage';
+import type { UpdateMetafields } from './commands';
+import { leavesToWrite, readableLeaves, valuesFromLeaves } from './storage';
 
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
@@ -113,24 +113,7 @@ export class CustomFieldValuesService {
         `${VALUES_TABLE}.value_text`,
       );
 
-    const leaves: StoredLeaf[] = [];
-    for (const row of rows) {
-      try {
-        leaves.push(DbCustomFieldLeaf.parse(row));
-      } catch (err) {
-        logging.warn(
-          {
-            event: { name: 'members.custom_fields.value_unreadable' },
-            err,
-            customFieldKey: row.key,
-            path: row.path,
-          },
-          'Skipping an unreadable custom field value',
-        );
-      }
-    }
-
-    const flat = valuesFromLeaves(leaves);
+    const flat = valuesFromLeaves(readableLeaves(rows));
     return new Map(
       memberIds.map((memberId) => [memberId, { [CUSTOM_NAMESPACE]: flat.get(memberId) ?? {} }]),
     );
@@ -190,6 +173,39 @@ export class CustomFieldValuesService {
    * validate before opening a transaction it would otherwise have to unwind, then apply
    * the same plan without re-resolving it.
    */
+  /**
+   * What a command implies, worked out without writing anything.
+   *
+   * Separate from applying it so a caller can find out that a value is
+   * unacceptable while abandoning the whole request is still free. Throws naming
+   * the address it refused, which is what a client shows the person who typed it.
+   */
+  async planUpdate(command: UpdateMetafields): Promise<PlannedWrite[]> {
+    return this.planWrite(this.unwrapWire(command.values));
+  }
+
+  /**
+   * Apply a plan, recorded against the writer the command names.
+   *
+   * Takes an executor so the write can join a transaction it is part of rather
+   * than opening one of its own: an importer's failed row takes its values with it.
+   */
+  async applyUpdate(
+    command: UpdateMetafields,
+    plan: PlannedWrite[],
+    { executor }: { executor?: Knex } = {},
+  ): Promise<void> {
+    await this.applyWrite(command.memberId, plan, {
+      writtenBy: command.writtenBy,
+      ...(executor ? { executor } : {}),
+    });
+  }
+
+  /** Whether a wire-shaped body names any values at all, asked without the catalog. */
+  namesAny(wire: unknown): boolean {
+    return this.namesValues(this.unwrapWire(wire));
+  }
+
   async planWrite(input: unknown): Promise<PlannedWrite[]> {
     const values = this.parseValues(input);
     const identities = Object.keys(values);

--- a/ghost/core/core/server/services/members/account/commands.ts
+++ b/ghost/core/core/server/services/members/account/commands.ts
@@ -34,6 +34,22 @@ export const UpdateAccount = z.object({
   newsletters: z.unknown().optional(),
   enable_comment_notifications: z.unknown().optional(),
   enable_updates_and_announcements: z.unknown().optional(),
+  /**
+   * The extra fields a publisher defined, keyed by namespace.
+   *
+   * Here rather than on a route of its own, which is how staff already set the
+   * same values: `PUT /members/:id` carries `metafields` beside `name`. A
+   * member's account panel is one form with one Save, and splitting the write
+   * would make it two requests with a half-succeeded state to explain.
+   *
+   * Unlike the fields above, a metafield naming something nobody defined is
+   * refused rather than ignored. An unrecognised key at the top level is a
+   * client sending more than this endpoint reads; a named field that does not
+   * exist is a client that believes something false, and saying so is more
+   * use than silence. What a field accepts is the business of the catalog that
+   * defines it, which validates the values and names the address it refused.
+   */
+  metafields: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type UpdateAccount = z.infer<typeof UpdateAccount>;

--- a/ghost/core/core/server/services/members/account/index.ts
+++ b/ghost/core/core/server/services/members/account/index.ts
@@ -4,7 +4,8 @@
  *
  * A barrel rather than a composition root: this module owns no boot step, and its
  * collaborators are the ones `members-api.js` already builds, so the service is
- * constructed there beside `MemberBREADService`.
+ * constructed there beside `MemberBREADService`. Answering a request belongs to the
+ * endpoint, not here.
  */
 export { MemberAccountService } from './service';
 export { MemberAccount, type DecodeDependencies } from './models';

--- a/ghost/core/core/server/services/members/account/models.ts
+++ b/ghost/core/core/server/services/members/account/models.ts
@@ -8,6 +8,9 @@ import {
   TierRow,
 } from './schema';
 
+import { CUSTOM_NAMESPACE } from '@tryghost/custom-field-types/identity';
+import { valuesFromLeaves, type StoredLeaf } from '../../members-custom-fields';
+
 const { MemberCommentingCodec } = require('../commenting');
 
 /**
@@ -230,6 +233,20 @@ export const Newsletter = NewsletterRow.transform((row) => ({
 }));
 export type Newsletter = z.infer<typeof Newsletter>;
 
+/**
+ * A member's values, rebuilt from the rows that store them by the same rule that
+ * wrote them — shared from the module that owns how they are stored, rather than
+ * restated here.
+ */
+function metafieldsFrom(
+  memberId: string,
+  leaves: StoredLeaf[] | null,
+): Record<string, Record<string, unknown>> | null {
+  return leaves === null
+    ? null
+    : { [CUSTOM_NAMESPACE]: valuesFromLeaves(leaves).get(memberId) ?? {} };
+}
+
 /** The whole account, as one schema over the rows that make one. */
 export const MemberAccount = (deps: DecodeDependencies) =>
   MemberRow.and(
@@ -237,6 +254,16 @@ export const MemberAccount = (deps: DecodeDependencies) =>
       newsletters: z.array(Newsletter),
       stripeSubscriptions: z.array(StripeSubscription(deps)),
       grantedSubscriptions: z.array(GrantedSubscription(deps)),
+      /**
+       * The rows behind the extra fields a publisher defined, already read.
+       *
+       * Null on a site that has defined none, which is not the same as a member who
+       * has answered none: the first has nothing to show and the second has nothing
+       * filled in. Which rows survived being read is settled by the query, where the
+       * one unreadable row can be reported; deciding it again here would either
+       * repeat that judgement or contradict it.
+       */
+      metafieldLeaves: z.array(z.custom<StoredLeaf>()).nullable().default(null),
     }),
   ).transform((row) => ({
     id: row.id,
@@ -267,6 +294,7 @@ export const MemberAccount = (deps: DecodeDependencies) =>
     },
     newsletters: row.newsletters,
     subscriptions: [...row.stripeSubscriptions, ...row.grantedSubscriptions],
+    metafields: metafieldsFrom(row.id, row.metafieldLeaves),
   }));
 
 export type MemberAccount = ReturnType<ReturnType<typeof MemberAccount>['parse']>;

--- a/ghost/core/core/server/services/members/account/queries.ts
+++ b/ghost/core/core/server/services/members/account/queries.ts
@@ -1,7 +1,17 @@
 import type { Knex } from 'knex';
+import { readableLeaves } from '../../members-custom-fields';
 
-/** Rows as the driver hands them over, before any schema has looked at them. */
+/**
+ * Rows as the driver hands them over, before any schema has looked at them.
+ *
+ * Values are unknown because only a schema should say what a column holds — except
+ * the member's own id, which every one of these queries selects by name and keys
+ * the rest of the read on.
+ */
 type RawRow = Record<string, unknown>;
+type RawMemberRow = RawRow & { id: string };
+/** The two identifiers a subscription is matched on, one Stripe's and one Ghost's. */
+type RawSubscriptionRow = RawRow & { subscription_id: string; ghost_subscription_row_id: string };
 export type RawAccount = RawRow;
 
 /** What another domain answered about one subscription. */
@@ -80,21 +90,24 @@ const LOOKUP_COLUMNS: Array<[keyof MemberLookup, string]> = [
  * switched it off, which a reader cannot tell apart and does not need to.
  */
 export function memberByLookup(knex: Knex, lookup: MemberLookup) {
-  const match = LOOKUP_COLUMNS.find(([key]) => lookup[key] !== undefined && lookup[key] !== null);
-  if (!match) {
-    return null;
-  }
-  const [key, column] = match;
+  for (const [key, column] of LOOKUP_COLUMNS) {
+    const value = lookup[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
 
-  return knex('members')
-    .leftJoin('suppressions', 'suppressions.email', 'members.email')
-    .where(column, lookup[key] as string)
-    .select(
-      ...MEMBER_COLUMNS,
-      'suppressions.reason as suppression_reason',
-      'suppressions.created_at as suppression_at',
-    )
-    .limit(1);
+    return knex<RawRow, RawMemberRow[]>('members')
+      .leftJoin('suppressions', 'suppressions.email', 'members.email')
+      .where(column, value)
+      .select(
+        ...MEMBER_COLUMNS,
+        'suppressions.reason as suppression_reason',
+        'suppressions.created_at as suppression_at',
+      )
+      .limit(1);
+  }
+
+  return null;
 }
 
 /** Ordered here because the projection promises this order and SQL can state it. */
@@ -127,7 +140,7 @@ export function newslettersForMembers(knex: Knex, memberIds: string[]) {
  * same exclusion is what `members_resolved_subscription` applies.
  */
 export function stripeSubscriptionsForMembers(knex: Knex, memberIds: string[]) {
-  return knex('members_stripe_customers_subscriptions as mscs')
+  return knex<RawRow, RawSubscriptionRow[]>('members_stripe_customers_subscriptions as mscs')
     .join('members_stripe_customers as msc', 'msc.customer_id', 'mscs.customer_id')
     .join('stripe_prices as sp', 'sp.stripe_price_id', 'mscs.stripe_price_id')
     .join('stripe_products as spr', 'spr.stripe_product_id', 'sp.stripe_product_id')
@@ -253,6 +266,36 @@ export function grantedSubscriptionsForMembers(knex: Knex, memberIds: string[]) 
 }
 
 /**
+ * The fields a publisher has defined, with whatever this member holds in them.
+ *
+ * Driven from the definitions rather than from the values, so one query answers
+ * two questions that a value-first query cannot tell apart. No rows at all means
+ * this site has defined nothing, and says nothing about metafields. Rows whose
+ * value columns are null mean fields this member has not filled in.
+ *
+ * One row per leaf, because a value can be a tree: an address is stored as a row
+ * per part, addressed by a dotted path. Ordered by that path so the parts of a
+ * value assemble the same way every time.
+ *
+ * Archived fields are excluded here rather than filtered afterwards. Nothing in
+ * the database stops a value row referencing an archived field, so a read that
+ * forgets is a silent bug.
+ */
+export function metafieldLeavesForMember(knex: Knex, memberId: string) {
+  return knex('members_custom_fields as f')
+    .leftJoin('members_custom_field_values as v', function () {
+      this.on('v.custom_field_key', '=', 'f.key').andOn(
+        'v.member_id',
+        '=',
+        knex.raw('?', [memberId]),
+      );
+    })
+    .where('f.status', 'active')
+    .orderBy('v.path', 'asc')
+    .select('v.member_id', 'f.key', 'f.type', 'v.path', 'v.value_text');
+}
+
+/**
  * The gift behind each gifted member, one per member.
  *
  * Ranked rather than joined. A member can hold more than one redeemed gift, and
@@ -314,7 +357,7 @@ export async function read(
     return null;
   }
 
-  const ids = [member.id];
+  const ids: string[] = [member.id];
   const [newsletters, stripeRows, grantedRows, gifts] = await Promise.all([
     newslettersForMembers(knex, ids),
     stripeSubscriptionsForMembers(knex, ids),
@@ -322,19 +365,30 @@ export async function read(
     activeGiftsForMembers(knex, ids),
   ]);
 
-  const facts = await externals.forSubscriptions(stripeRows);
+  const [facts, metafieldRows] = await Promise.all([
+    externals.forSubscriptions(stripeRows),
+    metafieldLeavesForMember(knex, member.id),
+  ]);
   const now = new Date();
 
   return {
     ...member,
+    // Null rather than empty on a site that has defined nothing, so the response
+    // keeps the shape it had before the feature existed. A row carrying no member
+    // is a field nobody has answered, which is absence rather than a value that
+    // cannot be read, so it never reaches the reader that reports those.
+    metafieldLeaves:
+      metafieldRows.length === 0
+        ? null
+        : readableLeaves(metafieldRows.filter((row) => row.member_id !== null)),
     newsletters,
-    stripeSubscriptions: stripeRows.map((row: RawRow) => ({
+    stripeSubscriptions: stripeRows.map((row) => ({
       ...row,
-      ...(facts.get(row.subscription_id as string) ?? {}),
+      ...(facts.get(row.subscription_id) ?? {}),
     })),
     // The gift and the clock travel with each granted subscription, because what
     // a granted subscription costs and when it started are answered from them.
-    grantedSubscriptions: grantedRows.map((row: RawRow) => ({
+    grantedSubscriptions: grantedRows.map((row) => ({
       ...row,
       gift: gifts[0] ?? null,
       now,

--- a/ghost/core/core/server/services/members/account/serializers.ts
+++ b/ghost/core/core/server/services/members/account/serializers.ts
@@ -114,7 +114,7 @@ export function toAccountResponse(account: MemberAccount | null): Wire | null {
     return null;
   }
 
-  return {
+  const wire: Wire = {
     uuid: account.uuid,
     email: account.email,
     name: account.name,
@@ -141,4 +141,12 @@ export function toAccountResponse(account: MemberAccount | null): Wire | null {
       info: account.emailSuppression.info,
     },
   };
+
+  // Absent, not empty, on a site that has defined no fields — which is most of them,
+  // and which is how those sites keep the response they had before this existed.
+  if (account.metafields !== null) {
+    wire.metafields = account.metafields;
+  }
+
+  return wire;
 }

--- a/ghost/core/core/server/services/members/account/service.ts
+++ b/ghost/core/core/server/services/members/account/service.ts
@@ -1,5 +1,6 @@
 import type { Knex } from 'knex';
 import { UpdateAccount } from './commands';
+import { UpdateMetafields } from '../../members-custom-fields';
 import { MemberAccount, type DecodeDependencies } from './models';
 import * as queries from './queries';
 import type { ExternalSubscriptionFacts, MemberLookup } from './queries';
@@ -11,6 +12,17 @@ const config = require('../../../../shared/config');
 
 interface Dependencies {
   knex: Knex;
+  /**
+   * The metafields domain.
+   *
+   * Reading these is part of this projection's own query — a value is rows in a
+   * table like anything else here. Writing one is not: what a field accepts, and
+   * what clearing one means, are rules that domain enforces, so a write asks it
+   * rather than reaching for the tables itself.
+   */
+  metafields: {
+    values: Anything;
+  };
   memberRepository: Anything;
   offersAPI: Anything;
   memberAttributionService: Anything;
@@ -34,6 +46,7 @@ interface Dependencies {
  */
 export class MemberAccountService {
   private knex: Knex;
+  private metafields: { values: Anything };
   private memberRepository: Anything;
   private offersAPI: Anything;
   private memberAttributionService: Anything;
@@ -42,6 +55,7 @@ export class MemberAccountService {
 
   constructor({
     knex,
+    metafields,
     memberRepository,
     offersAPI,
     memberAttributionService,
@@ -49,6 +63,7 @@ export class MemberAccountService {
     nextPaymentCalculator,
   }: Dependencies) {
     this.knex = knex;
+    this.metafields = metafields;
     this.memberRepository = memberRepository;
     this.offersAPI = offersAPI;
     this.memberAttributionService = memberAttributionService;
@@ -125,8 +140,11 @@ export class MemberAccountService {
     };
 
     try {
-      for (const id of new Set(rows.map((row) => row.offer_id).filter(Boolean))) {
-        await loadOffer(id as string);
+      const offerIds = new Set(
+        rows.flatMap((row) => (row.offer_id === null ? [] : [row.offer_id])),
+      );
+      for (const id of offerIds) {
+        await loadOffer(id);
       }
 
       const stripeIdByRowId = new Map(
@@ -167,13 +185,45 @@ export class MemberAccountService {
    * The read is what the caller gets rather than the model the update returned: a
    * member who changes their newsletters expects the response to describe them as
    * they now are, and the update's own result carries only what it touched.
+   *
+   * Metafield values are planned before anything is written, so a value the
+   * catalog refuses fails the whole request before the member's record is touched
+   * rather than after. They are recorded as written by the member, which is the
+   * one writer whose edits leave no action behind: the action log records what
+   * staff did, and no member-initiated change has ever written to it.
    */
   async edit(data: Json, options: Json = {}): Promise<Json | null> {
-    const model = await this.memberRepository.update(UpdateAccount.parse(data), {
+    const { metafields, ...fields } = UpdateAccount.parse(data);
+
+    // A member is recorded as the writer of their own answers, and is the one
+    // writer whose changes leave no action behind: the action log records what
+    // staff did, and no member-initiated change has ever written to it.
+    const command: UpdateMetafields | null =
+      metafields === undefined
+        ? null
+        : UpdateMetafields.parse({
+            memberId: options.id,
+            values: metafields,
+            writtenBy: { type: 'member', id: options.id },
+          });
+
+    // Planned before anything is written, so a value the catalog refuses fails the
+    // whole request rather than half of it.
+    const plan = command === null ? null : await this.metafields.values.planUpdate(command);
+
+    const model = await this.memberRepository.update(fields, {
       ...options,
       withRelated: ['newsletters'],
     });
 
-    return model ? this.read({ id: model.id }) : null;
+    if (!model) {
+      return null;
+    }
+
+    if (command !== null && plan !== null) {
+      await this.metafields.values.applyUpdate(command, plan);
+    }
+
+    return this.read({ id: model.id });
   }
 }

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -163,6 +163,8 @@ module.exports = function MembersAPI({
   // ../account/CONTEXT.md.
   const memberAccountService = new MemberAccountService({
     knex: require('../../../data/db').knex,
+    // Built by boot before the members service, so it is here by now.
+    metafields: { values: customFieldValues },
     memberRepository,
     offersAPI,
     memberAttributionService,

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -2,6 +2,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const moment = require('moment');
+const { UpdateMetafields } = require('../../../members-custom-fields');
 
 const messages = {
   stripeNotConnected: 'Missing Stripe connection.',
@@ -462,7 +463,7 @@ module.exports = class MemberBREADService {
   }
 
   async add(data, options) {
-    if (this.customFieldValues.namesValues(this.customFieldValues.unwrapWire(data.metafields))) {
+    if (this.customFieldValues.namesAny(data.metafields)) {
       throw new errors.ValidationError({
         message: tpl(messages.customFieldsOnAdd),
         property: 'metafields',
@@ -565,16 +566,39 @@ module.exports = class MemberBREADService {
   async edit(data, options) {
     delete data.last_seen_at;
 
-    const customFields = this.customFieldValues.unwrapWire(data.metafields);
-    const writeCustomFields = customFields !== undefined;
+    // Who is writing has to be known before anything is planned, because it is
+    // part of the command rather than something supplied when it is applied. The
+    // only route here is the authenticated Admin API, so a request that is neither
+    // a user nor an integration is a mistake upstream rather than a writer to
+    // invent a name for; refusing keeps every stored writer resolvable.
+    const metafieldValues = data.metafields;
     delete data.metafields;
 
-    // Plan (which validates) before the member is touched, so a bad value 422s
-    // here rather than after the member edit has been applied — and keep the
-    // plan to apply once below, so the values aren't resolved and validated
-    // twice.
-    const plannedCustomFields = writeCustomFields
-      ? await this.customFieldValues.planWrite(customFields)
+    let metafieldCommand = null;
+    if (metafieldValues !== undefined) {
+      const context = options.context || {};
+      if (!context.integration && !context.user) {
+        throw new errors.IncorrectUsageError({
+          message: tpl(messages.customFieldsWithoutWriter),
+        });
+      }
+
+      metafieldCommand = UpdateMetafields.parse({
+        memberId: options.id,
+        values: metafieldValues,
+        // The same pair the action log records, so the two agree about who did it
+        // rather than one saying only that it was "admin".
+        writtenBy: context.integration
+          ? { type: 'integration', id: context.integration.id }
+          : { type: 'user', id: context.user },
+      });
+    }
+
+    // Planned before the member is touched, so a bad value 422s here rather than
+    // after the edit has been applied, and planned once so the values are not
+    // resolved and validated twice.
+    const plannedCustomFields = metafieldCommand
+      ? await this.customFieldValues.planUpdate(metafieldCommand)
       : null;
 
     let model;
@@ -628,23 +652,7 @@ module.exports = class MemberBREADService {
     }
 
     if (plannedCustomFields) {
-      // Every value reaching here was typed into the Admin API, so the writer is
-      // whoever made the request — the same pair the action log records, so the two
-      // agree about who did it rather than one saying only that it was "admin".
-      //
-      // The only route to this branch is the authenticated Admin API, so an anonymous
-      // request is a mistake somewhere upstream rather than a writer to invent a name
-      // for. Refusing keeps every stored writer resolvable.
-      const context = options.context || {};
-      if (!context.integration && !context.user) {
-        throw new errors.IncorrectUsageError({
-          message: tpl(messages.customFieldsWithoutWriter),
-        });
-      }
-      const writtenBy = context.integration
-        ? { type: 'integration', id: context.integration.id }
-        : { type: 'user', id: context.user };
-      await this.customFieldValues.applyWrite(model.id, plannedCustomFields, { writtenBy });
+      await this.customFieldValues.applyUpdate(metafieldCommand, plannedCustomFields);
 
       // Custom fields aren't a member column or relation, so an edit touching
       // only them leaves `model._changed` empty and the save fires nothing.

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -78,6 +78,25 @@ module.exports = function setupMembersApp() {
     middleware.loadMemberSession,
     http(api.membersAccount.update),
   );
+
+  // What extra fields this publisher has defined for members to fill in. Served by
+  // the metafields domain, from the same definitions service Admin reads — this is
+  // the same list, answered for a different audience. A route of its own because it
+  // describes the site rather than the member: the payload above says what someone
+  // has answered, and this says what there is to answer. Setting a value is part of
+  // the member update, the way staff already set the same values.
+  //
+  // Deliberately not behind the feature flag, matching the Admin API. Only defining
+  // a field is flagged, and nothing else can happen without one: a site with no
+  // definitions answers with an empty list and carries no values, so the flag would
+  // decide nothing here. It would also strand a publisher who defined fields and
+  // later turned the flag off, leaving their members holding data they could see and
+  // not correct.
+  membersApp.get(
+    '/api/member/metafields/:namespace',
+    middleware.loadMemberSession,
+    http(api.metafieldsMembers.browse),
+  );
   membersApp.post('/api/member/email', bodyParser.json({ limit: '50mb' }), (req, res, next) =>
     membersService.api.middleware.updateEmailAddress(req, res, next),
   );

--- a/ghost/core/test/e2e-api/members/custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/members/custom-fields.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 
-const { agentProvider, fixtureManager, mockManager } = require('../../utils/e2e-framework');
+const { agentProvider, fixtureManager } = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
+// From the catalog, which is where a client reads it too. A browser takes the
+// structure-only entry point so it does not carry the validator; this runs in Node,
+// where that costs nothing.
+const { subFieldsOf } = require('@tryghost/custom-field-types');
 
 // Custom fields are staff-only. Nothing in the members API is written to expose or
 // accept them — the member response is built from a field whitelist that predates the
@@ -41,8 +45,6 @@ describe('Member Custom Fields Members API', function () {
   });
 
   beforeEach(async function () {
-    mockManager.mockLabsEnabled('membersCustomFields');
-
     fieldCounter += 1;
     const { body } = await adminAgent
       .post('members/metafields/custom/')
@@ -57,7 +59,6 @@ describe('Member Custom Fields Members API', function () {
   });
 
   afterEach(async function () {
-    mockManager.restore();
     // Whether a member payload carries custom fields at all follows from the site defining
     // any, so a definition left behind here changes the shape of member responses in every
     // suite that runs after this one.
@@ -65,22 +66,212 @@ describe('Member Custom Fields Members API', function () {
     await models.Base.knex('members_custom_fields').del();
   });
 
-  it('does not return custom fields to the member who holds them', async function () {
+  it('returns the fields a member holds, on their own payload', async function () {
     const { body } = await membersAgent.get('/api/member/').expectStatus(200);
 
-    assert.equal(Object.hasOwn(body, 'metafields'), false);
+    assert.deepEqual(body.metafields, { custom: { [fieldKey]: '9' } });
   });
 
-  it('does not write custom fields a member sends', async function () {
-    const { body } = await membersAgent
-      .put('/api/member/')
-      .body({ name: 'Renamed', metafields: { custom: { [fieldKey]: '12' } } })
+  it('returns the definitions a member needs to be shown anything', async function () {
+    const { body } = await membersAgent.get('/api/member/metafields/custom/').expectStatus(200);
+
+    const field = body.members_metafields.find((f: { key: string }) => f.key === fieldKey);
+    assert.ok(field, 'the field a publisher defined is offered to the member');
+    assert.equal(field.namespace, 'custom');
+    assert.equal(field.type, 'short_text');
+    // No database id: a field is addressed by its namespace and key, and neither is
+    // reissued once minted.
+    assert.equal(Object.hasOwn(field, 'id'), false);
+  });
+
+  it('names a field made of several parts by its type, not by listing them', async function () {
+    const { body: created } = await adminAgent
+      .post('members/metafields/custom/')
+      .body({ members_metafields: [{ name: `Address ${fieldCounter}`, type: 'address' }] })
+      .expectStatus(201);
+
+    const { body } = await membersAgent.get('/api/member/metafields/custom/').expectStatus(200);
+    const field = body.members_metafields.find(
+      (f: { key: string }) => f.key === created.members_metafields[0].key,
+    );
+
+    // The response says the type and stops there. What an address is made of is
+    // declared once in the shared catalog, which both sides validate against, so a
+    // client reads it from there rather than being told — and being told would let
+    // the two disagree about what a valid value is.
+    assert.equal(field.type, 'address');
+    assert.deepEqual(subFieldsOf('address'), [
+      'line1',
+      'line2',
+      'city',
+      'state',
+      'postal_code',
+      'country',
+    ]);
+  });
+
+  it('gives a client everything it needs to write a value back', async function () {
+    // The round trip a Portal-style client actually makes: ask what fields exist,
+    // then set one using only what that answer told it. Nothing here reaches for
+    // knowledge the client was not given.
+    const { body: catalogue } = await membersAgent
+      .get('/api/member/metafields/custom/')
       .expectStatus(200);
 
-    // The rest of the body still applies, so the value is dropped rather than
-    // the request being rejected — the same way `email` behaves here.
+    const field = catalogue.members_metafields.find((f: { key: string }) => f.key === fieldKey);
+    const write = { [field.namespace]: { [field.key]: 'Written from the catalogue' } };
+
+    const { body } = await membersAgent
+      .put('/api/member/')
+      .body({ metafields: write })
+      .expectStatus(200);
+
+    assert.equal(body.metafields[field.namespace][field.key], 'Written from the catalogue');
+  });
+
+  it('sets each part of a field made of several', async function () {
+    const { body: created } = await adminAgent
+      .post('members/metafields/custom/')
+      .body({ members_metafields: [{ name: `Shipping ${fieldCounter}`, type: 'address' }] })
+      .expectStatus(201);
+    const addressKey = created.members_metafields[0].key;
+
+    const { body: catalogue } = await membersAgent
+      .get('/api/member/metafields/custom/')
+      .expectStatus(200);
+    const field = catalogue.members_metafields.find((f: { key: string }) => f.key === addressKey);
+
+    // A composite is addressed as a whole and its parts are named inside it. The
+    // part names come from the shared catalog, which is where a client gets them.
+    const value = Object.fromEntries(
+      subFieldsOf('address')
+        .filter((part: string) => part !== 'country')
+        .map((part: string) => [part, `a ${part}`]),
+    );
+
+    const { body } = await membersAgent
+      .put('/api/member/')
+      .body({ metafields: { [field.namespace]: { [field.key]: value } } })
+      .expectStatus(200);
+
+    assert.deepEqual(body.metafields[field.namespace][field.key], value);
+  });
+
+  it('offers the fields in the order the publisher put them', async function () {
+    // A client renders them in the order it is given, so the order is part of the
+    // answer rather than something a client sorts for itself.
+    const names = [`Zulu ${fieldCounter}`, `Alpha ${fieldCounter}`];
+    for (const name of names) {
+      await adminAgent
+        .post('members/metafields/custom/')
+        .body({ members_metafields: [{ name, type: 'short_text' }] })
+        .expectStatus(201);
+    }
+
+    const { body } = await membersAgent.get('/api/member/metafields/custom/').expectStatus(200);
+    const offered = body.members_metafields.map((f: { name: string }) => f.name);
+
+    // Newest last, which is where the publisher's list puts them — not alphabetical.
+    assert.deepEqual(offered.slice(-2), names);
+  });
+
+  it('writes a value a member sets on themselves', async function () {
+    const { body } = await membersAgent
+      .put('/api/member/')
+      .body({ metafields: { custom: { [fieldKey]: '12' } } })
+      .expectStatus(200);
+
+    assert.deepEqual(body.metafields, { custom: { [fieldKey]: '12' } });
+    assert.equal((await readValuesAsStaff())[fieldKey], '12');
+  });
+
+  it('changes a name and a field in one request', async function () {
+    // The reason this is one endpoint: the account panel is one form with one
+    // Save, and a member who fills it in expects one answer.
+    const { body } = await membersAgent
+      .put('/api/member/')
+      .body({ name: 'Renamed', metafields: { custom: { [fieldKey]: '14' } } })
+      .expectStatus(200);
+
     assert.equal(body.name, 'Renamed');
-    assert.equal(Object.hasOwn(body, 'metafields'), false);
-    assert.equal((await readValuesAsStaff())[fieldKey], '9');
+    assert.deepEqual(body.metafields, { custom: { [fieldKey]: '14' } });
+  });
+
+  it('records the member as the writer', async function () {
+    await membersAgent
+      .put('/api/member/')
+      .body({ metafields: { custom: { [fieldKey]: '13' } } })
+      .expectStatus(200);
+
+    const [row] = await models.Base.knex('members_custom_field_values')
+      .where({ member_id: memberId, custom_field_key: fieldKey })
+      .select('written_by_type', 'written_by_id');
+
+    // Who wrote a value is a fact about the value, and a member writing their own
+    // is the one writer that leaves no action behind.
+    assert.equal(row.written_by_type, 'member');
+    assert.equal(row.written_by_id, memberId);
+  });
+
+  it('clears a value a member empties', async function () {
+    await membersAgent
+      .put('/api/member/')
+      .body({ metafields: { custom: { [fieldKey]: null } } })
+      .expectStatus(200);
+
+    assert.equal((await readValuesAsStaff())[fieldKey], undefined);
+  });
+
+  it('refuses a field nobody defined, and changes nothing at all', async function () {
+    // Unlike an unrecognised key at the top level, which is a client sending more
+    // than this endpoint reads, a named field that does not exist is a client
+    // believing something false. Nothing is written, including the name alongside
+    // it: the values are planned before the member's record is touched.
+    await membersAgent
+      .put('/api/member/')
+      .body({ name: 'Should Not Stick', metafields: { custom: { not_a_field: 'x' } } })
+      .expectStatus(422);
+
+    const { body } = await membersAgent.get('/api/member/').expectStatus(200);
+    assert.notEqual(body.name, 'Should Not Stick');
+    assert.equal((await readValuesAsStaff())[fieldKey], '9', 'the existing value is untouched');
+  });
+
+  it('still ignores keys a member may not change', async function () {
+    const { body } = await membersAgent
+      .put('/api/member/')
+      .body({ name: 'Renamed', status: 'comped', labels: [{ name: 'VIP' }] })
+      .expectStatus(200);
+
+    // Dropped rather than refused, so the rest of the request still applies.
+    assert.equal(body.name, 'Renamed');
+    assert.equal(body.status, 'free');
+  });
+
+  describe('on a site that has defined no fields', function () {
+    // Which is most sites, and the reason none of this is behind the feature flag:
+    // defining a field is what the flag gates, and without one there is nothing to
+    // show and nothing to write. A publisher who defined fields and later turned
+    // the flag off would otherwise leave their members holding data they could see
+    // and not correct.
+    beforeEach(async function () {
+      await models.Base.knex('members_custom_field_values').del();
+      await models.Base.knex('members_custom_fields').del();
+    });
+
+    it('answers with an empty list rather than a 404', async function () {
+      const { body } = await membersAgent.get('/api/member/metafields/custom/').expectStatus(200);
+
+      assert.deepEqual(body.members_metafields, []);
+    });
+
+    it('leaves the member payload as it was before the feature existed', async function () {
+      const { body } = await membersAgent.get('/api/member/').expectStatus(200);
+
+      // A key added to a response cannot be withdrawn once clients read it, so a
+      // site with nothing to say says nothing rather than saying it is empty. The
+      // Admin API answers the same way about the same values.
+      assert.equal(Object.hasOwn(body, 'metafields'), false);
+    });
   });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -10,10 +10,9 @@ const moment = require('moment');
 // assume rather than on the behaviour it is checking.
 const createCustomFieldValuesStub = () => ({
   getValuesForMembers: sinon.stub().resolves(new Map()),
-  unwrapWire: sinon.stub().callsFake((input) => input),
-  namesValues: sinon.stub().returns(false),
-  planWrite: sinon.stub().resolves([]),
-  applyWrite: sinon.stub().resolves(),
+  namesAny: sinon.stub().returns(false),
+  planUpdate: sinon.stub().resolves([]),
+  applyUpdate: sinon.stub().resolves(),
 });
 
 const createCustomFieldDefinitionsStub = (hasAnyActive = false) => ({
@@ -110,7 +109,7 @@ describe('MemberBreadService', function () {
       // counts as naming them, so drive it directly rather than through a body
       // shape, which is the values service's own contract to test.
       const customFieldValues = createCustomFieldValuesStub();
-      customFieldValues.namesValues.returns(true);
+      customFieldValues.namesAny.returns(true);
       const { service, createStub } = createService({}, customFieldValues);
 
       await assert.rejects(
@@ -137,8 +136,8 @@ describe('MemberBreadService', function () {
       assert.equal(createStub.calledOnce, true);
       // Asked unconditionally: the member data is handed over whether or not it
       // carries the key, and an absent one is the values service's to judge.
-      assert.equal(customFieldValues.namesValues.calledOnce, true);
-      assert.equal(customFieldValues.namesValues.firstCall.args[0], undefined);
+      assert.equal(customFieldValues.namesAny.calledOnce, true);
+      assert.equal(customFieldValues.namesAny.firstCall.args[0], undefined);
     });
 
     it('passes context to linkStripeCustomer when stripe_customer_id is provided', async function () {


### PR DESCRIPTION
Stacked on #30436, which gave the members API a projection of its own. This puts the feature on it.

## Problem

The extra fields a publisher defines about their members, such as a shipping address or a job title, can only be changed by staff. The member the data is about cannot touch it.

So it rots. People move, change jobs, change numbers, and the only way a correction reaches Ghost is if someone on staff types it in. The person who knows the right answer is the one person who cannot give it.

## Solution

A member's own account now carries what they hold in those fields and accepts a change back.

Setting a value is part of the ordinary "update my account" request, which is how staff already do it, with the member edit carrying these values beside the name. A member's account panel is one form with one Save, and giving the values their own route would make that two requests, with a half-succeeded state to explain to whoever is looking at the form. The values are worked out before the member's record is touched, so a value that is not allowed fails the whole request rather than half of it.

That does leave the request answering two ways, which is deliberate. A key it does not recognise is ignored, because that is a client sending more than this endpoint reads. A field that is named but does not exist is refused, because that is a client believing something false, and saying so is more use than silence.

The list of fields is a separate request, because it describes the site rather than the member. The values say what someone has answered, not what there is to answer, and a stored value with no matching definition has no label and nothing to type into. A member is offered only the fields still in use, in the order the publisher put them, so a client can render them as given.

A field can be built out of several parts, an address being the obvious case, and the response names the kind of field rather than listing its parts. Both sides already share one description of what each kind is made of, and both check answers against it, so a client reads the parts from there. Sending them again here would create a second answer that could drift from the first.

That list is the same shape staff receive, deliberately. Building a narrower one meant maintaining a second description of the same thing to withhold a field's status and the date it was made, neither of which is secret and neither of which a member can act on, since they are only ever shown fields that are still in use.

None of this sits behind the feature flag, which matches how the same feature behaves for staff. The flag covers defining a field, and nothing here can happen without one: a site that has defined none gets an empty list, and its members' accounts look exactly as they did before any of this existed. Guarding it would only punish a publisher who defined some fields and later switched the flag off, leaving their members looking at answers they could no longer correct.

A member is now recorded as the author of the values they set. They are also the only author whose changes leave nothing in the staff activity log, which is deliberate. That log is a record of what staff did, and no change a member makes to their own account has ever appeared in it.

## Not doing

The Portal screens that will use this. This is the API they need, and it can be exercised on its own; the account panel is being designed in parallel. Nothing here decides how any of it looks.

Every field is readable and writable by the member who owns it. Letting a publisher decide that per field is the next piece of work, and nothing here assumes the answer is always yes.

ref https://linear.app/ghost/issue/BER-3794/members-manage-their-own-custom-fields-in-their-account
