### PR TITLE
Added email preview and retry hooks to the framework data layer

### DIFF
--- a/apps/admin-x-framework/src/api/content-types.ts
+++ b/apps/admin-x-framework/src/api/content-types.ts
@@ -3,9 +3,11 @@
 type Override<Base, Changes> = Omit<Base, keyof Changes> & Changes;
 
 export type Email = {
+  id?: string;
   opened_count: number;
   email_count: number;
-  status?: string;
+  status?: 'pending' | 'submitting' | 'submitted' | 'failed';
+  error?: string | null;
   track_opens?: boolean;
   track_clicks?: boolean;
 };

--- a/apps/admin-x-framework/src/api/email-previews.ts
+++ b/apps/admin-x-framework/src/api/email-previews.ts
@@ -1,0 +1,67 @@
+import { createMutation, createQueryWithId } from '../utils/api/hooks';
+
+export type EmailPreview = {
+  html: string;
+  plaintext: string;
+  subject: string;
+};
+
+export interface EmailPreviewResponseType {
+  email_previews: EmailPreview[];
+}
+
+export interface EmailPreviewParams {
+  memberStatus?: 'free' | 'paid';
+  /** Tier slug - narrows the paid audience to a single tier */
+  memberTier?: string;
+  /** Newsletter slug - the server falls back to the post's, then the default newsletter */
+  newsletter?: string;
+}
+
+const dataType = 'EmailPreviewResponseType';
+
+const useEmailPreviewQuery = createQueryWithId<EmailPreviewResponseType>({
+  dataType,
+  path: (id) => `/email_previews/posts/${id}/`,
+});
+
+export const useEmailPreview = (
+  id: string,
+  options: EmailPreviewParams & Parameters<typeof useEmailPreviewQuery>[1] = {},
+) => {
+  const { memberStatus, memberTier, newsletter, searchParams, ...query } = options;
+
+  const params: Record<string, string> = { ...searchParams };
+  if (memberStatus) {
+    params.member_status = memberStatus;
+  }
+  if (memberTier) {
+    params.member_tier = memberTier;
+  }
+  if (newsletter) {
+    params.newsletter = newsletter;
+  }
+
+  return useEmailPreviewQuery(id, { ...query, searchParams: params });
+};
+
+export interface SendTestEmailPayload {
+  postId: string;
+  /** The server accepts exactly one recipient per request */
+  emails: string[];
+  memberStatus?: 'free' | 'paid';
+  memberTier?: string;
+  newsletter?: string;
+}
+
+/** Sends a test email for a post. Responds 204 with no body. */
+export const useSendTestEmail = createMutation<unknown, SendTestEmailPayload>({
+  method: 'POST',
+  path: ({ postId }) => `/email_previews/posts/${postId}/`,
+  body: ({ emails, memberStatus, memberTier, newsletter }) => ({
+    emails,
+    ...(newsletter && { newsletter }),
+    ...(memberStatus && { member_status: memberStatus }),
+    ...(memberTier && { member_tier: memberTier }),
+  }),
+});

--- a/apps/admin-x-framework/src/api/emails.ts
+++ b/apps/admin-x-framework/src/api/emails.ts
@@ -2,8 +2,6 @@ import { createMutation } from '../utils/api/hooks';
 import { postsDataType } from './posts';
 import type { Email } from './content-types';
 
-export type { Email } from './content-types';
-
 export interface EmailsResponseType {
   emails: Email[];
 }

--- a/apps/admin-x-framework/src/api/emails.ts
+++ b/apps/admin-x-framework/src/api/emails.ts
@@ -1,0 +1,23 @@
+import { createMutation } from '../utils/api/hooks';
+import { postsDataType } from './posts';
+import type { Email } from './content-types';
+
+export type { Email } from './content-types';
+
+export interface EmailsResponseType {
+  emails: Email[];
+}
+
+/**
+ * Retry a failed email send.
+ *
+ * The framework has no email queries - the email consumers see is the copy
+ * embedded on the post (the editor read contract includes `email`), so a
+ * successful retry invalidates post queries to refresh that embedded copy.
+ */
+export const useRetryEmail = createMutation<EmailsResponseType, string>({
+  method: 'PUT',
+  path: (id) => `/emails/${id}/retry/`,
+  body: () => ({}),
+  invalidateQueries: { dataType: postsDataType },
+});

--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -51,7 +51,9 @@ export interface PostResponseType {
   posts: PostEditorRecord[];
 }
 
-const dataType = 'PostsResponseType';
+export const postsDataType = 'PostsResponseType';
+
+const dataType = postsDataType;
 
 export const useBrowsePosts = createQuery<PostsResponseType>({
   dataType,

--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -51,9 +51,9 @@ export interface PostResponseType {
   posts: PostEditorRecord[];
 }
 
-export const postsDataType = 'PostsResponseType';
+const dataType = 'PostsResponseType';
 
-const dataType = postsDataType;
+export const postsDataType = dataType;
 
 export const useBrowsePosts = createQuery<PostsResponseType>({
   dataType,

--- a/apps/admin-x-framework/test/unit/api/email-previews.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/email-previews.test.tsx
@@ -1,0 +1,110 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '../../../src/test/test-utils';
+import { useEmailPreview, useSendTestEmail } from '../../../src/api/email-previews';
+import { withMockFetch } from '../../utils/mock-fetch';
+
+const previewCall = (mock: any) =>
+  mock.calls.find(([input]: [unknown]) => String(input).includes('/email_previews/'));
+
+const requestBody = (mock: any) => JSON.parse(previewCall(mock)[1].body as string);
+
+describe('email previews api', () => {
+  it('reads an email preview with the full audience and newsletter params', async () => {
+    await withMockFetch(
+      {
+        json: {
+          email_previews: [{ html: '<p>Hi</p>', plaintext: 'Hi', subject: 'Hello' }],
+          // the permissions gate fetches the current user through the same mock
+          users: [{ id: 'user-1', roles: [] }],
+        },
+        headers: { 'content-type': 'application/json' },
+      },
+      async (mock) => {
+        const { result } = renderHookWithProviders(() =>
+          useEmailPreview('post-1', {
+            memberStatus: 'paid',
+            memberTier: 'gold',
+            newsletter: 'weekly',
+          }),
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const url = new URL(previewCall(mock)[0] as string);
+        expect(url.pathname).toBe('/ghost/api/admin/email_previews/posts/post-1/');
+        expect(Object.fromEntries(url.searchParams.entries())).toEqual({
+          member_status: 'paid',
+          member_tier: 'gold',
+          newsletter: 'weekly',
+        });
+        expect(result.current.data?.email_previews[0].subject).toBe('Hello');
+      },
+    );
+  });
+
+  it('omits audience params that are not provided', async () => {
+    await withMockFetch(
+      {
+        json: {
+          email_previews: [{ html: '<p>Hi</p>', plaintext: 'Hi', subject: 'Hello' }],
+          users: [{ id: 'user-1', roles: [] }],
+        },
+        headers: { 'content-type': 'application/json' },
+      },
+      async (mock) => {
+        const { result } = renderHookWithProviders(() =>
+          useEmailPreview('post-1', { memberStatus: 'free' }),
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const url = new URL(previewCall(mock)[0] as string);
+        expect(Object.fromEntries(url.searchParams.entries())).toEqual({
+          member_status: 'free',
+        });
+      },
+    );
+  });
+
+  it('sends a test email with the audience and newsletter in the body', async () => {
+    await withMockFetch({ status: 204 }, async (mock) => {
+      const { result } = renderHookWithProviders(() => useSendTestEmail());
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          postId: 'post-1',
+          emails: ['test@example.com'],
+          memberStatus: 'paid',
+          memberTier: 'gold',
+          newsletter: 'weekly',
+        });
+      });
+
+      const [url, options] = previewCall(mock);
+      expect(new URL(url as string).pathname).toBe('/ghost/api/admin/email_previews/posts/post-1/');
+      expect(options.method).toBe('POST');
+      expect(requestBody(mock)).toEqual({
+        emails: ['test@example.com'],
+        newsletter: 'weekly',
+        member_status: 'paid',
+        member_tier: 'gold',
+      });
+    });
+  });
+
+  it('sends a test email with only the recipient when no audience is given', async () => {
+    await withMockFetch({ status: 204 }, async (mock) => {
+      const { result } = renderHookWithProviders(() => useSendTestEmail());
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          postId: 'post-1',
+          emails: ['test@example.com'],
+        });
+      });
+
+      expect(requestBody(mock)).toEqual({ emails: ['test@example.com'] });
+    });
+  });
+});

--- a/apps/admin-x-framework/test/unit/api/emails.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/emails.test.tsx
@@ -1,0 +1,59 @@
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createTestQueryClient, renderHookWithProviders } from '../../../src/test/test-utils';
+import { useRetryEmail } from '../../../src/api/emails';
+import { postsDataType } from '../../../src/api/posts';
+import { withMockFetch } from '../../utils/mock-fetch';
+
+describe('emails api', () => {
+  it('retries a failed email via the retry endpoint', async () => {
+    await withMockFetch(
+      {
+        json: { emails: [{ id: 'email-1', status: 'pending', email_count: 10, opened_count: 0 }] },
+        headers: { 'content-type': 'application/json' },
+      },
+      async (mock) => {
+        const { result } = renderHookWithProviders(() => useRetryEmail());
+
+        let response;
+        await act(async () => {
+          response = await result.current.mutateAsync('email-1');
+        });
+
+        const [url, options] = mock.calls[0];
+        expect(new URL(url as string).pathname).toBe('/ghost/api/admin/emails/email-1/retry/');
+        expect(options.method).toBe('PUT');
+        expect(JSON.parse(options.body as string)).toEqual({});
+        expect(response).toEqual({
+          emails: [{ id: 'email-1', status: 'pending', email_count: 10, opened_count: 0 }],
+        });
+      },
+    );
+  });
+
+  it('invalidates post queries so the embedded email refreshes', async () => {
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const onInvalidate = vi.fn();
+
+    await withMockFetch(
+      {
+        json: { emails: [{ id: 'email-1', status: 'pending', email_count: 10, opened_count: 0 }] },
+        headers: { 'content-type': 'application/json' },
+      },
+      async () => {
+        const { result } = renderHookWithProviders(() => useRetryEmail(), {
+          queryClient,
+          frameworkProps: { onInvalidate },
+        });
+
+        await act(async () => {
+          await result.current.mutateAsync('email-1');
+        });
+
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [postsDataType] });
+        expect(onInvalidate).toHaveBeenCalledWith(postsDataType);
+      },
+    );
+  });
+});

--- a/apps/admin/src/posts/analytics/providers/post-analytics-context.ts
+++ b/apps/admin/src/posts/analytics/providers/post-analytics-context.ts
@@ -10,11 +10,6 @@ export interface Post extends PostBase {
   authors?: {
     name?: string;
   }[];
-  email?: {
-    opened_count: number;
-    email_count: number;
-    status?: string;
-  } | null;
   newsletter?: {
     feedback_enabled?: boolean;
   } | null;


### PR DESCRIPTION
Adds email-preview and email-retry support to the `admin-x-framework` data layer so the React publish flow can render newsletter previews, send test emails, and retry failed sends.

## New hooks

**`src/api/email-previews.ts`**
- `useEmailPreview(postId, {memberStatus, memberTier, newsletter})` — `GET /email_previews/posts/:id/`. Optional params map to the server's accepted options: `member_status` (`free`/`paid`), `member_tier` (tier slug), `newsletter` (newsletter slug; the server falls back to the post's newsletter, then the default). Params are part of the query key, so previews for different audiences/newsletters cache independently. Response is `{email_previews: [{html, plaintext, subject}]}` per the email service's preview payload.
- `useSendTestEmail` — `POST /email_previews/posts/:id/` with `{emails, newsletter?, member_status?, member_tier?}`, matching the request the Ember preview modal sends. The server responds 204 with no body and accepts exactly one recipient per request.

**`src/api/emails.ts`**
- `useRetryEmail` — `PUT /emails/:id/retry/` with an empty JSON object body (matching the Ember email adapter). Response is `{emails: [Email]}` from the default serializer.

## Retry invalidation

The framework has no email queries — the email state consumers read is the copy embedded on the post (`include=email` in the editor read contract). A successful retry therefore invalidates `PostsResponseType` so post queries refetch with the updated embedded email. No separate email dataType invalidation is needed until something actually queries `/emails/`.

## Types

- Extended the existing `Email` type in `content-types.ts` with `id` and `error`, and narrowed `status` to the schema's `pending | submitting | submitted | failed` enum — retry consumers poll `status` and surface `error`, and every value outside that enum is rejected by the DB schema.
- Exported `postsDataType` from `posts.ts` so `emails.ts` can invalidate it without duplicating the literal.

Deliberately out of scope: polling after retry, iframe/preview rendering, and any consumers — the publish flow owns those.

## Verification

- `pnpm lint` and `pnpm test:unit` in `apps/admin-x-framework` (48 files, 558 tests passing)
- New unit tests pin the URL, params, and body for each hook, plus the retry invalidation behaviour
