### PR TITLE
Added recipient-filter utilities and a members-count hook to the framework

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -10,7 +10,7 @@ import {
 import { apiUrl } from '../utils/api/fetch-api';
 import type { FieldValue } from '@tryghost/custom-field-types';
 import { useCurrentUser } from './current-user';
-import { canManageMembers, isEditorUser, isSuperEditorUser } from './users';
+import { canManageMembers } from './users';
 import { FREE_SEGMENT, PAID_SEGMENT } from '../utils/recipient-filter';
 
 export type MemberLabel = {
@@ -213,7 +213,9 @@ export interface MembersCountResult {
  * request with `limit=1` reading `meta.pagination.total`, cached per-filter
  * for 60 seconds. As in Ember, roles that cannot manage members get
  * `count: null` without a request, a nullish filter counts as 0 without a
- * request, and request errors resolve to 0 with no error toast.
+ * request, and request errors resolve to 0 with no error toast. While the
+ * current user is still loading the result is `{count: null, isLoading: true}`
+ * so callers can tell it apart from a role that cannot browse members.
  */
 export function useMembersCount(filter: string | null | undefined): MembersCountResult {
   const { data: currentUser } = useCurrentUser();
@@ -227,6 +229,10 @@ export function useMembersCount(filter: string | null | undefined): MembersCount
     enabled,
     defaultErrorHandler: false,
   });
+
+  if (currentUser === undefined) {
+    return { count: null, isLoading: true };
+  }
 
   if (!enabled || result.isError) {
     return { count: canFetch ? 0 : null, isLoading: false };
@@ -245,10 +251,12 @@ function pluralizedCount(count: number, noun: string): string {
 }
 
 export interface MembersCountStringOptions {
-  /** The signed-in user; drives the can't-browse-members fallback copy. */
-  user: Parameters<typeof isEditorUser>[0];
-  /** The fetched (or already-known) recipient count. */
-  count?: number;
+  /**
+   * The recipient count, usually from `useMembersCount`: a number renders
+   * numeric copy; `null` (role cannot browse members) and `undefined` (not
+   * fetched) render the descriptive fallback copy instead.
+   */
+  count?: number | null;
   /** With `hasMultipleNewsletters`, switches copy to "subscribers of <name>". */
   newsletter?: { name: string; recipientFilter: string };
   hasMultipleNewsletters?: boolean;
@@ -261,7 +269,7 @@ export interface MembersCountStringOptions {
  */
 export function membersCountString(
   filter: string = '',
-  { user, count, newsletter, hasMultipleNewsletters = false }: MembersCountStringOptions,
+  { count, newsletter, hasMultipleNewsletters = false }: MembersCountStringOptions = {},
 ): string {
   const nounSingular = newsletter && hasMultipleNewsletters ? 'subscriber' : 'member';
   const nounPlural = `${nounSingular}s`;
@@ -278,11 +286,10 @@ export function membersCountString(
   const isAll =
     !filter || (filterParts.includes(FREE_SEGMENT) && filterParts.includes(PAID_SEGMENT));
 
-  // Ember gated on `user.isEditor`, which is plain Editors only — Super
-  // Editors can manage members, so they must fall through to real counts.
-  const isPlainEditor = isEditorUser(user) && !isSuperEditorUser(user);
-
-  if (isPlainEditor && count === undefined) {
+  // Ember reserved this copy for plain Editors and fetched a count for every
+  // other role on the spot; a pure function can't fetch, so an absent count —
+  // whatever the role — gets the descriptive copy rather than a bogus "0".
+  if (count === undefined || count === null) {
     if (isFree) {
       return `all free ${nounPlural}${suffix}`;
     }
@@ -296,18 +303,15 @@ export function membersCountString(
     return 'a custom members segment';
   }
 
-  // Ember's count fetch resolved errors to 0, so an absent count reads as 0.
-  const recipientCount = count ?? 0;
-
   if (isFree) {
-    return pluralizedCount(recipientCount, `free ${nounSingular}`) + suffix;
+    return pluralizedCount(count, `free ${nounSingular}`) + suffix;
   }
 
   if (isPaid) {
-    return pluralizedCount(recipientCount, `paid ${nounSingular}`) + suffix;
+    return pluralizedCount(count, `paid ${nounSingular}`) + suffix;
   }
 
-  return pluralizedCount(recipientCount, nounSingular) + suffix;
+  return pluralizedCount(count, nounSingular) + suffix;
 }
 
 export type NewMember = {

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -10,7 +10,8 @@ import {
 import { apiUrl } from '../utils/api/fetch-api';
 import type { FieldValue } from '@tryghost/custom-field-types';
 import { useCurrentUser } from './current-user';
-import { canManageMembers } from './users';
+import { canManageMembers, isEditorUser, isSuperEditorUser } from './users';
+import { FREE_SEGMENT, PAID_SEGMENT } from '../utils/recipient-filter';
 
 export type MemberLabel = {
   id: string;
@@ -185,6 +186,128 @@ export function useMemberCount() {
   });
 
   return data?.meta?.pagination.total;
+}
+
+// -----------------------------------------------------------------------------
+// Filtered member counts (email recipients)
+// -----------------------------------------------------------------------------
+
+// The Ember members-count-cache's TTL; the framework default staleTime (5min)
+// is too stale for publish-flow recipient counts.
+const MEMBERS_COUNT_STALE_TIME = 60 * 1000;
+
+const useBrowseMembersCountQuery = createQuery<MembersResponseType>({
+  dataType,
+  path: membersPath,
+});
+
+export interface MembersCountResult {
+  /** `null` while loading and for roles that cannot browse members. */
+  count: number | null;
+  isLoading: boolean;
+}
+
+/**
+ * Number of members matching a filter, consolidated from the Ember
+ * `members-count-cache` service + `members-count-fetcher` resource: a browse
+ * request with `limit=1` reading `meta.pagination.total`, cached per-filter
+ * for 60 seconds. As in Ember, roles that cannot manage members get
+ * `count: null` without a request, a nullish filter counts as 0 without a
+ * request, and request errors resolve to 0 with no error toast.
+ */
+export function useMembersCount(filter: string | null | undefined): MembersCountResult {
+  const { data: currentUser } = useCurrentUser();
+  const canFetch = Boolean(currentUser && canManageMembers(currentUser));
+  const enabled = canFetch && filter !== null && filter !== undefined;
+
+  const result = useBrowseMembersCountQuery({
+    // order/page pin the same cheap, stable request shape the Ember cache used
+    searchParams: { filter: filter ?? '', order: 'id', limit: '1', page: '1' },
+    staleTime: MEMBERS_COUNT_STALE_TIME,
+    enabled,
+    defaultErrorHandler: false,
+  });
+
+  if (!enabled || result.isError) {
+    return { count: canFetch ? 0 : null, isLoading: false };
+  }
+
+  return {
+    count: result.data?.meta?.pagination.total ?? null,
+    isLoading: result.isLoading,
+  };
+}
+
+// gh-pluralize combined toLocaleString with ember-inflector; every noun used
+// below pluralizes regularly so a trailing "s" matches its output.
+function pluralizedCount(count: number, noun: string): string {
+  return `${count.toLocaleString()} ${count === 1 ? noun : `${noun}s`}`;
+}
+
+export interface MembersCountStringOptions {
+  /** The signed-in user; drives the can't-browse-members fallback copy. */
+  user: Parameters<typeof isEditorUser>[0];
+  /** The fetched (or already-known) recipient count. */
+  count?: number;
+  /** With `hasMultipleNewsletters`, switches copy to "subscribers of <name>". */
+  newsletter?: { name: string; recipientFilter: string };
+  hasMultipleNewsletters?: boolean;
+}
+
+/**
+ * Human-readable copy for a recipient count, ported from the Ember
+ * `members-count-cache#countString` (which fetched the count itself; this
+ * pure port takes it from `useMembersCount`, which matches its semantics).
+ */
+export function membersCountString(
+  filter: string = '',
+  { user, count, newsletter, hasMultipleNewsletters = false }: MembersCountStringOptions,
+): string {
+  const nounSingular = newsletter && hasMultipleNewsletters ? 'subscriber' : 'member';
+  const nounPlural = `${nounSingular}s`;
+  const suffix = newsletter && hasMultipleNewsletters ? ` of ${newsletter.name}` : '';
+
+  // Strips the newsletter scope composed by getFullRecipientFilter to get back
+  // the user-selected segment; a plain comma split like the Ember original.
+  const basicFilter = newsletter
+    ? filter.replace(newsletter.recipientFilter, '').replace(/^\+\((.*)\)$/, '$1')
+    : filter;
+  const filterParts = basicFilter.split(',');
+  const isFree = filterParts.length === 1 && filterParts[0] === FREE_SEGMENT;
+  const isPaid = filterParts.length === 1 && filterParts[0] === PAID_SEGMENT;
+  const isAll =
+    !filter || (filterParts.includes(FREE_SEGMENT) && filterParts.includes(PAID_SEGMENT));
+
+  // Ember gated on `user.isEditor`, which is plain Editors only — Super
+  // Editors can manage members, so they must fall through to real counts.
+  const isPlainEditor = isEditorUser(user) && !isSuperEditorUser(user);
+
+  if (isPlainEditor && count === undefined) {
+    if (isFree) {
+      return `all free ${nounPlural}${suffix}`;
+    }
+    if (isPaid) {
+      return `all paid ${nounPlural}${suffix}`;
+    }
+    if (isAll) {
+      return `all ${nounPlural}${suffix}`;
+    }
+
+    return 'a custom members segment';
+  }
+
+  // Ember's count fetch resolved errors to 0, so an absent count reads as 0.
+  const recipientCount = count ?? 0;
+
+  if (isFree) {
+    return pluralizedCount(recipientCount, `free ${nounSingular}`) + suffix;
+  }
+
+  if (isPaid) {
+    return pluralizedCount(recipientCount, `paid ${nounSingular}`) + suffix;
+  }
+
+  return pluralizedCount(recipientCount, nounSingular) + suffix;
 }
 
 export type NewMember = {

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -53,6 +53,19 @@ export {
 } from './utils/post-helpers';
 export { focusKoenigEditorOnBottomClick } from './utils/focus-koenig-editor-on-bottom-click';
 
+// Recipient filter utilities
+export {
+  EVERYONE_RECIPIENT_FILTER,
+  FREE_SEGMENT,
+  PAID_SEGMENT,
+  buildRecipientFilter,
+  getFullRecipientFilter,
+  getNewsletterRecipientFilter,
+  getRecipientType,
+  parseRecipientFilter,
+} from './utils/recipient-filter';
+export type { RecipientFilterSegments, RecipientType } from './utils/recipient-filter';
+
 // Source utilities
 export {
   getFaviconDomain,

--- a/apps/admin-x-framework/src/utils/recipient-filter.ts
+++ b/apps/admin-x-framework/src/utils/recipient-filter.ts
@@ -1,0 +1,158 @@
+// Email recipient-filter string handling, consolidated from the Ember admin's
+// four copies of the same comma-split logic: `utils/publish-options.js`,
+// `components/gh-members-recipient-select.js`,
+// `components/editor/modals/publish-flow.js` and
+// `services/members-count-cache.js`. Behavior (including quirks) is preserved
+// so Ember and React screens classify and rebuild filters identically.
+
+export const FREE_SEGMENT = 'status:free';
+export const PAID_SEGMENT = 'status:-free';
+
+/**
+ * The canonical "everyone" spelling. Selecting both the free and paid
+ * checkboxes produces this filter, and the server treats it as all members.
+ */
+export const EVERYONE_RECIPIENT_FILTER = `${FREE_SEGMENT},${PAID_SEGMENT}`;
+
+const BASE_SEGMENTS: string[] = [FREE_SEGMENT, PAID_SEGMENT];
+
+export interface RecipientFilterSegments {
+  /** Exact `status:free` present among the base segments (the "free members" checkbox). */
+  free: boolean;
+  /** Exact `status:-free` present among the base segments (the "paid members" checkbox). */
+  paid: boolean;
+  /**
+   * Raw base segments in first-occurrence order. Kept verbatim (untrimmed)
+   * because a padded segment like `" status:free"` is classified as a base
+   * segment but does not check the free checkbox, and survives a rebuild as-is.
+   */
+  base: string[];
+  /**
+   * Raw non-blank segments that are not base segments — `label:<slug>`,
+   * `tier:<slug>` and any other custom NQL segments — in first-occurrence order.
+   */
+  specific: string[];
+}
+
+/**
+ * Splits a recipient filter into base (free/paid) and specific (label/tier)
+ * segments by comma, the way `gh-members-recipient-select` does. This is a
+ * plain comma split, not an NQL parse: a specific segment whose value contains
+ * a comma is split apart the same way the Ember component splits it.
+ */
+export function parseRecipientFilter(filter: string | null | undefined): RecipientFilterSegments {
+  const items = (filter || '').split(',');
+  const base: string[] = [];
+  const specific: string[] = [];
+
+  for (const item of items) {
+    if (BASE_SEGMENTS.includes(item.trim())) {
+      if (!base.includes(item)) {
+        base.push(item);
+      }
+    } else if (item.trim() !== '') {
+      if (!specific.includes(item)) {
+        specific.push(item);
+      }
+    }
+  }
+
+  return {
+    free: base.includes(FREE_SEGMENT),
+    paid: base.includes(PAID_SEGMENT),
+    base,
+    specific,
+  };
+}
+
+/**
+ * Rebuilds a recipient filter string from parsed segments, mirroring
+ * `gh-members-recipient-select#updateFilter`: base segments first, then
+ * specific segments, deduplicated, joined by comma. Returns `null` for an
+ * empty selection (the "no recipients" state).
+ *
+ * `paidAvailable: false` drops the paid segment, matching the component's
+ * behavior when Stripe is not connected.
+ */
+export function buildRecipientFilter(
+  segments: Pick<RecipientFilterSegments, 'base' | 'specific'>,
+  { paidAvailable = true }: { paidAvailable?: boolean } = {},
+): string | null {
+  const selected = new Set([...segments.base, ...segments.specific]);
+
+  if (!paidAvailable) {
+    selected.delete(PAID_SEGMENT);
+  }
+
+  return Array.from(selected).join(',') || null;
+}
+
+export type RecipientType = 'none' | 'all' | 'free' | 'paid' | 'specific';
+
+/**
+ * Classifies a recipient filter the way the publish flow does
+ * (`editor/modals/publish-flow.js#recipientType`).
+ *
+ * The "all" case is a substring check, not a segment check, so any filter
+ * containing both `status:free` and `status:-free` anywhere classifies as
+ * "all" even alongside other segments — e.g. `label:x,status:free,status:-free`.
+ */
+export function getRecipientType(filter: string | null | undefined): RecipientType {
+  if (!filter) {
+    return 'none';
+  }
+
+  if (filter === FREE_SEGMENT) {
+    return 'free';
+  }
+
+  if (filter === PAID_SEGMENT) {
+    return 'paid';
+  }
+
+  if (filter.includes(FREE_SEGMENT) && filter.includes(PAID_SEGMENT)) {
+    return 'all';
+  }
+
+  return 'specific';
+}
+
+/**
+ * Derives the filter that scopes members to a newsletter's audience
+ * (`models/newsletter.js#recipientFilter`): actively subscribed to the
+ * newsletter, email not disabled, and paid-only when the newsletter's
+ * visibility is `paid`.
+ */
+export function getNewsletterRecipientFilter({
+  slug,
+  visibility,
+}: {
+  slug: string;
+  visibility?: string;
+}): string {
+  const filter = [`newsletters.slug:${slug}`, 'email_disabled:0'];
+
+  if (visibility === 'paid') {
+    filter.push(PAID_SEGMENT);
+  }
+
+  return filter.join('+');
+}
+
+/**
+ * Composes the full filter sent to the email service
+ * (`utils/publish-options.js#fullRecipientFilter`): the newsletter's audience
+ * filter, optionally AND-ed with the selected recipient filter.
+ */
+export function getFullRecipientFilter(
+  newsletterRecipientFilter: string,
+  recipientFilter: string | null | undefined,
+): string {
+  let filter = newsletterRecipientFilter;
+
+  if (recipientFilter) {
+    filter += `+(${recipientFilter})`;
+  }
+
+  return filter;
+}

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -16,7 +16,9 @@ import {
   useMemberActivityFeed,
   useMemberCount,
   useMemberLogout,
+  useMembersCount,
   useRemoveMemberEmailSuppression,
+  membersCountString,
 } from '../../../src/api/members';
 import type {
   MemberActivityEvent,
@@ -308,6 +310,177 @@ describe('members api', () => {
 
       expect(result.current).toBeUndefined();
       expect(mockFetch.calls).toHaveLength(0);
+    });
+  });
+
+  describe('useMembersCount', () => {
+    it('fetches the count for a filter via a limit=1 browse request', async () => {
+      const queryClient = createQueryClientWithCurrentUser([
+        { id: 'role-1', name: 'Administrator' },
+      ]);
+
+      await withMockFetch(
+        {
+          json: membersResponse(4289),
+        },
+        async (mockFetch) => {
+          const { result } = renderHookWithProviders(
+            () => useMembersCount('status:free,label:vip'),
+            { queryClient },
+          );
+
+          await waitFor(() => {
+            expect(result.current.count).toBe(4289);
+          });
+
+          expect(result.current.isLoading).toBe(false);
+
+          const url = new URL(mockFetch.calls[0][0].toString());
+          expect(url.pathname).toBe('/ghost/api/admin/members/');
+          expect(url.searchParams.get('filter')).toBe('status:free,label:vip');
+          expect(url.searchParams.get('order')).toBe('id');
+          expect(url.searchParams.get('limit')).toBe('1');
+          expect(url.searchParams.get('page')).toBe('1');
+        },
+      );
+    });
+
+    it('returns a null count without fetching for roles that cannot manage members', async () => {
+      const queryClient = createQueryClientWithCurrentUser([{ id: 'role-1', name: 'Editor' }]);
+
+      await withMockFetch({}, async (mockFetch) => {
+        const { result } = renderHookWithProviders(() => useMembersCount('status:free'), {
+          queryClient,
+        });
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(result.current).toEqual({ count: null, isLoading: false });
+        expect(mockFetch.calls).toHaveLength(0);
+      });
+    });
+
+    it('counts a nullish filter as 0 without fetching', async () => {
+      const queryClient = createQueryClientWithCurrentUser([
+        { id: 'role-1', name: 'Administrator' },
+      ]);
+
+      await withMockFetch({}, async (mockFetch) => {
+        const { result } = renderHookWithProviders(() => useMembersCount(null), { queryClient });
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(result.current).toEqual({ count: 0, isLoading: false });
+        expect(mockFetch.calls).toHaveLength(0);
+      });
+    });
+
+    it('resolves request errors to a count of 0', async () => {
+      const queryClient = createQueryClientWithCurrentUser([
+        { id: 'role-1', name: 'Administrator' },
+      ]);
+
+      await withMockFetch(
+        { json: { errors: [{ message: 'Nope' }] }, status: 500, ok: false },
+        async () => {
+          const { result } = renderHookWithProviders(() => useMembersCount('status:free'), {
+            queryClient,
+          });
+
+          await waitFor(() => {
+            expect(result.current).toEqual({ count: 0, isLoading: false });
+          });
+        },
+      );
+    });
+  });
+
+  describe('membersCountString', () => {
+    const admin = { roles: [{ name: 'Administrator' }] } as const;
+    const editor = { roles: [{ name: 'Editor' }] } as const;
+    const superEditor = { roles: [{ name: 'Super Editor' }] } as const;
+
+    it('pluralizes counts per recipient type', () => {
+      expect(membersCountString('status:free', { user: admin, count: 1 })).toBe('1 free member');
+      expect(membersCountString('status:free', { user: admin, count: 0 })).toBe('0 free members');
+      expect(membersCountString('status:-free', { user: admin, count: 5 })).toBe('5 paid members');
+      expect(membersCountString('status:free,status:-free', { user: admin, count: 2 })).toBe(
+        '2 members',
+      );
+      expect(membersCountString('label:vip', { user: admin, count: 3 })).toBe('3 members');
+      expect(membersCountString('status:free,label:vip', { user: admin, count: 3 })).toBe(
+        '3 members',
+      );
+    });
+
+    it('formats large counts with the locale separator', () => {
+      expect(membersCountString('status:free,status:-free', { user: admin, count: 12345 })).toBe(
+        `${(12345).toLocaleString()} members`,
+      );
+    });
+
+    it('falls back to descriptive copy for editors without a known count', () => {
+      expect(membersCountString('status:free', { user: editor })).toBe('all free members');
+      expect(membersCountString('status:-free', { user: editor })).toBe('all paid members');
+      expect(membersCountString('status:free,status:-free', { user: editor })).toBe('all members');
+      expect(membersCountString('', { user: editor })).toBe('all members');
+      expect(membersCountString('label:vip', { user: editor })).toBe('a custom members segment');
+    });
+
+    it('uses a known count for editors instead of the fallback copy', () => {
+      expect(membersCountString('status:free', { user: editor, count: 7 })).toBe('7 free members');
+    });
+
+    it('does not apply the editor fallback to super editors', () => {
+      // Super Editors can manage members, so they get real counts (an absent
+      // count reads as 0, matching the Ember fetch-error fallback).
+      expect(membersCountString('status:free', { user: superEditor })).toBe('0 free members');
+    });
+
+    it('switches to subscriber copy and strips the newsletter scope when there are multiple newsletters', () => {
+      const newsletter = {
+        name: 'Weekly',
+        recipientFilter: 'newsletters.slug:weekly+email_disabled:0',
+      };
+      const fullFilter = `${newsletter.recipientFilter}+(status:free)`;
+
+      expect(
+        membersCountString(fullFilter, {
+          user: editor,
+          newsletter,
+          hasMultipleNewsletters: true,
+        }),
+      ).toBe('all free subscribers of Weekly');
+
+      expect(
+        membersCountString(fullFilter, {
+          user: admin,
+          count: 9,
+          newsletter,
+          hasMultipleNewsletters: true,
+        }),
+      ).toBe('9 free subscribers of Weekly');
+    });
+
+    it('keeps member copy for a single newsletter', () => {
+      const newsletter = {
+        name: 'Weekly',
+        recipientFilter: 'newsletters.slug:weekly+email_disabled:0',
+      };
+      const fullFilter = `${newsletter.recipientFilter}+(status:free)`;
+
+      expect(
+        membersCountString(fullFilter, {
+          user: admin,
+          count: 9,
+          newsletter,
+          hasMultipleNewsletters: false,
+        }),
+      ).toBe('9 free members');
     });
   });
 

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -345,6 +345,22 @@ describe('members api', () => {
       );
     });
 
+    it('reports loading while the current user is unresolved', () => {
+      const queryClient = createTestQueryClient();
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(() => new Promise<Response>(() => {})) as typeof globalThis.fetch;
+
+      try {
+        const { result } = renderHookWithProviders(() => useMembersCount('status:free'), {
+          queryClient,
+        });
+
+        expect(result.current).toEqual({ count: null, isLoading: true });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it('returns a null count without fetching for roles that cannot manage members', async () => {
       const queryClient = createQueryClientWithCurrentUser([{ id: 'role-1', name: 'Editor' }]);
 
@@ -400,45 +416,34 @@ describe('members api', () => {
   });
 
   describe('membersCountString', () => {
-    const admin = { roles: [{ name: 'Administrator' }] } as const;
-    const editor = { roles: [{ name: 'Editor' }] } as const;
-    const superEditor = { roles: [{ name: 'Super Editor' }] } as const;
-
     it('pluralizes counts per recipient type', () => {
-      expect(membersCountString('status:free', { user: admin, count: 1 })).toBe('1 free member');
-      expect(membersCountString('status:free', { user: admin, count: 0 })).toBe('0 free members');
-      expect(membersCountString('status:-free', { user: admin, count: 5 })).toBe('5 paid members');
-      expect(membersCountString('status:free,status:-free', { user: admin, count: 2 })).toBe(
-        '2 members',
-      );
-      expect(membersCountString('label:vip', { user: admin, count: 3 })).toBe('3 members');
-      expect(membersCountString('status:free,label:vip', { user: admin, count: 3 })).toBe(
-        '3 members',
-      );
+      expect(membersCountString('status:free', { count: 1 })).toBe('1 free member');
+      expect(membersCountString('status:free', { count: 0 })).toBe('0 free members');
+      expect(membersCountString('status:-free', { count: 5 })).toBe('5 paid members');
+      expect(membersCountString('status:free,status:-free', { count: 2 })).toBe('2 members');
+      expect(membersCountString('label:vip', { count: 3 })).toBe('3 members');
+      expect(membersCountString('status:free,label:vip', { count: 3 })).toBe('3 members');
     });
 
     it('formats large counts with the locale separator', () => {
-      expect(membersCountString('status:free,status:-free', { user: admin, count: 12345 })).toBe(
+      expect(membersCountString('status:free,status:-free', { count: 12345 })).toBe(
         `${(12345).toLocaleString()} members`,
       );
     });
 
-    it('falls back to descriptive copy for editors without a known count', () => {
-      expect(membersCountString('status:free', { user: editor })).toBe('all free members');
-      expect(membersCountString('status:-free', { user: editor })).toBe('all paid members');
-      expect(membersCountString('status:free,status:-free', { user: editor })).toBe('all members');
-      expect(membersCountString('', { user: editor })).toBe('all members');
-      expect(membersCountString('label:vip', { user: editor })).toBe('a custom members segment');
+    it('falls back to descriptive copy when no count was fetched', () => {
+      expect(membersCountString('status:free')).toBe('all free members');
+      expect(membersCountString('status:-free')).toBe('all paid members');
+      expect(membersCountString('status:free,status:-free')).toBe('all members');
+      expect(membersCountString('')).toBe('all members');
+      expect(membersCountString('label:vip')).toBe('a custom members segment');
     });
 
-    it('uses a known count for editors instead of the fallback copy', () => {
-      expect(membersCountString('status:free', { user: editor, count: 7 })).toBe('7 free members');
-    });
-
-    it('does not apply the editor fallback to super editors', () => {
-      // Super Editors can manage members, so they get real counts (an absent
-      // count reads as 0, matching the Ember fetch-error fallback).
-      expect(membersCountString('status:free', { user: superEditor })).toBe('0 free members');
+    it('falls back to descriptive copy for a null count from useMembersCount', () => {
+      // null is useMembersCount's "role cannot browse members" value; it must
+      // never render as a zero count.
+      expect(membersCountString('status:free', { count: null })).toBe('all free members');
+      expect(membersCountString('label:vip', { count: null })).toBe('a custom members segment');
     });
 
     it('switches to subscriber copy and strips the newsletter scope when there are multiple newsletters', () => {
@@ -450,7 +455,6 @@ describe('members api', () => {
 
       expect(
         membersCountString(fullFilter, {
-          user: editor,
           newsletter,
           hasMultipleNewsletters: true,
         }),
@@ -458,7 +462,6 @@ describe('members api', () => {
 
       expect(
         membersCountString(fullFilter, {
-          user: admin,
           count: 9,
           newsletter,
           hasMultipleNewsletters: true,
@@ -475,7 +478,6 @@ describe('members api', () => {
 
       expect(
         membersCountString(fullFilter, {
-          user: admin,
           count: 9,
           newsletter,
           hasMultipleNewsletters: false,

--- a/apps/admin-x-framework/test/unit/utils/recipient-filter.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/recipient-filter.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EVERYONE_RECIPIENT_FILTER,
+  FREE_SEGMENT,
+  PAID_SEGMENT,
+  buildRecipientFilter,
+  getFullRecipientFilter,
+  getNewsletterRecipientFilter,
+  getRecipientType,
+  parseRecipientFilter,
+} from '../../../src/utils/recipient-filter';
+
+describe('recipient-filter', () => {
+  describe('parseRecipientFilter', () => {
+    it('returns empty segments for null, undefined and empty filters', () => {
+      for (const filter of [null, undefined, '']) {
+        expect(parseRecipientFilter(filter)).toEqual({
+          free: false,
+          paid: false,
+          base: [],
+          specific: [],
+        });
+      }
+    });
+
+    it('parses the base segments into checkbox state', () => {
+      expect(parseRecipientFilter(FREE_SEGMENT)).toEqual({
+        free: true,
+        paid: false,
+        base: [FREE_SEGMENT],
+        specific: [],
+      });
+
+      expect(parseRecipientFilter(PAID_SEGMENT)).toEqual({
+        free: false,
+        paid: true,
+        base: [PAID_SEGMENT],
+        specific: [],
+      });
+
+      expect(parseRecipientFilter(EVERYONE_RECIPIENT_FILTER)).toEqual({
+        free: true,
+        paid: true,
+        base: [FREE_SEGMENT, PAID_SEGMENT],
+        specific: [],
+      });
+    });
+
+    it('splits base and specific segments preserving order', () => {
+      expect(
+        parseRecipientFilter('label:vip,status:free,tier:gold,status:-free,label:beta'),
+      ).toEqual({
+        free: true,
+        paid: true,
+        base: [FREE_SEGMENT, PAID_SEGMENT],
+        specific: ['label:vip', 'tier:gold', 'label:beta'],
+      });
+    });
+
+    it('drops blank segments and deduplicates', () => {
+      expect(parseRecipientFilter('label:vip,,  ,status:free,label:vip,status:free')).toEqual({
+        free: true,
+        paid: false,
+        base: [FREE_SEGMENT],
+        specific: ['label:vip'],
+      });
+    });
+
+    it('classifies padded base segments as base without checking the checkbox, like Ember', () => {
+      // gh-members-recipient-select trims for base classification but tests
+      // checkbox state against the raw segment.
+      expect(parseRecipientFilter(' status:free,label:vip')).toEqual({
+        free: false,
+        paid: false,
+        base: [' status:free'],
+        specific: ['label:vip'],
+      });
+    });
+  });
+
+  describe('buildRecipientFilter', () => {
+    it('round-trips every recipient type', () => {
+      const filters = [
+        FREE_SEGMENT,
+        PAID_SEGMENT,
+        EVERYONE_RECIPIENT_FILTER,
+        'label:vip',
+        'tier:gold',
+        'status:free,label:vip,tier:gold',
+        'status:free,status:-free,label:vip,label:beta,tier:gold,tier:silver',
+        ' status:free,label:vip',
+      ];
+
+      for (const filter of filters) {
+        expect(buildRecipientFilter(parseRecipientFilter(filter))).toBe(filter);
+      }
+    });
+
+    it('rebuilds with base segments first, like the Ember select', () => {
+      expect(buildRecipientFilter(parseRecipientFilter('label:vip,status:free'))).toBe(
+        'status:free,label:vip',
+      );
+    });
+
+    it('returns null for an empty selection', () => {
+      expect(buildRecipientFilter({ base: [], specific: [] })).toBeNull();
+      expect(buildRecipientFilter(parseRecipientFilter(null))).toBeNull();
+    });
+
+    it('drops the paid segment when paid is unavailable', () => {
+      expect(
+        buildRecipientFilter(parseRecipientFilter(EVERYONE_RECIPIENT_FILTER), {
+          paidAvailable: false,
+        }),
+      ).toBe(FREE_SEGMENT);
+
+      expect(
+        buildRecipientFilter(parseRecipientFilter(PAID_SEGMENT), { paidAvailable: false }),
+      ).toBeNull();
+    });
+  });
+
+  describe('getRecipientType', () => {
+    it('classifies each filter shape', () => {
+      expect(getRecipientType(null)).toBe('none');
+      expect(getRecipientType(undefined)).toBe('none');
+      expect(getRecipientType('')).toBe('none');
+      expect(getRecipientType(FREE_SEGMENT)).toBe('free');
+      expect(getRecipientType(PAID_SEGMENT)).toBe('paid');
+      expect(getRecipientType(EVERYONE_RECIPIENT_FILTER)).toBe('all');
+      expect(getRecipientType('label:vip')).toBe('specific');
+      expect(getRecipientType('label:vip,tier:gold')).toBe('specific');
+      expect(getRecipientType('status:free,label:vip')).toBe('specific');
+      expect(getRecipientType('status:-free,tier:gold')).toBe('specific');
+    });
+
+    it('classifies both base segments as all even alongside specific segments', () => {
+      // Substring semantics from the Ember publish flow.
+      expect(getRecipientType('status:free,status:-free,label:vip')).toBe('all');
+      expect(getRecipientType('label:vip,status:free,status:-free')).toBe('all');
+    });
+  });
+
+  describe('getNewsletterRecipientFilter', () => {
+    it('scopes to newsletter subscribers with email enabled', () => {
+      expect(getNewsletterRecipientFilter({ slug: 'weekly' })).toBe(
+        'newsletters.slug:weekly+email_disabled:0',
+      );
+    });
+
+    it('adds the paid segment for paid-visibility newsletters', () => {
+      expect(getNewsletterRecipientFilter({ slug: 'weekly', visibility: 'paid' })).toBe(
+        'newsletters.slug:weekly+email_disabled:0+status:-free',
+      );
+      expect(getNewsletterRecipientFilter({ slug: 'weekly', visibility: 'members' })).toBe(
+        'newsletters.slug:weekly+email_disabled:0',
+      );
+    });
+  });
+
+  describe('getFullRecipientFilter', () => {
+    const newsletterFilter = 'newsletters.slug:weekly+email_disabled:0';
+
+    it('returns the newsletter filter alone when there is no recipient filter', () => {
+      expect(getFullRecipientFilter(newsletterFilter, null)).toBe(newsletterFilter);
+      expect(getFullRecipientFilter(newsletterFilter, undefined)).toBe(newsletterFilter);
+      expect(getFullRecipientFilter(newsletterFilter, '')).toBe(newsletterFilter);
+    });
+
+    it('ANDs the recipient filter onto the newsletter filter', () => {
+      expect(getFullRecipientFilter(newsletterFilter, EVERYONE_RECIPIENT_FILTER)).toBe(
+        'newsletters.slug:weekly+email_disabled:0+(status:free,status:-free)',
+      );
+      expect(getFullRecipientFilter(newsletterFilter, 'label:vip,tier:gold')).toBe(
+        'newsletters.slug:weekly+email_disabled:0+(label:vip,tier:gold)',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The Ember admin handles email recipient filters in four separate places — `utils/publish-options.js`, `components/gh-members-recipient-select.js`, `components/editor/modals/publish-flow.js` and `services/members-count-cache.js` — each re-implementing the same comma-split parsing, rebuilding, classification, or count fetching. The React editor needs the same behavior, so this consolidates it into `@tryghost/admin-x-framework` with no consumers changed yet.

### `src/utils/recipient-filter.ts` (pure functions)

- `parseRecipientFilter` — splits a filter into base (`status:free` / `status:-free`) and specific (`label:…` / `tier:…`) segments with the exact `gh-members-recipient-select` semantics: plain comma split, trim-based base classification, checkbox state from exact raw membership, blanks dropped, first-occurrence dedupe.
- `buildRecipientFilter` — rebuilds base-first, deduplicated, `null` for an empty selection, with the Stripe-disabled `paidAvailable: false` drop of the paid segment.
- `getRecipientType` — the publish-flow classification (`none`/`free`/`paid`/`all`/`specific`), including its substring-based "all" check.
- `getNewsletterRecipientFilter` — the newsletter model's audience filter (`newsletters.slug:<slug>+email_disabled:0`, plus `status:-free` for paid-visibility newsletters).
- `getFullRecipientFilter` — the publish-options composition (`<newsletter filter>+(<recipient filter>)`).

Quirks are preserved bug-for-bug (e.g. a padded `" status:free"` segment is classified as base but doesn't check the free checkbox and round-trips verbatim) and noted in constraint comments where non-obvious.

### `src/api/members.ts`

- `useMembersCount(filter)` — the members-count-cache/fetcher behavior on react-query: a members browse request with `filter`, `order=id`, `limit=1`, `page=1` reading `meta.pagination.total`. `staleTime` is set to an explicit 60s to match the Ember cache's TTL (the framework default is 5 minutes, which is too stale for publish-flow counts). As in Ember: roles that cannot manage members get `count: null` with no request, a nullish filter counts as 0 with no request, and request errors resolve to 0 without an error toast. While the current user is still loading the hook reports `{count: null, isLoading: true}` so callers can distinguish that from a role that cannot browse members.
- `membersCountString(filter, {count, newsletter, hasMultipleNewsletters})` — a pure port of the count copy (`"1,234 free members"`, `"all paid subscribers of Weekly"`, `"a custom members segment"`). The `count` option accepts `number | null | undefined`: a number renders numeric copy, while `null` (role cannot browse members, pairing with `useMembersCount`'s null) and `undefined` (not fetched) render the descriptive fallback copy — an absent count never renders as "0 members". In Ember only plain Editors got the fallback and every other role fetched a count on the spot; a pure function can't fetch, so the seam is the count itself and no role predicate is needed.

## Verification

- `pnpm lint` in `apps/admin-x-framework`
- `pnpm test:types` in `apps/admin-x-framework`
- `pnpm test:unit` in `apps/admin-x-framework` — 47 files / 578 tests passing, including new coverage for filter round-trips across every recipient type, multi-label+tier combinations, the `status:free,status:-free` ≡ everyone case, the count hook's request shape, current-user loading state and role/error/nullish-filter behavior, and the role-fallback strings.
