### PR TITLE
Added editor e2e coverage for session expiry and scheduled-post editing

### DIFF
--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -37,7 +37,7 @@ class ReAuthenticateModal extends BasePage {
     super(page);
 
     this.modal = page.locator('[data-test-modal="re-authenticate"]');
-    this.passwordInput = this.modal.locator('input[name="password"]');
+    this.passwordInput = this.modal.getByLabel('Your password');
     this.signInButton = this.modal.getByRole('button', { name: /Sign in/ });
   }
 

--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -28,6 +28,25 @@ class SettingsMenu extends BasePage {
   }
 }
 
+class ReAuthenticateModal extends BasePage {
+  readonly modal: Locator;
+  readonly passwordInput: Locator;
+  readonly signInButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.modal = page.locator('[data-test-modal="re-authenticate"]');
+    this.passwordInput = this.modal.locator('input[name="password"]');
+    this.signInButton = this.modal.getByRole('button', { name: /Sign in/ });
+  }
+
+  async signIn(password: string): Promise<void> {
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+}
+
 class PublishFlow extends BasePage {
   readonly publishButton: Locator;
   readonly publishTypeSetting: Locator;
@@ -144,6 +163,7 @@ export class PostEditorPage extends AdminPage {
   readonly backButton: Locator;
 
   readonly settingsMenu: SettingsMenu;
+  readonly reauthenticateModal: ReAuthenticateModal;
 
   constructor(page: Page) {
     super(page);
@@ -164,6 +184,20 @@ export class PostEditorPage extends AdminPage {
     this.backButton = page.locator('[data-test-breadcrumb]');
 
     this.settingsMenu = new SettingsMenu(page);
+    this.reauthenticateModal = new ReAuthenticateModal(page);
+  }
+
+  /**
+   * The id of the post currently open in the editor. Waits for the URL to
+   * carry an id first: a new draft only gets one after its first save.
+   */
+  async getPostId(): Promise<string> {
+    await this.page.waitForURL(/#\/editor\/post\/[0-9a-f]{24}/);
+    const match = this.page.url().match(/#\/editor\/post\/([0-9a-f]{24})/);
+    if (!match) {
+      throw new Error(`No post id in editor URL: ${this.page.url()}`);
+    }
+    return match[1];
   }
 
   async gotoPost(postId: string): Promise<void> {
@@ -201,6 +235,10 @@ export class PostEditorPage extends AdminPage {
 
   async appendToBody(text: string): Promise<void> {
     await this.lexicalEditor.click();
+    // The click can land the caret mid-content; select all and collapse the
+    // selection so the text is genuinely appended at the end
+    await this.page.keyboard.press('ControlOrMeta+a');
+    await this.page.keyboard.press('ArrowRight');
     await this.page.keyboard.type(text);
   }
 

--- a/e2e/tests/admin/posts/editor-session-expiry.test.ts
+++ b/e2e/tests/admin/posts/editor-session-expiry.test.ts
@@ -24,6 +24,23 @@ test.describe('Ghost Admin - Editor session expiry', () => {
     // The draft autosave assigns the post an id and moves the URL onto it
     const postId = await editor.getPostId();
 
+    // Typing the draft can leave content unsaved with no autosave pending
+    // (performs during the in-flight create are dropped) or with a debounced
+    // autosave still to come. Flush deterministically before expiring the
+    // session - type a marker and wait for the save that carries it - so the
+    // 401 comes from the post-expiry typing below, not a stale autosave
+    const flushMarker = 'Flushed before expiry.';
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === 'PUT' &&
+          response.url().includes(`/ghost/api/admin/posts/${postId}/`) &&
+          response.status() === 200 &&
+          (response.request().postData() ?? '').includes(flushMarker),
+      ),
+      editor.appendToBody(` ${flushMarker}`),
+    ]);
+
     // Expire the session server-side while the editor stays open
     const logoutResponse = await page.request.delete('/ghost/api/admin/session/');
     expect(logoutResponse.ok()).toBeTruthy();
@@ -62,6 +79,7 @@ test.describe('Ghost Admin - Editor session expiry', () => {
       posts: [post],
     } = await postResponse.json();
     expect(post.status).toBe('draft');
+    expect(post.lexical).toContain('Written before the session expired.');
     expect(post.lexical).toContain('Written after the session expired.');
     expect(post.lexical).toContain('Written after re-authenticating.');
   });

--- a/e2e/tests/admin/posts/editor-session-expiry.test.ts
+++ b/e2e/tests/admin/posts/editor-session-expiry.test.ts
@@ -1,0 +1,68 @@
+import { PostEditorPage, PostsPage } from '@/admin-pages';
+import { expect, test } from '@/helpers/playwright';
+
+test.describe('Ghost Admin - Editor session expiry', () => {
+  test('save recovers through re-authentication after the session expires', async ({
+    page,
+    ghostAccountOwner,
+  }) => {
+    // Draft creation, expiry, re-authentication and a second autosave do not
+    // fit the default local budget
+    test.setTimeout(60000);
+
+    const postData = {
+      title: `session-expiry-${Date.now()}`,
+      body: 'Written before the session expired.',
+    };
+
+    const postsPage = new PostsPage(page);
+    await postsPage.goto();
+    await postsPage.newPostButton.click();
+
+    const editor = new PostEditorPage(page);
+    await editor.createDraft(postData);
+    // The draft autosave assigns the post an id and moves the URL onto it
+    const postId = await editor.getPostId();
+
+    // Expire the session server-side while the editor stays open
+    const logoutResponse = await page.request.delete('/ghost/api/admin/session/');
+    expect(logoutResponse.ok()).toBeTruthy();
+
+    // Typing more triggers the draft autosave, which now fails authentication
+    await editor.appendToBody(' Written after the session expired.');
+
+    // The editor must not redirect away and lose content; it keeps the post
+    // on screen and asks for the password instead
+    await expect(editor.reauthenticateModal.modal).toBeVisible({ timeout: 15000 });
+    expect(page.url()).toContain(`/editor/post/${postId}`);
+    await expect(editor.lexicalEditor).toContainText('Written after the session expired.');
+
+    // Re-authenticating closes the modal and restores the session
+    await editor.reauthenticateModal.signIn(ghostAccountOwner.password);
+    await expect(editor.reauthenticateModal.modal).toBeHidden();
+
+    // Saving works again: the next edit autosaves successfully
+    const [saveResponse] = await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === 'PUT' &&
+          response.url().includes(`/ghost/api/admin/posts/${postId}/`) &&
+          response.status() === 200,
+      ),
+      editor.appendToBody(' Written after re-authenticating.'),
+    ]);
+    expect(saveResponse.status()).toBe(200);
+
+    // Nothing typed across the expiry was lost
+    const postResponse = await page.request.get(
+      `/ghost/api/admin/posts/${postId}/?formats=lexical`,
+    );
+    expect(postResponse.status()).toBe(200);
+    const {
+      posts: [post],
+    } = await postResponse.json();
+    expect(post.status).toBe('draft');
+    expect(post.lexical).toContain('Written after the session expired.');
+    expect(post.lexical).toContain('Written after re-authenticating.');
+  });
+});

--- a/e2e/tests/admin/posts/scheduled-post-editing.test.ts
+++ b/e2e/tests/admin/posts/scheduled-post-editing.test.ts
@@ -79,6 +79,7 @@ test.describe('Ghost Admin - Scheduled post editing', () => {
     const updated = await getPost(page, postId);
     expect(updated.status).toBe('scheduled');
     expect(updated.published_at).toBe(scheduled.published_at);
+    expect(updated.lexical).toContain('Scheduled post body.');
     expect(updated.lexical).toContain('Edited while scheduled.');
   });
 

--- a/e2e/tests/admin/posts/scheduled-post-editing.test.ts
+++ b/e2e/tests/admin/posts/scheduled-post-editing.test.ts
@@ -1,0 +1,125 @@
+import { Page } from '@playwright/test';
+import { PostEditorPage, PostsPage } from '@/admin-pages';
+import { createPostFactory } from '@/data-factory';
+import { expect, test } from '@/helpers/playwright';
+
+// Server-side: config times.cannotScheduleAPostBeforeInMinutes (default 2),
+// enforced only when published_at changes.
+const MIN_SCHEDULE_LEAD_MS = 2 * 60 * 1000;
+
+async function getPost(page: Page, postId: string) {
+  const response = await page.request.get(`/ghost/api/admin/posts/${postId}/?formats=lexical`);
+  expect(response.status()).toBe(200);
+  const { posts } = await response.json();
+  return posts[0];
+}
+
+function waitForPostSave(page: Page, postId: string) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' &&
+      response.url().includes(`/ghost/api/admin/posts/${postId}/`) &&
+      response.status() === 200,
+  );
+}
+
+test.describe('Ghost Admin - Scheduled post editing', () => {
+  test('keeps the schedule and publish time when content is edited', async ({ page }) => {
+    // Scheduling via the publish flow plus a reopen of the post does not fit
+    // the default local budget
+    test.setTimeout(60000);
+
+    // ~25h out: always beyond the minimum lead time, and always on a
+    // different calendar day than the picker default (now + 10 minutes) so
+    // filling the date input observably changes the schedule summary
+    const target = new Date(Date.now() + 25 * 60 * 60 * 1000);
+    const isoTarget = target.toISOString();
+    const scheduleDate = isoTarget.slice(0, 10);
+    const scheduleTime = isoTarget.slice(11, 16);
+
+    const postsPage = new PostsPage(page);
+    await postsPage.goto();
+    await postsPage.newPostButton.click();
+
+    const editor = new PostEditorPage(page);
+    await editor.createDraft({
+      title: `scheduled-edit-${Date.now()}`,
+      body: 'Scheduled post body.',
+    });
+    // The draft autosave assigns the post an id and moves the URL onto it
+    const postId = await editor.getPostId();
+
+    await editor.publishFlow.open();
+    await editor.publishFlow.schedule({ date: scheduleDate, time: scheduleTime });
+    await Promise.all([waitForPostSave(page, postId), editor.publishFlow.confirm()]);
+
+    // Completing the publish flow navigates to the posts list with a success
+    // modal, so editing means closing it and reopening the post
+    await editor.publishFlow.close();
+    await editor.gotoPost(postId);
+
+    await expect(editor.postStatus.first()).toContainText('Scheduled');
+
+    // A schedule set through the picker round-trips without validation
+    // errors: the editor zeroes milliseconds before saving (the API only
+    // stores whole seconds), so re-saves send back an identical published_at
+    // and cannot trip date-changed validation. Seconds are not zeroed - they
+    // are inherited from the moment scheduling was toggled - so pin the
+    // picked minute and the zeroed milliseconds only
+    const scheduled = await getPost(page, postId);
+    expect(scheduled.status).toBe('scheduled');
+    expect(scheduled.published_at).toMatch(
+      new RegExp(`^${scheduleDate}T${scheduleTime}:\\d{2}\\.000Z$`),
+    );
+
+    await editor.appendToBody(' Edited while scheduled.');
+    await Promise.all([waitForPostSave(page, postId), editor.publishSaveButton.click()]);
+
+    await expect(editor.postStatus.first()).toContainText('Scheduled');
+    const updated = await getPost(page, postId);
+    expect(updated.status).toBe('scheduled');
+    expect(updated.published_at).toBe(scheduled.published_at);
+    expect(updated.lexical).toContain('Edited while scheduled.');
+  });
+
+  test('saves edits and unschedules close to the publish time', async ({ page }) => {
+    // Waiting into the minimum-lead window takes real clock time
+    test.setTimeout(120000);
+
+    const postFactory = createPostFactory(page.request);
+    // Far enough out to pass creation validation, close enough that the wait
+    // into the minimum-lead window stays short. Whole seconds only: the API
+    // stores second precision
+    const publishAt = new Date(Math.ceil(Date.now() / 1000) * 1000 + 150 * 1000);
+    const post = await postFactory.create({
+      title: `near-publish-edit-${Date.now()}`,
+      status: 'scheduled',
+      published_at: publishAt,
+    });
+
+    const editor = new PostEditorPage(page);
+    await editor.gotoPost(post.id);
+    await expect(editor.postStatus.first()).toContainText('Scheduled');
+
+    // Enter the window in which a *changed* publish time would be rejected
+    await expect
+      .poll(() => Date.now(), { timeout: 60000 })
+      .toBeGreaterThan(publishAt.getTime() - MIN_SCHEDULE_LEAD_MS);
+
+    await editor.appendToBody(' Last minute edit.');
+    // Re-saving with an unchanged publish time succeeds inside the window:
+    // the minimum lead is enforced only when published_at changes
+    await Promise.all([waitForPostSave(page, post.id), editor.publishSaveButton.click()]);
+
+    const updated = await getPost(page, post.id);
+    expect(updated.status).toBe('scheduled');
+    expect(updated.published_at).toBe(publishAt.toISOString());
+    expect(updated.lexical).toContain('Last minute edit.');
+
+    // Unscheduling still works this close to the publish time
+    await editor.revertToDraft();
+    await expect(editor.postStatus.first()).toContainText('Draft');
+    const reverted = await getPost(page, post.id);
+    expect(reverted.status).toBe('draft');
+  });
+});


### PR DESCRIPTION
The editor's data-loss-critical flows had no browser e2e coverage. These two specs pin the current behavior of the Ember editor so it cannot regress silently.

## Session expiry save recovery (`e2e/tests/admin/posts/editor-session-expiry.test.ts`)

Creates a draft, destroys the server-side session (`DELETE /ghost/api/admin/session/` through the page's own request context), then keeps typing so the draft autosave fails auth. Asserts:

- the editor does not redirect away or reload: the URL stays on the post and the typed content stays in the editor
- the re-authenticate modal (`data-test-modal="re-authenticate"`) appears
- after re-entering the password, the next edit autosaves successfully (`PUT` 200) and the post fetched via the Admin API contains everything typed before, during, and after the expiry

One nuance discovered while writing this: the re-auth-retry in `controllers/lexical-editor.js` (`autosaveTask.perform()` after the modal closes) is dropped when the failed save originated from the autosave itself, because `autosaveTask` is a drop-task that is still running at that point. The spec therefore pins the user-visible contract - no content loss and saving resumes on the next edit - rather than an immediate automatic retry.

## Scheduled post editing (`e2e/tests/admin/posts/scheduled-post-editing.test.ts`)

- schedules a post through the publish flow picker, reopens it (completing the publish flow intentionally navigates to the posts list with a success modal), edits the body and saves via Update; asserts it stays `scheduled` with an unchanged `published_at` and the edit persisted
- asserts the picker round-trips without validation errors: milliseconds are zeroed client-side before save. Seconds are *not* zeroed - they are inherited from the moment scheduling was toggled - so the assertion pins the picked minute plus `.000Z`
- creates a scheduled post via the API ~2.5 minutes out, waits (polling the clock, no fixed sleeps) until inside the 2-minute minimum-lead window, then edits and saves; asserts the re-save of an unchanged `published_at` succeeds inside the window (the lead time is only enforced when the date changes), and that unscheduling back to draft still works that close to publish time

## Page object changes

`post-editor-page.ts` gains a `ReAuthenticateModal` section (existing `data-test` hooks - no template changes were needed) and a `getPostId()` helper that waits for the editor URL to carry the id after the first save. `appendToBody()` now collapses the selection to the end of the document before typing, so the appended text can't be spliced into the middle of existing content by the click position.

## How I ran them

Dev-mode e2e against the docker dev environment (`pnpm dev` at the repo root, then from `e2e/`):

```
pnpm test tests/admin/posts/editor-session-expiry.test.ts tests/admin/posts/scheduled-post-editing.test.ts
```

Both specs pass (3 tests, ~1.3m), plus `pnpm lint` and `pnpm test:types` in the `e2e` workspace. `tests/admin/posts/post-updates-and-list.test.ts` (the one existing `appendToBody` consumer) was re-run as well; its `updates a published post` test passes with the change, and the posts-list flakes seen locally in that file reproduce without this diff.