### PR TITLE
Changed the field type catalog to separate structure from validation

### DIFF
--- a/packages/metafield-types/README.md
+++ b/packages/metafield-types/README.md
@@ -21,6 +21,19 @@ imports in `src/` must carry an explicit extension; write the real `.ts` one —
 `import {x} from './x.ts'` — and `tsc` rewrites it to `.js` on emit
 (`rewriteRelativeImportExtensions`).
 
+`./structure` is the half of the catalog a renderer needs — which parts a field type
+has, and what each holds — and it stands apart from `./index` so that importing it
+costs a bundle almost nothing. The rules in `./index` are built on zod, some
+seventeen kilobytes gzipped that a renderer never runs. Portal imports `./structure`
+and loads on every page view of every themed site, so the difference reaches every
+visitor of every Ghost site.
+
+That holds only while `./structure` depends on nothing, and no bundler enforces it: an
+import added here would ship to every one of those visitors with every check still
+green. So **`src/structure.ts` must not import anything** — an ESLint rule enforces
+it, relative imports included, since anything reached through one is bundled too.
+Whatever needs an import belongs in `./index`, which is free to use them.
+
 `ghost/core` is CommonJS but consumes this package via `require()`, which works
 on Ghost's Node version (22.13+/24) through Node's `require(esm)` support. That
 support has one hard constraint: **no top-level `await`** anywhere in this

--- a/packages/metafield-types/eslint.config.mjs
+++ b/packages/metafield-types/eslint.config.mjs
@@ -1,3 +1,30 @@
 import { nodeLibConfig } from '@internal/cfg-eslint';
 
-export default nodeLibConfig();
+// `./structure` exists so that a renderer can have the shape of a field type without the
+// rules for validating one. Portal is the renderer that made it worth doing: it loads on
+// every page view of every themed site, and the rules next door are built on zod, which
+// costs about seventeen kilobytes gzipped that a renderer never runs.
+//
+// Nothing in a bundler holds that. `./structure` is cheap only for as long as it depends
+// on nothing, and one import here — or one reached through it — is enough to put whatever
+// it pulls in front of every visitor to every Ghost site, with every check still green.
+// So the constraint is stated as a rule rather than left to whoever edits the file next.
+const structureDependsOnNothing = {
+  files: ['src/structure.ts'],
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['*', '**', './*', '../*'],
+            message:
+              'structure.ts must depend on nothing — Portal bundles it on every page view of every Ghost site, so whatever this reaches ships to every visitor. Anything needing an import belongs in index.ts.',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export default nodeLibConfig({ extraBlocks: [structureDependsOnNothing] });

--- a/packages/metafield-types/package.json
+++ b/packages/metafield-types/package.json
@@ -27,6 +27,11 @@
       "types": "./build/csv.d.ts",
       "default": "./build/csv.js"
     },
+    "./structure": {
+      "source": "./src/structure.ts",
+      "types": "./build/structure.d.ts",
+      "default": "./build/structure.js"
+    },
     "./identity": {
       "source": "./src/identity.ts",
       "types": "./build/identity.d.ts",

--- a/packages/metafield-types/src/index.ts
+++ b/packages/metafield-types/src/index.ts
@@ -1,4 +1,20 @@
 import { z } from 'zod';
+import { FIELD_PARTS, FIELD_TYPE_IDS, type FieldType, type PartType } from './structure.js';
+
+// Re-exported so a caller that needs both halves still has one import. The split is
+// about what a bundle pays for, not about where the catalog lives.
+export {
+  FIELD_KINDS,
+  FIELD_PARTS,
+  FIELD_TYPE_IDS,
+  PART_TYPE_IDS,
+  partTypesOf,
+  subFieldsOf,
+  type FieldKind,
+  type FieldType,
+  type PartsOf,
+  type PartType,
+} from './structure.js';
 
 /**
  * The shared catalog of member metafield types.
@@ -55,9 +71,6 @@ import { z } from 'zod';
  * collection form, which cannot reach admin's packages, moves the labels here.
  */
 
-/** The source for the union type, the zod enum and the `FIELD_TYPES` keys alike. */
-export const FIELD_TYPE_IDS = ['short_text', 'long_text', 'address'] as const;
-export type FieldType = (typeof FIELD_TYPE_IDS)[number];
 export const FieldTypeSchema = z.enum(FIELD_TYPE_IDS);
 
 /**
@@ -77,20 +90,6 @@ export const MEMBER_ACCESS = {
   read: 'read',
   write: 'write',
 } as const satisfies Record<MemberAccess, MemberAccess>;
-
-/**
- * What kind of thing a type's value is, as anything comparing values needs to know.
- *
- * Coarser than the type: `short_text` and `long_text` are both text, and differ only in how
- * much of it. This is the level at which a value can be ordered, matched or grouped, so it
- * is what a filter, a sort or an export reads to decide how to treat a value — without
- * either of them enumerating the types themselves.
- *
- * Deliberately not presentation: it says a value is a date, not that its operator is called
- * "is before". Naming the operators stays with whoever renders them.
- */
-export const FIELD_KINDS = ['text', 'date', 'number', 'record'] as const;
-export type FieldKind = (typeof FIELD_KINDS)[number];
 
 /**
  * Bytes, not characters, because MySQL TEXT holds 65,535 of them: a character bound would
@@ -151,17 +150,11 @@ export const PART_TYPES = {
   country_code: text()
     .regex(/^[A-Za-z]{2}$/, { error: 'Enter a 2-letter country code, like US.' })
     .toUpperCase(),
-} satisfies Record<string, PartSchema>;
+  // Every part type declared next door needs a rule here, and nothing here may
+  // invent one that is not declared there.
+} satisfies Record<PartType, PartSchema>;
 
-export type PartType = keyof typeof PART_TYPES;
-export const PART_TYPE_IDS = Object.keys(PART_TYPES) as PartType[];
-
-interface TypedPart<T extends PartType = PartType> {
-  type: T;
-  schema: (typeof PART_TYPES)[T];
-}
-
-const part = <T extends PartType>(type: T): TypedPart<T> => ({ type, schema: PART_TYPES[type] });
+const partSchemas: Record<PartType, PartSchema> = PART_TYPES;
 
 /**
  * A part as a write may name it: absent, empty, or a value of its own kind.
@@ -174,15 +167,26 @@ const clearable = <T extends PartSchema>(schema: T) =>
     .pipe(z.union([z.literal(''), schema]))
     .optional();
 
+/** The types whose value is made of parts, rather than being a single thing. */
+type RecordFieldType = {
+  [T in FieldType]: (typeof FIELD_PARTS)[T] extends null ? never : T;
+}[FieldType];
+
+/**
+ * The shape a record type's schema is built from: its declared parts, each carrying the
+ * rule for what that part holds. Keyed off `./structure`, so the schema a value is parsed
+ * against admits exactly the parts a renderer would draw.
+ */
+type PartShape<T extends RecordFieldType> = {
+  [K in keyof (typeof FIELD_PARTS)[T]]: ReturnType<
+    typeof clearable<(typeof PART_TYPES)[(typeof FIELD_PARTS)[T][K] & PartType]>
+  >;
+};
+
 export interface FieldTypeDefinition {
   /** What kind of value this is, for anything that has to compare one. */
-  kind: FieldKind;
+  kind: import('./structure.js').FieldKind;
   value: z.ZodType;
-  /**
-   * A record type's parts, in declaration order. Each part's own rule, and nothing
-   * about how a write may name it: validate against `value`, never against these.
-   */
-  fields?: Record<string, TypedPart>;
 }
 
 /**
@@ -204,12 +208,18 @@ function defineFieldTypes<D extends Record<FieldType, FieldTypeDefinition>>(decl
  * explicitly undefined survives parsing as a key holding undefined, and a bare presence
  * check would let `{line1: undefined}` through as if it named something.
  */
-function record<F extends Record<string, TypedPart>>(fields: F, { error }: { error: string }) {
-  // Restated for the type system, which loses the key-to-schema mapping through
-  // `Object.fromEntries`; without it every type built on a record infers as `unknown`.
+function record<T extends RecordFieldType>(type: T, { error }: { error: string }) {
+  // The parts, and what each holds, are declared in `./structure`; this turns each
+  // into the rule a write must satisfy. Reading them from there is what stops the
+  // structure a renderer draws and the rules a server enforces from drifting apart.
+  const declared = FIELD_PARTS[type] as Readonly<Record<string, PartType>>;
+
+  // Restated for the type system, which loses the key-to-part mapping through
+  // `Object.fromEntries`. Without it the parsed value widens to a string-keyed record,
+  // and a caller could name a part that compiles and is then refused at runtime.
   const shape = Object.fromEntries(
-    Object.entries(fields).map(([key, declared]) => [key, clearable(declared.schema)]),
-  ) as { [K in keyof F]: ReturnType<typeof clearable<F[K]['schema']>> };
+    Object.entries(declared).map(([key, partType]) => [key, clearable(partSchemas[partType])]),
+  ) as PartShape<T>;
 
   // Strict, so a part nobody declared is refused rather than dropped. That refusal keeps
   // zod's wording, which names the offending key.
@@ -217,7 +227,7 @@ function record<F extends Record<string, TypedPart>>(fields: F, { error }: { err
     .strictObject(shape)
     .refine((parts) => Object.values(parts).some((entry) => typeof entry === 'string'), { error });
 
-  return { kind: 'record' as const, value, fields };
+  return { kind: 'record' as const, value };
 }
 
 export const FIELD_TYPES = defineFieldTypes({
@@ -231,17 +241,7 @@ export const FIELD_TYPES = defineFieldTypes({
   // and the name is often not the account name — gift subscriptions, workplace
   // deliveries, c/o. A site that needs one keeps it in a field of its own, which is
   // also how Stripe hands it back: beside the address rather than inside it.
-  address: record(
-    {
-      line1: part('short_text'),
-      line2: part('short_text'),
-      city: part('short_text'),
-      state: part('short_text'),
-      postal_code: part('postal_code'),
-      country: part('country_code'),
-    },
-    { error: 'Enter at least one part of the address.' },
-  ),
+  address: record('address', { error: 'Enter at least one part of the address.' }),
 });
 
 /** Named for the admin types built on it, which speak of an address rather than a record. */
@@ -255,43 +255,3 @@ export type Address = z.infer<typeof AddressValue>;
  * anyone remembering to.
  */
 export type FieldValue = { [T in FieldType]: z.infer<(typeof FIELD_TYPES)[T]['value']> }[FieldType];
-
-/**
- * The parts a record type declares, or never for a type whose value is a single thing.
- *
- * Distributed over `T`, so a caller holding a type it only knows as `FieldType` gets every
- * part any type declares rather than the empty intersection of all of them.
- */
-export type PartsOf<T extends FieldType> = T extends FieldType
-  ? (typeof FIELD_TYPES)[T] extends { fields: infer F }
-    ? Extract<keyof F, string>
-    : never
-  : never;
-
-/**
- * The parts of a record type in declaration order, or null for a type with none.
- *
- * Typed to the parts the caller's type declares, so a caller holding one of these can
- * index a value of that type without restating which parts exist.
- */
-export function subFieldsOf<T extends FieldType>(type: T): PartsOf<T>[] | null {
-  // Through the interface, not the literal: a type with no parts has no `fields` key.
-  // Optional because a caller built against an older catalog than the server it talks to
-  // reaches here with a type this build has never heard of, which reads as no parts.
-  const definition: FieldTypeDefinition | undefined = FIELD_TYPES[type];
-  // The keys are `PartsOf<T>` by construction: `fields` is the object it reads `keyof` from.
-  return definition?.fields ? (Object.keys(definition.fields) as PartsOf<T>[]) : null;
-}
-
-/** Each part's declared type, keyed by part; null for a type with no parts, and for one this build has never heard of. */
-export function partTypesOf<T extends FieldType>(type: T): Record<PartsOf<T>, PartType> | null {
-  const definition: FieldTypeDefinition | undefined = FIELD_TYPES[type];
-
-  if (!definition?.fields) {
-    return null;
-  }
-
-  return Object.fromEntries(
-    Object.entries(definition.fields).map(([key, declared]) => [key, declared.type]),
-  ) as Record<PartsOf<T>, PartType>;
-}

--- a/packages/metafield-types/src/structure.ts
+++ b/packages/metafield-types/src/structure.ts
@@ -1,0 +1,96 @@
+/**
+ * What a field type is made of, with no opinion on what a valid value looks like.
+ *
+ * This is the half of the catalog a renderer needs. Drawing an address means knowing
+ * it has six parts, in that order, and that the last of them holds a country code —
+ * nothing about lengths, formats, or what happens when one is left blank.
+ *
+ * It is separate from `./index` because that half is built out of zod, and zod is
+ * sixty-odd kilobytes. Ghost's server enforces the rules and can afford them; Portal
+ * only draws the inputs, and it loads on every page view of every themed site. Split
+ * this way a renderer imports well under a kilobyte and still gets the types.
+ *
+ * The two halves cannot drift, because the schemas are built from these declarations
+ * rather than beside them: adding a part here without a rule in `./index` fails to
+ * compile.
+ */
+
+/** The source for the union type, the zod enum and the `FIELD_TYPES` keys alike. */
+export const FIELD_TYPE_IDS = ['short_text', 'long_text', 'address'] as const;
+export type FieldType = (typeof FIELD_TYPE_IDS)[number];
+
+/**
+ * What kind of thing a type's value is, as anything comparing values needs to know.
+ *
+ * Coarser than the type: `short_text` and `long_text` are both text, and differ only in
+ * how much of it. This is the level at which a value can be ordered, matched or grouped,
+ * so it is what a filter, a sort or an export reads to decide how to treat a value —
+ * without either of them enumerating the types themselves.
+ *
+ * Deliberately not presentation: it says a value is a date, not that its operator is
+ * called "is before". Naming the operators stays with whoever renders them.
+ */
+export const FIELD_KINDS = ['text', 'date', 'number', 'record'] as const;
+export type FieldKind = (typeof FIELD_KINDS)[number];
+
+/**
+ * The types a composite's parts can declare. A country code and a postal code both
+ * store short text, but they are different things — the part's type is what a control
+ * or a filter dispatches on, the way a field's own type is for a scalar.
+ */
+export const PART_TYPE_IDS = ['short_text', 'postal_code', 'country_code'] as const;
+export type PartType = (typeof PART_TYPE_IDS)[number];
+
+/**
+ * Which parts each type has, in the order they are shown, and what each part holds.
+ * `null` for a type whose value is a single thing.
+ *
+ * An address is a delivery address, modeled on Stripe's Address object. Who the parcel
+ * is addressed to is not here: a parcel needs a name as well as an address, but that is
+ * a fact about posting parcels rather than about either type, and the name is often not
+ * the account name — gift subscriptions, workplace deliveries, c/o. A site that needs
+ * one keeps it in a field of its own, which is also how Stripe hands it back.
+ */
+export const FIELD_PARTS = {
+  short_text: null,
+  long_text: null,
+  address: {
+    line1: 'short_text',
+    line2: 'short_text',
+    city: 'short_text',
+    state: 'short_text',
+    postal_code: 'postal_code',
+    country: 'country_code',
+  },
+} as const satisfies Record<FieldType, Readonly<Record<string, PartType>> | null>;
+
+/**
+ * The parts a record type declares, or never for a type whose value is a single thing.
+ *
+ * Distributed over `T`, so a caller holding a type it only knows as `FieldType` gets
+ * every part any type declares rather than the empty intersection of all of them.
+ */
+export type PartsOf<T extends FieldType> = T extends FieldType
+  ? (typeof FIELD_PARTS)[T] extends null
+    ? never
+    : Extract<keyof (typeof FIELD_PARTS)[T], string>
+  : never;
+
+/**
+ * The parts of a record type in declaration order, or null for a type with none.
+ *
+ * Typed to the parts the caller's type declares, so a caller holding one of these can
+ * index a value of that type without restating which parts exist.
+ */
+export function subFieldsOf<T extends FieldType>(type: T): PartsOf<T>[] | null {
+  // Optional because a caller built against an older catalog than the server it talks
+  // to reaches here with a type this build has never heard of, which reads as no parts.
+  const parts: Readonly<Record<string, PartType>> | null | undefined = FIELD_PARTS[type];
+  return parts ? (Object.keys(parts) as PartsOf<T>[]) : null;
+}
+
+/** Each part's declared type, keyed by part; null for a type with none, and for one this build has never heard of. */
+export function partTypesOf<T extends FieldType>(type: T): Record<PartsOf<T>, PartType> | null {
+  const parts: Readonly<Record<string, PartType>> | null | undefined = FIELD_PARTS[type];
+  return parts ? ({ ...parts } as Record<PartsOf<T>, PartType>) : null;
+}

--- a/packages/metafield-types/test/index.test.ts
+++ b/packages/metafield-types/test/index.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_LONG_TEXT_BYTES,
   partTypesOf,
   subFieldsOf,
+  type Address,
   type FieldType,
 } from '../src/index.ts';
 
@@ -115,6 +116,19 @@ describe('metafield-types catalog', function () {
     // a name keeps it in a field of its own.
     it('is not where a recipient name lives', function () {
       assert.equal(parse({ name: 'Bex Jones' }), false);
+    });
+
+    // The compiler has to agree with the parser about which parts exist. The schema is
+    // mapped over the parts declared in `../src/structure`, and that key mapping is lost
+    // through `Object.fromEntries` unless restated: without the restatement an address
+    // admits any part at all, and only the parser objects.
+    it('is typed to the parts it parses', function () {
+      const declared: Address = { line1: 'Cloonlara', country: 'IE' };
+      // @ts-expect-error -- the same part the parser refuses just above
+      const undeclared: Address = { name: 'Bex Jones' };
+
+      assert.equal(parse(declared), true);
+      assert.equal(parse(undeclared), false);
     });
 
     it('rejects an address that names nothing', function () {


### PR DESCRIPTION
## Problem

Ghost lets a publisher define extra fields to collect about their members. A shared package describes what kinds of field exist, and it answers two questions that are usually asked by different people.

One is structural: what is a field type made of? An address is six parts, being two address lines, a city, a state, a postal code and a country, in that order, and the last of them holds a country code rather than free text. That is what anything drawing a form needs to know.

The other is about validity: what counts as an acceptable value? That is what the server needs when someone submits one.

Both were declared together, written using a validation library, so asking the first question meant loading the machinery for the second. Nothing can strip that out automatically, because the descriptions are themselves built by calling that library when the file loads.

Ghost's server enforces the rules and can happily carry the cost. Portal cannot: it is the script that runs on every page view of every Ghost site, and asking it to download a validator it will never run, purely to find out that an address has six parts, is the wrong trade. So today Portal does not use the package at all, which means it also gets none of the type-checking the package exists to provide, and would have to hardcode the part names as strings and hope they match.

## Solution

The structural half now stands alone and depends on nothing.

Measured through Portal's real build, with the import actually used so it survives dead-code removal:

| Portal bundle | gzipped | validator included? |
|---|---|---|
| as it is today | 697,179 B | no |
| taking the structure alone | 697,356 B (+177) | no |
| taking the whole catalog | 714,708 B (+17,529) | yes |

So a client can afford the structure, and gets the type-checking along with it.

The two halves cannot drift apart, which was the reason for keeping them together in the first place. The rules are now built from the structure rather than written alongside it: an address's parts are stated once, and the rule for each part is looked up from that statement. Adding a part without a rule, or a rule for a part that does not exist, stops the build.

Splitting them also emptied something out. A field type used to carry a map of its parts, pairing each name with both its declared type and its rule, because the two were needed in different places and there was nowhere else to put the type. The type is stated in the structure now, and nothing reads that map any more, so it goes, and takes the last of the coupling with it.

Nothing changes for anything that uses this today. Admin and the server both import exactly as before, the package's own tests pass unchanged, and both consumers still type-check.

## Why now

This unblocks Portal showing members the fields a publisher has defined, so they can keep their own details up to date. That work needs the part structure on the client, and this is what makes it affordable. Putting it up on its own because it is a change to a shared package with its own reasoning, and it should be judged on that rather than as a detail of the feature that prompted it.
