### PR TITLE
🐛 Fixed saving account preferences failing for some members

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -878,10 +878,10 @@ module.exports = class MemberRepository {
         (n) => n.attributes.status === 'archived',
       );
 
-      if (archivedNewsletters.length > 0) {
-        // if (!memberData.newsletters) {
-        //     memberData.newsletters = [];
-        // }
+      // bookshelf-relations only touches the join table when the key is present,
+      // so an update that does not set newsletters leaves them all attached and
+      // has nothing to preserve.
+      if (memberData.newsletters && archivedNewsletters.length > 0) {
         archivedNewsletters.forEach((n) => memberData.newsletters.push(n));
       }
     }

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -160,6 +160,82 @@ describe('Comments API', function () {
       assert.equal(member.get('expertise'), 'Head of Testing');
     });
 
+    describe('and subscribed to a newsletter the publisher has archived', function () {
+      let archived;
+      let active;
+      let name;
+
+      beforeEach(async function () {
+        name = member.get('name');
+        archived = await models.Newsletter.add(
+          {
+            name: 'Archived for resubscribe test',
+            status: 'archived',
+            visibility: 'members',
+            subscribe_on_signup: false,
+            sort_order: 100,
+          },
+          { context: { internal: true } },
+        );
+
+        const before = await models.Member.findOne(
+          { id: member.id },
+          { require: true, withRelated: ['newsletters'] },
+        );
+        active = before.related('newsletters').models.map((n) => ({ id: n.id }));
+        assert.ok(active.length > 0, 'the member starts with an active newsletter');
+
+        await models.Member.edit(
+          {
+            newsletters: [...active, { id: archived.id }],
+          },
+          { id: member.id, context: { internal: true } },
+        );
+      });
+
+      afterEach(async function () {
+        await models.Member.edit(
+          { name, newsletters: active },
+          { id: member.id, context: { internal: true } },
+        );
+        await models.Newsletter.destroy({ id: archived.id, context: { internal: true } });
+        member = await models.Member.findOne({ id: member.id }, { require: true });
+      });
+
+      it('can still resubscribe', async function () {
+        await membersAgent.put(`/api/member/`).body({ subscribed: true }).expectStatus(200);
+
+        const after = await models.Member.findOne(
+          { id: member.id },
+          { require: true, withRelated: ['newsletters'] },
+        );
+        const ids = after.related('newsletters').models.map((n) => n.id);
+
+        assert.ok(ids.includes(archived.id), 'the archived newsletter is kept');
+        for (const { id } of active) {
+          assert.ok(ids.includes(id), 'the active newsletters are kept');
+        }
+      });
+
+      it('keeps the archived newsletter when changing something unrelated', async function () {
+        await membersAgent
+          .put(`/api/member/`)
+          .body({ name: 'Renamed with an archived newsletter' })
+          .expectStatus(200);
+
+        const after = await models.Member.findOne(
+          { id: member.id },
+          { require: true, withRelated: ['newsletters'] },
+        );
+        const ids = after.related('newsletters').models.map((n) => n.id);
+
+        assert.ok(ids.includes(archived.id), 'the archived newsletter is kept');
+        for (const { id } of active) {
+          assert.ok(ids.includes(id), 'the active newsletters are kept');
+        }
+      });
+    });
+
     it('trims whitespace from expertise', async function () {
       await membersAgent
         .put(`/api/member/`)


### PR DESCRIPTION
## Problem

A member who is subscribed to a newsletter the publisher has since archived cannot save anything from their account panel. Changing their name, their expertise, their comment notification preference, or resubscribing to emails all fail the same way, with an error and nothing saved.

Publishers archive newsletters when they stop sending one. Members already receiving it keep it, because archiving is not meant to unsubscribe anyone. Those members are the ones affected, and nothing about the account panel suggests why it is failing.

## Solution

Ghost carries a member's archived newsletters back into any update that sets newsletters, so that saving a preference does not quietly unsubscribe them from something the account panel never showed. It was doing that carrying even when the update was not setting newsletters at all, and in that case there was nothing to carry them into, so the save failed outright.

It now only carries them over when the request is actually setting newsletters, which is the only time there is anything to carry them into. When a request does not mention newsletters, the member's newsletters are left alone entirely, so nothing needs preserving.

There was an attempt at this fix already present but commented out, which would have started the list empty instead. That is worse than the error: it would have saved successfully while unsubscribing the member from every newsletter they still wanted.

A test drives the real request over HTTP, as a member holding both an active and an archived newsletter, and checks both survive. It fails on the current code with the error a member would see.
