### PR TITLE
Added improveSendingUI Labs flag

### DIFF
--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -61,6 +61,11 @@ const features: Feature[] = [
     flag: 'emailUniqueid',
   },
   {
+    title: 'Improve sending UI',
+    description: 'Enables improvements to email sending and delivery status for large email sends',
+    flag: 'improveSendingUI',
+  },
+  {
     title: 'Updated theme translation (beta)',
     description: 'Enable theme translation using i18next instead of the old translation package.',
     flag: 'themeTranslation',

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -49,6 +49,7 @@ const PRIVATE_FEATURES = [
   'admin7PageChrome',
   'tagsX',
   'emailUniqueid',
+  'improveSendingUI',
   'themeTranslation',
   'pictureImageFormats',
   'getHelperDeduplication',


### PR DESCRIPTION
## Summary

- register improveSendingUI as a private Labs flag in Ghost Core
- add the matching Private features toggle in Admin
- describe the flag as gating email sending and delivery-status improvements for large sends