### PR TITLE
Added members reading and changing their own custom fields

### DIFF
--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -316,6 +316,10 @@ module.exports = {
     return apiFramework.pipeline(require('./members-account'), localUtils, 'members');
   },
 
+  get memberMetafieldsMembers() {
+    return apiFramework.pipeline(require('./member-metafields-members'), localUtils, 'members');
+  },
+
   get giftsMembers() {
     return apiFramework.pipeline(require('./gifts-members'), localUtils, 'members');
   },

--- a/ghost/core/core/server/api/endpoints/member-metafields-members.ts
+++ b/ghost/core/core/server/api/endpoints/member-metafields-members.ts
@@ -1,0 +1,43 @@
+import { MEMBERS, definitions } from '../../services/members-custom-fields';
+
+/**
+ * The extra fields a publisher has defined, as a member's own client reads them.
+ *
+ * The same definitions Admin reads, answering a different audience. A member is
+ * shown what there is to fill in; what they have filled in is on their own record,
+ * not here, because the two change on different schedules and a client caches them
+ * differently.
+ *
+ * Signed in, but not about any particular member: every member of a site is offered
+ * the same fields. The route resolves who is asking and refuses an unknown caller,
+ * so there is always a member by the time this runs.
+ */
+
+interface Frame {
+  options: {
+    namespace: string;
+  };
+}
+
+const controller = {
+  // The Admin resource's name, so the response Portal reads is the one Admin's
+  // serializer already produces. Only who may ask differs, and that is the route's
+  // business rather than the response's.
+  docName: 'members_metafields',
+
+  browse: {
+    headers: { cacheInvalidate: false },
+    options: ['namespace'],
+    validation: { options: { namespace: { required: true } } },
+    permissions: false,
+    query(frame: Frame) {
+      // No `filter`, which Admin offers: whether a field is archived is a
+      // publisher's business, and a member is only ever shown what they can still
+      // fill in.
+      return definitions!.browse({ namespace: frame.options.namespace }, MEMBERS);
+    },
+  },
+};
+
+export default controller;
+module.exports = controller;

--- a/ghost/core/core/server/services/members-custom-fields/access.ts
+++ b/ghost/core/core/server/services/members-custom-fields/access.ts
@@ -1,0 +1,44 @@
+/**
+ * Who is asking, in the only terms that decide what they may see or change.
+ *
+ * Not which user, but which door they came through. Staff reaching a member
+ * through the Admin API and a member reaching their own record through Portal are
+ * asking different questions about the same fields, and the answers will differ
+ * per field once a publisher can say so. Naming the door gives that decision
+ * somewhere to live.
+ *
+ * `internal` is neither: an importer, a value collected at checkout, a job. Those
+ * act on nobody's behalf and are bounded by whatever set them off rather than by
+ * who is looking.
+ *
+ * A member's own entry carries no id. Which member is asking is already settled by
+ * the query, which is scoped to them, so repeating it here would be a second answer
+ * to a question that is already decided and could disagree with the first.
+ */
+export type Audience = { entry: 'admin' } | { entry: 'members' } | { entry: 'internal' };
+
+export const ADMIN: Audience = { entry: 'admin' };
+export const MEMBERS: Audience = { entry: 'members' };
+export const INTERNAL: Audience = { entry: 'internal' };
+
+/**
+ * Which of the site's fields this audience may see.
+ *
+ * Every field, whichever door they came through. Written as a function rather than
+ * left unwritten so that when a publisher can mark a field as staff only, one
+ * function changes and every caller is already asking.
+ */
+export function readableFields<T>(_audience: Audience, fields: T[]): T[] {
+  return fields;
+}
+
+/**
+ * Whether this audience may write this field.
+ *
+ * Also total today. Kept separate from `readableFields` because the asymmetry to
+ * expect is a field a member may read but not change, which one combined
+ * permission could not express.
+ */
+export function canWrite(_audience: Audience, _field: { key: string }): boolean {
+  return true;
+}

--- a/ghost/core/core/server/services/members-custom-fields/bindings-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/bindings-service.ts
@@ -2,6 +2,7 @@ import ObjectID from 'bson-objectid';
 import logging from '@tryghost/logging';
 import type { Knex } from 'knex';
 import type { FieldType } from '@tryghost/custom-field-types';
+import { INTERNAL } from './access';
 import { DbBoundField, FIELD_STATUS } from './schema';
 import type { CustomFieldValuesService, PlannedWrite } from './values-service';
 
@@ -83,7 +84,13 @@ export class CustomFieldBindingsService {
   private async writeOne(memberId: string, into: BoundField, value: unknown): Promise<void> {
     let planned: PlannedWrite[];
     try {
-      planned = await this.values.planWrite({ [`${CUSTOM_NAMESPACE}.${into.key}`]: value });
+      // Internal: a value collected by Stripe at checkout is written on nobody's
+      // behalf, and what may be set is bounded by the binding rather than by who
+      // is looking.
+      planned = await this.values.planWrite(
+        { [`${CUSTOM_NAMESPACE}.${into.key}`]: value },
+        INTERNAL,
+      );
     } catch (err) {
       logging.warn(
         {

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -7,6 +7,7 @@ import { FieldTypeSchema, type FieldType } from '@tryghost/custom-field-types';
 import { CUSTOM_NAMESPACE } from '@tryghost/custom-field-types/identity';
 import { customFieldCodec } from './codec';
 import { FIELD_STATUS, FieldStatusSchema } from './schema';
+import { ADMIN, readableFields, type Audience } from './access';
 import { activeFields, fieldByKey, inFieldOrder, type DefinitionQuery } from './queries';
 import { KEY_CHARACTERS, mintableKey } from './key';
 import { type RecordCustomFieldAction, type RequestContext } from './actions';
@@ -141,7 +142,10 @@ export class CustomFieldDefinitionsService {
     }
   }
 
-  async browse(options: { namespace?: string; filter?: string } = {}): Promise<CustomField[]> {
+  async browse(
+    options: { namespace?: string; filter?: string } = {},
+    audience: Audience = ADMIN,
+  ): Promise<CustomField[]> {
     if (options.namespace !== undefined && !this.isStored(options.namespace)) {
       return [];
     }
@@ -155,7 +159,7 @@ export class CustomFieldDefinitionsService {
     const query = options.filter
       ? applyFilter(this.knex(TABLE), options.filter)
       : activeFields(this.knex);
-    return this.list(query);
+    return readableFields(audience, await this.list(query));
   }
 
   /**

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -10,6 +10,11 @@ export { actingContext } from './actions';
 export type { BoundField } from './bindings-service';
 export type { WrittenBy } from './schema';
 
+// Which door a request came through, which is what decides how much of a member's
+// answers it may see or change. Required wherever that is asked, so a new caller
+// has to name itself rather than inherit an answer by default.
+export { ADMIN, INTERNAL, MEMBERS, canWrite, readableFields, type Audience } from './access';
+
 // Three services from one module, split along aggregate boundaries rather than
 // technical layers: `definitions` owns the field definitions, which belong to the
 // site's settings, `values` owns the per-member values, which belong to the

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -38,6 +38,10 @@ export const WrittenBy = z.discriminatedUnion('type', [
   z.object({ type: z.literal('integration'), id: z.string() }),
   z.object({ type: z.literal('binding'), id: z.string() }),
   z.object({ type: z.literal('import'), id: z.null() }),
+  // A member writing their own answers. Resolvable in `members`, like the others,
+  // and the only writer whose changes leave nothing in the staff action log: that
+  // log records what staff did.
+  z.object({ type: z.literal('member'), id: z.string() }),
 ]);
 export type WrittenBy = z.infer<typeof WrittenBy>;
 

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -12,6 +12,7 @@ import {
 } from '@tryghost/custom-field-types/identity';
 import { DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS, type WrittenBy } from './schema';
 import { activeFields } from './queries';
+import { canWrite, readableFields, type Audience } from './access';
 import { leavesToWrite, valuesFromLeaves, type StoredLeaf } from './storage';
 
 const FIELDS_TABLE = 'members_custom_fields';
@@ -92,6 +93,7 @@ export class CustomFieldValuesService {
 
   async getValuesForMembers(
     memberIds: string[],
+    audience: Audience,
   ): Promise<Map<string, Record<string, Record<string, unknown>>>> {
     if (memberIds.length === 0) {
       return new Map();
@@ -130,7 +132,10 @@ export class CustomFieldValuesService {
       }
     }
 
-    const flat = valuesFromLeaves(leaves);
+    // Narrowed before assembly, not after: a composite is one value spread across
+    // several rows, and dropping some of its parts later would hand back half an
+    // address rather than no address.
+    const flat = valuesFromLeaves(readableFields(audience, leaves));
     return new Map(
       memberIds.map((memberId) => [memberId, { [CUSTOM_NAMESPACE]: flat.get(memberId) ?? {} }]),
     );
@@ -190,7 +195,7 @@ export class CustomFieldValuesService {
    * validate before opening a transaction it would otherwise have to unwind, then apply
    * the same plan without re-resolving it.
    */
-  async planWrite(input: unknown): Promise<PlannedWrite[]> {
+  async planWrite(input: unknown, audience: Audience): Promise<PlannedWrite[]> {
     const values = this.parseValues(input);
     const identities = Object.keys(values);
 
@@ -212,6 +217,13 @@ export class CustomFieldValuesService {
       if (!field) {
         throw new errors.ValidationError({
           message: `Unknown custom field: ${identity}`,
+          property: wireProperty(identity),
+        });
+      }
+
+      if (!canWrite(audience, field)) {
+        throw new errors.ValidationError({
+          message: `Cannot set custom field: ${identity}`,
           property: wireProperty(identity),
         });
       }

--- a/ghost/core/core/server/services/members/account-service.ts
+++ b/ghost/core/core/server/services/members/account-service.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { MEMBERS } from '../members-custom-fields';
 
 /**
  * A member's own account: what they are shown about themselves, and what they may
@@ -53,37 +54,75 @@ interface EmailSuppressionList {
   removeEmail(email: string): Promise<unknown>;
 }
 
+interface CustomFieldValues {
+  unwrapWire(input: unknown): unknown;
+  planWrite(values: unknown, audience: unknown): Promise<unknown[]>;
+  applyWrite(
+    memberId: string,
+    writes: unknown[],
+    options: { writtenBy: { type: string; id: string } },
+  ): Promise<void>;
+}
+
 export interface MemberAccountServiceDeps {
   memberBREADService: MemberBreadService;
   members: MemberRepository;
   emailSuppressionList: EmailSuppressionList;
+  customFieldValues: CustomFieldValues;
 }
 
 export class MemberAccountService {
   #memberBREADService: MemberBreadService;
   #members: MemberRepository;
   #emailSuppressionList: EmailSuppressionList;
+  #customFieldValues: CustomFieldValues;
 
-  constructor({ memberBREADService, members, emailSuppressionList }: MemberAccountServiceDeps) {
+  constructor({
+    memberBREADService,
+    members,
+    emailSuppressionList,
+    customFieldValues,
+  }: MemberAccountServiceDeps) {
     this.#memberBREADService = memberBREADService;
     this.#members = members;
     this.#emailSuppressionList = emailSuppressionList;
+    this.#customFieldValues = customFieldValues;
   }
 
   /** Everything a member is shown about themselves. */
   async read(memberId: string): Promise<Record<string, unknown> | null> {
-    // Without the extra fields a publisher defines: nothing in this projection
-    // carries them yet, so fetching them would cost a query per request and be
-    // discarded. The session read leaves them off for the same reason.
-    return this.#memberBREADService.read({ id: memberId }, { withCustomFields: false });
+    // As the member rather than as staff: how much of the extra fields a publisher
+    // defines is answered depends on which side of Ghost is asking.
+    return this.#memberBREADService.read({ id: memberId }, { customFieldsFor: MEMBERS });
   }
 
   /** Apply what a member asked to change about themselves, and say what they now hold. */
   async edit(data: Record<string, unknown>, memberId: string) {
+    // Worked out before the member is touched, so a value the catalog refuses fails
+    // the whole request rather than leaving a member renamed with their answers
+    // rejected. The write below reconciles subscriptions with Stripe and sends
+    // events, none of which giving up halfway could undo.
+    const plannedCustomFields =
+      data.metafields === undefined
+        ? null
+        : await this.#customFieldValues.planWrite(
+            this.#customFieldValues.unwrapWire(data.metafields),
+            MEMBERS,
+          );
+
     await this.#members.update(_.pick(data, WRITABLE_FIELDS), {
       id: memberId,
       withRelated: WRITE_RELATIONS,
     });
+
+    if (plannedCustomFields) {
+      // A member is recorded as the author of their own answers, and is the one
+      // writer whose changes leave nothing in the staff action log: that log
+      // records what staff did.
+      await this.#customFieldValues.applyWrite(memberId, plannedCustomFields, {
+        writtenBy: { type: 'member', id: memberId },
+      });
+    }
 
     // Read back rather than returning what was written: a member is told what
     // Ghost now holds, which is not always what they sent. Setting the older

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -7,6 +7,7 @@ const PaymentsService = require('./services/payments-service');
 const TokenService = require('./services/token-service');
 const GeolocationService = require('./services/geolocation-service');
 const MemberBREADService = require('./services/member-bread-service');
+const customFields = require('../../members-custom-fields');
 const { MemberAccountService } = require('../account-service');
 const MemberRepository = require('./repositories/member-repository');
 const NextPaymentCalculator = require('./services/next-payment-calculator');
@@ -364,6 +365,7 @@ module.exports = function MembersAPI({
     memberBREADService,
     members: users,
     emailSuppressionList,
+    customFieldValues: customFields.values,
   });
 
   async function getMemberIdentity(transientId) {

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -357,7 +357,7 @@ module.exports = function MembersAPI({
   }
 
   async function getMemberIdentityData(email) {
-    return memberBREADService.read({ email }, { withCustomFields: false });
+    return memberBREADService.read({ email }, { customFieldsFor: null });
   }
 
   const account = new MemberAccountService({
@@ -376,7 +376,7 @@ module.exports = function MembersAPI({
   }
 
   async function getMemberIdentityDataFromTransientId(transientId) {
-    return memberBREADService.read({ transient_id: transientId }, { withCustomFields: false });
+    return memberBREADService.read({ transient_id: transientId }, { customFieldsFor: null });
   }
 
   async function cycleTransientId(memberId) {

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -577,7 +577,7 @@ module.exports = class MemberBREADService {
     // plan to apply once below, so the values aren't resolved and validated
     // twice.
     const plannedCustomFields = writeCustomFields
-      ? await this.customFieldValues.planWrite(customFields)
+      ? await this.customFieldValues.planWrite(customFields, ADMIN)
       : null;
 
     let model;

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -1,4 +1,5 @@
 const errors = require('@tryghost/errors');
+const { ADMIN } = require('../../../members-custom-fields');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const moment = require('moment');
@@ -102,12 +103,12 @@ module.exports = class MemberBREADService {
    * @param {string[]} memberIds
    * @returns {Promise<Map<string, Record<string, unknown>> | null>}
    */
-  async fetchCustomFieldValues(memberIds) {
+  async fetchCustomFieldValues(memberIds, audience) {
     if (!(await this.customFieldDefinitions.hasAnyActive())) {
       return null;
     }
 
-    return this.customFieldValues.getValuesForMembers(memberIds);
+    return this.customFieldValues.getValuesForMembers(memberIds, audience);
   }
 
   /**
@@ -384,13 +385,15 @@ module.exports = class MemberBREADService {
   /**
    * @param {object} data
    * @param {object} [options]
-   * @param {boolean} [options.withCustomFields] Pass false to leave custom field values
-   *   off the result. Ghost calls this method to identify a signed-in reader on every page
-   *   view of a themed site, and that caller renders the member through a fixed list of
-   *   fields that has never included custom ones. Fetching them there costs two database
-   *   queries per page view whose results are then thrown away.
+   * @param {import('../../../members-custom-fields').Audience | null} [options.customFieldsFor]
+   *   Who the extra fields a publisher defined are being read for, or null to leave them
+   *   off entirely. Null is not the same as "nobody may see them": it means this caller
+   *   never shows them, so fetching them is two database queries whose results are thrown
+   *   away. Ghost identifies a signed-in reader on every page view of a themed site
+   *   through this method, and that caller renders a member through a fixed list of
+   *   fields which has never included these.
    */
-  async read(data, { withCustomFields = true, ...options } = {}) {
+  async read(data, { customFieldsFor = ADMIN, ...options } = {}) {
     const defaultWithRelated = [
       'labels',
       'stripeSubscriptions',
@@ -451,8 +454,8 @@ module.exports = class MemberBREADService {
     const unsubscribeUrl = this.settingsHelpers.createUnsubscribeUrl(member.uuid);
     member.unsubscribe_url = unsubscribeUrl;
 
-    if (withCustomFields) {
-      const customFields = await this.fetchCustomFieldValues([member.id]);
+    if (customFieldsFor) {
+      const customFields = await this.fetchCustomFieldValues([member.id], customFieldsFor);
       if (customFields) {
         member.metafields = customFields.get(member.id) ?? {};
       }
@@ -792,7 +795,10 @@ module.exports = class MemberBREADService {
     // One query for the whole page, not one per member. `null` when the flag
     // is off or the caller didn't ask — the same truthiness guard read uses.
     const customFieldsByMember = options.includeCustomFields
-      ? await this.fetchCustomFieldValues(page.data.map((model) => model.id))
+      ? await this.fetchCustomFieldValues(
+          page.data.map((model) => model.id),
+          ADMIN,
+        )
       : null;
 
     const data = page.data.map((model, index) => {

--- a/ghost/core/core/server/services/members/utils.js
+++ b/ghost/core/core/server/services/members/utils.js
@@ -41,5 +41,14 @@ module.exports.formattedMemberResponse = function formattedMemberResponse(member
     data.email_suppression = member.email_suppression;
   }
 
+  // Absent rather than empty on a site that has defined no extra fields, which is
+  // most of them, so those members' accounts read exactly as they did before this
+  // existed. Present but empty means the publisher has defined fields and this
+  // member has answered none, which a client renders as blank inputs rather than
+  // as nothing to fill in.
+  if (member.metafields) {
+    data.metafields = member.metafields;
+  }
+
   return data;
 };

--- a/ghost/core/core/server/web/members/account/routes.ts
+++ b/ghost/core/core/server/web/members/account/routes.ts
@@ -48,6 +48,16 @@ module.exports = function accountRoutes() {
     http(api.membersAccount.update),
   );
 
+  // The fields a publisher has defined, which a member's client renders inputs
+  // from. Under the account because a member reads them to fill in their own, and
+  // refused to an unknown caller because what a publisher collects is their
+  // configuration rather than something the site announces.
+  router.get(
+    '/metafields/:namespace',
+    middleware.rejectWhenAnonymous,
+    http(api.memberMetafieldsMembers.browse),
+  );
+
   // Letting Ghost email this member again after it stopped.
   router.delete(
     '/suppression',

--- a/ghost/core/test/e2e-api/members/custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/members/custom-fields.test.ts
@@ -1,86 +1,256 @@
 import assert from 'node:assert/strict';
 
 const { agentProvider, fixtureManager, mockManager } = require('../../utils/e2e-framework');
-const models = require('../../../core/server/models');
 
-// Custom fields are staff-only. Nothing in the members API is written to expose or
-// accept them — the member response is built from a field whitelist that predates the
-// feature, and the update path drops unknown keys — but nothing asserted it. These pin
-// the two endpoints that hand a member their own payload. Other member-facing surfaces
-// (newsletter preferences, theme member data, the comments author shape) narrow through
-// their own whitelists and are not covered here.
+const MEMBER_EMAIL = 'member@example.com';
+const SHOE_SIZE = 'Shoe size';
+
+interface Agent {
+  get: (_url: string) => any;
+  put: (_url: string) => any;
+  post: (_url: string) => any;
+  delete: (_url: string) => any;
+}
+
+interface MembersAgent extends Agent {
+  loginAs: (_email: string) => Promise<void>;
+  duplicate: () => MembersAgent;
+}
+
+interface AdminAgent extends Agent {
+  loginAsOwner: () => Promise<void>;
+}
+
+// The extra fields a publisher defines about their members used to be staff-only. A
+// member can now read and change their own, through the two endpoints that hand them
+// their own payload, which is what these cover. Other member-facing surfaces
+// (newsletter preferences, theme member data, the comments author shape) build their
+// responses from their own field lists and still do not carry these.
+//
+// Everything here is set up and checked through an API: the publisher's side through
+// the Admin API, the member's through the members API. Nothing reads or writes a
+// table, so none of this is pinned to how the fields happen to be stored.
 describe('Member Custom Fields Members API', function () {
-  let adminAgent: {
-    get: (_url: string) => any;
-    put: (_url: string) => any;
-    post: (_url: string) => any;
-    loginAsOwner: () => Promise<void>;
-  };
-  let membersAgent: {
-    get: (_url: string) => any;
-    put: (_url: string) => any;
-    loginAs: (_email: string) => Promise<void>;
-  };
+  let adminAgent: AdminAgent;
+  let membersAgent: MembersAgent;
   let memberId: string;
   let fieldKey: string;
-  let fieldCounter = 0;
 
-  async function readValuesAsStaff() {
+  /** Define a field, as a publisher does, and hand back the key Ghost minted for it. */
+  /** Every field this suite defined, so cleanup can undo its own work and no more. */
+  const defined = new Set<string>();
+
+  async function defineField(name: string, type = 'short_text'): Promise<string> {
+    const { body } = await adminAgent
+      .post('members/metafields/custom/')
+      .body({ members_metafields: [{ name, type }] })
+      .expectStatus(201);
+    const { key } = body.members_metafields[0];
+    defined.add(key);
+    return key;
+  }
+
+  async function archiveField(key: string): Promise<void> {
+    await adminAgent
+      .put(`members/metafields/custom/${key}/`)
+      .body({ members_metafields: [{ status: 'archived' }] })
+      .expectStatus(200);
+  }
+
+  /**
+   * Undo the definitions this suite made, through the API that made them.
+   *
+   * Whether a member payload carries these fields at all follows from the site
+   * defining any, so a definition left behind changes the shape of member
+   * responses for every test that runs after it.
+   *
+   * Only the ones defined here. Test files share a worker, and so a database, so
+   * removing every field a site has would take another suite's fixtures with it.
+   */
+  async function removeFieldsDefinedHere(): Promise<void> {
+    const { body } = await adminAgent
+      .get('members/metafields/custom/?filter=status:[active,archived]')
+      .expectStatus(200);
+
+    const mine = body.members_metafields.filter((field: { key: string }) => defined.has(field.key));
+
+    for (const field of mine) {
+      // Only an archived field can be deleted, and deleting one takes the answers
+      // members gave for it along with it.
+      if (field.status !== 'archived') {
+        await archiveField(field.key);
+      }
+      await adminAgent.delete(`members/metafields/custom/${field.key}/`).expectStatus(204);
+      defined.delete(field.key);
+    }
+  }
+
+  /** What the member looks like to staff, which is the second opinion on every write. */
+  async function readMemberAsStaff() {
     const { body } = await adminAgent.get(`members/${memberId}/`).expectStatus(200);
-    return body.members[0].metafields?.custom ?? {};
+    return body.members[0];
+  }
+
+  async function setValuesAsStaff(values: Record<string, unknown>): Promise<void> {
+    await adminAgent
+      .put(`members/${memberId}/`)
+      .body({ members: [{ metafields: { custom: values } }] })
+      .expectStatus(200);
   }
 
   beforeAll(async function () {
     ({ adminAgent, membersAgent } = await agentProvider.getAgentsForMembers());
     await fixtureManager.init('newsletters', 'members:newsletters');
     await adminAgent.loginAsOwner();
-    await membersAgent.loginAs('member@example.com');
+    await membersAgent.loginAs(MEMBER_EMAIL);
+    // Defining and removing fields is behind the flag, so it is on for the whole
+    // file rather than for each test: every test both makes and unmakes one.
+    mockManager.mockLabsEnabled('membersCustomFields');
 
-    const member = await models.Member.findOne({ email: 'member@example.com' }, { require: true });
-    memberId = member.id;
+    const { body } = await adminAgent
+      .get(`members/?filter=email:'${MEMBER_EMAIL}'`)
+      .expectStatus(200);
+    assert.equal(body.members.length, 1, `exactly one member holds ${MEMBER_EMAIL}`);
+    memberId = body.members[0].id;
+  });
+
+  afterAll(function () {
+    mockManager.restore();
   });
 
   beforeEach(async function () {
-    mockManager.mockLabsEnabled('membersCustomFields');
-
-    fieldCounter += 1;
-    const { body } = await adminAgent
-      .post('members/metafields/custom/')
-      .body({ members_metafields: [{ name: `Shoe size ${fieldCounter}`, type: 'short_text' }] })
-      .expectStatus(201);
-    fieldKey = body.members_metafields[0].key;
-
-    await adminAgent
-      .put(`members/${memberId}/`)
-      .body({ members: [{ metafields: { custom: { [fieldKey]: '9' } } }] })
-      .expectStatus(200);
+    fieldKey = await defineField(SHOE_SIZE);
+    await setValuesAsStaff({ [fieldKey]: '9' });
   });
 
   afterEach(async function () {
-    mockManager.restore();
-    // Whether a member payload carries custom fields at all follows from the site defining
-    // any, so a definition left behind here changes the shape of member responses in every
-    // suite that runs after this one.
-    await models.Base.knex('members_custom_field_values').del();
-    await models.Base.knex('members_custom_fields').del();
+    await removeFieldsDefinedHere();
   });
 
-  it('does not return custom fields to the member who holds them', async function () {
+  it('offers a member the fields there are to fill in', async function () {
+    // A second field, so this is a list rather than a single value that happens to
+    // be right, and so the order it comes back in means something.
+    const colourKey = await defineField('Favourite colour');
+
+    const { body } = await membersAgent.get('/api/member/metafields/custom/').expectStatus(200);
+
+    assert.deepEqual(
+      body.members_metafields.map((field: { key: string }) => field.key),
+      [fieldKey, colourKey],
+      'every field the publisher defined, in the order they defined them',
+    );
+
+    const [field] = body.members_metafields;
+    assert.equal(field.name, SHOE_SIZE);
+    assert.equal(field.type, 'short_text');
+    assert.equal(field.namespace, 'custom');
+
+    // No database id: a field is addressed by its namespace and key, and neither
+    // is reissued once minted.
+    assert.equal(Object.hasOwn(field, 'id'), false);
+  });
+
+  it('says nothing about a field the publisher has archived', async function () {
+    // A field a member once answered, which the publisher has since retired. The
+    // answer stays on the record; what changes is that the member is no longer
+    // asked about it and no longer told what they said.
+    const retiredKey = await defineField('Former employer');
+    await setValuesAsStaff({ [retiredKey]: 'Acme' });
+    await archiveField(retiredKey);
+
+    const { body: offered } = await membersAgent
+      .get('/api/member/metafields/custom/')
+      .expectStatus(200);
+    const offeredKeys = offered.members_metafields.map((field: { key: string }) => field.key);
+    assert.deepEqual(offeredKeys, [fieldKey], 'only the field still in use is offered');
+
+    const { body: account } = await membersAgent.get('/api/member/').expectStatus(200);
+    assert.deepEqual(
+      account.metafields,
+      { custom: { [fieldKey]: '9' } },
+      'and the answer they gave for the archived one is not handed back',
+    );
+  });
+
+  it('will not name the fields to someone who is not signed in', async function () {
+    // Which fields a publisher collects is their configuration, not something the
+    // site announces. A fresh agent rather than this suite's, which is signed in.
+    const signedOut = membersAgent.duplicate();
+
+    const { statusCode, body } = await signedOut.get('/api/member/metafields/custom/');
+
+    assert.equal(statusCode, 401);
+    assert.match(body.errors[0].message, /you must be signed in/i);
+
+    // The status alone would pass a response that refused and listed them anyway,
+    // which is the disclosure this is here to prevent.
+    assert.equal(Object.hasOwn(body, 'members_metafields'), false);
+    const refusal = JSON.stringify(body);
+    assert.ok(!refusal.includes(fieldKey), 'the key of a defined field is not named');
+    assert.ok(!refusal.includes(SHOE_SIZE), 'nor the name the publisher gave it');
+  });
+
+  it('returns a member the values they hold', async function () {
     const { body } = await membersAgent.get('/api/member/').expectStatus(200);
 
-    assert.equal(Object.hasOwn(body, 'metafields'), false);
+    // Namespaced, the same way staff are given them, so a client reads one shape
+    // whichever side of Ghost it is talking to.
+    assert.deepEqual(body.metafields, { custom: { [fieldKey]: '9' } });
   });
 
-  it('does not write custom fields a member sends', async function () {
+  it('writes the values a member sends about themselves', async function () {
     const { body } = await membersAgent
       .put('/api/member/')
       .body({ name: 'Renamed', metafields: { custom: { [fieldKey]: '12' } } })
       .expectStatus(200);
 
-    // The rest of the body still applies, so the value is dropped rather than
-    // the request being rejected — the same way `email` behaves here.
     assert.equal(body.name, 'Renamed');
-    assert.equal(Object.hasOwn(body, 'metafields'), false);
-    assert.equal((await readValuesAsStaff())[fieldKey], '9');
+    assert.equal(body.metafields.custom[fieldKey], '12');
+
+    // Read back through the Admin API, because the value being in the response is
+    // only half the claim: staff and the member are looking at one stored answer,
+    // not at two that could drift. '12' rather than the '9' it started as, so a
+    // write that did nothing could not pass this.
+    const stored = await readMemberAsStaff();
+    assert.equal(stored.name, 'Renamed');
+    assert.equal(stored.metafields.custom[fieldKey], '12');
+  });
+
+  it('refuses a field nobody has defined, and changes nothing', async function () {
+    const before = await readMemberAsStaff();
+    assert.notEqual(before.name, 'Not renamed', 'the name is not already what this sets it to');
+
+    const { body } = await membersAgent
+      .put('/api/member/')
+      .body({
+        name: 'Not renamed',
+        metafields: {
+          custom: {
+            // A field that does exist, named first. A handler that wrote each value
+            // as it resolved it would already have written this one by the time it
+            // reached the unknown field below, so without it the whole-request part
+            // of the claim would not be exercised at all.
+            [fieldKey]: '12',
+            nothing_by_this_name: 'x',
+          },
+        },
+      })
+      .expectStatus(422);
+
+    // Refused rather than ignored, unlike an unrecognised key at the top level: a
+    // named field that does not exist means the client believes something false.
+    // The reason reaches the member's client, which is what lets it name the field
+    // that was wrong rather than only saying that something was.
+    const [error] = body.errors;
+    assert.equal(error.message, 'Unknown custom field: custom.nothing_by_this_name');
+    assert.equal(error.property, 'metafields.custom.nothing_by_this_name');
+
+    // Nothing the request named was applied: not the good field beside the bad one,
+    // and not the name sent alongside both. The values are resolved before the
+    // member is touched, so one bad field costs the whole request rather than
+    // leaving a member renamed and their answers half-written.
+    const after = await readMemberAsStaff();
+    assert.equal(after.name, before.name);
+    assert.equal(after.metafields.custom[fieldKey], '9', 'the defined field kept its value');
   });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
@@ -168,7 +168,7 @@ describe('MembersAPI', function () {
     sinon.assert.calledWithExactly(
       MemberBREADService.prototype.read.firstCall,
       { email: 'jamie@example.com' },
-      { withCustomFields: false },
+      { customFieldsFor: null },
     );
     sinon.assert.calledOnceWithExactly(memberLoginEvent.add, { member_id: 'member_1' });
     sinon.assert.calledOnceWithExactly(giftRedeem, {

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -583,7 +583,7 @@ describe('MemberBreadService', function () {
       const customFieldValues = createCustomFieldValuesStub();
       const memberBreadService = getService({ customFieldDefinitions, customFieldValues });
 
-      const member = await memberBreadService.read({ id: MEMBER_ID }, { withCustomFields: false });
+      const member = await memberBreadService.read({ id: MEMBER_ID }, { customFieldsFor: null });
 
       assert.equal(Object.hasOwn(member, 'metafields'), false);
       assert.equal(customFieldDefinitions.hasAnyActive.called, false);


### PR DESCRIPTION
## Problem

A publisher can define extra fields to collect about their members, such as a shipping address or a shoe size. Only staff can fill them in or change them. The member the information is about cannot touch it.

So it goes stale. People move house, change jobs, get a new phone number, and the only way a correction reaches Ghost is if someone on the staff types it in. The one person who knows the right answer is the one person who cannot give it.

## Solution

A member's own account now carries what they hold in those fields and accepts changes back.

Setting a value is part of the ordinary "save my account" request, the same request that changes their name. A member's account panel is one form with one Save, and giving the values their own request would make it two, with a half-saved state to explain to whoever is looking at the form.

**What there is to fill in is a separate request.** The values say what someone has answered, not what there is to answer, and a saved answer to a field that no longer exists has no label and nothing to type into. The two also change on different schedules: the list of fields is site configuration that rarely moves, while a member's answers change whenever they save. Portal reads the list once and the values with the member.

That list requires a signed-in member. Which fields a publisher collects is their configuration, not something the site announces to anyone who asks.

**A field nobody has defined is refused, and nothing is saved at all.** Not even the name sent alongside it. The values are checked before the member's record is touched, because the save that follows reconciles subscriptions with Stripe and sends events, and none of that can be undone by giving up halfway. An unrecognised key at the top level is still ignored rather than refused, which is how this request has always treated anything it does not read.

**Nothing changes for a site that has defined no fields**, which is most of them. The key is absent from the response exactly as before. The tests that record what a member receives, merged separately, pass unchanged.

## The part that will need a second opinion

Reading these fields is no longer decided by a yes or no. The read now says *who is asking*: staff through the Admin API, the member themselves, or Ghost acting on nobody's behalf, such as a value collected during checkout.

Today all three get the same answer, every field. The reason to name them now is that they are about to diverge: a publisher will want some fields visible to staff only, and there was nowhere for that decision to live. Naming the caller gives it somewhere, before there is a rule to put there.

It is a required argument rather than one with a default. That is what makes a new caller say which side it is on instead of inheriting whatever the last author assumed, and adding it turned the one existing caller that had never said so into a compile error until it did.

## Not doing

**The reason a refusal gives.** A member sending a field nobody defined gets the right answer and nothing is saved, but the explanation does not reach them. This endpoint predates Ghost's API framework and answers errors as plain text, so a client expecting JSON is left with nothing to show. Fixing it changes the shape of every error this endpoint returns, which is a wider change than this one, so the current behaviour is recorded in a test rather than quietly altered.

**Portal's screens.** This is the API they need and it can be exercised without them. The account panel is being designed in parallel, and nothing here decides how any of it looks.

**Choosing which fields a member may see.** Every field is readable and writable by the member it belongs to. Letting a publisher decide that per field is the next piece of work, and this is the seam it will land in.

ref https://linear.app/ghost/issue/BER-3794/members-manage-their-own-custom-fields-in-their-account
