### PR TITLE
Added the editor save engine as a pure module in Admin

### DIFF
--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -1,0 +1,175 @@
+# Editor engine
+
+The pure-TypeScript core of the React post editor: the save engine (`save-engine.ts`), the change tracker (`change-tracker.ts` + `lexical-compare.ts`), and the slug machine (`slug-machine.ts`). None of them import React or the network; every side effect goes through an injected port, and the editor's wiring hook composes the three. This file states the intended behavior for a maintainer who has not read the design spec; the modules' tests pin it.
+
+## Save engine
+
+Replaces the Ember editor's three ember-concurrency modifiers (an `enqueue` group, a `drop` autosave, a `restartable` debounce) and the ad-hoc branches of the `lexical-editor` controller with one single-flight queue over typed save commands.
+
+### Intents
+
+| Intent                            | Trigger                                                              | Debounce                            | `save_revision` | Changes status?                                                                                                                           |
+| --------------------------------- | -------------------------------------------------------------------- | ----------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `autosave`                        | body change; a new post's first edit fires immediately               | 3s restartable (none for new posts) | no              | never; drafts only, pinned to `draft`                                                                                                     |
+| `timed`                           | armed by an autosave dispatch, fires after 60s of continuous editing | 60s cycle                           | no              | never; drafts only                                                                                                                        |
+| `field`                           | title blur, excerpt blur, feature-image change                       | none                                | no              | never; drafts only. On a published/scheduled/sent post it is dropped with reason `not-draft`: the sidebar stages those edits until Update |
+| `explicit`                        | Cmd-S / Save / Update                                                | none                                | yes             | never; preserves the current status (a past-scheduled post saves as `scheduled`, the server owns that transition)                         |
+| `leave`                           | navigating away from a dirty draft with unrevisioned changes         | none                                | yes             | never; preserves the current status                                                                                                       |
+| `publish` / `schedule` / `revert` | the publish flow                                                     | none                                | no              | the only status-changing commands; each carries an explicit target                                                                        |
+
+### Commands
+
+`dispatch(kind, options?)` captures an immutable `SaveCommand` (`{kind, target?, requiresRevision, requiresReconfirmation}`) at dispatch time. Status commands derive their `target` from the source transition when captured and never re-derive it from a later snapshot, so a response resync cannot turn a queued schedule into a publish:
+
+| Command                          | Target                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `publish`                        | `published`; keeps the post's publish time unless `publishedAt` is given |
+| `schedule`                       | `scheduled` at the given time                                            |
+| `revert` from `scheduled`        | `draft`, publish time cleared, `emailOnly: false`                        |
+| `revert` from `published`/`sent` | `draft`, publish time kept as history, `emailOnly: false`                |
+
+Email extras (`newsletter`, `emailSegment`, `emailOnly`) ride on exactly that command's request. A failed status command is disarmed: nothing retains its target, the publish flow dispatches a fresh command. Publish times are serialized with zeroed milliseconds.
+
+### Queue semantics
+
+One save in flight, one pending slot. A command arriving while idle runs immediately (after its debounce); one arriving during a save lands in the pending slot and coalesces: priority `publish`/`schedule`/`revert` > `explicit` > `leave` > `field` > `timed` > `autosave`, the winner's kind executes, every waiter keeps its own command, `requiresRevision` ORs across the slot, and the payload is rebuilt from the current post at execution, so coalescing never loses newer content. A later status command supersedes only the earlier status command; its riders stay with the winner. A new autosave restarts the debounce; an explicit cancels it and carries its waiters. The pending slot exists because Ember's `drop` autosave starved: autosaves fired during an in-flight create were silently lost.
+
+Every dispatch settles with a typed `SaveCompletion`:
+
+| Completion                       | Meaning                                                                                   |
+| -------------------------------- | ----------------------------------------------------------------------------------------- |
+| `saved` (`result`, `executedAs`) | the save that carried this command's content landed; `executedAs` names the kind that ran |
+| `failed` (`error`, `executedAs`) | typed error; content stays dirty                                                          |
+| `dropped` (`reason`)             | `not-draft`, `clean`, `suppressed`, `conflict`, `halted`, `disposed`                      |
+| `superseded` (`by`)              | a later status command replaced this one before it ran                                    |
+| `needs-retry`                    | re-auth interrupted a status-changing command; the publish flow re-confirms               |
+
+### Lifecycle
+
+`capture → prepare → execute → reconcile → drain`, all inside the single-flight unit:
+
+1. **Prepare** awaits pending manual slug work (`slug.settled()`), re-reads the snapshot, substitutes `(Untitled)` for a blank or whitespace title, asks `slug.fromTitle()` for every draft save and whenever the post has no slug (the machine answers `generated` or `unchanged`; after an `unchanged` answer the slug current at that moment is sent), resolves the target, then hands the `SaveRequest` to the adapter's `prepare()` to build and validate the candidate. IO starts only after prepare settles; a rejected prepare is a typed failure with no request sent.
+2. **Execute** is IO only and returns a typed `SaveOutcome`; its `AbortSignal` is aborted on `dispose()`, and a response arriving after dispose is never reconciled.
+3. **Reconcile** is awaited before the pending slot drains and must not throw: adopt the acknowledged id, status and `updated_at` first, keep edits made after `prepared.snapshot.version`, resync server-normalized values only where the local value did not change in flight.
+4. **Drain** starts the pending slot only when nothing is in flight.
+
+Reconcile-before-drain is a hard ordering contract because Core enforces optimistic concurrency on posts: `@tryghost/bookshelf-collision` (registered in `models/base/bookshelf.js`) rejects any post update whose `updated_at` differs from the server's, when a meaningful field changed, with `UPDATE_COLLISION`. A queued save built from the pre-response snapshot would manufacture exactly the false "someone else is editing" collision Ember users hit today. The persisted snapshot type therefore requires `updatedAt` alongside `id`.
+
+### Errors and states
+
+| Error kind                      | State                                                                                                                                                                     | Exit                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `session-invalid`               | `reauth-pending`; queue frozen, later commands coalesce into the pending slot, content untouched                                                                          | `reauthSucceeded()` / `reauthAbandoned()`                                    |
+| `not-found` with an id          | `halted` (deleted elsewhere); every queued command dropped `halted`, content kept for copy-out                                                                            | none                                                                         |
+| `not-found` without an id       | `crashed` (corrupt new-post state)                                                                                                                                        | none                                                                         |
+| `conflict` (`UPDATE_COLLISION`) | `conflict`; timers and the pending slot dropped `conflict`, background saves refused while the snapshot still carries the rejected `updated_at`, content intact and dirty | an explicit save, or adopting a fresh baseline (reload) which lifts the halt |
+| `validation`                    | `error`; background saves suppressed until the snapshot version moves                                                                                                     | next edit, or an explicit save                                               |
+| `host-limit`                    | `error`; suppression as for validation, but only when the failing save was itself a draft save (a publish limit never halts autosave)                                     | next edit, or an explicit save                                               |
+| `transport` / `unknown`         | `error`, no suppression                                                                                                                                                   | next save                                                                    |
+
+`error` and `conflict` persist until a save actually starts; timers arming or a dropped save do not clear them. Other states: `idle`, `debouncing`, `saving`, `pending-coalesced`, `disposed`.
+
+### Re-auth
+
+`reauthSucceeded()` inspects every waiter in both the frozen and the pending slot and judges each by its resolved effect against the current post: a command whose target would change the status resolves `needs-retry` and never auto-fires (Ember's post-re-auth retry is a no-op; the real contract is "no content loss"); everything else re-enters through the normal enqueue path with its own intent, so a frozen explicit rider re-runs while the publish it coalesced into does not. Content a disarmed status command would have carried resumes through the autosave path; if the snapshot cannot be read at that point the debounce is re-armed so the retry surfaces a failure instead of abandoning content. `reauthAbandoned()` settles every waiter with the session error and moves to `error`; the shell decides on a sign-in redirect, the queue never dangles.
+
+### Leave
+
+`leaveRequested()` returns `proceed` or `confirm` and loops until nothing is in flight, pending, or armed with dirty content, re-reading the post after every wait: `saving` is never safe to leave. Save-on-leave (with a revision) fires at most once per attempt, only for a dirty draft with unrevisioned changes or an armed autosave, never on a stale baseline, never while frozen or halted. A post still dirty afterwards asks for confirmation. Concurrent calls share one decision; a decision that outlives the engine resolves `proceed`.
+
+### Subscriptions
+
+`subscribe()` suits `useSyncExternalStore`: emissions are deduplicated, listeners receive the emitted value, a throwing `onStateChange` port or subscriber is reported through `onListenerError` without interrupting the save, and a nested transition ends the outer pass so no listener sees an out-of-order state.
+
+## Change tracker
+
+`change-tracker.ts` + `lexical-compare.ts`. Answers one question for the editor: does the live post differ from what is persisted, and why. Pure, React-free; the hidden second Koenig instance stays — the tracker consumes its serialization as the baseline.
+
+### State model
+
+Three documents: **saved** (last persisted state, from load/refetch/ack), **baseline** (the hidden instance's post-load serialization — the document after Lexical's load-time transforms), **live** (the visible editor). Body verdict: dirty ⇔ live differs from saved **and** from baseline. Baseline readiness is separate from its value: `pending` (not reported yet), `ready` (a known document; `null`, `''`, and an empty root are all known-empty), `failed`. A live edit while pending is dirty (`BASELINE_PENDING`, fail closed); a failed baseline falls back to live-vs-saved (`BASELINE_FAILED`) and never disables body protection. Title, ordered tag names, and the editable attributes contribute their own dirty bits. Reason codes mirror Ember's (`POST_HAS_ERROR`, `POST_TAGS_DIVERGED`, `POST_TITLE_DIVERGED`, `SCRATCH_DIVERGED_FROM_SECONDARY`, `NEW_POST_HAS_CHANGED_ATTRIBUTES`, `POST_HAS_DIRTY_ATTRIBUTES`) plus `BASELINE_PENDING`, `BASELINE_FAILED`, `LEXICAL_PARSE_FAILED` (malformed or structurally invalid Lexical is dirty, never a thrown route blocker).
+
+### API (id-first; events for another post are dropped)
+
+| Method                                                           | Meaning                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `load(postId, post)`                                             | Reset for a post; `postId` is `null` for a new post until the create acks                                                                                                                                                                                                                                                                                                 |
+| `setSaved(postId, post)`                                         | Query refetch only. Never re-baselines. Dropped entirely if its `updated_at` is older than the held one                                                                                                                                                                                                                                                                   |
+| `saveAcknowledged(postId, submitted, acknowledged)`              | Mutation response, from the engine's reconcile port. Three-way rebase per key: base = submitted value (or previous saved when omitted); live still equal to base adopts the server value, otherwise the later edit wins. Always adopts `acknowledged.updated_at`; re-baselines to the acknowledged body. A create ack passes the created id — the projection carries none |
+| `setBaseline(postId, lexical)` / `baselineFailed(postId, error)` | The hidden instance's report                                                                                                                                                                                                                                                                                                                                              |
+| `setLive(postId, patch)`                                         | Patch semantics; `updated_at` in a patch is ignored                                                                                                                                                                                                                                                                                                                       |
+| `revisionRestored(postId, projection)`                           | After the restore save acks: adopts body, title, custom excerpt, feature image + alt + caption into saved and live atomically; baseline goes pending until the hidden instance re-reports                                                                                                                                                                                 |
+| `markSaveError()` / `clearSaveError()`                           | A failed save keeps the post dirty until an acknowledged save                                                                                                                                                                                                                                                                                                             |
+| `verdict({includeDiff?})`                                        | `{dirty, reasons[, diff]}`                                                                                                                                                                                                                                                                                                                                                |
+| `hasChangedSinceRevision(latest)`                                | The server's revision projection (body, title, custom excerpt, feature image), body compared semantically                                                                                                                                                                                                                                                                 |
+| `dispose()`                                                      | Inert thereafter                                                                                                                                                                                                                                                                                                                                                          |
+
+After a create ack promotes `null → id`, `null` is accepted as an alias on `setLive`/`setBaseline`/`baselineFailed` until the next `load()`/`dispose()`, so keystrokes between the ack and the caller's id swap are not dropped. While the id is still `null`, an ack for an id this tracker has already held is refused (a stale completion from a previous post).
+
+### Normalization
+
+Element-node `direction` is stripped recursively before compare (Lexical's reconciler infers it per environment). Site URLs are normalized to relative **only on known URL-bearing node properties** (the same map the server's URL transforms use: link `url`, image/gallery/audio/video/file sources, bookmark url + icon/thumbnail, button/header/email-cta urls, product image, embed url), tolerant of trailing-slash and subdirectory site URLs; prose, code, html, markdown, captions, and opaque card payloads are never rewritten, so a deleted literal site URL stays dirty. Snapshots are cloned at ingress; tags compare as ordered name arrays.
+
+## Slug machine
+
+`slug-machine.ts`. Tracks whether the slug follows the title (`derived`), was edited by hand (`custom`, sticky for the session), or is frozen for blank/`(Untitled)` titles; a saved title ending in `(Copy)` is an exception to custom detection, so a duplicated post's slug regenerates on its first rename. Details land with the machine.
+
+## Contracts between modules
+
+- **Engine → tracker.** The engine's `reconcile(prepared, result)` port calls `tracker.saveAcknowledged(postId, submitted = prepared.snapshot, acknowledged = the full post the server returned)`; `execute` therefore returns the full acknowledged post as its `R`, and `SaveResult.id` is the id a create ack promotes the tracker to.
+- **Engine ← tracker.** The engine's `SaveSnapshot` is a structural superset of the tracker's `EditablePostProjection` (id, `updatedAt`, status, publish time, title, slug, dirty bits, version); the wiring hook builds it from the tracker's verdict plus post metadata.
+- **Engine ← slug machine.** `SlugPort` is an adapter over the machine: `settled()` awaits the machine's latest submission chain (not its `pending` flag, which drops at the emit before the deferred submission starts); `fromTitle(title, postId, signal)` runs `titleCommitted` and resolves the settled proposal as `{slug, source: 'generated' | 'unchanged'}`.
+- **Prepared object.** `prepared` is handed unchanged from `prepare` through `reconcile`; it is a plain structural superset of the `SaveRequest` (no brand), and `prepared.snapshot` is the complete post as read at execution time.
+
+## Invariants
+
+| Invariant                                                                                                                     | Pinned in                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| A background command (`autosave`/`timed`/`field`) can never change status, publish, or send email                             | `save-engine.test.ts` "invariant 1"                           |
+| No two saves are in flight; payloads are built at execution; coalescing never loses the newest content                        | "invariant 2", "lifecycle"                                    |
+| Session expiry during a save loses nothing: re-auth completes, the save lands, content is present                             | "invariant 3", "re-auth outcomes"                             |
+| Save-on-leave fires at most once per attempt and only for dirty drafts                                                        | "invariant 4", "leave outcomes"                               |
+| Loading any post, including old-schema fixtures, is a clean verdict until the user edits                                      | `change-tracker.test.ts` fixture corpus                       |
+| A failed save leaves the post dirty and recoverable; no error path discards the payload                                       | "invariant 6", "collisions"                                   |
+| Explicit and leave saves set `save_revision`; background saves do not; publish does not force one (coalescing ORs)            | "invariant 7"                                                 |
+| A published/scheduled/sent post's persisted state changes only via explicit Update, publish-flow commands, delete, or restore | "invariant 1", "commands"                                     |
+| Slug generation never overwrites a custom slug and never applies a stale proposal                                             | `slug-machine.test.ts`; "prepare stage" for the port contract |
+| Scheduled saves serialize with zeroed milliseconds and preserve the publish time unless the user changed it                   | "invariant 10", `deriveTarget`                                |
+
+## Deliberate Ember deltas
+
+- Pending-slot coalescing instead of `drop`-task starvation: autosaves during an in-flight create are carried, not lost.
+- Leaving a post that is still dirty after the leave save asks for confirmation instead of proceeding.
+- Sidebar edits on published/scheduled/sent posts are staged until Update; nothing persists immediately.
+- An explicit save on a past-scheduled post preserves `scheduled` and lets the server own the transition (Ember guessed `published`/`draft`).
+- `UPDATE_COLLISION` is a typed `conflict` state with a retry affordance, not a generic error.
+- After re-auth, publish/schedule/revert resolve `needs-retry` and safe saves re-run; Ember's retry was a no-op.
+- A manually edited slug stays custom for the session; a server-deduplicated slug keeps following the title.
+- Recursive `direction` strip before compare (Ember: top level only).
+- A query refetch never re-baselines; only an acknowledged save does.
+- Structural site-URL normalization on known URL-bearing node props (Ember: none on the dirty check).
+- Fail closed on malformed Lexical (Ember threw and the route blocker failed open).
+- Explicitly clearing a non-empty body is dirty.
+- The leave-modal diff humanizer actually runs (Ember's read a nonexistent field and threw).
+
+## What the caller owns
+
+### Save engine
+
+- A no-redirect request mode: the framework transport redirects on 401 (`apps/admin-x-framework/src/utils/api/fetch-api.ts`); the editor adapter must instead throw `SessionExpiredError` so the engine can enter `reauth-pending`.
+- Mapping API failures to `SaveError` kinds in `execute` (401 → `session-invalid`, 404 → `not-found`, `UPDATE_COLLISION` → `conflict`, 422 → `validation`, host-limit errors → `host-limit`, unreachable → `transport`).
+- Past-scheduled detection for the UI (Ember's `pastScheduledTime`); the engine only preserves the status.
+- Replacing the URL from new → edit as a state-driven effect after the create ack, with the editor screen keyed on the editing-session instance so the switch does not remount the editor.
+- The `SlugPort` adapter over the slug machine (`settled` = latest submission chain, `fromTitle` = `titleCommitted` → settled proposal), including pre-slugifying the raw title before the generator request.
+- `(Untitled)` substitution is the engine's prepare duty; the title input never shows it.
+
+### Change tracker
+
+- A fresh tracker per editing session, including a new one for each new-post session.
+- Query data goes to `setSaved`, mutation responses to `saveAcknowledged`; never the reverse.
+- `revisionRestored` only after the restore save acks.
+- Pass the execution-time snapshot (`prepared.snapshot`) as `submitted`.
+
+### Slug machine
+
+- Wiring duties land with the machine.

--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -1,6 +1,6 @@
 # Editor engine
 
-The pure-TypeScript core of the React post editor: the save engine (`save-engine.ts`), the change tracker (`change-tracker.ts` + `lexical-compare.ts`), and the slug machine (`slug-machine.ts`). None of them import React or the network; every side effect goes through an injected port, and the editor's wiring hook composes the three. This file states the intended behavior for a maintainer who has not read the design spec; the modules' tests pin it.
+The pure-TypeScript core of the React post editor: the save engine (`save-engine.ts`, this PR), the change tracker and the slug machine (each lands with its own PR). None of them import React or the network; every side effect goes through an injected port, and the editor's wiring hook composes the three. This file states the intended behavior; the modules' tests pin it.
 
 ## Save engine
 
@@ -32,7 +32,7 @@ Email extras (`newsletter`, `emailSegment`, `emailOnly`) ride on exactly that co
 
 ### Queue semantics
 
-One save in flight, one pending slot. A command arriving while idle runs immediately (after its debounce); one arriving during a save lands in the pending slot and coalesces: priority `publish`/`schedule`/`revert` > `explicit` > `leave` > `field` > `timed` > `autosave`, the winner's kind executes, every waiter keeps its own command, `requiresRevision` ORs across the slot, and the payload is rebuilt from the current post at execution, so coalescing never loses newer content. A later status command supersedes only the earlier status command; its riders stay with the winner. A new autosave restarts the debounce; an explicit cancels it and carries its waiters. The pending slot exists because Ember's `drop` autosave starved: autosaves fired during an in-flight create were silently lost.
+One save in flight, one pending slot. A command arriving while idle runs immediately (after its debounce); one arriving during a save lands in the pending slot and coalesces: priority `publish`/`schedule`/`revert` > `explicit` > `leave` > `field` > `timed` > `autosave`, the winner's kind executes, every waiter keeps its own command, `requiresRevision` ORs across the slot, and the payload is rebuilt from the current post at execution, so coalescing never loses newer content. A later status command supersedes only the earlier status command; its riders stay with the winner. A new autosave restarts the debounce; an explicit cancels it and carries its waiters.
 
 Every dispatch settles with a typed `SaveCompletion`:
 
@@ -53,7 +53,7 @@ Every dispatch settles with a typed `SaveCompletion`:
 3. **Reconcile** is awaited before the pending slot drains and must not throw: adopt the acknowledged id, status and `updated_at` first, keep edits made after `prepared.snapshot.version`, resync server-normalized values only where the local value did not change in flight.
 4. **Drain** starts the pending slot only when nothing is in flight.
 
-Reconcile-before-drain is a hard ordering contract because Core enforces optimistic concurrency on posts: `@tryghost/bookshelf-collision` (registered in `models/base/bookshelf.js`) rejects any post update whose `updated_at` differs from the server's, when a meaningful field changed, with `UPDATE_COLLISION`. A queued save built from the pre-response snapshot would manufacture exactly the false "someone else is editing" collision Ember users hit today. The persisted snapshot type therefore requires `updatedAt` alongside `id`.
+Reconcile-before-drain is a hard ordering contract because Core enforces optimistic concurrency on posts: `@tryghost/bookshelf-collision` (registered in `models/base/bookshelf.js`) rejects any post update whose `updated_at` differs from the server's, when a meaningful field changed, with `UPDATE_COLLISION`. A queued save built from the pre-response snapshot carries the superseded `updated_at` and is rejected. The persisted snapshot type therefore requires `updatedAt` alongside `id`.
 
 ### Errors and states
 
@@ -71,7 +71,7 @@ Reconcile-before-drain is a hard ordering contract because Core enforces optimis
 
 ### Re-auth
 
-`reauthSucceeded()` inspects every waiter in both the frozen and the pending slot and judges each by its resolved effect against the current post: a command whose target would change the status resolves `needs-retry` and never auto-fires (Ember's post-re-auth retry is a no-op; the real contract is "no content loss"); everything else re-enters through the normal enqueue path with its own intent, so a frozen explicit rider re-runs while the publish it coalesced into does not. Content a disarmed status command would have carried resumes through the autosave path; if the snapshot cannot be read at that point the debounce is re-armed so the retry surfaces a failure instead of abandoning content. `reauthAbandoned()` settles every waiter with the session error and moves to `error`; the shell decides on a sign-in redirect, the queue never dangles.
+`reauthSucceeded()` inspects every waiter in both the frozen and the pending slot and judges each by its resolved effect against the current post: a command whose target would change the status resolves `needs-retry` and never auto-fires; everything else re-enters through the normal enqueue path with its own intent, so a frozen explicit rider re-runs while the publish it coalesced into does not. Content a disarmed status command would have carried resumes through the autosave path; if the snapshot cannot be read at that point the debounce is re-armed so the retry surfaces a failure instead of abandoning content. `reauthAbandoned()` settles every waiter with the session error and moves to `error`; the shell decides on a sign-in redirect, the queue never dangles.
 
 ### Leave
 
@@ -83,7 +83,7 @@ Reconcile-before-drain is a hard ordering contract because Core enforces optimis
 
 ## Change tracker
 
-`change-tracker.ts` + `lexical-compare.ts`. Answers one question for the editor: does the live post differ from what is persisted, and why. Pure, React-free; the hidden second Koenig instance stays — the tracker consumes its serialization as the baseline.
+Lands with the change tracker PR. Answers one question for the editor: does the live post differ from what is persisted, and why. Pure, React-free; the hidden second Koenig instance stays — the tracker consumes its serialization as the baseline.
 
 ### State model
 
@@ -112,7 +112,7 @@ Element-node `direction` is stripped recursively before compare (Lexical's recon
 
 ## Slug machine
 
-`slug-machine.ts`. Tracks whether the slug follows the title (`derived`), was edited by hand (`custom`, sticky for the session), or is frozen for blank/`(Untitled)` titles; a saved title ending in `(Copy)` is an exception to custom detection, so a duplicated post's slug regenerates on its first rename. Details land with the machine.
+Lands with the slug machine PR. Tracks whether the slug follows the title (`derived`), was edited by hand (`custom`, sticky for the session), or is frozen for blank/`(Untitled)` titles; a saved title ending in `(Copy)` is an exception to custom detection, so a duplicated post's slug regenerates on its first rename. Details land with the machine.
 
 ## Contracts between modules
 
@@ -123,18 +123,18 @@ Element-node `direction` is stripped recursively before compare (Lexical's recon
 
 ## Invariants
 
-| Invariant                                                                                                                     | Pinned in                                                     |
-| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| A background command (`autosave`/`timed`/`field`) can never change status, publish, or send email                             | `save-engine.test.ts` "invariant 1"                           |
-| No two saves are in flight; payloads are built at execution; coalescing never loses the newest content                        | "invariant 2", "lifecycle"                                    |
-| Session expiry during a save loses nothing: re-auth completes, the save lands, content is present                             | "invariant 3", "re-auth outcomes"                             |
-| Save-on-leave fires at most once per attempt and only for dirty drafts                                                        | "invariant 4", "leave outcomes"                               |
-| Loading any post, including old-schema fixtures, is a clean verdict until the user edits                                      | `change-tracker.test.ts` fixture corpus                       |
-| A failed save leaves the post dirty and recoverable; no error path discards the payload                                       | "invariant 6", "collisions"                                   |
-| Explicit and leave saves set `save_revision`; background saves do not; publish does not force one (coalescing ORs)            | "invariant 7"                                                 |
-| A published/scheduled/sent post's persisted state changes only via explicit Update, publish-flow commands, delete, or restore | "invariant 1", "commands"                                     |
-| Slug generation never overwrites a custom slug and never applies a stale proposal                                             | `slug-machine.test.ts`; "prepare stage" for the port contract |
-| Scheduled saves serialize with zeroed milliseconds and preserve the publish time unless the user changed it                   | "invariant 10", `deriveTarget`                                |
+| Invariant                                                                                                                     | Pinned in                                                  |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| A background command (`autosave`/`timed`/`field`) can never change status, publish, or send email                             | `save-engine.test.ts` "invariant 1"                        |
+| No two saves are in flight; payloads are built at execution; coalescing never loses the newest content                        | "invariant 2", "lifecycle"                                 |
+| Session expiry during a save loses nothing: re-auth completes, the save lands, content is present                             | "invariant 3", "re-auth outcomes"                          |
+| Save-on-leave fires at most once per attempt and only for dirty drafts                                                        | "invariant 4", "leave outcomes"                            |
+| Loading any post, including old-schema fixtures, is a clean verdict until the user edits                                      | the change tracker PR (fixture corpus)                     |
+| A failed save leaves the post dirty and recoverable; no error path discards the payload                                       | "invariant 6", "collisions"                                |
+| Explicit and leave saves set `save_revision`; background saves do not; publish does not force one (coalescing ORs)            | "invariant 7"                                              |
+| A published/scheduled/sent post's persisted state changes only via explicit Update, publish-flow commands, delete, or restore | "invariant 1", "commands"                                  |
+| Slug generation never overwrites a custom slug and never applies a stale proposal                                             | the slug machine PR; "prepare stage" for the port contract |
+| Scheduled saves serialize with zeroed milliseconds and preserve the publish time unless the user changed it                   | "invariant 10", `deriveTarget`                             |
 
 ## Deliberate Ember deltas
 

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -837,9 +837,49 @@ describe('createSaveEngine', () => {
         await flush();
         await expect(completion).resolves.toEqual({ kind: 'needs-retry' });
         expect(h.execute).toHaveBeenCalledTimes(1);
-        expect(h.engine.getState()).toEqual({ kind: 'idle' });
+
+        // A dirty draft resumes autosaving on its own; a published post has nothing to resume.
+        if (intent === 'publish') {
+          expect(h.engine.getState()).toEqual({ kind: 'debouncing' });
+          await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+          expect(h.execute).toHaveBeenCalledTimes(2);
+          expect(h.requests[1]).toMatchObject({ intent: 'autosave', status: 'draft' });
+        } else {
+          expect(h.engine.getState()).toEqual({ kind: 'idle' });
+          await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+          expect(h.execute).toHaveBeenCalledTimes(1);
+        }
       },
     );
+
+    it('re-saves rider content folded into a publish that needs retry', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      h.patch({ willPublish: true });
+      const publish = h.engine.dispatch('publish');
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({ intent: 'publish' });
+      await h.fail(sessionInvalid);
+      expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'publish' });
+
+      h.engine.reauthSucceeded();
+      await flush();
+      await expect(publish).resolves.toEqual({ kind: 'needs-retry' });
+      await expect(autosave).resolves.toEqual({ kind: 'needs-retry' });
+      expect(h.engine.getState()).toEqual({ kind: 'debouncing' });
+
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.execute).toHaveBeenCalledTimes(3);
+      expect(h.requests[2]).toMatchObject({
+        intent: 'autosave',
+        status: 'draft',
+        snapshot: { version: 2 },
+      });
+    });
 
     it('settles every waiter with the session error when re-auth is abandoned', async () => {
       const h = setup();
@@ -929,6 +969,42 @@ describe('createSaveEngine', () => {
       });
       expect(h.execute).not.toHaveBeenCalled();
       expect(h.engine.getState()).toMatchObject({ kind: 'error', intent: 'explicit' });
+    });
+
+    it('resolves a background dispatch as failed when the snapshot port throws', async () => {
+      const h = setup();
+      const cause = new Error('snapshot exploded');
+      h.throwNextSnapshot(cause);
+
+      await expect(h.engine.dispatch('autosave')).resolves.toEqual({
+        kind: 'failed',
+        error: { kind: 'unknown', message: 'snapshot exploded', cause },
+      });
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).not.toHaveBeenCalled();
+    });
+
+    it('asks for confirmation when the snapshot port throws during a leave decision', async () => {
+      const h = setup();
+      h.throwNextSnapshot(new Error('snapshot exploded'));
+      await expect(h.engine.leaveRequested()).resolves.toBe('confirm');
+
+      const decision = h.engine.leaveRequested();
+      await flush();
+      expect(h.requests[0]).toMatchObject({ intent: 'leave' });
+      h.throwNextSnapshot(new Error('snapshot exploded'));
+      await h.succeed();
+      await expect(decision).resolves.toBe('confirm');
+    });
+
+    it('lets a leave decision through once the engine is disposed mid-wait', async () => {
+      const h = setup();
+      const decision = h.engine.leaveRequested();
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      h.engine.dispose();
+      await expect(decision).resolves.toBe('proceed');
     });
 
     it('tolerates listeners that dispatch or unsubscribe during notification', () => {

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -3,47 +3,96 @@ import { deferred, type Deferred } from '@/utils/deferred';
 import {
   AUTOSAVE_DEBOUNCE_MS,
   createSaveEngine,
-  resolveStatus,
+  DEFAULT_TITLE,
+  deriveTarget,
+  resolveTarget,
   TIMED_SAVE_INTERVAL_MS,
   zeroMilliseconds,
   type DispatchIntent,
   type PostStatus,
+  type SaveCommand,
+  type SaveEngine,
   type SaveEngineState,
   type SaveError,
-  type SaveIntent,
   type SaveOutcome,
   type SaveRequest,
+  type SaveResult,
   type SaveSnapshot,
+  type SaveTarget,
+  type SlugPort,
 } from './save-engine';
 
 const NOW = Date.parse('2026-09-02T12:00:00.000Z');
 const FUTURE = '2026-09-03T09:30:00.000Z';
 const PAST = '2026-09-01T09:30:00.000Z';
+const BASELINE = '2026-09-02T11:00:00.000Z';
 
 const flush = () => vi.advanceTimersByTimeAsync(0);
 
-function setup(overrides: Partial<SaveSnapshot> = {}) {
-  let snapshot: SaveSnapshot = {
-    id: 'post-1',
-    isNew: false,
-    status: 'draft',
-    publishedAt: null,
-    willPublish: false,
-    willSchedule: false,
-    isDirty: true,
-    changedSinceLastRevision: true,
-    version: 1,
-    ...overrides,
-  };
+type SnapshotFields = Omit<SaveSnapshot, 'id' | 'updatedAt'> & {
+  id: string | null;
+  updatedAt: string | null;
+};
+
+const BASE: SnapshotFields = {
+  id: 'post-1',
+  updatedAt: BASELINE,
+  status: 'draft',
+  publishedAt: null,
+  title: 'Hello',
+  slug: 'hello',
+  titleDirty: false,
+  slugIsCustom: false,
+  isDirty: true,
+  changedSinceLastRevision: true,
+  version: 1,
+};
+
+const idleSlug: SlugPort = {
+  settled: () => Promise.resolve(),
+  fromTitle: () => Promise.reject(new Error('unexpected slug request')),
+};
+
+function dispatchAny(engine: SaveEngine, kind: DispatchIntent) {
+  switch (kind) {
+    case 'schedule':
+      return engine.dispatch('schedule', { publishedAt: FUTURE });
+    case 'publish':
+      return engine.dispatch('publish');
+    default:
+      return engine.dispatch(kind);
+  }
+}
+
+function setup(overrides: Partial<SnapshotFields> = {}) {
+  let snapshot = { ...BASE, ...overrides } as SaveSnapshot;
   const requests: SaveRequest[] = [];
+  const signals: AbortSignal[] = [];
   const outstanding: Deferred<SaveOutcome>[] = [];
   const states: SaveEngineState[] = [];
+  const listenerErrors: unknown[] = [];
+  const slugRequests: Array<{ title: string; postId: string | null; outcome: Deferred<string> }> =
+    [];
   let concurrent = 0;
   let maxConcurrent = 0;
   let snapshotError: Error | null = null;
+  let slugSettled: Deferred<void> | null = null;
+  let sequence = 0;
 
-  const execute = vi.fn(async (request: SaveRequest) => {
-    requests.push(request);
+  const slug: SlugPort = {
+    settled: vi.fn(() => (slugSettled ? slugSettled.promise : Promise.resolve())),
+    fromTitle: vi.fn((title: string, postId: string | null) => {
+      const outcome = deferred<string>();
+      slugRequests.push({ title, postId, outcome });
+      return outcome.promise;
+    }),
+  };
+
+  const prepare = vi.fn((request: SaveRequest) => Promise.resolve(request));
+
+  const execute = vi.fn(async (prepared: SaveRequest, signal: AbortSignal) => {
+    requests.push(prepared);
+    signals.push(signal);
     concurrent += 1;
     maxConcurrent = Math.max(maxConcurrent, concurrent);
     const outcome = deferred<SaveOutcome>();
@@ -55,6 +104,21 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
     }
   });
 
+  // Adopts the response; edits made after the request left keep the post dirty.
+  const reconcile = vi.fn((prepared: SaveRequest, result: SaveResult) => {
+    const editedInFlight = snapshot.version !== prepared.snapshot.version;
+    snapshot = {
+      ...snapshot,
+      id: result.id,
+      updatedAt: result.updatedAt,
+      status: result.status,
+      publishedAt: prepared.target.publishedAt,
+      slug: prepared.slug,
+      titleDirty: editedInFlight && snapshot.titleDirty,
+      isDirty: editedInFlight,
+    };
+  });
+
   const engine = createSaveEngine({
     getSnapshot: () => {
       if (snapshotError) {
@@ -64,9 +128,12 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
       }
       return snapshot;
     },
+    slug,
+    prepare,
     execute,
-    now: () => NOW,
+    reconcile,
     onStateChange: (state) => states.push(state),
+    onListenerError: (error) => listenerErrors.push(error),
   });
 
   function nextRequest() {
@@ -76,14 +143,21 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
   return {
     engine,
     execute,
+    prepare,
+    reconcile,
+    slug,
+    slugRequests,
     requests,
+    signals,
     states,
+    listenerErrors,
+    nextRequest,
     get snapshot() {
       return snapshot;
     },
     maxConcurrent: () => maxConcurrent,
-    patch(changes: Partial<SaveSnapshot>) {
-      snapshot = { ...snapshot, ...changes };
+    patch(changes: Partial<SnapshotFields>) {
+      snapshot = { ...snapshot, ...changes } as SaveSnapshot;
     },
     edit() {
       snapshot = { ...snapshot, isDirty: true, version: snapshot.version + 1 };
@@ -91,41 +165,56 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
     throwNextSnapshot(error: Error) {
       snapshotError = error;
     },
-    // Mirrors what the editor does on a successful response: adopt id/status, dirty iff edited since the request left.
-    async succeed(changes: Partial<SaveSnapshot> = {}) {
+    holdSlugWork() {
+      slugSettled = deferred<void>();
+      return async () => {
+        slugSettled?.resolve();
+        slugSettled = null;
+        await flush();
+      };
+    },
+    async resolveSlug(value: string) {
+      slugRequests.shift()!.outcome.resolve(value);
+      await flush();
+    },
+    // Each of these lets the prepare stage reach execute before answering the request.
+    async succeed(result: Partial<SaveResult> = {}) {
+      await flush();
       const request = nextRequest();
       const outcome = outstanding.shift()!;
-      const id = request.snapshot.id ?? 'post-1';
-      snapshot = {
-        ...snapshot,
-        id,
-        isNew: false,
-        status: request.status,
-        isDirty: snapshot.version !== request.snapshot.version,
-        ...changes,
-      };
+      sequence += 1;
       outcome.resolve({
         ok: true,
-        result: { id, status: request.status, updatedAt: '2026-09-02T12:00:00.000Z' },
+        result: {
+          id: request.snapshot.id ?? 'post-1',
+          status: request.target.status,
+          updatedAt: new Date(NOW + sequence * 1000).toISOString(),
+          ...result,
+        },
       });
       await flush();
     },
     async fail(error: SaveError) {
+      await flush();
       outstanding.shift()!.resolve({ ok: false, error });
       await flush();
     },
     async reject(cause: unknown) {
+      await flush();
       outstanding.shift()!.reject(cause);
       await flush();
     },
   };
 }
 
+type Harness = ReturnType<typeof setup>;
+
 const validation: SaveError = { kind: 'validation', message: 'Title is too long' };
 const hostLimit: SaveError = { kind: 'host-limit', message: 'Upgrade required' };
 const transport: SaveError = { kind: 'transport', message: 'Server unreachable' };
 const sessionInvalid: SaveError = { kind: 'session-invalid', message: 'Unauthorized' };
 const notFound: SaveError = { kind: 'not-found', message: 'Post not found' };
+const conflict: SaveError = { kind: 'conflict', message: 'Someone else is editing this post' };
 const unknown: SaveError = { kind: 'unknown', message: 'Boom' };
 
 beforeEach(() => {
@@ -136,38 +225,104 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('resolveStatus', () => {
-  const rows: Array<[SaveIntent, PostStatus, boolean, boolean, string | null, PostStatus]> = [
-    ['autosave', 'draft', true, false, null, 'draft'],
-    ['timed', 'draft', false, true, null, 'draft'],
-    ['field', 'draft', true, true, null, 'draft'],
-    ['explicit', 'draft', false, false, null, 'draft'],
-    ['explicit', 'draft', true, false, null, 'published'],
-    ['explicit', 'draft', false, true, FUTURE, 'scheduled'],
-    ['explicit', 'draft', true, true, FUTURE, 'published'],
-    ['explicit', 'published', false, false, PAST, 'published'],
-    ['explicit', 'sent', false, false, PAST, 'sent'],
-    ['explicit', 'scheduled', false, true, FUTURE, 'scheduled'],
-    ['explicit', 'scheduled', false, false, FUTURE, 'scheduled'],
-    ['explicit', 'scheduled', false, false, PAST, 'draft'],
-    ['explicit', 'scheduled', false, true, PAST, 'published'],
-    ['explicit', 'scheduled', true, false, PAST, 'published'],
-    ['leave', 'published', false, false, PAST, 'published'],
-    ['leave', 'draft', true, true, null, 'draft'],
-    ['publish', 'draft', false, false, null, 'published'],
-    ['publish', 'draft', false, true, FUTURE, 'scheduled'],
-    ['revert', 'published', false, false, PAST, 'draft'],
-    ['revert', 'scheduled', false, true, FUTURE, 'draft'],
-  ];
+describe('deriveTarget', () => {
+  it('publishes now and keeps the post’s existing publish time unless told otherwise', () => {
+    expect(deriveTarget('publish', { status: 'draft', publishedAt: null })).toEqual({
+      status: 'published',
+      publishedAt: null,
+    });
+    expect(
+      deriveTarget('publish', { status: 'draft', publishedAt: '2026-09-01T09:30:15.789Z' }),
+    ).toEqual({ status: 'published', publishedAt: '2026-09-01T09:30:15.000Z' });
+    expect(
+      deriveTarget('publish', { status: 'draft', publishedAt: PAST }, { publishedAt: null }),
+    ).toEqual({ status: 'published', publishedAt: null });
+  });
 
-  it.each(rows)(
-    '%s on a %s post (willPublish=%s, willSchedule=%s, publishedAt=%s) resolves to %s',
-    (intent, status, willPublish, willSchedule, publishedAt, expected) => {
-      expect(resolveStatus({ status, publishedAt, willPublish, willSchedule }, intent, NOW)).toBe(
-        expected,
-      );
+  it('carries email extras only when the flow provides them', () => {
+    expect(
+      deriveTarget(
+        'publish',
+        { status: 'draft', publishedAt: null },
+        { emailOnly: true, newsletter: 'weekly', emailSegment: 'status:free' },
+      ),
+    ).toEqual({
+      status: 'published',
+      publishedAt: null,
+      emailOnly: true,
+      newsletter: 'weekly',
+      emailSegment: 'status:free',
+    });
+  });
+
+  it('schedules with a zeroed publish time', () => {
+    expect(
+      deriveTarget(
+        'schedule',
+        { status: 'draft', publishedAt: null },
+        { publishedAt: '2026-09-03T09:30:15.789Z' },
+      ),
+    ).toEqual({ status: 'scheduled', publishedAt: '2026-09-03T09:30:15.000Z' });
+  });
+
+  it('unschedules to a draft with no publish time', () => {
+    expect(deriveTarget('revert', { status: 'scheduled', publishedAt: FUTURE })).toEqual({
+      status: 'draft',
+      publishedAt: null,
+      emailOnly: false,
+    });
+  });
+
+  it.each<PostStatus>(['published', 'sent'])(
+    'unpublishes a %s post to a draft that keeps its historical publish time',
+    (status) => {
+      expect(deriveTarget('revert', { status, publishedAt: PAST })).toEqual({
+        status: 'draft',
+        publishedAt: PAST,
+        emailOnly: false,
+      });
     },
   );
+});
+
+describe('resolveTarget', () => {
+  const command = (kind: SaveCommand['kind']): SaveCommand => ({
+    kind,
+    requiresRevision: false,
+    requiresReconfirmation: false,
+  });
+
+  it.each<SaveCommand['kind']>(['autosave', 'timed', 'field'])(
+    '%s pins the status to draft and leaves the publish time alone',
+    (kind) => {
+      expect(resolveTarget(command(kind), { status: 'draft', publishedAt: PAST })).toEqual({
+        status: 'draft',
+        publishedAt: PAST,
+      });
+    },
+  );
+
+  it.each<[SaveCommand['kind'], PostStatus, string | null]>([
+    ['explicit', 'draft', null],
+    ['explicit', 'published', PAST],
+    ['explicit', 'scheduled', FUTURE],
+    ['explicit', 'scheduled', PAST],
+    ['explicit', 'sent', PAST],
+    ['leave', 'published', PAST],
+    ['leave', 'draft', null],
+  ])('%s on a %s post preserves the status', (kind, status, publishedAt) => {
+    expect(resolveTarget(command(kind), { status, publishedAt })).toEqual({
+      status,
+      publishedAt,
+    });
+  });
+
+  it('returns a captured target untouched', () => {
+    const target: SaveTarget = { status: 'scheduled', publishedAt: FUTURE, newsletter: 'weekly' };
+    expect(
+      resolveTarget({ ...command('schedule'), target }, { status: 'published', publishedAt: PAST }),
+    ).toBe(target);
+  });
 });
 
 describe('zeroMilliseconds', () => {
@@ -180,21 +335,22 @@ describe('zeroMilliseconds', () => {
 
 describe('createSaveEngine', () => {
   describe('invariant 1: background saves never change status', () => {
-    it('pins background intents to draft and never requests a revision', () => {
-      const h = setup({ willPublish: true, willSchedule: true });
+    it('persists a field change on a draft pinned to draft without a revision', async () => {
+      const h = setup({ publishedAt: PAST });
 
       void h.engine.dispatch('field');
+      await flush();
 
       expect(h.requests).toHaveLength(1);
       expect(h.requests[0]).toMatchObject({
-        intent: 'field',
-        status: 'draft',
+        command: { kind: 'field', requiresRevision: false },
+        target: { status: 'draft', publishedAt: PAST },
         saveRevision: false,
       });
     });
 
     it.each<PostStatus>(['published', 'scheduled', 'sent'])(
-      'drops background intents for a %s post',
+      'drops field and autosave intents for a %s post with a typed reason',
       async (status) => {
         const h = setup({ status, publishedAt: FUTURE });
 
@@ -210,14 +366,14 @@ describe('createSaveEngine', () => {
     );
 
     it('drops a pending background save once the in-flight save has published the post', async () => {
-      const h = setup({ willPublish: true });
+      const h = setup();
       const publish = h.engine.dispatch('publish');
       const field = h.engine.dispatch('field');
 
       await h.succeed();
 
       expect(h.snapshot.status).toBe('published');
-      await expect(publish).resolves.toMatchObject({ kind: 'saved' });
+      await expect(publish).resolves.toMatchObject({ kind: 'saved', executedAs: 'publish' });
       await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'not-draft' });
       expect(h.execute).toHaveBeenCalledTimes(1);
     });
@@ -227,6 +383,7 @@ describe('createSaveEngine', () => {
     it('runs one save at a time and builds each payload from the snapshot current at execution', async () => {
       const h = setup();
       const first = h.engine.dispatch('explicit');
+      await flush();
       h.edit();
       const second = h.engine.dispatch('field');
       h.edit();
@@ -241,12 +398,15 @@ describe('createSaveEngine', () => {
 
       await h.succeed();
       expect(h.execute).toHaveBeenCalledTimes(2);
-      expect(h.requests[1]).toMatchObject({ intent: 'explicit', snapshot: { version: 3 } });
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'explicit' },
+        snapshot: { version: 3 },
+      });
 
       await h.succeed();
-      await expect(first).resolves.toMatchObject({ kind: 'saved' });
-      await expect(second).resolves.toMatchObject({ kind: 'saved' });
-      await expect(third).resolves.toMatchObject({ kind: 'saved' });
+      await expect(first).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+      await expect(second).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+      await expect(third).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
       expect(h.maxConcurrent()).toBe(1);
       expect(h.engine.getState()).toEqual({ kind: 'idle' });
     });
@@ -264,7 +424,10 @@ describe('createSaveEngine', () => {
 
       await vi.advanceTimersByTimeAsync(1000);
       expect(h.execute).toHaveBeenCalledTimes(1);
-      expect(h.requests[0]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+      expect(h.requests[0]).toMatchObject({
+        command: { kind: 'autosave' },
+        snapshot: { version: 2 },
+      });
     });
   });
 
@@ -287,7 +450,10 @@ describe('createSaveEngine', () => {
       h.engine.reauthSucceeded();
       await flush();
       expect(h.execute).toHaveBeenCalledTimes(2);
-      expect(h.requests[1]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'autosave' },
+        snapshot: { version: 2 },
+      });
 
       await h.succeed();
       await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
@@ -295,9 +461,9 @@ describe('createSaveEngine', () => {
       expect(h.snapshot.isDirty).toBe(false);
     });
 
-    it('lets a higher-priority intent queued during re-auth win the re-dispatch', async () => {
+    it('lets a higher-priority intent queued during re-auth carry the frozen save', async () => {
       const h = setup();
-      void h.engine.dispatch('field');
+      const field = h.engine.dispatch('field');
       await h.fail(sessionInvalid);
 
       const explicit = h.engine.dispatch('explicit');
@@ -305,10 +471,12 @@ describe('createSaveEngine', () => {
 
       h.engine.reauthSucceeded();
       await flush();
-      expect(h.requests[1]).toMatchObject({ intent: 'explicit', saveRevision: true });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'explicit' }, saveRevision: true });
 
       await h.succeed();
-      await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+      await expect(field).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
     });
 
     it('ignores reauthSucceeded when nothing is waiting on re-authentication', async () => {
@@ -336,7 +504,11 @@ describe('createSaveEngine', () => {
       await flush();
 
       expect(h.requests).toHaveLength(1);
-      expect(h.requests[0]).toMatchObject({ intent: 'leave', status: 'draft', saveRevision: true });
+      expect(h.requests[0]).toMatchObject({
+        command: { kind: 'leave' },
+        target: { status: 'draft' },
+        saveRevision: true,
+      });
 
       await h.succeed();
       await expect(decision).resolves.toBe('proceed');
@@ -361,7 +533,7 @@ describe('createSaveEngine', () => {
 
       const decision = h.engine.leaveRequested();
       await flush();
-      expect(h.requests[0]).toMatchObject({ intent: 'leave', saveRevision: true });
+      expect(h.requests[0]).toMatchObject({ command: { kind: 'leave' }, saveRevision: true });
 
       await h.succeed();
       await expect(decision).resolves.toBe('proceed');
@@ -391,10 +563,10 @@ describe('createSaveEngine', () => {
         const explicit = h.engine.dispatch('explicit');
 
         await h.fail(error);
-        await expect(failing).resolves.toEqual({ kind: 'failed', error });
+        await expect(failing).resolves.toEqual({ kind: 'failed', error, executedAs: 'field' });
         expect(h.snapshot.isDirty).toBe(true);
         expect(h.execute).toHaveBeenCalledTimes(2);
-        expect(h.requests[1]).toMatchObject({ intent: 'explicit' });
+        expect(h.requests[1]).toMatchObject({ command: { kind: 'explicit' } });
 
         await h.succeed();
         await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
@@ -421,35 +593,64 @@ describe('createSaveEngine', () => {
       await expect(completion).resolves.toEqual({
         kind: 'failed',
         error: { kind: 'unknown', message: 'network down', cause },
+        executedAs: 'explicit',
       });
+    });
+
+    it('treats a rejected prepare as an unknown error before any IO starts', async () => {
+      const h = setup();
+      const cause = new Error('invalid candidate');
+      h.prepare.mockRejectedValueOnce(cause);
+
+      await expect(h.engine.dispatch('explicit')).resolves.toEqual({
+        kind: 'failed',
+        error: { kind: 'unknown', message: 'invalid candidate', cause },
+        executedAs: 'explicit',
+      });
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toMatchObject({ kind: 'error', intent: 'explicit' });
     });
   });
 
-  describe('invariant 7: only explicit and leave saves create revisions', () => {
+  describe('invariant 7: only explicit and leave saves set save_revision', () => {
     it.each<[DispatchIntent, boolean]>([
       ['explicit', true],
       ['leave', true],
       ['autosave', false],
       ['field', false],
       ['publish', false],
+      ['schedule', false],
       ['revert', false],
     ])('%s requests save_revision=%s', async (intent, saveRevision) => {
       const h = setup();
-      void h.engine.dispatch(intent);
+      void dispatchAny(h.engine, intent);
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
 
       expect(h.requests).toHaveLength(1);
-      expect(h.requests[0]).toMatchObject({ intent, saveRevision });
+      expect(h.requests[0]).toMatchObject({ command: { kind: intent }, saveRevision });
+    });
+
+    it('ORs the revision requirement across coalesced work', async () => {
+      const h = setup();
+      void h.engine.dispatch('field');
+      const explicit = h.engine.dispatch('explicit');
+      const publish = h.engine.dispatch('publish');
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'publish', requiresRevision: true },
+        saveRevision: true,
+      });
+
+      await h.succeed();
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved', executedAs: 'publish' });
+      await expect(publish).resolves.toMatchObject({ kind: 'saved', executedAs: 'publish' });
     });
   });
 
   describe('invariant 10: scheduled saves zero milliseconds and preserve the publish time', () => {
     it('serializes a future scheduled post with a zeroed publish time across saves', async () => {
-      const h = setup({
-        status: 'scheduled',
-        willSchedule: true,
-        publishedAt: '2026-09-03T09:30:15.789Z',
-      });
+      const h = setup({ status: 'scheduled', publishedAt: '2026-09-03T09:30:15.789Z' });
 
       void h.engine.dispatch('explicit');
       await h.succeed();
@@ -459,47 +660,331 @@ describe('createSaveEngine', () => {
       expect(h.requests).toHaveLength(2);
       for (const request of h.requests) {
         expect(request).toMatchObject({
-          status: 'scheduled',
-          publishedAt: '2026-09-03T09:30:15.000Z',
+          target: { status: 'scheduled', publishedAt: '2026-09-03T09:30:15.000Z' },
         });
       }
     });
 
-    it('compares a past scheduled time after zeroing milliseconds', () => {
-      const publishedAt = new Date(NOW + 500).toISOString();
-      expect(
-        resolveStatus(
-          { status: 'scheduled', publishedAt, willPublish: false, willSchedule: true },
-          'explicit',
-          NOW,
-        ),
-      ).toBe('scheduled');
-      expect(
-        resolveStatus(
-          { status: 'scheduled', publishedAt, willPublish: false, willSchedule: true },
-          'explicit',
-          NOW + 1000,
-        ),
-      ).toBe('published');
+    it('preserves a past scheduled time on an explicit save and leaves the transition to the server', async () => {
+      const h = setup({ status: 'scheduled', publishedAt: PAST });
+      void h.engine.dispatch('explicit');
+      await flush();
+      expect(h.requests[0]).toMatchObject({ target: { status: 'scheduled', publishedAt: PAST } });
     });
   });
 
-  describe('interleavings', () => {
-    it('saves a new post immediately on its first edit', () => {
-      const h = setup({ id: null, isNew: true });
+  describe('lifecycle: capture, prepare, execute, reconcile, drain', () => {
+    it('reconciles the create response before the queued save runs: one POST, then one PUT with the newest content and the returned updated_at', async () => {
+      type Doc = SaveSnapshot & { body: string };
+      type Prepared = SaveRequest<Doc> & { method: 'POST' | 'PUT' };
+      let doc = { ...BASE, id: null, updatedAt: null, body: 'first' } as Doc;
+      const wire: Array<{ method: string; body: string; updatedAt: string | null }> = [];
+      const responses: Deferred<SaveOutcome>[] = [];
+
+      const engine = createSaveEngine<Doc, Prepared>({
+        getSnapshot: () => doc,
+        slug: idleSlug,
+        prepare: (request) =>
+          Promise.resolve({ ...request, method: request.snapshot.id ? 'PUT' : 'POST' }),
+        execute: async (prepared) => {
+          wire.push({
+            method: prepared.method,
+            body: prepared.snapshot.body,
+            updatedAt: prepared.snapshot.updatedAt,
+          });
+          const response = deferred<SaveOutcome>();
+          responses.push(response);
+          return response.promise;
+        },
+        reconcile: (prepared, result) => {
+          doc = {
+            ...doc,
+            id: result.id,
+            updatedAt: result.updatedAt,
+            status: result.status,
+            isDirty: doc.version !== prepared.snapshot.version,
+          };
+        },
+      });
+
+      const create = engine.dispatch('explicit');
+      await flush();
+      doc = { ...doc, body: 'second', version: 2 };
+      const autosave = engine.dispatch('autosave');
+      expect(wire).toEqual([{ method: 'POST', body: 'first', updatedAt: null }]);
+
+      responses[0].resolve({
+        ok: true,
+        result: { id: 'post-9', status: 'draft', updatedAt: '2026-09-02T12:00:01.000Z' },
+      });
+      await flush();
+      expect(wire).toEqual([
+        { method: 'POST', body: 'first', updatedAt: null },
+        { method: 'PUT', body: 'second', updatedAt: '2026-09-02T12:00:01.000Z' },
+      ]);
+
+      responses[1].resolve({
+        ok: true,
+        result: { id: 'post-9', status: 'draft', updatedAt: '2026-09-02T12:00:02.000Z' },
+      });
+      await flush();
+      await expect(create).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved', executedAs: 'autosave' });
+      expect(doc).toMatchObject({
+        id: 'post-9',
+        updatedAt: '2026-09-02T12:00:02.000Z',
+        isDirty: false,
+      });
+    });
+
+    it('starts IO only after prepare settles', async () => {
+      const h = setup();
+      const prepared = deferred<SaveRequest>();
+      h.prepare.mockReturnValueOnce(prepared.promise);
+
+      void h.engine.dispatch('explicit');
+      await flush();
+      expect(h.engine.getState()).toEqual({ kind: 'saving', intent: 'explicit' });
+      expect(h.execute).not.toHaveBeenCalled();
+
+      prepared.resolve(h.prepare.mock.calls[0][0]);
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts the in-flight signal on dispose and never reconciles the late response', async () => {
+      const h = setup();
+      const explicit = h.engine.dispatch('explicit');
+      await flush();
+      expect(h.signals[0].aborted).toBe(false);
+
+      h.engine.dispose();
+      expect(h.signals[0].aborted).toBe(true);
+      await expect(explicit).resolves.toEqual({ kind: 'dropped', reason: 'disposed' });
+
+      await h.succeed();
+      expect(h.reconcile).not.toHaveBeenCalled();
+      expect(h.snapshot.updatedAt).toBe(BASELINE);
+      expect(h.engine.getState()).toEqual({ kind: 'disposed' });
+    });
+  });
+
+  describe('prepare stage: title and slug', () => {
+    it('serializes an explicit save behind manual slug work in progress', async () => {
+      const h = setup();
+      const release = h.holdSlugWork();
+
+      const explicit = h.engine.dispatch('explicit');
+      await flush();
+      expect(h.engine.getState()).toEqual({ kind: 'saving', intent: 'explicit' });
+      expect(h.execute).not.toHaveBeenCalled();
+
+      await release();
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      await h.succeed();
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+    });
+
+    it('waits for a slow slug request before a leave save leaves', async () => {
+      const h = setup({ slug: '' });
+      const decision = h.engine.leaveRequested();
+      await flush();
+      expect(h.slug.fromTitle).toHaveBeenCalledWith('Hello', 'post-1', expect.any(AbortSignal));
+      expect(h.execute).not.toHaveBeenCalled();
+
+      await h.resolveSlug('hello');
+      expect(h.requests[0]).toMatchObject({ command: { kind: 'leave' }, slug: 'hello' });
+
+      await h.succeed();
+      await expect(decision).resolves.toBe('proceed');
+    });
+
+    it('creates a titleless body-first post as (Untitled) with a generated slug', async () => {
+      const h = setup({ id: null, updatedAt: null, title: '', slug: '' });
       void h.engine.dispatch('autosave');
+      await flush();
+      expect(h.slug.fromTitle).toHaveBeenCalledWith(DEFAULT_TITLE, null, expect.any(AbortSignal));
+
+      await h.resolveSlug('untitled');
+      expect(h.requests[0]).toMatchObject({
+        title: DEFAULT_TITLE,
+        slug: 'untitled',
+        target: { status: 'draft' },
+        snapshot: { id: null, title: '' },
+      });
+    });
+
+    it('treats a whitespace title as blank', async () => {
+      const h = setup({ id: null, updatedAt: null, title: '   ', slug: '' });
+      void h.engine.dispatch('explicit');
+      await flush();
+      expect(h.slug.fromTitle).toHaveBeenCalledWith(DEFAULT_TITLE, null, expect.any(AbortSignal));
+
+      await h.resolveSlug('untitled');
+      expect(h.requests[0]).toMatchObject({ title: DEFAULT_TITLE, slug: 'untitled' });
+    });
+
+    it('never regenerates a custom slug', async () => {
+      const h = setup({ title: 'Renamed', titleDirty: true, slug: 'my-slug', slugIsCustom: true });
+      void h.engine.dispatch('explicit');
+      await flush();
+
+      expect(h.slug.fromTitle).not.toHaveBeenCalled();
+      expect(h.requests[0]).toMatchObject({ title: 'Renamed', slug: 'my-slug' });
+    });
+
+    it('applies the server-deduplicated slug requested with the post id', async () => {
+      const h = setup({ title: 'Hello world', titleDirty: true });
+      void h.engine.dispatch('explicit');
+      await flush();
+      expect(h.slug.fromTitle).toHaveBeenCalledWith(
+        'Hello world',
+        'post-1',
+        expect.any(AbortSignal),
+      );
+
+      await h.resolveSlug('hello-world-2');
+      expect(h.requests[0]).toMatchObject({ slug: 'hello-world-2', snapshot: { id: 'post-1' } });
+      await h.succeed();
+      expect(h.snapshot.slug).toBe('hello-world-2');
+    });
+
+    it('keeps the existing slug when a draft title is cleared', async () => {
+      const h = setup({ title: '', titleDirty: true });
+      void h.engine.dispatch('explicit');
+      await flush();
+
+      expect(h.slug.fromTitle).not.toHaveBeenCalled();
+      expect(h.requests[0]).toMatchObject({ title: DEFAULT_TITLE, slug: 'hello' });
+    });
+
+    it('does not regenerate a published post’s slug when its title changes', async () => {
+      const h = setup({
+        status: 'published',
+        publishedAt: PAST,
+        title: 'Renamed',
+        titleDirty: true,
+      });
+      void h.engine.dispatch('explicit');
+      await flush();
+
+      expect(h.slug.fromTitle).not.toHaveBeenCalled();
+      expect(h.requests[0]).toMatchObject({ slug: 'hello' });
+    });
+
+    it('generates a slug for a post of any status that has none', async () => {
+      const h = setup({ status: 'published', publishedAt: PAST, slug: '' });
+      void h.engine.dispatch('explicit');
+      await flush();
+
+      expect(h.slug.fromTitle).toHaveBeenCalledWith('Hello', 'post-1', expect.any(AbortSignal));
+    });
+  });
+
+  describe('commands: captured at dispatch', () => {
+    it('captures a schedule target that a response resync cannot turn into a publish', async () => {
+      const h = setup({ id: null, updatedAt: null });
+      void h.engine.dispatch('explicit');
+      await flush();
+      const schedule = h.engine.dispatch('schedule', { publishedAt: FUTURE });
+      h.patch({ publishedAt: PAST });
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'schedule', target: { status: 'scheduled', publishedAt: FUTURE } },
+        target: { status: 'scheduled', publishedAt: FUTURE },
+        snapshot: { id: 'post-1', publishedAt: null },
+      });
+
+      await h.succeed();
+      await expect(schedule).resolves.toMatchObject({ kind: 'saved', executedAs: 'schedule' });
+    });
+
+    it('attaches email extras to exactly the publish request', async () => {
+      const h = setup();
+      void h.engine.dispatch('publish', { newsletter: 'weekly', emailSegment: 'all' });
+      const explicit = h.engine.dispatch('explicit');
+
+      await h.succeed();
+      expect(h.requests[0].target).toEqual({
+        status: 'published',
+        publishedAt: null,
+        newsletter: 'weekly',
+        emailSegment: 'all',
+      });
+      expect(h.requests[1].target).toEqual({ status: 'published', publishedAt: null });
+
+      await h.succeed();
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+    });
+
+    it('disarms a failed publish: the next explicit save preserves the draft status', async () => {
+      const h = setup();
+      const publish = h.engine.dispatch('publish', { newsletter: 'weekly' });
+      await h.fail(transport);
+      await expect(publish).resolves.toEqual({
+        kind: 'failed',
+        error: transport,
+        executedAs: 'publish',
+      });
+
+      void h.engine.dispatch('explicit');
+      await flush();
+      expect(h.requests[1].target).toEqual({ status: 'draft', publishedAt: null });
+    });
+
+    it('unschedules to a draft with no publish time', async () => {
+      const h = setup({ status: 'scheduled', publishedAt: FUTURE });
+      void h.engine.dispatch('revert');
+      await flush();
+      expect(h.requests[0].target).toEqual({
+        status: 'draft',
+        publishedAt: null,
+        emailOnly: false,
+      });
+    });
+
+    it('unpublishes to a draft that keeps its historical publish time', async () => {
+      const h = setup({ status: 'published', publishedAt: PAST });
+      void h.engine.dispatch('revert');
+      await flush();
+      expect(h.requests[0].target).toEqual({
+        status: 'draft',
+        publishedAt: PAST,
+        emailOnly: false,
+      });
+    });
+
+    it.each<PostStatus>(['published', 'scheduled', 'sent'])(
+      'preserves the %s status on an explicit save',
+      async (status) => {
+        const h = setup({ status, publishedAt: status === 'scheduled' ? FUTURE : PAST });
+        void h.engine.dispatch('explicit');
+        await flush();
+        expect(h.requests[0].target.status).toBe(status);
+      },
+    );
+  });
+
+  describe('interleavings', () => {
+    it('saves a new post immediately on its first edit', async () => {
+      const h = setup({ id: null, updatedAt: null });
+      void h.engine.dispatch('autosave');
+      expect(h.engine.getState()).toEqual({ kind: 'saving', intent: 'autosave' });
+      await flush();
 
       expect(h.execute).toHaveBeenCalledTimes(1);
       expect(h.requests[0]).toMatchObject({
-        intent: 'autosave',
-        status: 'draft',
+        command: { kind: 'autosave' },
+        target: { status: 'draft' },
         snapshot: { id: null },
       });
     });
 
     it('coalesces an autosave arriving during an in-flight create and rebuilds its payload', async () => {
-      const h = setup({ id: null, isNew: true });
+      const h = setup({ id: null, updatedAt: null });
       const create = h.engine.dispatch('explicit');
+      await flush();
       h.edit();
       const autosave = h.engine.dispatch('autosave');
 
@@ -510,11 +995,11 @@ describe('createSaveEngine', () => {
       });
       expect(h.execute).toHaveBeenCalledTimes(1);
 
-      await h.succeed({ id: 'post-1' });
+      await h.succeed();
       expect(h.execute).toHaveBeenCalledTimes(2);
       expect(h.requests[1]).toMatchObject({
-        intent: 'autosave',
-        snapshot: { id: 'post-1', isNew: false, version: 2 },
+        command: { kind: 'autosave' },
+        snapshot: { id: 'post-1', version: 2 },
       });
 
       await h.succeed();
@@ -525,6 +1010,7 @@ describe('createSaveEngine', () => {
     it('coalesces a debounced autosave that fires during a slow explicit save', async () => {
       const h = setup();
       void h.engine.dispatch('explicit');
+      await flush();
       h.edit();
       void h.engine.dispatch('autosave');
       await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
@@ -536,7 +1022,10 @@ describe('createSaveEngine', () => {
       });
 
       await h.succeed();
-      expect(h.requests[1]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'autosave' },
+        snapshot: { version: 2 },
+      });
     });
 
     it('lets an explicit save cancel a pending autosave debounce and supersede it', async () => {
@@ -545,14 +1034,15 @@ describe('createSaveEngine', () => {
       await vi.advanceTimersByTimeAsync(1000);
 
       const explicit = h.engine.dispatch('explicit');
+      await flush();
       expect(h.execute).toHaveBeenCalledTimes(1);
-      expect(h.requests[0]).toMatchObject({ intent: 'explicit' });
+      expect(h.requests[0]).toMatchObject({ command: { kind: 'explicit' } });
 
       await h.succeed();
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
       expect(h.execute).toHaveBeenCalledTimes(1);
-      await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
-      await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
     });
 
     it('waits for an in-flight save on leave, then saves once with a revision', async () => {
@@ -564,7 +1054,7 @@ describe('createSaveEngine', () => {
 
       await h.succeed();
       expect(h.execute).toHaveBeenCalledTimes(2);
-      expect(h.requests[1]).toMatchObject({ intent: 'leave', saveRevision: true });
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'leave' }, saveRevision: true });
 
       await h.succeed();
       await expect(decision).resolves.toBe('proceed');
@@ -573,6 +1063,7 @@ describe('createSaveEngine', () => {
     it('lets publish win the pending slot over a queued autosave', async () => {
       const h = setup();
       void h.engine.dispatch('field');
+      await flush();
       h.edit();
       const autosave = h.engine.dispatch('autosave');
       await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
@@ -582,7 +1073,6 @@ describe('createSaveEngine', () => {
         pending: 'autosave',
       });
 
-      h.patch({ willPublish: true });
       const publish = h.engine.dispatch('publish');
       expect(h.engine.getState()).toEqual({
         kind: 'pending-coalesced',
@@ -592,14 +1082,14 @@ describe('createSaveEngine', () => {
 
       await h.succeed();
       expect(h.requests[1]).toMatchObject({
-        intent: 'publish',
-        status: 'published',
+        command: { kind: 'publish' },
+        target: { status: 'published' },
         snapshot: { version: 2 },
       });
 
       await h.succeed();
-      await expect(publish).resolves.toMatchObject({ kind: 'saved' });
-      await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
+      await expect(publish).resolves.toMatchObject({ kind: 'saved', executedAs: 'publish' });
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved', executedAs: 'publish' });
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
       expect(h.execute).toHaveBeenCalledTimes(2);
     });
@@ -607,12 +1097,18 @@ describe('createSaveEngine', () => {
     it('halts permanently on a 404 for a known post id', async () => {
       const h = setup();
       const failing = h.engine.dispatch('explicit');
+      await flush();
       h.edit();
-      void h.engine.dispatch('autosave');
+      const autosave = h.engine.dispatch('autosave');
 
       await h.fail(notFound);
       expect(h.engine.getState()).toEqual({ kind: 'halted' });
-      await expect(failing).resolves.toEqual({ kind: 'failed', error: notFound });
+      await expect(failing).resolves.toEqual({
+        kind: 'failed',
+        error: notFound,
+        executedAs: 'explicit',
+      });
+      await expect(autosave).resolves.toEqual({ kind: 'dropped', reason: 'halted' });
 
       await expect(h.engine.dispatch('explicit')).resolves.toEqual({
         kind: 'dropped',
@@ -628,7 +1124,7 @@ describe('createSaveEngine', () => {
     });
 
     it('crashes on a 404 for a post that has no id yet', async () => {
-      const h = setup({ id: null, isNew: true });
+      const h = setup({ id: null, updatedAt: null });
       void h.engine.dispatch('explicit');
 
       await h.fail(notFound);
@@ -640,7 +1136,7 @@ describe('createSaveEngine', () => {
     });
 
     it.each([validation, hostLimit])(
-      'suppresses background saves after a $kind error until the snapshot changes',
+      'suppresses background saves after a $kind error on a draft save until the snapshot changes',
       async (error) => {
         const h = setup();
         void h.engine.dispatch('explicit');
@@ -659,6 +1155,7 @@ describe('createSaveEngine', () => {
         expect(h.execute).toHaveBeenCalledTimes(1);
 
         void h.engine.dispatch('explicit');
+        await flush();
         expect(h.execute).toHaveBeenCalledTimes(2);
         await h.fail(error);
 
@@ -666,9 +1163,24 @@ describe('createSaveEngine', () => {
         void h.engine.dispatch('autosave');
         await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
         expect(h.execute).toHaveBeenCalledTimes(3);
-        expect(h.requests[2]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+        expect(h.requests[2]).toMatchObject({
+          command: { kind: 'autosave' },
+          snapshot: { version: 2 },
+        });
       },
     );
+
+    it('scopes host-limit suppression to the failing operation: a publish limit never halts autosave', async () => {
+      const h = setup();
+      const publish = h.engine.dispatch('publish');
+      await h.fail(hostLimit);
+      await expect(publish).resolves.toMatchObject({ kind: 'failed', error: hostLimit });
+
+      void h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'autosave' } });
+    });
 
     it('keeps autosaving after a transport error', async () => {
       const h = setup();
@@ -678,7 +1190,7 @@ describe('createSaveEngine', () => {
       void h.engine.dispatch('autosave');
       await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
       expect(h.execute).toHaveBeenCalledTimes(2);
-      expect(h.requests[1]).toMatchObject({ intent: 'autosave' });
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'autosave' } });
     });
 
     it('forces a timed save after 60s of continuous editing', async () => {
@@ -692,8 +1204,8 @@ describe('createSaveEngine', () => {
 
       expect(h.execute).toHaveBeenCalledTimes(1);
       expect(h.requests[0]).toMatchObject({
-        intent: 'timed',
-        status: 'draft',
+        command: { kind: 'timed' },
+        target: { status: 'draft' },
         saveRevision: false,
         snapshot: { version: 61 },
       });
@@ -702,7 +1214,7 @@ describe('createSaveEngine', () => {
       const completions = await Promise.all(autosaves);
       expect(completions).toHaveLength(60);
       for (const completion of completions) {
-        expect(completion).toMatchObject({ kind: 'saved' });
+        expect(completion).toMatchObject({ kind: 'saved', executedAs: 'timed' });
       }
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
       expect(h.execute).toHaveBeenCalledTimes(1);
@@ -715,6 +1227,20 @@ describe('createSaveEngine', () => {
       await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
 
       await expect(autosave).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
+    });
+
+    it('skips a background save that finds the post clean after slug work settled', async () => {
+      const h = setup();
+      const release = h.holdSlugWork();
+      const field = h.engine.dispatch('field');
+      await flush();
+      expect(h.engine.getState()).toEqual({ kind: 'saving', intent: 'field' });
+
+      h.patch({ isDirty: false });
+      await release();
+      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
       expect(h.execute).not.toHaveBeenCalled();
       expect(h.engine.getState()).toEqual({ kind: 'idle' });
     });
@@ -737,6 +1263,7 @@ describe('createSaveEngine', () => {
     it('dispose cancels timers and settles every outstanding dispatch', async () => {
       const h = setup();
       const explicit = h.engine.dispatch('explicit');
+      await flush();
       h.edit();
       const autosave = h.engine.dispatch('autosave');
 
@@ -755,6 +1282,80 @@ describe('createSaveEngine', () => {
     });
   });
 
+  describe('collisions', () => {
+    // Two engines over the same post; the fake server accepts only the updated_at it last returned.
+    it('gives the second writer a typed conflict that halts its automatic saves until it reloads', async () => {
+      const server = { updatedAt: BASELINE };
+      async function respond(h: Harness) {
+        await flush();
+        if (h.nextRequest().snapshot.updatedAt !== server.updatedAt) {
+          await h.fail(conflict);
+          return;
+        }
+        server.updatedAt = new Date(Date.parse(server.updatedAt) + 60000).toISOString();
+        await h.succeed({ updatedAt: server.updatedAt });
+      }
+      const first = setup();
+      const second = setup();
+
+      void first.engine.dispatch('explicit');
+      await respond(first);
+      expect(first.snapshot.updatedAt).toBe(server.updatedAt);
+
+      const explicit = second.engine.dispatch('explicit');
+      await respond(second);
+      await expect(explicit).resolves.toEqual({
+        kind: 'failed',
+        error: conflict,
+        executedAs: 'explicit',
+      });
+      expect(second.engine.getState()).toEqual({
+        kind: 'conflict',
+        intent: 'explicit',
+        error: conflict,
+      });
+      expect(second.snapshot).toMatchObject({ isDirty: true, updatedAt: BASELINE });
+
+      await expect(second.engine.dispatch('autosave')).resolves.toEqual({
+        kind: 'dropped',
+        reason: 'conflict',
+      });
+      await expect(second.engine.dispatch('field')).resolves.toEqual({
+        kind: 'dropped',
+        reason: 'conflict',
+      });
+      await expect(second.engine.leaveRequested()).resolves.toBe('confirm');
+
+      const retry = second.engine.dispatch('explicit');
+      await flush();
+      expect(second.execute).toHaveBeenCalledTimes(2);
+      await respond(second);
+      await expect(retry).resolves.toMatchObject({ kind: 'failed', error: conflict });
+
+      second.patch({ updatedAt: server.updatedAt });
+      void second.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(second.execute).toHaveBeenCalledTimes(3);
+      await respond(second);
+      expect(second.engine.getState()).toEqual({ kind: 'idle' });
+      expect(second.snapshot).toMatchObject({ isDirty: false, updatedAt: server.updatedAt });
+    });
+
+    it('drops queued background work on a conflict and keeps the content dirty', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      await flush();
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+
+      await h.fail(conflict);
+      await expect(autosave).resolves.toEqual({ kind: 'dropped', reason: 'conflict' });
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.snapshot).toMatchObject({ isDirty: true, version: 2 });
+    });
+  });
+
   describe('leave outcomes', () => {
     it('asks for confirmation when the in-flight save it waited for fails', async () => {
       const h = setup({ changedSinceLastRevision: false });
@@ -767,12 +1368,25 @@ describe('createSaveEngine', () => {
       expect(h.execute).toHaveBeenCalledTimes(1);
     });
 
+    it('re-reads the post after the in-flight save and asks for confirmation when it is still dirty', async () => {
+      const h = setup({ changedSinceLastRevision: false });
+      void h.engine.dispatch('explicit');
+      const decision = h.engine.leaveRequested();
+      await flush();
+
+      h.edit();
+      await h.succeed();
+      expect(h.snapshot.isDirty).toBe(true);
+      await expect(decision).resolves.toBe('confirm');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
     it('asks for confirmation when the leave save replacing an armed autosave fails', async () => {
       const h = setup({ changedSinceLastRevision: false });
       void h.engine.dispatch('autosave');
       const decision = h.engine.leaveRequested();
       await flush();
-      expect(h.requests[0]).toMatchObject({ intent: 'leave' });
+      expect(h.requests[0]).toMatchObject({ command: { kind: 'leave' } });
 
       await h.fail(transport);
       await expect(decision).resolves.toBe('confirm');
@@ -801,7 +1415,7 @@ describe('createSaveEngine', () => {
 
       h.engine.reauthSucceeded();
       await flush();
-      expect(h.requests[1]).toMatchObject({ intent: 'leave', saveRevision: true });
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'leave' }, saveRevision: true });
 
       await h.succeed();
       await expect(decision).resolves.toBe('proceed');
@@ -824,13 +1438,11 @@ describe('createSaveEngine', () => {
   });
 
   describe('re-auth outcomes', () => {
-    it.each<DispatchIntent>(['publish', 'revert'])(
+    it.each<DispatchIntent>(['publish', 'schedule', 'revert'])(
       'never auto-fires a %s after re-auth; it resolves needs-retry',
       async (intent) => {
-        const h = setup(
-          intent === 'revert' ? { status: 'published', publishedAt: PAST } : { willPublish: true },
-        );
-        const completion = h.engine.dispatch(intent);
+        const h = setup(intent === 'revert' ? { status: 'published', publishedAt: PAST } : {});
+        const completion = dispatchAny(h.engine, intent);
         await h.fail(sessionInvalid);
 
         h.engine.reauthSucceeded();
@@ -839,46 +1451,169 @@ describe('createSaveEngine', () => {
         expect(h.execute).toHaveBeenCalledTimes(1);
 
         // A dirty draft resumes autosaving on its own; a published post has nothing to resume.
-        if (intent === 'publish') {
-          expect(h.engine.getState()).toEqual({ kind: 'debouncing' });
-          await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
-          expect(h.execute).toHaveBeenCalledTimes(2);
-          expect(h.requests[1]).toMatchObject({ intent: 'autosave', status: 'draft' });
-        } else {
+        if (intent === 'revert') {
           expect(h.engine.getState()).toEqual({ kind: 'idle' });
           await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
           expect(h.execute).toHaveBeenCalledTimes(1);
+        } else {
+          expect(h.engine.getState()).toEqual({ kind: 'debouncing' });
+          await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+          expect(h.execute).toHaveBeenCalledTimes(2);
+          expect(h.requests[1]).toMatchObject({
+            command: { kind: 'autosave' },
+            target: { status: 'draft' },
+          });
         }
       },
     );
 
-    it('re-saves rider content folded into a publish that needs retry', async () => {
+    it('never auto-fires a publish queued while a background save was frozen', async () => {
       const h = setup();
-      void h.engine.dispatch('explicit');
-      h.edit();
-      const autosave = h.engine.dispatch('autosave');
-      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
-      h.patch({ willPublish: true });
-      const publish = h.engine.dispatch('publish');
+      const field = h.engine.dispatch('field');
+      await h.fail(sessionInvalid);
+      const publish = h.engine.dispatch('publish', { newsletter: 'weekly' });
+
+      h.engine.reauthSucceeded();
+      await flush();
+      await expect(publish).resolves.toEqual({ kind: 'needs-retry' });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'field' },
+        target: { status: 'draft', publishedAt: null },
+      });
 
       await h.succeed();
-      expect(h.requests[1]).toMatchObject({ intent: 'publish' });
+      await expect(field).resolves.toMatchObject({ kind: 'saved', executedAs: 'field' });
+      expect(h.snapshot.status).toBe('draft');
+    });
+
+    it('re-runs a frozen explicit rider on its own but never the publish it coalesced into', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      const rider = h.engine.dispatch('explicit');
+      const publish = h.engine.dispatch('publish');
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'publish' }, saveRevision: true });
+
       await h.fail(sessionInvalid);
       expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'publish' });
 
       h.engine.reauthSucceeded();
       await flush();
       await expect(publish).resolves.toEqual({ kind: 'needs-retry' });
-      await expect(autosave).resolves.toEqual({ kind: 'needs-retry' });
+      expect(h.execute).toHaveBeenCalledTimes(3);
+      expect(h.requests[2]).toMatchObject({
+        command: { kind: 'explicit' },
+        target: { status: 'draft' },
+        saveRevision: true,
+      });
+
+      await h.succeed();
+      await expect(rider).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+    });
+
+    it('judges re-auth by the resolved effect: a frozen revert whose post is already a draft re-runs', async () => {
+      const h = setup({ status: 'published', publishedAt: PAST });
+      const revert = h.engine.dispatch('revert');
+      await h.fail(sessionInvalid);
+
+      h.patch({ status: 'draft' });
+      h.engine.reauthSucceeded();
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'revert' },
+        target: { status: 'draft', publishedAt: PAST },
+      });
+
+      await h.succeed();
+      await expect(revert).resolves.toMatchObject({ kind: 'saved', executedAs: 'revert' });
+    });
+
+    it('never double-creates a new post whose publish needs retry after re-auth', async () => {
+      const h = setup({ id: null, updatedAt: null });
+      const publish = h.engine.dispatch('publish');
+      await h.fail(sessionInvalid);
+      const explicit = h.engine.dispatch('explicit');
+
+      h.engine.reauthSucceeded();
+      await flush();
+      await expect(publish).resolves.toEqual({ kind: 'needs-retry' });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'explicit' },
+        target: { status: 'draft' },
+        snapshot: { id: null },
+      });
+      expect(h.engine.getState()).toEqual({ kind: 'saving', intent: 'explicit' });
+
+      await h.succeed();
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.maxConcurrent()).toBe(1);
+    });
+
+    it('resumes a new post’s autosave after a failed publish without a concurrent create', async () => {
+      const h = setup({ id: null, updatedAt: null });
+      void h.engine.dispatch('publish');
+      await h.fail(sessionInvalid);
+
+      h.engine.reauthSucceeded();
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'autosave' },
+        target: { status: 'draft' },
+      });
+
+      await h.succeed();
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.maxConcurrent()).toBe(1);
+    });
+
+    it('re-saves rider content folded into a publish that needs retry', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      await flush();
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      const publish = h.engine.dispatch('publish');
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'publish' } });
+      await h.fail(sessionInvalid);
+      expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'publish' });
+
+      h.engine.reauthSucceeded();
+      await flush();
+      await expect(publish).resolves.toEqual({ kind: 'needs-retry' });
+      expect(h.execute).toHaveBeenCalledTimes(3);
+      expect(h.requests[2]).toMatchObject({
+        command: { kind: 'autosave' },
+        target: { status: 'draft' },
+        snapshot: { version: 2 },
+      });
+
+      await h.succeed();
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved', executedAs: 'autosave' });
+    });
+
+    it('re-arms the autosave when the snapshot cannot be read after re-auth', async () => {
+      const h = setup();
+      void h.engine.dispatch('publish');
+      await h.fail(sessionInvalid);
+
+      h.throwNextSnapshot(new Error('snapshot exploded'));
+      h.engine.reauthSucceeded();
+      await flush();
       expect(h.engine.getState()).toEqual({ kind: 'debouncing' });
 
       await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
-      expect(h.execute).toHaveBeenCalledTimes(3);
-      expect(h.requests[2]).toMatchObject({
-        intent: 'autosave',
-        status: 'draft',
-        snapshot: { version: 2 },
-      });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ command: { kind: 'autosave' } });
     });
 
     it('settles every waiter with the session error when re-auth is abandoned', async () => {
@@ -890,9 +1625,21 @@ describe('createSaveEngine', () => {
       const autosave = h.engine.dispatch('autosave');
 
       h.engine.reauthAbandoned();
-      await expect(field).resolves.toEqual({ kind: 'failed', error: sessionInvalid });
-      await expect(explicit).resolves.toEqual({ kind: 'failed', error: sessionInvalid });
-      await expect(autosave).resolves.toEqual({ kind: 'failed', error: sessionInvalid });
+      await expect(field).resolves.toEqual({
+        kind: 'failed',
+        error: sessionInvalid,
+        executedAs: 'field',
+      });
+      await expect(explicit).resolves.toEqual({
+        kind: 'failed',
+        error: sessionInvalid,
+        executedAs: 'explicit',
+      });
+      await expect(autosave).resolves.toEqual({
+        kind: 'failed',
+        error: sessionInvalid,
+        executedAs: 'autosave',
+      });
       expect(h.engine.getState()).toEqual({
         kind: 'error',
         intent: 'field',
@@ -902,6 +1649,7 @@ describe('createSaveEngine', () => {
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
       expect(h.execute).toHaveBeenCalledTimes(1);
       void h.engine.dispatch('explicit');
+      await flush();
       expect(h.execute).toHaveBeenCalledTimes(2);
     });
 
@@ -913,10 +1661,10 @@ describe('createSaveEngine', () => {
   });
 
   describe('coalescing and state reporting', () => {
-    it('lets a contradictory revert replace a pending publish and marks the publish superseded', async () => {
-      const h = setup();
+    it('lets a later revert supersede only the pending publish and keeps its riders', async () => {
+      const h = setup({ status: 'scheduled', publishedAt: FUTURE });
       void h.engine.dispatch('explicit');
-      h.patch({ willPublish: true });
+      const rider = h.engine.dispatch('explicit');
       const publish = h.engine.dispatch('publish');
       const revert = h.engine.dispatch('revert');
 
@@ -928,9 +1676,14 @@ describe('createSaveEngine', () => {
       });
 
       await h.succeed();
-      expect(h.requests[1]).toMatchObject({ intent: 'revert', status: 'draft' });
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'revert', requiresRevision: true },
+        target: { status: 'draft', publishedAt: null, emailOnly: false },
+        saveRevision: true,
+      });
       await h.succeed();
-      await expect(revert).resolves.toMatchObject({ kind: 'saved' });
+      await expect(revert).resolves.toMatchObject({ kind: 'saved', executedAs: 'revert' });
+      await expect(rider).resolves.toMatchObject({ kind: 'saved', executedAs: 'revert' });
       expect(h.execute).toHaveBeenCalledTimes(2);
     });
 
@@ -966,6 +1719,7 @@ describe('createSaveEngine', () => {
       await expect(h.engine.dispatch('explicit')).resolves.toEqual({
         kind: 'failed',
         error: { kind: 'unknown', message: 'snapshot exploded', cause },
+        executedAs: 'explicit',
       });
       expect(h.execute).not.toHaveBeenCalled();
       expect(h.engine.getState()).toMatchObject({ kind: 'error', intent: 'explicit' });
@@ -979,6 +1733,7 @@ describe('createSaveEngine', () => {
       await expect(h.engine.dispatch('autosave')).resolves.toEqual({
         kind: 'failed',
         error: { kind: 'unknown', message: 'snapshot exploded', cause },
+        executedAs: 'autosave',
       });
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
       expect(h.execute).not.toHaveBeenCalled();
@@ -991,7 +1746,7 @@ describe('createSaveEngine', () => {
 
       const decision = h.engine.leaveRequested();
       await flush();
-      expect(h.requests[0]).toMatchObject({ intent: 'leave' });
+      expect(h.requests[0]).toMatchObject({ command: { kind: 'leave' } });
       h.throwNextSnapshot(new Error('snapshot exploded'));
       await h.succeed();
       await expect(decision).resolves.toBe('confirm');
@@ -1021,12 +1776,27 @@ describe('createSaveEngine', () => {
 
       void h.engine.dispatch('explicit');
 
-      expect(seen).toEqual(['saving', 'other:pending-coalesced', 'other:pending-coalesced']);
+      expect(seen).toEqual(['saving', 'other:pending-coalesced']);
       expect(h.engine.getState()).toEqual({
         kind: 'pending-coalesced',
         intent: 'explicit',
         pending: 'field',
       });
+    });
+
+    it('reports a throwing listener without interrupting the others', () => {
+      const h = setup();
+      const failure = new Error('listener exploded');
+      const seen: SaveEngineState[] = [];
+      h.engine.subscribe(() => {
+        throw failure;
+      });
+      h.engine.subscribe((state) => seen.push(state));
+
+      void h.engine.dispatch('explicit');
+
+      expect(h.listenerErrors).toEqual([failure]);
+      expect(seen).toEqual([{ kind: 'saving', intent: 'explicit' }]);
     });
   });
 });

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -1,0 +1,739 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { deferred, type Deferred } from '@/utils/deferred';
+import {
+  AUTOSAVE_DEBOUNCE_MS,
+  createSaveEngine,
+  resolveStatus,
+  TIMED_SAVE_INTERVAL_MS,
+  zeroMilliseconds,
+  type PostStatus,
+  type SaveEngineState,
+  type SaveError,
+  type SaveIntent,
+  type SaveOutcome,
+  type SaveRequest,
+  type SaveSnapshot,
+} from './save-engine';
+
+const NOW = Date.parse('2026-09-02T12:00:00.000Z');
+const FUTURE = '2026-09-03T09:30:00.000Z';
+const PAST = '2026-09-01T09:30:00.000Z';
+
+const flush = () => vi.advanceTimersByTimeAsync(0);
+
+function setup(overrides: Partial<SaveSnapshot> = {}) {
+  let snapshot: SaveSnapshot = {
+    id: 'post-1',
+    isNew: false,
+    status: 'draft',
+    publishedAt: null,
+    willPublish: false,
+    willSchedule: false,
+    isDirty: true,
+    changedSinceLastRevision: true,
+    version: 1,
+    ...overrides,
+  };
+  const requests: SaveRequest[] = [];
+  const outstanding: Deferred<SaveOutcome>[] = [];
+  const states: SaveEngineState[] = [];
+  let concurrent = 0;
+  let maxConcurrent = 0;
+
+  const execute = vi.fn(async (request: SaveRequest) => {
+    requests.push(request);
+    concurrent += 1;
+    maxConcurrent = Math.max(maxConcurrent, concurrent);
+    const outcome = deferred<SaveOutcome>();
+    outstanding.push(outcome);
+    try {
+      return await outcome.promise;
+    } finally {
+      concurrent -= 1;
+    }
+  });
+
+  const engine = createSaveEngine({
+    getSnapshot: () => snapshot,
+    execute,
+    now: () => NOW,
+    onStateChange: (state) => states.push(state),
+  });
+
+  function nextRequest() {
+    return requests[requests.length - outstanding.length];
+  }
+
+  return {
+    engine,
+    execute,
+    requests,
+    states,
+    get snapshot() {
+      return snapshot;
+    },
+    maxConcurrent: () => maxConcurrent,
+    patch(changes: Partial<SaveSnapshot>) {
+      snapshot = { ...snapshot, ...changes };
+    },
+    edit() {
+      snapshot = { ...snapshot, isDirty: true, version: snapshot.version + 1 };
+    },
+    // Mirrors what the editor does on a successful response: adopt id/status, dirty iff edited since the request left.
+    async succeed(changes: Partial<SaveSnapshot> = {}) {
+      const request = nextRequest();
+      const outcome = outstanding.shift()!;
+      const id = request.snapshot.id ?? 'post-1';
+      snapshot = {
+        ...snapshot,
+        id,
+        isNew: false,
+        status: request.status,
+        isDirty: snapshot.version !== request.snapshot.version,
+        ...changes,
+      };
+      outcome.resolve({
+        ok: true,
+        result: { id, status: request.status, updatedAt: '2026-09-02T12:00:00.000Z' },
+      });
+      await flush();
+    },
+    async fail(error: SaveError) {
+      outstanding.shift()!.resolve({ ok: false, error });
+      await flush();
+    },
+    async reject(cause: unknown) {
+      outstanding.shift()!.reject(cause);
+      await flush();
+    },
+  };
+}
+
+const validation: SaveError = { kind: 'validation', message: 'Title is too long' };
+const hostLimit: SaveError = { kind: 'host-limit', message: 'Upgrade required' };
+const transport: SaveError = { kind: 'transport', message: 'Server unreachable' };
+const sessionInvalid: SaveError = { kind: 'session-invalid', message: 'Unauthorized' };
+const notFound: SaveError = { kind: 'not-found', message: 'Post not found' };
+const unknown: SaveError = { kind: 'unknown', message: 'Boom' };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('resolveStatus', () => {
+  const rows: Array<[SaveIntent, PostStatus, boolean, boolean, string | null, PostStatus]> = [
+    ['autosave', 'draft', true, false, null, 'draft'],
+    ['timed', 'draft', false, true, null, 'draft'],
+    ['field', 'draft', true, true, null, 'draft'],
+    ['explicit', 'draft', false, false, null, 'draft'],
+    ['explicit', 'draft', true, false, null, 'published'],
+    ['explicit', 'draft', false, true, FUTURE, 'scheduled'],
+    ['explicit', 'draft', true, true, FUTURE, 'published'],
+    ['explicit', 'published', false, false, PAST, 'published'],
+    ['explicit', 'sent', false, false, PAST, 'sent'],
+    ['explicit', 'scheduled', false, true, FUTURE, 'scheduled'],
+    ['explicit', 'scheduled', false, false, FUTURE, 'scheduled'],
+    ['explicit', 'scheduled', false, false, PAST, 'draft'],
+    ['explicit', 'scheduled', false, true, PAST, 'published'],
+    ['explicit', 'scheduled', true, false, PAST, 'published'],
+    ['leave', 'published', false, false, PAST, 'published'],
+    ['leave', 'draft', true, true, null, 'draft'],
+    ['publish', 'draft', false, false, null, 'published'],
+    ['publish', 'draft', false, true, FUTURE, 'scheduled'],
+    ['revert', 'published', false, false, PAST, 'draft'],
+    ['revert', 'scheduled', false, true, FUTURE, 'draft'],
+  ];
+
+  it.each(rows)(
+    '%s on a %s post (willPublish=%s, willSchedule=%s, publishedAt=%s) resolves to %s',
+    (intent, status, willPublish, willSchedule, publishedAt, expected) => {
+      expect(resolveStatus({ status, publishedAt, willPublish, willSchedule }, intent, NOW)).toBe(
+        expected,
+      );
+    },
+  );
+});
+
+describe('zeroMilliseconds', () => {
+  it('drops milliseconds and leaves everything else untouched', () => {
+    expect(zeroMilliseconds('2026-09-03T09:30:15.789Z')).toBe('2026-09-03T09:30:15.000Z');
+    expect(zeroMilliseconds(null)).toBeNull();
+    expect(zeroMilliseconds('not a date')).toBe('not a date');
+  });
+});
+
+describe('createSaveEngine', () => {
+  describe('invariant 1: background saves never change status', () => {
+    it('pins background intents to draft and never requests a revision', () => {
+      const h = setup({ willPublish: true, willSchedule: true });
+
+      void h.engine.dispatch('field');
+
+      expect(h.requests).toHaveLength(1);
+      expect(h.requests[0]).toMatchObject({
+        intent: 'field',
+        status: 'draft',
+        saveRevision: false,
+      });
+    });
+
+    it.each<PostStatus>(['published', 'scheduled', 'sent'])(
+      'drops background intents for a %s post',
+      async (status) => {
+        const h = setup({ status, publishedAt: FUTURE });
+
+        const completions = await Promise.all([
+          h.engine.dispatch('autosave'),
+          h.engine.dispatch('timed'),
+          h.engine.dispatch('field'),
+        ]);
+        await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS + AUTOSAVE_DEBOUNCE_MS);
+
+        expect(completions).toEqual(Array(3).fill({ kind: 'dropped', reason: 'not-draft' }));
+        expect(h.execute).not.toHaveBeenCalled();
+      },
+    );
+
+    it('drops a pending background save once the in-flight save has published the post', async () => {
+      const h = setup({ willPublish: true });
+      const publish = h.engine.dispatch('publish');
+      const field = h.engine.dispatch('field');
+
+      await h.succeed();
+
+      expect(h.snapshot.status).toBe('published');
+      await expect(publish).resolves.toMatchObject({ kind: 'saved' });
+      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'not-draft' });
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invariant 2: single flight, payload built at execution time, coalescing loses nothing', () => {
+    it('runs one save at a time and builds each payload from the snapshot current at execution', async () => {
+      const h = setup();
+      const first = h.engine.dispatch('explicit');
+      h.edit();
+      const second = h.engine.dispatch('field');
+      h.edit();
+      const third = h.engine.dispatch('explicit');
+
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'explicit',
+        pending: 'explicit',
+      });
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      await h.succeed();
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ intent: 'explicit', snapshot: { version: 3 } });
+
+      await h.succeed();
+      await expect(first).resolves.toMatchObject({ kind: 'saved' });
+      await expect(second).resolves.toMatchObject({ kind: 'saved' });
+      await expect(third).resolves.toMatchObject({ kind: 'saved' });
+      expect(h.maxConcurrent()).toBe(1);
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
+    });
+
+    it('restarts the autosave debounce on every edit and fires once, 3s after the last one', async () => {
+      const h = setup();
+
+      void h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(2000);
+      h.edit();
+      void h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toEqual({ kind: 'debouncing' });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.requests[0]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+    });
+  });
+
+  describe('invariant 3: session expiry loses nothing', () => {
+    it('freezes the queue on 401 and re-dispatches the failed save after re-authentication', async () => {
+      const h = setup();
+      const autosave = h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      await h.fail(sessionInvalid);
+      expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'autosave' });
+
+      h.edit();
+      const laterAutosave = h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'autosave' });
+
+      h.engine.reauthSucceeded();
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+
+      await h.succeed();
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
+      await expect(laterAutosave).resolves.toMatchObject({ kind: 'saved' });
+      expect(h.snapshot.isDirty).toBe(false);
+    });
+
+    it('lets a higher-priority intent queued during re-auth win the re-dispatch', async () => {
+      const h = setup();
+      void h.engine.dispatch('field');
+      await h.fail(sessionInvalid);
+
+      const explicit = h.engine.dispatch('explicit');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      h.engine.reauthSucceeded();
+      await flush();
+      expect(h.requests[1]).toMatchObject({ intent: 'explicit', saveRevision: true });
+
+      await h.succeed();
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+    });
+
+    it('ignores reauthSucceeded when nothing is waiting on re-authentication', async () => {
+      const h = setup();
+      h.engine.reauthSucceeded();
+      await flush();
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
+    });
+
+    it('asks for confirmation instead of enqueueing a leave save while re-auth is pending', async () => {
+      const h = setup();
+      void h.engine.dispatch('field');
+      await h.fail(sessionInvalid);
+
+      await expect(h.engine.leaveRequested()).resolves.toBe('confirm');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invariant 4: save-on-leave fires at most once and only for dirty drafts', () => {
+    it('saves a dirty draft with unrevisioned changes exactly once, with a revision, then proceeds', async () => {
+      const h = setup();
+      const decision = h.engine.leaveRequested();
+      await flush();
+
+      expect(h.requests).toHaveLength(1);
+      expect(h.requests[0]).toMatchObject({ intent: 'leave', status: 'draft', saveRevision: true });
+
+      await h.succeed();
+      await expect(decision).resolves.toBe('proceed');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('proceeds without saving when the post is clean', async () => {
+      const h = setup({ isDirty: false });
+      await expect(h.engine.leaveRequested()).resolves.toBe('proceed');
+      expect(h.execute).not.toHaveBeenCalled();
+    });
+
+    it('never saves a dirty published post on leave and asks for confirmation', async () => {
+      const h = setup({ status: 'published', publishedAt: PAST });
+      await expect(h.engine.leaveRequested()).resolves.toBe('confirm');
+      expect(h.execute).not.toHaveBeenCalled();
+    });
+
+    it('cancels an armed autosave and saves once for an already-revisioned dirty draft', async () => {
+      const h = setup({ changedSinceLastRevision: false });
+      void h.engine.dispatch('autosave');
+
+      const decision = h.engine.leaveRequested();
+      await flush();
+      expect(h.requests[0]).toMatchObject({ intent: 'leave', saveRevision: true });
+
+      await h.succeed();
+      await expect(decision).resolves.toBe('proceed');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not save a second time in the same leave attempt when the first leave save failed', async () => {
+      const h = setup();
+      const decision = h.engine.leaveRequested();
+      await flush();
+      h.edit();
+      void h.engine.dispatch('autosave');
+
+      await h.fail(transport);
+      await expect(decision).resolves.toBe('confirm');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invariant 6: a failed save keeps the post dirty and recoverable', () => {
+    it.each([validation, hostLimit, transport, unknown])(
+      'surfaces a $kind error to the dispatcher and still runs the pending explicit save',
+      async (error) => {
+        const h = setup();
+        const failing = h.engine.dispatch('field');
+        const explicit = h.engine.dispatch('explicit');
+
+        await h.fail(error);
+        await expect(failing).resolves.toEqual({ kind: 'failed', error });
+        expect(h.snapshot.isDirty).toBe(true);
+        expect(h.execute).toHaveBeenCalledTimes(2);
+        expect(h.requests[1]).toMatchObject({ intent: 'explicit' });
+
+        await h.succeed();
+        await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+      },
+    );
+
+    it('reports an error state until the next save starts', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      await h.fail(transport);
+      expect(h.engine.getState()).toEqual({ kind: 'error', intent: 'explicit', error: transport });
+
+      void h.engine.dispatch('explicit');
+      expect(h.engine.getState()).toEqual({ kind: 'saving', intent: 'explicit' });
+    });
+
+    it('treats a rejected execute as an unknown error rather than swallowing it', async () => {
+      const h = setup();
+      const completion = h.engine.dispatch('explicit');
+      const cause = new Error('network down');
+
+      await h.reject(cause);
+
+      await expect(completion).resolves.toEqual({
+        kind: 'failed',
+        error: { kind: 'unknown', message: 'network down', cause },
+      });
+    });
+  });
+
+  describe('invariant 7: only explicit and leave saves create revisions', () => {
+    it.each<[SaveIntent, boolean]>([
+      ['explicit', true],
+      ['leave', true],
+      ['autosave', false],
+      ['timed', false],
+      ['field', false],
+      ['publish', false],
+      ['revert', false],
+    ])('%s requests save_revision=%s', async (intent, saveRevision) => {
+      const h = setup();
+      void h.engine.dispatch(intent);
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+
+      expect(h.requests).toHaveLength(1);
+      expect(h.requests[0]).toMatchObject({ intent, saveRevision });
+    });
+  });
+
+  describe('invariant 10: scheduled saves zero milliseconds and preserve the publish time', () => {
+    it('serializes a future scheduled post with a zeroed publish time across saves', async () => {
+      const h = setup({
+        status: 'scheduled',
+        willSchedule: true,
+        publishedAt: '2026-09-03T09:30:15.789Z',
+      });
+
+      void h.engine.dispatch('explicit');
+      await h.succeed();
+      void h.engine.dispatch('explicit');
+      await h.succeed();
+
+      expect(h.requests).toHaveLength(2);
+      for (const request of h.requests) {
+        expect(request).toMatchObject({
+          status: 'scheduled',
+          publishedAt: '2026-09-03T09:30:15.000Z',
+        });
+      }
+    });
+
+    it('compares a past scheduled time after zeroing milliseconds', () => {
+      const publishedAt = new Date(NOW + 500).toISOString();
+      expect(
+        resolveStatus(
+          { status: 'scheduled', publishedAt, willPublish: false, willSchedule: true },
+          'explicit',
+          NOW,
+        ),
+      ).toBe('scheduled');
+      expect(
+        resolveStatus(
+          { status: 'scheduled', publishedAt, willPublish: false, willSchedule: true },
+          'explicit',
+          NOW + 1000,
+        ),
+      ).toBe('published');
+    });
+  });
+
+  describe('interleavings', () => {
+    it('saves a new post immediately on its first edit', () => {
+      const h = setup({ id: null, isNew: true });
+      void h.engine.dispatch('autosave');
+
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.requests[0]).toMatchObject({
+        intent: 'autosave',
+        status: 'draft',
+        snapshot: { id: null },
+      });
+    });
+
+    it('coalesces an autosave arriving during an in-flight create and rebuilds its payload', async () => {
+      const h = setup({ id: null, isNew: true });
+      const create = h.engine.dispatch('explicit');
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'explicit',
+        pending: 'autosave',
+      });
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      await h.succeed({ id: 'post-1' });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({
+        intent: 'autosave',
+        snapshot: { id: 'post-1', isNew: false, version: 2 },
+      });
+
+      await h.succeed();
+      await expect(create).resolves.toMatchObject({ kind: 'saved' });
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
+    });
+
+    it('coalesces a debounced autosave that fires during a slow explicit save', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      h.edit();
+      void h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'explicit',
+        pending: 'autosave',
+      });
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+    });
+
+    it('lets an explicit save cancel a pending autosave debounce and supersede it', async () => {
+      const h = setup();
+      const autosave = h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const explicit = h.engine.dispatch('explicit');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.requests[0]).toMatchObject({ intent: 'explicit' });
+
+      await h.succeed();
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved' });
+    });
+
+    it('waits for an in-flight save on leave, then saves once with a revision', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      const decision = h.engine.leaveRequested();
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      await h.succeed();
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ intent: 'leave', saveRevision: true });
+
+      await h.succeed();
+      await expect(decision).resolves.toBe('proceed');
+    });
+
+    it('lets publish win the pending slot over a queued autosave', async () => {
+      const h = setup();
+      void h.engine.dispatch('field');
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'field',
+        pending: 'autosave',
+      });
+
+      h.patch({ willPublish: true });
+      const publish = h.engine.dispatch('publish');
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'field',
+        pending: 'publish',
+      });
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({
+        intent: 'publish',
+        status: 'published',
+        snapshot: { version: 2 },
+      });
+
+      await h.succeed();
+      await expect(publish).resolves.toMatchObject({ kind: 'saved' });
+      await expect(autosave).resolves.toMatchObject({ kind: 'saved' });
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('halts permanently on a 404 for a known post id', async () => {
+      const h = setup();
+      const failing = h.engine.dispatch('explicit');
+      h.edit();
+      void h.engine.dispatch('autosave');
+
+      await h.fail(notFound);
+      expect(h.engine.getState()).toEqual({ kind: 'halted' });
+      await expect(failing).resolves.toEqual({ kind: 'failed', error: notFound });
+
+      await expect(h.engine.dispatch('explicit')).resolves.toEqual({
+        kind: 'dropped',
+        reason: 'halted',
+      });
+      await expect(h.engine.dispatch('autosave')).resolves.toEqual({
+        kind: 'dropped',
+        reason: 'halted',
+      });
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      await expect(h.engine.leaveRequested()).resolves.toBe('confirm');
+    });
+
+    it('crashes on a 404 for a post that has no id yet', async () => {
+      const h = setup({ id: null, isNew: true });
+      void h.engine.dispatch('explicit');
+
+      await h.fail(notFound);
+      expect(h.engine.getState()).toEqual({ kind: 'crashed' });
+      await expect(h.engine.dispatch('field')).resolves.toEqual({
+        kind: 'dropped',
+        reason: 'halted',
+      });
+    });
+
+    it.each([validation, hostLimit])(
+      'suppresses background saves after a $kind error until the snapshot changes',
+      async (error) => {
+        const h = setup();
+        void h.engine.dispatch('explicit');
+        await h.fail(error);
+        expect(h.engine.getState()).toEqual({ kind: 'error', intent: 'explicit', error });
+
+        await expect(h.engine.dispatch('autosave')).resolves.toEqual({
+          kind: 'dropped',
+          reason: 'suppressed',
+        });
+        await expect(h.engine.dispatch('field')).resolves.toEqual({
+          kind: 'dropped',
+          reason: 'suppressed',
+        });
+        await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+        expect(h.execute).toHaveBeenCalledTimes(1);
+
+        void h.engine.dispatch('explicit');
+        expect(h.execute).toHaveBeenCalledTimes(2);
+        await h.fail(error);
+
+        h.edit();
+        void h.engine.dispatch('autosave');
+        await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+        expect(h.execute).toHaveBeenCalledTimes(3);
+        expect(h.requests[2]).toMatchObject({ intent: 'autosave', snapshot: { version: 2 } });
+      },
+    );
+
+    it('keeps autosaving after a transport error', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      await h.fail(transport);
+
+      void h.engine.dispatch('autosave');
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({ intent: 'autosave' });
+    });
+
+    it('forces a timed save after 60s of continuous editing', async () => {
+      const h = setup();
+      for (let second = 0; second < 60; second += 1) {
+        h.edit();
+        void h.engine.dispatch('autosave');
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.requests[0]).toMatchObject({
+        intent: 'timed',
+        status: 'draft',
+        saveRevision: false,
+      });
+
+      await h.succeed();
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips a background save that finds the post clean at execution time', async () => {
+      const h = setup();
+      const autosave = h.engine.dispatch('autosave');
+      h.patch({ isDirty: false });
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+      await expect(autosave).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
+    });
+
+    it('notifies subscribers of every transition until they unsubscribe', async () => {
+      const h = setup();
+      const seen: SaveEngineState[] = [];
+      const unsubscribe = h.engine.subscribe((state) => seen.push(state));
+
+      void h.engine.dispatch('explicit');
+      await h.succeed();
+      expect(seen).toEqual([{ kind: 'saving', intent: 'explicit' }, { kind: 'idle' }]);
+      expect(h.states).toEqual(seen);
+
+      unsubscribe();
+      void h.engine.dispatch('explicit');
+      expect(seen).toHaveLength(2);
+    });
+
+    it('dispose cancels timers and settles every outstanding dispatch', async () => {
+      const h = setup();
+      const explicit = h.engine.dispatch('explicit');
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+
+      h.engine.dispose();
+      await expect(explicit).resolves.toEqual({ kind: 'dropped', reason: 'disposed' });
+      await expect(autosave).resolves.toEqual({ kind: 'dropped', reason: 'disposed' });
+
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      await expect(h.engine.dispatch('explicit')).resolves.toEqual({
+        kind: 'dropped',
+        reason: 'disposed',
+      });
+      await expect(h.engine.leaveRequested()).resolves.toBe('proceed');
+    });
+  });
+});

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -908,10 +908,10 @@ describe('createSaveEngine', () => {
 
       h.patch({ status: 'published', publishedAt: PAST, updatedAt: FUTURE });
       await h.resolveSlug('hello', 'unchanged');
-      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'not-draft' });
       expect(h.prepare).not.toHaveBeenCalled();
       expect(h.execute).not.toHaveBeenCalled();
       expect(h.engine.getState()).toEqual({ kind: 'idle' });
+      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'not-draft' });
     });
 
     it('drops a background save whose post went clean during the slug request', async () => {
@@ -922,9 +922,9 @@ describe('createSaveEngine', () => {
 
       h.patch({ isDirty: false });
       await h.resolveSlug('hello', 'unchanged');
-      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
       expect(h.prepare).not.toHaveBeenCalled();
       expect(h.execute).not.toHaveBeenCalled();
+      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
     });
 
     it('never prepares a save disposed while slug work was settling', async () => {

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -20,6 +20,7 @@ import {
   type SaveSnapshot,
   type SaveTarget,
   type SlugPort,
+  type SlugProposal,
 } from './save-engine';
 
 const NOW = Date.parse('2026-09-02T12:00:00.000Z');
@@ -41,8 +42,6 @@ const BASE: SnapshotFields = {
   publishedAt: null,
   title: 'Hello',
   slug: 'hello',
-  titleDirty: false,
-  slugIsCustom: false,
   isDirty: true,
   changedSinceLastRevision: true,
   version: 1,
@@ -50,7 +49,7 @@ const BASE: SnapshotFields = {
 
 const idleSlug: SlugPort = {
   settled: () => Promise.resolve(),
-  fromTitle: () => Promise.reject(new Error('unexpected slug request')),
+  fromTitle: () => Promise.resolve({ slug: '', source: 'unchanged' }),
 };
 
 function dispatchAny(engine: SaveEngine, kind: DispatchIntent) {
@@ -71,18 +70,26 @@ function setup(overrides: Partial<SnapshotFields> = {}) {
   const outstanding: Deferred<SaveOutcome>[] = [];
   const states: SaveEngineState[] = [];
   const listenerErrors: unknown[] = [];
-  const slugRequests: Array<{ title: string; postId: string | null; outcome: Deferred<string> }> =
-    [];
+  const slugRequests: Array<{
+    title: string;
+    postId: string | null;
+    outcome: Deferred<SlugProposal>;
+  }> = [];
   let concurrent = 0;
   let maxConcurrent = 0;
   let snapshotError: Error | null = null;
   let slugSettled: Deferred<void> | null = null;
+  let holdSlugRequests = false;
   let sequence = 0;
 
+  // Answers "unchanged" immediately unless a test holds the requests to answer them itself.
   const slug: SlugPort = {
     settled: vi.fn(() => (slugSettled ? slugSettled.promise : Promise.resolve())),
     fromTitle: vi.fn((title: string, postId: string | null) => {
-      const outcome = deferred<string>();
+      if (!holdSlugRequests) {
+        return Promise.resolve<SlugProposal>({ slug: snapshot.slug, source: 'unchanged' });
+      }
+      const outcome = deferred<SlugProposal>();
       slugRequests.push({ title, postId, outcome });
       return outcome.promise;
     }),
@@ -114,7 +121,6 @@ function setup(overrides: Partial<SnapshotFields> = {}) {
       status: result.status,
       publishedAt: prepared.target.publishedAt,
       slug: prepared.slug,
-      titleDirty: editedInFlight && snapshot.titleDirty,
       isDirty: editedInFlight,
     };
   });
@@ -173,8 +179,11 @@ function setup(overrides: Partial<SnapshotFields> = {}) {
         await flush();
       };
     },
-    async resolveSlug(value: string) {
-      slugRequests.shift()!.outcome.resolve(value);
+    holdSlugRequests() {
+      holdSlugRequests = true;
+    },
+    async resolveSlug(value: string, source: SlugProposal['source'] = 'generated') {
+      slugRequests.shift()!.outcome.resolve({ slug: value, source });
       await flush();
     },
     // Each of these lets the prepare stage reach execute before answering the request.
@@ -787,6 +796,7 @@ describe('createSaveEngine', () => {
 
     it('waits for a slow slug request before a leave save leaves', async () => {
       const h = setup({ slug: '' });
+      h.holdSlugRequests();
       const decision = h.engine.leaveRequested();
       await flush();
       expect(h.slug.fromTitle).toHaveBeenCalledWith('Hello', 'post-1', expect.any(AbortSignal));
@@ -801,6 +811,7 @@ describe('createSaveEngine', () => {
 
     it('creates a titleless body-first post as (Untitled) with a generated slug', async () => {
       const h = setup({ id: null, updatedAt: null, title: '', slug: '' });
+      h.holdSlugRequests();
       void h.engine.dispatch('autosave');
       await flush();
       expect(h.slug.fromTitle).toHaveBeenCalledWith(DEFAULT_TITLE, null, expect.any(AbortSignal));
@@ -816,6 +827,7 @@ describe('createSaveEngine', () => {
 
     it('treats a whitespace title as blank', async () => {
       const h = setup({ id: null, updatedAt: null, title: '   ', slug: '' });
+      h.holdSlugRequests();
       void h.engine.dispatch('explicit');
       await flush();
       expect(h.slug.fromTitle).toHaveBeenCalledWith(DEFAULT_TITLE, null, expect.any(AbortSignal));
@@ -824,17 +836,9 @@ describe('createSaveEngine', () => {
       expect(h.requests[0]).toMatchObject({ title: DEFAULT_TITLE, slug: 'untitled' });
     });
 
-    it('never regenerates a custom slug', async () => {
-      const h = setup({ title: 'Renamed', titleDirty: true, slug: 'my-slug', slugIsCustom: true });
-      void h.engine.dispatch('explicit');
-      await flush();
-
-      expect(h.slug.fromTitle).not.toHaveBeenCalled();
-      expect(h.requests[0]).toMatchObject({ title: 'Renamed', slug: 'my-slug' });
-    });
-
-    it('applies the server-deduplicated slug requested with the post id', async () => {
-      const h = setup({ title: 'Hello world', titleDirty: true });
+    it('applies a generated proposal requested with the post id', async () => {
+      const h = setup({ title: 'Hello world' });
+      h.holdSlugRequests();
       void h.engine.dispatch('explicit');
       await flush();
       expect(h.slug.fromTitle).toHaveBeenCalledWith(
@@ -849,22 +853,32 @@ describe('createSaveEngine', () => {
       expect(h.snapshot.slug).toBe('hello-world-2');
     });
 
-    it('keeps the existing slug when a draft title is cleared', async () => {
-      const h = setup({ title: '', titleDirty: true });
+    it('sends the slug current after an unchanged answer, not the one read before the request', async () => {
+      const h = setup({ slug: 'my-slug' });
+      h.holdSlugRequests();
       void h.engine.dispatch('explicit');
       await flush();
 
-      expect(h.slug.fromTitle).not.toHaveBeenCalled();
+      h.patch({ slug: 'my-custom-slug' });
+      await h.resolveSlug('ignored', 'unchanged');
+      expect(h.requests[0]).toMatchObject({ slug: 'my-custom-slug' });
+    });
+
+    it('asks the slug port on every draft save and lets it keep the slug', async () => {
+      const h = setup({ title: '' });
+      void h.engine.dispatch('explicit');
+      await flush();
+
+      expect(h.slug.fromTitle).toHaveBeenCalledWith(
+        DEFAULT_TITLE,
+        'post-1',
+        expect.any(AbortSignal),
+      );
       expect(h.requests[0]).toMatchObject({ title: DEFAULT_TITLE, slug: 'hello' });
     });
 
-    it('does not regenerate a published post’s slug when its title changes', async () => {
-      const h = setup({
-        status: 'published',
-        publishedAt: PAST,
-        title: 'Renamed',
-        titleDirty: true,
-      });
+    it('never asks for a slug when a non-draft post already has one', async () => {
+      const h = setup({ status: 'published', publishedAt: PAST, title: 'Renamed' });
       void h.engine.dispatch('explicit');
       await flush();
 
@@ -872,12 +886,42 @@ describe('createSaveEngine', () => {
       expect(h.requests[0]).toMatchObject({ slug: 'hello' });
     });
 
-    it('generates a slug for a post of any status that has none', async () => {
+    it('asks for a slug for a post of any status that has none', async () => {
       const h = setup({ status: 'published', publishedAt: PAST, slug: '' });
+      h.holdSlugRequests();
       void h.engine.dispatch('explicit');
       await flush();
 
       expect(h.slug.fromTitle).toHaveBeenCalledWith('Hello', 'post-1', expect.any(AbortSignal));
+      await h.resolveSlug('hello');
+      expect(h.requests[0]).toMatchObject({ slug: 'hello' });
+    });
+
+    it('never prepares a save disposed while slug work was settling', async () => {
+      const h = setup();
+      const release = h.holdSlugWork();
+      const explicit = h.engine.dispatch('explicit');
+      await flush();
+
+      h.engine.dispose();
+      await expect(explicit).resolves.toEqual({ kind: 'dropped', reason: 'disposed' });
+      await release();
+      expect(h.prepare).not.toHaveBeenCalled();
+      expect(h.execute).not.toHaveBeenCalled();
+    });
+
+    it('never prepares a save disposed while a slug proposal was pending', async () => {
+      const h = setup();
+      h.holdSlugRequests();
+      const explicit = h.engine.dispatch('explicit');
+      await flush();
+      expect(h.slug.fromTitle).toHaveBeenCalledTimes(1);
+
+      h.engine.dispose();
+      await expect(explicit).resolves.toEqual({ kind: 'dropped', reason: 'disposed' });
+      await h.resolveSlug('late');
+      expect(h.prepare).not.toHaveBeenCalled();
+      expect(h.execute).not.toHaveBeenCalled();
     });
   });
 
@@ -1354,6 +1398,50 @@ describe('createSaveEngine', () => {
       expect(h.execute).toHaveBeenCalledTimes(1);
       expect(h.snapshot).toMatchObject({ isDirty: true, version: 2 });
     });
+
+    it('never auto-retries a pending explicit save against the stale baseline', async () => {
+      const h = setup();
+      void h.engine.dispatch('field');
+      const explicit = h.engine.dispatch('explicit');
+
+      await h.fail(conflict);
+      await expect(explicit).resolves.toEqual({ kind: 'dropped', reason: 'conflict' });
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      expect(h.engine.getState()).toEqual({ kind: 'conflict', intent: 'field', error: conflict });
+
+      void h.engine.dispatch('explicit');
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('drains a publish with the updated_at the preceding save reconciled', async () => {
+      const h = setup();
+      void h.engine.dispatch('field');
+      const publish = h.engine.dispatch('publish');
+
+      await h.succeed({ updatedAt: '2026-09-02T12:30:00.000Z' });
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'publish' },
+        snapshot: { updatedAt: '2026-09-02T12:30:00.000Z' },
+      });
+
+      await h.succeed();
+      await expect(publish).resolves.toMatchObject({ kind: 'saved', executedAs: 'publish' });
+    });
+
+    it('fails a past-scheduled explicit save whose changed publish time the server rejects', async () => {
+      const h = setup({ status: 'scheduled', publishedAt: PAST });
+      const explicit = h.engine.dispatch('explicit');
+      await h.fail(validation);
+
+      await expect(explicit).resolves.toEqual({
+        kind: 'failed',
+        error: validation,
+        executedAs: 'explicit',
+      });
+      expect(h.snapshot).toMatchObject({ isDirty: true, status: 'scheduled', publishedAt: PAST });
+      expect(h.engine.getState()).toEqual({ kind: 'error', intent: 'explicit', error: validation });
+    });
   });
 
   describe('leave outcomes', () => {
@@ -1797,6 +1885,55 @@ describe('createSaveEngine', () => {
 
       expect(h.listenerErrors).toEqual([failure]);
       expect(seen).toEqual([{ kind: 'saving', intent: 'explicit' }]);
+    });
+
+    it('still saves when the onStateChange port throws, and reports it', async () => {
+      const failure = new Error('state port exploded');
+      const reported: unknown[] = [];
+      const snapshot = { ...BASE, status: 'published', publishedAt: PAST } as SaveSnapshot;
+      const engine = createSaveEngine({
+        getSnapshot: () => snapshot,
+        slug: idleSlug,
+        prepare: (request) => Promise.resolve(request),
+        execute: (prepared) =>
+          Promise.resolve<SaveOutcome>({
+            ok: true,
+            result: { id: prepared.snapshot.id!, status: 'published', updatedAt: FUTURE },
+          }),
+        reconcile: () => {},
+        onStateChange: () => {
+          throw failure;
+        },
+        onListenerError: (error) => reported.push(error),
+      });
+
+      await expect(engine.dispatch('explicit')).resolves.toMatchObject({ kind: 'saved' });
+      expect(engine.getState()).toEqual({ kind: 'idle' });
+      expect(reported).toEqual([failure, failure]);
+    });
+
+    it('re-runs a frozen explicit after a superseded publish while the winning revert needs retry', async () => {
+      const h = setup({ status: 'scheduled', publishedAt: FUTURE });
+      const explicit = h.engine.dispatch('explicit');
+      const publish = h.engine.dispatch('publish');
+      const revert = h.engine.dispatch('revert');
+      await expect(publish).resolves.toEqual({ kind: 'superseded', by: 'revert' });
+
+      await h.fail(sessionInvalid);
+      expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'explicit' });
+
+      h.engine.reauthSucceeded();
+      await flush();
+      await expect(revert).resolves.toEqual({ kind: 'needs-retry' });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+      expect(h.requests[1]).toMatchObject({
+        command: { kind: 'explicit' },
+        target: { status: 'scheduled', publishedAt: FUTURE },
+      });
+
+      await h.succeed();
+      await expect(explicit).resolves.toMatchObject({ kind: 'saved', executedAs: 'explicit' });
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
     });
   });
 });

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -6,6 +6,7 @@ import {
   resolveStatus,
   TIMED_SAVE_INTERVAL_MS,
   zeroMilliseconds,
+  type DispatchIntent,
   type PostStatus,
   type SaveEngineState,
   type SaveError,
@@ -39,6 +40,7 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
   const states: SaveEngineState[] = [];
   let concurrent = 0;
   let maxConcurrent = 0;
+  let snapshotError: Error | null = null;
 
   const execute = vi.fn(async (request: SaveRequest) => {
     requests.push(request);
@@ -54,7 +56,14 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
   });
 
   const engine = createSaveEngine({
-    getSnapshot: () => snapshot,
+    getSnapshot: () => {
+      if (snapshotError) {
+        const error = snapshotError;
+        snapshotError = null;
+        throw error;
+      }
+      return snapshot;
+    },
     execute,
     now: () => NOW,
     onStateChange: (state) => states.push(state),
@@ -78,6 +87,9 @@ function setup(overrides: Partial<SaveSnapshot> = {}) {
     },
     edit() {
       snapshot = { ...snapshot, isDirty: true, version: snapshot.version + 1 };
+    },
+    throwNextSnapshot(error: Error) {
+      snapshotError = error;
     },
     // Mirrors what the editor does on a successful response: adopt id/status, dirty iff edited since the request left.
     async succeed(changes: Partial<SaveSnapshot> = {}) {
@@ -188,12 +200,11 @@ describe('createSaveEngine', () => {
 
         const completions = await Promise.all([
           h.engine.dispatch('autosave'),
-          h.engine.dispatch('timed'),
           h.engine.dispatch('field'),
         ]);
         await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS + AUTOSAVE_DEBOUNCE_MS);
 
-        expect(completions).toEqual(Array(3).fill({ kind: 'dropped', reason: 'not-draft' }));
+        expect(completions).toEqual(Array(2).fill({ kind: 'dropped', reason: 'not-draft' }));
         expect(h.execute).not.toHaveBeenCalled();
       },
     );
@@ -415,11 +426,10 @@ describe('createSaveEngine', () => {
   });
 
   describe('invariant 7: only explicit and leave saves create revisions', () => {
-    it.each<[SaveIntent, boolean]>([
+    it.each<[DispatchIntent, boolean]>([
       ['explicit', true],
       ['leave', true],
       ['autosave', false],
-      ['timed', false],
       ['field', false],
       ['publish', false],
       ['revert', false],
@@ -673,9 +683,10 @@ describe('createSaveEngine', () => {
 
     it('forces a timed save after 60s of continuous editing', async () => {
       const h = setup();
+      const autosaves: Promise<unknown>[] = [];
       for (let second = 0; second < 60; second += 1) {
         h.edit();
-        void h.engine.dispatch('autosave');
+        autosaves.push(h.engine.dispatch('autosave'));
         await vi.advanceTimersByTimeAsync(1000);
       }
 
@@ -684,9 +695,15 @@ describe('createSaveEngine', () => {
         intent: 'timed',
         status: 'draft',
         saveRevision: false,
+        snapshot: { version: 61 },
       });
 
       await h.succeed();
+      const completions = await Promise.all(autosaves);
+      expect(completions).toHaveLength(60);
+      for (const completion of completions) {
+        expect(completion).toMatchObject({ kind: 'saved' });
+      }
       await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
       expect(h.execute).toHaveBeenCalledTimes(1);
     });
@@ -734,6 +751,206 @@ describe('createSaveEngine', () => {
         reason: 'disposed',
       });
       await expect(h.engine.leaveRequested()).resolves.toBe('proceed');
+      expect(h.engine.getState()).toEqual({ kind: 'disposed' });
+    });
+  });
+
+  describe('leave outcomes', () => {
+    it('asks for confirmation when the in-flight save it waited for fails', async () => {
+      const h = setup({ changedSinceLastRevision: false });
+      void h.engine.dispatch('explicit');
+      const decision = h.engine.leaveRequested();
+      await flush();
+
+      await h.fail(transport);
+      await expect(decision).resolves.toBe('confirm');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('asks for confirmation when the leave save replacing an armed autosave fails', async () => {
+      const h = setup({ changedSinceLastRevision: false });
+      void h.engine.dispatch('autosave');
+      const decision = h.engine.leaveRequested();
+      await flush();
+      expect(h.requests[0]).toMatchObject({ intent: 'leave' });
+
+      await h.fail(transport);
+      await expect(decision).resolves.toBe('confirm');
+    });
+
+    it('shares one leave save across concurrent leave requests', async () => {
+      const h = setup();
+      const first = h.engine.leaveRequested();
+      const second = h.engine.leaveRequested();
+      await flush();
+      expect(h.execute).toHaveBeenCalledTimes(1);
+
+      await h.succeed();
+      await expect(first).resolves.toBe('proceed');
+      await expect(second).resolves.toBe('proceed');
+      expect(h.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-runs a leave save interrupted by re-auth and then proceeds', async () => {
+      const h = setup();
+      const decision = h.engine.leaveRequested();
+      await flush();
+
+      await h.fail(sessionInvalid);
+      expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent: 'leave' });
+
+      h.engine.reauthSucceeded();
+      await flush();
+      expect(h.requests[1]).toMatchObject({ intent: 'leave', saveRevision: true });
+
+      await h.succeed();
+      await expect(decision).resolves.toBe('proceed');
+    });
+
+    it('asks for confirmation when re-auth is abandoned during a leave save', async () => {
+      const h = setup();
+      const decision = h.engine.leaveRequested();
+      await flush();
+      await h.fail(sessionInvalid);
+
+      h.engine.reauthAbandoned();
+      await expect(decision).resolves.toBe('confirm');
+      expect(h.engine.getState()).toEqual({
+        kind: 'error',
+        intent: 'leave',
+        error: sessionInvalid,
+      });
+    });
+  });
+
+  describe('re-auth outcomes', () => {
+    it.each<DispatchIntent>(['publish', 'revert'])(
+      'never auto-fires a %s after re-auth; it resolves needs-retry',
+      async (intent) => {
+        const h = setup(
+          intent === 'revert' ? { status: 'published', publishedAt: PAST } : { willPublish: true },
+        );
+        const completion = h.engine.dispatch(intent);
+        await h.fail(sessionInvalid);
+
+        h.engine.reauthSucceeded();
+        await flush();
+        await expect(completion).resolves.toEqual({ kind: 'needs-retry' });
+        expect(h.execute).toHaveBeenCalledTimes(1);
+        expect(h.engine.getState()).toEqual({ kind: 'idle' });
+      },
+    );
+
+    it('settles every waiter with the session error when re-auth is abandoned', async () => {
+      const h = setup();
+      const field = h.engine.dispatch('field');
+      await h.fail(sessionInvalid);
+      const explicit = h.engine.dispatch('explicit');
+      h.edit();
+      const autosave = h.engine.dispatch('autosave');
+
+      h.engine.reauthAbandoned();
+      await expect(field).resolves.toEqual({ kind: 'failed', error: sessionInvalid });
+      await expect(explicit).resolves.toEqual({ kind: 'failed', error: sessionInvalid });
+      await expect(autosave).resolves.toEqual({ kind: 'failed', error: sessionInvalid });
+      expect(h.engine.getState()).toEqual({
+        kind: 'error',
+        intent: 'field',
+        error: sessionInvalid,
+      });
+
+      await vi.advanceTimersByTimeAsync(TIMED_SAVE_INTERVAL_MS);
+      expect(h.execute).toHaveBeenCalledTimes(1);
+      void h.engine.dispatch('explicit');
+      expect(h.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores reauthAbandoned when nothing is waiting on re-authentication', () => {
+      const h = setup();
+      h.engine.reauthAbandoned();
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
+    });
+  });
+
+  describe('coalescing and state reporting', () => {
+    it('lets a contradictory revert replace a pending publish and marks the publish superseded', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      h.patch({ willPublish: true });
+      const publish = h.engine.dispatch('publish');
+      const revert = h.engine.dispatch('revert');
+
+      await expect(publish).resolves.toEqual({ kind: 'superseded', by: 'revert' });
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'explicit',
+        pending: 'revert',
+      });
+
+      await h.succeed();
+      expect(h.requests[1]).toMatchObject({ intent: 'revert', status: 'draft' });
+      await h.succeed();
+      await expect(revert).resolves.toMatchObject({ kind: 'saved' });
+      expect(h.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('emits each state once even when several timers arm', () => {
+      const h = setup();
+      void h.engine.dispatch('autosave');
+      h.edit();
+      void h.engine.dispatch('autosave');
+      h.edit();
+      void h.engine.dispatch('autosave');
+
+      expect(h.states).toEqual([{ kind: 'debouncing' }]);
+    });
+
+    it('keeps an error state while a dropped-clean autosave passes through', async () => {
+      const h = setup();
+      void h.engine.dispatch('explicit');
+      await h.fail(transport);
+
+      const autosave = h.engine.dispatch('autosave');
+      h.patch({ isDirty: false });
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+      await expect(autosave).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
+      expect(h.engine.getState()).toEqual({ kind: 'error', intent: 'explicit', error: transport });
+    });
+
+    it('surfaces a throwing snapshot port as an unknown failure', async () => {
+      const h = setup();
+      const cause = new Error('snapshot exploded');
+      h.throwNextSnapshot(cause);
+
+      await expect(h.engine.dispatch('explicit')).resolves.toEqual({
+        kind: 'failed',
+        error: { kind: 'unknown', message: 'snapshot exploded', cause },
+      });
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toMatchObject({ kind: 'error', intent: 'explicit' });
+    });
+
+    it('tolerates listeners that dispatch or unsubscribe during notification', () => {
+      const h = setup();
+      const seen: string[] = [];
+      const unsubscribe = h.engine.subscribe((state) => {
+        seen.push(state.kind);
+        if (state.kind === 'saving') {
+          unsubscribe();
+          void h.engine.dispatch('field');
+        }
+      });
+      h.engine.subscribe((state) => seen.push(`other:${state.kind}`));
+
+      void h.engine.dispatch('explicit');
+
+      expect(seen).toEqual(['saving', 'other:pending-coalesced', 'other:pending-coalesced']);
+      expect(h.engine.getState()).toEqual({
+        kind: 'pending-coalesced',
+        intent: 'explicit',
+        pending: 'field',
+      });
     });
   });
 });

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -861,7 +861,10 @@ describe('createSaveEngine', () => {
 
       h.patch({ slug: 'my-custom-slug' });
       await h.resolveSlug('ignored', 'unchanged');
-      expect(h.requests[0]).toMatchObject({ slug: 'my-custom-slug' });
+      expect(h.requests[0]).toMatchObject({
+        slug: 'my-custom-slug',
+        snapshot: { slug: 'my-custom-slug' },
+      });
     });
 
     it('asks the slug port on every draft save and lets it keep the slug', async () => {
@@ -895,6 +898,33 @@ describe('createSaveEngine', () => {
       expect(h.slug.fromTitle).toHaveBeenCalledWith('Hello', 'post-1', expect.any(AbortSignal));
       await h.resolveSlug('hello');
       expect(h.requests[0]).toMatchObject({ slug: 'hello' });
+    });
+
+    it('drops a background save whose post was published during the slug request', async () => {
+      const h = setup();
+      h.holdSlugRequests();
+      const field = h.engine.dispatch('field');
+      await flush();
+
+      h.patch({ status: 'published', publishedAt: PAST, updatedAt: FUTURE });
+      await h.resolveSlug('hello', 'unchanged');
+      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'not-draft' });
+      expect(h.prepare).not.toHaveBeenCalled();
+      expect(h.execute).not.toHaveBeenCalled();
+      expect(h.engine.getState()).toEqual({ kind: 'idle' });
+    });
+
+    it('drops a background save whose post went clean during the slug request', async () => {
+      const h = setup();
+      h.holdSlugRequests();
+      const field = h.engine.dispatch('field');
+      await flush();
+
+      h.patch({ isDirty: false });
+      await h.resolveSlug('hello', 'unchanged');
+      await expect(field).resolves.toEqual({ kind: 'dropped', reason: 'clean' });
+      expect(h.prepare).not.toHaveBeenCalled();
+      expect(h.execute).not.toHaveBeenCalled();
     });
 
     it('never prepares a save disposed while slug work was settling', async () => {

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -430,7 +430,7 @@ export function createSaveEngine<
     return staleUpdatedAt !== null && snapshot.updatedAt === staleUpdatedAt;
   }
 
-  // Sidebar edits on published/scheduled/sent posts stage until Update (spec §4); never promote them to saves.
+  // Field saves on published/scheduled/sent posts are dropped: the sidebar stages those edits until Update.
   function backgroundDropReason(snapshot: S): DropReason | null {
     if (snapshot.status !== 'draft') {
       return 'not-draft';
@@ -537,31 +537,38 @@ export function createSaveEngine<
   }
 
   // Status is the one rule the slug machine cannot know; it answers custom/same-title/frozen itself.
-  async function buildRequest(
+  function proposeSlug(snapshot: S, signal: AbortSignal): Promise<SlugProposal | null> {
+    if (snapshot.slug && snapshot.status !== 'draft') {
+      return Promise.resolve(null);
+    }
+    return ports.slug.fromTitle(blankToDefault(snapshot.title), snapshot.id, signal);
+  }
+
+  function buildRequest(
     command: SaveCommand,
     snapshot: S,
-    signal: AbortSignal,
-  ): Promise<SaveRequest<S>> {
-    let slug = snapshot.slug;
-    if (!snapshot.slug || snapshot.status === 'draft') {
-      const proposal = await ports.slug.fromTitle(
-        blankToDefault(snapshot.title),
-        snapshot.id,
-        signal,
-      );
-      // A slug committed while the proposal was in flight wins over the one read before it.
-      snapshot = ports.getSnapshot();
-      slug = proposal.source === 'generated' ? proposal.slug : snapshot.slug;
-    }
-    const title = blankToDefault(snapshot.title);
+    proposal: SlugProposal | null,
+  ): SaveRequest<S> {
     return {
       command,
       snapshot,
-      title,
-      slug,
+      title: blankToDefault(snapshot.title),
+      slug: proposal?.source === 'generated' ? proposal.slug : snapshot.slug,
       target: resolveTarget(command, snapshot),
       saveRevision: command.requiresRevision,
     };
+  }
+
+  function dropInFlight(slot: Slot, snapshot: S): boolean {
+    const reason = dropReason(slot, snapshot);
+    if (!reason) {
+      return false;
+    }
+    inFlight = null;
+    inFlightAbort = null;
+    settle(slot.waiters, dropped(reason));
+    drain();
+    return true;
   }
 
   function dropReason(slot: Slot, snapshot: S): DropReason | null {
@@ -606,22 +613,25 @@ export function createSaveEngine<
       if (disposed) {
         return;
       }
-      // Manual slug work may have taken time; the payload reflects the post as it is now.
+      // Every await re-reads the post and re-runs the drop rules on it; the payload reflects the post as it is now.
       snapshot = ports.getSnapshot();
-      const late = dropReason(slot, snapshot);
-      if (late) {
-        inFlight = null;
-        inFlightAbort = null;
-        settle(slot.waiters, dropped(late));
-        drain();
+      if (dropInFlight(slot, snapshot)) {
         return;
       }
-      const request = await buildRequest(slot.command, snapshot, abort.signal);
-      snapshot = request.snapshot;
+      const proposal = await proposeSlug(snapshot, abort.signal);
       if (disposed) {
         return;
       }
-      const prepared = await ports.prepare(request, abort.signal);
+      if (proposal) {
+        snapshot = ports.getSnapshot();
+        if (dropInFlight(slot, snapshot)) {
+          return;
+        }
+      }
+      const prepared = await ports.prepare(
+        buildRequest(slot.command, snapshot, proposal),
+        abort.signal,
+      );
       if (disposed) {
         return;
       }

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -85,10 +85,6 @@ export type SaveSnapshot = PersistedIdentity & {
   title: string;
   /** Empty until generated */
   slug: string;
-  /** Title differs from the last saved title; a draft's derived slug regenerates on save. */
-  titleDirty: boolean;
-  /** The slug machine's custom mode: the slug never follows the title again. */
-  slugIsCustom: boolean;
   isDirty: boolean;
   changedSinceLastRevision: boolean;
   /** Monotonic local edit counter; validation/host-limit suppression lifts once it moves. */
@@ -102,9 +98,9 @@ export interface SaveRequest<S extends SaveSnapshot = SaveSnapshot> {
   readonly snapshot: S;
   /** `(Untitled)` substituted for a blank title */
   readonly title: string;
-  /** Generated when missing or when a draft's derived slug is stale */
+  /** The slug port's generated proposal, else the slug current after slug work settled */
   readonly slug: string;
-  readonly target: SaveTarget;
+  readonly target: Readonly<SaveTarget>;
   readonly saveRevision: boolean;
 }
 
@@ -160,11 +156,17 @@ export type SaveEngineState =
 
 export type LeaveDecision = 'proceed' | 'confirm';
 
+/** A fresh generation, or `unchanged` when the slug machine keeps the current slug (custom, same title, frozen). */
+export interface SlugProposal {
+  slug: string;
+  source: 'generated' | 'unchanged';
+}
+
 export interface SlugPort {
-  /** Resolves once any manual slug edit in progress has settled. */
+  /** Must await the machine's latest submission chain, not its `pending` flag: the flag drops at the emit before the deferred submission starts. */
   settled: () => Promise<void>;
-  /** Server-deduplicated slug for a title; `postId` excludes the post itself. */
-  fromTitle: (title: string, postId: string | null, signal: AbortSignal) => Promise<string>;
+  /** Asked for every draft save and whenever the post has no slug; `postId` excludes the post from dedup. */
+  fromTitle: (title: string, postId: string | null, signal: AbortSignal) => Promise<SlugProposal>;
 }
 
 /** `P` is a plain structural superset of the request (no brand); `R` of the acknowledged result. */
@@ -179,17 +181,12 @@ export interface SaveEnginePorts<
   prepare: (request: SaveRequest<S>, signal: AbortSignal) => Promise<P>;
   /** IO only. A rejected promise is treated as an `unknown` error. */
   execute: (prepared: P, signal: AbortSignal) => Promise<SaveOutcome<R>>;
-  /**
-   * Awaited before the pending slot drains. Adopt the id, the authoritative status
-   * and updated_at; preserve edits made after `prepared.snapshot.version`; resync
-   * server-normalized values only where the local value did not change in flight;
-   * advance the saved/revision baselines without marking newer edits clean.
-   */
+  /** Awaited before the pending slot drains. Must not throw: adopt the acknowledged id/status/updated_at before any work that can fail. */
   reconcile: (prepared: P, result: R) => Promise<void> | void;
   setTimeout?: (fn: () => void, ms: number) => unknown;
   clearTimeout?: (handle: unknown) => void;
   onStateChange?: (state: SaveEngineState) => void;
-  /** A throwing subscriber is reported here instead of interrupting the others. */
+  /** A throwing `onStateChange` or subscriber is reported here instead of interrupting the save. */
   onListenerError?: (error: unknown) => void;
 }
 
@@ -265,7 +262,7 @@ export function deriveTarget(
 }
 
 /** Background intents pin draft; explicit and leave preserve the status; status intents carry their own target. */
-export function resolveTarget(command: SaveCommand, snapshot: TargetSource): SaveTarget {
+export function resolveTarget(command: SaveCommand, snapshot: TargetSource): Readonly<SaveTarget> {
   if (command.target) {
     return command.target;
   }
@@ -382,14 +379,13 @@ export function createSaveEngine<
       return;
     }
     state = next;
-    ports.onStateChange?.(next);
-    for (const listener of [...listeners]) {
+    for (const listener of [ports.onStateChange, ...listeners]) {
       // A nested transition already notified everyone with the newer state.
       if (state !== next) {
         break;
       }
       try {
-        listener(next);
+        listener?.(next);
       } catch (error) {
         reportListenerError(error);
       }
@@ -536,28 +532,28 @@ export function createSaveEngine<
     drain();
   }
 
-  function needsSlug(snapshot: S, title: string): boolean {
-    if (!snapshot.slug) {
-      return true;
-    }
-    return (
-      snapshot.status === 'draft' &&
-      snapshot.titleDirty &&
-      !snapshot.slugIsCustom &&
-      title !== DEFAULT_TITLE
-    );
+  function blankToDefault(title: string): string {
+    return title.trim() ? title : DEFAULT_TITLE;
   }
 
+  // Status is the one rule the slug machine cannot know; it answers custom/same-title/frozen itself.
   async function buildRequest(
     command: SaveCommand,
     snapshot: S,
     signal: AbortSignal,
   ): Promise<SaveRequest<S>> {
-    const title = snapshot.title.trim() ? snapshot.title : DEFAULT_TITLE;
     let slug = snapshot.slug;
-    if (needsSlug(snapshot, title)) {
-      slug = (await ports.slug.fromTitle(title, snapshot.id, signal)) || slug;
+    if (!snapshot.slug || snapshot.status === 'draft') {
+      const proposal = await ports.slug.fromTitle(
+        blankToDefault(snapshot.title),
+        snapshot.id,
+        signal,
+      );
+      // A slug committed while the proposal was in flight wins over the one read before it.
+      snapshot = ports.getSnapshot();
+      slug = proposal.source === 'generated' ? proposal.slug : snapshot.slug;
     }
+    const title = blankToDefault(snapshot.title);
     return {
       command,
       snapshot,
@@ -620,10 +616,12 @@ export function createSaveEngine<
         drain();
         return;
       }
-      const prepared = await ports.prepare(
-        await buildRequest(slot.command, snapshot, abort.signal),
-        abort.signal,
-      );
+      const request = await buildRequest(slot.command, snapshot, abort.signal);
+      snapshot = request.snapshot;
+      if (disposed) {
+        return;
+      }
+      const prepared = await ports.prepare(request, abort.signal);
       if (disposed) {
         return;
       }
@@ -680,14 +678,18 @@ export function createSaveEngine<
       return;
     }
 
+    // No automatic retry against the stale baseline: queued work is dropped, an explicit retry is the way out.
     if (error.kind === 'conflict') {
       staleUpdatedAt = snapshot.updatedAt;
       const dropWaiters: Waiter[] = [];
       clearTimers(dropWaiters);
+      if (pending) {
+        dropWaiters.push(...pending.waiters);
+        pending = null;
+      }
       settle(dropWaiters, dropped('conflict'));
       settle(slot.waiters, failed(error, intent));
       setState({ kind: 'conflict', intent, error });
-      drain();
       return;
     }
 

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -294,12 +294,14 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     timedCycle = null;
   }
 
-  function restartDebounce(waiter: Waiter): void {
+  function restartDebounce(waiter?: Waiter): void {
     const waiters = debounce ? debounce.waiters : [];
     if (debounce) {
       cancel(debounce.handle);
     }
-    waiters.push(waiter);
+    if (waiter) {
+      waiters.push(waiter);
+    }
     const handle = schedule(() => {
       debounce = null;
       enqueue('autosave', waiters);
@@ -477,7 +479,13 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
         return;
       }
 
-      const snapshot = ports.getSnapshot();
+      let snapshot: S;
+      try {
+        snapshot = ports.getSnapshot();
+      } catch (cause) {
+        resolve({ kind: 'failed', error: toSaveError(cause) });
+        return;
+      }
       if (snapshot.status !== 'draft') {
         resolve(dropped('not-draft'));
         return;
@@ -508,10 +516,33 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     frozen = null;
     if (isStatusChangingIntent(slot.intent)) {
       settle(slot.waiters, { kind: 'needs-retry' });
+      resumeAutosave();
     } else {
       coalesce(slot.intent, slot.waiters);
     }
     drain();
+  }
+
+  // Riders folded into a publish/revert slot got needs-retry too; keep their content saving.
+  function resumeAutosave(): void {
+    const snapshot = readSnapshot();
+    if (!snapshot || snapshot.status !== 'draft' || !snapshot.isDirty || isSuppressed(snapshot)) {
+      return;
+    }
+    armTimedCycle();
+    if (snapshot.isNew) {
+      enqueue('autosave', []);
+      return;
+    }
+    restartDebounce();
+  }
+
+  function readSnapshot(): S | null {
+    try {
+      return ports.getSnapshot();
+    } catch {
+      return null;
+    }
   }
 
   function reauthAbandoned(): void {
@@ -553,11 +584,23 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     return leaveInProgress;
   }
 
+  // Fails closed: an unreadable snapshot asks for confirmation; a disposed engine lets the caller go.
+  function dirtyDecision(): LeaveDecision {
+    if (disposed) {
+      return 'proceed';
+    }
+    const snapshot = readSnapshot();
+    return !snapshot || snapshot.isDirty ? 'confirm' : 'proceed';
+  }
+
   async function decideLeave(): Promise<LeaveDecision> {
     if (disposed) {
       return 'proceed';
     }
-    let snapshot = ports.getSnapshot();
+    let snapshot = readSnapshot();
+    if (!snapshot) {
+      return 'confirm';
+    }
     if (isTerminal() || frozen) {
       return snapshot.isDirty ? 'confirm' : 'proceed';
     }
@@ -565,8 +608,14 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     let saveOnLeavePerformed = false;
     if (shouldSaveOnLeave(snapshot)) {
       await dispatch('leave');
+      if (disposed) {
+        return 'proceed';
+      }
       saveOnLeavePerformed = true;
-      snapshot = ports.getSnapshot();
+      snapshot = readSnapshot();
+      if (!snapshot) {
+        return 'confirm';
+      }
     }
 
     if (!snapshot.isDirty) {
@@ -577,14 +626,14 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     }
     if (inFlight || pending) {
       await queueSettled();
-      return ports.getSnapshot().isDirty ? 'confirm' : 'proceed';
+      return dirtyDecision();
     }
     if (debounce || timedCycle) {
       if (saveOnLeavePerformed) {
         return 'confirm';
       }
       await dispatch('leave');
-      return ports.getSnapshot().isDirty ? 'confirm' : 'proceed';
+      return dirtyDecision();
     }
     return 'confirm';
   }

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -4,6 +4,8 @@ export type { PostStatus };
 
 export const AUTOSAVE_DEBOUNCE_MS = 3000;
 export const TIMED_SAVE_INTERVAL_MS = 60000;
+/** Title the API stores for a blank editor title. */
+export const DEFAULT_TITLE = '(Untitled)';
 
 export type SaveIntent =
   | 'autosave'
@@ -12,10 +14,14 @@ export type SaveIntent =
   | 'explicit'
   | 'leave'
   | 'publish'
+  | 'schedule'
   | 'revert';
 
 /** `timed` is engine-internal: an autosave dispatch arms the 60s cycle. */
 export type DispatchIntent = Exclude<SaveIntent, 'timed'>;
+
+/** The only intents that may change a post's status. */
+export type StatusIntent = 'publish' | 'schedule' | 'revert';
 
 // Coalescing ladder: the higher number wins the pending slot.
 const PRIORITY: Record<SaveIntent, number> = {
@@ -25,6 +31,7 @@ const PRIORITY: Record<SaveIntent, number> = {
   leave: 3,
   explicit: 4,
   publish: 5,
+  schedule: 5,
   revert: 5,
 };
 
@@ -32,33 +39,76 @@ export function isBackgroundIntent(intent: SaveIntent): boolean {
   return intent === 'autosave' || intent === 'timed' || intent === 'field';
 }
 
-function isStatusChangingIntent(intent: SaveIntent): boolean {
-  return intent === 'publish' || intent === 'revert';
+export function isStatusIntent(intent: SaveIntent): intent is StatusIntent {
+  return intent === 'publish' || intent === 'schedule' || intent === 'revert';
 }
 
-export interface SaveSnapshot {
-  /** null until the create request has succeeded */
-  id: string | null;
-  isNew: boolean;
+export interface SaveTarget {
+  status: PostStatus;
+  /** ISO 8601 with zeroed milliseconds, or null */
+  publishedAt: string | null;
+  emailOnly?: boolean;
+  newsletter?: string;
+  emailSegment?: string;
+}
+
+export interface PublishOptions {
+  /** Omitted keeps the post's current publish time; null clears it. */
+  publishedAt?: string | null;
+  emailOnly?: boolean;
+  newsletter?: string;
+  emailSegment?: string;
+}
+
+export interface ScheduleOptions extends PublishOptions {
+  publishedAt: string;
+}
+
+/** Captured at dispatch and never re-derived from a later snapshot. */
+export interface SaveCommand {
+  readonly kind: SaveIntent;
+  /** Present only for status intents; email extras ride on exactly this command's request. */
+  readonly target?: Readonly<SaveTarget>;
+  /** ORed across coalesced work: a rider that needs a revision makes the carrying save request one. */
+  readonly requiresRevision: boolean;
+  /** The target changed the status when captured; re-auth falls back to this when the snapshot is unreadable. */
+  readonly requiresReconfirmation: boolean;
+}
+
+/** A persisted post always carries the server's updated_at; every update sends it for the collision check. */
+export type PersistedIdentity = { id: string; updatedAt: string } | { id: null; updatedAt: null };
+
+export type SaveSnapshot = PersistedIdentity & {
   status: PostStatus;
   /** ISO 8601 or null */
   publishedAt: string | null;
-  willPublish: boolean;
-  willSchedule: boolean;
+  title: string;
+  /** Empty until generated */
+  slug: string;
+  /** Title differs from the last saved title; a draft's derived slug regenerates on save. */
+  titleDirty: boolean;
+  /** The slug machine's custom mode: the slug never follows the title again. */
+  slugIsCustom: boolean;
   isDirty: boolean;
   changedSinceLastRevision: boolean;
   /** Monotonic local edit counter; validation/host-limit suppression lifts once it moves. */
   version: number;
-}
+};
 
+/** Handed unchanged from prepare through reconcile; the engine never mutates it. */
 export interface SaveRequest<S extends SaveSnapshot = SaveSnapshot> {
-  intent: SaveIntent;
-  snapshot: S;
-  status: PostStatus;
-  publishedAt: string | null;
-  saveRevision: boolean;
+  readonly command: SaveCommand;
+  /** The complete post as read at execution time, after pending slug work settled. */
+  readonly snapshot: S;
+  /** `(Untitled)` substituted for a blank title */
+  readonly title: string;
+  /** Generated when missing or when a draft's derived slug is stale */
+  readonly slug: string;
+  readonly target: SaveTarget;
+  readonly saveRevision: boolean;
 }
 
+/** The acknowledged identity; a create exposes the id the tracker adopts. */
 export interface SaveResult {
   id: string;
   status: PostStatus;
@@ -68,6 +118,7 @@ export interface SaveResult {
 export type SaveErrorKind =
   | 'session-invalid'
   | 'not-found'
+  | 'conflict'
   | 'host-limit'
   | 'transport'
   | 'validation'
@@ -79,17 +130,19 @@ export interface SaveError {
   cause?: unknown;
 }
 
-export type SaveOutcome = { ok: true; result: SaveResult } | { ok: false; error: SaveError };
+export type SaveOutcome<R extends SaveResult = SaveResult> =
+  | { ok: true; result: R }
+  | { ok: false; error: SaveError };
 
-export type DropReason = 'not-draft' | 'clean' | 'suppressed' | 'halted' | 'disposed';
+export type DropReason = 'not-draft' | 'clean' | 'suppressed' | 'conflict' | 'halted' | 'disposed';
 
 export type SaveCompletion =
-  | { kind: 'saved'; result: SaveResult }
-  | { kind: 'failed'; error: SaveError }
+  | { kind: 'saved'; result: SaveResult; executedAs: SaveIntent }
+  | { kind: 'failed'; error: SaveError; executedAs: SaveIntent }
   | { kind: 'dropped'; reason: DropReason }
-  /** A contradictory status-changing intent replaced this one before it ran. */
+  /** A later status command replaced this one before it ran; riders stayed with the winner. */
   | { kind: 'superseded'; by: SaveIntent }
-  /** Publish/revert interrupted by re-auth; the publish flow must re-confirm, never auto-fire. */
+  /** The command would change the status and re-auth interrupted it; the publish flow must re-confirm. */
   | { kind: 'needs-retry' };
 
 export type SaveEngineState =
@@ -99,38 +152,61 @@ export type SaveEngineState =
   | { kind: 'pending-coalesced'; intent: SaveIntent; pending: SaveIntent }
   | { kind: 'reauth-pending'; intent: SaveIntent }
   | { kind: 'error'; intent: SaveIntent; error: SaveError }
+  /** The server rejected a stale updated_at; automatic saves halt until the baseline changes. */
+  | { kind: 'conflict'; intent: SaveIntent; error: SaveError }
   | { kind: 'halted' }
   | { kind: 'crashed' }
-  | { kind: 'disposed' }
-  // Reserved for server-side OCC; posts are last-write-wins today so it is never entered.
-  | { kind: 'conflict' };
+  | { kind: 'disposed' };
 
 export type LeaveDecision = 'proceed' | 'confirm';
 
-export interface SaveEnginePorts<S extends SaveSnapshot = SaveSnapshot> {
+export interface SlugPort {
+  /** Resolves once any manual slug edit in progress has settled. */
+  settled: () => Promise<void>;
+  /** Server-deduplicated slug for a title; `postId` excludes the post itself. */
+  fromTitle: (title: string, postId: string | null, signal: AbortSignal) => Promise<string>;
+}
+
+/** `P` is a plain structural superset of the request (no brand); `R` of the acknowledged result. */
+export interface SaveEnginePorts<
+  S extends SaveSnapshot = SaveSnapshot,
+  P extends SaveRequest<S> = SaveRequest<S>,
+  R extends SaveResult = SaveResult,
+> {
   getSnapshot: () => S;
-  /** The only IO port. A rejected promise is treated as an `unknown` error. */
-  execute: (request: SaveRequest<S>) => Promise<SaveOutcome>;
-  now?: () => number;
+  slug: SlugPort;
+  /** Builds and validates the candidate; runs inside the single-flight unit, before any IO. */
+  prepare: (request: SaveRequest<S>, signal: AbortSignal) => Promise<P>;
+  /** IO only. A rejected promise is treated as an `unknown` error. */
+  execute: (prepared: P, signal: AbortSignal) => Promise<SaveOutcome<R>>;
+  /**
+   * Awaited before the pending slot drains. Adopt the id, the authoritative status
+   * and updated_at; preserve edits made after `prepared.snapshot.version`; resync
+   * server-normalized values only where the local value did not change in flight;
+   * advance the saved/revision baselines without marking newer edits clean.
+   */
+  reconcile: (prepared: P, result: R) => Promise<void> | void;
   setTimeout?: (fn: () => void, ms: number) => unknown;
   clearTimeout?: (handle: unknown) => void;
   onStateChange?: (state: SaveEngineState) => void;
+  /** A throwing subscriber is reported here instead of interrupting the others. */
+  onListenerError?: (error: unknown) => void;
 }
 
 export interface SaveEngine {
-  dispatch(intent: DispatchIntent): Promise<SaveCompletion>;
+  dispatch(kind: 'schedule', options: ScheduleOptions): Promise<SaveCompletion>;
+  dispatch(kind: 'publish', options?: PublishOptions): Promise<SaveCompletion>;
+  dispatch(kind: Exclude<DispatchIntent, 'publish' | 'schedule'>): Promise<SaveCompletion>;
   getState(): SaveEngineState;
   subscribe(listener: (state: SaveEngineState) => void): () => void;
   reauthSucceeded(): void;
   reauthAbandoned(): void;
   leaveRequested(): Promise<LeaveDecision>;
+  /** Also aborts the in-flight signal; a response arriving afterwards is never reconciled. */
   dispose(): void;
 }
 
-export type StatusInputs = Pick<
-  SaveSnapshot,
-  'status' | 'publishedAt' | 'willPublish' | 'willSchedule'
->;
+export type TargetSource = Pick<SaveSnapshot, 'status' | 'publishedAt'>;
 
 export function zeroMilliseconds(iso: string | null): string | null {
   if (iso === null) {
@@ -143,49 +219,73 @@ export function zeroMilliseconds(iso: string | null): string | null {
   return new Date(time - (time % 1000)).toISOString();
 }
 
-function isPastScheduledTime(snapshot: StatusInputs, now: number): boolean {
-  if (snapshot.status !== 'scheduled' || snapshot.publishedAt === null) {
-    return false;
+function withEmail(target: SaveTarget, options: PublishOptions): SaveTarget {
+  if (options.emailOnly !== undefined) {
+    target.emailOnly = options.emailOnly;
   }
-  const publishedAt = Date.parse(zeroMilliseconds(snapshot.publishedAt) ?? '');
-  return !Number.isNaN(publishedAt) && publishedAt < now;
+  if (options.newsletter !== undefined) {
+    target.newsletter = options.newsletter;
+  }
+  if (options.emailSegment !== undefined) {
+    target.emailSegment = options.emailSegment;
+  }
+  return target;
 }
 
-export function resolveStatus(snapshot: StatusInputs, intent: SaveIntent, now: number): PostStatus {
-  if (isBackgroundIntent(intent)) {
-    return 'draft';
-  }
-  if (intent === 'leave') {
-    return snapshot.status;
-  }
-  if (intent === 'revert') {
-    return 'draft';
-  }
-  if (intent === 'publish') {
-    return snapshot.willSchedule ? 'scheduled' : 'published';
-  }
-  switch (snapshot.status) {
-    case 'draft':
-      if (snapshot.willPublish) {
-        return 'published';
-      }
-      return snapshot.willSchedule ? 'scheduled' : 'draft';
-    case 'published':
-      return 'published';
-    case 'sent':
-      return 'sent';
-    case 'scheduled':
-      if (isPastScheduledTime(snapshot, now)) {
-        return snapshot.willPublish || snapshot.willSchedule ? 'published' : 'draft';
-      }
-      return 'scheduled';
+/** Transition-derived target for a status intent, from the source the command was captured against. */
+export function deriveTarget(
+  kind: StatusIntent,
+  source: TargetSource,
+  options: PublishOptions = {},
+): SaveTarget {
+  switch (kind) {
+    case 'publish':
+      return withEmail(
+        {
+          status: 'published',
+          publishedAt: zeroMilliseconds(
+            options.publishedAt === undefined ? source.publishedAt : options.publishedAt,
+          ),
+        },
+        options,
+      );
+    case 'schedule':
+      return withEmail(
+        { status: 'scheduled', publishedAt: zeroMilliseconds(options.publishedAt ?? null) },
+        options,
+      );
+    case 'revert':
+      // Unscheduling clears the publish time; unpublishing keeps it as history.
+      return {
+        status: 'draft',
+        publishedAt: source.status === 'scheduled' ? null : zeroMilliseconds(source.publishedAt),
+        emailOnly: false,
+      };
   }
 }
 
-type Waiter = (completion: SaveCompletion) => void;
+/** Background intents pin draft; explicit and leave preserve the status; status intents carry their own target. */
+export function resolveTarget(command: SaveCommand, snapshot: TargetSource): SaveTarget {
+  if (command.target) {
+    return command.target;
+  }
+  return {
+    status: isBackgroundIntent(command.kind) ? 'draft' : snapshot.status,
+    publishedAt: zeroMilliseconds(snapshot.publishedAt),
+  };
+}
+
+function changesStatus(command: SaveCommand, snapshot: TargetSource): boolean {
+  return resolveTarget(command, snapshot).status !== snapshot.status;
+}
+
+interface Waiter {
+  command: SaveCommand;
+  resolve: (completion: SaveCompletion) => void;
+}
 
 interface Slot {
-  intent: SaveIntent;
+  command: SaveCommand;
   waiters: Waiter[];
 }
 
@@ -199,14 +299,35 @@ interface Frozen {
   error: SaveError;
 }
 
+const AUTOSAVE: SaveCommand = {
+  kind: 'autosave',
+  requiresRevision: false,
+  requiresReconfirmation: false,
+};
+const TIMED: SaveCommand = {
+  kind: 'timed',
+  requiresRevision: false,
+  requiresReconfirmation: false,
+};
+
 function dropped(reason: DropReason): SaveCompletion {
   return { kind: 'dropped', reason };
 }
 
+function failed(error: SaveError, executedAs: SaveIntent): SaveCompletion {
+  return { kind: 'failed', error, executedAs };
+}
+
 function settle(waiters: Waiter[], completion: SaveCompletion): void {
   for (const waiter of waiters) {
-    waiter(completion);
+    waiter.resolve(completion);
   }
+}
+
+function withRevision(command: SaveCommand, waiters: Waiter[]): SaveCommand {
+  const requiresRevision =
+    command.requiresRevision || waiters.some((waiter) => waiter.command.requiresRevision);
+  return requiresRevision === command.requiresRevision ? command : { ...command, requiresRevision };
 }
 
 function toSaveError(cause: unknown): SaveError {
@@ -225,22 +346,34 @@ function sameState(a: SaveEngineState, b: SaveEngineState): boolean {
   );
 }
 
-export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
-  ports: SaveEnginePorts<S>,
-): SaveEngine {
-  const now = ports.now ?? (() => Date.now());
+function rethrowAsync(error: unknown): void {
+  queueMicrotask(() => {
+    throw error;
+  });
+}
+
+export function createSaveEngine<
+  S extends SaveSnapshot = SaveSnapshot,
+  P extends SaveRequest<S> = SaveRequest<S>,
+  R extends SaveResult = SaveResult,
+>(ports: SaveEnginePorts<S, P, R>): SaveEngine {
   const schedule = ports.setTimeout ?? ((fn, ms) => globalThis.setTimeout(fn, ms));
   const cancel = ports.clearTimeout ?? ((handle) => globalThis.clearTimeout(handle as number));
+  const reportListenerError = ports.onListenerError ?? rethrowAsync;
   const listeners = new Set<(state: SaveEngineState) => void>();
+  const transitionWatchers = new Set<() => void>();
 
   let state: SaveEngineState = { kind: 'idle' };
   let inFlight: Slot | null = null;
+  let inFlightAbort: AbortController | null = null;
   let pending: Slot | null = null;
   // Set while re-authentication is pending: the failed slot freezes the queue until reauth resolves.
   let frozen: Frozen | null = null;
   let debounce: Timer | null = null;
   let timedCycle: Timer | null = null;
   let suppressedVersion: number | null = null;
+  // updated_at the server rejected; automatic saves stay halted while the snapshot still carries it.
+  let staleUpdatedAt: string | null = null;
   let leaveInProgress: Promise<LeaveDecision> | null = null;
   let disposed = false;
 
@@ -249,9 +382,20 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
       return;
     }
     state = next;
-    ports.onStateChange?.(state);
+    ports.onStateChange?.(next);
     for (const listener of [...listeners]) {
-      listener(state);
+      // A nested transition already notified everyone with the newer state.
+      if (state !== next) {
+        break;
+      }
+      try {
+        listener(next);
+      } catch (error) {
+        reportListenerError(error);
+      }
+    }
+    for (const watcher of [...transitionWatchers]) {
+      watcher();
     }
   }
 
@@ -266,10 +410,14 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     }
     if (inFlight) {
       return pending
-        ? { kind: 'pending-coalesced', intent: inFlight.intent, pending: pending.intent }
-        : { kind: 'saving', intent: inFlight.intent };
+        ? {
+            kind: 'pending-coalesced',
+            intent: inFlight.command.kind,
+            pending: pending.command.kind,
+          }
+        : { kind: 'saving', intent: inFlight.command.kind };
     }
-    if (state.kind === 'error') {
+    if (state.kind === 'error' || state.kind === 'conflict') {
       return state;
     }
     if (debounce || timedCycle) {
@@ -280,6 +428,24 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
 
   function isSuppressed(snapshot: S): boolean {
     return suppressedVersion !== null && snapshot.version === suppressedVersion;
+  }
+
+  function isStale(snapshot: S): boolean {
+    return staleUpdatedAt !== null && snapshot.updatedAt === staleUpdatedAt;
+  }
+
+  // Sidebar edits on published/scheduled/sent posts stage until Update (spec §4); never promote them to saves.
+  function backgroundDropReason(snapshot: S): DropReason | null {
+    if (snapshot.status !== 'draft') {
+      return 'not-draft';
+    }
+    if (isSuppressed(snapshot)) {
+      return 'suppressed';
+    }
+    if (isStale(snapshot)) {
+      return 'conflict';
+    }
+    return null;
   }
 
   // Any save start cancels both timers; their waiters chain into the save that supersedes them.
@@ -304,7 +470,7 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     }
     const handle = schedule(() => {
       debounce = null;
-      enqueue('autosave', waiters);
+      enqueue(AUTOSAVE, waiters);
     }, AUTOSAVE_DEBOUNCE_MS);
     debounce = { handle, waiters };
     setState(deriveState());
@@ -317,46 +483,44 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     const waiters: Waiter[] = [];
     const handle = schedule(() => {
       timedCycle = null;
-      enqueue('timed', waiters);
+      enqueue(TIMED, waiters);
     }, TIMED_SAVE_INTERVAL_MS);
     timedCycle = { handle, waiters };
     setState(deriveState());
   }
 
-  // Higher priority wins and carries the loser's content; contradictory publish/revert is last-wins.
-  function coalesce(intent: SaveIntent, waiters: Waiter[]): void {
+  // Higher priority wins and carries the riders; a later status command supersedes only the earlier one.
+  function coalesce(command: SaveCommand, waiters: Waiter[]): void {
     if (!pending) {
-      pending = { intent, waiters };
+      pending = { command: withRevision(command, waiters), waiters };
       return;
     }
-    const current = pending.intent;
-    if (PRIORITY[intent] > PRIORITY[current]) {
-      pending.intent = intent;
-      pending.waiters.push(...waiters);
-      return;
-    }
-    if (
-      PRIORITY[intent] === PRIORITY[current] &&
-      intent !== current &&
-      isStatusChangingIntent(intent)
-    ) {
-      settle(pending.waiters, { kind: 'superseded', by: intent });
-      pending = { intent, waiters };
-      return;
+    let winner = pending.command;
+    if (isStatusIntent(command.kind) && isStatusIntent(pending.command.kind)) {
+      const superseded = pending.waiters.filter((waiter) => isStatusIntent(waiter.command.kind));
+      pending.waiters = pending.waiters.filter((waiter) => !isStatusIntent(waiter.command.kind));
+      settle(superseded, { kind: 'superseded', by: command.kind });
+      winner = command;
+    } else if (PRIORITY[command.kind] > PRIORITY[pending.command.kind]) {
+      winner = command;
     }
     pending.waiters.push(...waiters);
+    pending.command = withRevision(winner, pending.waiters);
   }
 
-  function enqueue(intent: SaveIntent, waiters: Waiter[]): void {
+  function enqueue(command: SaveCommand, waiters: Waiter[]): void {
     if (inFlight || frozen) {
-      coalesce(intent, waiters);
+      coalesce(command, waiters);
       setState(deriveState());
       return;
     }
-    void run({ intent, waiters });
+    void run({ command, waiters });
   }
 
   function drain(): void {
+    if (inFlight) {
+      return;
+    }
     const next = pending;
     pending = null;
     if (next) {
@@ -367,17 +531,59 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
   }
 
   function failSlot(slot: Slot, error: SaveError): void {
-    settle(slot.waiters, { kind: 'failed', error });
-    setState({ kind: 'error', intent: slot.intent, error });
-    if (pending) {
-      const next = pending;
-      pending = null;
-      void run(next);
+    settle(slot.waiters, failed(error, slot.command.kind));
+    setState({ kind: 'error', intent: slot.command.kind, error });
+    drain();
+  }
+
+  function needsSlug(snapshot: S, title: string): boolean {
+    if (!snapshot.slug) {
+      return true;
     }
+    return (
+      snapshot.status === 'draft' &&
+      snapshot.titleDirty &&
+      !snapshot.slugIsCustom &&
+      title !== DEFAULT_TITLE
+    );
+  }
+
+  async function buildRequest(
+    command: SaveCommand,
+    snapshot: S,
+    signal: AbortSignal,
+  ): Promise<SaveRequest<S>> {
+    const title = snapshot.title.trim() ? snapshot.title : DEFAULT_TITLE;
+    let slug = snapshot.slug;
+    if (needsSlug(snapshot, title)) {
+      slug = (await ports.slug.fromTitle(title, snapshot.id, signal)) || slug;
+    }
+    return {
+      command,
+      snapshot,
+      title,
+      slug,
+      target: resolveTarget(command, snapshot),
+      saveRevision: command.requiresRevision,
+    };
+  }
+
+  function dropReason(slot: Slot, snapshot: S): DropReason | null {
+    if (!isBackgroundIntent(slot.command.kind)) {
+      return null;
+    }
+    if (snapshot.status !== 'draft') {
+      return 'not-draft';
+    }
+    if (!snapshot.isDirty) {
+      return 'clean';
+    }
+    return backgroundDropReason(snapshot);
   }
 
   async function run(slot: Slot): Promise<void> {
     clearTimers(slot.waiters);
+    slot.command = withRevision(slot.command, slot.waiters);
 
     let snapshot: S;
     try {
@@ -386,37 +592,48 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
       failSlot(slot, toSaveError(cause));
       return;
     }
-
-    if (isBackgroundIntent(slot.intent)) {
-      let reason: DropReason | null = null;
-      if (snapshot.status !== 'draft') {
-        reason = 'not-draft';
-      } else if (!snapshot.isDirty) {
-        reason = 'clean';
-      } else if (isSuppressed(snapshot)) {
-        reason = 'suppressed';
-      }
-      if (reason) {
-        settle(slot.waiters, dropped(reason));
-        drain();
-        return;
-      }
+    const early = dropReason(slot, snapshot);
+    if (early) {
+      settle(slot.waiters, dropped(early));
+      drain();
+      return;
     }
 
     inFlight = slot;
+    const abort = new AbortController();
+    inFlightAbort = abort;
     setState(deriveState());
 
-    const request: SaveRequest<S> = {
-      intent: slot.intent,
-      snapshot,
-      status: resolveStatus(snapshot, slot.intent, now()),
-      publishedAt: zeroMilliseconds(snapshot.publishedAt),
-      saveRevision: slot.intent === 'explicit' || slot.intent === 'leave',
-    };
-
-    let outcome: SaveOutcome;
+    let outcome: SaveOutcome<R>;
     try {
-      outcome = await ports.execute(request);
+      await ports.slug.settled();
+      if (disposed) {
+        return;
+      }
+      // Manual slug work may have taken time; the payload reflects the post as it is now.
+      snapshot = ports.getSnapshot();
+      const late = dropReason(slot, snapshot);
+      if (late) {
+        inFlight = null;
+        inFlightAbort = null;
+        settle(slot.waiters, dropped(late));
+        drain();
+        return;
+      }
+      const prepared = await ports.prepare(
+        await buildRequest(slot.command, snapshot, abort.signal),
+        abort.signal,
+      );
+      if (disposed) {
+        return;
+      }
+      outcome = await ports.execute(prepared, abort.signal);
+      if (disposed) {
+        return;
+      }
+      if (outcome.ok) {
+        await ports.reconcile(prepared, outcome.result);
+      }
     } catch (cause) {
       outcome = { ok: false, error: toSaveError(cause) };
     }
@@ -425,10 +642,16 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
       return;
     }
     inFlight = null;
+    inFlightAbort = null;
 
     if (outcome.ok) {
       suppressedVersion = null;
-      settle(slot.waiters, { kind: 'saved', result: outcome.result });
+      staleUpdatedAt = null;
+      settle(slot.waiters, {
+        kind: 'saved',
+        result: outcome.result,
+        executedAs: slot.command.kind,
+      });
       drain();
       return;
     }
@@ -436,9 +659,11 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
   }
 
   function handleError(slot: Slot, snapshot: S, error: SaveError): void {
+    const intent = slot.command.kind;
+
     if (error.kind === 'session-invalid') {
       frozen = { slot, error };
-      setState({ kind: 'reauth-pending', intent: slot.intent });
+      setState({ kind: 'reauth-pending', intent });
       return;
     }
 
@@ -450,18 +675,50 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
         pending = null;
       }
       settle(dropWaiters, dropped('halted'));
-      settle(slot.waiters, { kind: 'failed', error });
+      settle(slot.waiters, failed(error, intent));
       setState({ kind: snapshot.id ? 'halted' : 'crashed' });
       return;
     }
 
-    if (error.kind === 'validation' || error.kind === 'host-limit') {
+    if (error.kind === 'conflict') {
+      staleUpdatedAt = snapshot.updatedAt;
+      const dropWaiters: Waiter[] = [];
+      clearTimers(dropWaiters);
+      settle(dropWaiters, dropped('conflict'));
+      settle(slot.waiters, failed(error, intent));
+      setState({ kind: 'conflict', intent, error });
+      drain();
+      return;
+    }
+
+    if (error.kind === 'validation') {
+      suppressedVersion = snapshot.version;
+    }
+    // A limit hit by a status change says nothing about draft persistence; only a draft save's limit halts it.
+    if (error.kind === 'host-limit' && !changesStatus(slot.command, snapshot)) {
       suppressedVersion = snapshot.version;
     }
     failSlot(slot, error);
   }
 
-  function dispatch(intent: DispatchIntent): Promise<SaveCompletion> {
+  function captureCommand(kind: DispatchIntent, snapshot: S | null, options?: PublishOptions) {
+    if (isStatusIntent(kind) && snapshot) {
+      const target = deriveTarget(kind, snapshot, options);
+      return {
+        kind,
+        target,
+        requiresRevision: false,
+        requiresReconfirmation: target.status !== snapshot.status,
+      } satisfies SaveCommand;
+    }
+    return {
+      kind,
+      requiresRevision: kind === 'explicit' || kind === 'leave',
+      requiresReconfirmation: false,
+    } satisfies SaveCommand;
+  }
+
+  function dispatch(kind: DispatchIntent, options?: PublishOptions): Promise<SaveCompletion> {
     return new Promise<SaveCompletion>((resolve) => {
       if (disposed) {
         resolve(dropped('disposed'));
@@ -472,69 +729,40 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
         return;
       }
 
-      if (!isBackgroundIntent(intent)) {
-        const waiters: Waiter[] = [resolve];
+      let snapshot: S | null = null;
+      if (isBackgroundIntent(kind) || isStatusIntent(kind)) {
+        try {
+          snapshot = ports.getSnapshot();
+        } catch (cause) {
+          resolve(failed(toSaveError(cause), kind));
+          return;
+        }
+      }
+      const waiter: Waiter = { command: captureCommand(kind, snapshot, options), resolve };
+
+      if (!isBackgroundIntent(kind) || !snapshot) {
+        const waiters = [waiter];
         clearTimers(waiters);
-        enqueue(intent, waiters);
+        enqueue(waiter.command, waiters);
         return;
       }
 
-      let snapshot: S;
-      try {
-        snapshot = ports.getSnapshot();
-      } catch (cause) {
-        resolve({ kind: 'failed', error: toSaveError(cause) });
+      const reason = backgroundDropReason(snapshot);
+      if (reason) {
+        resolve(dropped(reason));
         return;
       }
-      if (snapshot.status !== 'draft') {
-        resolve(dropped('not-draft'));
-        return;
-      }
-      if (isSuppressed(snapshot)) {
-        resolve(dropped('suppressed'));
-        return;
-      }
-
-      if (intent === 'field') {
-        enqueue('field', [resolve]);
+      if (kind === 'field') {
+        enqueue(waiter.command, [waiter]);
         return;
       }
       armTimedCycle();
-      if (snapshot.isNew) {
-        enqueue('autosave', [resolve]);
+      if (snapshot.id === null) {
+        enqueue(waiter.command, [waiter]);
         return;
       }
-      restartDebounce(resolve);
+      restartDebounce(waiter);
     });
-  }
-
-  function reauthSucceeded(): void {
-    if (!frozen || disposed) {
-      return;
-    }
-    const { slot } = frozen;
-    frozen = null;
-    if (isStatusChangingIntent(slot.intent)) {
-      settle(slot.waiters, { kind: 'needs-retry' });
-      resumeAutosave();
-    } else {
-      coalesce(slot.intent, slot.waiters);
-    }
-    drain();
-  }
-
-  // Riders folded into a publish/revert slot got needs-retry too; keep their content saving.
-  function resumeAutosave(): void {
-    const snapshot = readSnapshot();
-    if (!snapshot || snapshot.status !== 'draft' || !snapshot.isDirty || isSuppressed(snapshot)) {
-      return;
-    }
-    armTimedCycle();
-    if (snapshot.isNew) {
-      enqueue('autosave', []);
-      return;
-    }
-    restartDebounce();
   }
 
   function readSnapshot(): S | null {
@@ -545,34 +773,85 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     }
   }
 
+  // Judged by the resolved effect against the current post, not by the intent label.
+  function needsReconfirmation(command: SaveCommand, snapshot: S | null): boolean {
+    return snapshot ? changesStatus(command, snapshot) : command.requiresReconfirmation;
+  }
+
+  function reauthSucceeded(): void {
+    if (!frozen || disposed) {
+      return;
+    }
+    const slots = pending ? [frozen.slot, pending] : [frozen.slot];
+    frozen = null;
+    pending = null;
+    const snapshot = readSnapshot();
+    let reconfirm = false;
+    for (const slot of slots) {
+      for (const waiter of slot.waiters) {
+        if (needsReconfirmation(waiter.command, snapshot)) {
+          waiter.resolve({ kind: 'needs-retry' });
+          reconfirm = true;
+        } else {
+          coalesce(waiter.command, [waiter]);
+        }
+      }
+    }
+    // Content a disarmed status command would have carried resumes through the normal autosave path.
+    if (reconfirm && !pending) {
+      resumeAutosave(snapshot);
+    }
+    drain();
+  }
+
+  function resumeAutosave(snapshot: S | null): void {
+    if (!snapshot) {
+      // The re-armed autosave re-reads the snapshot and surfaces a failure instead of abandoning content.
+      armTimedCycle();
+      restartDebounce();
+      return;
+    }
+    if (snapshot.status !== 'draft' || !snapshot.isDirty || backgroundDropReason(snapshot)) {
+      return;
+    }
+    armTimedCycle();
+    if (snapshot.id === null) {
+      enqueue(AUTOSAVE, []);
+      return;
+    }
+    restartDebounce();
+  }
+
   function reauthAbandoned(): void {
     if (!frozen || disposed) {
       return;
     }
     const { slot, error } = frozen;
     frozen = null;
-    const waiters = [...slot.waiters];
+    settle(slot.waiters, failed(error, slot.command.kind));
+    const waiters: Waiter[] = [];
     clearTimers(waiters);
     if (pending) {
       waiters.push(...pending.waiters);
       pending = null;
     }
-    settle(waiters, { kind: 'failed', error });
-    setState({ kind: 'error', intent: slot.intent, error });
-  }
-
-  function queueSettled(): Promise<SaveCompletion> {
-    const slot = pending ?? inFlight;
-    if (!slot) {
-      return Promise.resolve(dropped('clean'));
+    for (const waiter of waiters) {
+      waiter.resolve(failed(error, waiter.command.kind));
     }
-    return new Promise<SaveCompletion>((resolve) => {
-      slot.waiters.push(resolve);
-    });
+    setState({ kind: 'error', intent: slot.command.kind, error });
   }
 
-  function shouldSaveOnLeave(snapshot: S): boolean {
-    return snapshot.status === 'draft' && snapshot.isDirty && snapshot.changedSinceLastRevision;
+  function queueSettled(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const check = () => {
+        if ((!inFlight && !pending) || frozen || disposed || isTerminal()) {
+          transitionWatchers.delete(check);
+          resolve();
+        }
+      };
+      transitionWatchers.add(check);
+      check();
+    });
   }
 
   function leaveRequested(): Promise<LeaveDecision> {
@@ -584,58 +863,45 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     return leaveInProgress;
   }
 
+  // Loops until nothing is in flight, pending, or armed, re-reading the post after every wait.
   // Fails closed: an unreadable snapshot asks for confirmation; a disposed engine lets the caller go.
-  function dirtyDecision(): LeaveDecision {
-    if (disposed) {
-      return 'proceed';
-    }
-    const snapshot = readSnapshot();
-    return !snapshot || snapshot.isDirty ? 'confirm' : 'proceed';
-  }
-
   async function decideLeave(): Promise<LeaveDecision> {
-    if (disposed) {
-      return 'proceed';
-    }
-    let snapshot = readSnapshot();
-    if (!snapshot) {
-      return 'confirm';
-    }
-    if (isTerminal() || frozen) {
-      return snapshot.isDirty ? 'confirm' : 'proceed';
-    }
-
     let saveOnLeavePerformed = false;
-    if (shouldSaveOnLeave(snapshot)) {
-      await dispatch('leave');
+    for (;;) {
       if (disposed) {
         return 'proceed';
       }
-      saveOnLeavePerformed = true;
-      snapshot = readSnapshot();
+      const snapshot = readSnapshot();
       if (!snapshot) {
         return 'confirm';
       }
-    }
-
-    if (!snapshot.isDirty) {
-      return 'proceed';
-    }
-    if (frozen) {
+      if (isTerminal() || frozen) {
+        return snapshot.isDirty ? 'confirm' : 'proceed';
+      }
+      const canSaveOnLeave =
+        !saveOnLeavePerformed &&
+        snapshot.isDirty &&
+        snapshot.status === 'draft' &&
+        !isStale(snapshot);
+      if (canSaveOnLeave && snapshot.changedSinceLastRevision) {
+        saveOnLeavePerformed = true;
+        await dispatch('leave');
+        continue;
+      }
+      if (inFlight || pending) {
+        await queueSettled();
+        continue;
+      }
+      if (!snapshot.isDirty) {
+        return 'proceed';
+      }
+      if (canSaveOnLeave && (debounce || timedCycle)) {
+        saveOnLeavePerformed = true;
+        await dispatch('leave');
+        continue;
+      }
       return 'confirm';
     }
-    if (inFlight || pending) {
-      await queueSettled();
-      return dirtyDecision();
-    }
-    if (debounce || timedCycle) {
-      if (saveOnLeavePerformed) {
-        return 'confirm';
-      }
-      await dispatch('leave');
-      return dirtyDecision();
-    }
-    return 'confirm';
   }
 
   function subscribe(listener: (state: SaveEngineState) => void): () => void {
@@ -650,6 +916,8 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
       return;
     }
     disposed = true;
+    inFlightAbort?.abort();
+    inFlightAbort = null;
     const waiters: Waiter[] = [];
     clearTimers(waiters);
     for (const slot of [inFlight, pending, frozen?.slot ?? null]) {

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -14,6 +14,9 @@ export type SaveIntent =
   | 'publish'
   | 'revert';
 
+/** `timed` is engine-internal: an autosave dispatch arms the 60s cycle. */
+export type DispatchIntent = Exclude<SaveIntent, 'timed'>;
+
 // Coalescing ladder: the higher number wins the pending slot.
 const PRIORITY: Record<SaveIntent, number> = {
   autosave: 0,
@@ -27,6 +30,10 @@ const PRIORITY: Record<SaveIntent, number> = {
 
 export function isBackgroundIntent(intent: SaveIntent): boolean {
   return intent === 'autosave' || intent === 'timed' || intent === 'field';
+}
+
+function isStatusChangingIntent(intent: SaveIntent): boolean {
+  return intent === 'publish' || intent === 'revert';
 }
 
 export interface SaveSnapshot {
@@ -79,7 +86,11 @@ export type DropReason = 'not-draft' | 'clean' | 'suppressed' | 'halted' | 'disp
 export type SaveCompletion =
   | { kind: 'saved'; result: SaveResult }
   | { kind: 'failed'; error: SaveError }
-  | { kind: 'dropped'; reason: DropReason };
+  | { kind: 'dropped'; reason: DropReason }
+  /** A contradictory status-changing intent replaced this one before it ran. */
+  | { kind: 'superseded'; by: SaveIntent }
+  /** Publish/revert interrupted by re-auth; the publish flow must re-confirm, never auto-fire. */
+  | { kind: 'needs-retry' };
 
 export type SaveEngineState =
   | { kind: 'idle' }
@@ -90,6 +101,7 @@ export type SaveEngineState =
   | { kind: 'error'; intent: SaveIntent; error: SaveError }
   | { kind: 'halted' }
   | { kind: 'crashed' }
+  | { kind: 'disposed' }
   // Reserved for server-side OCC; posts are last-write-wins today so it is never entered.
   | { kind: 'conflict' };
 
@@ -106,10 +118,11 @@ export interface SaveEnginePorts<S extends SaveSnapshot = SaveSnapshot> {
 }
 
 export interface SaveEngine {
-  dispatch(intent: SaveIntent): Promise<SaveCompletion>;
+  dispatch(intent: DispatchIntent): Promise<SaveCompletion>;
   getState(): SaveEngineState;
   subscribe(listener: (state: SaveEngineState) => void): () => void;
   reauthSucceeded(): void;
+  reauthAbandoned(): void;
   leaveRequested(): Promise<LeaveDecision>;
   dispose(): void;
 }
@@ -181,6 +194,11 @@ interface Timer {
   waiters: Waiter[];
 }
 
+interface Frozen {
+  slot: Slot;
+  error: SaveError;
+}
+
 function dropped(reason: DropReason): SaveCompletion {
   return { kind: 'dropped', reason };
 }
@@ -191,13 +209,20 @@ function settle(waiters: Waiter[], completion: SaveCompletion): void {
   }
 }
 
-function higherPriority(current: SaveIntent, incoming: SaveIntent): SaveIntent {
-  return PRIORITY[incoming] > PRIORITY[current] ? incoming : current;
-}
-
 function toSaveError(cause: unknown): SaveError {
   const message = cause instanceof Error ? cause.message : 'Save failed';
   return { kind: 'unknown', message, cause };
+}
+
+function sameState(a: SaveEngineState, b: SaveEngineState): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  const left = a as Partial<Record<'intent' | 'pending' | 'error', unknown>>;
+  const right = b as Partial<Record<'intent' | 'pending' | 'error', unknown>>;
+  return (
+    left.intent === right.intent && left.pending === right.pending && left.error === right.error
+  );
 }
 
 export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
@@ -211,17 +236,21 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
   let state: SaveEngineState = { kind: 'idle' };
   let inFlight: Slot | null = null;
   let pending: Slot | null = null;
-  // Set while re-authentication is pending: the failed slot, and the reason the queue is frozen.
-  let resume: Slot | null = null;
+  // Set while re-authentication is pending: the failed slot freezes the queue until reauth resolves.
+  let frozen: Frozen | null = null;
   let debounce: Timer | null = null;
   let timedCycle: Timer | null = null;
   let suppressedVersion: number | null = null;
+  let leaveInProgress: Promise<LeaveDecision> | null = null;
   let disposed = false;
 
   function setState(next: SaveEngineState): void {
+    if (sameState(state, next)) {
+      return;
+    }
     state = next;
     ports.onStateChange?.(state);
-    for (const listener of listeners) {
+    for (const listener of [...listeners]) {
       listener(state);
     }
   }
@@ -230,8 +259,9 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     return state.kind === 'halted' || state.kind === 'crashed';
   }
 
+  // Errors persist until a save actually starts; timers arming or dropping do not clear them.
   function deriveState(): SaveEngineState {
-    if (resume || isTerminal()) {
+    if (frozen || isTerminal() || disposed) {
       return state;
     }
     if (inFlight) {
@@ -239,10 +269,13 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
         ? { kind: 'pending-coalesced', intent: inFlight.intent, pending: pending.intent }
         : { kind: 'saving', intent: inFlight.intent };
     }
+    if (state.kind === 'error') {
+      return state;
+    }
     if (debounce || timedCycle) {
       return { kind: 'debouncing' };
     }
-    return state.kind === 'error' ? state : { kind: 'idle' };
+    return { kind: 'idle' };
   }
 
   function isSuppressed(snapshot: S): boolean {
@@ -275,14 +308,11 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     setState(deriveState());
   }
 
-  function armTimedCycle(waiter?: Waiter): void {
+  function armTimedCycle(): void {
     if (timedCycle) {
-      if (waiter) {
-        timedCycle.waiters.push(waiter);
-      }
       return;
     }
-    const waiters = waiter ? [waiter] : [];
+    const waiters: Waiter[] = [];
     const handle = schedule(() => {
       timedCycle = null;
       enqueue('timed', waiters);
@@ -291,17 +321,34 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     setState(deriveState());
   }
 
+  // Higher priority wins and carries the loser's content; contradictory publish/revert is last-wins.
+  function coalesce(intent: SaveIntent, waiters: Waiter[]): void {
+    if (!pending) {
+      pending = { intent, waiters };
+      return;
+    }
+    const current = pending.intent;
+    if (PRIORITY[intent] > PRIORITY[current]) {
+      pending.intent = intent;
+      pending.waiters.push(...waiters);
+      return;
+    }
+    if (
+      PRIORITY[intent] === PRIORITY[current] &&
+      intent !== current &&
+      isStatusChangingIntent(intent)
+    ) {
+      settle(pending.waiters, { kind: 'superseded', by: intent });
+      pending = { intent, waiters };
+      return;
+    }
+    pending.waiters.push(...waiters);
+  }
+
   function enqueue(intent: SaveIntent, waiters: Waiter[]): void {
-    if (inFlight || resume) {
-      if (pending) {
-        pending.intent = higherPriority(pending.intent, intent);
-        pending.waiters.push(...waiters);
-      } else {
-        pending = { intent, waiters };
-      }
-      if (!resume) {
-        setState(deriveState());
-      }
+    if (inFlight || frozen) {
+      coalesce(intent, waiters);
+      setState(deriveState());
       return;
     }
     void run({ intent, waiters });
@@ -317,9 +364,26 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     }
   }
 
+  function failSlot(slot: Slot, error: SaveError): void {
+    settle(slot.waiters, { kind: 'failed', error });
+    setState({ kind: 'error', intent: slot.intent, error });
+    if (pending) {
+      const next = pending;
+      pending = null;
+      void run(next);
+    }
+  }
+
   async function run(slot: Slot): Promise<void> {
     clearTimers(slot.waiters);
-    const snapshot = ports.getSnapshot();
+
+    let snapshot: S;
+    try {
+      snapshot = ports.getSnapshot();
+    } catch (cause) {
+      failSlot(slot, toSaveError(cause));
+      return;
+    }
 
     if (isBackgroundIntent(slot.intent)) {
       let reason: DropReason | null = null;
@@ -371,7 +435,7 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
 
   function handleError(slot: Slot, snapshot: S, error: SaveError): void {
     if (error.kind === 'session-invalid') {
-      resume = slot;
+      frozen = { slot, error };
       setState({ kind: 'reauth-pending', intent: slot.intent });
       return;
     }
@@ -392,17 +456,10 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     if (error.kind === 'validation' || error.kind === 'host-limit') {
       suppressedVersion = snapshot.version;
     }
-    settle(slot.waiters, { kind: 'failed', error });
-    setState({ kind: 'error', intent: slot.intent, error });
-
-    if (pending) {
-      const next = pending;
-      pending = null;
-      void run(next);
-    }
+    failSlot(slot, error);
   }
 
-  function dispatch(intent: SaveIntent): Promise<SaveCompletion> {
+  function dispatch(intent: DispatchIntent): Promise<SaveCompletion> {
     return new Promise<SaveCompletion>((resolve) => {
       if (disposed) {
         resolve(dropped('disposed'));
@@ -434,10 +491,6 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
         enqueue('field', [resolve]);
         return;
       }
-      if (intent === 'timed') {
-        armTimedCycle(resolve);
-        return;
-      }
       armTimedCycle();
       if (snapshot.isNew) {
         enqueue('autosave', [resolve]);
@@ -448,18 +501,33 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
   }
 
   function reauthSucceeded(): void {
-    if (!resume || disposed) {
+    if (!frozen || disposed) {
       return;
     }
-    const slot = resume;
-    resume = null;
-    if (pending) {
-      pending.intent = higherPriority(pending.intent, slot.intent);
-      pending.waiters.push(...slot.waiters);
+    const { slot } = frozen;
+    frozen = null;
+    if (isStatusChangingIntent(slot.intent)) {
+      settle(slot.waiters, { kind: 'needs-retry' });
     } else {
-      pending = slot;
+      coalesce(slot.intent, slot.waiters);
     }
     drain();
+  }
+
+  function reauthAbandoned(): void {
+    if (!frozen || disposed) {
+      return;
+    }
+    const { slot, error } = frozen;
+    frozen = null;
+    const waiters = [...slot.waiters];
+    clearTimers(waiters);
+    if (pending) {
+      waiters.push(...pending.waiters);
+      pending = null;
+    }
+    settle(waiters, { kind: 'failed', error });
+    setState({ kind: 'error', intent: slot.intent, error });
   }
 
   function queueSettled(): Promise<SaveCompletion> {
@@ -476,12 +544,21 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     return snapshot.status === 'draft' && snapshot.isDirty && snapshot.changedSinceLastRevision;
   }
 
-  async function leaveRequested(): Promise<LeaveDecision> {
+  function leaveRequested(): Promise<LeaveDecision> {
+    if (!leaveInProgress) {
+      leaveInProgress = decideLeave().finally(() => {
+        leaveInProgress = null;
+      });
+    }
+    return leaveInProgress;
+  }
+
+  async function decideLeave(): Promise<LeaveDecision> {
     if (disposed) {
       return 'proceed';
     }
     let snapshot = ports.getSnapshot();
-    if (isTerminal() || resume) {
+    if (isTerminal() || frozen) {
       return snapshot.isDirty ? 'confirm' : 'proceed';
     }
 
@@ -495,19 +572,19 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     if (!snapshot.isDirty) {
       return 'proceed';
     }
-    if (resume) {
+    if (frozen) {
       return 'confirm';
     }
     if (inFlight || pending) {
       await queueSettled();
-      return 'proceed';
+      return ports.getSnapshot().isDirty ? 'confirm' : 'proceed';
     }
     if (debounce || timedCycle) {
       if (saveOnLeavePerformed) {
         return 'confirm';
       }
       await dispatch('leave');
-      return 'proceed';
+      return ports.getSnapshot().isDirty ? 'confirm' : 'proceed';
     }
     return 'confirm';
   }
@@ -526,15 +603,16 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     disposed = true;
     const waiters: Waiter[] = [];
     clearTimers(waiters);
-    for (const slot of [inFlight, pending, resume]) {
+    for (const slot of [inFlight, pending, frozen?.slot ?? null]) {
       if (slot) {
         waiters.push(...slot.waiters);
       }
     }
     inFlight = null;
     pending = null;
-    resume = null;
+    frozen = null;
     settle(waiters, dropped('disposed'));
+    setState({ kind: 'disposed' });
     listeners.clear();
   }
 
@@ -543,6 +621,7 @@ export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
     getState: () => state,
     subscribe,
     reauthSucceeded,
+    reauthAbandoned,
     leaveRequested,
     dispose,
   };

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -1,0 +1,549 @@
+import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
+
+export type { PostStatus };
+
+export const AUTOSAVE_DEBOUNCE_MS = 3000;
+export const TIMED_SAVE_INTERVAL_MS = 60000;
+
+export type SaveIntent =
+  | 'autosave'
+  | 'timed'
+  | 'field'
+  | 'explicit'
+  | 'leave'
+  | 'publish'
+  | 'revert';
+
+// Coalescing ladder: the higher number wins the pending slot.
+const PRIORITY: Record<SaveIntent, number> = {
+  autosave: 0,
+  timed: 1,
+  field: 2,
+  leave: 3,
+  explicit: 4,
+  publish: 5,
+  revert: 5,
+};
+
+export function isBackgroundIntent(intent: SaveIntent): boolean {
+  return intent === 'autosave' || intent === 'timed' || intent === 'field';
+}
+
+export interface SaveSnapshot {
+  /** null until the create request has succeeded */
+  id: string | null;
+  isNew: boolean;
+  status: PostStatus;
+  /** ISO 8601 or null */
+  publishedAt: string | null;
+  willPublish: boolean;
+  willSchedule: boolean;
+  isDirty: boolean;
+  changedSinceLastRevision: boolean;
+  /** Monotonic local edit counter; validation/host-limit suppression lifts once it moves. */
+  version: number;
+}
+
+export interface SaveRequest<S extends SaveSnapshot = SaveSnapshot> {
+  intent: SaveIntent;
+  snapshot: S;
+  status: PostStatus;
+  publishedAt: string | null;
+  saveRevision: boolean;
+}
+
+export interface SaveResult {
+  id: string;
+  status: PostStatus;
+  updatedAt: string;
+}
+
+export type SaveErrorKind =
+  | 'session-invalid'
+  | 'not-found'
+  | 'host-limit'
+  | 'transport'
+  | 'validation'
+  | 'unknown';
+
+export interface SaveError {
+  kind: SaveErrorKind;
+  message: string;
+  cause?: unknown;
+}
+
+export type SaveOutcome = { ok: true; result: SaveResult } | { ok: false; error: SaveError };
+
+export type DropReason = 'not-draft' | 'clean' | 'suppressed' | 'halted' | 'disposed';
+
+export type SaveCompletion =
+  | { kind: 'saved'; result: SaveResult }
+  | { kind: 'failed'; error: SaveError }
+  | { kind: 'dropped'; reason: DropReason };
+
+export type SaveEngineState =
+  | { kind: 'idle' }
+  | { kind: 'debouncing' }
+  | { kind: 'saving'; intent: SaveIntent }
+  | { kind: 'pending-coalesced'; intent: SaveIntent; pending: SaveIntent }
+  | { kind: 'reauth-pending'; intent: SaveIntent }
+  | { kind: 'error'; intent: SaveIntent; error: SaveError }
+  | { kind: 'halted' }
+  | { kind: 'crashed' }
+  // Reserved for server-side OCC; posts are last-write-wins today so it is never entered.
+  | { kind: 'conflict' };
+
+export type LeaveDecision = 'proceed' | 'confirm';
+
+export interface SaveEnginePorts<S extends SaveSnapshot = SaveSnapshot> {
+  getSnapshot: () => S;
+  /** The only IO port. A rejected promise is treated as an `unknown` error. */
+  execute: (request: SaveRequest<S>) => Promise<SaveOutcome>;
+  now?: () => number;
+  setTimeout?: (fn: () => void, ms: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
+  onStateChange?: (state: SaveEngineState) => void;
+}
+
+export interface SaveEngine {
+  dispatch(intent: SaveIntent): Promise<SaveCompletion>;
+  getState(): SaveEngineState;
+  subscribe(listener: (state: SaveEngineState) => void): () => void;
+  reauthSucceeded(): void;
+  leaveRequested(): Promise<LeaveDecision>;
+  dispose(): void;
+}
+
+export type StatusInputs = Pick<
+  SaveSnapshot,
+  'status' | 'publishedAt' | 'willPublish' | 'willSchedule'
+>;
+
+export function zeroMilliseconds(iso: string | null): string | null {
+  if (iso === null) {
+    return null;
+  }
+  const time = Date.parse(iso);
+  if (Number.isNaN(time)) {
+    return iso;
+  }
+  return new Date(time - (time % 1000)).toISOString();
+}
+
+function isPastScheduledTime(snapshot: StatusInputs, now: number): boolean {
+  if (snapshot.status !== 'scheduled' || snapshot.publishedAt === null) {
+    return false;
+  }
+  const publishedAt = Date.parse(zeroMilliseconds(snapshot.publishedAt) ?? '');
+  return !Number.isNaN(publishedAt) && publishedAt < now;
+}
+
+export function resolveStatus(snapshot: StatusInputs, intent: SaveIntent, now: number): PostStatus {
+  if (isBackgroundIntent(intent)) {
+    return 'draft';
+  }
+  if (intent === 'leave') {
+    return snapshot.status;
+  }
+  if (intent === 'revert') {
+    return 'draft';
+  }
+  if (intent === 'publish') {
+    return snapshot.willSchedule ? 'scheduled' : 'published';
+  }
+  switch (snapshot.status) {
+    case 'draft':
+      if (snapshot.willPublish) {
+        return 'published';
+      }
+      return snapshot.willSchedule ? 'scheduled' : 'draft';
+    case 'published':
+      return 'published';
+    case 'sent':
+      return 'sent';
+    case 'scheduled':
+      if (isPastScheduledTime(snapshot, now)) {
+        return snapshot.willPublish || snapshot.willSchedule ? 'published' : 'draft';
+      }
+      return 'scheduled';
+  }
+}
+
+type Waiter = (completion: SaveCompletion) => void;
+
+interface Slot {
+  intent: SaveIntent;
+  waiters: Waiter[];
+}
+
+interface Timer {
+  handle: unknown;
+  waiters: Waiter[];
+}
+
+function dropped(reason: DropReason): SaveCompletion {
+  return { kind: 'dropped', reason };
+}
+
+function settle(waiters: Waiter[], completion: SaveCompletion): void {
+  for (const waiter of waiters) {
+    waiter(completion);
+  }
+}
+
+function higherPriority(current: SaveIntent, incoming: SaveIntent): SaveIntent {
+  return PRIORITY[incoming] > PRIORITY[current] ? incoming : current;
+}
+
+function toSaveError(cause: unknown): SaveError {
+  const message = cause instanceof Error ? cause.message : 'Save failed';
+  return { kind: 'unknown', message, cause };
+}
+
+export function createSaveEngine<S extends SaveSnapshot = SaveSnapshot>(
+  ports: SaveEnginePorts<S>,
+): SaveEngine {
+  const now = ports.now ?? (() => Date.now());
+  const schedule = ports.setTimeout ?? ((fn, ms) => globalThis.setTimeout(fn, ms));
+  const cancel = ports.clearTimeout ?? ((handle) => globalThis.clearTimeout(handle as number));
+  const listeners = new Set<(state: SaveEngineState) => void>();
+
+  let state: SaveEngineState = { kind: 'idle' };
+  let inFlight: Slot | null = null;
+  let pending: Slot | null = null;
+  // Set while re-authentication is pending: the failed slot, and the reason the queue is frozen.
+  let resume: Slot | null = null;
+  let debounce: Timer | null = null;
+  let timedCycle: Timer | null = null;
+  let suppressedVersion: number | null = null;
+  let disposed = false;
+
+  function setState(next: SaveEngineState): void {
+    state = next;
+    ports.onStateChange?.(state);
+    for (const listener of listeners) {
+      listener(state);
+    }
+  }
+
+  function isTerminal(): boolean {
+    return state.kind === 'halted' || state.kind === 'crashed';
+  }
+
+  function deriveState(): SaveEngineState {
+    if (resume || isTerminal()) {
+      return state;
+    }
+    if (inFlight) {
+      return pending
+        ? { kind: 'pending-coalesced', intent: inFlight.intent, pending: pending.intent }
+        : { kind: 'saving', intent: inFlight.intent };
+    }
+    if (debounce || timedCycle) {
+      return { kind: 'debouncing' };
+    }
+    return state.kind === 'error' ? state : { kind: 'idle' };
+  }
+
+  function isSuppressed(snapshot: S): boolean {
+    return suppressedVersion !== null && snapshot.version === suppressedVersion;
+  }
+
+  // Any save start cancels both timers; their waiters chain into the save that supersedes them.
+  function clearTimers(into: Waiter[]): void {
+    for (const timer of [debounce, timedCycle]) {
+      if (timer) {
+        cancel(timer.handle);
+        into.push(...timer.waiters);
+      }
+    }
+    debounce = null;
+    timedCycle = null;
+  }
+
+  function restartDebounce(waiter: Waiter): void {
+    const waiters = debounce ? debounce.waiters : [];
+    if (debounce) {
+      cancel(debounce.handle);
+    }
+    waiters.push(waiter);
+    const handle = schedule(() => {
+      debounce = null;
+      enqueue('autosave', waiters);
+    }, AUTOSAVE_DEBOUNCE_MS);
+    debounce = { handle, waiters };
+    setState(deriveState());
+  }
+
+  function armTimedCycle(waiter?: Waiter): void {
+    if (timedCycle) {
+      if (waiter) {
+        timedCycle.waiters.push(waiter);
+      }
+      return;
+    }
+    const waiters = waiter ? [waiter] : [];
+    const handle = schedule(() => {
+      timedCycle = null;
+      enqueue('timed', waiters);
+    }, TIMED_SAVE_INTERVAL_MS);
+    timedCycle = { handle, waiters };
+    setState(deriveState());
+  }
+
+  function enqueue(intent: SaveIntent, waiters: Waiter[]): void {
+    if (inFlight || resume) {
+      if (pending) {
+        pending.intent = higherPriority(pending.intent, intent);
+        pending.waiters.push(...waiters);
+      } else {
+        pending = { intent, waiters };
+      }
+      if (!resume) {
+        setState(deriveState());
+      }
+      return;
+    }
+    void run({ intent, waiters });
+  }
+
+  function drain(): void {
+    const next = pending;
+    pending = null;
+    if (next) {
+      void run(next);
+    } else {
+      setState(deriveState());
+    }
+  }
+
+  async function run(slot: Slot): Promise<void> {
+    clearTimers(slot.waiters);
+    const snapshot = ports.getSnapshot();
+
+    if (isBackgroundIntent(slot.intent)) {
+      let reason: DropReason | null = null;
+      if (snapshot.status !== 'draft') {
+        reason = 'not-draft';
+      } else if (!snapshot.isDirty) {
+        reason = 'clean';
+      } else if (isSuppressed(snapshot)) {
+        reason = 'suppressed';
+      }
+      if (reason) {
+        settle(slot.waiters, dropped(reason));
+        drain();
+        return;
+      }
+    }
+
+    inFlight = slot;
+    setState(deriveState());
+
+    const request: SaveRequest<S> = {
+      intent: slot.intent,
+      snapshot,
+      status: resolveStatus(snapshot, slot.intent, now()),
+      publishedAt: zeroMilliseconds(snapshot.publishedAt),
+      saveRevision: slot.intent === 'explicit' || slot.intent === 'leave',
+    };
+
+    let outcome: SaveOutcome;
+    try {
+      outcome = await ports.execute(request);
+    } catch (cause) {
+      outcome = { ok: false, error: toSaveError(cause) };
+    }
+
+    if (disposed) {
+      return;
+    }
+    inFlight = null;
+
+    if (outcome.ok) {
+      suppressedVersion = null;
+      settle(slot.waiters, { kind: 'saved', result: outcome.result });
+      drain();
+      return;
+    }
+    handleError(slot, snapshot, outcome.error);
+  }
+
+  function handleError(slot: Slot, snapshot: S, error: SaveError): void {
+    if (error.kind === 'session-invalid') {
+      resume = slot;
+      setState({ kind: 'reauth-pending', intent: slot.intent });
+      return;
+    }
+
+    if (error.kind === 'not-found') {
+      const dropWaiters: Waiter[] = [];
+      clearTimers(dropWaiters);
+      if (pending) {
+        dropWaiters.push(...pending.waiters);
+        pending = null;
+      }
+      settle(dropWaiters, dropped('halted'));
+      settle(slot.waiters, { kind: 'failed', error });
+      setState({ kind: snapshot.id ? 'halted' : 'crashed' });
+      return;
+    }
+
+    if (error.kind === 'validation' || error.kind === 'host-limit') {
+      suppressedVersion = snapshot.version;
+    }
+    settle(slot.waiters, { kind: 'failed', error });
+    setState({ kind: 'error', intent: slot.intent, error });
+
+    if (pending) {
+      const next = pending;
+      pending = null;
+      void run(next);
+    }
+  }
+
+  function dispatch(intent: SaveIntent): Promise<SaveCompletion> {
+    return new Promise<SaveCompletion>((resolve) => {
+      if (disposed) {
+        resolve(dropped('disposed'));
+        return;
+      }
+      if (isTerminal()) {
+        resolve(dropped('halted'));
+        return;
+      }
+
+      if (!isBackgroundIntent(intent)) {
+        const waiters: Waiter[] = [resolve];
+        clearTimers(waiters);
+        enqueue(intent, waiters);
+        return;
+      }
+
+      const snapshot = ports.getSnapshot();
+      if (snapshot.status !== 'draft') {
+        resolve(dropped('not-draft'));
+        return;
+      }
+      if (isSuppressed(snapshot)) {
+        resolve(dropped('suppressed'));
+        return;
+      }
+
+      if (intent === 'field') {
+        enqueue('field', [resolve]);
+        return;
+      }
+      if (intent === 'timed') {
+        armTimedCycle(resolve);
+        return;
+      }
+      armTimedCycle();
+      if (snapshot.isNew) {
+        enqueue('autosave', [resolve]);
+        return;
+      }
+      restartDebounce(resolve);
+    });
+  }
+
+  function reauthSucceeded(): void {
+    if (!resume || disposed) {
+      return;
+    }
+    const slot = resume;
+    resume = null;
+    if (pending) {
+      pending.intent = higherPriority(pending.intent, slot.intent);
+      pending.waiters.push(...slot.waiters);
+    } else {
+      pending = slot;
+    }
+    drain();
+  }
+
+  function queueSettled(): Promise<SaveCompletion> {
+    const slot = pending ?? inFlight;
+    if (!slot) {
+      return Promise.resolve(dropped('clean'));
+    }
+    return new Promise<SaveCompletion>((resolve) => {
+      slot.waiters.push(resolve);
+    });
+  }
+
+  function shouldSaveOnLeave(snapshot: S): boolean {
+    return snapshot.status === 'draft' && snapshot.isDirty && snapshot.changedSinceLastRevision;
+  }
+
+  async function leaveRequested(): Promise<LeaveDecision> {
+    if (disposed) {
+      return 'proceed';
+    }
+    let snapshot = ports.getSnapshot();
+    if (isTerminal() || resume) {
+      return snapshot.isDirty ? 'confirm' : 'proceed';
+    }
+
+    let saveOnLeavePerformed = false;
+    if (shouldSaveOnLeave(snapshot)) {
+      await dispatch('leave');
+      saveOnLeavePerformed = true;
+      snapshot = ports.getSnapshot();
+    }
+
+    if (!snapshot.isDirty) {
+      return 'proceed';
+    }
+    if (resume) {
+      return 'confirm';
+    }
+    if (inFlight || pending) {
+      await queueSettled();
+      return 'proceed';
+    }
+    if (debounce || timedCycle) {
+      if (saveOnLeavePerformed) {
+        return 'confirm';
+      }
+      await dispatch('leave');
+      return 'proceed';
+    }
+    return 'confirm';
+  }
+
+  function subscribe(listener: (state: SaveEngineState) => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  function dispose(): void {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    const waiters: Waiter[] = [];
+    clearTimers(waiters);
+    for (const slot of [inFlight, pending, resume]) {
+      if (slot) {
+        waiters.push(...slot.waiters);
+      }
+    }
+    inFlight = null;
+    pending = null;
+    resume = null;
+    settle(waiters, dropped('disposed'));
+    listeners.clear();
+  }
+
+  return {
+    dispatch,
+    getState: () => state,
+    subscribe,
+    reauthSucceeded,
+    leaveRequested,
+    dispose,
+  };
+}


### PR DESCRIPTION
The React editor needs the Ember editor's save machinery before any editor UI can be ported. In Ember that machinery is three ember-concurrency modifiers (an `enqueue` group, a `drop` autosave, a `restartable` debounce) plus ad-hoc branches in the 1,600-line `lexical-editor` controller. This PR lands it as a pure TypeScript state machine in `apps/admin/src/editor/engine/save-engine.ts`, with no React, no network, and no wiring into the editor screen yet.

### Lifecycle

Every save runs `capture → prepare → execute → reconcile → drain` inside one single-flight unit:

- **Capture.** `dispatch(kind, options?)` captures an immutable `SaveCommand` (`{kind, target?, requiresRevision, requiresReconfirmation}`). `publish`/`schedule`/`revert` are the only status-changing commands and carry an explicit `target` derived from the source transition at dispatch: `publish` keeps the post's publish time unless told otherwise, `schedule` takes the given time, `revert` from scheduled clears `publishedAt` and from published/sent keeps it as history (Ember's `revertToDraftTask`), all with `emailOnly: false`. Email extras (`newsletter`, `emailSegment`, `emailOnly`) ride on exactly that command's request. Command metadata is never re-derived from a later snapshot, so a response resync cannot turn a queued schedule into an immediate publish; `willPublish`/`willSchedule` no longer exist on the snapshot. A failed status command is disarmed: nothing retains its target.
- **Prepare** (serialized inside the single-flight unit, before any IO): await pending manual slug work via the injected `slug.settled()` (which must await the machine's latest submission chain, not its `pending` flag), re-read the snapshot, substitute `(Untitled)` for a blank or whitespace title, ask `slug.fromTitle(title, postId, signal)` for every draft save and whenever the post has no slug (status is the one rule the slug machine cannot know; it answers `{slug, source: 'generated' | 'unchanged'}` for custom/same-title/frozen itself, and after an `unchanged` answer the engine sends the slug current at that moment rather than the one read before the request), resolve the target (`autosave`/`timed`/`field` pin draft; `explicit`/`leave` preserve the current status; status commands use their captured target), then hand the `SaveRequest` to the adapter's `prepare(request, signal)` to build and validate the candidate. A rejected prepare is a typed failure with no IO, and prepare is never called for a save disposed while slug work was pending.
- **Execute.** `execute(prepared, signal)` is IO-only and returns a typed `SaveOutcome`. The `AbortSignal` is aborted on `dispose()` (the post-switch fence); a response arriving afterwards is never reconciled.
- **Reconcile.** `reconcile(prepared, result)` is awaited before the pending slot drains and must not throw (a throwing reconcile would turn a server-accepted save into a failure and guarantee a false conflict on the next save). Contract: adopt the acknowledged id, authoritative status and `updated_at` before any work that can fail; preserve edits made after `prepared.snapshot.version`; resync server-normalized values only where the local value did not change in flight; advance the saved/revision baselines without marking newer edits clean. `prepared` is handed unchanged from prepare through reconcile (an unbranded structural superset of the request, `prepared.snapshot` being the complete execution-time snapshot, `target` read-only), and `SaveResult.id` exposes the acknowledged id a create returns.
- **Drain.** Only when nothing is in flight; the queued save is rebuilt from the reconciled snapshot, so it carries the new id and the server's `updated_at`.

### Collisions

Core enforces optimistic concurrency on posts through `@tryghost/bookshelf-collision` (registered in `models/base/bookshelf.js`): an update whose `updated_at` differs from the server's, with any meaningful field changed, rolls back with `UPDATE_COLLISION`. The persisted snapshot type therefore requires `updatedAt` (`{id: string; updatedAt: string} | {id: null; updatedAt: null}`), and the reconcile-before-drain ordering above is what keeps a queued save from manufacturing the false collision Ember users see today. An `UPDATE_COLLISION` response maps to the typed `conflict` error and state: timers and the pending slot are dropped with reason `conflict` (no automatic retry against the known-stale baseline), background saves stay refused while the snapshot still carries the rejected `updated_at`, local content stays dirty and intact, leave asks for confirmation, and a new explicit save remains the retry affordance; adopting a fresh baseline (reload) lifts the halt.

### Queue kernel

- **Single flight + one coalescing pending slot.** Priority `publish`/`schedule`/`revert` > `explicit` > `leave` > `field` > `timed` > `autosave`. Each waiter keeps its original command; `requiresRevision` ORs across coalesced work (a publish carrying an explicit rider requests `save_revision`); completions report `executedAs`. A later status command supersedes only the earlier status command (`superseded`), riders stay with the winner and resolve `saved`.
- **Timers on injectable clocks.** 3s restartable autosave debounce, a 60s timed cycle armed by autosave dispatches, instant first-edit save for new posts; any save start clears both.
- **Intent classification.** `autosave`/`timed`/`field` are draft-only and pinned to draft; a `field` on a published/scheduled/sent post is dropped with the typed reason `not-draft` because the sidebar stages those edits until Update (spec §4). `explicit` is status-preserving plus `save_revision`; a past-scheduled post saves as `scheduled` and the server owns the transition.
- **Re-auth.** `session-invalid` freezes the queue. `reauthSucceeded()` inspects every waiter in both the frozen and pending slots and judges each by its resolved effect against the current post: a command whose target would change the status resolves `needs-retry` and never auto-fires; everything else re-enters through the normal enqueue path, so a frozen explicit rider re-runs on its own while the publish it coalesced into does not. Content a disarmed status command would have carried resumes through the autosave path; if the snapshot cannot be read at that point the debounce is re-armed so the retry surfaces a failure instead of abandoning content. `drain()` refuses to start while a save is in flight, so a failed new-post publish can no longer resume into a concurrent create. `reauthAbandoned()` settles every waiter with the session error.
- **Other errors.** `not-found` halts (known id) or crashes (no id). `validation` suppresses background saves until the snapshot version moves; `host-limit` does the same only when the failing operation was itself a draft save, so a publish limit never halts autosave. `transport`/`unknown` surface without suppression.
- **Leave.** `leaveRequested()` loops until nothing is in flight, pending, or armed with dirty content, re-reading the post after every wait; `saving` is never safe to leave. Save-on-leave with a revision fires at most once, only for dirty drafts, never on a stale baseline. Concurrent calls share one decision.
- **Subscriptions.** Emissions are deduplicated, listeners receive the emitted value, a throwing `onStateChange` port or subscriber is reported through `onListenerError` without interrupting the save, and a nested transition ends the outer pass so no listener sees an out-of-order state.

### README

`apps/admin/src/editor/engine/README.md` states the desired behaviour of the engine directory for a maintainer who has not read the spec: the save engine (intents, queue, lifecycle with the reconcile-before-drain rationale, error/state table, re-auth, leave), the change tracker, a slug-machine stub (its details land with the machine), the contracts between the modules, the ten invariants with where each is pinned, the deliberate Ember deltas, and what the caller owns per module.

### Wiring dependency (not this PR)

The framework transport redirects on 401 (`apps/admin-x-framework/src/utils/api/fetch-api.ts`, `redirectOnSessionExpiry()` before throwing `SessionExpiredError`). The editor adapter needs a no-redirect request mode that throws `SessionExpiredError` so the engine can enter `reauth-pending` instead of losing the page.

### Tests

`save-engine.test.ts` (126 tests) drives the engine with fake timers, a held `execute`, and controllable slug ports. It table-tests `deriveTarget`, `resolveTarget` and `zeroMilliseconds`, pins each spec invariant, and covers: the adapter-style lifecycle (create in flight → edit → one POST then one PUT carrying the newest content and the returned `updated_at`; a drained publish carrying the reconciled `updated_at`), IO starting only after prepare, the abort fence on dispose, a throwing `onStateChange` port not stranding the save; the prepare stage (Cmd-S serialized behind slug blur, leave waiting on a slow slug request, titleless body-first create, whitespace title, generated proposal requested with the post id, the slug current after an `unchanged` answer, the port asked on every draft save, non-drafts with a slug never asked, a post published or gone clean during the slug request dropped with a typed reason, missing slug on any status, dispose during `settled()` and during a pending proposal never reaching prepare); command capture (schedule surviving a response resync, email extras on exactly one request, disarm on failure, unschedule vs unpublish, explicit preserving every status, validation on a past-scheduled explicit); re-auth (needs-retry for publish/schedule/revert, frozen background + queued publish never auto-firing, a frozen explicit rider re-running alone, a superseded publish plus freeze plus re-auth, effect-based judgement for a revert whose post is already a draft, no double-create for new posts in both the pending and resume paths, snapshot fault re-arming the debounce); collisions (two writers on one post, queued background work and a pending explicit dropped on conflict); coalescing (revision OR, riders surviving a supersede); leave quiescence; host-limit scoping; listener isolation; plus the existing interleavings (404 halt/crash, suppression, timed save under continuous typing, dispose, re-entrant listeners).

### Verification

- `apps/admin`: `eslint .` (0 errors), `tsc -b`, and `vitest run` (178 files, 2273 tests) all pass.
