### PR TITLE
Added the editor change-detection module to Admin

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -51,6 +51,7 @@
     "i18n-iso-countries": "7.14.0",
     "jszip": "3.10.1",
     "lucide-react": "catalog:",
+    "microdiff": "catalog:",
     "mingo": "catalog:",
     "moment": "catalog:",
     "moment-timezone": "catalog:",

--- a/apps/admin/src/editor/engine/__fixtures__/adjacent-lists-merge.json
+++ b/apps/admin/src/editor/engine/__fixtures__/adjacent-lists-merge.json
@@ -1,0 +1,198 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "One",
+                  "type": "text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Two",
+                  "type": "text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Numbered",
+                  "type": "text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "number",
+          "start": 1,
+          "tag": "ol"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "One",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            },
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Two",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 2
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Numbered",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "number",
+          "start": 1,
+          "tag": "ol"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/after-load.test.tsx
+++ b/apps/admin/src/editor/engine/__fixtures__/after-load.test.tsx
@@ -1,0 +1,76 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { koenigFileUploadTypes } from '@tryghost/admin-x-framework/hooks';
+import { KoenigComposer, KoenigEditor } from '@tryghost/koenig-lexical';
+import { OLD_SCHEMA_CORPUS } from '@/editor/engine/__fixtures__';
+import { stripDirection, type LexicalDocument } from '@/editor/engine/lexical-compare';
+
+interface EditorApi {
+  editorInstance: {
+    update(fn: () => void, options: { discrete: boolean }): void;
+    getEditorState(): { toJSON(): LexicalDocument };
+  };
+}
+
+const fileUploader = {
+  useFileUpload: () => ({
+    progress: 0,
+    isLoading: false,
+    errors: [],
+    filesNumber: 0,
+    upload: () => Promise.resolve(null),
+  }),
+  fileTypes: koenigFileUploadTypes,
+};
+
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+// Mirrors the hidden secondary instance in Ember's koenig-lexical-editor.js.
+async function loadThroughKoenig(before: LexicalDocument): Promise<LexicalDocument> {
+  let api: EditorApi | undefined;
+
+  render(
+    <KoenigComposer
+      cardConfig={{}}
+      fileUploader={fileUploader}
+      initialEditorState={JSON.stringify(before)}
+      isTKEnabled={true}
+    >
+      <KoenigEditor
+        registerAPI={(registered: EditorApi) => {
+          api = registered;
+        }}
+      />
+    </KoenigComposer>,
+  );
+
+  await act(tick);
+  if (!api) {
+    throw new Error('Koenig did not register its API');
+  }
+  const { editorInstance } = api;
+  await act(async () => {
+    editorInstance.update(() => {}, { discrete: true });
+    await tick();
+  });
+
+  return editorInstance.getEditorState().toJSON();
+}
+
+// `direction` is inferred by the reconciler and differs between jsdom, a real
+// browser, and a headless parse; the comparator strips it, so this does too.
+describe('old-schema corpus freshness', () => {
+  afterEach(cleanup);
+
+  it.each(OLD_SCHEMA_CORPUS)(
+    '$name loads to its recorded after state',
+    async ({ before, after }) => {
+      const loaded = await loadThroughKoenig(before);
+
+      expect(stripDirection(loaded.root)).toEqual(stripDirection(after.root));
+    },
+  );
+});

--- a/apps/admin/src/editor/engine/__fixtures__/aligned-blocks.json
+++ b/apps/admin/src/editor/engine/__fixtures__/aligned-blocks.json
@@ -1,0 +1,98 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Centered paragraph",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "center",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Right heading",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "right",
+          "indent": 0,
+          "type": "heading",
+          "version": 1,
+          "tag": "h2"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Centered paragraph",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Right heading",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "extended-heading",
+          "version": 1,
+          "tag": "h2"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/direction-null-vs-ltr.json
+++ b/apps/admin/src/editor/engine/__fixtures__/direction-null-vs-ltr.json
@@ -1,0 +1,220 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Paragraph text",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Nested item",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "Deeper item",
+                          "type": "extended-text",
+                          "version": 1
+                        }
+                      ],
+                      "direction": null,
+                      "format": "",
+                      "indent": 1,
+                      "type": "listitem",
+                      "version": 1,
+                      "value": 1
+                    }
+                  ],
+                  "direction": null,
+                  "format": "",
+                  "indent": 0,
+                  "type": "list",
+                  "version": 1,
+                  "listType": "bullet",
+                  "start": 1,
+                  "tag": "ul"
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 2
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        },
+        {
+          "children": [],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Paragraph text",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": "ltr",
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Nested item",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": "ltr",
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "detail": 0,
+                          "format": 0,
+                          "mode": "normal",
+                          "style": "",
+                          "text": "Deeper item",
+                          "type": "extended-text",
+                          "version": 1
+                        }
+                      ],
+                      "direction": "ltr",
+                      "format": "",
+                      "indent": 1,
+                      "type": "listitem",
+                      "version": 1,
+                      "value": 1
+                    }
+                  ],
+                  "direction": "ltr",
+                  "format": "",
+                  "indent": 0,
+                  "type": "list",
+                  "version": 1,
+                  "listType": "bullet",
+                  "start": 1,
+                  "tag": "ul"
+                }
+              ],
+              "direction": "ltr",
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 2
+            }
+          ],
+          "direction": "ltr",
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        },
+        {
+          "children": [],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": "ltr",
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/empty-document-paragraph.json
+++ b/apps/admin/src/editor/engine/__fixtures__/empty-document-paragraph.json
@@ -1,0 +1,31 @@
+{
+  "before": {
+    "root": {
+      "children": [],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/heading-in-listitem.json
+++ b/apps/admin/src/editor/engine/__fixtures__/heading-in-listitem.json
@@ -1,0 +1,111 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "detail": 0,
+                      "format": 0,
+                      "mode": "normal",
+                      "style": "",
+                      "text": "Heading",
+                      "type": "extended-text",
+                      "version": 1
+                    }
+                  ],
+                  "direction": null,
+                  "format": "",
+                  "indent": 0,
+                  "type": "extended-heading",
+                  "version": 1,
+                  "tag": "h4"
+                },
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Paragraph",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Heading",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": "ltr",
+          "format": "",
+          "indent": 0,
+          "type": "extended-heading",
+          "version": 1,
+          "tag": "h4"
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Paragraph",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": "ltr",
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/index.ts
+++ b/apps/admin/src/editor/engine/__fixtures__/index.ts
@@ -1,0 +1,43 @@
+import adjacentListsMerge from './adjacent-lists-merge.json';
+import alignedBlocks from './aligned-blocks.json';
+import directionNullVsLtr from './direction-null-vs-ltr.json';
+import emptyDocumentParagraph from './empty-document-paragraph.json';
+import invalidNesting from './invalid-nesting.json';
+import legacyHeadingQuoteNodes from './legacy-heading-quote-nodes.json';
+import legacyTextNodes from './legacy-text-nodes.json';
+import missingDefaultProps from './missing-default-props.json';
+import nestedEditorHtml from './nested-editor-html.json';
+import oldVisibilityFormat from './old-visibility-format.json';
+import type { LexicalDocument } from '@/editor/engine/lexical-compare';
+
+// headless-koenig: `after` = `before` parsed by koenig-lexical DEFAULT_NODES + default transforms.
+// hand-authored: the divergence only exists in a mounted editor, so the pair mirrors it by hand.
+export type FixtureProvenance = 'headless-koenig' | 'hand-authored';
+
+export interface OldSchemaFixture {
+  name: string;
+  provenance: FixtureProvenance;
+  before: LexicalDocument;
+  after: LexicalDocument;
+}
+
+function fixture(
+  name: string,
+  provenance: FixtureProvenance,
+  pair: { before: LexicalDocument; after: LexicalDocument },
+): OldSchemaFixture {
+  return { name, provenance, before: pair.before, after: pair.after };
+}
+
+export const OLD_SCHEMA_CORPUS: OldSchemaFixture[] = [
+  fixture('legacy-text-nodes', 'headless-koenig', legacyTextNodes),
+  fixture('legacy-heading-quote-nodes', 'headless-koenig', legacyHeadingQuoteNodes),
+  fixture('old-visibility-format', 'headless-koenig', oldVisibilityFormat),
+  fixture('missing-default-props', 'headless-koenig', missingDefaultProps),
+  fixture('invalid-nesting', 'headless-koenig', invalidNesting),
+  fixture('adjacent-lists-merge', 'headless-koenig', adjacentListsMerge),
+  fixture('aligned-blocks', 'headless-koenig', alignedBlocks),
+  fixture('nested-editor-html', 'headless-koenig', nestedEditorHtml),
+  fixture('direction-null-vs-ltr', 'hand-authored', directionNullVsLtr),
+  fixture('empty-document-paragraph', 'hand-authored', emptyDocumentParagraph),
+];

--- a/apps/admin/src/editor/engine/__fixtures__/index.ts
+++ b/apps/admin/src/editor/engine/__fixtures__/index.ts
@@ -10,9 +10,9 @@ import nestedEditorHtml from './nested-editor-html.json';
 import oldVisibilityFormat from './old-visibility-format.json';
 import type { LexicalDocument } from '@/editor/engine/lexical-compare';
 
-// headless-koenig: `after` = `before` parsed by koenig-lexical DEFAULT_NODES + default transforms.
-// hand-authored: the divergence only exists in a mounted editor, so the pair mirrors it by hand.
-export type FixtureProvenance = 'headless-koenig' | 'hand-authored';
+// headless-koenig / mounted-koenig: `after` recorded from koenig-lexical loading `before`.
+// hand-authored: pair written by hand; after-load.test.tsx verifies every pair regardless.
+export type FixtureProvenance = 'headless-koenig' | 'mounted-koenig' | 'hand-authored';
 
 export interface OldSchemaFixture {
   name: string;
@@ -37,7 +37,7 @@ export const OLD_SCHEMA_CORPUS: OldSchemaFixture[] = [
   fixture('invalid-nesting', 'headless-koenig', invalidNesting),
   fixture('adjacent-lists-merge', 'headless-koenig', adjacentListsMerge),
   fixture('aligned-blocks', 'headless-koenig', alignedBlocks),
-  fixture('nested-editor-html', 'headless-koenig', nestedEditorHtml),
+  fixture('nested-editor-html', 'mounted-koenig', nestedEditorHtml),
   fixture('direction-null-vs-ltr', 'hand-authored', directionNullVsLtr),
   fixture('empty-document-paragraph', 'hand-authored', emptyDocumentParagraph),
 ];

--- a/apps/admin/src/editor/engine/__fixtures__/index.ts
+++ b/apps/admin/src/editor/engine/__fixtures__/index.ts
@@ -2,12 +2,15 @@ import adjacentListsMerge from './adjacent-lists-merge.json';
 import alignedBlocks from './aligned-blocks.json';
 import directionNullVsLtr from './direction-null-vs-ltr.json';
 import emptyDocumentParagraph from './empty-document-paragraph.json';
+import headingInListitem from './heading-in-listitem.json';
 import invalidNesting from './invalid-nesting.json';
 import legacyHeadingQuoteNodes from './legacy-heading-quote-nodes.json';
 import legacyTextNodes from './legacy-text-nodes.json';
+import listInHeading from './list-in-heading.json';
 import missingDefaultProps from './missing-default-props.json';
 import nestedEditorHtml from './nested-editor-html.json';
 import oldVisibilityFormat from './old-visibility-format.json';
+import partialVisibilityFormat from './partial-visibility-format.json';
 import type { LexicalDocument } from '@/editor/engine/lexical-compare';
 
 // headless-koenig / mounted-koenig: `after` recorded from koenig-lexical loading `before`.
@@ -38,6 +41,9 @@ export const OLD_SCHEMA_CORPUS: OldSchemaFixture[] = [
   fixture('adjacent-lists-merge', 'headless-koenig', adjacentListsMerge),
   fixture('aligned-blocks', 'headless-koenig', alignedBlocks),
   fixture('nested-editor-html', 'mounted-koenig', nestedEditorHtml),
+  fixture('partial-visibility-format', 'mounted-koenig', partialVisibilityFormat),
+  fixture('list-in-heading', 'mounted-koenig', listInHeading),
+  fixture('heading-in-listitem', 'mounted-koenig', headingInListitem),
   fixture('direction-null-vs-ltr', 'hand-authored', directionNullVsLtr),
   fixture('empty-document-paragraph', 'hand-authored', emptyDocumentParagraph),
 ];

--- a/apps/admin/src/editor/engine/__fixtures__/invalid-nesting.json
+++ b/apps/admin/src/editor/engine/__fixtures__/invalid-nesting.json
@@ -1,0 +1,248 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Intro ",
+              "type": "text",
+              "version": 1
+            },
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Nested heading",
+                  "type": "text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "heading",
+              "version": 1,
+              "tag": "h3"
+            },
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": " outro",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Item one",
+                  "type": "text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            },
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Item with image",
+                  "type": "text",
+                  "version": 1
+                },
+                {
+                  "type": "image",
+                  "version": 1,
+                  "src": "https://example.com/content/images/nested.jpg",
+                  "width": 100,
+                  "height": 100,
+                  "title": "",
+                  "alt": "",
+                  "caption": "",
+                  "cardWidth": "regular",
+                  "href": ""
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 2
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Intro ",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Nested heading",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "extended-heading",
+          "version": 1,
+          "tag": "h3"
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": " outro",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "Item one",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "bullet",
+          "start": 1,
+          "tag": "ul"
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Item with image",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "type": "image",
+          "version": 1,
+          "src": "https://example.com/content/images/nested.jpg",
+          "width": 100,
+          "height": 100,
+          "title": "",
+          "alt": "",
+          "caption": "",
+          "cardWidth": "regular",
+          "href": ""
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/legacy-heading-quote-nodes.json
+++ b/apps/admin/src/editor/engine/__fixtures__/legacy-heading-quote-nodes.json
@@ -1,0 +1,134 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Heading two",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "heading",
+          "version": 1,
+          "tag": "h2"
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "A quotation",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "quote",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Body",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Heading two",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "extended-heading",
+          "version": 1,
+          "tag": "h2"
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "A quotation",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "extended-quote",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Body",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/legacy-text-nodes.json
+++ b/apps/admin/src/editor/engine/__fixtures__/legacy-text-nodes.json
@@ -1,0 +1,176 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Plain ",
+              "type": "text",
+              "version": 1
+            },
+            {
+              "detail": 0,
+              "format": 1,
+              "mode": "normal",
+              "style": "",
+              "text": "bold",
+              "type": "text",
+              "version": 1
+            },
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": " text.",
+              "type": "text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Second paragraph with a ",
+              "type": "text",
+              "version": 1
+            },
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "link",
+                  "type": "text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "link",
+              "version": 1,
+              "rel": null,
+              "target": null,
+              "title": null,
+              "url": "https://example.com/"
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Plain ",
+              "type": "extended-text",
+              "version": 1
+            },
+            {
+              "detail": 0,
+              "format": 1,
+              "mode": "normal",
+              "style": "",
+              "text": "bold",
+              "type": "extended-text",
+              "version": 1
+            },
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": " text.",
+              "type": "extended-text",
+              "version": 1
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        },
+        {
+          "children": [
+            {
+              "detail": 0,
+              "format": 0,
+              "mode": "normal",
+              "style": "",
+              "text": "Second paragraph with a ",
+              "type": "extended-text",
+              "version": 1
+            },
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "link",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": null,
+              "format": "",
+              "indent": 0,
+              "type": "link",
+              "version": 1,
+              "rel": null,
+              "target": null,
+              "title": null,
+              "url": "https://example.com/"
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "paragraph",
+          "version": 1
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/list-in-heading.json
+++ b/apps/admin/src/editor/engine/__fixtures__/list-in-heading.json
@@ -1,0 +1,96 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "detail": 0,
+                      "format": 0,
+                      "mode": "normal",
+                      "style": "",
+                      "text": "This should be plain text",
+                      "type": "extended-text",
+                      "version": 1
+                    }
+                  ],
+                  "direction": "ltr",
+                  "format": "",
+                  "indent": 0,
+                  "type": "listitem",
+                  "version": 1,
+                  "value": 1
+                }
+              ],
+              "direction": "ltr",
+              "format": "",
+              "indent": 0,
+              "type": "list",
+              "version": 1,
+              "listType": "number",
+              "start": 1,
+              "tag": "ol"
+            }
+          ],
+          "direction": "ltr",
+          "format": "",
+          "indent": 0,
+          "type": "heading",
+          "version": 1,
+          "tag": "h3"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "detail": 0,
+                  "format": 0,
+                  "mode": "normal",
+                  "style": "",
+                  "text": "This should be plain text",
+                  "type": "extended-text",
+                  "version": 1
+                }
+              ],
+              "direction": "ltr",
+              "format": "",
+              "indent": 0,
+              "type": "listitem",
+              "version": 1,
+              "value": 1
+            }
+          ],
+          "direction": "ltr",
+          "format": "",
+          "indent": 0,
+          "type": "list",
+          "version": 1,
+          "listType": "number",
+          "start": 1,
+          "tag": "ol"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/missing-default-props.json
+++ b/apps/admin/src/editor/engine/__fixtures__/missing-default-props.json
@@ -1,0 +1,135 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "type": "image",
+          "version": 1,
+          "src": "https://example.com/content/images/photo.jpg",
+          "width": 800,
+          "height": 600,
+          "caption": "",
+          "alt": ""
+        },
+        {
+          "type": "callout",
+          "version": 1,
+          "calloutText": "Heads up"
+        },
+        {
+          "type": "header",
+          "version": 1,
+          "size": "small",
+          "style": "dark",
+          "buttonEnabled": false,
+          "buttonUrl": "",
+          "buttonText": "",
+          "header": "Hello",
+          "subheader": "",
+          "backgroundImageSrc": ""
+        },
+        {
+          "type": "signup",
+          "version": 1,
+          "alignment": "left",
+          "header": "Sign up",
+          "subheader": "",
+          "disclaimer": "",
+          "labels": [],
+          "layout": "wide"
+        },
+        {
+          "type": "button",
+          "version": 1,
+          "buttonText": "Go",
+          "buttonUrl": "https://example.com/",
+          "alignment": "center"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "type": "image",
+          "version": 1,
+          "src": "https://example.com/content/images/photo.jpg",
+          "width": 800,
+          "height": 600,
+          "title": "",
+          "alt": "",
+          "caption": "",
+          "cardWidth": "regular",
+          "href": ""
+        },
+        {
+          "type": "callout",
+          "version": 1,
+          "calloutText": "<p><span style=\"white-space: pre-wrap;\">Heads up</span></p>",
+          "calloutEmoji": "💡",
+          "backgroundColor": "blue"
+        },
+        {
+          "type": "header",
+          "version": 1,
+          "size": "small",
+          "style": "dark",
+          "buttonEnabled": false,
+          "buttonUrl": "",
+          "buttonText": "",
+          "header": "<span style=\"white-space: pre-wrap;\">Hello</span>",
+          "subheader": "",
+          "backgroundImageSrc": "",
+          "accentColor": "#FF1A75",
+          "alignment": "center",
+          "backgroundColor": "#000000",
+          "backgroundImageWidth": null,
+          "backgroundImageHeight": null,
+          "backgroundSize": "cover",
+          "textColor": "#FFFFFF",
+          "buttonColor": "#ffffff",
+          "buttonTextColor": "#000000",
+          "layout": "full",
+          "swapped": false
+        },
+        {
+          "type": "signup",
+          "version": 1,
+          "alignment": "left",
+          "backgroundColor": "#F0F0F0",
+          "backgroundImageSrc": "",
+          "backgroundSize": "cover",
+          "textColor": "#000000",
+          "buttonColor": "accent",
+          "buttonTextColor": "#FFFFFF",
+          "buttonText": "Subscribe",
+          "disclaimer": "",
+          "header": "<span style=\"white-space: pre-wrap;\">Sign up</span>",
+          "layout": "wide",
+          "subheader": "",
+          "successMessage": "Email sent! Check your inbox to complete your signup.",
+          "swapped": false,
+          "labels": []
+        },
+        {
+          "type": "button",
+          "version": 1,
+          "buttonText": "Go",
+          "alignment": "center",
+          "buttonUrl": "https://example.com/"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/nested-editor-html.json
+++ b/apps/admin/src/editor/engine/__fixtures__/nested-editor-html.json
@@ -1,0 +1,50 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "type": "callout",
+          "version": 1,
+          "calloutText": "Callout with <b>bold</b> and <i>italic</i>",
+          "calloutEmoji": "💡",
+          "backgroundColor": "blue"
+        },
+        {
+          "type": "toggle",
+          "version": 1,
+          "heading": "Toggle <i>heading</i>",
+          "content": "<p>First paragraph</p><p>Second with a <a href=\"https://example.com/\">link</a></p>"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "type": "callout",
+          "version": 1,
+          "calloutText": "<p><span style=\"white-space: pre-wrap;\">Callout with </span><b><strong style=\"white-space: pre-wrap;\">bold</strong></b><span style=\"white-space: pre-wrap;\"> and </span><i><em style=\"white-space: pre-wrap;\">italic</em></i></p>",
+          "calloutEmoji": "💡",
+          "backgroundColor": "blue"
+        },
+        {
+          "type": "toggle",
+          "version": 1,
+          "heading": "<span style=\"white-space: pre-wrap;\">Toggle </span><i><em style=\"white-space: pre-wrap;\">heading</em></i>",
+          "content": "<p><span style=\"white-space: pre-wrap;\">First paragraph</span></p><p><span style=\"white-space: pre-wrap;\">Second with a </span><a href=\"https://example.com/\"><span style=\"white-space: pre-wrap;\">link</span></a></p>"
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/nested-editor-html.json
+++ b/apps/admin/src/editor/engine/__fixtures__/nested-editor-html.json
@@ -29,14 +29,14 @@
         {
           "type": "callout",
           "version": 1,
-          "calloutText": "<p><span style=\"white-space: pre-wrap;\">Callout with </span><b><strong style=\"white-space: pre-wrap;\">bold</strong></b><span style=\"white-space: pre-wrap;\"> and </span><i><em style=\"white-space: pre-wrap;\">italic</em></i></p>",
+          "calloutText": "<p><span style=\"white-space: pre-wrap;\">Callout with </span><b><strong style=\"white-space: pre-wrap;\">bold</strong></b><span style=\"white-space: pre-wrap;\"> and </span><i><em class=\"italic\" style=\"white-space: pre-wrap;\">italic</em></i></p>",
           "calloutEmoji": "💡",
           "backgroundColor": "blue"
         },
         {
           "type": "toggle",
           "version": 1,
-          "heading": "<span style=\"white-space: pre-wrap;\">Toggle </span><i><em style=\"white-space: pre-wrap;\">heading</em></i>",
+          "heading": "<span style=\"white-space: pre-wrap;\">Toggle </span><i><em class=\"italic\" style=\"white-space: pre-wrap;\">heading</em></i>",
           "content": "<p><span style=\"white-space: pre-wrap;\">First paragraph</span></p><p><span style=\"white-space: pre-wrap;\">Second with a </span><a href=\"https://example.com/\"><span style=\"white-space: pre-wrap;\">link</span></a></p>"
         }
       ],

--- a/apps/admin/src/editor/engine/__fixtures__/old-visibility-format.json
+++ b/apps/admin/src/editor/engine/__fixtures__/old-visibility-format.json
@@ -1,0 +1,103 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>free members only</p>",
+          "visibility": {
+            "showOnEmail": true,
+            "showOnWeb": true,
+            "segment": "status:free"
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>email only</p>",
+          "visibility": {
+            "emailOnly": true,
+            "segment": ""
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>web only</p>",
+          "visibility": {
+            "showOnEmail": false,
+            "showOnWeb": true,
+            "segment": "status:-free+status:-paid"
+          }
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>free members only</p>",
+          "visibility": {
+            "showOnEmail": true,
+            "showOnWeb": true,
+            "segment": "status:free",
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            },
+            "email": {
+              "memberSegment": "status:free"
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>email only</p>",
+          "visibility": {
+            "emailOnly": true,
+            "segment": "",
+            "web": {
+              "nonMember": false,
+              "memberSegment": ""
+            },
+            "email": {
+              "memberSegment": "status:free,status:-free"
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>web only</p>",
+          "visibility": {
+            "showOnEmail": false,
+            "showOnWeb": true,
+            "segment": "status:-free+status:-paid",
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            },
+            "email": {
+              "memberSegment": ""
+            }
+          }
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/__fixtures__/partial-visibility-format.json
+++ b/apps/admin/src/editor/engine/__fixtures__/partial-visibility-format.json
@@ -1,0 +1,123 @@
+{
+  "before": {
+    "root": {
+      "children": [
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>web object only</p>",
+          "visibility": {
+            "web": {
+              "nonMember": true
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>web without email</p>",
+          "visibility": {
+            "web": {
+              "nonMember": false,
+              "memberSegment": ""
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>email object only</p>",
+          "visibility": {
+            "email": {
+              "memberSegment": "status:free"
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>email without segment</p>",
+          "visibility": {
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            },
+            "email": {}
+          }
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  },
+  "after": {
+    "root": {
+      "children": [
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>web object only</p>",
+          "visibility": {
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            },
+            "email": {
+              "memberSegment": "status:free,status:-free"
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>web without email</p>",
+          "visibility": {
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            },
+            "email": {
+              "memberSegment": "status:free,status:-free"
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>email object only</p>",
+          "visibility": {
+            "email": {
+              "memberSegment": "status:free,status:-free"
+            },
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            }
+          }
+        },
+        {
+          "type": "html",
+          "version": 1,
+          "html": "<p>email without segment</p>",
+          "visibility": {
+            "web": {
+              "nonMember": true,
+              "memberSegment": "status:free,status:-free"
+            },
+            "email": {
+              "memberSegment": "status:free,status:-free"
+            }
+          }
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }
+}

--- a/apps/admin/src/editor/engine/change-tracker.test.ts
+++ b/apps/admin/src/editor/engine/change-tracker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { OLD_SCHEMA_CORPUS } from '@/editor/engine/__fixtures__';
 import { createChangeTracker, type SavedPostState } from '@/editor/engine/change-tracker';
-import type { LexicalDocument } from '@/editor/engine/lexical-compare';
+import { stripDirection, type LexicalDocument } from '@/editor/engine/lexical-compare';
 
 const textNode = (text: string) => ({
   detail: 0,
@@ -133,13 +133,41 @@ describe('createChangeTracker', () => {
       expect(tracker.verdict().dirty).toBe(false);
     });
 
-    it('is not dirty for a new post without saved content', () => {
+    it('is dirty for a new post without saved content once the user types', () => {
       const tracker = createChangeTracker();
       tracker.setSaved(savedPost({ isNew: true, lexical: null }));
-      tracker.setBaseline(serialize(doc([paragraph('')])));
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
-
+      const blank = serialize(doc([{ ...paragraph(''), children: [] }]));
+      tracker.setBaseline(blank);
+      tracker.setLive({ lexical: blank });
       expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setLive({ lexical: serialize(doc([paragraph('Typed')])) });
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
+        'SCRATCH_DIVERGED_FROM_SECONDARY',
+      ]);
+    });
+
+    it('fails closed when the lexical state cannot be parsed', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ lexical: '{not json' });
+
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'LEXICAL_PARSE_FAILED',
+          reason: 'lexical state could not be parsed for comparison',
+          context: { error: expect.stringContaining('JSON') as string },
+        },
+      ]);
+    });
+
+    it('ignores undefined fields passed to setLive', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      tracker.setLive({ lexical: undefined, title: undefined });
+
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
+        'SCRATCH_DIVERGED_FROM_SECONDARY',
+      ]);
     });
 
     it('carries the three serialized states in the reason context', () => {
@@ -301,20 +329,41 @@ describe('createChangeTracker', () => {
       expect(tracker.verdict().dirty).toBe(false);
     });
 
-    it('keeps the baseline across an acknowledged save', () => {
+    it('re-baselines on an acknowledged save', () => {
       const [fixture] = OLD_SCHEMA_CORPUS;
       const tracker = createChangeTracker();
       tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
       tracker.setBaseline(serialize(fixture.after));
       tracker.setLive({ lexical: serialize(fixture.after) });
 
-      tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
+      const edited = serialize(appendParagraph(fixture.after, 'Edit'));
+      tracker.setLive({ lexical: edited });
+      tracker.setSaved(savedPost({ lexical: edited }));
       expect(tracker.verdict().dirty).toBe(false);
 
-      tracker.setLive({ lexical: serialize(appendParagraph(fixture.after, 'Edit')) });
+      tracker.setLive({ lexical: serialize(fixture.after) });
       expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
         'SCRATCH_DIVERGED_FROM_SECONDARY',
       ]);
+    });
+
+    it('does not touch the baseline on the initial load', () => {
+      const [fixture] = OLD_SCHEMA_CORPUS;
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
+      tracker.setLive({ lexical: serialize(fixture.after) });
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setBaseline(serialize(fixture.after));
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('reports dirty when a save fails after a restore', () => {
+      const tracker = loadedTracker();
+      tracker.revisionRestored(doc([paragraph('Restored')]));
+      tracker.markSaveError(['Server error']);
+
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_HAS_ERROR']);
     });
 
     it('re-captures the baseline when a revision is restored', () => {
@@ -407,7 +456,7 @@ describe('createChangeTracker', () => {
       expect(tracker.verdict().diff).toBeUndefined();
     });
 
-    it('humanizes the live-vs-baseline difference with node types', () => {
+    it('humanizes the baseline-to-live difference with node types', () => {
       const tracker = loadedTracker();
       tracker.setLive({ lexical: serialize(doc([paragraph('Hello world', 'ltr')], 'ltr')) });
 
@@ -415,8 +464,23 @@ describe('createChangeTracker', () => {
         {
           type: 'CHANGE',
           path: 'root.children.0[paragraph].children.0[extended-text].text',
-          value: 'Hello',
-          oldValue: 'Hello world',
+          value: 'Hello world',
+          oldValue: 'Hello',
+        },
+      ]);
+    });
+
+    it('reports a deleted block as a removal', () => {
+      const tracker = loadedTracker(
+        savedPost({ lexical: serialize(doc([paragraph('Hello'), paragraph('Gone')])) }),
+      );
+      tracker.setLive({ lexical: serialize(doc([paragraph('Hello')])) });
+
+      expect(tracker.verdict({ includeDiff: true }).diff).toEqual([
+        {
+          type: 'REMOVE',
+          path: 'root.children.1[paragraph]',
+          oldValue: stripDirection(paragraph('Gone')),
         },
       ]);
     });

--- a/apps/admin/src/editor/engine/change-tracker.test.ts
+++ b/apps/admin/src/editor/engine/change-tracker.test.ts
@@ -257,9 +257,17 @@ describe('createChangeTracker', () => {
     it('is cleared by an acknowledged save', () => {
       const tracker = loadedTracker();
       tracker.markSaveError();
-      tracker.setSaved(savedPost());
+      tracker.saveAcknowledged(savedPost());
 
       expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('survives a refetch of the saved post', () => {
+      const tracker = loadedTracker();
+      tracker.markSaveError();
+      tracker.setSaved(savedPost());
+
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_HAS_ERROR']);
     });
 
     it('is listed first when other reasons apply', () => {
@@ -325,7 +333,7 @@ describe('createChangeTracker', () => {
       tracker.setLive({ lexical: edited, title: 'Edited' });
       expect(tracker.verdict().dirty).toBe(true);
 
-      tracker.setSaved(savedPost({ lexical: edited, title: 'Edited' }));
+      tracker.saveAcknowledged(savedPost({ lexical: edited, title: 'Edited' }));
       expect(tracker.verdict().dirty).toBe(false);
     });
 
@@ -338,7 +346,7 @@ describe('createChangeTracker', () => {
 
       const edited = serialize(appendParagraph(fixture.after, 'Edit'));
       tracker.setLive({ lexical: edited });
-      tracker.setSaved(savedPost({ lexical: edited }));
+      tracker.saveAcknowledged(savedPost({ lexical: edited }));
       expect(tracker.verdict().dirty).toBe(false);
 
       tracker.setLive({ lexical: serialize(fixture.after) });
@@ -346,6 +354,19 @@ describe('createChangeTracker', () => {
         'SCRATCH_DIVERGED_FROM_SECONDARY',
       ]);
     });
+
+    it.each(OLD_SCHEMA_CORPUS)(
+      '$name: a refetch of the saved post after load stays clean',
+      ({ before, after }) => {
+        const tracker = createChangeTracker();
+        tracker.setSaved(savedPost({ lexical: serialize(before) }));
+        tracker.setBaseline(serialize(after));
+        tracker.setLive({ lexical: serialize(after) });
+
+        tracker.setSaved(savedPost({ lexical: serialize(before) }));
+        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      },
+    );
 
     it('does not touch the baseline on the initial load', () => {
       const [fixture] = OLD_SCHEMA_CORPUS;
@@ -375,7 +396,7 @@ describe('createChangeTracker', () => {
       tracker.revisionRestored(restored);
       expect(tracker.verdict().dirty).toBe(false);
 
-      tracker.setSaved(savedPost({ lexical: serialize(restored) }));
+      tracker.saveAcknowledged(savedPost({ lexical: serialize(restored) }));
       expect(tracker.verdict().dirty).toBe(false);
 
       tracker.setLive({ lexical: serialize(appendParagraph(restored, 'After restore')) });
@@ -442,6 +463,69 @@ describe('createChangeTracker', () => {
       const tracker = loadedTracker(savedPost({ lexical: absolute }));
 
       expect(tracker.hasChangedSinceRevision(serialize(SAVED_DOC), siteUrl)).toBe(true);
+    });
+  });
+
+  describe('site URL normalization', () => {
+    const siteUrl = 'https://site.example';
+    const link = (href: string) => ({
+      children: [textNode('link')],
+      direction: null,
+      format: '',
+      indent: 0,
+      type: 'link',
+      version: 1,
+      rel: null,
+      target: null,
+      title: null,
+      url: href,
+    });
+    const withLink = (href: string) =>
+      serialize(doc([{ ...paragraph('See the '), children: [textNode('See the '), link(href)] }]));
+
+    it('treats a relative live link and its absolute saved form as the same content', () => {
+      const tracker = createChangeTracker({ siteUrl });
+      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
+      tracker.setBaseline(withLink(`${siteUrl}/about/`));
+      tracker.setLive({ lexical: withLink('/about/') });
+
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+    });
+
+    it('still detects a changed link', () => {
+      const tracker = createChangeTracker({ siteUrl });
+      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
+      tracker.setBaseline(withLink(`${siteUrl}/about/`));
+      tracker.setLive({ lexical: withLink('/contact/') });
+
+      expect(tracker.verdict({ includeDiff: true })).toEqual({
+        dirty: true,
+        reasons: [expect.objectContaining({ code: 'SCRATCH_DIVERGED_FROM_SECONDARY' })],
+        diff: [
+          {
+            type: 'CHANGE',
+            path: 'root.children.0[paragraph].children.1[link].url',
+            value: '/contact/',
+            oldValue: '/about/',
+          },
+        ],
+      });
+    });
+
+    it('compares verbatim when no site URL is configured', () => {
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
+      tracker.setBaseline(withLink(`${siteUrl}/about/`));
+      tracker.setLive({ lexical: withLink('/about/') });
+
+      expect(tracker.verdict().dirty).toBe(true);
+    });
+
+    it('is the default for hasChangedSinceRevision', () => {
+      const tracker = createChangeTracker({ siteUrl });
+      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
+
+      expect(tracker.hasChangedSinceRevision(withLink('/about/'))).toBe(false);
     });
   });
 

--- a/apps/admin/src/editor/engine/change-tracker.test.ts
+++ b/apps/admin/src/editor/engine/change-tracker.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from 'vitest';
+import { OLD_SCHEMA_CORPUS } from '@/editor/engine/__fixtures__';
+import { createChangeTracker, type SavedPostState } from '@/editor/engine/change-tracker';
+import type { LexicalDocument } from '@/editor/engine/lexical-compare';
+
+const textNode = (text: string) => ({
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  text,
+  type: 'extended-text',
+  version: 1,
+});
+
+const paragraph = (text: string, direction: string | null = null) => ({
+  children: [textNode(text)],
+  direction,
+  format: '',
+  indent: 0,
+  type: 'paragraph',
+  version: 1,
+});
+
+const doc = (children: unknown[], direction: string | null = null): LexicalDocument => ({
+  root: { children, direction, format: '', indent: 0, type: 'root', version: 1 },
+});
+
+const serialize = (document: LexicalDocument) => JSON.stringify(document);
+
+function appendParagraph(document: LexicalDocument, text: string): LexicalDocument {
+  const copy = JSON.parse(JSON.stringify(document)) as { root: { children: unknown[] } };
+  copy.root.children.push(paragraph(text));
+  return copy;
+}
+
+function withLtrEverywhere(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(withLtrEverywhere);
+  }
+  if (typeof value === 'object' && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      out[key] = key === 'direction' ? 'ltr' : withLtrEverywhere(child);
+    }
+    return out;
+  }
+  return value;
+}
+
+const SAVED_DOC = doc([paragraph('Hello')]);
+
+function savedPost(overrides: Partial<SavedPostState> = {}): SavedPostState {
+  return {
+    isNew: false,
+    title: 'Title',
+    lexical: serialize(SAVED_DOC),
+    tags: [{ name: 'News' }],
+    attributes: { custom_excerpt: null, feature_image: null },
+    ...overrides,
+  };
+}
+
+function loadedTracker(saved: SavedPostState = savedPost()) {
+  const tracker = createChangeTracker();
+  tracker.setSaved(saved);
+  tracker.setBaseline(saved.lexical);
+  tracker.setLive({ lexical: saved.lexical });
+  return tracker;
+}
+
+describe('createChangeTracker', () => {
+  it('is clean before a post is loaded', () => {
+    expect(createChangeTracker().verdict()).toEqual({ dirty: false, reasons: [] });
+  });
+
+  it('is clean right after load, before the editors report', () => {
+    const tracker = createChangeTracker();
+    tracker.setSaved(savedPost());
+
+    expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+  });
+
+  describe('invariant 5: loading old-schema content is clean until the user edits', () => {
+    it.each(OLD_SCHEMA_CORPUS)('$name ($provenance)', ({ before, after }) => {
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ lexical: serialize(before) }));
+      tracker.setBaseline(serialize(after));
+      tracker.setLive({ lexical: serialize(after) });
+
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+    });
+
+    it.each(OLD_SCHEMA_CORPUS)('$name: a user edit after load is dirty', ({ before, after }) => {
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ lexical: serialize(before) }));
+      tracker.setBaseline(serialize(after));
+      tracker.setLive({ lexical: serialize(appendParagraph(after, 'User typed this')) });
+
+      const verdict = tracker.verdict();
+      expect(verdict.dirty).toBe(true);
+      expect(verdict.reasons.map((r) => r.code)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+    });
+
+    it.each(OLD_SCHEMA_CORPUS)(
+      '$name: direction inferred at depth by a mounted editor is ignored',
+      ({ before, after }) => {
+        const tracker = createChangeTracker();
+        tracker.setSaved(savedPost({ lexical: serialize(before) }));
+        tracker.setBaseline(serialize(after));
+        tracker.setLive({ lexical: serialize(withLtrEverywhere(after) as LexicalDocument) });
+
+        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      },
+    );
+  });
+
+  describe('lexical divergence', () => {
+    it('requires divergence from both the saved and the baseline state', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      expect(tracker.verdict().dirty).toBe(true);
+
+      tracker.setLive({ lexical: serialize(SAVED_DOC) });
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('is not dirty while the baseline is still unknown', () => {
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost());
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('is not dirty for a new post without saved content', () => {
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ isNew: true, lexical: null }));
+      tracker.setBaseline(serialize(doc([paragraph('')])));
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('carries the three serialized states in the reason context', () => {
+      const tracker = loadedTracker();
+      const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
+      tracker.setLive({ lexical: edited });
+
+      expect(tracker.verdict().reasons[0]).toEqual({
+        code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
+        reason: 'main editor content has diverged from both hidden editor and saved content',
+        context: {
+          secondaryLexical: serialize(SAVED_DOC),
+          lexical: serialize(SAVED_DOC),
+          scratch: edited,
+        },
+      });
+    });
+  });
+
+  describe('tags', () => {
+    it('compares tags by name list', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ tags: [{ name: 'News' }, { name: 'Tech' }] });
+
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'POST_TAGS_DIVERGED',
+          reason: 'tags are different',
+          context: { currentTags: 'News, Tech', previousTags: 'News' },
+        },
+      ]);
+    });
+
+    it('ignores identity when the names match', () => {
+      const tracker = loadedTracker(savedPost({ tags: [{ name: 'News', id: '1' } as never] }));
+      tracker.setLive({ tags: [{ name: 'News', id: 'unsaved' } as never] });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('treats reordered tags as a change', () => {
+      const tracker = loadedTracker(savedPost({ tags: [{ name: 'A' }, { name: 'B' }] }));
+      tracker.setLive({ tags: [{ name: 'B' }, { name: 'A' }] });
+
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_TAGS_DIVERGED']);
+    });
+  });
+
+  describe('title', () => {
+    it('reports a changed title', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ title: 'New title' });
+
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'POST_TITLE_DIVERGED',
+          reason: 'title is different',
+          context: { current: 'Title', scratch: 'New title' },
+        },
+      ]);
+    });
+
+    it('ignores surrounding whitespace', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ title: '  Title ' });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+  });
+
+  describe('save errors', () => {
+    it('keeps the post dirty until the error is cleared', () => {
+      const tracker = loadedTracker();
+      tracker.markSaveError(['Validation failed']);
+
+      expect(tracker.verdict().reasons).toEqual([
+        { code: 'POST_HAS_ERROR', reason: 'isError', context: { messages: ['Validation failed'] } },
+      ]);
+
+      tracker.setLive({ lexical: serialize(SAVED_DOC) });
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_HAS_ERROR']);
+
+      tracker.clearSaveError();
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('is cleared by an acknowledged save', () => {
+      const tracker = loadedTracker();
+      tracker.markSaveError();
+      tracker.setSaved(savedPost());
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('is listed first when other reasons apply', () => {
+      const tracker = loadedTracker();
+      tracker.markSaveError();
+      tracker.setLive({ title: 'Changed' });
+
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
+        'POST_HAS_ERROR',
+        'POST_TITLE_DIVERGED',
+      ]);
+    });
+  });
+
+  describe('attributes', () => {
+    it('reports changed attributes on an existing post', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ attributes: { custom_excerpt: 'Excerpt', feature_image: null } });
+
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'POST_HAS_DIRTY_ATTRIBUTES',
+          reason: 'post.hasDirtyAttributes === true',
+          context: { custom_excerpt: [null, 'Excerpt'] },
+        },
+      ]);
+    });
+
+    it('reports changed attributes on a new post under its own code', () => {
+      const tracker = loadedTracker(savedPost({ isNew: true, attributes: {} }));
+      tracker.setLive({ attributes: { feature_image: 'https://site.example/a.jpg' } });
+
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'NEW_POST_HAS_CHANGED_ATTRIBUTES',
+          reason: 'post.changedAttributes.length > 0',
+          context: { feature_image: [undefined, 'https://site.example/a.jpg'] },
+        },
+      ]);
+    });
+
+    it('compares nested values structurally', () => {
+      const tracker = loadedTracker(savedPost({ attributes: { authors: [{ id: '1' }] } }));
+      tracker.setLive({ attributes: { authors: [{ id: '1' }] } });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+  });
+
+  describe('saved-state lifecycle', () => {
+    it('seeds the live state from the first saved state only', () => {
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ title: 'First' }));
+      tracker.setLive({ title: 'Edited' });
+      tracker.setSaved(savedPost({ title: 'First' }));
+
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_TITLE_DIVERGED']);
+    });
+
+    it('becomes clean once the acknowledged save matches the live state', () => {
+      const tracker = loadedTracker();
+      const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
+      tracker.setLive({ lexical: edited, title: 'Edited' });
+      expect(tracker.verdict().dirty).toBe(true);
+
+      tracker.setSaved(savedPost({ lexical: edited, title: 'Edited' }));
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('keeps the baseline across an acknowledged save', () => {
+      const [fixture] = OLD_SCHEMA_CORPUS;
+      const tracker = createChangeTracker();
+      tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
+      tracker.setBaseline(serialize(fixture.after));
+      tracker.setLive({ lexical: serialize(fixture.after) });
+
+      tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setLive({ lexical: serialize(appendParagraph(fixture.after, 'Edit')) });
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
+        'SCRATCH_DIVERGED_FROM_SECONDARY',
+      ]);
+    });
+
+    it('re-captures the baseline when a revision is restored', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      expect(tracker.verdict().dirty).toBe(true);
+
+      const restored = doc([paragraph('Restored')]);
+      tracker.revisionRestored(restored);
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setSaved(savedPost({ lexical: serialize(restored) }));
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setLive({ lexical: serialize(appendParagraph(restored, 'After restore')) });
+      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
+        'SCRATCH_DIVERGED_FROM_SECONDARY',
+      ]);
+    });
+
+    it('clears everything on reset', () => {
+      const tracker = loadedTracker();
+      tracker.markSaveError();
+      tracker.setLive({ title: 'Edited' });
+      tracker.reset();
+
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      expect(tracker.hasChangedSinceRevision(null, '')).toBe(false);
+    });
+  });
+
+  describe('hasChangedSinceRevision', () => {
+    const siteUrl = 'https://site.example';
+    const absolute = serialize(
+      doc([
+        {
+          type: 'image',
+          version: 1,
+          src: `${siteUrl}/content/images/a.jpg`,
+          href: `${siteUrl}/about/`,
+        },
+      ]),
+    );
+    const relative = serialize(
+      doc([{ type: 'image', version: 1, src: '/content/images/a.jpg', href: '/about/' }]),
+    );
+
+    it('is true when there is no revision yet', () => {
+      const tracker = loadedTracker();
+
+      expect(tracker.hasChangedSinceRevision(undefined, siteUrl)).toBe(true);
+      expect(tracker.hasChangedSinceRevision(null, siteUrl)).toBe(true);
+    });
+
+    it('is false for a new post', () => {
+      const tracker = loadedTracker(savedPost({ isNew: true, lexical: absolute }));
+
+      expect(tracker.hasChangedSinceRevision(relative, siteUrl)).toBe(false);
+    });
+
+    it('strips the site URL from both sides before comparing', () => {
+      const tracker = loadedTracker(savedPost({ lexical: absolute }));
+
+      expect(tracker.hasChangedSinceRevision(relative, siteUrl)).toBe(false);
+      expect(tracker.hasChangedSinceRevision(absolute, siteUrl)).toBe(false);
+    });
+
+    it('compares the saved state, not the live scratch', () => {
+      const tracker = loadedTracker(savedPost({ lexical: absolute }));
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Unsaved')) });
+
+      expect(tracker.hasChangedSinceRevision(absolute, siteUrl)).toBe(false);
+    });
+
+    it('detects a saved change since the revision', () => {
+      const tracker = loadedTracker(savedPost({ lexical: absolute }));
+
+      expect(tracker.hasChangedSinceRevision(serialize(SAVED_DOC), siteUrl)).toBe(true);
+    });
+  });
+
+  describe('diff', () => {
+    it('is omitted unless requested and the content diverged', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ title: 'Edited' });
+
+      expect(tracker.verdict({ includeDiff: true }).diff).toBeUndefined();
+
+      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      expect(tracker.verdict().diff).toBeUndefined();
+    });
+
+    it('humanizes the live-vs-baseline difference with node types', () => {
+      const tracker = loadedTracker();
+      tracker.setLive({ lexical: serialize(doc([paragraph('Hello world', 'ltr')], 'ltr')) });
+
+      expect(tracker.verdict({ includeDiff: true }).diff).toEqual([
+        {
+          type: 'CHANGE',
+          path: 'root.children.0[paragraph].children.0[extended-text].text',
+          value: 'Hello',
+          oldValue: 'Hello world',
+        },
+      ]);
+    });
+  });
+});

--- a/apps/admin/src/editor/engine/change-tracker.test.ts
+++ b/apps/admin/src/editor/engine/change-tracker.test.ts
@@ -684,6 +684,17 @@ describe('createChangeTracker', () => {
       ]);
     });
 
+    it('treats an undefined submitted field as not submitted', () => {
+      const tracker = loadedTracker();
+      tracker.saveAcknowledged(
+        POST_ID,
+        { title: undefined },
+        post({ title: 'Server title', updated_at: T1 }),
+      );
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
     it('treats a semantically equal body as still matching the submission', () => {
       const tracker = loadedTracker();
       const submittedBody = serialize(appendParagraph(SAVED_DOC, 'Edit'));
@@ -728,6 +739,56 @@ describe('createChangeTracker', () => {
 
       tracker.setSaved(null, post({ title: 'Stale', lexical: null }));
       expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+    });
+
+    it('keeps accepting null-id editor events after the created id is adopted', () => {
+      const tracker = createChangeTracker();
+      tracker.load(null, post({ lexical: null, updated_at: null }));
+      tracker.setBaseline(null, serialize(BLANK_DOC));
+      tracker.setLive(null, { lexical: serialize(BLANK_DOC) });
+      const submitted = post({ lexical: serialize(BLANK_DOC), updated_at: null });
+      tracker.saveAcknowledged('new1', submitted, { ...submitted, updated_at: T1 });
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setLive(null, { lexical: serialize(doc([paragraph('Typed')])) });
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+
+      tracker.setBaseline(null, serialize(doc([paragraph('Typed')])));
+      expect(tracker.verdict().dirty).toBe(false);
+      tracker.baselineFailed(null, 'boom');
+      tracker.setLive(null, { lexical: serialize(doc([paragraph('Typed more')])) });
+      expect(codes(tracker)).toEqual(['BASELINE_FAILED']);
+
+      tracker.setSaved(null, post({ title: 'Stale' }));
+      expect(codes(tracker)).toEqual(['BASELINE_FAILED']);
+    });
+
+    it('does not alias null to a post loaded with an id', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(null, { title: 'Edited' });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('rejects a late acknowledgement for a previously held post while a new post is open', () => {
+      const tracker = loadedTracker(post({ title: 'A' }), 'a');
+      tracker.setLive('a', { title: 'A edited' });
+      tracker.load(null, post({ title: '', lexical: null, updated_at: null }));
+
+      tracker.saveAcknowledged(
+        'a',
+        post({ title: 'A edited' }),
+        post({ title: 'A edited', updated_at: T2 }),
+      );
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      tracker.setSaved('a', post({ title: 'A refetched', updated_at: T2 }));
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+
+      const submitted = post({ title: 'New', lexical: null, updated_at: null });
+      tracker.setLive(null, { title: 'New' });
+      tracker.saveAcknowledged('new1', submitted, { ...submitted, updated_at: T2 });
+      tracker.setSaved('new1', post({ title: 'New refetched', lexical: null, updated_at: T2 }));
+      expect(codes(tracker)).toEqual(['POST_TITLE_DIVERGED']);
     });
 
     it('ignores a refetch of the previous post after switching', () => {

--- a/apps/admin/src/editor/engine/change-tracker.test.ts
+++ b/apps/admin/src/editor/engine/change-tracker.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { OLD_SCHEMA_CORPUS } from '@/editor/engine/__fixtures__';
-import { createChangeTracker, type SavedPostState } from '@/editor/engine/change-tracker';
-import { stripDirection, type LexicalDocument } from '@/editor/engine/lexical-compare';
+import {
+  createChangeTracker,
+  type EditablePostProjection,
+  type PostId,
+} from '@/editor/engine/change-tracker';
+import {
+  lexicalEquals,
+  stripDirection,
+  type LexicalDocument,
+} from '@/editor/engine/lexical-compare';
 
 const textNode = (text: string) => ({
   detail: 0,
@@ -49,25 +57,37 @@ function withLtrEverywhere(value: unknown): unknown {
 }
 
 const SAVED_DOC = doc([paragraph('Hello')]);
+const BLANK_DOC = doc([{ ...paragraph(''), children: [] }]);
+const POST_ID = 'post-1';
+const T0 = '2026-09-01T10:00:00.000Z';
+const T1 = '2026-09-01T10:01:00.000Z';
+const T2 = '2026-09-01T10:02:00.000Z';
 
-function savedPost(overrides: Partial<SavedPostState> = {}): SavedPostState {
+function post(overrides: Partial<EditablePostProjection> = {}): EditablePostProjection {
   return {
-    isNew: false,
     title: 'Title',
+    slug: 'title',
     lexical: serialize(SAVED_DOC),
     tags: [{ name: 'News' }],
-    attributes: { custom_excerpt: null, feature_image: null },
+    custom_excerpt: null,
+    feature_image: null,
+    feature_image_alt: null,
+    feature_image_caption: null,
+    updated_at: T0,
     ...overrides,
   };
 }
 
-function loadedTracker(saved: SavedPostState = savedPost()) {
+function loadedTracker(saved: EditablePostProjection = post(), id: PostId = POST_ID) {
   const tracker = createChangeTracker();
-  tracker.setSaved(saved);
-  tracker.setBaseline(saved.lexical);
-  tracker.setLive({ lexical: saved.lexical });
+  tracker.load(id, saved);
+  tracker.setBaseline(id, saved.lexical);
+  tracker.setLive(id, { lexical: saved.lexical });
   return tracker;
 }
+
+const codes = (tracker: ReturnType<typeof createChangeTracker>) =>
+  tracker.verdict().reasons.map((r) => r.code);
 
 describe('createChangeTracker', () => {
   it('is clean before a post is loaded', () => {
@@ -76,7 +96,7 @@ describe('createChangeTracker', () => {
 
   it('is clean right after load, before the editors report', () => {
     const tracker = createChangeTracker();
-    tracker.setSaved(savedPost());
+    tracker.load(POST_ID, post());
 
     expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
   });
@@ -84,32 +104,59 @@ describe('createChangeTracker', () => {
   describe('invariant 5: loading old-schema content is clean until the user edits', () => {
     it.each(OLD_SCHEMA_CORPUS)('$name ($provenance)', ({ before, after }) => {
       const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ lexical: serialize(before) }));
-      tracker.setBaseline(serialize(after));
-      tracker.setLive({ lexical: serialize(after) });
+      tracker.load(POST_ID, post({ lexical: serialize(before) }));
+      tracker.setBaseline(POST_ID, serialize(after));
+      tracker.setLive(POST_ID, { lexical: serialize(after) });
 
       expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
     });
 
     it.each(OLD_SCHEMA_CORPUS)('$name: a user edit after load is dirty', ({ before, after }) => {
       const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ lexical: serialize(before) }));
-      tracker.setBaseline(serialize(after));
-      tracker.setLive({ lexical: serialize(appendParagraph(after, 'User typed this')) });
+      tracker.load(POST_ID, post({ lexical: serialize(before) }));
+      tracker.setBaseline(POST_ID, serialize(after));
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(after, 'User typed this')) });
 
-      const verdict = tracker.verdict();
-      expect(verdict.dirty).toBe(true);
-      expect(verdict.reasons.map((r) => r.code)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
     });
 
     it.each(OLD_SCHEMA_CORPUS)(
       '$name: direction inferred at depth by a mounted editor is ignored',
       ({ before, after }) => {
         const tracker = createChangeTracker();
-        tracker.setSaved(savedPost({ lexical: serialize(before) }));
-        tracker.setBaseline(serialize(after));
-        tracker.setLive({ lexical: serialize(withLtrEverywhere(after) as LexicalDocument) });
+        tracker.load(POST_ID, post({ lexical: serialize(before) }));
+        tracker.setBaseline(POST_ID, serialize(after));
+        tracker.setLive(POST_ID, {
+          lexical: serialize(withLtrEverywhere(after) as LexicalDocument),
+        });
 
+        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      },
+    );
+
+    it.each(OLD_SCHEMA_CORPUS)(
+      '$name: a refetch of the saved post after load stays clean',
+      ({ before, after }) => {
+        const tracker = createChangeTracker();
+        tracker.load(POST_ID, post({ lexical: serialize(before) }));
+        tracker.setBaseline(POST_ID, serialize(after));
+        tracker.setLive(POST_ID, { lexical: serialize(after) });
+
+        tracker.setSaved(POST_ID, post({ lexical: serialize(before) }));
+        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      },
+    );
+
+    it.each(OLD_SCHEMA_CORPUS)(
+      '$name: the transformed live state is dirty only until the baseline reports',
+      ({ before, after }) => {
+        const tracker = createChangeTracker();
+        tracker.load(POST_ID, post({ lexical: serialize(before) }));
+        tracker.setLive(POST_ID, { lexical: serialize(after) });
+        const transformed = !lexicalEquals(before, after);
+        expect(codes(tracker)).toEqual(transformed ? ['BASELINE_PENDING'] : []);
+
+        tracker.setBaseline(POST_ID, serialize(after));
         expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
       },
     );
@@ -118,38 +165,27 @@ describe('createChangeTracker', () => {
   describe('lexical divergence', () => {
     it('requires divergence from both the saved and the baseline state', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
       expect(tracker.verdict().dirty).toBe(true);
 
-      tracker.setLive({ lexical: serialize(SAVED_DOC) });
-      expect(tracker.verdict().dirty).toBe(false);
-    });
-
-    it('is not dirty while the baseline is still unknown', () => {
-      const tracker = createChangeTracker();
-      tracker.setSaved(savedPost());
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
-
+      tracker.setLive(POST_ID, { lexical: serialize(SAVED_DOC) });
       expect(tracker.verdict().dirty).toBe(false);
     });
 
     it('is dirty for a new post without saved content once the user types', () => {
       const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ isNew: true, lexical: null }));
-      const blank = serialize(doc([{ ...paragraph(''), children: [] }]));
-      tracker.setBaseline(blank);
-      tracker.setLive({ lexical: blank });
+      tracker.load(null, post({ lexical: null }));
+      tracker.setBaseline(null, serialize(BLANK_DOC));
+      tracker.setLive(null, { lexical: serialize(BLANK_DOC) });
       expect(tracker.verdict().dirty).toBe(false);
 
-      tracker.setLive({ lexical: serialize(doc([paragraph('Typed')])) });
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
-        'SCRATCH_DIVERGED_FROM_SECONDARY',
-      ]);
+      tracker.setLive(null, { lexical: serialize(doc([paragraph('Typed')])) });
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
     });
 
     it('fails closed when the lexical state cannot be parsed', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ lexical: '{not json' });
+      tracker.setLive(POST_ID, { lexical: '{not json' });
 
       expect(tracker.verdict().reasons).toEqual([
         {
@@ -160,20 +196,35 @@ describe('createChangeTracker', () => {
       ]);
     });
 
+    it.each(['{}', '{"root":{}}', '{"root":{"children":"invalid"}}'])(
+      'fails closed for the structurally invalid document %s',
+      (invalid) => {
+        const tracker = loadedTracker();
+        tracker.setLive(POST_ID, { lexical: invalid });
+
+        expect(tracker.verdict().reasons).toEqual([
+          {
+            code: 'LEXICAL_PARSE_FAILED',
+            reason: 'lexical state could not be parsed for comparison',
+            context: { error: 'lexical root must be an object with a children array' },
+          },
+        ]);
+        expect(tracker.verdict({ includeDiff: true }).diff).toBeUndefined();
+      },
+    );
+
     it('ignores undefined fields passed to setLive', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
-      tracker.setLive({ lexical: undefined, title: undefined });
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      tracker.setLive(POST_ID, { lexical: undefined, title: undefined });
 
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
-        'SCRATCH_DIVERGED_FROM_SECONDARY',
-      ]);
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
     });
 
     it('carries the three serialized states in the reason context', () => {
       const tracker = loadedTracker();
       const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
-      tracker.setLive({ lexical: edited });
+      tracker.setLive(POST_ID, { lexical: edited });
 
       expect(tracker.verdict().reasons[0]).toEqual({
         code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
@@ -187,39 +238,157 @@ describe('createChangeTracker', () => {
     });
   });
 
-  describe('tags', () => {
-    it('compares tags by name list', () => {
+  describe('baseline readiness', () => {
+    it('is dirty when the user types before the hidden editor reports', () => {
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post());
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'BASELINE_PENDING',
+          reason:
+            'main editor content has diverged from saved content before the hidden editor reported',
+          context: {
+            lexical: serialize(SAVED_DOC),
+            scratch: serialize(appendParagraph(SAVED_DOC, 'Edit')),
+          },
+        },
+      ]);
+    });
+
+    it('is dirty when a new post is typed into before the hidden editor reports', () => {
+      const tracker = createChangeTracker();
+      tracker.load(null, post({ lexical: null }));
+      tracker.setLive(null, { lexical: serialize(doc([paragraph('Typed')])) });
+
+      expect(codes(tracker)).toEqual(['BASELINE_PENDING']);
+    });
+
+    it('stays clean while pending when the live state matches the saved state', () => {
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post());
+      tracker.setLive(POST_ID, { lexical: serialize(SAVED_DOC) });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it.each([null, '', serialize(doc([]))])(
+      'treats a ready baseline of %j as a known empty document',
+      (empty) => {
+        const tracker = createChangeTracker();
+        tracker.load(POST_ID, post({ lexical: null }));
+        tracker.setBaseline(POST_ID, empty);
+        tracker.setLive(POST_ID, { lexical: null });
+        expect(tracker.verdict().dirty).toBe(false);
+
+        tracker.setLive(POST_ID, { lexical: serialize(doc([paragraph('Typed')])) });
+        expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+      },
+    );
+
+    it.each([null, ''])(
+      'treats explicitly clearing non-empty content to %j as dirty',
+      (cleared) => {
+        const tracker = loadedTracker();
+        tracker.setLive(POST_ID, { lexical: cleared });
+
+        expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+      },
+    );
+
+    it('treats clearing to an empty root as dirty', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ tags: [{ name: 'News' }, { name: 'Tech' }] });
+      tracker.setLive(POST_ID, { lexical: serialize(doc([])) });
+
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+    });
+
+    it('falls back to a live-vs-saved compare when the hidden editor fails', () => {
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post());
+      tracker.baselineFailed(POST_ID, new Error('hidden editor crashed'));
+      tracker.setLive(POST_ID, { lexical: serialize(SAVED_DOC) });
+      expect(tracker.verdict().dirty).toBe(false);
+
+      const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
+      tracker.setLive(POST_ID, { lexical: edited });
+      expect(tracker.verdict().reasons).toEqual([
+        {
+          code: 'BASELINE_FAILED',
+          reason:
+            'main editor content has diverged from saved content and the hidden editor failed',
+          context: {
+            lexical: serialize(SAVED_DOC),
+            scratch: edited,
+            error: 'hidden editor crashed',
+          },
+        },
+      ]);
+    });
+
+    it('keeps body protection for an old-schema post after the hidden editor fails', () => {
+      const [fixture] = OLD_SCHEMA_CORPUS;
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post({ lexical: serialize(fixture.before) }));
+      tracker.baselineFailed(POST_ID, 'boom');
+      tracker.setLive(POST_ID, { lexical: serialize(fixture.after) });
+
+      expect(codes(tracker)).toEqual(['BASELINE_FAILED']);
+    });
+
+    it('recovers once a late baseline report arrives after a failure', () => {
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post());
+      tracker.baselineFailed(POST_ID, 'boom');
+      const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
+      tracker.setLive(POST_ID, { lexical: edited });
+
+      tracker.setBaseline(POST_ID, edited);
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+  });
+
+  describe('tags', () => {
+    it('compares tags by ordered name list', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { tags: [{ name: 'News' }, { name: 'Tech' }] });
 
       expect(tracker.verdict().reasons).toEqual([
         {
           code: 'POST_TAGS_DIVERGED',
           reason: 'tags are different',
-          context: { currentTags: 'News, Tech', previousTags: 'News' },
+          context: { currentTags: ['News', 'Tech'], previousTags: ['News'] },
         },
       ]);
     });
 
     it('ignores identity when the names match', () => {
-      const tracker = loadedTracker(savedPost({ tags: [{ name: 'News', id: '1' } as never] }));
-      tracker.setLive({ tags: [{ name: 'News', id: 'unsaved' } as never] });
+      const tracker = loadedTracker(post({ tags: [{ name: 'News', id: '1' } as never] }));
+      tracker.setLive(POST_ID, { tags: [{ name: 'News', id: 'unsaved' } as never] });
 
       expect(tracker.verdict().dirty).toBe(false);
     });
 
     it('treats reordered tags as a change', () => {
-      const tracker = loadedTracker(savedPost({ tags: [{ name: 'A' }, { name: 'B' }] }));
-      tracker.setLive({ tags: [{ name: 'B' }, { name: 'A' }] });
+      const tracker = loadedTracker(post({ tags: [{ name: 'A' }, { name: 'B' }] }));
+      tracker.setLive(POST_ID, { tags: [{ name: 'B' }, { name: 'A' }] });
 
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_TAGS_DIVERGED']);
+      expect(codes(tracker)).toEqual(['POST_TAGS_DIVERGED']);
+    });
+
+    it('does not collide on delimiter-bearing names', () => {
+      const tracker = loadedTracker(post({ tags: [{ name: 'A, B' }] }));
+      tracker.setLive(POST_ID, { tags: [{ name: 'A' }, { name: 'B' }] });
+
+      expect(codes(tracker)).toEqual(['POST_TAGS_DIVERGED']);
     });
   });
 
   describe('title', () => {
     it('reports a changed title', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ title: 'New title' });
+      tracker.setLive(POST_ID, { title: 'New title' });
 
       expect(tracker.verdict().reasons).toEqual([
         {
@@ -232,7 +401,7 @@ describe('createChangeTracker', () => {
 
     it('ignores surrounding whitespace', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ title: '  Title ' });
+      tracker.setLive(POST_ID, { title: '  Title ' });
 
       expect(tracker.verdict().dirty).toBe(false);
     });
@@ -247,8 +416,8 @@ describe('createChangeTracker', () => {
         { code: 'POST_HAS_ERROR', reason: 'isError', context: { messages: ['Validation failed'] } },
       ]);
 
-      tracker.setLive({ lexical: serialize(SAVED_DOC) });
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_HAS_ERROR']);
+      tracker.setLive(POST_ID, { lexical: serialize(SAVED_DOC) });
+      expect(codes(tracker)).toEqual(['POST_HAS_ERROR']);
 
       tracker.clearSaveError();
       expect(tracker.verdict().dirty).toBe(false);
@@ -257,7 +426,7 @@ describe('createChangeTracker', () => {
     it('is cleared by an acknowledged save', () => {
       const tracker = loadedTracker();
       tracker.markSaveError();
-      tracker.saveAcknowledged(savedPost());
+      tracker.saveAcknowledged(POST_ID, post(), post());
 
       expect(tracker.verdict().dirty).toBe(false);
     });
@@ -265,27 +434,24 @@ describe('createChangeTracker', () => {
     it('survives a refetch of the saved post', () => {
       const tracker = loadedTracker();
       tracker.markSaveError();
-      tracker.setSaved(savedPost());
+      tracker.setSaved(POST_ID, post());
 
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_HAS_ERROR']);
+      expect(codes(tracker)).toEqual(['POST_HAS_ERROR']);
     });
 
     it('is listed first when other reasons apply', () => {
       const tracker = loadedTracker();
       tracker.markSaveError();
-      tracker.setLive({ title: 'Changed' });
+      tracker.setLive(POST_ID, { title: 'Changed' });
 
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
-        'POST_HAS_ERROR',
-        'POST_TITLE_DIVERGED',
-      ]);
+      expect(codes(tracker)).toEqual(['POST_HAS_ERROR', 'POST_TITLE_DIVERGED']);
     });
   });
 
   describe('attributes', () => {
     it('reports changed attributes on an existing post', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ attributes: { custom_excerpt: 'Excerpt', feature_image: null } });
+      tracker.setLive(POST_ID, { custom_excerpt: 'Excerpt' });
 
       expect(tracker.verdict().reasons).toEqual([
         {
@@ -297,122 +463,383 @@ describe('createChangeTracker', () => {
     });
 
     it('reports changed attributes on a new post under its own code', () => {
-      const tracker = loadedTracker(savedPost({ isNew: true, attributes: {} }));
-      tracker.setLive({ attributes: { feature_image: 'https://site.example/a.jpg' } });
+      const tracker = loadedTracker(post({ lexical: null }), null);
+      tracker.setLive(null, { feature_image: 'https://site.example/a.jpg' });
 
       expect(tracker.verdict().reasons).toEqual([
         {
           code: 'NEW_POST_HAS_CHANGED_ATTRIBUTES',
           reason: 'post.changedAttributes.length > 0',
-          context: { feature_image: [undefined, 'https://site.example/a.jpg'] },
+          context: { feature_image: [null, 'https://site.example/a.jpg'] },
         },
       ]);
     });
 
-    it('compares nested values structurally', () => {
-      const tracker = loadedTracker(savedPost({ attributes: { authors: [{ id: '1' }] } }));
-      tracker.setLive({ attributes: { authors: [{ id: '1' }] } });
+    it('patches the projection so independent observers do not clobber each other', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { custom_excerpt: 'Excerpt' });
+      tracker.setLive(POST_ID, { feature_image: 'https://site.example/a.jpg' });
+
+      expect(tracker.verdict().reasons[0]?.context).toEqual({
+        custom_excerpt: [null, 'Excerpt'],
+        feature_image: [null, 'https://site.example/a.jpg'],
+      });
+
+      tracker.setLive(POST_ID, { custom_excerpt: null });
+      expect(tracker.verdict().reasons[0]?.context).toEqual({
+        feature_image: [null, 'https://site.example/a.jpg'],
+      });
+    });
+
+    it('reports a changed slug', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { slug: 'custom' });
+
+      expect(tracker.verdict().reasons[0]?.context).toEqual({ slug: ['title', 'custom'] });
+    });
+
+    it('never treats updated_at as a live edit', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { updated_at: T2 });
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+  });
+
+  describe('mutable aliasing', () => {
+    it('clones the saved state at ingress', () => {
+      const saved = post({ tags: [{ name: 'News' }], feature_image_caption: 'Caption' });
+      const tracker = loadedTracker(saved);
+      (saved.tags as Array<{ name: string }>).push({ name: 'Injected' });
+      saved.feature_image_caption = 'Mutated';
+
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('clones live patches at ingress', () => {
+      const tracker = loadedTracker();
+      const patch = { tags: [{ name: 'News' }] };
+      tracker.setLive(POST_ID, patch);
+      patch.tags.push({ name: 'Injected' });
 
       expect(tracker.verdict().dirty).toBe(false);
     });
   });
 
   describe('saved-state lifecycle', () => {
-    it('seeds the live state from the first saved state only', () => {
-      const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ title: 'First' }));
-      tracker.setLive({ title: 'Edited' });
-      tracker.setSaved(savedPost({ title: 'First' }));
+    it('does not reseed the live state on a refetch', () => {
+      const tracker = loadedTracker(post({ title: 'First' }));
+      tracker.setLive(POST_ID, { title: 'Edited' });
+      tracker.setSaved(POST_ID, post({ title: 'First' }));
 
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_TITLE_DIVERGED']);
+      expect(codes(tracker)).toEqual(['POST_TITLE_DIVERGED']);
+    });
+
+    it('does not touch the baseline on a refetch', () => {
+      const [fixture] = OLD_SCHEMA_CORPUS;
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post({ lexical: serialize(fixture.before) }));
+      tracker.setBaseline(POST_ID, serialize(fixture.after));
+      tracker.setLive(POST_ID, { lexical: serialize(fixture.after) });
+
+      tracker.setSaved(POST_ID, post({ lexical: serialize(fixture.before), updated_at: T1 }));
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('adopts a refetch carrying a newer collision token', () => {
+      const tracker = loadedTracker();
+      tracker.setSaved(POST_ID, post({ title: 'Renamed elsewhere', updated_at: T1 }));
+
+      expect(tracker.verdict().reasons[0]).toMatchObject({
+        code: 'POST_TITLE_DIVERGED',
+        context: { current: 'Renamed elsewhere', scratch: 'Title' },
+      });
+    });
+
+    it('drops a refetch older than the held collision token', () => {
+      const tracker = loadedTracker();
+      const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
+      tracker.setLive(POST_ID, { lexical: edited, title: 'Edited' });
+      tracker.saveAcknowledged(
+        POST_ID,
+        post({ lexical: edited, title: 'Edited' }),
+        post({ lexical: edited, title: 'Edited', updated_at: T1 }),
+      );
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setSaved(POST_ID, post({ updated_at: T0 }));
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setSaved(POST_ID, post({ lexical: edited, title: 'Edited', updated_at: T1 }));
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('always adopts the acknowledged collision token', () => {
+      const tracker = loadedTracker(post({ updated_at: T2 }));
+      tracker.saveAcknowledged(POST_ID, post(), post({ updated_at: T1 }));
+
+      tracker.setSaved(POST_ID, post({ title: 'Refetched', updated_at: T1 }));
+      expect(codes(tracker)).toEqual(['POST_TITLE_DIVERGED']);
     });
 
     it('becomes clean once the acknowledged save matches the live state', () => {
       const tracker = loadedTracker();
       const edited = serialize(appendParagraph(SAVED_DOC, 'Edit'));
-      tracker.setLive({ lexical: edited, title: 'Edited' });
+      tracker.setLive(POST_ID, { lexical: edited, title: 'Edited' });
       expect(tracker.verdict().dirty).toBe(true);
 
-      tracker.saveAcknowledged(savedPost({ lexical: edited, title: 'Edited' }));
+      const submitted = post({ lexical: edited, title: 'Edited' });
+      tracker.saveAcknowledged(POST_ID, submitted, { ...submitted, updated_at: T1 });
       expect(tracker.verdict().dirty).toBe(false);
     });
 
     it('re-baselines on an acknowledged save', () => {
       const [fixture] = OLD_SCHEMA_CORPUS;
       const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
-      tracker.setBaseline(serialize(fixture.after));
-      tracker.setLive({ lexical: serialize(fixture.after) });
+      tracker.load(POST_ID, post({ lexical: serialize(fixture.before) }));
+      tracker.setBaseline(POST_ID, serialize(fixture.after));
+      tracker.setLive(POST_ID, { lexical: serialize(fixture.after) });
 
       const edited = serialize(appendParagraph(fixture.after, 'Edit'));
-      tracker.setLive({ lexical: edited });
-      tracker.saveAcknowledged(savedPost({ lexical: edited }));
+      tracker.setLive(POST_ID, { lexical: edited });
+      tracker.saveAcknowledged(POST_ID, post({ lexical: edited }), post({ lexical: edited }));
       expect(tracker.verdict().dirty).toBe(false);
 
-      tracker.setLive({ lexical: serialize(fixture.after) });
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
+      tracker.setLive(POST_ID, { lexical: serialize(fixture.after) });
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+    });
+  });
+
+  describe('acknowledgement rebase', () => {
+    it('keeps edits made while the save was in flight', () => {
+      const tracker = loadedTracker();
+      const submittedBody = serialize(appendParagraph(SAVED_DOC, 'Submitted'));
+      tracker.setLive(POST_ID, {
+        lexical: submittedBody,
+        title: 'Submitted',
+        tags: [{ name: 'News' }, { name: 'Tech' }],
+        custom_excerpt: 'Submitted excerpt',
+      });
+      const submitted = post({
+        lexical: submittedBody,
+        title: 'Submitted',
+        tags: [{ name: 'News' }, { name: 'Tech' }],
+        custom_excerpt: 'Submitted excerpt',
+      });
+
+      const laterBody = serialize(
+        appendParagraph(appendParagraph(SAVED_DOC, 'Submitted'), 'Later'),
+      );
+      tracker.setLive(POST_ID, {
+        lexical: laterBody,
+        title: 'Later',
+        tags: [{ name: 'News' }, { name: 'Tech' }, { name: 'Later' }],
+        custom_excerpt: 'Later excerpt',
+      });
+
+      tracker.saveAcknowledged(POST_ID, submitted, { ...submitted, updated_at: T1 });
+
+      const verdict = tracker.verdict();
+      expect(verdict.reasons.map((r) => r.code)).toEqual([
+        'POST_TAGS_DIVERGED',
+        'POST_TITLE_DIVERGED',
         'SCRATCH_DIVERGED_FROM_SECONDARY',
+        'POST_HAS_DIRTY_ATTRIBUTES',
+      ]);
+      expect(verdict.reasons[3]?.context).toEqual({
+        custom_excerpt: ['Submitted excerpt', 'Later excerpt'],
+      });
+    });
+
+    it('adopts server-canonicalized values where the live state still matches the submission', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { title: '  My post ', slug: '' });
+      const submitted = post({ title: '  My post ', slug: '' });
+      tracker.saveAcknowledged(POST_ID, submitted, {
+        ...submitted,
+        title: 'My post',
+        slug: 'my-post',
+        updated_at: T1,
+      });
+
+      expect(tracker.verdict().dirty).toBe(false);
+      tracker.setSaved(POST_ID, post({ title: 'My post', slug: 'my-post', updated_at: T1 }));
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+
+    it('rebases fields absent from a partial submission against the previous saved state', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { custom_excerpt: 'Typed during the save' });
+      tracker.saveAcknowledged(
+        POST_ID,
+        { title: 'Title' },
+        post({ slug: 'title-2', updated_at: T1 }),
+      );
+
+      expect(tracker.verdict().reasons).toEqual([
+        expect.objectContaining({
+          code: 'POST_HAS_DIRTY_ATTRIBUTES',
+          context: { custom_excerpt: [null, 'Typed during the save'] },
+        }),
       ]);
     });
 
-    it.each(OLD_SCHEMA_CORPUS)(
-      '$name: a refetch of the saved post after load stays clean',
-      ({ before, after }) => {
-        const tracker = createChangeTracker();
-        tracker.setSaved(savedPost({ lexical: serialize(before) }));
-        tracker.setBaseline(serialize(after));
-        tracker.setLive({ lexical: serialize(after) });
+    it('treats a semantically equal body as still matching the submission', () => {
+      const tracker = loadedTracker();
+      const submittedBody = serialize(appendParagraph(SAVED_DOC, 'Edit'));
+      tracker.setLive(POST_ID, {
+        lexical: serialize(
+          withLtrEverywhere(appendParagraph(SAVED_DOC, 'Edit')) as LexicalDocument,
+        ),
+      });
+      const submitted = post({ lexical: submittedBody });
+      tracker.saveAcknowledged(POST_ID, submitted, { ...submitted, updated_at: T1 });
 
-        tracker.setSaved(savedPost({ lexical: serialize(before) }));
-        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
-      },
-    );
+      expect(tracker.verdict().dirty).toBe(false);
+    });
+  });
 
-    it('does not touch the baseline on the initial load', () => {
-      const [fixture] = OLD_SCHEMA_CORPUS;
+  describe('post identity', () => {
+    it('adopts the created id from the first acknowledgement and keeps the live state', () => {
       const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ lexical: serialize(fixture.before) }));
-      tracker.setLive({ lexical: serialize(fixture.after) });
-      expect(tracker.verdict().dirty).toBe(false);
+      tracker.load(null, post({ title: '', slug: '', lexical: null, tags: [], updated_at: null }));
+      tracker.setBaseline(null, serialize(BLANK_DOC));
+      tracker.setLive(null, { lexical: serialize(BLANK_DOC) });
 
-      tracker.setBaseline(serialize(fixture.after));
-      expect(tracker.verdict().dirty).toBe(false);
+      const typed = serialize(doc([paragraph('Typed')]));
+      tracker.setLive(null, { lexical: typed, title: 'Hi' });
+      const submitted = post({ title: 'Hi', slug: '', lexical: typed, tags: [], updated_at: null });
+
+      const typedMore = serialize(doc([paragraph('Typed more')]));
+      tracker.setLive(null, { lexical: typedMore });
+      tracker.saveAcknowledged('created-1', submitted, {
+        ...submitted,
+        slug: 'hi',
+        updated_at: T1,
+      });
+
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+
+      tracker.setSaved(
+        'created-1',
+        post({ title: 'Hi', slug: 'hi', lexical: typed, tags: [], updated_at: T1 }),
+      );
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+
+      tracker.setSaved(null, post({ title: 'Stale', lexical: null }));
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
     });
 
-    it('reports dirty when a save fails after a restore', () => {
-      const tracker = loadedTracker();
-      tracker.revisionRestored(doc([paragraph('Restored')]));
-      tracker.markSaveError(['Server error']);
+    it('ignores a refetch of the previous post after switching', () => {
+      const tracker = loadedTracker(post({ title: 'A' }), 'a');
+      tracker.load('b', post({ title: 'B' }));
+      tracker.setBaseline('b', serialize(SAVED_DOC));
+      tracker.saveAcknowledged('b', post({ title: 'B' }), post({ title: 'B', updated_at: T1 }));
 
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual(['POST_HAS_ERROR']);
+      tracker.setSaved('a', post({ title: 'A refetched', updated_at: T2 }));
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
     });
 
-    it('re-captures the baseline when a revision is restored', () => {
-      const tracker = loadedTracker();
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
-      expect(tracker.verdict().dirty).toBe(true);
+    it('ignores callbacks from the previous post after switching', () => {
+      const tracker = loadedTracker(post({ title: 'A' }), 'a');
+      tracker.load('b', post({ title: 'B' }));
 
-      const restored = doc([paragraph('Restored')]);
-      tracker.revisionRestored(restored);
-      expect(tracker.verdict().dirty).toBe(false);
-
-      tracker.saveAcknowledged(savedPost({ lexical: serialize(restored) }));
-      expect(tracker.verdict().dirty).toBe(false);
-
-      tracker.setLive({ lexical: serialize(appendParagraph(restored, 'After restore')) });
-      expect(tracker.verdict().reasons.map((r) => r.code)).toEqual([
-        'SCRATCH_DIVERGED_FROM_SECONDARY',
-      ]);
-    });
-
-    it('clears everything on reset', () => {
-      const tracker = loadedTracker();
-      tracker.markSaveError();
-      tracker.setLive({ title: 'Edited' });
-      tracker.reset();
+      tracker.setBaseline('a', serialize(doc([paragraph('A baseline')])));
+      tracker.baselineFailed('a', 'boom');
+      tracker.setLive('a', { title: 'A edited', lexical: serialize(doc([paragraph('A typed')])) });
+      tracker.saveAcknowledged(
+        'a',
+        post({ title: 'A edited' }),
+        post({ title: 'A edited', updated_at: T2 }),
+      );
+      tracker.revisionRestored('a', {
+        lexical: serialize(doc([paragraph('A restored')])),
+        title: 'A restored',
+        custom_excerpt: null,
+        feature_image: null,
+        feature_image_alt: null,
+        feature_image_caption: null,
+      });
 
       expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
-      expect(tracker.hasChangedSinceRevision(null, '')).toBe(false);
+      tracker.setLive('b', { lexical: serialize(doc([paragraph('B typed')])) });
+      expect(codes(tracker)).toEqual(['BASELINE_PENDING']);
+    });
+
+    it('is inert after dispose', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, { title: 'Edited' });
+      tracker.dispose();
+
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      expect(tracker.hasChangedSinceRevision(null)).toBe(false);
+
+      tracker.load(POST_ID, post());
+      tracker.setLive(POST_ID, { title: 'Edited again' });
+      tracker.markSaveError('boom');
+      tracker.setSaved(POST_ID, post());
+      tracker.saveAcknowledged(POST_ID, post(), post());
+      tracker.setBaseline(POST_ID, serialize(SAVED_DOC));
+      tracker.baselineFailed(POST_ID, 'boom');
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+    });
+  });
+
+  describe('revision restore', () => {
+    const restored = {
+      lexical: serialize(doc([paragraph('Restored')])),
+      title: 'Restored title',
+      custom_excerpt: 'Restored excerpt',
+      feature_image: 'https://site.example/restored.jpg',
+      feature_image_alt: 'Restored alt',
+      feature_image_caption: 'Restored caption',
+    };
+
+    it('adopts the full restored projection into saved and live', () => {
+      const tracker = loadedTracker();
+      tracker.setLive(POST_ID, {
+        lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')),
+        title: 'Edited',
+        custom_excerpt: 'Edited excerpt',
+      });
+      expect(tracker.verdict().dirty).toBe(true);
+
+      tracker.revisionRestored(POST_ID, restored);
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+
+      tracker.setLive(POST_ID, { lexical: restored.lexical, title: restored.title });
+      expect(tracker.verdict().dirty).toBe(false);
+
+      tracker.setLive(POST_ID, { title: 'Edited after restore' });
+      expect(tracker.verdict().reasons[0]).toMatchObject({
+        code: 'POST_TITLE_DIVERGED',
+        context: { current: 'Restored title', scratch: 'Edited after restore' },
+      });
+    });
+
+    it('waits for the hidden editor to re-report after an old-schema restore', () => {
+      const [fixture] = OLD_SCHEMA_CORPUS;
+      const tracker = loadedTracker();
+      tracker.revisionRestored(POST_ID, { ...restored, lexical: serialize(fixture.before) });
+
+      tracker.setLive(POST_ID, { lexical: serialize(fixture.after) });
+      expect(codes(tracker)).toEqual(['BASELINE_PENDING']);
+
+      tracker.setBaseline(POST_ID, serialize(fixture.after));
+      expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+
+      tracker.setLive(POST_ID, {
+        lexical: serialize(appendParagraph(fixture.after, 'After restore')),
+      });
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+    });
+
+    it('reports dirty when a later save fails', () => {
+      const tracker = loadedTracker();
+      tracker.revisionRestored(POST_ID, restored);
+      tracker.markSaveError(['Server error']);
+
+      expect(codes(tracker)).toEqual(['POST_HAS_ERROR']);
     });
   });
 
@@ -431,43 +858,103 @@ describe('createChangeTracker', () => {
     const relative = serialize(
       doc([{ type: 'image', version: 1, src: '/content/images/a.jpg', href: '/about/' }]),
     );
+    const revision = (overrides: Partial<EditablePostProjection> = {}) => {
+      const saved = post(overrides);
+      return {
+        lexical: saved.lexical,
+        title: saved.title,
+        custom_excerpt: saved.custom_excerpt,
+        feature_image: saved.feature_image,
+      };
+    };
+
+    function trackerWithSite(saved: EditablePostProjection) {
+      const tracker = createChangeTracker({ siteUrl });
+      tracker.load(POST_ID, saved);
+      tracker.setBaseline(POST_ID, saved.lexical);
+      tracker.setLive(POST_ID, { lexical: saved.lexical });
+      return tracker;
+    }
 
     it('is true when there is no revision yet', () => {
       const tracker = loadedTracker();
 
-      expect(tracker.hasChangedSinceRevision(undefined, siteUrl)).toBe(true);
-      expect(tracker.hasChangedSinceRevision(null, siteUrl)).toBe(true);
+      expect(tracker.hasChangedSinceRevision(undefined)).toBe(true);
+      expect(tracker.hasChangedSinceRevision(null)).toBe(true);
     });
 
     it('is false for a new post', () => {
-      const tracker = loadedTracker(savedPost({ isNew: true, lexical: absolute }));
+      const tracker = createChangeTracker({ siteUrl });
+      tracker.load(null, post({ lexical: absolute }));
 
-      expect(tracker.hasChangedSinceRevision(relative, siteUrl)).toBe(false);
+      expect(tracker.hasChangedSinceRevision(revision({ lexical: relative }))).toBe(false);
     });
 
-    it('strips the site URL from both sides before comparing', () => {
-      const tracker = loadedTracker(savedPost({ lexical: absolute }));
+    it('normalizes site URLs on both sides before comparing', () => {
+      const tracker = trackerWithSite(post({ lexical: absolute }));
 
-      expect(tracker.hasChangedSinceRevision(relative, siteUrl)).toBe(false);
-      expect(tracker.hasChangedSinceRevision(absolute, siteUrl)).toBe(false);
+      expect(tracker.hasChangedSinceRevision(revision({ lexical: relative }))).toBe(false);
+      expect(tracker.hasChangedSinceRevision(revision({ lexical: absolute }))).toBe(false);
     });
 
     it('compares the saved state, not the live scratch', () => {
-      const tracker = loadedTracker(savedPost({ lexical: absolute }));
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Unsaved')) });
+      const tracker = trackerWithSite(post({ lexical: absolute }));
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(SAVED_DOC, 'Unsaved')) });
 
-      expect(tracker.hasChangedSinceRevision(absolute, siteUrl)).toBe(false);
+      expect(tracker.hasChangedSinceRevision(revision({ lexical: absolute }))).toBe(false);
     });
 
-    it('detects a saved change since the revision', () => {
-      const tracker = loadedTracker(savedPost({ lexical: absolute }));
+    it('detects a saved body change since the revision', () => {
+      const tracker = trackerWithSite(post({ lexical: absolute }));
 
-      expect(tracker.hasChangedSinceRevision(serialize(SAVED_DOC), siteUrl)).toBe(true);
+      expect(tracker.hasChangedSinceRevision(revision())).toBe(true);
+    });
+
+    it.each([
+      ['title', { title: 'Renamed' }],
+      ['custom_excerpt', { custom_excerpt: 'Excerpt' }],
+      ['feature_image', { feature_image: 'https://site.example/a.jpg' }],
+    ] as const)('detects a %s change without a body change', (_field, change) => {
+      const tracker = loadedTracker(post(change));
+
+      expect(tracker.hasChangedSinceRevision(revision())).toBe(true);
+      expect(tracker.hasChangedSinceRevision(revision(change))).toBe(false);
+    });
+
+    it('treats a missing revision excerpt or feature image as null', () => {
+      const tracker = loadedTracker();
+
+      expect(
+        tracker.hasChangedSinceRevision({ lexical: serialize(SAVED_DOC), title: 'Title' }),
+      ).toBe(false);
+    });
+
+    it('ignores key order and direction in the body', () => {
+      const tracker = loadedTracker(
+        post({ lexical: serialize(doc([paragraph('Hello', 'ltr')], 'ltr')) }),
+      );
+      const reordered = JSON.stringify({
+        root: {
+          version: 1,
+          type: 'root',
+          indent: 0,
+          format: '',
+          direction: null,
+          children: [paragraph('Hello')],
+        },
+      });
+
+      expect(tracker.hasChangedSinceRevision(revision({ lexical: reordered }))).toBe(false);
+    });
+
+    it('fails closed when the revision body cannot be parsed', () => {
+      const tracker = loadedTracker();
+
+      expect(tracker.hasChangedSinceRevision(revision({ lexical: '{}' }))).toBe(true);
     });
   });
 
   describe('site URL normalization', () => {
-    const siteUrl = 'https://site.example';
     const link = (href: string) => ({
       children: [textNode('link')],
       direction: null,
@@ -483,20 +970,61 @@ describe('createChangeTracker', () => {
     const withLink = (href: string) =>
       serialize(doc([{ ...paragraph('See the '), children: [textNode('See the '), link(href)] }]));
 
-    it('treats a relative live link and its absolute saved form as the same content', () => {
+    function trackerWithSite(siteUrl: string, savedLexical: string) {
       const tracker = createChangeTracker({ siteUrl });
-      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
-      tracker.setBaseline(withLink(`${siteUrl}/about/`));
-      tracker.setLive({ lexical: withLink('/about/') });
+      tracker.load(POST_ID, post({ lexical: savedLexical }));
+      tracker.setBaseline(POST_ID, savedLexical);
+      return tracker;
+    }
+
+    it.each(['https://site.example', 'https://site.example/'])(
+      'treats a relative live link and its absolute saved form as the same content (%s)',
+      (siteUrl) => {
+        const tracker = trackerWithSite(siteUrl, withLink('https://site.example/about/'));
+        tracker.setLive(POST_ID, { lexical: withLink('/about/') });
+
+        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+      },
+    );
+
+    it.each(['https://site.example/blog', 'https://site.example/blog/'])(
+      'keeps the subdirectory of a subdirectory install (%s)',
+      (siteUrl) => {
+        const tracker = trackerWithSite(siteUrl, withLink('https://site.example/blog/about/'));
+        tracker.setLive(POST_ID, { lexical: withLink('/blog/about/') });
+        expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
+
+        tracker.setLive(POST_ID, { lexical: withLink('https://site.example/other/') });
+        expect(tracker.verdict().dirty).toBe(true);
+      },
+    );
+
+    it('normalizes card URL properties', () => {
+      const siteUrl = 'https://site.example';
+      const image = (prefix: string) =>
+        serialize(
+          doc([
+            {
+              type: 'image',
+              version: 1,
+              src: `${prefix}/content/images/a.jpg`,
+              href: `${prefix}/about/`,
+              caption: 'Caption',
+            },
+          ]),
+        );
+      const tracker = trackerWithSite(siteUrl, image(siteUrl));
+      tracker.setLive(POST_ID, { lexical: image('') });
 
       expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
     });
 
     it('still detects a changed link', () => {
-      const tracker = createChangeTracker({ siteUrl });
-      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
-      tracker.setBaseline(withLink(`${siteUrl}/about/`));
-      tracker.setLive({ lexical: withLink('/contact/') });
+      const tracker = trackerWithSite(
+        'https://site.example',
+        withLink('https://site.example/about/'),
+      );
+      tracker.setLive(POST_ID, { lexical: withLink('/contact/') });
 
       expect(tracker.verdict({ includeDiff: true })).toEqual({
         dirty: true,
@@ -512,37 +1040,75 @@ describe('createChangeTracker', () => {
       });
     });
 
-    it('compares verbatim when no site URL is configured', () => {
-      const tracker = createChangeTracker();
-      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
-      tracker.setBaseline(withLink(`${siteUrl}/about/`));
-      tracker.setLive({ lexical: withLink('/about/') });
+    it('keeps a literal site URL deleted from prose dirty', () => {
+      const tracker = trackerWithSite(
+        'https://site.example',
+        serialize(doc([paragraph('Read https://site.example')])),
+      );
+      tracker.setLive(POST_ID, { lexical: serialize(doc([paragraph('Read ')])) });
 
-      expect(tracker.verdict().dirty).toBe(true);
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
     });
 
-    it('is the default for hasChangedSinceRevision', () => {
-      const tracker = createChangeTracker({ siteUrl });
-      tracker.setSaved(savedPost({ lexical: withLink(`${siteUrl}/about/`) }));
+    it.each([
+      [
+        'codeblock',
+        { type: 'codeblock', version: 1, language: '', code: 'fetch("https://site.example/api/")' },
+      ],
+      ['html', { type: 'html', version: 1, html: '<a href="https://site.example/about/">x</a>' }],
+      ['markdown', { type: 'markdown', version: 1, markdown: '[x](https://site.example/about/)' }],
+      [
+        'image caption',
+        { type: 'image', version: 1, src: '/a.jpg', caption: 'See https://site.example/about/' },
+      ],
+      [
+        'call-to-action',
+        { type: 'call-to-action', version: 1, buttonUrl: 'https://site.example/about/' },
+      ],
+    ])('keeps a literal URL edited in %s dirty', (_name, node) => {
+      const siteUrl = 'https://site.example';
+      const tracker = trackerWithSite(siteUrl, serialize(doc([node])));
+      const edited = JSON.parse(JSON.stringify(node).replaceAll(siteUrl, '')) as Record<
+        string,
+        unknown
+      >;
+      tracker.setLive(POST_ID, { lexical: serialize(doc([edited])) });
 
-      expect(tracker.hasChangedSinceRevision(withLink('/about/'))).toBe(false);
+      expect(codes(tracker)).toEqual(['SCRATCH_DIVERGED_FROM_SECONDARY']);
+    });
+
+    it('compares verbatim when no site URL is configured', () => {
+      const tracker = trackerWithSite('', withLink('https://site.example/about/'));
+      tracker.setLive(POST_ID, { lexical: withLink('/about/') });
+
+      expect(tracker.verdict().dirty).toBe(true);
     });
   });
 
   describe('diff', () => {
     it('is omitted unless requested and the content diverged', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ title: 'Edited' });
+      tracker.setLive(POST_ID, { title: 'Edited' });
 
       expect(tracker.verdict({ includeDiff: true }).diff).toBeUndefined();
 
-      tracker.setLive({ lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
       expect(tracker.verdict().diff).toBeUndefined();
+    });
+
+    it('is omitted while the baseline is pending', () => {
+      const tracker = createChangeTracker();
+      tracker.load(POST_ID, post());
+      tracker.setLive(POST_ID, { lexical: serialize(appendParagraph(SAVED_DOC, 'Edit')) });
+
+      expect(tracker.verdict({ includeDiff: true }).diff).toBeUndefined();
     });
 
     it('humanizes the baseline-to-live difference with node types', () => {
       const tracker = loadedTracker();
-      tracker.setLive({ lexical: serialize(doc([paragraph('Hello world', 'ltr')], 'ltr')) });
+      tracker.setLive(POST_ID, {
+        lexical: serialize(doc([paragraph('Hello world', 'ltr')], 'ltr')),
+      });
 
       expect(tracker.verdict({ includeDiff: true }).diff).toEqual([
         {
@@ -556,9 +1122,9 @@ describe('createChangeTracker', () => {
 
     it('reports a deleted block as a removal', () => {
       const tracker = loadedTracker(
-        savedPost({ lexical: serialize(doc([paragraph('Hello'), paragraph('Gone')])) }),
+        post({ lexical: serialize(doc([paragraph('Hello'), paragraph('Gone')])) }),
       );
-      tracker.setLive({ lexical: serialize(doc([paragraph('Hello')])) });
+      tracker.setLive(POST_ID, { lexical: serialize(doc([paragraph('Hello')])) });
 
       expect(tracker.verdict({ includeDiff: true }).diff).toEqual([
         {

--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -13,6 +13,7 @@ export type ChangeReasonCode =
   | 'POST_TAGS_DIVERGED'
   | 'POST_TITLE_DIVERGED'
   | 'SCRATCH_DIVERGED_FROM_SECONDARY'
+  | 'LEXICAL_PARSE_FAILED'
   | 'NEW_POST_HAS_CHANGED_ATTRIBUTES'
   | 'POST_HAS_DIRTY_ATTRIBUTES';
 
@@ -137,14 +138,22 @@ export function createChangeTracker(): ChangeTracker {
     }
 
     const scratch = live.lexical ?? null;
-    if (saved.lexical && baseline && scratch) {
-      const divergedFromBaseline = !lexicalEquals(baseline, scratch);
-      const divergedFromSaved = !lexicalEquals(saved.lexical, scratch);
-      if (divergedFromBaseline && divergedFromSaved) {
+    if (baseline && scratch) {
+      try {
+        const divergedFromBaseline = !lexicalEquals(baseline, scratch);
+        const divergedFromSaved = !lexicalEquals(saved.lexical, scratch);
+        if (divergedFromBaseline && divergedFromSaved) {
+          reasons.push({
+            code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
+            reason: 'main editor content has diverged from both hidden editor and saved content',
+            context: { secondaryLexical: baseline, lexical: saved.lexical, scratch },
+          });
+        }
+      } catch (error) {
         reasons.push({
-          code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
-          reason: 'main editor content has diverged from both hidden editor and saved content',
-          context: { secondaryLexical: baseline, lexical: saved.lexical, scratch },
+          code: 'LEXICAL_PARSE_FAILED',
+          reason: 'lexical state could not be parsed for comparison',
+          context: { error: error instanceof Error ? error.message : String(error) },
         });
       }
     }
@@ -171,6 +180,9 @@ export function createChangeTracker(): ChangeTracker {
 
   return {
     setSaved(next) {
+      if (saved) {
+        baseline = next.lexical;
+      }
       saved = next;
       saveError = null;
       live = {
@@ -186,7 +198,10 @@ export function createChangeTracker(): ChangeTracker {
     },
 
     setLive(next) {
-      live = { ...live, ...next };
+      const defined = Object.fromEntries(
+        Object.entries(next).filter(([, value]) => value !== undefined),
+      ) as LivePostState;
+      live = { ...live, ...defined };
     },
 
     markSaveError(messages) {
@@ -197,6 +212,8 @@ export function createChangeTracker(): ChangeTracker {
       saveError = null;
     },
 
+    // Call only after the restore save is acknowledged: Ember updates the
+    // editors on success, so a failed restore never reaches the baseline.
     revisionRestored(lexical) {
       const restored = serializeLexical(lexical);
       baseline = restored;
@@ -211,7 +228,7 @@ export function createChangeTracker(): ChangeTracker {
         options.includeDiff &&
         reasons.some((r) => r.code === 'SCRATCH_DIVERGED_FROM_SECONDARY')
       ) {
-        result.diff = humanizeLexicalDiff(live.lexical, baseline);
+        result.diff = humanizeLexicalDiff(baseline, live.lexical);
       }
 
       return result;

--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -353,8 +353,8 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
 
     // Single-flight save engine with one coalescing pending slot: acknowledgements
     // arrive in submit order, so no save-attempt id is needed here.
-    // The save engine's post-generation fence is the primary guard against stale
-    // completions; a new post only refuses acks for ids this tracker has already held.
+    // Callers must build a fresh tracker per load(null) or fence stale completions
+    // themselves; a new post only refuses acks for ids this tracker has already held.
     saveAcknowledged(id, submitted, acknowledged) {
       if (disposed || !saved || !live || (postId !== null && id !== postId)) {
         return;

--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -54,8 +54,13 @@ export interface VerdictOptions {
   includeDiff?: boolean;
 }
 
+export interface ChangeTrackerOptions {
+  siteUrl?: string;
+}
+
 export interface ChangeTracker {
   setSaved(saved: SavedPostState): void;
+  saveAcknowledged(saved: SavedPostState): void;
   setBaseline(lexical: LexicalInput): void;
   setLive(live: LivePostState): void;
   markSaveError(messages?: unknown): void;
@@ -64,7 +69,7 @@ export interface ChangeTracker {
   verdict(options?: VerdictOptions): ChangeVerdict;
   hasChangedSinceRevision(
     latestRevisionLexical: string | null | undefined,
-    siteUrl: string,
+    siteUrl?: string,
   ): boolean;
   reset(): void;
 }
@@ -97,11 +102,28 @@ function changedAttributes(
   return changed;
 }
 
-export function createChangeTracker(): ChangeTracker {
+export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeTracker {
+  const siteUrl = options.siteUrl ?? '';
   let saved: SavedPostState | null = null;
   let baseline: string | null = null;
   let live: LivePostState = {};
   let saveError: SaveError | null = null;
+
+  // The server rewrites relative URLs to absolute on save, so both sides are
+  // compared with the site URL removed.
+  function sameLexical(a: string | null, b: string): boolean {
+    return lexicalEquals(stripSiteUrl(a ?? '', siteUrl), stripSiteUrl(b, siteUrl));
+  }
+
+  function adoptSaved(next: SavedPostState) {
+    saved = next;
+    live = {
+      title: live.title ?? next.title,
+      lexical: live.lexical === undefined ? next.lexical : live.lexical,
+      tags: live.tags ?? next.tags,
+      attributes: live.attributes ?? next.attributes,
+    };
+  }
 
   function collectReasons(): ChangeReason[] {
     if (!saved) {
@@ -140,8 +162,8 @@ export function createChangeTracker(): ChangeTracker {
     const scratch = live.lexical ?? null;
     if (baseline && scratch) {
       try {
-        const divergedFromBaseline = !lexicalEquals(baseline, scratch);
-        const divergedFromSaved = !lexicalEquals(saved.lexical, scratch);
+        const divergedFromBaseline = !sameLexical(baseline, scratch);
+        const divergedFromSaved = !sameLexical(saved.lexical, scratch);
         if (divergedFromBaseline && divergedFromSaved) {
           reasons.push({
             code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
@@ -179,18 +201,16 @@ export function createChangeTracker(): ChangeTracker {
   }
 
   return {
+    // Query data (load, refetch) goes through setSaved and never moves the
+    // baseline; mutation responses go through saveAcknowledged, which does.
     setSaved(next) {
-      if (saved) {
-        baseline = next.lexical;
-      }
-      saved = next;
+      adoptSaved(next);
+    },
+
+    saveAcknowledged(next) {
+      adoptSaved(next);
+      baseline = next.lexical;
       saveError = null;
-      live = {
-        title: live.title ?? next.title,
-        lexical: live.lexical === undefined ? next.lexical : live.lexical,
-        tags: live.tags ?? next.tags,
-        attributes: live.attributes ?? next.attributes,
-      };
     },
 
     setBaseline(lexical) {
@@ -220,21 +240,21 @@ export function createChangeTracker(): ChangeTracker {
       live = { ...live, lexical: restored };
     },
 
-    verdict(options = {}) {
+    verdict({ includeDiff = false } = {}) {
       const reasons = collectReasons();
       const result: ChangeVerdict = { dirty: reasons.length > 0, reasons };
 
-      if (
-        options.includeDiff &&
-        reasons.some((r) => r.code === 'SCRATCH_DIVERGED_FROM_SECONDARY')
-      ) {
-        result.diff = humanizeLexicalDiff(baseline, live.lexical);
+      if (includeDiff && reasons.some((r) => r.code === 'SCRATCH_DIVERGED_FROM_SECONDARY')) {
+        result.diff = humanizeLexicalDiff(
+          stripSiteUrl(baseline ?? '', siteUrl),
+          stripSiteUrl(live.lexical ?? '', siteUrl),
+        );
       }
 
       return result;
     },
 
-    hasChangedSinceRevision(latestRevisionLexical, siteUrl) {
+    hasChangedSinceRevision(latestRevisionLexical, revisionSiteUrl = siteUrl) {
       if (!saved) {
         return false;
       }
@@ -245,7 +265,8 @@ export function createChangeTracker(): ChangeTracker {
         return false;
       }
       return (
-        stripSiteUrl(saved.lexical ?? '', siteUrl) !== stripSiteUrl(latestRevisionLexical, siteUrl)
+        stripSiteUrl(saved.lexical ?? '', revisionSiteUrl) !==
+        stripSiteUrl(latestRevisionLexical, revisionSiteUrl)
       );
     },
 

--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -1,0 +1,242 @@
+import { dequal } from 'dequal';
+import {
+  humanizeLexicalDiff,
+  lexicalEquals,
+  stripSiteUrl,
+  type HumanizedDiffEntry,
+  type LexicalInput,
+} from '@/editor/engine/lexical-compare';
+
+// Codes are reported to Sentry when the leave modal opens; keep them stable.
+export type ChangeReasonCode =
+  | 'POST_HAS_ERROR'
+  | 'POST_TAGS_DIVERGED'
+  | 'POST_TITLE_DIVERGED'
+  | 'SCRATCH_DIVERGED_FROM_SECONDARY'
+  | 'NEW_POST_HAS_CHANGED_ATTRIBUTES'
+  | 'POST_HAS_DIRTY_ATTRIBUTES';
+
+export interface ChangeReason {
+  code: ChangeReasonCode;
+  reason: string;
+  context: Record<string, unknown>;
+}
+
+export interface ChangeVerdict {
+  dirty: boolean;
+  reasons: ChangeReason[];
+  diff?: HumanizedDiffEntry[];
+}
+
+export interface PostTagLike {
+  name: string;
+}
+
+export type PostAttributes = Record<string, unknown>;
+
+export interface SavedPostState {
+  isNew: boolean;
+  title: string;
+  lexical: string | null;
+  tags: ReadonlyArray<PostTagLike>;
+  attributes?: PostAttributes;
+}
+
+export interface LivePostState {
+  title?: string;
+  lexical?: string | null;
+  tags?: ReadonlyArray<PostTagLike>;
+  attributes?: PostAttributes;
+}
+
+export interface VerdictOptions {
+  includeDiff?: boolean;
+}
+
+export interface ChangeTracker {
+  setSaved(saved: SavedPostState): void;
+  setBaseline(lexical: LexicalInput): void;
+  setLive(live: LivePostState): void;
+  markSaveError(messages?: unknown): void;
+  clearSaveError(): void;
+  revisionRestored(lexical: LexicalInput): void;
+  verdict(options?: VerdictOptions): ChangeVerdict;
+  hasChangedSinceRevision(
+    latestRevisionLexical: string | null | undefined,
+    siteUrl: string,
+  ): boolean;
+  reset(): void;
+}
+
+interface SaveError {
+  messages: unknown;
+}
+
+function tagNames(tags: ReadonlyArray<PostTagLike> | undefined): string {
+  return (tags ?? []).map((tag) => tag.name).join(', ');
+}
+
+function serializeLexical(lexical: LexicalInput): string | null {
+  if (lexical === null || lexical === undefined) {
+    return null;
+  }
+  return typeof lexical === 'string' ? lexical : JSON.stringify(lexical);
+}
+
+function changedAttributes(
+  saved: PostAttributes,
+  live: PostAttributes,
+): Record<string, [unknown, unknown]> {
+  const changed: Record<string, [unknown, unknown]> = {};
+  for (const key of new Set([...Object.keys(saved), ...Object.keys(live)])) {
+    if (!dequal(saved[key], live[key])) {
+      changed[key] = [saved[key], live[key]];
+    }
+  }
+  return changed;
+}
+
+export function createChangeTracker(): ChangeTracker {
+  let saved: SavedPostState | null = null;
+  let baseline: string | null = null;
+  let live: LivePostState = {};
+  let saveError: SaveError | null = null;
+
+  function collectReasons(): ChangeReason[] {
+    if (!saved) {
+      return [];
+    }
+
+    const reasons: ChangeReason[] = [];
+
+    if (saveError) {
+      reasons.push({
+        code: 'POST_HAS_ERROR',
+        reason: 'isError',
+        context: { messages: saveError.messages },
+      });
+    }
+
+    const currentTags = tagNames(live.tags);
+    const previousTags = tagNames(saved.tags);
+    if (currentTags !== previousTags) {
+      reasons.push({
+        code: 'POST_TAGS_DIVERGED',
+        reason: 'tags are different',
+        context: { currentTags, previousTags },
+      });
+    }
+
+    const scratchTitle = live.title ?? '';
+    if (scratchTitle.trim() !== saved.title.trim()) {
+      reasons.push({
+        code: 'POST_TITLE_DIVERGED',
+        reason: 'title is different',
+        context: { current: saved.title, scratch: scratchTitle },
+      });
+    }
+
+    const scratch = live.lexical ?? null;
+    if (saved.lexical && baseline && scratch) {
+      const divergedFromBaseline = !lexicalEquals(baseline, scratch);
+      const divergedFromSaved = !lexicalEquals(saved.lexical, scratch);
+      if (divergedFromBaseline && divergedFromSaved) {
+        reasons.push({
+          code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
+          reason: 'main editor content has diverged from both hidden editor and saved content',
+          context: { secondaryLexical: baseline, lexical: saved.lexical, scratch },
+        });
+      }
+    }
+
+    const changed = changedAttributes(saved.attributes ?? {}, live.attributes ?? {});
+    if (Object.keys(changed).length > 0) {
+      reasons.push(
+        saved.isNew
+          ? {
+              code: 'NEW_POST_HAS_CHANGED_ATTRIBUTES',
+              reason: 'post.changedAttributes.length > 0',
+              context: changed,
+            }
+          : {
+              code: 'POST_HAS_DIRTY_ATTRIBUTES',
+              reason: 'post.hasDirtyAttributes === true',
+              context: changed,
+            },
+      );
+    }
+
+    return reasons;
+  }
+
+  return {
+    setSaved(next) {
+      saved = next;
+      saveError = null;
+      live = {
+        title: live.title ?? next.title,
+        lexical: live.lexical === undefined ? next.lexical : live.lexical,
+        tags: live.tags ?? next.tags,
+        attributes: live.attributes ?? next.attributes,
+      };
+    },
+
+    setBaseline(lexical) {
+      baseline = serializeLexical(lexical);
+    },
+
+    setLive(next) {
+      live = { ...live, ...next };
+    },
+
+    markSaveError(messages) {
+      saveError = { messages };
+    },
+
+    clearSaveError() {
+      saveError = null;
+    },
+
+    revisionRestored(lexical) {
+      const restored = serializeLexical(lexical);
+      baseline = restored;
+      live = { ...live, lexical: restored };
+    },
+
+    verdict(options = {}) {
+      const reasons = collectReasons();
+      const result: ChangeVerdict = { dirty: reasons.length > 0, reasons };
+
+      if (
+        options.includeDiff &&
+        reasons.some((r) => r.code === 'SCRATCH_DIVERGED_FROM_SECONDARY')
+      ) {
+        result.diff = humanizeLexicalDiff(live.lexical, baseline);
+      }
+
+      return result;
+    },
+
+    hasChangedSinceRevision(latestRevisionLexical, siteUrl) {
+      if (!saved) {
+        return false;
+      }
+      if (latestRevisionLexical === null || latestRevisionLexical === undefined) {
+        return true;
+      }
+      if (saved.isNew) {
+        return false;
+      }
+      return (
+        stripSiteUrl(saved.lexical ?? '', siteUrl) !== stripSiteUrl(latestRevisionLexical, siteUrl)
+      );
+    },
+
+    reset() {
+      saved = null;
+      baseline = null;
+      live = {};
+      saveError = null;
+    },
+  };
+}

--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -2,7 +2,6 @@ import { dequal } from 'dequal';
 import {
   humanizeLexicalDiff,
   lexicalEquals,
-  stripSiteUrl,
   type HumanizedDiffEntry,
   type LexicalInput,
 } from '@/editor/engine/lexical-compare';
@@ -13,6 +12,8 @@ export type ChangeReasonCode =
   | 'POST_TAGS_DIVERGED'
   | 'POST_TITLE_DIVERGED'
   | 'SCRATCH_DIVERGED_FROM_SECONDARY'
+  | 'BASELINE_PENDING'
+  | 'BASELINE_FAILED'
   | 'LEXICAL_PARSE_FAILED'
   | 'NEW_POST_HAS_CHANGED_ATTRIBUTES'
   | 'POST_HAS_DIRTY_ATTRIBUTES';
@@ -29,25 +30,45 @@ export interface ChangeVerdict {
   diff?: HumanizedDiffEntry[];
 }
 
+/** null until the create request has been acknowledged. */
+export type PostId = string | null;
+
 export interface PostTagLike {
-  name: string;
+  name?: string;
 }
 
-export type PostAttributes = Record<string, unknown>;
-
-export interface SavedPostState {
-  isNew: boolean;
+// Client-owned editable fields only; other server metadata lives with the save engine.
+export interface EditablePostProjection {
   title: string;
+  slug: string;
   lexical: string | null;
   tags: ReadonlyArray<PostTagLike>;
-  attributes?: PostAttributes;
+  custom_excerpt: string | null;
+  feature_image: string | null;
+  feature_image_alt: string | null;
+  feature_image_caption: string | null;
+  /** Server collision token: carried and rebased, never a dirty signal. */
+  updated_at: string | null;
 }
 
-export interface LivePostState {
-  title?: string;
-  lexical?: string | null;
-  tags?: ReadonlyArray<PostTagLike>;
-  attributes?: PostAttributes;
+export type EditablePostPatch = Partial<EditablePostProjection>;
+
+export type RestoredRevision = Pick<
+  EditablePostProjection,
+  | 'lexical'
+  | 'title'
+  | 'custom_excerpt'
+  | 'feature_image'
+  | 'feature_image_alt'
+  | 'feature_image_caption'
+>;
+
+// The server's own revision projection (post-revisions.ts).
+export interface RevisionProjection {
+  lexical: string | null;
+  title: string;
+  custom_excerpt?: string | null;
+  feature_image?: string | null;
 }
 
 export interface VerdictOptions {
@@ -59,27 +80,85 @@ export interface ChangeTrackerOptions {
 }
 
 export interface ChangeTracker {
-  setSaved(saved: SavedPostState): void;
-  saveAcknowledged(saved: SavedPostState): void;
-  setBaseline(lexical: LexicalInput): void;
-  setLive(live: LivePostState): void;
+  load(postId: PostId, post: EditablePostProjection): void;
+  setSaved(postId: PostId, post: EditablePostProjection): void;
+  saveAcknowledged(
+    postId: PostId,
+    submitted: EditablePostPatch,
+    acknowledged: EditablePostProjection,
+  ): void;
+  setBaseline(postId: PostId, lexical: LexicalInput): void;
+  baselineFailed(postId: PostId, error: unknown): void;
+  setLive(postId: PostId, patch: EditablePostPatch): void;
   markSaveError(messages?: unknown): void;
   clearSaveError(): void;
-  revisionRestored(lexical: LexicalInput): void;
+  revisionRestored(postId: PostId, restored: RestoredRevision): void;
   verdict(options?: VerdictOptions): ChangeVerdict;
-  hasChangedSinceRevision(
-    latestRevisionLexical: string | null | undefined,
-    siteUrl?: string,
-  ): boolean;
-  reset(): void;
+  hasChangedSinceRevision(latestRevision: RevisionProjection | null | undefined): boolean;
+  dispose(): void;
 }
+
+type ProjectionKey = keyof EditablePostProjection;
+
+const PROJECTION_KEYS: ReadonlyArray<ProjectionKey> = [
+  'title',
+  'slug',
+  'lexical',
+  'tags',
+  'custom_excerpt',
+  'feature_image',
+  'feature_image_alt',
+  'feature_image_caption',
+  'updated_at',
+];
+
+const RUNG_KEYS: ReadonlySet<ProjectionKey> = new Set(['title', 'lexical', 'tags', 'updated_at']);
+
+type Baseline =
+  | { status: 'pending' }
+  | { status: 'ready'; lexical: string | null }
+  | { status: 'failed'; error: string };
 
 interface SaveError {
   messages: unknown;
 }
 
-function tagNames(tags: ReadonlyArray<PostTagLike> | undefined): string {
-  return (tags ?? []).map((tag) => tag.name).join(', ');
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function clonePlain<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(clonePlain) as T;
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, clonePlain(entry)]),
+    ) as T;
+  }
+  return value;
+}
+
+function pickProjection(post: EditablePostProjection): EditablePostProjection {
+  const out: Record<string, unknown> = {};
+  for (const key of PROJECTION_KEYS) {
+    out[key] = clonePlain(post[key]);
+  }
+  return out as unknown as EditablePostProjection;
+}
+
+function pickPatch(patch: EditablePostPatch): EditablePostPatch {
+  const out: Record<string, unknown> = {};
+  for (const key of PROJECTION_KEYS) {
+    if (key in patch && patch[key] !== undefined) {
+      out[key] = clonePlain(patch[key]);
+    }
+  }
+  return out;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function serializeLexical(lexical: LexicalInput): string | null {
@@ -89,44 +168,68 @@ function serializeLexical(lexical: LexicalInput): string | null {
   return typeof lexical === 'string' ? lexical : JSON.stringify(lexical);
 }
 
-function changedAttributes(
-  saved: PostAttributes,
-  live: PostAttributes,
-): Record<string, [unknown, unknown]> {
-  const changed: Record<string, [unknown, unknown]> = {};
-  for (const key of new Set([...Object.keys(saved), ...Object.keys(live)])) {
-    if (!dequal(saved[key], live[key])) {
-      changed[key] = [saved[key], live[key]];
-    }
+function tagNames(tags: ReadonlyArray<PostTagLike> | undefined): string[] {
+  return (tags ?? []).map((tag) => tag.name ?? '');
+}
+
+function isOlderToken(candidate: string | null, held: string | null): boolean {
+  if (candidate === null || held === null) {
+    return false;
   }
-  return changed;
+  const candidateTime = Date.parse(candidate);
+  const heldTime = Date.parse(held);
+  return !Number.isNaN(candidateTime) && !Number.isNaN(heldTime) && candidateTime < heldTime;
 }
 
 export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeTracker {
   const siteUrl = options.siteUrl ?? '';
-  let saved: SavedPostState | null = null;
-  let baseline: string | null = null;
-  let live: LivePostState = {};
+  let postId: PostId = null;
+  let saved: EditablePostProjection | null = null;
+  let live: EditablePostProjection | null = null;
+  let baseline: Baseline = { status: 'pending' };
   let saveError: SaveError | null = null;
+  let disposed = false;
 
-  // The server rewrites relative URLs to absolute on save, so both sides are
-  // compared with the site URL removed.
-  function sameLexical(a: string | null, b: string): boolean {
-    return lexicalEquals(stripSiteUrl(a ?? '', siteUrl), stripSiteUrl(b, siteUrl));
+  function sameLexical(a: string | null, b: string | null): boolean {
+    return lexicalEquals(a, b, siteUrl);
   }
 
-  function adoptSaved(next: SavedPostState) {
-    saved = next;
-    live = {
-      title: live.title ?? next.title,
-      lexical: live.lexical === undefined ? next.lexical : live.lexical,
-      tags: live.tags ?? next.tags,
-      attributes: live.attributes ?? next.attributes,
-    };
+  function sameField(key: ProjectionKey, a: unknown, b: unknown): boolean {
+    if (key === 'lexical') {
+      try {
+        return sameLexical(a as string | null, b as string | null);
+      } catch {
+        return false;
+      }
+    }
+    if (key === 'tags') {
+      return dequal(
+        tagNames(a as ReadonlyArray<PostTagLike>),
+        tagNames(b as ReadonlyArray<PostTagLike>),
+      );
+    }
+    return dequal(a, b);
+  }
+
+  function isCurrent(id: PostId): boolean {
+    return !disposed && saved !== null && id === postId;
+  }
+
+  function changedAttributes(): Record<string, [unknown, unknown]> {
+    const changed: Record<string, [unknown, unknown]> = {};
+    if (!saved || !live) {
+      return changed;
+    }
+    for (const key of PROJECTION_KEYS) {
+      if (!RUNG_KEYS.has(key) && !sameField(key, saved[key], live[key])) {
+        changed[key] = [saved[key], live[key]];
+      }
+    }
+    return changed;
   }
 
   function collectReasons(): ChangeReason[] {
-    if (!saved) {
+    if (!saved || !live) {
       return [];
     }
 
@@ -142,7 +245,7 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
 
     const currentTags = tagNames(live.tags);
     const previousTags = tagNames(saved.tags);
-    if (currentTags !== previousTags) {
+    if (!dequal(currentTags, previousTags)) {
       reasons.push({
         code: 'POST_TAGS_DIVERGED',
         reason: 'tags are different',
@@ -150,40 +253,51 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
       });
     }
 
-    const scratchTitle = live.title ?? '';
-    if (scratchTitle.trim() !== saved.title.trim()) {
+    if (live.title.trim() !== saved.title.trim()) {
       reasons.push({
         code: 'POST_TITLE_DIVERGED',
         reason: 'title is different',
-        context: { current: saved.title, scratch: scratchTitle },
+        context: { current: saved.title, scratch: live.title },
       });
     }
 
-    const scratch = live.lexical ?? null;
-    if (baseline && scratch) {
-      try {
-        const divergedFromBaseline = !sameLexical(baseline, scratch);
-        const divergedFromSaved = !sameLexical(saved.lexical, scratch);
-        if (divergedFromBaseline && divergedFromSaved) {
+    const scratch = live.lexical;
+    try {
+      if (!sameLexical(saved.lexical, scratch)) {
+        if (baseline.status === 'pending') {
+          reasons.push({
+            code: 'BASELINE_PENDING',
+            reason:
+              'main editor content has diverged from saved content before the hidden editor reported',
+            context: { lexical: saved.lexical, scratch },
+          });
+        } else if (baseline.status === 'failed') {
+          reasons.push({
+            code: 'BASELINE_FAILED',
+            reason:
+              'main editor content has diverged from saved content and the hidden editor failed',
+            context: { lexical: saved.lexical, scratch, error: baseline.error },
+          });
+        } else if (!sameLexical(baseline.lexical, scratch)) {
           reasons.push({
             code: 'SCRATCH_DIVERGED_FROM_SECONDARY',
             reason: 'main editor content has diverged from both hidden editor and saved content',
-            context: { secondaryLexical: baseline, lexical: saved.lexical, scratch },
+            context: { secondaryLexical: baseline.lexical, lexical: saved.lexical, scratch },
           });
         }
-      } catch (error) {
-        reasons.push({
-          code: 'LEXICAL_PARSE_FAILED',
-          reason: 'lexical state could not be parsed for comparison',
-          context: { error: error instanceof Error ? error.message : String(error) },
-        });
       }
+    } catch (error) {
+      reasons.push({
+        code: 'LEXICAL_PARSE_FAILED',
+        reason: 'lexical state could not be parsed for comparison',
+        context: { error: errorMessage(error) },
+      });
     }
 
-    const changed = changedAttributes(saved.attributes ?? {}, live.attributes ?? {});
+    const changed = changedAttributes();
     if (Object.keys(changed).length > 0) {
       reasons.push(
-        saved.isNew
+        postId === null
           ? {
               code: 'NEW_POST_HAS_CHANGED_ATTRIBUTES',
               reason: 'post.changedAttributes.length > 0',
@@ -201,79 +315,153 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
   }
 
   return {
-    // Query data (load, refetch) goes through setSaved and never moves the
-    // baseline; mutation responses go through saveAcknowledged, which does.
-    setSaved(next) {
-      adoptSaved(next);
-    },
-
-    saveAcknowledged(next) {
-      adoptSaved(next);
-      baseline = next.lexical;
+    load(id, post) {
+      if (disposed) {
+        return;
+      }
+      postId = id;
+      saved = pickProjection(post);
+      live = pickProjection(post);
+      baseline = { status: 'pending' };
       saveError = null;
     },
 
-    setBaseline(lexical) {
-      baseline = serializeLexical(lexical);
+    // Query data (load, refetch) never moves the baseline or the live state;
+    // a refetch older than the held collision token is stale and dropped.
+    setSaved(id, post) {
+      if (!isCurrent(id) || !saved || !live) {
+        return;
+      }
+      const next = pickProjection(post);
+      if (isOlderToken(next.updated_at, saved.updated_at)) {
+        return;
+      }
+      saved = next;
+      live = { ...live, updated_at: next.updated_at };
     },
 
-    setLive(next) {
-      const defined = Object.fromEntries(
-        Object.entries(next).filter(([, value]) => value !== undefined),
-      ) as LivePostState;
+    // Single-flight save engine with one coalescing pending slot: acknowledgements
+    // arrive in submit order, so no save-attempt id is needed here.
+    saveAcknowledged(id, submitted, acknowledged) {
+      if (disposed || !saved || !live || (postId !== null && id !== postId)) {
+        return;
+      }
+      const next = pickProjection(acknowledged);
+      const rebased: Record<string, unknown> = { ...live };
+      for (const key of PROJECTION_KEYS) {
+        const base = key in submitted ? submitted[key] : saved[key];
+        if (key === 'updated_at' || sameField(key, live[key], base)) {
+          rebased[key] = next[key];
+        }
+      }
+      postId = id;
+      saved = next;
+      live = rebased as unknown as EditablePostProjection;
+      baseline = { status: 'ready', lexical: next.lexical };
+      saveError = null;
+    },
+
+    setBaseline(id, lexical) {
+      if (!isCurrent(id)) {
+        return;
+      }
+      baseline = { status: 'ready', lexical: serializeLexical(lexical) };
+    },
+
+    baselineFailed(id, error) {
+      if (!isCurrent(id)) {
+        return;
+      }
+      baseline = { status: 'failed', error: errorMessage(error) };
+    },
+
+    setLive(id, patch) {
+      if (!isCurrent(id) || !live) {
+        return;
+      }
+      const defined = pickPatch(patch);
+      delete defined.updated_at;
       live = { ...live, ...defined };
     },
 
     markSaveError(messages) {
+      if (disposed) {
+        return;
+      }
       saveError = { messages };
     },
 
     clearSaveError() {
+      if (disposed) {
+        return;
+      }
       saveError = null;
     },
 
-    // Call only after the restore save is acknowledged: Ember updates the
-    // editors on success, so a failed restore never reaches the baseline.
-    revisionRestored(lexical) {
-      const restored = serializeLexical(lexical);
-      baseline = restored;
-      live = { ...live, lexical: restored };
+    // Call only after the restore save is acknowledged; a failed restore never reaches here.
+    revisionRestored(id, restored) {
+      if (!isCurrent(id) || !saved || !live) {
+        return;
+      }
+      const adopted = clonePlain({
+        lexical: restored.lexical,
+        title: restored.title,
+        custom_excerpt: restored.custom_excerpt,
+        feature_image: restored.feature_image,
+        feature_image_alt: restored.feature_image_alt,
+        feature_image_caption: restored.feature_image_caption,
+      });
+      saved = { ...saved, ...adopted };
+      live = { ...live, ...adopted };
+      baseline = { status: 'pending' };
+      saveError = null;
     },
 
     verdict({ includeDiff = false } = {}) {
       const reasons = collectReasons();
       const result: ChangeVerdict = { dirty: reasons.length > 0, reasons };
 
-      if (includeDiff && reasons.some((r) => r.code === 'SCRATCH_DIVERGED_FROM_SECONDARY')) {
-        result.diff = humanizeLexicalDiff(
-          stripSiteUrl(baseline ?? '', siteUrl),
-          stripSiteUrl(live.lexical ?? '', siteUrl),
-        );
+      if (
+        includeDiff &&
+        baseline.status === 'ready' &&
+        reasons.some((r) => r.code === 'SCRATCH_DIVERGED_FROM_SECONDARY')
+      ) {
+        result.diff = humanizeLexicalDiff(baseline.lexical, live?.lexical, siteUrl);
       }
 
       return result;
     },
 
-    hasChangedSinceRevision(latestRevisionLexical, revisionSiteUrl = siteUrl) {
-      if (!saved) {
+    hasChangedSinceRevision(latestRevision) {
+      if (disposed || !saved) {
         return false;
       }
-      if (latestRevisionLexical === null || latestRevisionLexical === undefined) {
+      if (!latestRevision) {
         return true;
       }
-      if (saved.isNew) {
+      if (postId === null) {
         return false;
       }
-      return (
-        stripSiteUrl(saved.lexical ?? '', revisionSiteUrl) !==
-        stripSiteUrl(latestRevisionLexical, revisionSiteUrl)
-      );
+      if (
+        saved.title !== latestRevision.title ||
+        saved.custom_excerpt !== (latestRevision.custom_excerpt ?? null) ||
+        saved.feature_image !== (latestRevision.feature_image ?? null)
+      ) {
+        return true;
+      }
+      try {
+        return !sameLexical(saved.lexical, latestRevision.lexical);
+      } catch {
+        return true;
+      }
     },
 
-    reset() {
+    dispose() {
+      disposed = true;
+      postId = null;
       saved = null;
-      baseline = null;
-      live = {};
+      live = null;
+      baseline = { status: 'pending' };
       saveError = null;
     },
   };

--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -184,6 +184,8 @@ function isOlderToken(candidate: string | null, held: string | null): boolean {
 export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeTracker {
   const siteUrl = options.siteUrl ?? '';
   let postId: PostId = null;
+  let idAdopted = false;
+  const heldIds = new Set<string>();
   let saved: EditablePostProjection | null = null;
   let live: EditablePostProjection | null = null;
   let baseline: Baseline = { status: 'pending' };
@@ -213,6 +215,11 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
 
   function isCurrent(id: PostId): boolean {
     return !disposed && saved !== null && id === postId;
+  }
+
+  // Editor-side events may still say null between a create ack and the caller learning the id.
+  function isCurrentOrAlias(id: PostId): boolean {
+    return isCurrent(id) || (id === null && idAdopted && !disposed && saved !== null);
   }
 
   function changedAttributes(): Record<string, [unknown, unknown]> {
@@ -320,6 +327,10 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
         return;
       }
       postId = id;
+      idAdopted = false;
+      if (id !== null) {
+        heldIds.add(id);
+      }
       saved = pickProjection(post);
       live = pickProjection(post);
       baseline = { status: 'pending' };
@@ -342,17 +353,26 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
 
     // Single-flight save engine with one coalescing pending slot: acknowledgements
     // arrive in submit order, so no save-attempt id is needed here.
+    // The save engine's post-generation fence is the primary guard against stale
+    // completions; a new post only refuses acks for ids this tracker has already held.
     saveAcknowledged(id, submitted, acknowledged) {
       if (disposed || !saved || !live || (postId !== null && id !== postId)) {
+        return;
+      }
+      if (postId === null && id !== null && heldIds.has(id)) {
         return;
       }
       const next = pickProjection(acknowledged);
       const rebased: Record<string, unknown> = { ...live };
       for (const key of PROJECTION_KEYS) {
-        const base = key in submitted ? submitted[key] : saved[key];
+        const base = submitted[key] !== undefined ? submitted[key] : saved[key];
         if (key === 'updated_at' || sameField(key, live[key], base)) {
           rebased[key] = next[key];
         }
+      }
+      if (postId === null && id !== null) {
+        idAdopted = true;
+        heldIds.add(id);
       }
       postId = id;
       saved = next;
@@ -362,21 +382,21 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
     },
 
     setBaseline(id, lexical) {
-      if (!isCurrent(id)) {
+      if (!isCurrentOrAlias(id)) {
         return;
       }
       baseline = { status: 'ready', lexical: serializeLexical(lexical) };
     },
 
     baselineFailed(id, error) {
-      if (!isCurrent(id)) {
+      if (!isCurrentOrAlias(id)) {
         return;
       }
       baseline = { status: 'failed', error: errorMessage(error) };
     },
 
     setLive(id, patch) {
-      if (!isCurrent(id) || !live) {
+      if (!isCurrentOrAlias(id) || !live) {
         return;
       }
       const defined = pickPatch(patch);
@@ -459,6 +479,8 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
     dispose() {
       disposed = true;
       postId = null;
+      idAdopted = false;
+      heldIds.clear();
       saved = null;
       live = null;
       baseline = { status: 'pending' };

--- a/apps/admin/src/editor/engine/lexical-compare.test.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import {
+  humanizeLexicalDiff,
+  lexicalEquals,
+  normalizeLexicalForCompare,
+  stripDirection,
+  stripSiteUrl,
+} from '@/editor/engine/lexical-compare';
+
+const textNode = (text: string) => ({
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  text,
+  type: 'extended-text',
+  version: 1,
+});
+
+const paragraph = (text: string, direction: string | null = null) => ({
+  children: [textNode(text)],
+  direction,
+  format: '',
+  indent: 0,
+  type: 'paragraph',
+  version: 1,
+});
+
+const doc = (children: unknown[], direction: string | null = null) => ({
+  root: { children, direction, format: '', indent: 0, type: 'root', version: 1 },
+});
+
+describe('stripDirection', () => {
+  it('removes direction from every nesting level', () => {
+    const input = {
+      direction: 'ltr',
+      children: [{ direction: 'ltr', children: [{ direction: null, text: 'x' }] }],
+    };
+
+    expect(stripDirection(input)).toEqual({ children: [{ children: [{ text: 'x' }] }] });
+  });
+
+  it('leaves primitives and arrays of primitives untouched', () => {
+    expect(stripDirection('a')).toBe('a');
+    expect(stripDirection([1, null, 'b'])).toEqual([1, null, 'b']);
+  });
+});
+
+describe('normalizeLexicalForCompare', () => {
+  it('accepts strings and objects and yields the same output', () => {
+    const asObject = doc([paragraph('Hello')]);
+
+    expect(normalizeLexicalForCompare(JSON.stringify(asObject))).toBe(
+      normalizeLexicalForCompare(asObject),
+    );
+  });
+
+  it('is independent of key order', () => {
+    const a = JSON.stringify(doc([paragraph('Hello')]));
+    const b = JSON.stringify({
+      root: {
+        version: 1,
+        type: 'root',
+        indent: 0,
+        format: '',
+        direction: null,
+        children: [
+          {
+            version: 1,
+            type: 'paragraph',
+            indent: 0,
+            format: '',
+            direction: null,
+            children: [{ ...textNode('Hello') }],
+          },
+        ],
+      },
+    });
+
+    expect(normalizeLexicalForCompare(a)).toBe(normalizeLexicalForCompare(b));
+  });
+
+  it('treats null, undefined, empty string and a childless root alike', () => {
+    expect(normalizeLexicalForCompare(null)).toBe('[]');
+    expect(normalizeLexicalForCompare(undefined)).toBe('[]');
+    expect(normalizeLexicalForCompare('')).toBe('[]');
+    expect(normalizeLexicalForCompare(doc([]))).toBe('[]');
+  });
+});
+
+describe('lexicalEquals', () => {
+  it('ignores direction differences at the root and at depth', () => {
+    const nullDirections = doc([
+      paragraph('Hello'),
+      {
+        children: [{ ...paragraph('Nested'), type: 'listitem', value: 1 }],
+        direction: null,
+        format: '',
+        indent: 0,
+        type: 'list',
+        version: 1,
+        listType: 'bullet',
+        start: 1,
+        tag: 'ul',
+      },
+    ]);
+    const ltrDirections = doc(
+      [
+        paragraph('Hello', 'ltr'),
+        {
+          children: [{ ...paragraph('Nested', 'ltr'), type: 'listitem', value: 1 }],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          type: 'list',
+          version: 1,
+          listType: 'bullet',
+          start: 1,
+          tag: 'ul',
+        },
+      ],
+      'ltr',
+    );
+
+    expect(lexicalEquals(nullDirections, ltrDirections)).toBe(true);
+  });
+
+  it('detects text edits', () => {
+    expect(lexicalEquals(doc([paragraph('Hello')]), doc([paragraph('Hello!')]))).toBe(false);
+  });
+
+  it('detects added and removed blocks', () => {
+    expect(lexicalEquals(doc([paragraph('A')]), doc([paragraph('A'), paragraph('B')]))).toBe(false);
+  });
+});
+
+describe('stripSiteUrl', () => {
+  it('removes every occurrence of the site URL', () => {
+    expect(
+      stripSiteUrl('a https://site.example/x b https://site.example/y', 'https://site.example'),
+    ).toBe('a /x b /y');
+  });
+
+  it('returns the input unchanged for an empty site URL', () => {
+    expect(stripSiteUrl('https://site.example/x', '')).toBe('https://site.example/x');
+  });
+});
+
+describe('humanizeLexicalDiff', () => {
+  it('annotates numeric path segments with the node type from the source document', () => {
+    const from = doc([paragraph('Hello')]);
+    const to = doc([paragraph('Hello world')]);
+
+    expect(humanizeLexicalDiff(from, to)).toEqual([
+      {
+        type: 'CHANGE',
+        path: 'root.children.0[paragraph].children.0[extended-text].text',
+        value: 'Hello world',
+        oldValue: 'Hello',
+      },
+    ]);
+  });
+
+  it('reports added blocks with a CREATE entry and removed blocks with a REMOVE entry', () => {
+    const one = doc([paragraph('A')]);
+    const two = doc([paragraph('A'), paragraph('B')]);
+
+    expect(humanizeLexicalDiff(one, two)).toEqual([
+      { type: 'CREATE', path: 'root.children.1', value: stripDirection(paragraph('B')) },
+    ]);
+    expect(humanizeLexicalDiff(two, one)).toEqual([
+      {
+        type: 'REMOVE',
+        path: 'root.children.1[paragraph]',
+        oldValue: stripDirection(paragraph('B')),
+      },
+    ]);
+  });
+
+  it('ignores direction-only differences', () => {
+    expect(humanizeLexicalDiff(doc([paragraph('A')]), doc([paragraph('A', 'ltr')], 'ltr'))).toEqual(
+      [],
+    );
+  });
+
+  it('accepts serialized strings and missing documents', () => {
+    expect(humanizeLexicalDiff(JSON.stringify(doc([paragraph('A')])), null)).toEqual([
+      { type: 'REMOVE', path: 'root', oldValue: stripDirection(doc([paragraph('A')]).root) },
+    ]);
+  });
+});

--- a/apps/admin/src/editor/engine/lexical-compare.test.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.test.ts
@@ -31,13 +31,21 @@ const doc = (children: unknown[], direction: string | null = null) => ({
 });
 
 describe('stripDirection', () => {
-  it('removes direction from every nesting level', () => {
+  it('removes direction from element nodes at every nesting level', () => {
     const input = {
       direction: 'ltr',
       children: [{ direction: 'ltr', children: [{ direction: null, text: 'x' }] }],
     };
 
-    expect(stripDirection(input)).toEqual({ children: [{ children: [{ text: 'x' }] }] });
+    expect(stripDirection(input)).toEqual({
+      children: [{ children: [{ direction: null, text: 'x' }] }],
+    });
+  });
+
+  it('does not reach into card payloads', () => {
+    const card = { type: 'html', html: '<p>x</p>', visibility: { direction: 'keep' } };
+
+    expect(stripDirection({ children: [card] })).toEqual({ children: [card] });
   });
 
   it('leaves primitives and arrays of primitives untouched', () => {
@@ -186,6 +194,9 @@ describe('humanizeLexicalDiff', () => {
   it('accepts serialized strings and missing documents', () => {
     expect(humanizeLexicalDiff(JSON.stringify(doc([paragraph('A')])), null)).toEqual([
       { type: 'REMOVE', path: 'root', oldValue: stripDirection(doc([paragraph('A')]).root) },
+    ]);
+    expect(humanizeLexicalDiff(null, doc([paragraph('A')]))).toEqual([
+      { type: 'CREATE', path: 'root', value: stripDirection(doc([paragraph('A')]).root) },
     ]);
   });
 });

--- a/apps/admin/src/editor/engine/lexical-compare.test.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.test.ts
@@ -288,13 +288,19 @@ describe('normalizeSiteUrls', () => {
   it('keeps the subdirectory of a subdirectory install and ignores paths outside it', () => {
     const nodes = [
       { type: 'link', url: 'https://site.example/blog/about/', children: [] },
+      { type: 'link', url: 'https://site.example/blog', children: [] },
       { type: 'link', url: 'https://site.example/other/', children: [] },
+      { type: 'link', url: 'https://site.example/blogger/x', children: [] },
     ];
 
-    expect(normalizeSiteUrls(nodes, 'https://site.example/blog')).toEqual([
-      { type: 'link', url: '/blog/about/', children: [] },
-      { type: 'link', url: 'https://site.example/other/', children: [] },
-    ]);
+    for (const subdirectorySite of ['https://site.example/blog', 'https://site.example/blog/']) {
+      expect(normalizeSiteUrls(nodes, subdirectorySite)).toEqual([
+        { type: 'link', url: '/blog/about/', children: [] },
+        { type: 'link', url: '/blog', children: [] },
+        { type: 'link', url: 'https://site.example/other/', children: [] },
+        { type: 'link', url: 'https://site.example/blogger/x', children: [] },
+      ]);
+    }
   });
 
   it('returns the input untouched without a valid site url', () => {

--- a/apps/admin/src/editor/engine/lexical-compare.test.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   humanizeLexicalDiff,
   lexicalEquals,
+  LexicalParseError,
   normalizeLexicalForCompare,
+  normalizeSiteUrls,
+  parseLexical,
   stripDirection,
-  stripSiteUrl,
 } from '@/editor/engine/lexical-compare';
 
 const textNode = (text: string) => ({
@@ -142,15 +144,160 @@ describe('lexicalEquals', () => {
   });
 });
 
-describe('stripSiteUrl', () => {
-  it('removes every occurrence of the site URL', () => {
-    expect(
-      stripSiteUrl('a https://site.example/x b https://site.example/y', 'https://site.example'),
-    ).toBe('a /x b /y');
+describe('parseLexical', () => {
+  it('treats null, undefined and an empty string as a known empty document', () => {
+    expect(parseLexical(null)).toBeNull();
+    expect(parseLexical(undefined)).toBeNull();
+    expect(parseLexical('')).toBeNull();
   });
 
-  it('returns the input unchanged for an empty site URL', () => {
-    expect(stripSiteUrl('https://site.example/x', '')).toBe('https://site.example/x');
+  it('accepts a serialized or parsed document with a children array', () => {
+    expect(parseLexical(doc([]))).toEqual(doc([]));
+    expect(parseLexical(JSON.stringify(doc([])))).toEqual(doc([]));
+  });
+
+  it('throws a typed error for invalid JSON', () => {
+    expect(() => parseLexical('{not json')).toThrow(LexicalParseError);
+  });
+
+  it.each(['{}', '{"root":{}}', '{"root":{"children":"invalid"}}', '[]', 'null', '"x"'])(
+    'throws a typed error for the structurally invalid document %s',
+    (invalid) => {
+      expect(() => parseLexical(invalid)).toThrow(LexicalParseError);
+      expect(() => lexicalEquals(invalid, doc([]))).toThrow(LexicalParseError);
+      expect(() => lexicalEquals(doc([]), invalid)).toThrow(LexicalParseError);
+      expect(() => humanizeLexicalDiff(invalid, doc([]))).toThrow(LexicalParseError);
+    },
+  );
+
+  it('rejects a parsed object without a children array', () => {
+    expect(() => parseLexical({ root: { children: 'invalid' } })).toThrow(
+      'lexical root must be an object with a children array',
+    );
+  });
+});
+
+describe('normalizeSiteUrls', () => {
+  const siteUrl = 'https://site.example';
+
+  it('rewrites link node urls to the site-relative form', () => {
+    const link = { type: 'link', url: `${siteUrl}/about/?q=1#top`, children: [] };
+
+    expect(normalizeSiteUrls([link], siteUrl)).toEqual([
+      { type: 'link', url: '/about/?q=1#top', children: [] },
+    ]);
+  });
+
+  it('rewrites only the url-typed properties of cards', () => {
+    const cards = [
+      {
+        type: 'image',
+        src: `${siteUrl}/a.jpg`,
+        href: `${siteUrl}/about/`,
+        caption: `See ${siteUrl}/about/`,
+      },
+      {
+        type: 'bookmark',
+        url: `${siteUrl}/post/`,
+        metadata: {
+          icon: `${siteUrl}/icon.png`,
+          thumbnail: `${siteUrl}/thumb.png`,
+          title: siteUrl,
+        },
+      },
+      {
+        type: 'gallery',
+        images: [{ src: `${siteUrl}/g.jpg`, caption: siteUrl }],
+        caption: siteUrl,
+      },
+      { type: 'html', html: `<a href="${siteUrl}/about/">x</a>` },
+      { type: 'markdown', markdown: `[x](${siteUrl}/about/)` },
+      { type: 'call-to-action', buttonUrl: `${siteUrl}/about/` },
+    ];
+
+    expect(normalizeSiteUrls(cards, siteUrl)).toEqual([
+      { type: 'image', src: '/a.jpg', href: '/about/', caption: `See ${siteUrl}/about/` },
+      {
+        type: 'bookmark',
+        url: '/post/',
+        metadata: { icon: '/icon.png', thumbnail: '/thumb.png', title: siteUrl },
+      },
+      { type: 'gallery', images: [{ src: '/g.jpg', caption: siteUrl }], caption: siteUrl },
+      { type: 'html', html: `<a href="${siteUrl}/about/">x</a>` },
+      { type: 'markdown', markdown: `[x](${siteUrl}/about/)` },
+      { type: 'call-to-action', buttonUrl: `${siteUrl}/about/` },
+    ]);
+  });
+
+  it('never rewrites text', () => {
+    const nodes = [paragraph(`Read ${siteUrl}`)];
+
+    expect(normalizeSiteUrls(nodes, siteUrl)).toEqual(nodes);
+  });
+
+  it('descends into element children', () => {
+    const nodes = [
+      { ...paragraph('x'), children: [{ type: 'link', url: `${siteUrl}/a/`, children: [] }] },
+    ];
+
+    expect(normalizeSiteUrls(nodes, siteUrl)).toEqual([
+      { ...paragraph('x'), children: [{ type: 'link', url: '/a/', children: [] }] },
+    ]);
+  });
+
+  it('leaves other hosts, relative urls and non-http urls alone', () => {
+    const nodes = [
+      { type: 'link', url: 'https://other.example/about/', children: [] },
+      { type: 'link', url: '/about/', children: [] },
+      { type: 'link', url: 'mailto:hi@site.example', children: [] },
+      { type: 'link', url: 'https://site.example.evil/', children: [] },
+    ];
+
+    expect(normalizeSiteUrls(nodes, siteUrl)).toEqual(nodes);
+  });
+
+  it('ignores the protocol and tolerates a trailing slash on the site url', () => {
+    const nodes = [{ type: 'link', url: 'http://site.example/about/', children: [] }];
+
+    expect(normalizeSiteUrls(nodes, 'https://site.example/')).toEqual([
+      { type: 'link', url: '/about/', children: [] },
+    ]);
+  });
+
+  it('keeps the subdirectory of a subdirectory install and ignores paths outside it', () => {
+    const nodes = [
+      { type: 'link', url: 'https://site.example/blog/about/', children: [] },
+      { type: 'link', url: 'https://site.example/other/', children: [] },
+    ];
+
+    expect(normalizeSiteUrls(nodes, 'https://site.example/blog')).toEqual([
+      { type: 'link', url: '/blog/about/', children: [] },
+      { type: 'link', url: 'https://site.example/other/', children: [] },
+    ]);
+  });
+
+  it('returns the input untouched without a valid site url', () => {
+    const nodes = [{ type: 'link', url: `${siteUrl}/about/`, children: [] }];
+
+    expect(normalizeSiteUrls(nodes, '')).toBe(nodes);
+    expect(normalizeSiteUrls(nodes, 'not a url')).toBe(nodes);
+  });
+
+  it('does not mutate the input', () => {
+    const nodes = [{ type: 'image', src: `${siteUrl}/a.jpg` }];
+    normalizeSiteUrls(nodes, siteUrl);
+
+    expect(nodes[0]?.src).toBe(`${siteUrl}/a.jpg`);
+  });
+});
+
+describe('lexicalEquals with a site url', () => {
+  it('treats absolute and relative site urls as equal', () => {
+    const absolute = doc([{ type: 'image', version: 1, src: 'https://site.example/a.jpg' }]);
+    const relative = doc([{ type: 'image', version: 1, src: '/a.jpg' }]);
+
+    expect(lexicalEquals(absolute, relative, 'https://site.example')).toBe(true);
+    expect(lexicalEquals(absolute, relative)).toBe(false);
   });
 });
 

--- a/apps/admin/src/editor/engine/lexical-compare.test.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.test.ts
@@ -256,6 +256,27 @@ describe('normalizeSiteUrls', () => {
     expect(normalizeSiteUrls(nodes, siteUrl)).toEqual(nodes);
   });
 
+  it('resolves protocol-relative urls against the site protocol', () => {
+    const nodes = [
+      { type: 'link', url: '//site.example/about/', children: [] },
+      { type: 'link', url: '//other.example/about/', children: [] },
+    ];
+
+    expect(normalizeSiteUrls(nodes, siteUrl)).toEqual([
+      { type: 'link', url: '/about/', children: [] },
+      { type: 'link', url: '//other.example/about/', children: [] },
+    ]);
+  });
+
+  it('leaves urls carrying credentials alone', () => {
+    const nodes = [
+      { type: 'link', url: 'https://user:pw@site.example/x', children: [] },
+      { type: 'link', url: 'https://other:pw@site.example/x', children: [] },
+    ];
+
+    expect(normalizeSiteUrls(nodes, siteUrl)).toEqual(nodes);
+  });
+
   it('ignores the protocol and tolerates a trailing slash on the site url', () => {
     const nodes = [{ type: 'link', url: 'http://site.example/about/', children: [] }];
 

--- a/apps/admin/src/editor/engine/lexical-compare.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.ts
@@ -1,0 +1,125 @@
+import microdiff from 'microdiff';
+
+export type LexicalDocument = Record<string, unknown>;
+export type LexicalInput = string | LexicalDocument | null | undefined;
+
+export interface HumanizedDiffEntry {
+  type: 'CREATE' | 'REMOVE' | 'CHANGE';
+  path: string;
+  value?: unknown;
+  oldValue?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseLexical(input: LexicalInput): LexicalDocument | null {
+  if (input === null || input === undefined || input === '') {
+    return null;
+  }
+  if (typeof input === 'string') {
+    const parsed: unknown = JSON.parse(input);
+    return isRecord(parsed) ? parsed : null;
+  }
+  return input;
+}
+
+// Lexical's reconciler infers `direction` from rendered text at mount time, so
+// it differs between a mounted editor, a headless parse, and the saved JSON.
+export function stripDirection(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripDirection);
+  }
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      if (key === 'direction') {
+        continue;
+      }
+      out[key] = stripDirection(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    const keys = Object.keys(value).sort();
+    const entries = keys
+      .filter((key) => value[key] !== undefined)
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function rootChildren(document: LexicalDocument | null): unknown[] {
+  const root = document?.root;
+  if (!isRecord(root) || !Array.isArray(root.children)) {
+    return [];
+  }
+  return root.children;
+}
+
+export function normalizeLexicalForCompare(input: LexicalInput): string {
+  return stableStringify(stripDirection(rootChildren(parseLexical(input))));
+}
+
+export function lexicalEquals(a: LexicalInput, b: LexicalInput): boolean {
+  return normalizeLexicalForCompare(a) === normalizeLexicalForCompare(b);
+}
+
+export function stripSiteUrl(lexical: string, siteUrl: string): string {
+  return siteUrl ? lexical.replaceAll(siteUrl, '') : lexical;
+}
+
+function nodeAt(document: unknown, path: ReadonlyArray<string | number>): unknown {
+  let current: unknown = document;
+  for (const segment of path) {
+    if (Array.isArray(current)) {
+      current = current[Number(segment)];
+    } else if (isRecord(current)) {
+      current = current[String(segment)];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function humanizePath(path: ReadonlyArray<string | number>, document: unknown): string {
+  return path
+    .map((segment, index) => {
+      if (typeof segment !== 'number') {
+        return segment;
+      }
+      const node = nodeAt(document, path.slice(0, index + 1));
+      const type = isRecord(node) ? node.type : undefined;
+      return typeof type === 'string' ? `${segment}[${type}]` : String(segment);
+    })
+    .join('.');
+}
+
+export function humanizeLexicalDiff(from: LexicalInput, to: LexicalInput): HumanizedDiffEntry[] {
+  const fromDocument = stripDirection(parseLexical(from) ?? {}) as LexicalDocument;
+  const toDocument = stripDirection(parseLexical(to) ?? {}) as LexicalDocument;
+
+  return microdiff(fromDocument, toDocument, { cyclesFix: false }).map((change) => {
+    const entry: HumanizedDiffEntry = {
+      type: change.type,
+      path: humanizePath(change.path, fromDocument),
+    };
+    if ('value' in change) {
+      entry.value = change.value;
+    }
+    if ('oldValue' in change) {
+      entry.oldValue = change.oldValue;
+    }
+    return entry;
+  });
+}

--- a/apps/admin/src/editor/engine/lexical-compare.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.ts
@@ -90,19 +90,22 @@ function parseSiteUrl(siteUrl: string): URL | null {
   }
 }
 
-// Same rule as url-utils' absoluteToRelative: host match (protocol ignored) and
-// a path under the site's subdirectory; the subdirectory is kept in the result.
+// Same rule as url-utils' absoluteToRelative: host match (protocol ignored), a path
+// under the site's subdirectory (kept in the result), and userinfo URLs left alone.
 function toSiteRelative(value: string, site: URL): string {
   let parsed: URL;
   try {
-    parsed = new URL(value);
+    parsed = new URL(value.startsWith('//') ? `${site.protocol}${value}` : value);
   } catch {
+    return value;
+  }
+  if (parsed.username || parsed.password) {
     return value;
   }
   if (parsed.host !== site.host || !parsed.pathname.startsWith(site.pathname)) {
     return value;
   }
-  return parsed.href.slice(parsed.origin.length);
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 }
 
 function updateAt(

--- a/apps/admin/src/editor/engine/lexical-compare.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.ts
@@ -25,19 +25,19 @@ export function parseLexical(input: LexicalInput): LexicalDocument | null {
   return input;
 }
 
-// Lexical's reconciler infers `direction` from rendered text at mount time, so
-// it differs between a mounted editor, a headless parse, and the saved JSON.
+// Lexical's reconciler infers element `direction` from rendered text at mount
+// time, so it differs between a mounted editor, a headless parse, and saved JSON.
 export function stripDirection(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stripDirection);
   }
-  if (isRecord(value)) {
+  if (isRecord(value) && Array.isArray(value.children)) {
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(value)) {
       if (key === 'direction') {
         continue;
       }
-      out[key] = stripDirection(value[key]);
+      out[key] = key === 'children' ? stripDirection(value.children) : value[key];
     }
     return out;
   }
@@ -105,9 +105,19 @@ function humanizePath(path: ReadonlyArray<string | number>, document: unknown): 
     .join('.');
 }
 
+function stripDocumentDirection(input: LexicalInput): LexicalDocument {
+  const document = parseLexical(input);
+  if (!document) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(document).map(([key, value]) => [key, stripDirection(value)]),
+  );
+}
+
 export function humanizeLexicalDiff(from: LexicalInput, to: LexicalInput): HumanizedDiffEntry[] {
-  const fromDocument = stripDirection(parseLexical(from) ?? {}) as LexicalDocument;
-  const toDocument = stripDirection(parseLexical(to) ?? {}) as LexicalDocument;
+  const fromDocument = stripDocumentDirection(from);
+  const toDocument = stripDocumentDirection(to);
 
   return microdiff(fromDocument, toDocument, { cyclesFix: false }).map((change) => {
     const entry: HumanizedDiffEntry = {

--- a/apps/admin/src/editor/engine/lexical-compare.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.ts
@@ -10,19 +10,36 @@ export interface HumanizedDiffEntry {
   oldValue?: unknown;
 }
 
+export class LexicalParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'LexicalParseError';
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+// null, undefined and '' are a known-empty document; anything else must carry
+// an object root with a children array or it is invalid, never empty.
 export function parseLexical(input: LexicalInput): LexicalDocument | null {
   if (input === null || input === undefined || input === '') {
     return null;
   }
+  let parsed: unknown = input;
   if (typeof input === 'string') {
-    const parsed: unknown = JSON.parse(input);
-    return isRecord(parsed) ? parsed : null;
+    try {
+      parsed = JSON.parse(input);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : 'invalid JSON';
+      throw new LexicalParseError(message, { cause });
+    }
   }
-  return input;
+  if (!isRecord(parsed) || !isRecord(parsed.root) || !Array.isArray(parsed.root.children)) {
+    throw new LexicalParseError('lexical root must be an object with a children array');
+  }
+  return parsed;
 }
 
 // Lexical's reconciler infers element `direction` from rendered text at mount
@@ -44,6 +61,111 @@ export function stripDirection(value: unknown): unknown {
   return value;
 }
 
+type UrlField = 'url' | Record<string, 'url'>;
+
+// Mirrors kg-default-nodes' urlTransformMap (the properties the server rewrites
+// on save), url-typed entries only; html/markdown/caption fields stay opaque.
+const CARD_URL_FIELDS: Record<string, Record<string, UrlField>> = {
+  audio: { src: 'url' },
+  bookmark: { url: 'url', 'metadata.icon': 'url', 'metadata.thumbnail': 'url' },
+  button: { buttonUrl: 'url' },
+  'email-cta': { buttonUrl: 'url' },
+  embed: { url: 'url' },
+  file: { src: 'url' },
+  gallery: { images: { src: 'url' } },
+  header: { buttonUrl: 'url', backgroundImageSrc: 'url' },
+  image: { src: 'url', href: 'url' },
+  product: { productImageSrc: 'url' },
+  video: { src: 'url', thumbnailSrc: 'url', customThumbnailSrc: 'url' },
+};
+
+function parseSiteUrl(siteUrl: string): URL | null {
+  if (!siteUrl) {
+    return null;
+  }
+  try {
+    return new URL(siteUrl);
+  } catch {
+    return null;
+  }
+}
+
+// Same rule as url-utils' absoluteToRelative: host match (protocol ignored) and
+// a path under the site's subdirectory; the subdirectory is kept in the result.
+function toSiteRelative(value: string, site: URL): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return value;
+  }
+  if (parsed.host !== site.host || !parsed.pathname.startsWith(site.pathname)) {
+    return value;
+  }
+  return parsed.href.slice(parsed.origin.length);
+}
+
+function updateAt(
+  record: Record<string, unknown>,
+  [head, ...rest]: string[],
+  update: (value: unknown) => unknown,
+): Record<string, unknown> {
+  if (head === undefined || !(head in record)) {
+    return record;
+  }
+  const current = record[head];
+  if (rest.length === 0) {
+    return { ...record, [head]: update(current) };
+  }
+  return isRecord(current) ? { ...record, [head]: updateAt(current, rest, update) } : record;
+}
+
+function normalizeUrlField(value: unknown, field: UrlField, site: URL): unknown {
+  if (field === 'url') {
+    return typeof value === 'string' ? toSiteRelative(value, site) : value;
+  }
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const items: unknown[] = value;
+  return items.map((item) => (isRecord(item) ? normalizeUrlFields(item, field, site) : item));
+}
+
+function normalizeUrlFields(
+  node: Record<string, unknown>,
+  fields: Record<string, UrlField>,
+  site: URL,
+): Record<string, unknown> {
+  let out = node;
+  for (const [path, field] of Object.entries(fields)) {
+    out = updateAt(out, path.split('.'), (value) => normalizeUrlField(value, field, site));
+  }
+  return out;
+}
+
+function normalizeNodeUrls(value: unknown, site: URL): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeNodeUrls(item, site));
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  const fields = typeof value.type === 'string' ? CARD_URL_FIELDS[value.type] : undefined;
+  let out = fields ? normalizeUrlFields(value, fields, site) : value;
+  if (!fields && typeof value.url === 'string') {
+    out = { ...out, url: toSiteRelative(value.url, site) };
+  }
+  if (Array.isArray(value.children)) {
+    out = { ...out, children: normalizeNodeUrls(value.children, site) };
+  }
+  return out;
+}
+
+export function normalizeSiteUrls(children: unknown[], siteUrl: string): unknown[] {
+  const site = parseSiteUrl(siteUrl);
+  return site ? (normalizeNodeUrls(children, site) as unknown[]) : children;
+}
+
 function stableStringify(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map(stableStringify).join(',')}]`;
@@ -60,22 +182,19 @@ function stableStringify(value: unknown): string {
 
 function rootChildren(document: LexicalDocument | null): unknown[] {
   const root = document?.root;
-  if (!isRecord(root) || !Array.isArray(root.children)) {
-    return [];
-  }
-  return root.children;
+  return isRecord(root) && Array.isArray(root.children) ? root.children : [];
 }
 
-export function normalizeLexicalForCompare(input: LexicalInput): string {
-  return stableStringify(stripDirection(rootChildren(parseLexical(input))));
+function comparableChildren(input: LexicalInput, siteUrl: string): unknown {
+  return stripDirection(normalizeSiteUrls(rootChildren(parseLexical(input)), siteUrl));
 }
 
-export function lexicalEquals(a: LexicalInput, b: LexicalInput): boolean {
-  return normalizeLexicalForCompare(a) === normalizeLexicalForCompare(b);
+export function normalizeLexicalForCompare(input: LexicalInput, siteUrl = ''): string {
+  return stableStringify(comparableChildren(input, siteUrl));
 }
 
-export function stripSiteUrl(lexical: string, siteUrl: string): string {
-  return siteUrl ? lexical.replaceAll(siteUrl, '') : lexical;
+export function lexicalEquals(a: LexicalInput, b: LexicalInput, siteUrl = ''): boolean {
+  return normalizeLexicalForCompare(a, siteUrl) === normalizeLexicalForCompare(b, siteUrl);
 }
 
 function nodeAt(document: unknown, path: ReadonlyArray<string | number>): unknown {
@@ -105,19 +224,28 @@ function humanizePath(path: ReadonlyArray<string | number>, document: unknown): 
     .join('.');
 }
 
-function stripDocumentDirection(input: LexicalInput): LexicalDocument {
+function comparableDocument(input: LexicalInput, siteUrl: string): LexicalDocument {
   const document = parseLexical(input);
   if (!document) {
     return {};
   }
+  const root = document.root as Record<string, unknown>;
+  const normalized = {
+    ...document,
+    root: { ...root, children: normalizeSiteUrls(rootChildren(document), siteUrl) },
+  };
   return Object.fromEntries(
-    Object.entries(document).map(([key, value]) => [key, stripDirection(value)]),
+    Object.entries(normalized).map(([key, value]) => [key, stripDirection(value)]),
   );
 }
 
-export function humanizeLexicalDiff(from: LexicalInput, to: LexicalInput): HumanizedDiffEntry[] {
-  const fromDocument = stripDocumentDirection(from);
-  const toDocument = stripDocumentDirection(to);
+export function humanizeLexicalDiff(
+  from: LexicalInput,
+  to: LexicalInput,
+  siteUrl = '',
+): HumanizedDiffEntry[] {
+  const fromDocument = comparableDocument(from, siteUrl);
+  const toDocument = comparableDocument(to, siteUrl);
 
   return microdiff(fromDocument, toDocument, { cyclesFix: false }).map((change) => {
     const entry: HumanizedDiffEntry = {

--- a/apps/admin/src/editor/engine/lexical-compare.ts
+++ b/apps/admin/src/editor/engine/lexical-compare.ts
@@ -90,6 +90,11 @@ function parseSiteUrl(siteUrl: string): URL | null {
   }
 }
 
+function underSubdirectory(pathname: string, sitePathname: string): boolean {
+  const subdirectory = sitePathname.endsWith('/') ? sitePathname.slice(0, -1) : sitePathname;
+  return pathname === subdirectory || pathname.startsWith(`${subdirectory}/`);
+}
+
 // Same rule as url-utils' absoluteToRelative: host match (protocol ignored), a path
 // under the site's subdirectory (kept in the result), and userinfo URLs left alone.
 function toSiteRelative(value: string, site: URL): string {
@@ -102,7 +107,7 @@ function toSiteRelative(value: string, site: URL): string {
   if (parsed.username || parsed.password) {
     return value;
   }
-  if (parsed.host !== site.host || !parsed.pathname.startsWith(site.pathname)) {
+  if (parsed.host !== site.host || !underSubdirectory(parsed.pathname, site.pathname)) {
     return value;
   }
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,9 @@ catalogs:
     markdownlint-cli2:
       specifier: 0.23.2
       version: 0.23.2
+    microdiff:
+      specifier: 1.5.0
+      version: 1.5.0
     mingo:
       specifier: 2.5.3
       version: 2.5.3
@@ -948,6 +951,9 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@18.3.1)
+      microdiff:
+        specifier: 'catalog:'
+        version: 1.5.0
       mingo:
         specifier: 'catalog:'
         version: 2.5.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -150,6 +150,7 @@ catalog:
   knex-migrator: 5.4.1
   lodash: 4.18.1
   lucide-react: 1.23.0
+  microdiff: 1.5.0
   mingo: 2.5.3
   moment: 2.30.1
   moment-timezone: 0.5.45


### PR DESCRIPTION
Ports the Ember editor's dirty-detection logic (`_hasDirtyAttributes`, `_assignLexicalDiffToLeaveModalReason`, the `hasChangedSinceLastRevision` leave check) into `apps/admin` as a pure TypeScript module with no React dependency, so it can be unit tested ahead of the editor UI and reused by the save engine.

## What's here

`apps/admin/src/editor/engine/`

- **`change-tracker.ts`** – `createChangeTracker({siteUrl?})`. Every server-data ingress is id-first so events for another post are dropped:
  - `load(postId, post)` – initial load / post switch: adopts saved, seeds live from it, baseline goes to `pending`.
  - `setSaved(postId, post)` – query data (refetch): replaces saved only; never moves the baseline or the live state; a refetch whose `updated_at` is older than the held token is dropped as stale.
  - `saveAcknowledged(postId, submitted, acknowledged)` – mutation responses: three-way rebase per field (live still equals what was submitted → adopt the server's canonical value, e.g. generated slug or trimmed title; otherwise the later live edit wins), then saved := acknowledged, baseline := acknowledged body, `updated_at` always adopted. For a create ack `postId` is the created id and is adopted when the tracker holds `null`. No save-attempt id: the save engine is single-flight with one coalescing pending slot, so out-of-order acks are unrepresentable.
  - `setBaseline(postId, lexical)` / `baselineFailed(postId, error)` – the hidden instance's post-load serialization (ready) or its failure.
  - `setLive(postId, patch)` – a patch over the live projection (`updated_at` is never a live edit).
  - Editor-side events (`setLive`, `setBaseline`, `baselineFailed`) accept `null` as a stand-in for the current post once a created id has been adopted, so keystrokes landing between the create ack and the caller learning the id are not dropped. While a new post is open, an ack for an id this tracker has already held is refused (the save engine's post-generation fence is the primary guard against stale completions).
  - `markSaveError` / `clearSaveError`.
  - `revisionRestored(postId, restored)` – call after the restore save acks; adopts the full restored projection (body, title, feature image + alt + caption, custom excerpt) into saved and live atomically and marks the baseline `pending` until the hidden instance re-reports its post-mount serialization.
  - `verdict({includeDiff?})`, `hasChangedSinceRevision(latestRevision)`, `dispose()`.
  - Typed `EditablePostProjection` (title, slug, lexical, tags, custom_excerpt, feature_image, feature_image_alt, feature_image_caption, updated_at) replaces the untyped attribute bag. It is a plain structural interface so a superset snapshot assigns directly; only projection keys are read, and every snapshot is cloned at ingress.
  - Verdict rule is unchanged from Ember: body content is dirty only when the live editor diverges from **both** the last saved state and the hidden second editor's post-load serialization, which this module consumes as its baseline. The hidden instance stays; this module does not replace it.
  - Baseline readiness is modelled separately from value: `pending` → a live body that differs from saved is dirty with `BASELINE_PENDING` (fail closed); `failed` → live-vs-saved only with `BASELINE_FAILED` (body protection is never disabled); `ready` with `null`/`''`/an empty root is a known-empty document, so explicitly clearing non-empty content is dirty.
  - Reason codes keep the Ember names (`POST_HAS_ERROR`, `POST_TAGS_DIVERGED`, `POST_TITLE_DIVERGED`, `SCRATCH_DIVERGED_FROM_SECONDARY`, `NEW_POST_HAS_CHANGED_ATTRIBUTES`, `POST_HAS_DIRTY_ATTRIBUTES`) because they are what Sentry receives when the leave modal opens, plus `LEXICAL_PARSE_FAILED`, `BASELINE_PENDING` and `BASELINE_FAILED` so malformed or not-yet-comparable state fails closed (dirty) instead of throwing inside a route blocker. `verdict().reasons` lists every rung that fires in ladder order, so `reasons[0]` is the code Ember would have reported.
- **`lexical-compare.ts`** – `parseLexical` (null/undefined/'' are known empty; anything without an object root and a `children` array throws a typed `LexicalParseError`), `normalizeLexicalForCompare`, `lexicalEquals`, `stripDirection` (element nodes only; card payloads are opaque), `normalizeSiteUrls`, `humanizeLexicalDiff` (microdiff from baseline to live, numeric path segments annotated as `index[nodeType]`).
- **`__fixtures__/`** – an old-schema corpus of before/after-load pairs, indexed with provenance in `index.ts`, plus `after-load.test.tsx` which keeps the corpus honest (below).

## Deliberate deltas from the Ember code

- `direction` is stripped **recursively** before comparing. Ember only nulled it on root children, so a direction the reconciler inferred on a nested list item could still read as an edit.
- The diff humanizer reads the live lexical state and the baseline. Ember read `post.scratch` (a property that does not exist) and `diff.path` (the array, not the change), so it threw and reported to Sentry on every leave modal instead of producing a diff. The diff is also computed on direction-stripped documents so it only shows meaningful divergence, and runs baseline→live so `value` is the user's text.
- Comparison uses a key-order-independent serialization.
- Baseline re-capture on acknowledged save — Ember kept the load-time baseline for the whole session, so undoing back to the load state after an autosave read clean.
- Site-URL normalization is **structural**, not a string replace. The server rewrites relative URLs to absolute on save, so a relative link typed in the editor otherwise acks back as a permanent divergence from both saved and baseline. The compare walks the parsed document and rewrites only the url-typed properties the server itself rewrites (mirroring `kg-default-nodes`' `urlTransformMap`: image src/href, gallery image src, bookmark url/icon/thumbnail, audio/file/video src, button/header/email-cta button URLs, product image, embed url) plus link-node `url`, to the site-relative form on both sides; trailing-slash and subdirectory site URLs, protocol-relative URLs and URLs carrying credentials (left alone) are handled the same way as `url-utils`' `absoluteToRelative`. Text, code, html, markdown, captions and other card payloads are never touched, so deleting a literal site URL from prose stays dirty.
- Tags are compared as ordered name arrays (Ember joined them with `', '`, which collides on a delimiter-bearing name); the joined form is gone.
- `hasChangedSinceRevision` uses the server's own revision projection (`post-revisions.ts`: lexical + title + custom_excerpt + feature_image) with the body compared semantically, instead of a string compare of the body alone.

Everything else is a faithful port, including: title compared trimmed, new posts detected through the lexical rung the same way as saved posts (Ember's model defaults `lexical` to a blank document, so the rung was never gated on a saved value), and the saved (not live) state being what the revision check reads.

## Fixture corpus

Thirteen before/after pairs: `legacy-text-nodes`, `legacy-heading-quote-nodes`, `old-visibility-format`, `missing-default-props`, `invalid-nesting`, `adjacent-lists-merge`, `aligned-blocks`, `nested-editor-html`, `partial-visibility-format` (only some of web/email/memberSegment present, which the visibility migration rebuilds from defaults), `list-in-heading` (denested to a top-level list), `heading-in-listitem` (hoisted to a heading and a paragraph), `direction-null-vs-ltr`, `empty-document-paragraph`.

`after-load.test.tsx` mounts koenig-lexical's real `KoenigComposer` + `KoenigEditor` in jsdom — the exact code path of Ember's hidden secondary instance — loads each `before`, flushes transforms with a discrete update, and asserts the serialized state equals the recorded `after` with `direction` stripped on both sides. `direction` is the one field the reconciler infers per environment (jsdom, a real browser, and a headless parse all differ), and the comparator strips it anyway, so the assertion covers everything the comparator can see. The three new pairs were recorded from this mount.

Why a mount rather than a headless parse in `apps/admin`: the `@tryghost/koenig-lexical` dist bundles `lexical` (only React is external) and exports no editor factory, so a separately imported `@lexical/headless` cannot drive its node classes.

## Tests

- Invariant 5 across the whole corpus: baseline = after-load, saved = before-load, live = after-load is clean; a user edit on top is dirty with `SCRATCH_DIVERGED_FROM_SECONDARY`; `direction: "ltr"` applied at every depth of the after-load state is still clean; a refetch after load stays clean; the transformed live state is dirty only until the baseline reports.
- Baseline readiness: typing while pending (existing and new post), pending but matching saved, `null`/`''`/empty-root ready baselines as known empty, explicit clear to `null`/`''`/empty root, hidden-editor failure (fallback compare, old-schema fail-closed, recovery on a late report).
- Sequence tests: edit during an in-flight save (body, title, tags, attribute), server-canonicalized slug/title on ack, partial submission rebased against the previous saved state, semantically-equal body still counts as submitted, older refetch after a successful save dropped, newer refetch adopted, ack token always adopted, new post → created id without losing live state, null-id editor events accepted after the created id is adopted (and not for a post loaded with an id), late ack for a previously held post refused while a new post is open, an undefined submitted field treated as not submitted, stale refetch/callbacks from post A after switching to B ignored, dispose makes every call a no-op.
- Every reason code with its context shape; structurally invalid lexical (`{}`, `{"root":{}}`, `{"root":{"children":"invalid"}}`) is one typed result across parse, equality, diff and verdict; save-error stickiness and ordering; tag name/order/identity/delimiter semantics; title trimming; new-vs-existing attribute codes; patch semantics for independent observers; `updated_at` never a live edit; mutable aliasing of saved state and patches.
- Full-projection revision restore, old-schema restore where the mounted output ≠ the stored revision JSON, dirty after a failed later save.
- `hasChangedSinceRevision`: title/excerpt/feature-image change without a body change, key-order/direction-only body change, absolute vs relative site URLs, missing revision fields, unparseable revision body.
- Site-URL normalization: absolute vs relative link props for site URLs with and without a trailing slash, subdirectory installs, card URL properties, literal site URL deleted from prose stays dirty, literal URLs edited in code/html/markdown/caption/CTA data stay dirty, verbatim compare without `siteUrl`; unit tests for `normalizeSiteUrls` (link nodes, url-typed card fields only, nested children, other hosts / relative / non-http untouched, protocol ignored, protocol-relative resolved, credentials left alone, no input mutation).
- Humanized diff shape for changes, additions, and removals; omitted while the baseline is pending.
- Corpus freshness against the mounted editor.

Verified with `apps/admin` lint, `tsc -b`, and the full unit suite.
