### PR TITLE
Added the Koenig post editor mount behind the editorReact flag

### DIFF
--- a/apps/admin/src/editor/card-config.test.ts
+++ b/apps/admin/src/editor/card-config.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '@tryghost/admin-x-framework/api/config';
+import type { Setting } from '@tryghost/admin-x-framework/api/settings';
+import type { SiteData } from '@tryghost/admin-x-framework/api/site';
+import {
+  type PostCardConfigPorts,
+  type PostCardConfigSources,
+  buildCardConfigPost,
+  buildPostCardConfig,
+  getCardVisibilitySettings,
+} from './card-config';
+
+const settingsFrom = (values: Record<string, Setting['value']>): Setting[] =>
+  Object.entries(values).map(([key, value]) => ({ key, value }));
+
+const baseSettings = {
+  title: 'Test Site',
+  description: 'Thoughts, stories and ideas.',
+  unsplash: true,
+  transistor: false,
+  members_signup_access: 'all',
+  stripe_connect_publishable_key: null,
+  stripe_connect_secret_key: null,
+  stripe_secret_key: null,
+  stripe_publishable_key: null,
+};
+
+const config = { stripeDirect: false, klipy: { apiKey: null }, labs: {} } as Config;
+const site = { url: 'https://example.com/blog', site_uuid: 'site-uuid' } as SiteData;
+const owner = { roles: [{ name: 'Owner' }] } as const;
+const contributor = { roles: [{ name: 'Contributor' }] } as const;
+const unsplashHeaders = { Authorization: 'Client-ID test', 'X-Unsplash-Cache': true };
+
+const ports: PostCardConfigPorts = {
+  fetchEmbed: vi.fn(),
+  fetchAutocompleteLinks: vi.fn(),
+  searchLinks: vi.fn(),
+  fetchLabels: vi.fn(),
+  createSnippet: vi.fn(),
+  deleteSnippet: vi.fn(),
+};
+
+const sources = (overrides: Partial<PostCardConfigSources> = {}): PostCardConfigSources => ({
+  settings: settingsFrom(baseSettings),
+  config,
+  site,
+  currentUser: owner,
+  unsplashHeaders,
+  pinturaConfig: null,
+  post: buildCardConfigPost({ displayName: 'post', visibility: 'members' }, 'public'),
+  snippets: [],
+  ...overrides,
+});
+
+describe('buildCardConfigPost', () => {
+  it('returns undefined without a post', () => {
+    expect(buildCardConfigPost(undefined, 'public')).toBeUndefined();
+  });
+
+  it('narrows the post to the fields cards read', () => {
+    expect(
+      buildCardConfigPost(
+        { displayName: 'page', showTitleAndFeatureImage: false, visibility: 'paid' },
+        'public',
+      ),
+    ).toEqual({
+      displayName: 'page',
+      isPage: true,
+      showTitleAndFeatureImage: false,
+      visibility: 'paid',
+    });
+  });
+
+  it('falls back to the site default visibility for an unsaved post', () => {
+    expect(buildCardConfigPost({ displayName: 'post' }, 'members')).toEqual({
+      displayName: 'post',
+      isPage: false,
+      showTitleAndFeatureImage: true,
+      visibility: 'members',
+    });
+  });
+});
+
+describe('getCardVisibilitySettings', () => {
+  it('restricts pages to web-only visibility', () => {
+    expect(getCardVisibilitySettings({ isPage: true, displayName: 'page' })).toBe('web only');
+    expect(getCardVisibilitySettings({ isPage: false, displayName: 'post' })).toBe('web and email');
+    expect(getCardVisibilitySettings(undefined)).toBe('web and email');
+  });
+});
+
+describe('buildPostCardConfig', () => {
+  it('assembles the Ember editor card config', () => {
+    const cardConfig = buildPostCardConfig(sources(), ports);
+
+    expect(cardConfig).toMatchObject({
+      unsplash: unsplashHeaders,
+      klipy: null,
+      pinturaConfig: null,
+      renderLabels: true,
+      feature: { transistor: false, paywallImprovements: false },
+      deprecated: { headerV1: true },
+      membersEnabled: true,
+      siteTitle: 'Test Site',
+      siteDescription: 'Thoughts, stories and ideas.',
+      siteUrl: 'https://example.com/blog/',
+      siteUuid: 'site-uuid',
+      stripeEnabled: false,
+      visibilitySettings: 'web and email',
+      post: { displayName: 'post', isPage: false, visibility: 'members' },
+      snippets: [],
+    });
+    expect(cardConfig.fetchEmbed).toBe(ports.fetchEmbed);
+    expect(cardConfig.fetchAutocompleteLinks).toBe(ports.fetchAutocompleteLinks);
+    expect(cardConfig.searchLinks).toBe(ports.searchLinks);
+    expect(cardConfig.fetchLabels).toBe(ports.fetchLabels);
+    expect(cardConfig.createSnippet).toBe(ports.createSnippet);
+    expect(cardConfig.deleteSnippet).toBe(ports.deleteSnippet);
+  });
+
+  it('drops Unsplash when the integration is off', () => {
+    const cardConfig = buildPostCardConfig(
+      sources({ settings: settingsFrom({ ...baseSettings, unsplash: false }) }),
+      ports,
+    );
+
+    expect(cardConfig.unsplash).toBeNull();
+  });
+
+  it('passes Klipy through only when an API key is configured', () => {
+    const klipy = { apiKey: 'key', contentFilter: 'off' };
+    const cardConfig = buildPostCardConfig(sources({ config: { ...config, klipy } }), ports);
+
+    expect(cardConfig.klipy).toEqual(klipy);
+  });
+
+  it('hides labels from contributors', () => {
+    const cardConfig = buildPostCardConfig(sources({ currentUser: contributor }), ports);
+
+    expect(cardConfig.renderLabels).toBe(false);
+  });
+
+  it('reads feature flags from settings and labs', () => {
+    const cardConfig = buildPostCardConfig(
+      sources({
+        settings: settingsFrom({ ...baseSettings, transistor: true }),
+        config: { ...config, labs: { paywallImprovements: true } },
+      }),
+      ports,
+    );
+
+    expect(cardConfig.feature).toEqual({ transistor: true, paywallImprovements: true });
+  });
+
+  it('treats invite-only member signup as members disabled', () => {
+    const cardConfig = buildPostCardConfig(
+      sources({ settings: settingsFrom({ ...baseSettings, members_signup_access: 'invite' }) }),
+      ports,
+    );
+
+    expect(cardConfig.membersEnabled).toBe(false);
+  });
+
+  it('reports Stripe as enabled from connect keys', () => {
+    const cardConfig = buildPostCardConfig(
+      sources({
+        settings: settingsFrom({
+          ...baseSettings,
+          stripe_connect_publishable_key: 'pk',
+          stripe_connect_secret_key: 'sk',
+        }),
+      }),
+      ports,
+    );
+
+    expect(cardConfig.stripeEnabled).toBe(true);
+  });
+
+  it('limits pages to web-only card visibility', () => {
+    const cardConfig = buildPostCardConfig(
+      sources({ post: buildCardConfigPost({ displayName: 'page' }, 'public') }),
+      ports,
+    );
+
+    expect(cardConfig.visibilitySettings).toBe('web only');
+  });
+
+  it('passes pintura and snippets through untouched', () => {
+    const pinturaConfig = { jsUrl: 'https://cdn/pintura.js', cssUrl: 'https://cdn/pintura.css' };
+    const snippets = [{ id: '1', name: 'Sign-off', value: '{"root":{}}' }];
+    const cardConfig = buildPostCardConfig(sources({ pinturaConfig, snippets }), ports);
+
+    expect(cardConfig.pinturaConfig).toBe(pinturaConfig);
+    expect(cardConfig.snippets).toBe(snippets);
+  });
+});

--- a/apps/admin/src/editor/card-config.ts
+++ b/apps/admin/src/editor/card-config.ts
@@ -1,0 +1,139 @@
+import { type Config } from '@tryghost/admin-x-framework/api/config';
+import {
+  type Setting,
+  checkStripeEnabled,
+  getSettingValue,
+} from '@tryghost/admin-x-framework/api/settings';
+import { type SiteData, getHomepageUrl } from '@tryghost/admin-x-framework/api/site';
+import { isContributorUser } from '@tryghost/admin-x-framework/api/users';
+import type { AutocompleteLink, LinkSearchGroup } from './link-suggestions';
+
+// Pure builder for the post editor's Koenig `cardConfig`; every asynchronous
+// piece (embeds, link search, labels, snippets) arrives as a port.
+
+export type PostType = 'post' | 'page';
+
+export interface CardConfigPost {
+  displayName: PostType;
+  isPage: boolean;
+  showTitleAndFeatureImage: boolean;
+  visibility: string;
+}
+
+export interface CardConfigPostSource {
+  displayName: PostType;
+  showTitleAndFeatureImage?: boolean;
+  visibility?: string | null;
+}
+
+export interface CardConfigSnippet {
+  id: string;
+  name: string;
+  value: string;
+}
+
+export interface CardConfigSnippetInput {
+  name: string;
+  value: string;
+}
+
+export interface PostCardConfigSources {
+  settings: Setting[];
+  config: Config;
+  site: SiteData;
+  currentUser: Parameters<typeof isContributorUser>[0];
+  unsplashHeaders: Record<string, string | boolean>;
+  pinturaConfig: { jsUrl: string; cssUrl: string } | null;
+  post: CardConfigPost | undefined;
+  snippets: CardConfigSnippet[];
+}
+
+export interface PostCardConfigPorts {
+  fetchEmbed: (url: string, options: { type?: string }) => Promise<unknown>;
+  fetchAutocompleteLinks: () => Promise<AutocompleteLink[]>;
+  searchLinks: (term?: string) => Promise<LinkSearchGroup[] | undefined>;
+  fetchLabels: () => Promise<string[]>;
+  createSnippet?: (snippet: CardConfigSnippetInput) => void;
+  deleteSnippet?: (snippet: { name: string }) => void;
+}
+
+export type CardVisibilitySettings = 'web only' | 'web and email';
+
+export interface PostCardConfig extends PostCardConfigPorts {
+  unsplash: Record<string, string | boolean> | null;
+  klipy: NonNullable<Config['klipy']> | null;
+  pinturaConfig: { jsUrl: string; cssUrl: string } | null;
+  renderLabels: boolean;
+  feature: { transistor: boolean; paywallImprovements: boolean };
+  deprecated: { headerV1: boolean };
+  membersEnabled: boolean;
+  siteTitle: string;
+  siteDescription: string;
+  siteUrl: string;
+  siteUuid: string;
+  stripeEnabled: boolean;
+  post: CardConfigPost | undefined;
+  snippets: CardConfigSnippet[];
+  visibilitySettings: CardVisibilitySettings;
+}
+
+// An unsaved post has no visibility until the first save applies the site
+// default, so it is resolved here to keep `visibility` present for cards.
+export function buildCardConfigPost(
+  post: CardConfigPostSource | undefined,
+  defaultContentVisibility: string,
+): CardConfigPost | undefined {
+  if (!post) {
+    return undefined;
+  }
+
+  return {
+    displayName: post.displayName,
+    isPage: post.displayName === 'page',
+    showTitleAndFeatureImage: post.showTitleAndFeatureImage ?? true,
+    visibility: post.visibility || defaultContentVisibility,
+  };
+}
+
+export function getCardVisibilitySettings(
+  post: Pick<CardConfigPost, 'isPage' | 'displayName'> | undefined,
+): CardVisibilitySettings {
+  const isPage = post?.isPage || post?.displayName === 'page';
+  return isPage ? 'web only' : 'web and email';
+}
+
+export function buildPostCardConfig(
+  sources: PostCardConfigSources,
+  ports: PostCardConfigPorts,
+): PostCardConfig {
+  const { settings, config, site, currentUser } = sources;
+
+  return {
+    unsplash: getSettingValue<boolean>(settings, 'unsplash') ? sources.unsplashHeaders : null,
+    klipy: config.klipy?.apiKey ? config.klipy : null,
+    pinturaConfig: sources.pinturaConfig,
+    fetchAutocompleteLinks: ports.fetchAutocompleteLinks,
+    fetchEmbed: ports.fetchEmbed,
+    fetchLabels: ports.fetchLabels,
+    renderLabels: !isContributorUser(currentUser),
+    feature: {
+      transistor: getSettingValue<boolean>(settings, 'transistor') === true,
+      paywallImprovements: config.labs?.paywallImprovements === true,
+    },
+    deprecated: {
+      headerV1: true,
+    },
+    membersEnabled: getSettingValue<string>(settings, 'members_signup_access') === 'all',
+    searchLinks: ports.searchLinks,
+    siteTitle: getSettingValue<string>(settings, 'title') ?? '',
+    siteDescription: getSettingValue<string>(settings, 'description') ?? '',
+    siteUrl: getHomepageUrl(site),
+    siteUuid: site.site_uuid,
+    stripeEnabled: checkStripeEnabled(settings, config),
+    post: sources.post,
+    snippets: sources.snippets,
+    createSnippet: ports.createSnippet,
+    deleteSnippet: ports.deleteSnippet,
+    visibilitySettings: getCardVisibilitySettings(sources.post),
+  };
+}

--- a/apps/admin/src/editor/card-config.ts
+++ b/apps/admin/src/editor/card-config.ts
@@ -8,9 +8,6 @@ import { type SiteData, getHomepageUrl } from '@tryghost/admin-x-framework/api/s
 import { isContributorUser } from '@tryghost/admin-x-framework/api/users';
 import type { AutocompleteLink, LinkSearchGroup } from './link-suggestions';
 
-// Pure builder for the post editor's Koenig `cardConfig`; every asynchronous
-// piece (embeds, link search, labels, snippets) arrives as a port.
-
 export type PostType = 'post' | 'page';
 
 export interface CardConfigPost {

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -1,16 +1,30 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AdminLink } from '@/shared/admin-link';
 import { NotFound } from '@/shared/not-found';
-import { useParams } from '@tryghost/admin-x-framework';
+import { Navigate, useNavigate, useParams } from '@tryghost/admin-x-framework';
 import { Button, LoadingIndicator } from '@tryghost/shade/components';
-import { Inline, Stack } from '@tryghost/shade/primitives';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { LucideIcon } from '@tryghost/shade/utils';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
-import { type PageEditorRecord, useEditorPage } from '@tryghost/admin-x-framework/api/pages';
-import { type PostEditorRecord, useEditorPost } from '@tryghost/admin-x-framework/api/posts';
-import { isAdminUser, isEditorUser, isOwnerUser } from '@tryghost/admin-x-framework/api/users';
-import type { KoenigInstance } from '@/settings/components/koenig-loader';
+import {
+  type PageEditorRecord,
+  useEditPage,
+  useEditorPage,
+} from '@tryghost/admin-x-framework/api/pages';
+import {
+  type PostEditorRecord,
+  useEditPost,
+  useEditorPost,
+} from '@tryghost/admin-x-framework/api/posts';
+import {
+  type User,
+  isAdminUser,
+  isAuthorOrContributor,
+  isContributorUser,
+  isEditorUser,
+  isOwnerUser,
+} from '@tryghost/admin-x-framework/api/users';
 import type { CardConfigPostSource, PostType } from './card-config';
 import { PostEditor } from './post-editor';
 import { usePostCardConfig } from './use-post-card-config';
@@ -22,6 +36,17 @@ function EditorLoading() {
   return (
     <Stack align="center" className="h-full" justify="center">
       <LoadingIndicator size="lg" />
+    </Stack>
+  );
+}
+
+function EditorLoadError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <Stack align="center" className="h-full" data-testid="editor-load-error" justify="center">
+      <Text tone="secondary">{message}</Text>
+      <Button variant="outline" onClick={onRetry}>
+        Retry
+      </Button>
     </Stack>
   );
 }
@@ -41,8 +66,6 @@ function EditorHeader({ postType }: { postType: PostType }) {
   );
 }
 
-// Keyed on the record so navigating to another post remounts with fresh state;
-// edits stay in memory until the save engine attaches to the callbacks below
 function EditorSurface({ postType, record }: { postType: PostType; record?: EditorRecord }) {
   const { data: currentUser } = useCurrentUser();
   const showExcerpt = useFeatureFlag('editorExcerpt');
@@ -50,10 +73,6 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
     record?.title === '(Untitled)' ? '' : (record?.title ?? ''),
   );
   const [excerpt, setExcerpt] = useState(() => record?.custom_excerpt ?? '');
-  const lexicalRef = useRef<unknown>(null);
-  const secondaryLexicalRef = useRef<unknown>(null);
-  const editorApiRef = useRef<KoenigInstance | null>(null);
-  const secondaryApiRef = useRef<KoenigInstance | null>(null);
 
   const canManageSnippets =
     !!currentUser &&
@@ -77,19 +96,6 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
     deleteSnippet,
   });
 
-  const onLexicalChange = useCallback((lexical: unknown) => {
-    lexicalRef.current = lexical;
-  }, []);
-  const onSecondaryChange = useCallback((lexical: unknown) => {
-    secondaryLexicalRef.current = lexical;
-  }, []);
-  const registerEditorApi = useCallback((api: KoenigInstance | null) => {
-    editorApiRef.current = api;
-  }, []);
-  const registerSecondaryApi = useCallback((api: KoenigInstance | null) => {
-    secondaryApiRef.current = api;
-  }, []);
-
   if (!cardConfig) {
     return <EditorLoading />;
   }
@@ -104,13 +110,9 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
           excerpt={excerpt}
           initialLexical={record?.lexical ?? null}
           postType={postType}
-          registerEditorApi={registerEditorApi}
-          registerSecondaryApi={registerSecondaryApi}
           showExcerpt={showExcerpt}
           title={title}
           onExcerptChange={setExcerpt}
-          onLexicalChange={onLexicalChange}
-          onSecondaryChange={onSecondaryChange}
           onTitleChange={setTitle}
         />
       </div>
@@ -119,19 +121,122 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
   );
 }
 
-function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }) {
-  const postQuery = useEditorPost(id, { enabled: postType === 'post' });
-  const pageQuery = useEditorPage(id, { enabled: postType === 'page' });
-  const query = postType === 'page' ? pageQuery : postQuery;
-  const record: EditorRecord | undefined =
-    postType === 'page' ? pageQuery.data?.pages[0] : postQuery.data?.posts[0];
+// The API returns posts the user cannot edit, so authorship is checked here
+function shouldReturnToList(user: User, record: EditorRecord): boolean {
+  const isAuthored = record.authors?.some((author) => author.id === user.id) ?? false;
 
-  if (query.isPending) {
+  if (isAuthorOrContributor(user) && !isAuthored) {
+    return true;
+  }
+
+  return isContributorUser(user) && record.status !== 'draft';
+}
+
+interface ConversionState {
+  id: string;
+  record?: EditorRecord;
+  error?: unknown;
+}
+
+// Mobiledoc content is converted server-side before the editor opens it
+function useLexicalConversion(postType: PostType) {
+  const { mutateAsync: editPost } = useEditPost();
+  const { mutateAsync: editPage } = useEditPage();
+  const [state, setState] = useState<ConversionState | null>(null);
+
+  const convert = useCallback(
+    async (source: EditorRecord) => {
+      const payload = { id: source.id, updated_at: source.updated_at };
+      const options = { convertToLexical: true };
+      setState({ id: source.id });
+
+      try {
+        const record: EditorRecord | undefined =
+          postType === 'page'
+            ? (await editPage({ page: payload, options })).pages[0]
+            : (await editPost({ post: payload, options })).posts[0];
+        setState({ id: source.id, record });
+      } catch (error) {
+        setState({ id: source.id, error });
+      }
+    },
+    [editPage, editPost, postType],
+  );
+
+  return { state, convert };
+}
+
+function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }) {
+  const navigate = useNavigate();
+  const { data: currentUser } = useCurrentUser();
+  const postQuery = useEditorPost(id, {
+    enabled: postType === 'post',
+    defaultErrorHandler: false,
+  });
+  const pageQuery = useEditorPage(id, {
+    enabled: postType === 'page',
+    defaultErrorHandler: false,
+  });
+  const query = postType === 'page' ? pageQuery : postQuery;
+  const loaded: EditorRecord | undefined =
+    postType === 'page' ? pageQuery.data?.pages[0] : postQuery.data?.posts[0];
+  const { state: conversion, convert } = useLexicalConversion(postType);
+  const listPath = postType === 'page' ? '/pages' : '/posts';
+
+  const returnToList = !!currentUser && !!loaded && shouldReturnToList(currentUser, loaded);
+  useEffect(() => {
+    if (returnToList) {
+      navigate(listPath, { replace: true });
+    }
+  }, [returnToList, navigate, listPath]);
+
+  const needsConversion = !!loaded?.mobiledoc && !loaded.lexical && !returnToList;
+  useEffect(() => {
+    if (needsConversion && loaded && conversion?.id !== loaded.id) {
+      void convert(loaded);
+    }
+  }, [needsConversion, loaded, conversion?.id, convert]);
+
+  const notFound = (query.error as { response?: Response } | null)?.response?.status === 404;
+  if (notFound) {
+    return <NotFound />;
+  }
+
+  if (query.error) {
+    return (
+      <EditorLoadError
+        message={`Couldn’t load this ${postType}.`}
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+
+  if (query.isPending || !currentUser || returnToList) {
     return <EditorLoading />;
   }
 
-  if (!record) {
+  if (!loaded) {
     return <NotFound />;
+  }
+
+  let record = loaded;
+  if (needsConversion) {
+    const converted = conversion?.id === loaded.id ? conversion : undefined;
+
+    if (converted?.error) {
+      return (
+        <EditorLoadError
+          message={`Couldn’t convert this ${postType} for editing.`}
+          onRetry={() => void convert(loaded)}
+        />
+      );
+    }
+
+    if (!converted?.record) {
+      return <EditorLoading />;
+    }
+
+    record = converted.record;
   }
 
   return <EditorSurface key={record.id} postType={postType} record={record} />;
@@ -139,12 +244,19 @@ function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }
 
 export default function EditorScreen() {
   const editorPath = useParams()['*'] ?? '';
-  const [typeSegment, id] = editorPath.split('/');
-  const postType: PostType = typeSegment === 'page' ? 'page' : 'post';
+  const [typeSegment, id, ...rest] = editorPath.split('/').filter(Boolean);
 
-  if (id) {
-    return <ExistingPostEditor id={id} postType={postType} />;
+  if (!typeSegment) {
+    return <Navigate to="/editor/post" replace />;
   }
 
-  return <EditorSurface key={postType} postType={postType} />;
+  if ((typeSegment !== 'post' && typeSegment !== 'page') || rest.length > 0) {
+    return <NotFound />;
+  }
+
+  if (id) {
+    return <ExistingPostEditor id={id} postType={typeSegment} />;
+  }
+
+  return <EditorSurface key={typeSegment} postType={typeSegment} />;
 }

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -1,33 +1,150 @@
+import { useCallback, useRef, useState } from 'react';
 import { AdminLink } from '@/shared/admin-link';
+import { NotFound } from '@/shared/not-found';
 import { useParams } from '@tryghost/admin-x-framework';
-import { Button } from '@tryghost/shade/components';
-import { Stack, Text } from '@tryghost/shade/primitives';
+import { Button, LoadingIndicator } from '@tryghost/shade/components';
+import { Inline, Stack } from '@tryghost/shade/primitives';
+import { LucideIcon } from '@tryghost/shade/utils';
+import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
+import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
+import { type PageEditorRecord, useEditorPage } from '@tryghost/admin-x-framework/api/pages';
+import { type PostEditorRecord, useEditorPost } from '@tryghost/admin-x-framework/api/posts';
+import { isAdminUser, isEditorUser, isOwnerUser } from '@tryghost/admin-x-framework/api/users';
+import type { KoenigInstance } from '@/settings/components/koenig-loader';
+import type { CardConfigPostSource, PostType } from './card-config';
+import { PostEditor } from './post-editor';
+import { usePostCardConfig } from './use-post-card-config';
+import { usePostSnippets } from './use-post-snippets';
 
-/**
- * Placeholder for the React editor, served behind the `editorReact` Labs
- * flag. It only proves the EditorGate cutover seam end to end; the editor
- * itself still lives in Ember while the flag is off.
- */
-export default function EditorScreen() {
-  const editorPath = useParams()['*'];
-  const isPage = editorPath?.split('/')[0] === 'page';
-  const listPath = isPage ? '/pages' : '/posts';
-  const listLabel = isPage ? 'Back to pages' : 'Back to posts';
+type EditorRecord = PostEditorRecord | PageEditorRecord;
 
+function EditorLoading() {
   return (
-    <Stack
-      align="center"
-      className="h-full px-6 text-center"
-      data-testid="editor-react-placeholder"
-      justify="center"
-    >
-      <Text className="max-w-lg" size="sm" tone="secondary">
-        The React editor is under construction. Turn off the “React editor” flag in Labs to use the
-        editor.
-      </Text>
-      <Button variant="outline" asChild>
-        <AdminLink to={listPath}>{listLabel}</AdminLink>
-      </Button>
+    <Stack align="center" className="h-full" justify="center">
+      <LoadingIndicator size="lg" />
     </Stack>
   );
+}
+
+function EditorHeader({ postType }: { postType: PostType }) {
+  const listLabel = postType === 'page' ? 'Pages' : 'Posts';
+
+  return (
+    <Inline className="shrink-0 px-4 py-3" gap="sm">
+      <Button size="sm" variant="ghost" asChild>
+        <AdminLink to={postType === 'page' ? '/pages' : '/posts'}>
+          <LucideIcon.ArrowLeft />
+          {listLabel}
+        </AdminLink>
+      </Button>
+    </Inline>
+  );
+}
+
+// Keyed on the record so navigating to another post remounts with fresh state;
+// edits stay in memory until the save engine attaches to the callbacks below
+function EditorSurface({ postType, record }: { postType: PostType; record?: EditorRecord }) {
+  const { data: currentUser } = useCurrentUser();
+  const showExcerpt = useFeatureFlag('editorExcerpt');
+  const [title, setTitle] = useState(() =>
+    record?.title === '(Untitled)' ? '' : (record?.title ?? ''),
+  );
+  const [excerpt, setExcerpt] = useState(() => record?.custom_excerpt ?? '');
+  const lexicalRef = useRef<unknown>(null);
+  const secondaryLexicalRef = useRef<unknown>(null);
+  const editorApiRef = useRef<KoenigInstance | null>(null);
+  const secondaryApiRef = useRef<KoenigInstance | null>(null);
+
+  const canManageSnippets =
+    !!currentUser &&
+    (isOwnerUser(currentUser) || isAdminUser(currentUser) || isEditorUser(currentUser));
+  const { snippets, createSnippet, deleteSnippet, snippetDialog } = usePostSnippets({
+    canManage: canManageSnippets,
+  });
+
+  const [cardConfigPost] = useState<CardConfigPostSource>(() => ({
+    displayName: postType,
+    showTitleAndFeatureImage:
+      record && 'show_title_and_feature_image' in record
+        ? record.show_title_and_feature_image
+        : undefined,
+    visibility: record?.visibility,
+  }));
+  const cardConfig = usePostCardConfig({
+    post: cardConfigPost,
+    snippets,
+    createSnippet,
+    deleteSnippet,
+  });
+
+  const onLexicalChange = useCallback((lexical: unknown) => {
+    lexicalRef.current = lexical;
+  }, []);
+  const onSecondaryChange = useCallback((lexical: unknown) => {
+    secondaryLexicalRef.current = lexical;
+  }, []);
+  const registerEditorApi = useCallback((api: KoenigInstance | null) => {
+    editorApiRef.current = api;
+  }, []);
+  const registerSecondaryApi = useCallback((api: KoenigInstance | null) => {
+    secondaryApiRef.current = api;
+  }, []);
+
+  if (!cardConfig) {
+    return <EditorLoading />;
+  }
+
+  return (
+    <Stack className="h-full" gap="none">
+      <EditorHeader postType={postType} />
+      <div className="min-h-0 flex-1">
+        <PostEditor
+          autofocusTitle={!record}
+          cardConfig={cardConfig}
+          excerpt={excerpt}
+          initialLexical={record?.lexical ?? null}
+          postType={postType}
+          registerEditorApi={registerEditorApi}
+          registerSecondaryApi={registerSecondaryApi}
+          showExcerpt={showExcerpt}
+          title={title}
+          onExcerptChange={setExcerpt}
+          onLexicalChange={onLexicalChange}
+          onSecondaryChange={onSecondaryChange}
+          onTitleChange={setTitle}
+        />
+      </div>
+      {snippetDialog}
+    </Stack>
+  );
+}
+
+function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }) {
+  const postQuery = useEditorPost(id, { enabled: postType === 'post' });
+  const pageQuery = useEditorPage(id, { enabled: postType === 'page' });
+  const query = postType === 'page' ? pageQuery : postQuery;
+  const record: EditorRecord | undefined =
+    postType === 'page' ? pageQuery.data?.pages[0] : postQuery.data?.posts[0];
+
+  if (query.isPending) {
+    return <EditorLoading />;
+  }
+
+  if (!record) {
+    return <NotFound />;
+  }
+
+  return <EditorSurface key={record.id} postType={postType} record={record} />;
+}
+
+export default function EditorScreen() {
+  const editorPath = useParams()['*'] ?? '';
+  const [typeSegment, id] = editorPath.split('/');
+  const postType: PostType = typeSegment === 'page' ? 'page' : 'post';
+
+  if (id) {
+    return <ExistingPostEditor id={id} postType={postType} />;
+  }
+
+  return <EditorSurface key={postType} postType={postType} />;
 }

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -5,6 +5,7 @@ import { Navigate, useNavigate, useParams } from '@tryghost/admin-x-framework';
 import { Button, LoadingIndicator } from '@tryghost/shade/components';
 import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { LucideIcon } from '@tryghost/shade/utils';
+import { APIError } from '@tryghost/admin-x-framework/errors';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
 import {
@@ -155,7 +156,7 @@ function useLexicalConversion(postType: PostType) {
           postType === 'page'
             ? (await editPage({ page: payload, options })).pages[0]
             : (await editPost({ post: payload, options })).posts[0];
-        setState({ id: source.id, record });
+        setState(record ? { id: source.id, record } : { id: source.id, error: true });
       } catch (error) {
         setState({ id: source.id, error });
       }
@@ -190,14 +191,14 @@ function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }
     }
   }, [returnToList, navigate, listPath]);
 
-  const needsConversion = !!loaded?.mobiledoc && !loaded.lexical && !returnToList;
+  const needsConversion = !!currentUser && !!loaded?.mobiledoc && !loaded.lexical && !returnToList;
   useEffect(() => {
     if (needsConversion && loaded && conversion?.id !== loaded.id) {
       void convert(loaded);
     }
   }, [needsConversion, loaded, conversion?.id, convert]);
 
-  const notFound = (query.error as { response?: Response } | null)?.response?.status === 404;
+  const notFound = query.error instanceof APIError && query.error.response?.status === 404;
   if (notFound) {
     return <NotFound />;
   }

--- a/apps/admin/src/editor/editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor.acceptance.test.tsx
@@ -1,58 +1,68 @@
 import { describe, expect, it } from 'vitest';
-import { page } from 'vitest/browser';
 
-import { renderAdminApp } from '@test-utils/acceptance';
+import {
+  fakeAdminEndpoint,
+  fakePosts,
+  fakeSnippets,
+  post,
+  renderAdminApp,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
 
 const FLAG_ON = { labs: { editorReact: true } };
 const FLAG_OFF = { labs: { editorReact: false } };
 
 /**
  * Proves the `editorReact` flag swap end-to-end in the real admin app: the
- * React placeholder appears only when the flag is on, and the Ember side of
- * the URL is delegated to otherwise.
+ * React editor appears only when the flag is on, and the Ember side of the
+ * URL is delegated to otherwise.
  *
  * There is no Ember app in this harness, so "Ember serves it" shows up as the
- * React placeholder being absent rather than as an Ember editor being present
- * — the Ember half of the handshake (the lexical-editor route aborting its
+ * React editor being absent rather than as an Ember editor being present —
+ * the Ember half of the handshake (the lexical-editor route aborting its
  * transition) is covered in
  * apps/ember-admin/tests/acceptance/editor-react-flag-test.js.
  */
 describe('Editor flag', () => {
-  const placeholder = () => page.getByTestId('editor-react-placeholder');
+  function fakeEditorWorld() {
+    fakeSnippets([]);
+    fakePosts([]);
+    fakeAdminEndpoint('GET', /^\/posts\/abc123\/\?/, { posts: [post({ id: 'abc123' })] });
+    fakeAdminEndpoint('GET', /^\/pages\/abc123\/\?/, { pages: [post({ id: 'abc123' })] });
+  }
 
-  it('renders the React placeholder when the flag is on', async () => {
+  it('renders the React editor when the flag is on', async () => {
+    fakeEditorWorld();
     await renderAdminApp('/editor/post/abc123', FLAG_ON);
 
-    await expect.element(placeholder()).toBeVisible();
-    await expect
-      .element(page.getByRole('link', { name: 'Back to posts' }))
-      .toHaveAttribute('href', '#/posts');
+    await expect.element(editorScreen.root()).toBeVisible();
+    await expect.element(editorScreen.backLink('post')).toHaveAttribute('href', '#/posts');
   });
 
   it('serves a new-post URL too', async () => {
+    fakeEditorWorld();
     await renderAdminApp('/editor/post', FLAG_ON);
 
-    await expect.element(placeholder()).toBeVisible();
+    await expect.element(editorScreen.root()).toBeVisible();
   });
 
   it('returns page editors to the pages list', async () => {
+    fakeEditorWorld();
     await renderAdminApp('/editor/page/abc123', FLAG_ON);
 
-    await expect.element(placeholder()).toBeVisible();
-    await expect
-      .element(page.getByRole('link', { name: 'Back to pages' }))
-      .toHaveAttribute('href', '#/pages');
+    await expect.element(editorScreen.root()).toBeVisible();
+    await expect.element(editorScreen.backLink('page')).toHaveAttribute('href', '#/pages');
   });
 
   it('defers to Ember when the flag is off', async () => {
     await renderAdminApp('/editor/post/abc123', FLAG_OFF);
 
-    await expect(placeholder()).toHaveCount(0);
+    await expect(editorScreen.root()).toHaveCount(0);
   });
 
   it('defers to Ember when the flag is absent entirely', async () => {
     await renderAdminApp('/editor/post/abc123');
 
-    await expect(placeholder()).toHaveCount(0);
+    await expect(editorScreen.root()).toHaveCount(0);
   });
 });

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -1,0 +1,29 @@
+import { page } from 'vitest/browser';
+import {
+  editorBody,
+  editorExcerptInput,
+  editorSecondaryInstance,
+  editorTitleInput,
+  editorWordCount,
+  pagesBackLink,
+  postEditor,
+  postsBackLink,
+  tkIndicator,
+} from '@tryghost/test-data/selectors/editor';
+
+/** Editor screen locators and gestures for acceptance specs; no assertions. */
+export const editorScreen = {
+  root: () => page.getByTestId(postEditor),
+  titleInput: () => page.getByTestId(editorTitleInput),
+  excerptInput: () => page.getByTestId(editorExcerptInput),
+  /** The primary Koenig content editable. */
+  body: () => page.getByTestId(editorBody).getByRole('textbox'),
+  secondaryInstance: () => page.getByTestId(editorSecondaryInstance),
+  wordCount: () => page.getByTestId(editorWordCount),
+  titleTkIndicator: () => page.getByTestId(tkIndicator),
+  backLink: (postType: 'post' | 'page') =>
+    page.getByRole('link', {
+      name: postType === 'page' ? pagesBackLink : postsBackLink,
+      exact: true,
+    }),
+};

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -2,6 +2,7 @@ import { page } from 'vitest/browser';
 import {
   editorBody,
   editorExcerptInput,
+  editorLoadError,
   editorSecondaryInstance,
   editorTitleInput,
   editorWordCount,
@@ -20,10 +21,16 @@ export const editorScreen = {
   body: () => page.getByTestId(editorBody).getByRole('textbox'),
   secondaryInstance: () => page.getByTestId(editorSecondaryInstance),
   wordCount: () => page.getByTestId(editorWordCount),
+  loadError: () => page.getByTestId(editorLoadError),
+  notFound: () => page.getByRole('heading', { name: 'Page not found' }),
   titleTkIndicator: () => page.getByTestId(tkIndicator),
   backLink: (postType: 'post' | 'page') =>
     page.getByRole('link', {
       name: postType === 'page' ? pagesBackLink : postsBackLink,
       exact: true,
     }),
+  /** Whether keyboard focus is inside the primary Koenig body. */
+  bodyHasFocus: (): boolean =>
+    document.querySelector(`[data-testid="${editorBody}"]`)?.contains(document.activeElement) ??
+    false,
 };

--- a/apps/admin/src/editor/koenig-post-editor.tsx
+++ b/apps/admin/src/editor/koenig-post-editor.tsx
@@ -23,8 +23,8 @@ export interface KoenigPostEditorProps {
   cardConfig: PostCardConfig;
   darkMode: boolean;
   cursorDidExitAtTop?: () => void;
-  onChange: (lexical: unknown) => void;
-  onSecondaryChange: (lexical: unknown) => void;
+  onChange?: (lexical: unknown) => void;
+  onSecondaryChange?: (lexical: unknown) => void;
   registerAPI: (api: KoenigInstance | null) => void;
   registerSecondaryAPI: (api: KoenigInstance | null) => void;
   onWordCountChange: (count: number) => void;

--- a/apps/admin/src/editor/koenig-post-editor.tsx
+++ b/apps/admin/src/editor/koenig-post-editor.tsx
@@ -1,0 +1,122 @@
+import * as Sentry from '@sentry/react';
+import { Suspense, useCallback, useMemo } from 'react';
+import { LoadingIndicator } from '@tryghost/shade/components';
+import { koenigFileUploadTypes, useKoenigFileUpload } from '@tryghost/admin-x-framework/hooks';
+import ErrorBoundary from '@/settings/components/error-boundary';
+import {
+  type EditorResource,
+  type KoenigInstance,
+  loadKoenig,
+} from '@/settings/components/koenig-loader';
+import type { PostCardConfig } from './card-config';
+
+const fileUploader = {
+  useFileUpload: useKoenigFileUpload,
+  fileTypes: koenigFileUploadTypes,
+};
+
+const NOOP = () => {};
+
+export interface KoenigPostEditorProps {
+  initialLexical: string | null;
+  placeholder: string;
+  cardConfig: PostCardConfig;
+  darkMode: boolean;
+  cursorDidExitAtTop?: () => void;
+  onChange: (lexical: unknown) => void;
+  onSecondaryChange: (lexical: unknown) => void;
+  registerAPI: (api: KoenigInstance | null) => void;
+  registerSecondaryAPI: (api: KoenigInstance | null) => void;
+  onWordCountChange: (count: number) => void;
+  onTkCountChange: (count: number) => void;
+}
+
+interface KoenigInstanceMountProps extends KoenigPostEditorProps {
+  editor: EditorResource;
+  isSecondary: boolean;
+  onError: (error: unknown) => void;
+}
+
+// The hidden secondary instance loads the same initial state: Koenig normalises
+// documents on load, so its output is the baseline change detection compares against
+function KoenigInstanceMount({
+  editor,
+  isSecondary,
+  onError,
+  initialLexical,
+  placeholder,
+  cardConfig,
+  darkMode,
+  cursorDidExitAtTop,
+  onChange,
+  onSecondaryChange,
+  registerAPI,
+  registerSecondaryAPI,
+  onWordCountChange,
+  onTkCountChange,
+}: KoenigInstanceMountProps) {
+  const { KoenigComposer, KoenigEditor, WordCountPlugin, TKCountPlugin } = editor.read();
+
+  return (
+    <div
+      data-secondary-instance={isSecondary ? 'true' : 'false'}
+      data-testid={isSecondary ? 'editor-secondary-instance' : 'editor-body'}
+      hidden={isSecondary}
+    >
+      <KoenigComposer
+        cardConfig={cardConfig}
+        darkMode={darkMode}
+        fileUploader={fileUploader}
+        initialEditorState={initialLexical ?? undefined}
+        isTKEnabled={true}
+        onError={onError}
+      >
+        <KoenigEditor
+          cursorDidExitAtTop={isSecondary ? undefined : cursorDidExitAtTop}
+          darkMode={isSecondary ? undefined : darkMode}
+          placeholderText={isSecondary ? undefined : placeholder}
+          registerAPI={isSecondary ? registerSecondaryAPI : registerAPI}
+          onChange={isSecondary ? onSecondaryChange : onChange}
+        />
+        <WordCountPlugin onChange={isSecondary ? NOOP : onWordCountChange} />
+        <TKCountPlugin onChange={isSecondary ? NOOP : onTkCountChange} />
+      </KoenigComposer>
+    </div>
+  );
+}
+
+export function KoenigPostEditor(props: KoenigPostEditorProps) {
+  const editor = useMemo(() => loadKoenig(), []);
+
+  const onError = useCallback((error: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    Sentry.captureException(error, {
+      tags: { lexical: true },
+      contexts: {
+        koenig: {
+          version: window['@tryghost/koenig-lexical']?.version,
+        },
+      },
+    });
+    // not rethrown: Lexical attempts to recover without losing user data
+  }, []);
+
+  return (
+    <div className="koenig-react-editor koenig-lexical mx-auto w-full max-w-[740px]">
+      <ErrorBoundary name="the editor">
+        <Suspense
+          fallback={
+            <div className="flex justify-center py-10">
+              <LoadingIndicator size="lg" />
+            </div>
+          }
+        >
+          <KoenigInstanceMount {...props} editor={editor} isSecondary={false} onError={onError} />
+          <KoenigInstanceMount {...props} editor={editor} isSecondary={true} onError={onError} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/apps/admin/src/editor/link-suggestions.test.ts
+++ b/apps/admin/src/editor/link-suggestions.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAutocompleteLinks,
+  buildLatestPostsGroup,
+  buildOfferLinks,
+  decoratePostSearchResult,
+  filterLinkSearchResults,
+  formatPublishedDate,
+  searchIndexEntitiesGroup,
+  searchIndexPostsGroup,
+} from './link-suggestions';
+
+const decoration = { timezone: 'Etc/UTC', membersEnabled: true };
+
+describe('buildAutocompleteLinks', () => {
+  const settings = {
+    postType: 'post' as const,
+    homepageUrl: 'https://example.com/',
+    paidMembersEnabled: true,
+    donationsEnabled: true,
+    recommendationsEnabled: true,
+  };
+
+  it('lists every portal link in the Ember order', () => {
+    const offerLinks = buildOfferLinks(
+      [{ name: 'Spring sale', code: 'spring' }],
+      settings.homepageUrl,
+    );
+
+    expect(buildAutocompleteLinks(settings, offerLinks)).toEqual([
+      { label: 'Homepage', value: 'https://example.com/' },
+      { label: 'Free signup', value: '#/portal/signup/free' },
+      { label: 'Paid signup', value: '#/portal/signup' },
+      { label: 'Upgrade or change plan', value: '#/portal/account/plans' },
+      { label: 'Tips and donations', value: '#/portal/support' },
+      { label: 'Gift subscriptions', value: '#/portal/gift' },
+      { label: 'Share post', value: '#/share' },
+      { label: 'Recommendations', value: '#/portal/recommendations' },
+      { label: 'Offer — Spring sale', value: 'https://example.com/spring' },
+    ]);
+  });
+
+  it('drops paid, donation and recommendation links when those features are off', () => {
+    const links = buildAutocompleteLinks(
+      {
+        ...settings,
+        postType: 'page',
+        paidMembersEnabled: false,
+        donationsEnabled: false,
+        recommendationsEnabled: false,
+      },
+      [],
+    );
+
+    expect(links).toEqual([
+      { label: 'Homepage', value: 'https://example.com/' },
+      { label: 'Free signup', value: '#/portal/signup/free' },
+      { label: 'Share page', value: '#/share' },
+    ]);
+  });
+
+  it('resolves offer codes against a subdirectory homepage', () => {
+    expect(buildOfferLinks([{ name: 'Sale', code: '/sale' }], 'https://example.com/blog/')).toEqual(
+      [{ label: 'Offer — Sale', value: 'https://example.com/blog/sale' }],
+    );
+  });
+});
+
+describe('formatPublishedDate', () => {
+  it('formats in the site timezone as day, short month, year', () => {
+    expect(formatPublishedDate('2026-03-01T23:30:00.000Z', 'Etc/UTC')).toBe('1 Mar 2026');
+    expect(formatPublishedDate('2026-03-01T23:30:00.000Z', 'Pacific/Auckland')).toBe('2 Mar 2026');
+  });
+});
+
+describe('decoratePostSearchResult', () => {
+  it('adds the published date and a members-only marker', () => {
+    const item = decoratePostSearchResult(
+      {
+        id: 'post.1',
+        title: 'Hello',
+        url: '/hello/',
+        visibility: 'members',
+        publishedAt: '2026-01-05T10:00:00.000Z',
+      },
+      decoration,
+    );
+
+    expect(item.metaText).toBe('5 Jan 2026');
+    expect(item.metaIconTitle).toBe('Members only');
+    expect(item.MetaIcon).toBeDefined();
+  });
+
+  it.each([
+    ['paid', 'Paid-members only'],
+    ['tiers', 'Specific tiers only'],
+  ])('marks %s content', (visibility, title) => {
+    const item = decoratePostSearchResult({ id: 'post.1', title: 'Hello', visibility }, decoration);
+
+    expect(item.metaIconTitle).toBe(title);
+  });
+
+  it('adds no marker when members are disabled or content is public', () => {
+    expect(
+      decoratePostSearchResult(
+        { id: 'post.1', title: 'Hello', visibility: 'paid' },
+        { ...decoration, membersEnabled: false },
+      ).MetaIcon,
+    ).toBeUndefined();
+    expect(
+      decoratePostSearchResult({ id: 'post.1', title: 'Hello', visibility: 'public' }, decoration)
+        .MetaIcon,
+    ).toBeUndefined();
+  });
+});
+
+describe('filterLinkSearchResults', () => {
+  it('keeps only linkable published content and decorates posts and pages', () => {
+    const groups = filterLinkSearchResults(
+      [
+        {
+          groupName: 'Staff',
+          options: [
+            { id: 'user.1', title: 'Ann', url: 'https://example.com/author/ann/' },
+            { id: 'user.2', title: 'Bob', url: 'https://example.com/404/' },
+          ],
+        },
+        { groupName: 'Tags', options: [{ id: 'tag.1', title: 'News', url: null }] },
+        {
+          groupName: 'Posts',
+          options: [
+            { id: 'post.1', title: 'Draft', url: 'https://example.com/p/1/', status: 'draft' },
+            {
+              id: 'post.2',
+              title: 'Live',
+              url: 'https://example.com/live/',
+              status: 'published',
+              visibility: 'paid',
+              publishedAt: '2026-02-02T00:00:00.000Z',
+            },
+          ],
+        },
+        {
+          groupName: 'Pages',
+          options: [
+            {
+              id: 'page.1',
+              title: 'About',
+              url: 'https://example.com/about/',
+              status: 'published',
+            },
+          ],
+        },
+      ],
+      decoration,
+    );
+
+    expect(groups.map((group) => group.label)).toEqual(['Staff', 'Posts', 'Pages']);
+    expect(groups[0].items.map((item) => item.title)).toEqual(['Ann']);
+    expect(groups[1].items).toHaveLength(1);
+    expect(groups[1].items[0]).toMatchObject({
+      title: 'Live',
+      metaText: '2 Feb 2026',
+      metaIconTitle: 'Paid-members only',
+    });
+    expect(groups[2].items[0].title).toBe('About');
+  });
+});
+
+describe('buildLatestPostsGroup', () => {
+  it('wraps the latest posts in a decorated group', () => {
+    const groups = buildLatestPostsGroup(
+      [
+        {
+          id: '1',
+          title: 'Latest',
+          url: 'https://example.com/latest/',
+          visibility: 'public',
+          published_at: '2026-04-10T00:00:00.000Z',
+        },
+      ],
+      decoration,
+    );
+
+    expect(groups).toEqual([
+      {
+        label: 'Latest posts',
+        items: [expect.objectContaining({ id: '1', title: 'Latest', metaText: '10 Apr 2026' })],
+      },
+    ]);
+  });
+});
+
+describe('search index groups', () => {
+  const posts = [
+    { id: '1', title: 'Getting started', url: '/start/', status: 'published' },
+    { id: '2', title: 'Other', url: '/other/', status: 'published' },
+  ];
+
+  it('matches post titles case-insensitively', () => {
+    expect(searchIndexPostsGroup('Posts', posts, 'STARTED').options).toEqual([
+      expect.objectContaining({ id: 'post.1', title: 'Getting started', url: '/start/' }),
+    ]);
+  });
+
+  it('matches staff and tag names', () => {
+    expect(
+      searchIndexEntitiesGroup('Staff', [{ id: 'u1', name: 'Ann Author', url: '/ann/' }], 'ann')
+        .options,
+    ).toEqual([{ id: 'user.u1', title: 'Ann Author', url: '/ann/' }]);
+    expect(
+      searchIndexEntitiesGroup('Tags', [{ id: 't1', name: 'News', url: '/tag/news/' }], 'ne')
+        .options,
+    ).toEqual([{ id: 'tag.t1', title: 'News', url: '/tag/news/' }]);
+  });
+
+  it('matches nothing for a blank term', () => {
+    expect(searchIndexPostsGroup('Pages', posts, '  ').options).toEqual([]);
+  });
+});

--- a/apps/admin/src/editor/link-suggestions.ts
+++ b/apps/admin/src/editor/link-suggestions.ts
@@ -2,9 +2,6 @@ import type { ComponentType } from 'react';
 import { LucideIcon } from '@tryghost/shade/utils';
 import type { PostType } from './card-config';
 
-// Link toolbar suggestions as pure functions over already-fetched data; the
-// hook layer owns the requests.
-
 export interface AutocompleteLink {
   label: string;
   value: string;

--- a/apps/admin/src/editor/link-suggestions.ts
+++ b/apps/admin/src/editor/link-suggestions.ts
@@ -1,0 +1,262 @@
+import type { ComponentType } from 'react';
+import { LucideIcon } from '@tryghost/shade/utils';
+import type { PostType } from './card-config';
+
+// Link toolbar suggestions as pure functions over already-fetched data; the
+// hook layer owns the requests.
+
+export interface AutocompleteLink {
+  label: string;
+  value: string;
+}
+
+export interface AutocompleteLinkSettings {
+  postType: PostType;
+  homepageUrl: string;
+  paidMembersEnabled: boolean;
+  donationsEnabled: boolean;
+  recommendationsEnabled: boolean;
+}
+
+export interface OfferLinkSource {
+  name: string;
+  code: string;
+}
+
+export interface LinkSearchItem {
+  id: string;
+  title: string;
+  url?: string | null;
+  status?: string;
+  visibility?: string;
+  publishedAt?: string | null;
+  metaText?: string;
+  MetaIcon?: ComponentType<{ className?: string }>;
+  metaIconTitle?: string;
+}
+
+export interface LinkSearchResultGroup {
+  groupName: string;
+  options: LinkSearchItem[];
+}
+
+export interface LinkSearchGroup {
+  label: string;
+  items: LinkSearchItem[];
+}
+
+export interface LinkDecorationSettings {
+  timezone: string;
+  membersEnabled: boolean;
+}
+
+export interface LatestPostSource {
+  id: string;
+  title: string;
+  url?: string | null;
+  visibility?: string;
+  published_at?: string | null;
+}
+
+export interface SearchIndexPost {
+  id: string;
+  title: string;
+  url?: string | null;
+  status?: string;
+  visibility?: string;
+  published_at?: string | null;
+}
+
+export interface SearchIndexEntity {
+  id: string;
+  name: string;
+  url?: string | null;
+}
+
+export function buildOfferLinks(
+  offers: OfferLinkSource[],
+  homepageUrl: string,
+): AutocompleteLink[] {
+  return offers.map((offer) => ({
+    label: `Offer — ${offer.name}`,
+    value: `${homepageUrl}${offer.code.replace(/^\//, '')}`,
+  }));
+}
+
+export function buildAutocompleteLinks(
+  settings: AutocompleteLinkSettings,
+  offerLinks: AutocompleteLink[],
+): AutocompleteLink[] {
+  const defaults = [
+    { label: 'Homepage', value: settings.homepageUrl },
+    { label: 'Free signup', value: '#/portal/signup/free' },
+  ];
+
+  const shareLink = [{ label: `Share ${settings.postType}`, value: '#/share' }];
+
+  const memberLinks = settings.paidMembersEnabled
+    ? [
+        { label: 'Paid signup', value: '#/portal/signup' },
+        { label: 'Upgrade or change plan', value: '#/portal/account/plans' },
+      ]
+    : [];
+
+  const donationLink = settings.donationsEnabled
+    ? [{ label: 'Tips and donations', value: '#/portal/support' }]
+    : [];
+
+  const recommendationLink = settings.recommendationsEnabled
+    ? [{ label: 'Recommendations', value: '#/portal/recommendations' }]
+    : [];
+
+  const giftLink = settings.paidMembersEnabled
+    ? [{ label: 'Gift subscriptions', value: '#/portal/gift' }]
+    : [];
+
+  return [
+    ...defaults,
+    ...memberLinks,
+    ...donationLink,
+    ...giftLink,
+    ...shareLink,
+    ...recommendationLink,
+    ...offerLinks,
+  ];
+}
+
+// Ember renders `D MMM YYYY` in the site timezone
+export function formatPublishedDate(publishedAt: string, timezone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: timezone,
+  }).formatToParts(new Date(publishedAt));
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((candidate) => candidate.type === type)?.value ?? '';
+
+  return `${part('day')} ${part('month')} ${part('year')}`;
+}
+
+export function decoratePostSearchResult(
+  item: LinkSearchItem,
+  settings: LinkDecorationSettings,
+): LinkSearchItem {
+  const decorated: LinkSearchItem = { ...item };
+
+  if (item.publishedAt) {
+    decorated.metaText = formatPublishedDate(item.publishedAt, settings.timezone);
+  }
+
+  if (settings.membersEnabled && item.visibility) {
+    if (item.visibility === 'members') {
+      decorated.MetaIcon = LucideIcon.Lock;
+      decorated.metaIconTitle = 'Members only';
+    } else if (item.visibility === 'paid') {
+      decorated.MetaIcon = LucideIcon.DollarSign;
+      decorated.metaIconTitle = 'Paid-members only';
+    } else if (item.visibility === 'tiers') {
+      decorated.MetaIcon = LucideIcon.DollarSign;
+      decorated.metaIconTitle = 'Specific tiers only';
+    }
+  }
+
+  return decorated;
+}
+
+export function filterLinkSearchResults(
+  results: LinkSearchResultGroup[],
+  settings: LinkDecorationSettings,
+): LinkSearchGroup[] {
+  const filteredResults: LinkSearchGroup[] = [];
+
+  results.forEach((group) => {
+    // only content with a public URL is linkable
+    let items = group.options.filter((item) => item.url);
+
+    if (group.groupName === 'Posts' || group.groupName === 'Pages') {
+      items = items.filter((item) => item.status === 'published');
+    }
+
+    if (group.groupName === 'Staff') {
+      items = items.filter((item) => !/\/404\//.test(item.url ?? ''));
+    }
+
+    if (items.length === 0) {
+      return;
+    }
+
+    if (group.groupName === 'Posts' || group.groupName === 'Pages') {
+      items = items.map((item) => decoratePostSearchResult(item, settings));
+    }
+
+    filteredResults.push({
+      label: group.groupName,
+      items,
+    });
+  });
+
+  return filteredResults;
+}
+
+export function buildLatestPostsGroup(
+  posts: LatestPostSource[],
+  settings: LinkDecorationSettings,
+): LinkSearchGroup[] {
+  const items = posts.map((post) =>
+    decoratePostSearchResult(
+      {
+        id: post.id,
+        title: post.title,
+        url: post.url,
+        visibility: post.visibility,
+        publishedAt: post.published_at,
+      },
+      settings,
+    ),
+  );
+
+  return [{ label: 'Latest posts', items }];
+}
+
+export function searchIndexPostsGroup(
+  groupName: 'Posts' | 'Pages',
+  entries: SearchIndexPost[],
+  term: string,
+): LinkSearchResultGroup {
+  return {
+    groupName,
+    options: matchTerm(entries, term, (entry) => entry.title).map((entry) => ({
+      id: `${groupName === 'Posts' ? 'post' : 'page'}.${entry.id}`,
+      title: entry.title,
+      url: entry.url,
+      status: entry.status,
+      visibility: entry.visibility,
+      publishedAt: entry.published_at,
+    })),
+  };
+}
+
+export function searchIndexEntitiesGroup(
+  groupName: 'Staff' | 'Tags',
+  entries: SearchIndexEntity[],
+  term: string,
+): LinkSearchResultGroup {
+  return {
+    groupName,
+    options: matchTerm(entries, term, (entry) => entry.name).map((entry) => ({
+      id: `${groupName === 'Staff' ? 'user' : 'tag'}.${entry.id}`,
+      title: entry.name,
+      url: entry.url,
+    })),
+  };
+}
+
+function matchTerm<Entry>(entries: Entry[], term: string, text: (entry: Entry) => string) {
+  const needle = term.trim().toLowerCase();
+  if (!needle) {
+    return [];
+  }
+
+  return entries.filter((entry) => text(entry).toLowerCase().includes(needle));
+}

--- a/apps/admin/src/editor/post-editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/post-editor.acceptance.test.tsx
@@ -153,25 +153,50 @@ describe('Post editor', () => {
     await expect(editorScreen.excerptInput()).toHaveCount(0);
   });
 
-  it('converts a mobiledoc post to lexical before opening it', async () => {
+  it.each<['post' | 'page']>([['post'], ['page']])(
+    'converts a mobiledoc %s to lexical before opening it',
+    async (type) => {
+      const resource = `${type}s`;
+      const legacy = post({
+        id: POST_ID,
+        title: `Legacy ${type}`,
+        mobiledoc: MOBILEDOC,
+        lexical: null,
+        updated_at: '2024-05-06T07:08:09.000Z',
+      });
+      fakeEditorChrome();
+      fakeAdminEndpoint('GET', new RegExp(`^/${resource}/${POST_ID}/\\?`), {
+        [resource]: [legacy],
+      });
+      const convertApi = fakeAdminEndpoint('PUT', new RegExp(`^/${resource}/${POST_ID}/\\?`), {
+        [resource]: [
+          post({
+            ...legacy,
+            mobiledoc: null,
+            lexical: buildLexicalParagraph('Converted from mobiledoc'),
+          }),
+        ],
+      });
+      await renderAdminApp(`/editor/${type}/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Converted from mobiledoc');
+      expect(convertApi.requests).toHaveLength(1);
+      expect(convertApi.lastRequest?.url).toContain('convert_to_lexical=true');
+      expect(convertApi.lastRequest?.url).toContain('formats=mobiledoc%2Clexical');
+      const body = convertApi.lastRequest?.body as Record<string, unknown[]>;
+      expect(body[resource]).toEqual([{ id: POST_ID, updated_at: legacy.updated_at }]);
+    },
+  );
+
+  it('shows an error when the conversion response carries no post', async () => {
     fakeEditorPost({ title: 'Legacy post', mobiledoc: MOBILEDOC, lexical: null });
-    const convertApi = fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), {
-      posts: [
-        post({
-          id: POST_ID,
-          title: 'Legacy post',
-          mobiledoc: null,
-          lexical: buildLexicalParagraph('Converted from mobiledoc'),
-        }),
-      ],
-    });
+    fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), { posts: [] });
     await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
 
-    await expect.element(editorScreen.body()).toHaveTextContent('Converted from mobiledoc');
-    expect(convertApi.requests).toHaveLength(1);
-    expect(convertApi.lastRequest?.url).toContain('convert_to_lexical=true');
-    expect(convertApi.lastRequest?.url).toContain('formats=mobiledoc%2Clexical');
-    expect((convertApi.lastRequest?.body as { posts: { id: string }[] }).posts[0].id).toBe(POST_ID);
+    await expect
+      .element(editorScreen.loadError())
+      .toHaveTextContent('Couldn’t convert this post for editing.');
+    await expect(editorScreen.body()).toHaveCount(0);
   });
 
   it('shows an error instead of an empty body when the conversion fails', async () => {
@@ -221,10 +246,20 @@ describe('Post editor', () => {
     async (_role, role, type, status, authorId, listPath) => {
       fakeEditorChrome();
       fakeAdminEndpoint('GET', new RegExp(`^/${type}s/${POST_ID}/\\?`), {
-        [`${type}s`]: [post({ id: POST_ID, status, authors: [{ id: authorId }] })],
+        [`${type}s`]: [
+          post({
+            id: POST_ID,
+            status,
+            authors: [{ id: authorId }],
+            mobiledoc: MOBILEDOC,
+            lexical: null,
+          }),
+        ],
       });
       await renderAdminApp(`/editor/${type}/${POST_ID}`, bootAs(role));
 
+      // a mobiledoc record must not be converted for a user who is redirected;
+      // the PUT has no fake, so it would 418 and fail the test
       await expect.poll(currentRoute).toBe(listPath);
       await expect(editorScreen.root()).toHaveCount(0);
     },

--- a/apps/admin/src/editor/post-editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/post-editor.acceptance.test.tsx
@@ -3,22 +3,30 @@ import { userEvent } from 'vitest/browser';
 import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
+  currentRoute,
+  currentUserResponse,
   fakeAdminEndpoint,
   fakePosts,
   fakeSnippets,
   post,
   renderAdminApp,
+  staffRole,
+  type RenderAdminAppOptions,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 
 const POST_ID = 'abc123';
 const FLAG_ON = { labs: { editorReact: true } };
+const CURRENT_USER_ID = '1';
+
+const MOBILEDOC =
+  '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"Legacy"]]]]}';
 
 // Every editor mount browses snippets for the card menu and, through Koenig's
 // link toolbar preload, the five latest published posts.
 function fakeEditorChrome() {
   fakeSnippets([]);
-  fakePosts([]);
+  return fakePosts([]);
 }
 
 function fakeEditorPost(overrides: Partial<ReturnType<typeof post>> = {}) {
@@ -36,10 +44,25 @@ function fakeEditorPost(overrides: Partial<ReturnType<typeof post>> = {}) {
   });
 }
 
+function bootAs(role: 'Author' | 'Contributor'): RenderAdminAppOptions {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name: role })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+function pasteText(content: string) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData('text/plain', content);
+  document.activeElement?.dispatchEvent(
+    new ClipboardEvent('paste', { clipboardData: dataTransfer, bubbles: true, cancelable: true }),
+  );
+}
+
 /**
  * The React post editor behind the `editorReact` flag: loads the post,
  * mounts Koenig with its hidden secondary instance and keeps edits in memory.
- * Nothing is saved yet — any write request would 418 and fail the test.
+ * Nothing is saved yet — any write request other than the mobiledoc
+ * conversion would 418 and fail the test.
  */
 describe('Post editor', () => {
   it('loads the post into the title and body', async () => {
@@ -53,8 +76,11 @@ describe('Post editor', () => {
     expect(postsApi.lastRequest?.url).toContain('include=tags%2Cauthors');
   });
 
-  it('mounts the hidden secondary Koenig instance', async () => {
-    fakeEditorPost();
+  it('mounts the hidden secondary Koenig instance without doubling its requests', async () => {
+    const latestPostsApi = fakeEditorChrome();
+    fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
+      posts: [post({ id: POST_ID, lexical: buildLexicalParagraph('Hello') })],
+    });
     await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
 
     await expect.element(editorScreen.body()).toBeVisible();
@@ -62,6 +88,8 @@ describe('Post editor', () => {
       .element(editorScreen.secondaryInstance())
       .toHaveAttribute('data-secondary-instance', 'true');
     await expect.element(editorScreen.secondaryInstance()).not.toBeVisible();
+    await expect.poll(() => latestPostsApi.requests.length).toBe(1);
+    expect(latestPostsApi.lastRequest?.limit).toBe(5);
   });
 
   it('updates the word count as the body is edited', async () => {
@@ -89,6 +117,25 @@ describe('Post editor', () => {
     await expect.element(editorScreen.titleTkIndicator()).toBeVisible();
   });
 
+  it('moves from the title into the body on Enter and cleans pasted titles', async () => {
+    fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    const title = editorScreen.titleInput();
+    await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+    await title.click();
+    await userEvent.keyboard('{Enter}');
+
+    await expect.poll(() => editorScreen.bodyHasFocus()).toBe(true);
+    await expect.element(title).toHaveValue('Hello from React');
+
+    await title.fill('');
+    await title.click();
+    pasteText('  Line one\nLine two\r\n\nLine three  ');
+
+    await expect.element(title).toHaveValue('Line one Line two Line three');
+  });
+
   it('shows the excerpt only behind the editorExcerpt flag', async () => {
     fakeEditorPost();
     await renderAdminApp(`/editor/post/${POST_ID}`, {
@@ -104,6 +151,94 @@ describe('Post editor', () => {
 
     await expect.element(editorScreen.titleInput()).toBeVisible();
     await expect(editorScreen.excerptInput()).toHaveCount(0);
+  });
+
+  it('converts a mobiledoc post to lexical before opening it', async () => {
+    fakeEditorPost({ title: 'Legacy post', mobiledoc: MOBILEDOC, lexical: null });
+    const convertApi = fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), {
+      posts: [
+        post({
+          id: POST_ID,
+          title: 'Legacy post',
+          mobiledoc: null,
+          lexical: buildLexicalParagraph('Converted from mobiledoc'),
+        }),
+      ],
+    });
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    await expect.element(editorScreen.body()).toHaveTextContent('Converted from mobiledoc');
+    expect(convertApi.requests).toHaveLength(1);
+    expect(convertApi.lastRequest?.url).toContain('convert_to_lexical=true');
+    expect(convertApi.lastRequest?.url).toContain('formats=mobiledoc%2Clexical');
+    expect((convertApi.lastRequest?.body as { posts: { id: string }[] }).posts[0].id).toBe(POST_ID);
+  });
+
+  it('shows an error instead of an empty body when the conversion fails', async () => {
+    fakeEditorPost({ title: 'Legacy post', mobiledoc: MOBILEDOC, lexical: null });
+    fakeAdminEndpoint(
+      'PUT',
+      new RegExp(`^/posts/${POST_ID}/\\?`),
+      { errors: [{ message: 'Invalid mobiledoc structure.' }] },
+      { status: 422 },
+    );
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    await expect
+      .element(editorScreen.loadError())
+      .toHaveTextContent('Couldn’t convert this post for editing.');
+    await expect(editorScreen.body()).toHaveCount(0);
+  });
+
+  it('shows a 404 for a post that does not exist', async () => {
+    fakeEditorChrome();
+    fakeAdminEndpoint(
+      'GET',
+      new RegExp(`^/posts/${POST_ID}/\\?`),
+      { errors: [{ message: 'Post not found.' }] },
+      { status: 404 },
+    );
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    await expect.element(editorScreen.notFound()).toBeVisible();
+  });
+
+  it('shows a 404 for an unknown editor type', async () => {
+    await renderAdminApp('/editor/article/abc123', FLAG_ON);
+
+    await expect.element(editorScreen.notFound()).toBeVisible();
+  });
+
+  type Role = 'Author' | 'Contributor';
+  type Status = ReturnType<typeof post>['status'];
+
+  it.each<[string, Role, 'post' | 'page', Status, string, string]>([
+    ['author', 'Author', 'post', 'published', 'other-user', '/posts'],
+    ['contributor', 'Contributor', 'post', 'draft', 'other-user', '/posts'],
+    ['contributor', 'Contributor', 'page', 'published', CURRENT_USER_ID, '/pages'],
+  ])(
+    'returns a %s to the list for a %s %s they cannot edit',
+    async (_role, role, type, status, authorId, listPath) => {
+      fakeEditorChrome();
+      fakeAdminEndpoint('GET', new RegExp(`^/${type}s/${POST_ID}/\\?`), {
+        [`${type}s`]: [post({ id: POST_ID, status, authors: [{ id: authorId }] })],
+      });
+      await renderAdminApp(`/editor/${type}/${POST_ID}`, bootAs(role));
+
+      await expect.poll(currentRoute).toBe(listPath);
+      await expect(editorScreen.root()).toHaveCount(0);
+    },
+  );
+
+  it.each<[string, Role, Status]>([
+    ['author', 'Author', 'published'],
+    ['contributor', 'Contributor', 'draft'],
+  ])('lets a %s edit their own %s post', async (_role, role, status) => {
+    fakeEditorPost({ status, authors: [{ id: CURRENT_USER_ID }] });
+    await renderAdminApp(`/editor/post/${POST_ID}`, bootAs(role));
+
+    await expect.element(editorScreen.titleInput()).toHaveValue('Hello from React');
+    expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
   });
 
   it('opens an empty editor for a new post', async () => {
@@ -122,5 +257,13 @@ describe('Post editor', () => {
 
     await expect.element(editorScreen.titleInput()).toHaveAttribute('placeholder', 'Page title');
     await expect.element(editorScreen.backLink('page')).toHaveAttribute('href', '#/pages');
+  });
+
+  it('sends the bare editor URL to a new post', async () => {
+    fakeEditorChrome();
+    await renderAdminApp('/editor', FLAG_ON);
+
+    await expect.poll(currentRoute).toBe('/editor/post');
+    await expect.element(editorScreen.titleInput()).toHaveAttribute('placeholder', 'Post title');
   });
 });

--- a/apps/admin/src/editor/post-editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/post-editor.acceptance.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  fakeAdminEndpoint,
+  fakePosts,
+  fakeSnippets,
+  post,
+  renderAdminApp,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const FLAG_ON = { labs: { editorReact: true } };
+
+// Every editor mount browses snippets for the card menu and, through Koenig's
+// link toolbar preload, the five latest published posts.
+function fakeEditorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+}
+
+function fakeEditorPost(overrides: Partial<ReturnType<typeof post>> = {}) {
+  fakeEditorChrome();
+  return fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
+    posts: [
+      post({
+        id: POST_ID,
+        title: 'Hello from React',
+        custom_excerpt: 'A short summary',
+        lexical: buildLexicalParagraph('Hello from React'),
+        ...overrides,
+      }),
+    ],
+  });
+}
+
+/**
+ * The React post editor behind the `editorReact` flag: loads the post,
+ * mounts Koenig with its hidden secondary instance and keeps edits in memory.
+ * Nothing is saved yet — any write request would 418 and fail the test.
+ */
+describe('Post editor', () => {
+  it('loads the post into the title and body', async () => {
+    const postsApi = fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    await expect.element(editorScreen.titleInput()).toHaveValue('Hello from React');
+    await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+    await expect.element(editorScreen.wordCount()).toHaveTextContent('3 words');
+    expect(postsApi.lastRequest?.url).toContain('formats=mobiledoc%2Clexical');
+    expect(postsApi.lastRequest?.url).toContain('include=tags%2Cauthors');
+  });
+
+  it('mounts the hidden secondary Koenig instance', async () => {
+    fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    await expect.element(editorScreen.body()).toBeVisible();
+    await expect
+      .element(editorScreen.secondaryInstance())
+      .toHaveAttribute('data-secondary-instance', 'true');
+    await expect.element(editorScreen.secondaryInstance()).not.toBeVisible();
+  });
+
+  it('updates the word count as the body is edited', async () => {
+    fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    const body = editorScreen.body();
+    await expect.element(editorScreen.wordCount()).toHaveTextContent('3 words');
+    await body.click();
+    await userEvent.keyboard('{End} and more');
+
+    await expect.element(body).toHaveTextContent('Hello from React and more');
+    await expect.element(editorScreen.wordCount()).toHaveTextContent('5 words');
+  });
+
+  it('keeps title edits in memory', async () => {
+    fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    const title = editorScreen.titleInput();
+    await expect.element(title).toHaveValue('Hello from React');
+    await title.fill('Changed title TK');
+
+    await expect.element(title).toHaveValue('Changed title TK');
+    await expect.element(editorScreen.titleTkIndicator()).toBeVisible();
+  });
+
+  it('shows the excerpt only behind the editorExcerpt flag', async () => {
+    fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, {
+      labs: { editorReact: true, editorExcerpt: true },
+    });
+
+    await expect.element(editorScreen.excerptInput()).toHaveValue('A short summary');
+  });
+
+  it('hides the excerpt without the flag', async () => {
+    fakeEditorPost();
+    await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+    await expect.element(editorScreen.titleInput()).toBeVisible();
+    await expect(editorScreen.excerptInput()).toHaveCount(0);
+  });
+
+  it('opens an empty editor for a new post', async () => {
+    fakeEditorChrome();
+    await renderAdminApp('/editor/post', FLAG_ON);
+
+    await expect.element(editorScreen.titleInput()).toHaveValue('');
+    await expect.element(editorScreen.titleInput()).toHaveAttribute('placeholder', 'Post title');
+    await expect.element(editorScreen.body()).toBeVisible();
+    await expect.element(editorScreen.wordCount()).toHaveTextContent('0 words');
+  });
+
+  it('labels a new page as a page', async () => {
+    fakeEditorChrome();
+    await renderAdminApp('/editor/page', FLAG_ON);
+
+    await expect.element(editorScreen.titleInput()).toHaveAttribute('placeholder', 'Page title');
+    await expect.element(editorScreen.backLink('page')).toHaveAttribute('href', '#/pages');
+  });
+});

--- a/apps/admin/src/editor/post-editor.tsx
+++ b/apps/admin/src/editor/post-editor.tsx
@@ -1,0 +1,306 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Textarea } from '@tryghost/shade/components';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
+import { useFocusContext } from '@tryghost/shade/app';
+import { focusKoenigEditorOnBottomClick } from '@tryghost/admin-x-framework';
+import type { KoenigInstance } from '@/settings/components/koenig-loader';
+import type { PostCardConfig, PostType } from './card-config';
+import { KoenigPostEditor } from './koenig-post-editor';
+import { textHasTk } from './tk';
+
+export interface PostEditorProps {
+  postType: PostType;
+  title: string;
+  excerpt: string;
+  /** Initial body; the editor owns its own state after mount. */
+  initialLexical: string | null;
+  cardConfig: PostCardConfig;
+  showExcerpt: boolean;
+  autofocusTitle?: boolean;
+  onTitleChange: (title: string) => void;
+  onExcerptChange: (excerpt: string) => void;
+  onLexicalChange: (lexical: unknown) => void;
+  onSecondaryChange: (lexical: unknown) => void;
+  registerEditorApi?: (api: KoenigInstance | null) => void;
+  registerSecondaryApi?: (api: KoenigInstance | null) => void;
+  onTkCountChange?: (count: number) => void;
+}
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+const fieldClassName = cn(
+  'min-h-0 w-full resize-none overflow-hidden rounded-none border-0 bg-transparent p-0 shadow-none',
+  'focus-visible:border-0 focus-visible:ring-0',
+);
+
+function useAutosize(ref: React.RefObject<HTMLTextAreaElement | null>, value: string) {
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    element.style.height = 'auto';
+    element.style.height = `${element.scrollHeight}px`;
+  }, [ref, value]);
+}
+
+function TkIndicator({ onClick, testId }: { onClick: () => void; testId: string }) {
+  return (
+    <button
+      className="absolute top-1 -left-12 rounded-sm bg-state-warning px-1.5 py-0.5 text-2xs font-bold text-foreground"
+      data-testid={testId}
+      type="button"
+      onClick={onClick}
+    >
+      TK
+    </button>
+  );
+}
+
+// Title, optional excerpt and the Koenig body with keyboard travel between them;
+// edits are reported through the callbacks, nothing is persisted here
+export function PostEditor({
+  postType,
+  title,
+  excerpt,
+  initialLexical,
+  cardConfig,
+  showExcerpt,
+  autofocusTitle = false,
+  onTitleChange,
+  onExcerptChange,
+  onLexicalChange,
+  onSecondaryChange,
+  registerEditorApi,
+  registerSecondaryApi,
+  onTkCountChange,
+}: PostEditorProps) {
+  const { darkMode } = useFocusContext();
+  const titleRef = useRef<HTMLTextAreaElement>(null);
+  const excerptRef = useRef<HTMLTextAreaElement>(null);
+  const editorApiRef = useRef<KoenigInstance | null>(null);
+  const skipFocusEditorRef = useRef(false);
+  const [wordCount, setWordCount] = useState(0);
+  const [bodyTkCount, setBodyTkCount] = useState(0);
+
+  useAutosize(titleRef, title);
+  useAutosize(excerptRef, excerpt);
+
+  const titleHasTk = textHasTk(title);
+  const excerptHasTk = showExcerpt && textHasTk(excerpt);
+
+  useEffect(() => {
+    onTkCountChange?.((titleHasTk ? 1 : 0) + (excerptHasTk ? 1 : 0) + bodyTkCount);
+  }, [onTkCountChange, titleHasTk, excerptHasTk, bodyTkCount]);
+
+  const focusTitle = useCallback(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const focusExcerpt = useCallback(() => {
+    excerptRef.current?.focus();
+    // runs after the keyboard event so the caret lands at the end
+    setTimeout(() => excerptRef.current?.setSelectionRange(-1, -1), 0);
+  }, []);
+
+  const registerApi = useCallback(
+    (api: KoenigInstance | null) => {
+      editorApiRef.current = api;
+      registerEditorApi?.(api);
+    },
+    [registerEditorApi],
+  );
+
+  const registerSecondary = useCallback(
+    (api: KoenigInstance | null) => {
+      registerSecondaryApi?.(api);
+    },
+    [registerSecondaryApi],
+  );
+
+  const moveIntoEditor = (key: string) => {
+    const editorApi = editorApiRef.current;
+    if (!editorApi) {
+      return;
+    }
+    if (key === 'Enter' && !editorApi.editorIsEmpty()) {
+      editorApi.insertParagraphAtTop({ focus: true });
+    } else {
+      editorApi.focusEditor({ position: 'top' });
+    }
+  };
+
+  const onTitleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const { key } = event;
+    const { value, selectionStart } = event.currentTarget;
+    const couldLeaveTitle = !value || selectionStart === value.length;
+
+    if (showExcerpt) {
+      // Tab is handled by the browser
+      if (key === 'Enter') {
+        event.preventDefault();
+        focusExcerpt();
+      }
+      if ((key === 'ArrowDown' || key === 'ArrowRight') && !event.shiftKey && couldLeaveTitle) {
+        event.preventDefault();
+        focusExcerpt();
+      }
+      return;
+    }
+
+    if (!editorApiRef.current || event.nativeEvent.isComposing) {
+      return;
+    }
+
+    const arrowLeavingTitle = (key === 'ArrowDown' || key === 'ArrowRight') && couldLeaveTitle;
+    if (key === 'Enter' || key === 'Tab' || arrowLeavingTitle) {
+      event.preventDefault();
+      moveIntoEditor(key);
+    }
+  };
+
+  const onExcerptKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const { key } = event;
+    const { value, selectionStart } = event.currentTarget;
+
+    if ((key === 'ArrowUp' || key === 'ArrowLeft') && !event.shiftKey) {
+      if (!value || selectionStart === 0) {
+        event.preventDefault();
+        focusTitle();
+        return;
+      }
+    }
+
+    const couldLeaveExcerpt = !value || selectionStart === value.length;
+    const arrowLeavingExcerpt = (key === 'ArrowRight' || key === 'ArrowDown') && couldLeaveExcerpt;
+    if (key === 'Enter' || (key === 'Tab' && !event.shiftKey) || arrowLeavingExcerpt) {
+      event.preventDefault();
+      moveIntoEditor(key);
+    }
+  };
+
+  const cleanPastedTitle = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const pastedText = event.clipboardData.getData('text');
+    if (!pastedText) {
+      return;
+    }
+    event.preventDefault();
+    // execCommand keeps the paste on the browser's undo stack
+    document.execCommand('insertText', false, pastedText.replace(/(\n|\r)+/g, ' ').trim());
+  };
+
+  // A mousedown on a card can deselect another card, so the mouseup can land
+  // outside the clicked card; refocusing then would change the selection
+  const trackMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    skipFocusEditorRef.current = event.nativeEvent
+      .composedPath()
+      .some(
+        (element) =>
+          element instanceof Element &&
+          element.matches('[data-lexical-decorator], [data-kg-slash-menu]'),
+      );
+  };
+
+  const focusEditorOnPaneClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      !skipFocusEditorRef.current &&
+      event.target === event.currentTarget &&
+      editorApiRef.current
+    ) {
+      focusKoenigEditorOnBottomClick(editorApiRef.current, event);
+    }
+    skipFocusEditorRef.current = false;
+  };
+
+  const onPaneDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (event.dataTransfer.files.length > 0) {
+      event.preventDefault();
+      editorApiRef.current?.insertFiles(Array.from(event.dataTransfer.files));
+    }
+  };
+
+  return (
+    <div className="relative h-full min-h-0" data-testid="post-editor">
+      <div className="h-full overflow-y-auto">
+        <Stack
+          className="min-h-full px-6 pt-12 pb-24"
+          gap="none"
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={onPaneDrop}
+          onMouseDown={trackMouseDown}
+          onMouseUp={focusEditorOnPaneClick}
+        >
+          <div className="relative mx-auto w-full max-w-[740px]">
+            {titleHasTk && <TkIndicator testId="tk-indicator" onClick={focusTitle} />}
+            <Textarea
+              ref={titleRef}
+              aria-label={`${capitalize(postType)} title`}
+              autoFocus={autofocusTitle}
+              className={cn(
+                fieldClassName,
+                'mb-4 text-4xl leading-tight font-bold tracking-tight text-foreground placeholder:font-bold placeholder:text-muted-foreground',
+              )}
+              data-testid="editor-title-input"
+              placeholder={`${capitalize(postType)} title`}
+              rows={1}
+              value={title}
+              onChange={(event) => onTitleChange(event.target.value)}
+              onKeyDown={onTitleKeyDown}
+              onPaste={cleanPastedTitle}
+            />
+            {showExcerpt && (
+              <div className="relative">
+                {excerptHasTk && (
+                  <TkIndicator testId="tk-indicator-excerpt" onClick={focusExcerpt} />
+                )}
+                <Textarea
+                  ref={excerptRef}
+                  aria-label="Excerpt"
+                  className={cn(
+                    fieldClassName,
+                    'text-xl leading-normal tracking-tight text-text-secondary placeholder:text-muted-foreground',
+                  )}
+                  data-testid="editor-excerpt-input"
+                  placeholder="Add an excerpt"
+                  rows={1}
+                  value={excerpt}
+                  onChange={(event) => onExcerptChange(event.target.value)}
+                  onKeyDown={onExcerptKeyDown}
+                />
+                <hr className="mt-4 mb-6 border-border" />
+              </div>
+            )}
+          </div>
+          <KoenigPostEditor
+            cardConfig={cardConfig}
+            cursorDidExitAtTop={showExcerpt ? focusExcerpt : focusTitle}
+            darkMode={darkMode}
+            initialLexical={initialLexical}
+            placeholder={`Begin writing your ${postType}...`}
+            registerAPI={registerApi}
+            registerSecondaryAPI={registerSecondary}
+            onChange={onLexicalChange}
+            onSecondaryChange={onSecondaryChange}
+            onTkCountChange={setBodyTkCount}
+            onWordCountChange={setWordCount}
+          />
+        </Stack>
+      </div>
+      <Inline className="absolute right-0 bottom-0 px-4 py-3" gap="sm">
+        <Text data-testid="editor-word-count" size="xs" tone="secondary">
+          {formatNumber(wordCount)} {wordCount === 1 ? 'word' : 'words'}
+        </Text>
+        <a
+          aria-label="Editor help"
+          className="text-text-secondary hover:text-foreground"
+          href="https://ghost.org/help/using-the-editor/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <LucideIcon.CircleHelp className="size-4" />
+        </a>
+      </Inline>
+    </div>
+  );
+}

--- a/apps/admin/src/editor/post-editor.tsx
+++ b/apps/admin/src/editor/post-editor.tsx
@@ -48,9 +48,17 @@ function useAutosize(ref: React.RefObject<HTMLTextAreaElement | null>, value: st
     if (!element) {
       return;
     }
-    const observer = new ResizeObserver(measure);
+    // measuring inside the observer callback would resize the observed element mid-loop
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(measure);
+    });
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
   }, [ref, measure]);
 }
 

--- a/apps/admin/src/editor/post-editor.tsx
+++ b/apps/admin/src/editor/post-editor.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { Textarea } from '@tryghost/shade/components';
 import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
 import { useFocusContext } from '@tryghost/shade/app';
@@ -20,8 +19,8 @@ export interface PostEditorProps {
   autofocusTitle?: boolean;
   onTitleChange: (title: string) => void;
   onExcerptChange: (excerpt: string) => void;
-  onLexicalChange: (lexical: unknown) => void;
-  onSecondaryChange: (lexical: unknown) => void;
+  onLexicalChange?: (lexical: unknown) => void;
+  onSecondaryChange?: (lexical: unknown) => void;
   registerEditorApi?: (api: KoenigInstance | null) => void;
   registerSecondaryApi?: (api: KoenigInstance | null) => void;
   onTkCountChange?: (count: number) => void;
@@ -29,20 +28,30 @@ export interface PostEditorProps {
 
 const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
-const fieldClassName = cn(
-  'min-h-0 w-full resize-none overflow-hidden rounded-none border-0 bg-transparent p-0 shadow-none',
-  'focus-visible:border-0 focus-visible:ring-0',
-);
+const fieldClassName =
+  'block w-full resize-none overflow-hidden border-0 bg-transparent p-0 outline-none';
 
 function useAutosize(ref: React.RefObject<HTMLTextAreaElement | null>, value: string) {
-  useLayoutEffect(() => {
+  const measure = useCallback(() => {
     const element = ref.current;
     if (!element) {
       return;
     }
     element.style.height = 'auto';
     element.style.height = `${element.scrollHeight}px`;
-  }, [ref, value]);
+  }, [ref]);
+
+  useLayoutEffect(measure, [measure, value]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref, measure]);
 }
 
 function TkIndicator({ onClick, testId }: { onClick: () => void; testId: string }) {
@@ -58,8 +67,6 @@ function TkIndicator({ onClick, testId }: { onClick: () => void; testId: string 
   );
 }
 
-// Title, optional excerpt and the Koenig body with keyboard travel between them;
-// edits are reported through the callbacks, nothing is persisted here
 export function PostEditor({
   postType,
   title,
@@ -233,7 +240,7 @@ export function PostEditor({
         >
           <div className="relative mx-auto w-full max-w-[740px]">
             {titleHasTk && <TkIndicator testId="tk-indicator" onClick={focusTitle} />}
-            <Textarea
+            <textarea
               ref={titleRef}
               aria-label={`${capitalize(postType)} title`}
               autoFocus={autofocusTitle}
@@ -254,7 +261,7 @@ export function PostEditor({
                 {excerptHasTk && (
                   <TkIndicator testId="tk-indicator-excerpt" onClick={focusExcerpt} />
                 )}
-                <Textarea
+                <textarea
                   ref={excerptRef}
                   aria-label="Excerpt"
                   className={cn(

--- a/apps/admin/src/editor/tk.test.ts
+++ b/apps/admin/src/editor/tk.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { textHasTk } from './tk';
+
+describe('textHasTk', () => {
+  it.each(['TK', 'Title TK', 'TK: draft', '[TK] later', 'Update (TKTK) soon', 'end. TK'])(
+    'detects a TK marker in %j',
+    (text) => {
+      expect(textHasTk(text)).toBe(true);
+    },
+  );
+
+  it.each(['', 'Talk', 'STKS', 'TKA', 'ATK', 'end.TK', 'network', 'tk'])(
+    'ignores TK inside a word in %j',
+    (text) => {
+      expect(textHasTk(text)).toBe(false);
+    },
+  );
+
+  it('skips an invalid match to find a later valid one', () => {
+    expect(textHasTk('ATK and then TK')).toBe(true);
+  });
+});

--- a/apps/admin/src/editor/tk.ts
+++ b/apps/admin/src/editor/tk.ts
@@ -1,0 +1,30 @@
+// Ported from the Ember lexical-editor controller; matches Koenig's TK node
+// detection for plain-text fields (title, excerpt).
+const TK_REGEX = /(^|.)([^\p{L}\p{N}\s]*(TK)+[^\p{L}\p{N}\s]*)(.)?/u;
+const WORD_CHAR_REGEX = /\p{L}|\p{N}/u;
+
+function isValidMatch(match: RegExpExecArray): boolean {
+  // negative lookbehind isn't supported before Safari 16.4, so the preceding
+  // and following characters are captured and tested here
+  if (match[1] && match[1].trim() && WORD_CHAR_REGEX.test(match[1])) {
+    return false;
+  }
+
+  if (match[4] && match[4].trim() && WORD_CHAR_REGEX.test(match[4])) {
+    return false;
+  }
+
+  return true;
+}
+
+export function textHasTk(text: string): boolean {
+  let remaining = text;
+  let match = TK_REGEX.exec(remaining);
+
+  while (match !== null && !isValidMatch(match)) {
+    remaining = remaining.slice(match.index + match[0].length - 1);
+    match = TK_REGEX.exec(remaining);
+  }
+
+  return match !== null;
+}

--- a/apps/admin/src/editor/use-post-card-config.ts
+++ b/apps/admin/src/editor/use-post-card-config.ts
@@ -1,0 +1,125 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useFramework } from '@tryghost/admin-x-framework';
+import { apiUrl } from '@tryghost/admin-x-framework/helpers';
+import {
+  useFetchApi,
+  useKoenigFetchEmbed,
+  usePinturaConfig,
+} from '@tryghost/admin-x-framework/hooks';
+import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
+import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
+import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
+import { getHomepageUrl, useBrowseSite } from '@tryghost/admin-x-framework/api/site';
+import {
+  type CardConfigPostSource,
+  type CardConfigSnippet,
+  type CardConfigSnippetInput,
+  type PostCardConfig,
+  buildCardConfigPost,
+  buildPostCardConfig,
+} from './card-config';
+import { usePostLinkSuggestions } from './use-post-link-suggestions';
+
+export interface PostCardConfigOptions {
+  post: CardConfigPostSource;
+  snippets: CardConfigSnippet[];
+  createSnippet?: (snippet: CardConfigSnippetInput) => void;
+  deleteSnippet?: (snippet: { name: string }) => void;
+}
+
+/**
+ * Assembles the post editor's Koenig `cardConfig` from the framework's data
+ * hooks. Returns null until the boot data it reads has resolved.
+ */
+export function usePostCardConfig({
+  post,
+  snippets,
+  createSnippet,
+  deleteSnippet,
+}: PostCardConfigOptions): PostCardConfig | null {
+  const { data: settingsData } = useBrowseSettings();
+  const { data: configData } = useBrowseConfig();
+  const { data: siteData } = useBrowseSite();
+  const { data: currentUser } = useCurrentUser();
+  const { unsplashConfig } = useFramework();
+  const pinturaConfig = usePinturaConfig();
+  const fetchEmbed = useKoenigFetchEmbed();
+  const fetchApi = useFetchApi();
+
+  const settings = settingsData?.settings ?? null;
+  const config = configData?.config;
+  const site = siteData?.site;
+
+  const labelsRequest = useRef<Promise<string[]> | null>(null);
+  const fetchLabels = useCallback(() => {
+    labelsRequest.current ??= fetchApi<{ labels: { name: string }[] }>(
+      apiUrl('/labels/', { limit: 'all', fields: 'id,name' }),
+    )
+      .then((response) => response.labels.map((label) => label.name))
+      .catch((error: unknown) => {
+        labelsRequest.current = null;
+        throw error;
+      });
+
+    return labelsRequest.current;
+  }, [fetchApi]);
+
+  const { fetchAutocompleteLinks, searchLinks } = usePostLinkSuggestions({
+    postType: post.displayName,
+    homepageUrl: site ? getHomepageUrl(site) : '/',
+    paidMembersEnabled: getSettingValue<boolean>(settings, 'paid_members_enabled') === true,
+    donationsEnabled: getSettingValue<boolean>(settings, 'donations_enabled') === true,
+    recommendationsEnabled: getSettingValue<boolean>(settings, 'recommendations_enabled') === true,
+    membersEnabled: getSettingValue<string>(settings, 'members_signup_access') !== 'none',
+    timezone: getSettingValue<string>(settings, 'timezone') ?? 'Etc/UTC',
+  });
+
+  const defaultContentVisibility =
+    getSettingValue<string>(settings, 'default_content_visibility') ?? 'public';
+  const cardConfigPost = useMemo(
+    () => buildCardConfigPost(post, defaultContentVisibility),
+    [post, defaultContentVisibility],
+  );
+
+  return useMemo(() => {
+    if (!settings || !config || !site || !currentUser) {
+      return null;
+    }
+
+    return buildPostCardConfig(
+      {
+        settings,
+        config,
+        site,
+        currentUser,
+        unsplashHeaders: unsplashConfig,
+        pinturaConfig,
+        post: cardConfigPost,
+        snippets,
+      },
+      {
+        fetchEmbed,
+        fetchAutocompleteLinks,
+        searchLinks,
+        fetchLabels,
+        createSnippet,
+        deleteSnippet,
+      },
+    );
+  }, [
+    settings,
+    config,
+    site,
+    currentUser,
+    unsplashConfig,
+    pinturaConfig,
+    cardConfigPost,
+    snippets,
+    fetchEmbed,
+    fetchAutocompleteLinks,
+    searchLinks,
+    fetchLabels,
+    createSnippet,
+    deleteSnippet,
+  ]);
+}

--- a/apps/admin/src/editor/use-post-link-suggestions.ts
+++ b/apps/admin/src/editor/use-post-link-suggestions.ts
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { apiUrl } from '@tryghost/admin-x-framework/helpers';
+import { useFetchApi } from '@tryghost/admin-x-framework/hooks';
+import type { Offer } from '@tryghost/admin-x-framework/api/offers';
+import type { PostType } from './card-config';
+import {
+  type AutocompleteLink,
+  type LatestPostSource,
+  type LinkSearchGroup,
+  type LinkSearchResultGroup,
+  type SearchIndexEntity,
+  type SearchIndexPost,
+  buildAutocompleteLinks,
+  buildLatestPostsGroup,
+  buildOfferLinks,
+  filterLinkSearchResults,
+  searchIndexEntitiesGroup,
+  searchIndexPostsGroup,
+} from './link-suggestions';
+
+export interface PostLinkSuggestionOptions {
+  postType: PostType;
+  homepageUrl: string;
+  paidMembersEnabled: boolean;
+  donationsEnabled: boolean;
+  recommendationsEnabled: boolean;
+  membersEnabled: boolean;
+  timezone: string;
+}
+
+interface SearchIndex {
+  posts: SearchIndexPost[];
+  pages: SearchIndexPost[];
+  tags: SearchIndexEntity[];
+  users: SearchIndexEntity[];
+}
+
+interface SuggestionCache {
+  offerLinks?: Promise<AutocompleteLink[]>;
+  latestPosts?: Promise<LinkSearchGroup[]>;
+  index: Partial<Record<keyof SearchIndex, Promise<unknown[]>>>;
+}
+
+// Link toolbar data is fetched on first use and cached for the editor's lifetime
+export function usePostLinkSuggestions({
+  postType,
+  homepageUrl,
+  paidMembersEnabled,
+  donationsEnabled,
+  recommendationsEnabled,
+  membersEnabled,
+  timezone,
+}: PostLinkSuggestionOptions) {
+  const fetchApi = useFetchApi();
+  const cache = useRef<SuggestionCache>({ index: {} });
+
+  const loadIndex = useCallback(
+    <Key extends keyof SearchIndex>(key: Key): Promise<SearchIndex[Key]> => {
+      const cached = cache.current.index[key];
+      if (cached) {
+        return cached as Promise<SearchIndex[Key]>;
+      }
+
+      const request: Promise<SearchIndex[Key]> = fetchApi<Record<Key, SearchIndex[Key]>>(
+        apiUrl(`/search-index/${key}/`),
+      )
+        .then((response) => response[key])
+        .catch(() => {
+          delete cache.current.index[key];
+          return [] as SearchIndex[Key];
+        });
+      cache.current.index[key] = request;
+      return request;
+    },
+    [fetchApi],
+  );
+
+  const fetchAutocompleteLinks = useCallback(async () => {
+    // Only active signup offers belong in link dropdowns: archived offers are
+    // gone and retention offers only surface in cancellation flows
+    cache.current.offerLinks ??= fetchApi<{ offers?: Offer[] }>(
+      apiUrl('/offers/', { filter: 'status:active+redemption_type:signup' }),
+    )
+      .then((response) => buildOfferLinks(response.offers ?? [], homepageUrl))
+      .catch(() => {
+        delete cache.current.offerLinks;
+        return [];
+      });
+
+    const offerLinks = await cache.current.offerLinks;
+
+    return buildAutocompleteLinks(
+      { postType, homepageUrl, paidMembersEnabled, donationsEnabled, recommendationsEnabled },
+      offerLinks,
+    );
+  }, [
+    fetchApi,
+    postType,
+    homepageUrl,
+    paidMembersEnabled,
+    donationsEnabled,
+    recommendationsEnabled,
+  ]);
+
+  const decorationSettings = useMemo(
+    () => ({ timezone, membersEnabled }),
+    [timezone, membersEnabled],
+  );
+
+  const searchLinks = useCallback(
+    async (term?: string): Promise<LinkSearchGroup[]> => {
+      if (!term) {
+        cache.current.latestPosts ??= fetchApi<{ posts: LatestPostSource[] }>(
+          apiUrl('/posts/', {
+            filter: 'status:published',
+            fields: 'id,url,title,visibility,published_at',
+            order: 'published_at desc',
+            limit: '5',
+          }),
+        )
+          .then((response) => buildLatestPostsGroup(response.posts, decorationSettings))
+          .catch((error: unknown) => {
+            delete cache.current.latestPosts;
+            throw error;
+          });
+
+        return cache.current.latestPosts;
+      }
+
+      const [users, tags, posts, pages] = await Promise.all([
+        loadIndex('users'),
+        loadIndex('tags'),
+        loadIndex('posts'),
+        loadIndex('pages'),
+      ]);
+
+      const groups: LinkSearchResultGroup[] = [
+        searchIndexEntitiesGroup('Staff', users, term),
+        searchIndexEntitiesGroup('Tags', tags, term),
+        searchIndexPostsGroup('Posts', posts, term),
+        searchIndexPostsGroup('Pages', pages, term),
+      ];
+
+      return filterLinkSearchResults(groups, decorationSettings);
+    },
+    [fetchApi, loadIndex, decorationSettings],
+  );
+
+  return { fetchAutocompleteLinks, searchLinks };
+}

--- a/apps/admin/src/editor/use-post-snippets.tsx
+++ b/apps/admin/src/editor/use-post-snippets.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+} from '@tryghost/shade/components';
+import { toast } from 'sonner';
+import {
+  type Snippet,
+  useAddSnippet,
+  useBrowseSnippets,
+  useDeleteSnippet,
+  useEditSnippet,
+} from '@tryghost/admin-x-framework/api/snippets';
+import type { CardConfigSnippet, CardConfigSnippetInput } from './card-config';
+
+type PendingSnippetAction =
+  | { kind: 'update'; snippet: Snippet; value: string }
+  | { kind: 'delete'; snippet: Snippet };
+
+export interface PostSnippets {
+  snippets: CardConfigSnippet[];
+  createSnippet?: (snippet: CardConfigSnippetInput) => void;
+  deleteSnippet?: (snippet: { name: string }) => void;
+  snippetDialog: React.ReactNode;
+}
+
+// Snippets for the card menu plus the create/update/delete flows and their
+// confirmation dialogs
+export function usePostSnippets({ canManage }: { canManage: boolean }): PostSnippets {
+  const { data } = useBrowseSnippets();
+  const addSnippet = useAddSnippet();
+  const editSnippet = useEditSnippet();
+  const removeSnippet = useDeleteSnippet();
+  const [pending, setPending] = useState<PendingSnippetAction | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const records = useMemo(
+    () =>
+      (data?.snippets ?? [])
+        .filter((snippet) => snippet.lexical !== null)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [data?.snippets],
+  );
+
+  const snippets = useMemo<CardConfigSnippet[]>(
+    () =>
+      records.map((snippet) => ({
+        id: snippet.id,
+        name: snippet.name,
+        value: snippet.lexical ?? '',
+      })),
+    [records],
+  );
+
+  const createSnippet = useCallback(
+    (input: CardConfigSnippetInput) => {
+      const nameLowerCase = input.name.trim().toLowerCase();
+      const existing = records.find((snippet) => snippet.name.toLowerCase() === nameLowerCase);
+
+      if (existing) {
+        setPending({ kind: 'update', snippet: existing, value: input.value });
+        return;
+      }
+
+      void addSnippet
+        .mutateAsync({ name: input.name, lexical: input.value, mobiledoc: '{}' })
+        .then(() => toast.success(`Snippet saved as "${input.name}"`))
+        .catch(() => toast.error('Snippet save failed'));
+    },
+    [addSnippet, records],
+  );
+
+  const deleteSnippet = useCallback(
+    ({ name }: { name: string }) => {
+      const existing = records.find((snippet) => snippet.name === name);
+      if (existing) {
+        setPending({ kind: 'delete', snippet: existing });
+      }
+    },
+    [records],
+  );
+
+  const close = () => setPending(null);
+
+  const confirm = async () => {
+    if (!pending) {
+      return;
+    }
+
+    setIsRunning(true);
+    try {
+      if (pending.kind === 'update') {
+        await editSnippet.mutateAsync({
+          id: pending.snippet.id,
+          name: pending.snippet.name,
+          lexical: pending.value,
+          mobiledoc: pending.snippet.mobiledoc || '{}',
+        });
+        toast.success(`Snippet "${pending.snippet.name}" updated`);
+      } else {
+        await removeSnippet.mutateAsync(pending.snippet.id);
+      }
+    } catch {
+      toast.error(pending.kind === 'update' ? 'Snippet save failed' : 'Snippet delete failed');
+    } finally {
+      setIsRunning(false);
+      close();
+    }
+  };
+
+  const snippetDialog = (
+    <AlertDialog open={pending !== null} onOpenChange={(open) => !open && !isRunning && close()}>
+      <AlertDialogContent data-testid="snippet-confirm-modal">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {pending?.kind === 'delete' ? 'Confirm snippet deletion' : 'Update this snippet?'}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {pending?.kind === 'delete' ? (
+              <>
+                You’re about to delete the “<strong>{pending.snippet.name}</strong>” snippet. This
+                is permanent, and will delete the snippet for all staff users. It will{' '}
+                <strong>not</strong> change any posts where you’ve used this snippet in the past.
+              </>
+            ) : (
+              <>
+                “<strong>{pending?.snippet.name}</strong>” will be overwritten. Don’t worry, this
+                will only affect using the snippet in the future. Any older posts using this snippet
+                will stay the same.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button disabled={isRunning} variant="outline" onClick={close}>
+            Cancel
+          </Button>
+          <Button
+            disabled={isRunning}
+            variant={pending?.kind === 'delete' ? 'destructive' : 'default'}
+            onClick={() => void confirm()}
+          >
+            {pending?.kind === 'delete' ? 'Delete snippet' : 'Update'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return {
+    snippets,
+    createSnippet: canManage ? createSnippet : undefined,
+    deleteSnippet: canManage ? deleteSnippet : undefined,
+    snippetDialog,
+  };
+}

--- a/apps/admin/src/layout/editor-sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/editor-sidebar.acceptance.test.tsx
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 
-import { renderAdminApp } from '@test-utils/acceptance';
+import {
+  fakeAdminEndpoint,
+  fakePosts,
+  fakeSnippets,
+  post,
+  renderAdminApp,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
 
 /**
  * The editor is a focused writing surface — Ghost hides the nav sidebar for it,
@@ -40,11 +47,14 @@ describe('Editor chrome', () => {
   });
 
   // The decision lives on the route handle, so it must hold on both sides of
-  // the `editorReact` gate — here the React placeholder serves the route.
+  // the `editorReact` gate — here the React editor serves the route.
   it('hides it with editorReact on', async () => {
+    fakeSnippets([]);
+    fakePosts([]);
+    fakeAdminEndpoint('GET', /^\/posts\/abc123\/\?/, { posts: [post({ id: 'abc123' })] });
     await renderAdminApp('/editor/post/abc123', { labs: { editorReact: true } });
 
-    await expect.element(page.getByTestId('editor-react-placeholder')).toBeVisible();
+    await expect.element(editorScreen.root()).toBeVisible();
     await expect(sidebar()).toHaveCount(0);
   });
 

--- a/apps/admin/src/settings/components/koenig-loader.ts
+++ b/apps/admin/src/settings/components/koenig-loader.ts
@@ -9,12 +9,15 @@ declare global {
 
 type KoenigComponent = React.ComponentType<Record<string, unknown>>;
 
-// Minimal surface of the untyped @tryghost/koenig-lexical bundle used by the settings editors
+// Minimal surface of the untyped @tryghost/koenig-lexical bundle used by the admin editors
 export type KoenigLexicalModule = {
   KoenigComposer: KoenigComponent;
   KoenigComposableEditor: KoenigComponent;
+  KoenigEditor: KoenigComponent;
   EmojiPickerPlugin: KoenigComponent;
   HtmlOutputPlugin: KoenigComponent;
+  WordCountPlugin: KoenigComponent;
+  TKCountPlugin: KoenigComponent;
   EmailEditor: KoenigComponent;
   DEFAULT_NODES: unknown;
   BASIC_NODES: unknown;
@@ -34,7 +37,10 @@ export type KoenigInstance = {
     getRootElement: () => HTMLElement | null;
   };
   focusEditor: (options?: { position?: 'top' | 'bottom' }) => void;
+  editorIsEmpty: () => boolean;
+  insertParagraphAtTop: (options?: { focus?: boolean }) => void;
   insertParagraphAtBottom: () => void;
+  insertFiles: (files: File[]) => void;
   lastNodeIsDecorator: () => boolean;
 };
 

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -21,6 +21,7 @@ export {
   fakePostsListScreen,
   fakeRoles,
   fakeSettingsScreens,
+  fakeSnippets,
   fakeTags,
   fakeThemes,
   fakeThemeUpload,

--- a/apps/admin/test-utils/acceptance/resources.ts
+++ b/apps/admin/test-utils/acceptance/resources.ts
@@ -2,6 +2,7 @@ import { HttpResponse } from 'msw';
 import type { Action } from '@tryghost/admin-x-framework/api/actions';
 import type { Integration } from '@tryghost/admin-x-framework/api/integrations';
 import type { MemberCustomField } from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type { Snippet } from '@tryghost/admin-x-framework/api/snippets';
 import {
   activeThemeResponse,
   browseResponse,
@@ -312,6 +313,12 @@ export const fakePosts = defineResource<Post>({
  */
 export const fakePages = defineResource<Post>({
   resource: 'pages',
+  semantics: { kind: 'passthrough' },
+});
+
+/** Snippets list fake (passthrough): the editor browses this endpoint once on mount. */
+export const fakeSnippets = defineResource<Snippet>({
+  resource: 'snippets',
   semantics: { kind: 'passthrough' },
 });
 

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -10,9 +10,8 @@ export const editorExcerptInput = 'editor-excerpt-input';
 export const editorBody = 'editor-body';
 export const editorSecondaryInstance = 'editor-secondary-instance';
 export const editorWordCount = 'editor-word-count';
+export const editorLoadError = 'editor-load-error';
 export const tkIndicator = 'tk-indicator';
-export const tkIndicatorExcerpt = 'tk-indicator-excerpt';
-export const snippetConfirmModal = 'snippet-confirm-modal';
 
 // accessible names
 export const postsBackLink = 'Posts';

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -1,0 +1,19 @@
+/**
+ * Editor selector strings, consumed by the admin screen helpers and the e2e
+ * page objects. Source of truth: apps/admin/src/editor.
+ */
+
+// testids
+export const postEditor = 'post-editor';
+export const editorTitleInput = 'editor-title-input';
+export const editorExcerptInput = 'editor-excerpt-input';
+export const editorBody = 'editor-body';
+export const editorSecondaryInstance = 'editor-secondary-instance';
+export const editorWordCount = 'editor-word-count';
+export const tkIndicator = 'tk-indicator';
+export const tkIndicatorExcerpt = 'tk-indicator-excerpt';
+export const snippetConfirmModal = 'snippet-confirm-modal';
+
+// accessible names
+export const postsBackLink = 'Posts';
+export const pagesBackLink = 'Pages';


### PR DESCRIPTION
The `editorReact` Labs flag currently serves a placeholder on `/editor/*`. This PR turns it into a real post editor: it reads the post or page, renders it in Koenig with the full post `cardConfig`, and keeps edits in memory. **Nothing is saved yet** — the only write is the mobiledoc-to-lexical conversion a legacy post needs before it can open; saving lands separately with the save engine. With the flag off, Ember serves the editor exactly as before.

## What's in the editor

- **`/editor/:type/:id`** loads the record through `useEditorPost`/`useEditorPage` (formats + full includes) and renders the title, the excerpt (behind the `editorExcerpt` flag) and the Koenig body. **`/editor/:type`** renders the same surface with an empty document; `/editor` redirects to `/editor/post` and an unknown type is a 404, as in Ember.
- **Mobiledoc posts** are converted before opening: a record with `mobiledoc` and no `lexical` is PUT with `convert_to_lexical=true` and the editor renders from the response, with a loading state meanwhile and an error state (never an empty editable body) if the conversion fails.
- **Role checks** from Ember's edit route: an author or contributor opening a post they don't author, and a contributor opening a non-draft, are returned to the posts or pages list.
- **Title and excerpt** are auto-sizing textareas (re-measured on resize) with the Ember keyboard travel (Enter/Tab/Arrow between title, excerpt and body; Enter into a non-empty body inserts a paragraph at the top), pasted-title newline cleaning, `(Untitled)` shown as empty, and TK indicators on both fields.
- **Koenig body** mounts the primary instance plus the hidden secondary instance (`data-secondary-instance="true"`) that loads the same initial state, with `WordCountPlugin` and `TKCountPlugin` feeding local state; the word count renders in the footer. Click-below-content focusing, file drag-and-drop into the editor, and `onError` Sentry capture are ported.
- **Seams for the save engine**, exposed as props on `PostEditor`: `onTitleChange`, `onExcerptChange`, `onLexicalChange`, `onSecondaryChange`, `registerEditorApi`, `registerSecondaryApi`, `onTkCountChange`. The screen only wires the title and excerpt into state.

## cardConfig

`card-config.ts` is a pure builder over settings, config, site and the current user, with every asynchronous piece (embed fetch, link search, labels, snippet callbacks) injected as a port — so it is unit-tested without Koenig. It carries the same surface as the Ember editor: Unsplash headers (from the framework's `unsplashConfig`, gated on the `unsplash` setting), Klipy, Pintura (`usePinturaConfig`), `fetchEmbed` (`useKoenigFetchEmbed`), `fetchLabels`, `renderLabels` (off for contributors), `feature.transistor`/`feature.paywallImprovements`, `deprecated.headerV1`, `membersEnabled`, `siteTitle`/`siteDescription`/`siteUrl`/`siteUuid`, `stripeEnabled`, the narrowed `post` (visibility resolved to the site default), `visibilitySettings` (web-only for pages), and snippets with `createSnippet`/`deleteSnippet`.

- **Link suggestions** (`link-suggestions.ts`) are ported from the Ember editor rather than reusing the framework's welcome-email hook, which lacks the gift-subscriptions link, the staff/tag search groups, the offer link spelling and the post metadata decoration (published date + members/paid marker). Data is fetched on first use and cached for the editor's lifetime: offers, the five-latest-published fallback, and the four search indexes (searched in memory, as Ember does). The Homepage link uses the site URL rather than the admin origin so subdirectory and split-domain installs get the right link.
- **Snippets** use the framework's snippet hooks: create, update-on-name-collision and delete each go through a Shade `AlertDialog` with the Ember copy; callbacks are only exposed to owners, admins and editors.

## Deferred from Ember's editor template

Compared with `lexical-editor.hbs` / `gh-koenig-editor-lexical.hbs`, these are not in this PR and land with later slices:

- The feature image uploader (`GhEditorFeatureImage`) and its TK count contribution — the TK total here covers title, excerpt and body.
- The hidden-title indicator and faded title for pages with `show_title_and_feature_image` off.
- `EmailSizeWarning` in the footer.
- The header's post status, publish management/buttons, settings-menu toggle, post history and the mobile menu.

## Tests

- Unit: `card-config`, `link-suggestions`, `tk`.
- Acceptance (Vitest browser mode): the post loads into the title and body with the editor read params; the hidden secondary instance exists and does not double the latest-posts request; typing updates the word count; title edits stay in memory; Enter in the title moves focus into the body and multi-line pastes become a single line; excerpt shows only behind `editorExcerpt`; a mobiledoc post is converted (method, `convert_to_lexical` param and body pinned) and renders the converted content, and a failed conversion shows the error state; 404s for a missing post and an unknown type; authors and contributors are returned to the list per role while their own editable posts open; new post/page URLs render an empty editor and `/editor` lands on a new post. The existing flag-swap and sidebar specs were updated from the placeholder to the editor root.
- The acceptance harness gains `fakeSnippets`.

Verified locally: `apps/admin` lint, `pnpm nx run @tryghost/admin:build`, the admin unit suite, and the editor acceptance specs.
