### PR TITLE
Changed the members API to resolve a session once, at the route

### DIFF
--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -312,6 +312,10 @@ module.exports = {
     return apiFramework.pipeline(require('./feedback-members'), localUtils, 'members');
   },
 
+  get membersAccount() {
+    return apiFramework.pipeline(require('./members-account'), localUtils, 'members');
+  },
+
   get giftsMembers() {
     return apiFramework.pipeline(require('./gifts-members'), localUtils, 'members');
   },

--- a/ghost/core/core/server/api/endpoints/members-account.ts
+++ b/ghost/core/core/server/api/endpoints/members-account.ts
@@ -1,0 +1,65 @@
+const membersService = require('../../services/members');
+
+/**
+ * A member's own record, as the member themselves.
+ *
+ * The route establishes who is asking before this runs, and answers for an
+ * unknown caller itself, so there is always a member here. What to load about them
+ * is decided here rather than there, because this is what knows what it renders.
+ *
+ * `docName` is this endpoint's own, not the Admin API's `members`, because the two
+ * describe the same record to different audiences and a serializer is chosen by
+ * that name. Sharing it would mean sharing the shape.
+ */
+
+interface Frame {
+  data: Record<string, unknown>;
+  options: {
+    context?: { member?: { id: string; email: string } | null };
+  };
+}
+
+const memberOf = (frame: Frame) => frame.options?.context?.member ?? null;
+
+const controller = {
+  docName: 'members_account',
+
+  read: {
+    headers: { cacheInvalidate: false },
+    permissions: false,
+    query(frame: Frame) {
+      return membersService.api.account.read(memberOf(frame)!.id);
+    },
+  },
+
+  /**
+   * Let Ghost email this member again.
+   *
+   * Under the account rather than as a resource of its own: being emailable is a
+   * fact about a member, and the only person who can restore it here is the member
+   * themselves.
+   */
+  destroySuppression: {
+    statusCode: 204,
+    headers: { cacheInvalidate: false },
+    permissions: false,
+    query(frame: Frame) {
+      const member = memberOf(frame)!;
+      return membersService.api.account.allowEmail(member.id, member.email);
+    },
+  },
+
+  // `update` rather than `edit`: the framework reserves `edit` for the Admin API's
+  // enveloped bodies, and this request has always carried a bare one. The
+  // members-facing gift endpoints name their own verbs for the same reason.
+  update: {
+    headers: { cacheInvalidate: false },
+    permissions: false,
+    query(frame: Frame) {
+      return membersService.api.account.edit(frame.data, memberOf(frame)!.id);
+    },
+  },
+};
+
+export default controller;
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -20,6 +20,10 @@ module.exports = {
     return require('./member-commenting');
   },
 
+  get members_account() {
+    return require('./members-account');
+  },
+
   get authentication() {
     return require('./authentication');
   },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members-account.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members-account.ts
@@ -1,0 +1,24 @@
+const { formattedMemberResponse } = require('../../../../../services/members/utils');
+
+interface Frame {
+  response?: unknown;
+}
+
+/**
+ * A member's own record, as this API has always written one down.
+ *
+ * The projection itself is unchanged and still lives beside the other member
+ * formatting; what changes is that it is now reached the way every other
+ * serializer is, by this endpoint's `docName`, rather than being called by hand
+ * from a request handler.
+ */
+const serialize = (member: unknown, _apiConfig: unknown, frame: Frame): void => {
+  frame.response = formattedMemberResponse(member);
+};
+
+// The API framework loads this file with `require()`, so it exports CommonJS-style;
+// `export default` would not be picked up.
+module.exports = {
+  read: serialize,
+  update: serialize,
+};

--- a/ghost/core/core/server/services/members/account-service.ts
+++ b/ghost/core/core/server/services/members/account-service.ts
@@ -1,0 +1,105 @@
+import _ from 'lodash';
+
+/**
+ * A member's own account: what they are shown about themselves, and what they may
+ * change.
+ *
+ * Separate from the request handlers that used to hold this, because none of it is
+ * a question about HTTP. Which fields a member may set is a fact about members, and
+ * the answer is the same whoever is asking.
+ *
+ * Takes a member id rather than a member. Everything here either writes or reads
+ * afresh, and a record loaded before a write is stale by the time the answer is
+ * built, so there is nothing a caller could usefully hand over.
+ */
+
+/** What a member is allowed to change about themselves. */
+const WRITABLE_FIELDS = [
+  'name',
+  'expertise',
+  'subscribed',
+  'newsletters',
+  'enable_comment_notifications',
+  'enable_updates_and_announcements',
+] as const;
+
+/**
+ * The relations a write needs loaded to work out what it is changing.
+ *
+ * Newsletters because the older `subscribed` flag is stored as a list of them, and
+ * the subscription chain because changing what a member is entitled to has to
+ * reconcile against what they are paying for.
+ */
+const WRITE_RELATIONS = [
+  'stripeSubscriptions',
+  'stripeSubscriptions.customer',
+  'stripeSubscriptions.stripePrice',
+  'newsletters',
+];
+
+interface MemberBreadService {
+  read(
+    data: { id: string },
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | null>;
+}
+
+interface MemberRepository {
+  update(data: Record<string, unknown>, options: Record<string, unknown>): Promise<unknown>;
+  update(data: Record<string, unknown>, options: Record<string, unknown>): Promise<unknown>;
+}
+
+interface EmailSuppressionList {
+  removeEmail(email: string): Promise<unknown>;
+}
+
+export interface MemberAccountServiceDeps {
+  memberBREADService: MemberBreadService;
+  members: MemberRepository;
+  emailSuppressionList: EmailSuppressionList;
+}
+
+export class MemberAccountService {
+  #memberBREADService: MemberBreadService;
+  #members: MemberRepository;
+  #emailSuppressionList: EmailSuppressionList;
+
+  constructor({ memberBREADService, members, emailSuppressionList }: MemberAccountServiceDeps) {
+    this.#memberBREADService = memberBREADService;
+    this.#members = members;
+    this.#emailSuppressionList = emailSuppressionList;
+  }
+
+  /** Everything a member is shown about themselves. */
+  async read(memberId: string): Promise<Record<string, unknown> | null> {
+    // Without the extra fields a publisher defines: nothing in this projection
+    // carries them yet, so fetching them would cost a query per request and be
+    // discarded. The session read leaves them off for the same reason.
+    return this.#memberBREADService.read({ id: memberId }, { withCustomFields: false });
+  }
+
+  /** Apply what a member asked to change about themselves, and say what they now hold. */
+  async edit(data: Record<string, unknown>, memberId: string) {
+    await this.#members.update(_.pick(data, WRITABLE_FIELDS), {
+      id: memberId,
+      withRelated: WRITE_RELATIONS,
+    });
+
+    // Read back rather than returning what was written: a member is told what
+    // Ghost now holds, which is not always what they sent. Setting the older
+    // `subscribed` flag, for one, is stored as a list of newsletters.
+    return this.read(memberId);
+  }
+
+  /**
+   * Let Ghost email this member again.
+   *
+   * Two records rather than one: the address is on a list the email provider also
+   * writes to, and the member carries a flag of their own. A member asking to hear
+   * from a site again means both.
+   */
+  async allowEmail(memberId: string, email: string): Promise<void> {
+    await this.#emailSuppressionList.removeEmail(email);
+    await this.#members.update({ email_disabled: false }, { id: memberId });
+  }
+}

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -7,6 +7,7 @@ const PaymentsService = require('./services/payments-service');
 const TokenService = require('./services/token-service');
 const GeolocationService = require('./services/geolocation-service');
 const MemberBREADService = require('./services/member-bread-service');
+const { MemberAccountService } = require('../account-service');
 const MemberRepository = require('./repositories/member-repository');
 const NextPaymentCalculator = require('./services/next-payment-calculator');
 
@@ -359,6 +360,21 @@ module.exports = function MembersAPI({
     return memberBREADService.read({ email }, { withCustomFields: false });
   }
 
+  const account = new MemberAccountService({
+    memberBREADService,
+    members: users,
+    emailSuppressionList,
+  });
+
+  async function getMemberIdentity(transientId) {
+    if (!transientId) {
+      return null;
+    }
+
+    const member = await users.get({ transient_id: transientId });
+    return member ? { id: member.id, email: member.get('email') } : null;
+  }
+
   async function getMemberIdentityDataFromTransientId(transientId) {
     return memberBREADService.read({ transient_id: transientId }, { withCustomFields: false });
   }
@@ -500,6 +516,7 @@ module.exports = function MembersAPI({
     getMemberIdentityToken,
     getMemberEntitlementToken,
     getMemberIdentityDataFromTransientId,
+    getMemberIdentity,
     getMemberIdentityData,
     cycleTransientId,
     setMemberGeolocationFromIp,
@@ -508,6 +525,7 @@ module.exports = function MembersAPI({
     sendEmailWithMagicLink,
     getMagicLink,
     members: users,
+    account,
     memberBREADService,
     events: eventRepository,
     productRepository,

--- a/ghost/core/core/server/services/members/members-ssr.js
+++ b/ghost/core/core/server/services/members/members-ssr.js
@@ -307,6 +307,24 @@ class MembersSSR {
    *
    * @returns {Promise<Member>}
    */
+  /**
+   * Who this session belongs to, without loading them.
+   *
+   * The counterpart to `getMemberDataFromSession`, for callers that need to know a
+   * member is there rather than what is on their record.
+   *
+   * @method getMemberIdentityFromSession
+   * @param {Request} req
+   * @param {Response} res
+   *
+   * @returns {Promise<{id: string, email: string} | null>}
+   */
+  async getMemberIdentityFromSession(req, res) {
+    const transientId = this._getSessionCookies(req, res);
+    const api = await this._getMembersApi();
+    return api.getMemberIdentity(transientId);
+  }
+
   async getMemberDataFromSession(req, res) {
     const transientId = this._getSessionCookies(req, res);
     const member = await this._getMemberIdentityDataFromTransientId(transientId);

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -2,11 +2,10 @@ const crypto = require('crypto');
 const _ = require('lodash');
 const logging = require('@tryghost/logging');
 const membersService = require('./service');
-const emailSuppressionList = require('../email-suppression-list');
 const models = require('../../models');
 const urlUtils = require('../../../shared/url-utils').default;
 const spamPrevention = require('../../web/shared/middleware/api/spam-prevention');
-const { formattedMemberResponse, formatNewsletterResponse } = require('./utils');
+const { formatNewsletterResponse } = require('./utils');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const onHeaders = require('on-headers');
@@ -18,6 +17,9 @@ const messages = {
   missingUuid: 'Missing uuid.',
   invalidUuid: 'Invalid uuid.',
   invalidKey: 'Invalid key.',
+  // Says that nobody is signed in, without naming the cookie that would have said
+  // so. Which cookie carries a session is Ghost's business, not the caller's.
+  noMemberSession: 'You must be signed in to do this.',
 };
 
 const getFreeTier = async function getFreeTier() {
@@ -114,6 +116,94 @@ const getRedirectUrl = function getRedirectUrl({ action, referrer, searchParams,
   }
 
   return redirectUrl.href;
+};
+
+/**
+ * Establish who is signed in, without loading them.
+ *
+ * Sets `req.identity` to an id and an email address, or to null when nobody is
+ * signed in. One lookup against an indexed column, with no relations attached and
+ * nothing fetched from outside Ghost.
+ *
+ * Deliberately not the member's record. Most endpoints that serve a member need to
+ * act on one rather than describe one, and the one that describes a member reads
+ * it again after writing anyway, because the response has to say what Ghost now
+ * holds rather than what was sent. What to load is the endpoint's own business.
+ *
+ * Distinct from `loadMemberSession`, which loads the whole member and is what a
+ * themed page renders from.
+ */
+const loadMemberIdentity = async function loadMemberIdentity(req, res, next) {
+  try {
+    Object.assign(req, {
+      identity: await membersService.ssr.getMemberIdentityFromSession(req, res),
+    });
+  } catch (err) {
+    // Only a missing or unreadable cookie means nobody is signed in. Establishing
+    // an identity also reaches the database, and answering "you are not signed in"
+    // to that failing would tell a signed-in member something false and leave the
+    // real fault unreported.
+    if (!errors.utils.isGhostError(err) || err.errorType !== 'BadRequestError') {
+      return next(err);
+    }
+    Object.assign(req, { identity: null });
+  }
+
+  return next();
+};
+
+/**
+ * Hand the identity to whatever comes next, in the place the API framework reads.
+ *
+ * The framework takes whoever is acting from `req.member` and nowhere else, so a
+ * controller behind either gate below finds the identity there.
+ */
+const carryIdentity = function carryIdentity(req, res) {
+  Object.assign(req, { member: req.identity });
+  res.locals.member = req.member;
+};
+
+/**
+ * Refuse a request that `loadMemberIdentity` could not put a name to.
+ *
+ * For endpoints where an unknown caller is asking for something they have no right
+ * to: changing a member's record, or reading what a publisher collects.
+ *
+ * Reads only `req.identity`, so a route using this must register
+ * `loadMemberIdentity` first. It looks nothing up itself: what a route needs is
+ * declared by the middleware it lists, rather than depending on what some earlier
+ * one happened to leave behind.
+ */
+const rejectWhenAnonymous = function rejectWhenAnonymous(req, res, next) {
+  if (!req.identity) {
+    return next(
+      new errors.UnauthorizedError({
+        message: tpl(messages.noMemberSession),
+      }),
+    );
+  }
+
+  carryIdentity(req, res);
+  return next();
+};
+
+/**
+ * Answer with nothing when `loadMemberIdentity` could not put a name to the request.
+ *
+ * For reading who you are, where not knowing is an ordinary answer rather than a
+ * failure: a themed page asks on every view and most of those views have no member.
+ *
+ * The counterpart to `rejectWhenAnonymous`, and separate from it because which of
+ * the two applies is a fact about the endpoint, not a setting on a shared one.
+ */
+const emptyWhenAnonymous = function emptyWhenAnonymous(req, res, next) {
+  if (!req.identity) {
+    res.writeHead(204);
+    return res.end();
+  }
+
+  carryIdentity(req, res);
+  return next();
 };
 
 /**
@@ -243,42 +333,6 @@ const deleteSession = async function deleteSession(req, res) {
   }
 };
 
-const getMemberData = async function getMemberData(req, res) {
-  try {
-    const member = await membersService.ssr.getMemberDataFromSession(req, res);
-    if (member) {
-      res.json(formattedMemberResponse(member));
-    } else {
-      res.json(null);
-    }
-  } catch (err) {
-    res.writeHead(204);
-    res.end();
-  }
-};
-
-const deleteSuppression = async function deleteSuppression(req, res) {
-  try {
-    const member = await membersService.ssr.getMemberDataFromSession(req, res);
-    const options = {
-      id: member.id,
-    };
-    await emailSuppressionList.removeEmail(member.email);
-    await membersService.api.members.update({ email_disabled: false }, options);
-
-    res.writeHead(204);
-    res.end();
-  } catch (err) {
-    if (!err.statusCode) {
-      logging.error(err);
-    }
-    res.writeHead(err.statusCode ?? 500, {
-      'Content-Type': 'text/plain;charset=UTF-8',
-    });
-    res.end(err.message);
-  }
-};
-
 const getMemberNewsletters = async function getMemberNewsletters(req, res) {
   try {
     const memberData = req.member; // validation assumed
@@ -348,46 +402,6 @@ const updateMemberNewsletters = async function updateMemberNewsletters(req, res)
   } catch (err) {
     res.writeHead(400);
     res.end('Failed to update newsletters');
-  }
-};
-
-const updateMemberData = async function updateMemberData(req, res) {
-  try {
-    const data = _.pick(
-      req.body,
-      'name',
-      'expertise',
-      'subscribed',
-      'newsletters',
-      'enable_comment_notifications',
-      'enable_updates_and_announcements',
-    );
-    const member = await membersService.ssr.getMemberDataFromSession(req, res);
-    if (member) {
-      const options = {
-        id: member.id,
-        withRelated: [
-          'stripeSubscriptions',
-          'stripeSubscriptions.customer',
-          'stripeSubscriptions.stripePrice',
-          'newsletters',
-        ],
-      };
-      await membersService.api.members.update(data, options);
-      const updatedMember = await membersService.ssr.getMemberDataFromSession(req, res);
-
-      res.json(formattedMemberResponse(updatedMember));
-    } else {
-      res.json(null);
-    }
-  } catch (err) {
-    if (!err.statusCode) {
-      logging.error(err);
-    }
-    res.writeHead(err.statusCode ?? 500, {
-      'Content-Type': 'text/plain;charset=UTF-8',
-    });
-    res.end(err.message);
   }
 };
 
@@ -500,17 +514,17 @@ const createSessionFromMagicLink = async function createSessionFromMagicLink(req
 // Set req.member & res.locals.member if a cookie is set
 module.exports = {
   loadMemberSession,
+  loadMemberIdentity,
+  rejectWhenAnonymous,
+  emptyWhenAnonymous,
   authMemberByUuid,
   createSessionFromMagicLink,
   getIdentityToken,
   getEntitlementToken,
   getMemberNewsletters,
-  getMemberData,
-  updateMemberData,
   updateMemberNewsletters,
   deleteSession,
   accessInfoSession,
-  deleteSuppression,
   createIntegrityToken,
   verifyIntegrityToken,
 };

--- a/ghost/core/core/server/web/members/account/index.ts
+++ b/ghost/core/core/server/web/members/account/index.ts
@@ -1,0 +1,1 @@
+module.exports = require('./routes');

--- a/ghost/core/core/server/web/members/account/routes.ts
+++ b/ghost/core/core/server/web/members/account/routes.ts
@@ -1,0 +1,59 @@
+const express = require('../../../../shared/express');
+const bodyParser = require('body-parser');
+const config = require('../../../../shared/config');
+const { http } = require('@tryghost/api-framework');
+const api = require('../../../api').endpoints;
+const middleware = require('../../../services/members/middleware');
+
+/**
+ * A member's own account, over HTTP.
+ *
+ * Everything reached by a signed-in member acting on their own record lives here,
+ * so how these routes authenticate is a property of the module rather than a line
+ * each one repeats. Establishing who is asking happens once; each route then says
+ * what it wants done when there is nobody.
+ *
+ * Endpoints reached by someone who is not signed in stay outside this: the
+ * unsubscribe links identify a member by a signed link, and changing an email
+ * address by a token in the body, because in both cases the person following them
+ * has no session.
+ */
+module.exports = function accountRoutes() {
+  const router = express.Router('member-account');
+
+  router.use(middleware.loadMemberIdentity);
+
+  // Reading who you are. Answering with nothing when there is no member is the
+  // right answer rather than a failure: a themed page asks this on every view.
+  if (config.get('cacheMembersContent:enabled')) {
+    router.get(
+      '/',
+      // Not for this route's benefit. This configuration stamps a cookie saying
+      // what the reader is entitled to, so a cache can vary on it, and that needs
+      // the member's subscriptions rather than only their identity. It rides here
+      // because Portal asks this endpoint on every page load.
+      middleware.loadMemberSession,
+      middleware.accessInfoSession,
+      middleware.emptyWhenAnonymous,
+      http(api.membersAccount.read),
+    );
+  } else {
+    router.get('/', middleware.emptyWhenAnonymous, http(api.membersAccount.read));
+  }
+
+  router.put(
+    '/',
+    bodyParser.json({ limit: '50mb' }),
+    middleware.rejectWhenAnonymous,
+    http(api.membersAccount.update),
+  );
+
+  // Letting Ghost email this member again after it stopped.
+  router.delete(
+    '/suppression',
+    middleware.rejectWhenAnonymous,
+    http(api.membersAccount.destroySuppression),
+  );
+
+  return router;
+};

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -8,10 +8,10 @@ const audienceFeedbackService = require('../../services/audience-feedback');
 const middleware = membersService.middleware;
 const shared = require('../shared');
 const errorHandler = require('@tryghost/mw-error-handler');
-const config = require('../../../shared/config');
 const { http } = require('@tryghost/api-framework');
 const api = require('../../api').endpoints;
 
+const accountRoutes = require('./account');
 const commentRouter = require('../comments');
 const announcementRouter = require('../announcement');
 const corsMiddleware = require('./middleware/cors');
@@ -57,21 +57,9 @@ module.exports = function setupMembersApp() {
     middleware.updateMemberNewsletters,
   );
 
-  // Get and update member data
-  // Caching members content is an experimental feature
-  const shouldCacheMembersContent = config.get('cacheMembersContent:enabled');
-  if (shouldCacheMembersContent) {
-    membersApp.get(
-      '/api/member',
-      middleware.loadMemberSession,
-      middleware.accessInfoSession,
-      middleware.getMemberData,
-    );
-  } else {
-    membersApp.get('/api/member', middleware.getMemberData);
-  }
+  // A member's own account. Its routes and how they authenticate live together.
+  membersApp.use('/api/member', accountRoutes());
 
-  membersApp.put('/api/member', bodyParser.json({ limit: '50mb' }), middleware.updateMemberData);
   membersApp.post('/api/member/email', bodyParser.json({ limit: '50mb' }), (req, res, next) =>
     membersService.api.middleware.updateEmailAddress(req, res, next),
   );
@@ -86,8 +74,6 @@ module.exports = function setupMembersApp() {
   );
 
   // Remove email from suppression list
-  membersApp.delete('/api/member/suppression', middleware.deleteSuppression);
-
   // Manage session
   membersApp.get('/api/session', middleware.getIdentityToken);
   membersApp.delete('/api/session', bodyParser.json({ limit: '5mb' }), middleware.deleteSession);

--- a/ghost/core/test/e2e-api/members/member-projection.test.ts
+++ b/ghost/core/test/e2e-api/members/member-projection.test.ts
@@ -172,10 +172,9 @@ describe('Members API member projection', function () {
 
       const { statusCode } = await signedOut.get('/api/member/');
 
-      // 204, and not by the route deciding so: resolving the session throws when
-      // there is none, and the handler's catch answers empty. Worth pinning
-      // because the deliberate no-session branch a few lines above it returns 200
-      // with a null body, and only one of the two is what anyone actually sees.
+      // The route decides this, rather than it falling out of a handler failing:
+      // reading who you are is the one place where not knowing is an ordinary
+      // answer, because a themed page asks on every view.
       assert.equal(statusCode, 204);
     });
 

--- a/ghost/core/test/e2e-api/members/session-auth.test.ts
+++ b/ghost/core/test/e2e-api/members/session-auth.test.ts
@@ -1,31 +1,100 @@
 import assert from 'node:assert/strict';
 
 const { agentProvider, fixtureManager } = require('../../utils/e2e-framework');
+const DomainEvents = require('@tryghost/domain-events');
+const {
+  EmailBouncedEvent,
+} = require('../../../core/server/services/email-service/events/email-bounced-event');
+
+const SIGNED_IN_EMAIL = 'session-auth@example.com';
+const ANONYMOUS_TARGET_EMAIL = 'session-auth-suppressed@example.com';
+
+interface Agent {
+  get: (_url: string) => any;
+  put: (_url: string) => any;
+  post: (_url: string) => any;
+  delete: (_url: string) => any;
+}
+
+interface MembersAgent extends Agent {
+  loginAs: (_email: string) => Promise<any>;
+  duplicate: () => MembersAgent;
+}
+
+interface AdminAgent extends Agent {
+  loginAsOwner: () => Promise<void>;
+}
 
 /**
  * What the members API does when it cannot tell who is asking.
  *
- * Several endpoints exist only to serve the member making the request, and each
- * works out who that is on its own. Nothing states what they should answer when
- * nobody is signed in, so each has arrived at its own answer, and these record
- * what those answers currently are.
+ * Endpoints that exist only to serve the member making the request now say so, by
+ * sitting behind a gate that resolves the member and answers for them when there
+ * is none. How it answers is the endpoint's choice, and there are two:
  *
- * Recorded before changing any of it. Where a later change moves one of these, the
- * change to this file is the statement of what was decided, rather than something
- * noticed afterwards.
+ * Reading the member is answered with nothing, because a themed page asks on every
+ * view and most of those views have no member. Everything else is refused, because
+ * changing a member's record is not something an unknown caller has a right to.
+ *
+ * Every fact these tests set up or check is set up and checked through an API: the
+ * Admin API stands in for the publisher, the members API for the member. The one
+ * exception is putting an address on the email suppression list, which no API can
+ * do — see `suppressEmail`.
  */
 describe('Members API session authentication', function () {
-  let membersAgent: {
-    get: (_url: string) => any;
-    put: (_url: string) => any;
-    delete: (_url: string) => any;
-    loginAs: (_email: string) => Promise<any>;
-    duplicate: () => any;
-  };
+  let membersAgent: MembersAgent;
+  let adminAgent: AdminAgent;
+
+  /**
+   * Put an address on the email suppression list, the way Ghost itself does.
+   *
+   * No API can do this. The Admin API takes an address off the list
+   * (`DELETE /members/:id/suppression`) but nothing puts one on: an address gets
+   * there only when the email provider reports a permanent bounce or a spam
+   * complaint, and Ghost hears about that as a domain event. Dispatching that
+   * event is the same entry point the provider's report arrives through, so this
+   * is setup through Ghost rather than around it — no row is written here and
+   * nothing depends on the shape of the table.
+   *
+   * Being unemailable is two records, and the real path sets both: the address
+   * joins a list the provider also writes to, and the member picks up a flag of
+   * their own. Everything below observes the pair through the Admin API, which
+   * reports a member as suppressed while either is set.
+   */
+  async function suppressEmail(email: string, memberId: string) {
+    DomainEvents.dispatch(
+      EmailBouncedEvent.create({
+        email,
+        memberId,
+        // No email was really sent, and nothing here is about which one it was.
+        emailId: null,
+        emailRecipientId: null,
+        // Ghost suppresses an address on a permanent failure and ignores the rest,
+        // so a code it acts on is the situation this is setting up.
+        error: { message: 'Recipient address rejected', code: 607 },
+      }),
+    );
+    await DomainEvents.allSettled();
+  }
+
+  async function readMemberAsStaff(email: string) {
+    const { body } = await adminAgent.get(`members/?filter=email:'${email}'`).expectStatus(200);
+    assert.equal(body.members.length, 1, `exactly one member holds ${email}`);
+    return body.members[0];
+  }
+
+  /** Every member the site holds, by name, as staff can see them. */
+  async function memberNamesAsStaff(): Promise<Record<string, string>> {
+    const { body } = await adminAgent.get('members/?limit=all').expectStatus(200);
+    return Object.fromEntries(
+      body.members.map((member: { id: string; name: string }) => [member.id, member.name]),
+    );
+  }
 
   beforeAll(async function () {
-    membersAgent = await agentProvider.getMembersAPIAgent();
+    ({ adminAgent, membersAgent } = await agentProvider.getAgentsForMembers());
     await fixtureManager.init('newsletters', 'members:newsletters');
+    await adminAgent.loginAsOwner();
   });
 
   describe('with nobody signed in', function () {
@@ -34,53 +103,130 @@ describe('Members API session authentication', function () {
     const anonymous = () => membersAgent.duplicate();
 
     it('answers an ask for the member themselves with nothing', async function () {
-      const { statusCode } = await anonymous().get('/api/member/');
+      // The site has members. Without that, an empty answer would only be saying
+      // the site is empty rather than that this request names nobody.
+      assert.ok(
+        Object.keys(await memberNamesAsStaff()).length > 0,
+        'the site holds members this could have answered with',
+      );
+
+      const { statusCode, text } = await anonymous().get('/api/member/');
 
       // The one endpoint where not knowing is an ordinary answer: a themed page
       // asks this on every view and most of those views have no member.
       assert.equal(statusCode, 204);
+      // And nothing in the body, because "no content" that carried a member would
+      // be handing one out to a caller who named none.
+      assert.equal(text, '');
     });
 
-    it('refuses a change to the member', async function () {
-      const { statusCode, text } = await anonymous().put('/api/member/').body({ name: 'Nobody' });
+    it('refuses a change to the member, and changes nothing', async function () {
+      // An anonymous request names no member, so what it must not do is change any
+      // of them. Every member is recorded, not one, because a write that reached
+      // some other member than the one a test happened to pick would still be a
+      // write that should not have happened.
+      const before = await memberNamesAsStaff();
+      assert.ok(Object.keys(before).length > 0, 'there are members a write could have reached');
 
-      // 400 rather than 401, and the reason names an internal cookie. Both are
-      // recorded as they are rather than as they should be, so that changing them
-      // is a decision this file shows.
-      assert.equal(statusCode, 400);
-      assert.match(text, /ghost-members-ssr/);
+      const { statusCode, body } = await anonymous().put('/api/member/').body({ name: 'Nobody' });
+
+      // Refused as unauthorized, which it is. This used to be a bad-request whose
+      // reason named the session cookie, telling a caller both the wrong thing and
+      // more than it needed to know.
+      assert.equal(statusCode, 401);
+      assert.match(body.errors[0].message, /you must be signed in/i);
+      assert.ok(
+        !JSON.stringify(body).includes('ghost-members-ssr'),
+        'the refusal does not name the cookie a session is carried in',
+      );
+
+      // Refusing is only half of it: a refusal that still wrote would pass on the
+      // status alone.
+      assert.deepEqual(await memberNamesAsStaff(), before);
     });
 
-    it('refuses removing an email from the suppression list', async function () {
-      const { statusCode, text } = await anonymous().delete('/api/member/suppression');
+    it('refuses removing an email from the suppression list, and removes nothing', async function () {
+      // A member of its own, so this does not depend on the member these tests
+      // sign in as, which does not exist until they do.
+      const { body: created } = await adminAgent
+        .post('members/')
+        .body({ members: [{ email: ANONYMOUS_TARGET_EMAIL, name: 'Suppressed' }] })
+        .expectStatus(201);
+      await suppressEmail(ANONYMOUS_TARGET_EMAIL, created.members[0].id);
+      assert.equal(
+        (await readMemberAsStaff(ANONYMOUS_TARGET_EMAIL)).email_suppression.suppressed,
+        true,
+        'the member starts out unemailable, so there is something to remove',
+      );
 
-      assert.equal(statusCode, 400);
-      assert.match(text, /ghost-members-ssr/);
+      const { statusCode, body } = await anonymous().delete('/api/member/suppression');
+
+      assert.equal(statusCode, 401);
+      assert.match(body.errors[0].message, /you must be signed in/i);
+      assert.ok(
+        !JSON.stringify(body).includes('ghost-members-ssr'),
+        'the refusal does not name the cookie a session is carried in',
+      );
+
+      assert.equal(
+        (await readMemberAsStaff(ANONYMOUS_TARGET_EMAIL)).email_suppression.suppressed,
+        true,
+        'the member is still unemailable',
+      );
     });
   });
 
   describe('with a member signed in', function () {
     beforeAll(async function () {
-      await membersAgent.loginAs('session-auth@example.com');
+      await membersAgent.loginAs(SIGNED_IN_EMAIL);
     });
 
     it('answers an ask for the member themselves', async function () {
       const { body } = await membersAgent.get('/api/member/').expectStatus(200);
 
-      assert.equal(body.email, 'session-auth@example.com');
+      assert.equal(body.email, SIGNED_IN_EMAIL);
+      // The same record staff are looking at, rather than something that merely
+      // carries the right address.
+      assert.equal(body.uuid, (await readMemberAsStaff(SIGNED_IN_EMAIL)).uuid);
     });
 
     it('applies a change to the member', async function () {
+      const before = await readMemberAsStaff(SIGNED_IN_EMAIL);
+      assert.notEqual(before.name, 'Signed In', 'the name is not already what this sets it to');
+
       const { body } = await membersAgent
         .put('/api/member/')
         .body({ name: 'Signed In' })
         .expectStatus(200);
 
       assert.equal(body.name, 'Signed In');
+
+      // Asked again rather than trusting the response. That the response happens
+      // to be a fresh read is this endpoint's business, not something a test of
+      // what it stores should rely on, and staff reading the same record is what
+      // says it was stored rather than echoed.
+      assert.equal((await readMemberAsStaff(SIGNED_IN_EMAIL)).name, 'Signed In');
     });
 
-    it('accepts removing an email from the suppression list', async function () {
+    it('lets Ghost email a member again after it stopped', async function () {
+      const member = await readMemberAsStaff(SIGNED_IN_EMAIL);
+      await suppressEmail(SIGNED_IN_EMAIL, member.id);
+      assert.equal(
+        (await readMemberAsStaff(SIGNED_IN_EMAIL)).email_suppression.suppressed,
+        true,
+        'the member starts out unemailable, so there is something to undo',
+      );
+
       await membersAgent.delete('/api/member/suppression').expectStatus(204);
+
+      // The status alone would pass whether or not anything was undone, which is
+      // the whole point of the endpoint. Staff are told a member is suppressed
+      // while either half of it holds, so this reading false is both halves gone.
+      assert.equal(
+        (await readMemberAsStaff(SIGNED_IN_EMAIL)).email_suppression.suppressed,
+        false,
+        'the member is emailable again',
+      );
     });
   });
 });

--- a/ghost/core/test/e2e-api/members/session-auth.test.ts
+++ b/ghost/core/test/e2e-api/members/session-auth.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+
+const { agentProvider, fixtureManager } = require('../../utils/e2e-framework');
+
+/**
+ * What the members API does when it cannot tell who is asking.
+ *
+ * Several endpoints exist only to serve the member making the request, and each
+ * works out who that is on its own. Nothing states what they should answer when
+ * nobody is signed in, so each has arrived at its own answer, and these record
+ * what those answers currently are.
+ *
+ * Recorded before changing any of it. Where a later change moves one of these, the
+ * change to this file is the statement of what was decided, rather than something
+ * noticed afterwards.
+ */
+describe('Members API session authentication', function () {
+  let membersAgent: {
+    get: (_url: string) => any;
+    put: (_url: string) => any;
+    delete: (_url: string) => any;
+    loginAs: (_email: string) => Promise<any>;
+    duplicate: () => any;
+  };
+
+  beforeAll(async function () {
+    membersAgent = await agentProvider.getMembersAPIAgent();
+    await fixtureManager.init('newsletters', 'members:newsletters');
+  });
+
+  describe('with nobody signed in', function () {
+    // A fresh agent per case: signing in is what these are the absence of, so a
+    // shared one would only be signed out while these happened to run first.
+    const anonymous = () => membersAgent.duplicate();
+
+    it('answers an ask for the member themselves with nothing', async function () {
+      const { statusCode } = await anonymous().get('/api/member/');
+
+      // The one endpoint where not knowing is an ordinary answer: a themed page
+      // asks this on every view and most of those views have no member.
+      assert.equal(statusCode, 204);
+    });
+
+    it('refuses a change to the member', async function () {
+      const { statusCode, text } = await anonymous().put('/api/member/').body({ name: 'Nobody' });
+
+      // 400 rather than 401, and the reason names an internal cookie. Both are
+      // recorded as they are rather than as they should be, so that changing them
+      // is a decision this file shows.
+      assert.equal(statusCode, 400);
+      assert.match(text, /ghost-members-ssr/);
+    });
+
+    it('refuses removing an email from the suppression list', async function () {
+      const { statusCode, text } = await anonymous().delete('/api/member/suppression');
+
+      assert.equal(statusCode, 400);
+      assert.match(text, /ghost-members-ssr/);
+    });
+  });
+
+  describe('with a member signed in', function () {
+    beforeAll(async function () {
+      await membersAgent.loginAs('session-auth@example.com');
+    });
+
+    it('answers an ask for the member themselves', async function () {
+      const { body } = await membersAgent.get('/api/member/').expectStatus(200);
+
+      assert.equal(body.email, 'session-auth@example.com');
+    });
+
+    it('applies a change to the member', async function () {
+      const { body } = await membersAgent
+        .put('/api/member/')
+        .body({ name: 'Signed In' })
+        .expectStatus(200);
+
+      assert.equal(body.name, 'Signed In');
+    });
+
+    it('accepts removing an email from the suppression list', async function () {
+      await membersAgent.delete('/api/member/suppression').expectStatus(204);
+    });
+  });
+});


### PR DESCRIPTION
Refactor. The only intended change in behaviour is the status and body that two endpoints return when nobody is signed in, described below and pinned by tests taken before the change.

## Problem

Some endpoints on the members API exist only to serve the member making the request. Reading your own details, changing them, taking your address back off the list of addresses Ghost has stopped emailing, and soon reading the extra fields a publisher has chosen to collect about their members.

Each of those worked out who the member was for itself, by calling the same session lookup from inside the request handler. Because each did that separately, each also decided separately what to do when nobody was signed in, and they decided differently:

- Reading your details answers with an empty response. That one is right: a site's theme asks this on every page view, and on most of those views nobody is signed in.
- Changing your details answers `400 Bad Request` with the text `Cookie ghost-members-ssr not found`. `400` says the request was malformed, when the truth is that nobody is signed in. The text names one of Ghost's own cookies, which tells the caller more about our internals than it needs and nothing it can act on.
- Taking an address off the suppression list answers the same way, and only by accident. It reads the `id` of a member that is not there, and the resulting crash is caught and reported as though the caller had sent something wrong.

The deeper problem is that every new endpoint of this kind has to remember to make that decision. One added recently did not: a request for the list of fields a publisher collects would have been answered for anybody who asked, signed in or not.

## Solution

A route now states what kind of endpoint it is, by the middleware it sits behind. That middleware establishes who is asking, and answers on the endpoint's behalf when nobody is.

**It establishes an identity, not a member.** It looks up the id and email address behind the session cookie, which is a single lookup on an indexed column with nothing else attached. It deliberately does not load the member's full record.

Two reasons. Most of these endpoints need to *act* on a member rather than *describe* one: taking an address off the suppression list needs an id and an email, and listing the fields a publisher collects needs only to know that somebody is signed in. Loading a full member for those means a dozen queries and a call out to the email suppression service, thrown away.

And for the endpoint that does describe a member, a record loaded before a write cannot be reused after it. Saving your details has to answer with what Ghost now holds, which is not always what you sent: setting the older `subscribed` flag to true is stored as a list of newsletters. So that endpoint reads the member again after saving regardless, and a copy loaded earlier would only be a stale one.

So the middleware settles who, and each endpoint loads what it actually renders. That is the part only the endpoint knows.

**What it does when nobody is signed in is the endpoint's choice**, because there are two right answers:

- **Answer with nothing.** Used by reading your own details, where not knowing who is asking is an ordinary answer rather than a failure.
- **Refuse.** Used by everything else, because changing a member's record, or asking what a publisher collects, is not something an unknown caller has a right to.

The refusal is `401` and says only that you must be signed in.

**Reading and changing your own details are now ordinary endpoints.** They were hand-written request handlers, so each did for itself what Ghost's API framework already does for every other endpoint here: shaping the response, and answering when something goes wrong. That is why these two were the only endpoints on this API answering errors as plain text while every other one answered JSON, and why the member's public shape had to be called by hand rather than being selected by the endpoint's name, the way every other response shape is.

**What a member is allowed to change about themselves moved out of the request handler**, into the members API alongside the rest of the member logic. None of it is a question about HTTP: which fields are writable is a fact about members, and the answer is the same whoever is asking.

## What changes for a caller

Two endpoints answer differently when nobody is signed in:

- `PUT /api/member` and `DELETE /api/member/suppression` return `401` instead of `400`, with a JSON error instead of a line of plain text.

Everything else is unchanged, including the empty answer from `GET /api/member`, which is the one that Portal and themes depend on. The errors from those two endpoints were already the odd ones out: every other endpoint on this API has always answered errors as JSON, through the same shared handler.

## Cost

`GET /api/member` now does one cheap identity lookup followed by one full member read, where it previously did a single full read. The extra lookup is a single row fetched by an indexed unique column, against a read that runs roughly a dozen queries and calls the email suppression service, so it is small. It is not nothing though, and this is the endpoint Portal asks on every page load.

## Not doing

**The other ways of authenticating.** The unsubscribe endpoints identify a member by a signed link rather than a session, deliberately, because they are opened from an email by someone who is not signed in. Changing an email address, and fetching offers, identify a member by a token in the request body. Those are untouched: they differ because whether the person can be expected to be signed in differs.

ref https://linear.app/ghost/issue/BER-3794/members-manage-their-own-custom-fields-in-their-account
