### PR TITLE
Added the editor slug machine as a pure module

### DIFF
--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -112,7 +112,182 @@ Element-node `direction` is stripped recursively before compare (Lexical's recon
 
 ## Slug machine
 
-Lands with the slug machine PR. Tracks whether the slug follows the title (`derived`), was edited by hand (`custom`, sticky for the session), or is frozen for blank/`(Untitled)` titles; a saved title ending in `(Copy)` is an exception to custom detection, so a duplicated post's slug regenerates on its first rename. Details land with the machine.
+[`slug-machine.ts`](./slug-machine.ts) owns slug intent for one post: it derives
+a slug from the title, accepts manual slug edits, sends both through the
+server's slug endpoint for sanitizing and deduplication, and reports the outcome
+as proposals. It ports the Ember editor controller's `generateSlugTask`,
+`updateSlugTask`, and slug-generator service contract (see
+[`lexical-editor.js`](../../../../ember-admin/app/controllers/lexical-editor.js))
+without the controller coupling. It never persists anything; the caller owns the
+input UI and the save.
+
+### State model
+
+Two modes and three statuses.
+
+| Mode      | Meaning                                                           |
+| --------- | ----------------------------------------------------------------- |
+| `derived` | The slug follows the title. Eligible title commits regenerate it. |
+| `custom`  | The slug belongs to the user. Title commits never touch it.       |
+
+Mode is `custom` while a manual edit that can still apply is in flight.
+Otherwise it is the settled mode, which changes only when a post loads or a
+manual edit applies. A manual edit that fails, returns nothing, or resolves back
+to the current slug leaves the settled mode as it was.
+
+| Status    | Meaning                                                                                                          |
+| --------- | ---------------------------------------------------------------------------------------------------------------- |
+| `custom`  | Mode is `custom`.                                                                                                |
+| `derived` | Mode is `derived` and the last committed title would generate.                                                   |
+| `frozen`  | Mode is `derived` but the last committed title would not generate: it is blank, or `(Untitled)` with a slug set. |
+
+Status follows the latest committed title regardless of what happened to that
+commit: a post whose blank title was just committed reads `frozen`, and a post
+whose commit failed reads `derived`.
+
+`getState()` returns `{status, mode, slug, title, lastCommittedTitle, pending}`.
+
+- `slug`: the current slug.
+- `title`: the title the slug was loaded with or last generated from. Only a
+  load or an applied generation advances it, so a refused or failed commit can
+  be retried with the same title.
+- `lastCommittedTitle`: the trimmed title of the most recent `titleCommitted`
+  call, whatever its outcome.
+- `pending`: true while a title or manual request that can still apply is in
+  flight. Withdrawn requests and requests from a previous post are not pending
+  even if their HTTP call has not returned. A submission waiting behind an
+  active request is not pending until it starts.
+
+### Inputs and proposals
+
+`createSlugMachine({generateSlug, onListenerError})` takes the generator port
+(`(text: string) => Promise<string>`) and an error sink for listener failures.
+
+| Call                    | Effect                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `loaded({slug, title})` | Document boundary. Resets the machine to the post, infers the settled mode, discards in-flight and waiting work from the previous post, notifies with a `null` proposal. |
+| `titleCommitted(title)` | The title was committed (blur). Resolves with a proposal; never rejects.                                                                                                 |
+| `slugEdited(input)`     | The slug input was committed. Resolves with a proposal; never rejects.                                                                                                   |
+| `getState()`            | Snapshot of the state above.                                                                                                                                             |
+| `subscribe(listener)`   | `listener(state, proposal)` on every state change, `proposal` being `null` when only `pending` changed or a post loaded. Returns an unsubscribe function.                |
+
+A listener that throws is reported to `onListenerError` and affects neither the
+transition nor the other listeners.
+
+Proposals are `{slug, source}`:
+
+| Source      | Meaning                                                      | Caller action               |
+| ----------- | ------------------------------------------------------------ | --------------------------- |
+| `generated` | A slug generated from the title was applied.                 | Show `slug` and persist it. |
+| `manual`    | A manual edit was applied after server sanitizing and dedup. | Show `slug` and persist it. |
+| `unchanged` | Nothing was applied; `reason` says why.                      | See the table below.        |
+
+`unchanged` proposals carry a `reason`:
+
+| Reason         | When                                                                                                                                                                  | Caller action                                                |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `same-title`   | The committed title equals the title the slug came from and a slug exists. No request was made.                                                                       | None.                                                        |
+| `custom`       | The machine is in custom mode. No request was made.                                                                                                                   | None.                                                        |
+| `frozen`       | The committed title is blank, or is `(Untitled)` while a slug exists. No request was made.                                                                            | None.                                                        |
+| `stale`        | The call was superseded before it could apply: replaced by a newer submission, withdrawn, or a post loaded. `slug` is the slug at call time, not necessarily current. | Ignore it.                                                   |
+| `empty-result` | The server returned a blank slug.                                                                                                                                     | None.                                                        |
+| `reverted`     | A manual edit was blank or unchanged, or the server resolved it back to the current slug.                                                                             | Reset the slug input to `slug`.                              |
+| `error`        | The generator threw; `error` carries the thrown value.                                                                                                                | Surface the error; reset the slug input to `slug` if manual. |
+
+Every proposal except `stale` is delivered to subscribers with the state it
+produced. Subscribers are also notified with a `null` proposal when a request
+starts (`pending` becomes true) and when a post loads.
+
+### Rules
+
+Generation
+
+- A title commit generates when mode is `derived`, the trimmed title is not
+  blank, and neither the `same-title` nor the `frozen` case applies. A blank
+  title never generates. `(Untitled)` generates `untitled` once, when no slug
+  exists, and is frozen after that.
+- The same-title check only applies when a slug exists; a post loaded with a
+  title and no slug generates on its first commit.
+- The server result is applied as returned. A deduplicated result (`hello-2`)
+  is still a derived slug and keeps following the title for the rest of the
+  session.
+- A whitespace-only server result is ignored (`empty-result`).
+
+Custom detection at load
+
+- A loaded slug is custom when it is non-empty and differs from
+  `slugify(title)`, unless the title is `(Untitled)` or ends with `(Copy)`. A
+  blank slug is never custom.
+- `(Copy)`: a duplicated post's slug is derived regardless of its value, so the
+  first rename regenerates it. This is the one case where a slug that differs
+  from `slugify(title)` is not custom.
+- Inherited flaw: posts do not store slug provenance, so any server-transformed
+  slug (a deduplicated `hello-2`, a truncated or protected-slug-suffixed result)
+  reads as custom after reload and stops following the title. Ember does the
+  same.
+
+Manual edits
+
+- Input is trimmed. Blank or unchanged input reverts without a request. The
+  trimmed text is sent to the generator as typed; the server sanitizes it and
+  the result is applied, so `My Slug` becomes `my-slug`.
+- If the server returns the current slug, the edit reverts.
+- Dedup guard: if the server returns `<current slug>-<N>` with `N > 0` and that
+  is not exactly `slugify(candidate)`, the server is assumed to have appended a
+  uniqueness counter to a candidate that sanitized back to the current slug, and
+  the edit reverts. Typing `top 10` on slug `top` still applies `top-10`. Known
+  false positive: the guard decides by shape, so a candidate the server
+  canonicalizes differently from the client-side `slugify` (protected slugs,
+  the 185-character cap) is reverted when its result happens to take that
+  shape.
+- An applied manual edit switches mode to `custom` for the rest of the session.
+  Reverted, empty, and failed edits leave the mode where it was.
+
+Ordering and staleness
+
+- At most one generator request is in flight. Further submissions wait behind
+  it; only the newest waiting submission is kept, and each one it replaces
+  resolves `stale` without reaching the server. The kept submission runs when
+  the active request settles and is evaluated against the state at that time.
+- A title commit behind an in-flight manual edit is deferred, not refused. If
+  the edit applies, the deferred commit resolves `custom`; if the edit fails or
+  reverts, the commit generates as normal.
+- A manual edit behind an in-flight title generation waits for it. Withdrawing
+  that waiting edit (blank or unchanged input) drops it and leaves the
+  generation running.
+- Withdrawing an in-flight manual edit makes its result `stale`, and mode and
+  `pending` fall back immediately; a title commit waiting behind it still runs
+  once the request physically settles.
+- Committing the slug's source title, or a frozen title, while a title
+  generation is in flight invalidates that generation immediately, drops any
+  waiting submission, and returns `same-title` or `frozen`.
+- `loaded()` invalidates everything from the previous post: in-flight results
+  resolve `stale` to their callers, are not delivered to subscribers, and the
+  new post reads not pending.
+- A failed or reverted manual edit never leaves the machine in custom mode and
+  never discards a title commit queued behind it.
+
+### Deliberate Ember deltas
+
+- Sticky mode within a session. Ember re-runs the custom heuristic against the
+  last saved title on every blur, so a server-deduplicated slug (`hello-2` for
+  "Hello") silently becomes custom and stops following the title. The machine
+  holds an explicit mode until the post is reloaded, where the load heuristic
+  still mirrors Ember.
+- Serialized requests. Ember lets overlapping generator responses land in
+  arrival order (the source of the "draft has title set with untitled slug"
+  reports). The machine runs one request at a time; superseded work resolves
+  `stale` and never reaches subscribers.
+- Reverted manual edits are reported. Ember returns silently when the server
+  resolves a manual edit back to the current slug, leaving the input showing
+  the rejected text; the machine emits `reverted` so the input is reset.
+- Dedup guard comparison. Ember compares the server result with the raw typed
+  text; the machine compares it with `slugify(candidate)`, so `top 10` on slug
+  `top` applies instead of reverting.
+
+Kept on purpose for parity: the load heuristic and its reload flaw, the
+`(Untitled)`-once and `(Copy)` rules, ignored whitespace-only server results,
+and the dedup guard's remaining false positive.
 
 ## Contracts between modules
 
@@ -172,4 +347,18 @@ Lands with the slug machine PR. Tracks whether the slug follows the title (`deri
 
 ### Slug machine
 
-- Wiring duties land with the machine.
+- Persistence. Proposals are intents; the save engine persists `generated` and
+  `manual` slugs (autosave for drafts, staged for published and scheduled
+  posts).
+- The generator port. The machine passes trimmed text as typed, whether a title
+  or a manual candidate. The port must send `encodeURIComponent(slugify(text))`
+  to `GET /slugs/post/:name/:id` (raw text such as a newline 404s on Pro) and
+  pass the post id so the server does not count the post's own slug as a
+  collision.
+- Draft-only title commits. Title blur drives generation for drafts only; do
+  not call `titleCommitted` on blur for published or scheduled posts.
+- Regenerate when there is no slug, for any status, before save (Ember's
+  `beforeSaveTask`), including after `(Untitled)` substitution.
+- `(Untitled)` substitution for a blank title before save.
+- No save for a new post on a manual edit; Ember defers it to the first
+  explicit save.

--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -115,11 +115,8 @@ Element-node `direction` is stripped recursively before compare (Lexical's recon
 [`slug-machine.ts`](./slug-machine.ts) owns slug intent for one post: it derives
 a slug from the title, accepts manual slug edits, sends both through the
 server's slug endpoint for sanitizing and deduplication, and reports the outcome
-as proposals. It ports the Ember editor controller's `generateSlugTask`,
-`updateSlugTask`, and slug-generator service contract (see
-[`lexical-editor.js`](../../../../ember-admin/app/controllers/lexical-editor.js))
-without the controller coupling. It never persists anything; the caller owns the
-input UI and the save.
+as proposals. It never persists anything; the caller owns the input UI and the
+save.
 
 ### State model
 
@@ -133,7 +130,9 @@ Two modes and three statuses.
 Mode is `custom` while a manual edit that can still apply is in flight.
 Otherwise it is the settled mode, which changes only when a post loads or a
 manual edit applies. A manual edit that fails, returns nothing, or resolves back
-to the current slug leaves the settled mode as it was.
+to the current slug leaves the settled mode as it was. Mode is never re-derived
+from the title while a post is open; only loading a post runs the custom
+detection described under Rules.
 
 | Status    | Meaning                                                                                                          |
 | --------- | ---------------------------------------------------------------------------------------------------------------- |
@@ -196,7 +195,9 @@ Proposals are `{slug, source}`:
 
 Every proposal except `stale` is delivered to subscribers with the state it
 produced. Subscribers are also notified with a `null` proposal when a request
-starts (`pending` becomes true) and when a post loads.
+starts (`pending` becomes true) and when a post loads. A rejected manual edit is
+always reported (`reverted`, `empty-result`, or `error`) so the input can be
+reset to the kept slug instead of showing the rejected text.
 
 ### Rules
 
@@ -221,10 +222,10 @@ Custom detection at load
 - `(Copy)`: a duplicated post's slug is derived regardless of its value, so the
   first rename regenerates it. This is the one case where a slug that differs
   from `slugify(title)` is not custom.
-- Inherited flaw: posts do not store slug provenance, so any server-transformed
-  slug (a deduplicated `hello-2`, a truncated or protected-slug-suffixed result)
-  reads as custom after reload and stops following the title. Ember does the
-  same.
+- Known limitation: posts do not store slug provenance, so any
+  server-transformed slug (a deduplicated `hello-2`, a truncated or
+  protected-slug-suffixed result) reads as custom after reload and stops
+  following the title.
 
 Manual edits
 
@@ -237,10 +238,10 @@ Manual edits
   uniqueness counter to a candidate that sanitized back to the current slug, and
   the edit reverts. Typing `top 10` on slug `top` still applies `top-10`. Known
   false positive: the guard decides by shape, so a candidate the server
-  canonicalizes differently from the client-side `slugify` (protected slugs,
-  the 185-character cap) is reverted when its result happens to take that
-  shape.
-- An applied manual edit switches mode to `custom` for the rest of the session.
+  canonicalizes differently from `slugify` (protected slugs, the 185-character
+  cap) is reverted when its result happens to take that shape.
+- An applied manual edit switches mode to `custom` for the rest of the session;
+  no later title commit regenerates the slug until the post is reloaded.
   Reverted, empty, and failed edits leave the mode where it was.
 
 Ordering and staleness
@@ -266,28 +267,6 @@ Ordering and staleness
   new post reads not pending.
 - A failed or reverted manual edit never leaves the machine in custom mode and
   never discards a title commit queued behind it.
-
-### Deliberate Ember deltas
-
-- Sticky mode within a session. Ember re-runs the custom heuristic against the
-  last saved title on every blur, so a server-deduplicated slug (`hello-2` for
-  "Hello") silently becomes custom and stops following the title. The machine
-  holds an explicit mode until the post is reloaded, where the load heuristic
-  still mirrors Ember.
-- Serialized requests. Ember lets overlapping generator responses land in
-  arrival order (the source of the "draft has title set with untitled slug"
-  reports). The machine runs one request at a time; superseded work resolves
-  `stale` and never reaches subscribers.
-- Reverted manual edits are reported. Ember returns silently when the server
-  resolves a manual edit back to the current slug, leaving the input showing
-  the rejected text; the machine emits `reverted` so the input is reset.
-- Dedup guard comparison. Ember compares the server result with the raw typed
-  text; the machine compares it with `slugify(candidate)`, so `top 10` on slug
-  `top` applies instead of reverting.
-
-Kept on purpose for parity: the load heuristic and its reload flaw, the
-`(Untitled)`-once and `(Copy)` rules, ignored whitespace-only server results,
-and the dedup guard's remaining false positive.
 
 ## Contracts between modules
 
@@ -347,18 +326,16 @@ and the dedup guard's remaining false positive.
 
 ### Slug machine
 
-- Persistence. Proposals are intents; the save engine persists `generated` and
-  `manual` slugs (autosave for drafts, staged for published and scheduled
-  posts).
+- Persistence. The machine does not save proposals; the caller persists
+  `generated` and `manual` slugs.
 - The generator port. The machine passes trimmed text as typed, whether a title
   or a manual candidate. The port must send `encodeURIComponent(slugify(text))`
-  to `GET /slugs/post/:name/:id` (raw text such as a newline 404s on Pro) and
-  pass the post id so the server does not count the post's own slug as a
-  collision.
+  to `GET /slugs/post/:name/:id` (raw text containing a character such as a
+  newline is not a valid path segment) and pass the post id so the server does
+  not count the post's own slug as a collision.
 - Draft-only title commits. Title blur drives generation for drafts only; do
   not call `titleCommitted` on blur for published or scheduled posts.
-- Regenerate when there is no slug, for any status, before save (Ember's
-  `beforeSaveTask`), including after `(Untitled)` substitution.
+- Regenerate when there is no slug, for any status, before save, including
+  after `(Untitled)` substitution.
 - `(Untitled)` substitution for a blank title before save.
-- No save for a new post on a manual edit; Ember defers it to the first
-  explicit save.
+- No save for a new post on a manual edit; the first explicit save persists it.

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -175,6 +175,57 @@ describe('createSlugMachine', () => {
       expect(generateSlug).not.toHaveBeenCalled();
     });
 
+    it('discards an in-flight generation when the title returns to the generated title', async () => {
+      const pending = deferred<string>();
+      const { machine, events, proposals } = createHarness(
+        vi.fn().mockReturnValueOnce(pending.promise),
+      );
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+      events.length = 0;
+
+      const commit = machine.titleCommitted('Changed');
+      await expect(machine.titleCommitted('Hello')).resolves.toMatchObject({
+        source: 'unchanged',
+        reason: 'same-title',
+      });
+      pending.resolve('changed');
+
+      await expect(commit).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'stale',
+      });
+      expect(machine.getState()).toMatchObject({
+        slug: 'hello',
+        title: 'Hello',
+        lastCommittedTitle: 'Hello',
+        pending: false,
+      });
+      expect(proposals.filter((proposal) => proposal.source === 'generated')).toEqual([]);
+      expect(events.at(-1)).toMatchObject({ state: { pending: false }, proposal: null });
+    });
+
+    it('discards an in-flight generation when a later title is frozen', async () => {
+      const pending = deferred<string>();
+      const { machine } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      const commit = machine.titleCommitted('Changed');
+      await expect(machine.titleCommitted('')).resolves.toMatchObject({
+        source: 'unchanged',
+        reason: 'frozen',
+      });
+      pending.resolve('changed');
+
+      await expect(commit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
+      expect(machine.getState()).toMatchObject({
+        slug: 'hello',
+        title: 'Hello',
+        lastCommittedTitle: '',
+        pending: false,
+      });
+    });
+
     it('generates for an unchanged title when the slug is missing', async () => {
       const { machine } = createHarness();
       machine.loaded({ slug: '', title: 'Hello' });
@@ -343,11 +394,12 @@ describe('createSlugMachine', () => {
 
     it('discards in-flight responses when a post is loaded', async () => {
       const pending = deferred<string>();
-      const { machine } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+      const { machine, events } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
       machine.loaded({ slug: '', title: '' });
 
       const commit = machine.titleCommitted('Old post');
       machine.loaded({ slug: 'other', title: 'Other' });
+      events.length = 0;
       pending.resolve('old-post');
 
       await expect(commit).resolves.toEqual({
@@ -356,6 +408,7 @@ describe('createSlugMachine', () => {
         reason: 'stale',
       });
       expect(machine.getState().slug).toBe('other');
+      expect(events).toEqual([]);
     });
 
     it('reports generator failures without changing the slug', async () => {
@@ -417,6 +470,34 @@ describe('createSlugMachine', () => {
       });
       expect(generateSlug).not.toHaveBeenCalled();
       expect(machine.getState().mode).toBe('derived');
+    });
+
+    it.each([
+      ['', 'blank'],
+      ['hello', 'current slug'],
+    ])('discards an in-flight manual edit when a later edit reverts to %j (%s)', async (input) => {
+      const pending = deferred<string>();
+      const { machine, proposals } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      const edit = machine.slugEdited('mine');
+      await expect(machine.slugEdited(input)).resolves.toMatchObject({
+        source: 'unchanged',
+        reason: 'reverted',
+      });
+      pending.resolve('mine');
+
+      await expect(edit).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'stale',
+      });
+      expect(machine.getState()).toMatchObject({
+        slug: 'hello',
+        mode: 'derived',
+        pending: false,
+      });
+      expect(proposals.filter((proposal) => proposal.source === 'manual')).toEqual([]);
     });
 
     it('applies the server result and switches to custom', async () => {

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -12,8 +12,11 @@ import {
   type SlugProposal,
 } from './slug-machine';
 
-function createHarness(generateSlug = vi.fn((text: string) => Promise.resolve(slugify(text)))) {
-  const machine = createSlugMachine({ generateSlug });
+function createHarness(
+  generateSlug = vi.fn((text: string) => Promise.resolve(slugify(text))),
+  onListenerError = vi.fn(),
+) {
+  const machine = createSlugMachine({ generateSlug, onListenerError });
   const proposals: SlugProposal[] = [];
   const events: Array<{ state: SlugMachineState; proposal: SlugProposal | null }> = [];
   machine.subscribe((state, proposal) => {
@@ -22,7 +25,7 @@ function createHarness(generateSlug = vi.fn((text: string) => Promise.resolve(sl
       proposals.push(proposal);
     }
   });
-  return { machine, generateSlug, proposals, events };
+  return { machine, generateSlug, onListenerError, proposals, events };
 }
 
 describe('isCustomSlug', () => {
@@ -88,8 +91,8 @@ describe('resolveDedupedSlug', () => {
     ['zero is not an increment', 'whatever-0', 'whatever 0', 'whatever', 'whatever-0'],
     ['trailing number that is a different base', 'other-2', 'other', 'whatever', 'other-2'],
     ['distinct slug', 'changed', 'changed', 'whatever', 'changed'],
-    ['typed number word on current base', 'top-10', 'top 10', 'top', 'top'],
-    ['Ember parity: numeric result on an empty current slug reverts to empty', '2', '2!', '', ''],
+    ['typed number word on current base', 'top-10', 'top 10', 'top', 'top-10'],
+    ['numeric result on an empty current slug', '2', '2!', '', '2'],
   ])('%s', (_label, serverSlug, candidate, current, expected) => {
     expect(resolveDedupedSlug(serverSlug, candidate, current)).toBe(expected);
   });
@@ -188,6 +191,7 @@ describe('createSlugMachine', () => {
         source: 'unchanged',
         reason: 'same-title',
       });
+      const eventCount = events.length;
       pending.resolve('changed');
 
       await expect(commit).resolves.toEqual({
@@ -202,7 +206,11 @@ describe('createSlugMachine', () => {
         pending: false,
       });
       expect(proposals.filter((proposal) => proposal.source === 'generated')).toEqual([]);
-      expect(events.at(-1)).toMatchObject({ state: { pending: false }, proposal: null });
+      expect(events).toHaveLength(eventCount);
+      expect(events.at(-1)).toMatchObject({
+        state: { pending: false },
+        proposal: { reason: 'same-title' },
+      });
     });
 
     it('discards an in-flight generation when a later title is frozen', async () => {
@@ -357,10 +365,11 @@ describe('createSlugMachine', () => {
 
       second.resolve('second');
       await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
+      expect(machine.getState().pending).toBe(false);
 
       first.resolve('first');
       await expect(firstCommit).resolves.toEqual({
-        slug: 'second',
+        slug: '',
         source: 'unchanged',
         reason: 'stale',
       });
@@ -403,7 +412,7 @@ describe('createSlugMachine', () => {
       pending.resolve('old-post');
 
       await expect(commit).resolves.toEqual({
-        slug: 'other',
+        slug: '',
         source: 'unchanged',
         reason: 'stale',
       });
@@ -451,6 +460,37 @@ describe('createSlugMachine', () => {
         reason: 'empty-result',
       });
     });
+
+    it('ignores a whitespace-only generator result like Ember does', async () => {
+      const { machine } = createHarness(vi.fn().mockResolvedValueOnce('   '));
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'empty-result',
+      });
+      expect(machine.getState()).toMatchObject({ slug: 'hello', title: 'Hello', mode: 'derived' });
+    });
+
+    it.each(['', 'hello'])(
+      'does not let a no-op manual %j cancel title generation',
+      async (input) => {
+        const pending = deferred<string>();
+        const { machine } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+        machine.loaded({ slug: 'hello', title: 'Hello' });
+
+        const commit = machine.titleCommitted('Changed');
+        await expect(machine.slugEdited(input)).resolves.toMatchObject({
+          source: 'unchanged',
+          reason: 'reverted',
+        });
+        expect(machine.getState()).toMatchObject({ mode: 'derived', pending: true });
+
+        pending.resolve('changed');
+        await expect(commit).resolves.toEqual({ slug: 'changed', source: 'generated' });
+      },
+    );
   });
 
   describe('slugEdited', () => {
@@ -485,7 +525,7 @@ describe('createSlugMachine', () => {
         source: 'unchanged',
         reason: 'reverted',
       });
-      expect(machine.getState()).toMatchObject({ mode: 'derived', pending: true });
+      expect(machine.getState()).toMatchObject({ mode: 'derived', pending: false });
       pending.resolve('mine');
 
       await expect(edit).resolves.toEqual({
@@ -520,7 +560,7 @@ describe('createSlugMachine', () => {
       expect(machine.getState()).toMatchObject({
         slug: 'changed',
         mode: 'derived',
-        pending: true,
+        pending: false,
       });
 
       pending.resolve('mine');
@@ -580,6 +620,18 @@ describe('createSlugMachine', () => {
         reason: 'reverted',
       });
       expect(machine.getState().mode).toBe('derived');
+    });
+
+    it('ignores a whitespace-only manual result like Ember does for generated slugs', async () => {
+      const { machine } = createHarness(vi.fn().mockResolvedValueOnce('   '));
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      await expect(machine.slugEdited('changed')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'empty-result',
+      });
+      expect(machine.getState()).toMatchObject({ slug: 'hello', mode: 'derived' });
     });
 
     it('returns to derived when the generator fails', async () => {
@@ -680,7 +732,7 @@ describe('createSlugMachine', () => {
 
       await expect(secondEdit).resolves.toEqual({ slug: 'two', source: 'manual' });
       await expect(firstEdit).resolves.toEqual({
-        slug: 'two',
+        slug: 'hello',
         source: 'unchanged',
         reason: 'stale',
       });
@@ -721,7 +773,7 @@ describe('createSlugMachine', () => {
         const { first, second, firstEdit, secondEdit, machine } = overlap();
         second.reject(new Error('boom'));
         await expect(secondEdit).resolves.toMatchObject({ reason: 'error' });
-        expect(machine.getState()).toMatchObject({ mode: 'derived', pending: true });
+        expect(machine.getState()).toMatchObject({ mode: 'derived', pending: false });
         first.resolve('one');
         await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
         await expectDerivedAndRegenerating(machine);
@@ -763,5 +815,45 @@ describe('createSlugMachine', () => {
       expect.objectContaining({ slug: 'one', status: 'derived', pending: false }),
       { slug: 'one', source: 'generated' },
     );
+  });
+
+  it('isolates subscriber failures from transitions and other subscribers', async () => {
+    const generateSlug = vi.fn().mockResolvedValue('changed');
+    const onListenerError = vi.fn();
+    const { machine, events } = createHarness(generateSlug, onListenerError);
+    machine.loaded({ slug: 'hello', title: 'Hello' });
+    machine.subscribe(() => {
+      throw new Error('listener failed');
+    });
+    const laterListener = vi.fn();
+    machine.subscribe(laterListener);
+
+    await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+      slug: 'changed',
+      source: 'generated',
+    });
+    expect(onListenerError).toHaveBeenCalledTimes(2);
+    expect(laterListener).toHaveBeenCalledTimes(2);
+    expect(events.at(-1)).toMatchObject({ state: { pending: false, slug: 'changed' } });
+    expect(machine.getState()).toMatchObject({ pending: false, mode: 'derived', slug: 'changed' });
+  });
+
+  it('keeps a manual response atomic with its pending custom mode', async () => {
+    const pending = deferred<string>();
+    const generateSlug = vi.fn().mockReturnValueOnce(pending.promise);
+    const { machine } = createHarness(generateSlug);
+    machine.loaded({ slug: 'hello', title: 'Hello' });
+
+    const edit = machine.slugEdited('mine');
+    const interleavedCommit = pending.promise.then(() => machine.titleCommitted('Changed'));
+    pending.resolve('mine');
+
+    await expect(edit).resolves.toEqual({ slug: 'mine', source: 'manual' });
+    await expect(interleavedCommit).resolves.toMatchObject({
+      source: 'unchanged',
+      reason: 'custom',
+    });
+    expect(generateSlug).toHaveBeenCalledTimes(1);
+    expect(machine.getState()).toMatchObject({ slug: 'mine', mode: 'custom', pending: false });
   });
 });

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -107,7 +107,7 @@ describe('createSlugMachine', () => {
     ] as const)('%s', (_label, post, mode, status) => {
       const { machine, events } = createHarness();
       machine.loaded(post);
-      const expected = { ...post, mode, status, pending: false };
+      const expected = { ...post, lastCommittedTitle: post.title, mode, status, pending: false };
       expect(machine.getState()).toEqual(expected);
       expect(events).toEqual([{ state: expected, proposal: null }]);
     });
@@ -195,7 +195,43 @@ describe('createSlugMachine', () => {
         reason: 'frozen',
       });
       expect(generateSlug).not.toHaveBeenCalled();
-      expect(machine.getState()).toMatchObject({ slug: 'hello', title: 'Hello' });
+      expect(machine.getState()).toMatchObject({
+        slug: 'hello',
+        title: 'Hello',
+        lastCommittedTitle: '',
+        status: 'frozen',
+      });
+    });
+
+    it('reports derived after a failed commit on an untitled post', async () => {
+      const { machine } = createHarness(vi.fn().mockRejectedValueOnce(new Error('boom')));
+      machine.loaded({ slug: 'untitled', title: DEFAULT_TITLE });
+      expect(machine.getState().status).toBe('frozen');
+
+      await expect(machine.titleCommitted('Hello')).resolves.toMatchObject({ reason: 'error' });
+
+      expect(machine.getState()).toMatchObject({
+        status: 'derived',
+        title: DEFAULT_TITLE,
+        lastCommittedTitle: 'Hello',
+        slug: 'untitled',
+      });
+    });
+
+    it('stops reporting pending for the previous post once a new one loads', async () => {
+      const pending = deferred<string>();
+      const { machine } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+      machine.loaded({ slug: '', title: '' });
+
+      const commit = machine.titleCommitted('Old post');
+      expect(machine.getState().pending).toBe(true);
+
+      machine.loaded({ slug: 'other', title: 'Other' });
+      expect(machine.getState().pending).toBe(false);
+
+      pending.resolve('old-post');
+      await expect(commit).resolves.toMatchObject({ reason: 'stale' });
+      expect(machine.getState().pending).toBe(false);
     });
 
     it('sets the untitled slug once and never again', async () => {

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -485,6 +485,7 @@ describe('createSlugMachine', () => {
         source: 'unchanged',
         reason: 'reverted',
       });
+      expect(machine.getState()).toMatchObject({ mode: 'derived', pending: true });
       pending.resolve('mine');
 
       await expect(edit).resolves.toEqual({
@@ -498,6 +499,33 @@ describe('createSlugMachine', () => {
         pending: false,
       });
       expect(proposals.filter((proposal) => proposal.source === 'manual')).toEqual([]);
+    });
+
+    it('generates from the title while an invalidated manual edit is still pending', async () => {
+      const pending = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(pending.promise)
+        .mockResolvedValueOnce('changed');
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      const edit = machine.slugEdited('mine');
+      await machine.slugEdited('hello');
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'changed',
+        source: 'generated',
+      });
+      expect(machine.getState()).toMatchObject({
+        slug: 'changed',
+        mode: 'derived',
+        pending: true,
+      });
+
+      pending.resolve('mine');
+      await expect(edit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
+      expect(machine.getState()).toMatchObject({ slug: 'changed', pending: false });
     });
 
     it('applies the server result and switches to custom', async () => {
@@ -693,6 +721,7 @@ describe('createSlugMachine', () => {
         const { first, second, firstEdit, secondEdit, machine } = overlap();
         second.reject(new Error('boom'));
         await expect(secondEdit).resolves.toMatchObject({ reason: 'error' });
+        expect(machine.getState()).toMatchObject({ mode: 'derived', pending: true });
         first.resolve('one');
         await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
         await expectDerivedAndRegenerating(machine);

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -349,7 +349,7 @@ describe('createSlugMachine', () => {
       });
     });
 
-    it('applies only the latest response when commits overlap', async () => {
+    it('serializes overlapping title commits', async () => {
       const first = deferred<string>();
       const second = deferred<string>();
       const generateSlug = vi
@@ -363,42 +363,47 @@ describe('createSlugMachine', () => {
       const secondCommit = machine.titleCommitted('Second');
       expect(machine.getState()).toMatchObject({ pending: true, title: '' });
 
-      second.resolve('second');
-      await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
-      expect(machine.getState().pending).toBe(false);
-
       first.resolve('first');
       await expect(firstCommit).resolves.toEqual({
-        slug: '',
-        source: 'unchanged',
-        reason: 'stale',
+        slug: 'first',
+        source: 'generated',
       });
+      expect(generateSlug).toHaveBeenCalledTimes(2);
+
+      second.resolve('second');
+      await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
 
       expect(machine.getState()).toMatchObject({ slug: 'second', title: 'Second', pending: false });
       expect(proposals.filter((p) => p.source === 'generated')).toEqual([
+        { slug: 'first', source: 'generated' },
         { slug: 'second', source: 'generated' },
       ]);
     });
 
-    it('discards a response that resolves before a later commit only if superseded', async () => {
+    it('retains only the latest deferred title commit', async () => {
       const first = deferred<string>();
-      const second = deferred<string>();
+      const third = deferred<string>();
       const generateSlug = vi
         .fn()
         .mockReturnValueOnce(first.promise)
-        .mockReturnValueOnce(second.promise);
+        .mockReturnValueOnce(third.promise);
       const { machine } = createHarness(generateSlug);
       machine.loaded({ slug: '', title: '' });
 
       const firstCommit = machine.titleCommitted('First');
       const secondCommit = machine.titleCommitted('Second');
+      const thirdCommit = machine.titleCommitted('Third');
+
+      await expect(secondCommit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
+      expect(generateSlug).toHaveBeenCalledTimes(1);
 
       first.resolve('first');
-      await expect(firstCommit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
-      expect(machine.getState().slug).toBe('');
+      await expect(firstCommit).resolves.toEqual({ slug: 'first', source: 'generated' });
+      expect(generateSlug).toHaveBeenCalledTimes(2);
 
-      second.resolve('second');
-      await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
+      third.resolve('third');
+      await expect(thirdCommit).resolves.toEqual({ slug: 'third', source: 'generated' });
+      expect(machine.getState()).toMatchObject({ slug: 'third', title: 'Third', pending: false });
     });
 
     it('discards in-flight responses when a post is loaded', async () => {
@@ -491,6 +496,27 @@ describe('createSlugMachine', () => {
         await expect(commit).resolves.toEqual({ slug: 'changed', source: 'generated' });
       },
     );
+
+    it('keeps title generation when a deferred manual edit is withdrawn', async () => {
+      const pending = deferred<string>();
+      const generateSlug = vi.fn().mockReturnValueOnce(pending.promise);
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      const commit = machine.titleCommitted('Changed');
+      const manual = machine.slugEdited('mine');
+      await expect(machine.slugEdited('')).resolves.toMatchObject({ reason: 'reverted' });
+      await expect(manual).resolves.toMatchObject({ reason: 'stale' });
+      expect(generateSlug).toHaveBeenCalledTimes(1);
+
+      pending.resolve('changed');
+      await expect(commit).resolves.toEqual({ slug: 'changed', source: 'generated' });
+      expect(machine.getState()).toMatchObject({
+        slug: 'changed',
+        mode: 'derived',
+        pending: false,
+      });
+    });
   });
 
   describe('slugEdited', () => {
@@ -541,7 +567,7 @@ describe('createSlugMachine', () => {
       expect(proposals.filter((proposal) => proposal.source === 'manual')).toEqual([]);
     });
 
-    it('generates from the title while an invalidated manual edit is still pending', async () => {
+    it('generates from the title after an invalidated manual request settles', async () => {
       const pending = deferred<string>();
       const generateSlug = vi
         .fn()
@@ -552,8 +578,11 @@ describe('createSlugMachine', () => {
 
       const edit = machine.slugEdited('mine');
       await machine.slugEdited('hello');
+      const commit = machine.titleCommitted('Changed');
 
-      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+      pending.resolve('mine');
+      await expect(edit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
+      await expect(commit).resolves.toEqual({
         slug: 'changed',
         source: 'generated',
       });
@@ -563,8 +592,6 @@ describe('createSlugMachine', () => {
         pending: false,
       });
 
-      pending.resolve('mine');
-      await expect(edit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
       expect(machine.getState()).toMatchObject({ slug: 'changed', pending: false });
     });
 
@@ -650,24 +677,22 @@ describe('createSlugMachine', () => {
       expect(machine.getState()).toMatchObject({ slug: 'hello', mode: 'derived', pending: false });
     });
 
-    it('reads as custom while a manual edit is in flight and refuses title generation', async () => {
+    it('defers title generation while a manual edit is in flight', async () => {
       const pending = deferred<string>();
       const generateSlug = vi.fn().mockReturnValueOnce(pending.promise);
       const { machine } = createHarness(generateSlug);
       machine.loaded({ slug: 'hello', title: 'Hello' });
 
       const edit = machine.slugEdited('mine');
-      await expect(machine.titleCommitted('Changed')).resolves.toMatchObject({
-        source: 'unchanged',
-        reason: 'custom',
-      });
+      const commit = machine.titleCommitted('Changed');
 
       pending.resolve('mine');
       await expect(edit).resolves.toEqual({ slug: 'mine', source: 'manual' });
+      await expect(commit).resolves.toMatchObject({ source: 'unchanged', reason: 'custom' });
       expect(generateSlug).toHaveBeenCalledTimes(1);
     });
 
-    it('lets a refused title commit regenerate once the in-flight manual edit fails', async () => {
+    it('runs a deferred title commit when the in-flight manual edit fails', async () => {
       const pending = deferred<string>();
       const generateSlug = vi
         .fn()
@@ -677,19 +702,22 @@ describe('createSlugMachine', () => {
       machine.loaded({ slug: 'hello', title: 'Hello' });
 
       const edit = machine.slugEdited('mine');
-      await expect(machine.titleCommitted('Changed')).resolves.toMatchObject({ reason: 'custom' });
+      const commit = machine.titleCommitted('Changed');
 
       pending.reject(new Error('boom'));
       await expect(edit).resolves.toMatchObject({ reason: 'error' });
-      expect(machine.getState()).toMatchObject({ mode: 'derived', slug: 'hello', title: 'Hello' });
-
-      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+      await expect(commit).resolves.toEqual({
         slug: 'changed',
         source: 'generated',
       });
+      expect(machine.getState()).toMatchObject({
+        mode: 'derived',
+        slug: 'changed',
+        title: 'Changed',
+      });
     });
 
-    it('lets a superseded title commit regenerate once the later manual edit fails', async () => {
+    it('finishes title generation before running a deferred manual edit', async () => {
       const generation = deferred<string>();
       const edit = deferred<string>();
       const generateSlug = vi
@@ -706,16 +734,18 @@ describe('createSlugMachine', () => {
       generation.resolve('changed');
 
       await expect(manual).resolves.toMatchObject({ reason: 'error' });
-      await expect(commit).resolves.toMatchObject({ reason: 'stale' });
-      expect(machine.getState()).toMatchObject({ mode: 'derived', slug: 'hello', title: 'Hello' });
-
-      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+      await expect(commit).resolves.toEqual({
         slug: 'changed',
         source: 'generated',
       });
+      expect(machine.getState()).toMatchObject({
+        mode: 'derived',
+        slug: 'changed',
+        title: 'Changed',
+      });
     });
 
-    it('applies only the latest of overlapping manual edits', async () => {
+    it('serializes overlapping manual edits', async () => {
       const first = deferred<string>();
       const second = deferred<string>();
       const generateSlug = vi
@@ -727,76 +757,34 @@ describe('createSlugMachine', () => {
 
       const firstEdit = machine.slugEdited('one');
       const secondEdit = machine.slugEdited('two');
-      second.resolve('two');
       first.resolve('one');
 
+      await expect(firstEdit).resolves.toEqual({ slug: 'one', source: 'manual' });
+      second.resolve('two');
       await expect(secondEdit).resolves.toEqual({ slug: 'two', source: 'manual' });
-      await expect(firstEdit).resolves.toEqual({
-        slug: 'hello',
-        source: 'unchanged',
-        reason: 'stale',
-      });
       expect(machine.getState().mode).toBe('custom');
     });
 
-    describe('overlapping manual edits where the latest does not apply', () => {
-      function overlap() {
-        const first = deferred<string>();
-        const second = deferred<string>();
-        const generateSlug = vi
-          .fn()
-          .mockReturnValueOnce(first.promise)
-          .mockReturnValueOnce(second.promise)
-          .mockResolvedValueOnce('changed');
-        const { machine } = createHarness(generateSlug);
-        machine.loaded({ slug: 'hello', title: 'Hello' });
-        const firstEdit = machine.slugEdited('one');
-        const secondEdit = machine.slugEdited('two');
-        return { first, second, firstEdit, secondEdit, machine };
-      }
+    it('retains only the latest deferred manual edit', async () => {
+      const first = deferred<string>();
+      const third = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(third.promise);
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
-      async function expectDerivedAndRegenerating(
-        machine: ReturnType<typeof createHarness>['machine'],
-      ) {
-        expect(machine.getState()).toMatchObject({
-          mode: 'derived',
-          slug: 'hello',
-          pending: false,
-        });
-        await expect(machine.titleCommitted('Changed')).resolves.toEqual({
-          slug: 'changed',
-          source: 'generated',
-        });
-      }
+      const firstEdit = machine.slugEdited('one');
+      const secondEdit = machine.slugEdited('two');
+      const thirdEdit = machine.slugEdited('three');
 
-      it('latest rejects, then the earlier one resolves', async () => {
-        const { first, second, firstEdit, secondEdit, machine } = overlap();
-        second.reject(new Error('boom'));
-        await expect(secondEdit).resolves.toMatchObject({ reason: 'error' });
-        expect(machine.getState()).toMatchObject({ mode: 'derived', pending: false });
-        first.resolve('one');
-        await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
-        await expectDerivedAndRegenerating(machine);
-      });
-
-      it('latest sanitizes back to the current slug, then the earlier one resolves', async () => {
-        const { first, second, firstEdit, secondEdit, machine } = overlap();
-        second.resolve('hello');
-        await expect(secondEdit).resolves.toMatchObject({ reason: 'reverted' });
-        first.resolve('one');
-        await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
-        await expectDerivedAndRegenerating(machine);
-      });
-
-      it('earlier one resolves, then the latest rejects', async () => {
-        const { first, second, firstEdit, secondEdit, machine } = overlap();
-        first.resolve('one');
-        await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
-        expect(machine.getState().mode).toBe('custom');
-        second.reject(new Error('boom'));
-        await expect(secondEdit).resolves.toMatchObject({ reason: 'error' });
-        await expectDerivedAndRegenerating(machine);
-      });
+      await expect(secondEdit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
+      first.resolve('one');
+      await expect(firstEdit).resolves.toEqual({ slug: 'one', source: 'manual' });
+      third.resolve('three');
+      await expect(thirdEdit).resolves.toEqual({ slug: 'three', source: 'manual' });
+      expect(machine.getState()).toMatchObject({ slug: 'three', mode: 'custom', pending: false });
     });
   });
 

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it, vi } from 'vitest';
+import { slugify } from '@tryghost/string';
+import { deferred } from '@/utils/deferred';
+import { DEFAULT_TITLE } from './save-engine';
+import {
+  createSlugMachine,
+  isCustomSlug,
+  normalizeManualSlug,
+  resolveDedupedSlug,
+  shouldGenerateSlug,
+  type SlugProposal,
+} from './slug-machine';
+
+function createHarness(generateSlug = vi.fn((text: string) => Promise.resolve(slugify(text)))) {
+  const machine = createSlugMachine({ generateSlug });
+  const proposals: SlugProposal[] = [];
+  machine.subscribe((proposal) => {
+    proposals.push(proposal);
+  });
+  return { machine, generateSlug, proposals };
+}
+
+describe('isCustomSlug', () => {
+  it.each([
+    ['', 'Hello', false],
+    ['hello', 'Hello', false],
+    ['hello-world', 'Hello World!', false],
+    ['unicode-ttitle', 'Ünïcödé Ttitle', false],
+    ['my-own-slug', 'Hello', true],
+    ['hello-2', 'Hello', true],
+    ['whatever', DEFAULT_TITLE, false],
+    ['untitled-3', DEFAULT_TITLE, false],
+    ['foo-copy-2', 'Foo (Copy)', false],
+    ['anything', 'Foo (Copy)', false],
+    ['anything', 'Foo (copy)', true],
+    ['anything', '', true],
+  ])('slug %j with saved title %j → custom: %s', (slug, title, expected) => {
+    expect(isCustomSlug(slug, title)).toBe(expected);
+  });
+});
+
+describe('shouldGenerateSlug', () => {
+  it.each([
+    ['custom mode', { mode: 'custom', slug: 'x' }, 'New title', false],
+    ['custom mode without slug', { mode: 'custom', slug: '' }, 'New title', false],
+    ['blank title', { mode: 'derived', slug: 'x' }, '', false],
+    ['whitespace title', { mode: 'derived', slug: 'x' }, '   ', false],
+    ['untitled with slug', { mode: 'derived', slug: 'untitled' }, DEFAULT_TITLE, false],
+    [
+      'padded untitled with slug',
+      { mode: 'derived', slug: 'untitled' },
+      ` ${DEFAULT_TITLE} `,
+      false,
+    ],
+    ['untitled without slug', { mode: 'derived', slug: '' }, DEFAULT_TITLE, true],
+    ['normal title', { mode: 'derived', slug: 'old' }, 'New title', true],
+    ['copy-suffixed title', { mode: 'derived', slug: 'foo-copy' }, 'Foo (Copy)', true],
+  ] as const)('%s', (_label, state, title, expected) => {
+    expect(shouldGenerateSlug(state, title)).toBe(expected);
+  });
+});
+
+describe('normalizeManualSlug', () => {
+  it.each([
+    ['', 'slug', null],
+    ['   ', 'slug', null],
+    ['slug', 'slug', null],
+    ['slug  ', 'slug', null],
+    ['', '', null],
+    ['  changed  ', 'slug', 'changed'],
+    ['Hello World', 'slug', 'Hello World'],
+  ])('input %j with current %j → %j', (input, current, expected) => {
+    expect(normalizeManualSlug(input, current)).toBe(expected);
+  });
+});
+
+describe('resolveDedupedSlug', () => {
+  it.each([
+    ['server returns current', 'whatever', 'whatever#slug', 'whatever', 'whatever'],
+    ['server appends increment to current', 'whatever-2', 'whatever!', 'whatever', 'whatever'],
+    ['user typed the incremented value', 'whatever-2', 'whatever-2', 'whatever', 'whatever-2'],
+    ['increment on a hyphenated current', 'a-b-3', 'a b', 'a-b', 'a-b'],
+    ['zero is not an increment', 'whatever-0', 'whatever 0', 'whatever', 'whatever-0'],
+    ['trailing number that is a different base', 'other-2', 'other', 'whatever', 'other-2'],
+    ['distinct slug', 'changed', 'changed', 'whatever', 'changed'],
+    ['typed number word on current base', 'top-10', 'top 10', 'top', 'top'],
+  ])('%s', (_label, serverSlug, candidate, current, expected) => {
+    expect(resolveDedupedSlug(serverSlug, candidate, current)).toBe(expected);
+  });
+});
+
+describe('createSlugMachine', () => {
+  describe('loaded', () => {
+    it.each([
+      ['new blank post', { slug: '', title: '', isNew: true }, 'derived', 'frozen'],
+      [
+        'saved untitled post',
+        { slug: 'untitled', title: DEFAULT_TITLE, isNew: false },
+        'derived',
+        'frozen',
+      ],
+      ['derived slug', { slug: 'hello', title: 'Hello', isNew: false }, 'derived', 'derived'],
+      ['custom slug', { slug: 'my-slug', title: 'Hello', isNew: false }, 'custom', 'custom'],
+      [
+        'deduped slug reads as custom',
+        { slug: 'hello-2', title: 'Hello', isNew: false },
+        'custom',
+        'custom',
+      ],
+      [
+        'duplicated post',
+        { slug: 'foo-copy-2', title: 'Foo (Copy)', isNew: false },
+        'derived',
+        'derived',
+      ],
+    ] as const)('%s', (_label, post, mode, status) => {
+      const { machine } = createHarness();
+      machine.loaded(post);
+      expect(machine.getState()).toEqual({ ...post, mode, status, pending: false });
+    });
+  });
+
+  describe('titleCommitted', () => {
+    it('generates a slug from the committed title and emits it', async () => {
+      const { machine, generateSlug, proposals } = createHarness();
+      machine.loaded({ slug: '', title: '', isNew: true });
+
+      const proposal = await machine.titleCommitted('  Hello World  ');
+
+      expect(generateSlug).toHaveBeenCalledWith('Hello World');
+      expect(proposal).toEqual({ slug: 'hello-world', source: 'generated' });
+      expect(proposals).toEqual([proposal]);
+      expect(machine.getState()).toMatchObject({
+        slug: 'hello-world',
+        title: 'Hello World',
+        status: 'derived',
+      });
+    });
+
+    it('keeps following the title after a deduplicated response', async () => {
+      const generateSlug = vi.fn().mockResolvedValueOnce('hello-2').mockResolvedValueOnce('world');
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: '', title: '', isNew: true });
+
+      await machine.titleCommitted('Hello');
+      expect(machine.getState()).toMatchObject({ slug: 'hello-2', mode: 'derived' });
+
+      await expect(machine.titleCommitted('World')).resolves.toEqual({
+        slug: 'world',
+        source: 'generated',
+      });
+    });
+
+    it('ignores an unchanged title when a slug exists', async () => {
+      const { machine, generateSlug } = createHarness();
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      await expect(machine.titleCommitted('Hello ')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'same-title',
+      });
+      expect(generateSlug).not.toHaveBeenCalled();
+    });
+
+    it('generates for an unchanged title when the slug is missing', async () => {
+      const { machine } = createHarness();
+      machine.loaded({ slug: '', title: 'Hello', isNew: false });
+
+      await expect(machine.titleCommitted('Hello')).resolves.toEqual({
+        slug: 'hello',
+        source: 'generated',
+      });
+    });
+
+    it('freezes blank titles without calling the generator', async () => {
+      const { machine, generateSlug } = createHarness();
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      await expect(machine.titleCommitted('   ')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'frozen',
+      });
+      expect(generateSlug).not.toHaveBeenCalled();
+      expect(machine.getState()).toMatchObject({ slug: 'hello', title: '', status: 'frozen' });
+    });
+
+    it('sets the untitled slug once and never again', async () => {
+      const { machine, generateSlug } = createHarness();
+      machine.loaded({ slug: '', title: '', isNew: true });
+
+      await expect(machine.titleCommitted(DEFAULT_TITLE)).resolves.toEqual({
+        slug: 'untitled',
+        source: 'generated',
+      });
+      await machine.titleCommitted('Draft');
+      await expect(machine.titleCommitted(DEFAULT_TITLE)).resolves.toEqual({
+        slug: 'draft',
+        source: 'unchanged',
+        reason: 'frozen',
+      });
+      expect(generateSlug).toHaveBeenCalledTimes(2);
+    });
+
+    it('regenerates when the saved title was (Untitled)', async () => {
+      const { machine } = createHarness();
+      machine.loaded({ slug: 'untitled-2', title: DEFAULT_TITLE, isNew: false });
+
+      await expect(machine.titleCommitted('Real title')).resolves.toEqual({
+        slug: 'real-title',
+        source: 'generated',
+      });
+    });
+
+    it('regenerates when the saved title ended with (Copy)', async () => {
+      const { machine } = createHarness();
+      machine.loaded({ slug: 'foo-copy-2', title: 'Foo (Copy)', isNew: false });
+
+      await expect(machine.titleCommitted('Bar')).resolves.toEqual({
+        slug: 'bar',
+        source: 'generated',
+      });
+    });
+
+    it('never touches a custom slug detected at load', async () => {
+      const { machine, generateSlug } = createHarness();
+      machine.loaded({ slug: 'my-slug', title: 'Hello', isNew: false });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'my-slug',
+        source: 'unchanged',
+        reason: 'custom',
+      });
+      await machine.titleCommitted(DEFAULT_TITLE);
+      await machine.titleCommitted('Foo (Copy)');
+      expect(generateSlug).not.toHaveBeenCalled();
+      expect(machine.getState()).toMatchObject({
+        slug: 'my-slug',
+        status: 'custom',
+        title: 'Foo (Copy)',
+      });
+    });
+
+    it('applies only the latest response when commits overlap', async () => {
+      const first = deferred<string>();
+      const second = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+      const { machine, proposals } = createHarness(generateSlug);
+      machine.loaded({ slug: '', title: '', isNew: true });
+
+      const firstCommit = machine.titleCommitted('First');
+      const secondCommit = machine.titleCommitted('Second');
+      expect(machine.getState()).toMatchObject({ pending: true, title: 'Second' });
+
+      second.resolve('second');
+      await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
+
+      first.resolve('first');
+      await expect(firstCommit).resolves.toEqual({
+        slug: 'second',
+        source: 'unchanged',
+        reason: 'stale',
+      });
+
+      expect(machine.getState()).toMatchObject({ slug: 'second', pending: false });
+      expect(proposals.filter((p) => p.source === 'generated')).toEqual([
+        { slug: 'second', source: 'generated' },
+      ]);
+    });
+
+    it('discards a response that resolves before a later commit only if superseded', async () => {
+      const first = deferred<string>();
+      const second = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: '', title: '', isNew: true });
+
+      const firstCommit = machine.titleCommitted('First');
+      const secondCommit = machine.titleCommitted('Second');
+
+      first.resolve('first');
+      await expect(firstCommit).resolves.toMatchObject({ source: 'unchanged', reason: 'stale' });
+      expect(machine.getState().slug).toBe('');
+
+      second.resolve('second');
+      await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
+    });
+
+    it('discards in-flight responses when a post is loaded', async () => {
+      const pending = deferred<string>();
+      const { machine } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+      machine.loaded({ slug: '', title: '', isNew: true });
+
+      const commit = machine.titleCommitted('Old post');
+      machine.loaded({ slug: 'other', title: 'Other', isNew: false });
+      pending.resolve('old-post');
+
+      await expect(commit).resolves.toEqual({
+        slug: 'other',
+        source: 'unchanged',
+        reason: 'stale',
+      });
+      expect(machine.getState().slug).toBe('other');
+    });
+
+    it('reports generator failures without changing the slug', async () => {
+      const error = new Error('boom');
+      const { machine } = createHarness(vi.fn().mockRejectedValueOnce(error));
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'error',
+        error,
+      });
+      expect(machine.getState()).toMatchObject({ slug: 'hello', pending: false });
+    });
+
+    it('ignores an empty generator result', async () => {
+      const { machine } = createHarness(vi.fn().mockResolvedValueOnce(''));
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'empty-result',
+      });
+    });
+  });
+
+  describe('slugEdited', () => {
+    it.each([
+      ['', 'blank'],
+      ['   ', 'whitespace'],
+      ['hello', 'unchanged'],
+      ['hello  ', 'padded unchanged'],
+    ])('reverts a %j (%s) edit without calling the generator', async (input) => {
+      const { machine, generateSlug } = createHarness();
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      await expect(machine.slugEdited(input)).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'reverted',
+      });
+      expect(generateSlug).not.toHaveBeenCalled();
+      expect(machine.getState().mode).toBe('derived');
+    });
+
+    it('applies the server result and switches to custom', async () => {
+      const { machine, generateSlug, proposals } = createHarness();
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      const proposal = await machine.slugEdited('  My Slug ');
+
+      expect(generateSlug).toHaveBeenCalledWith('My Slug');
+      expect(proposal).toEqual({ slug: 'my-slug', source: 'manual' });
+      expect(proposals).toEqual([proposal]);
+      expect(machine.getState()).toMatchObject({
+        slug: 'my-slug',
+        mode: 'custom',
+        status: 'custom',
+      });
+    });
+
+    it('never regenerates after a manual edit', async () => {
+      const { machine, generateSlug } = createHarness();
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      await machine.slugEdited('custom');
+
+      await expect(machine.titleCommitted('Another title')).resolves.toEqual({
+        slug: 'custom',
+        source: 'unchanged',
+        reason: 'custom',
+      });
+      await machine.titleCommitted(DEFAULT_TITLE);
+      expect(generateSlug).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the current slug when the server only appended an increment', async () => {
+      const { machine } = createHarness(vi.fn().mockResolvedValueOnce('whatever-2'));
+      machine.loaded({ slug: 'whatever', title: 'Whatever', isNew: false });
+
+      await expect(machine.slugEdited('whatever!')).resolves.toEqual({
+        slug: 'whatever',
+        source: 'unchanged',
+        reason: 'reverted',
+      });
+      expect(machine.getState().mode).toBe('derived');
+    });
+
+    it('keeps the current slug when the server sanitizes back to it', async () => {
+      const { machine } = createHarness(vi.fn().mockResolvedValueOnce('whatever'));
+      machine.loaded({ slug: 'whatever', title: 'Whatever', isNew: false });
+
+      await expect(machine.slugEdited('whatever#slug')).resolves.toMatchObject({
+        source: 'unchanged',
+        reason: 'reverted',
+      });
+      expect(machine.getState().mode).toBe('derived');
+    });
+
+    it('restores the previous mode when the generator fails', async () => {
+      const error = new Error('boom');
+      const { machine } = createHarness(vi.fn().mockRejectedValueOnce(error));
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      await expect(machine.slugEdited('changed')).resolves.toEqual({
+        slug: 'hello',
+        source: 'unchanged',
+        reason: 'error',
+        error,
+      });
+      expect(machine.getState()).toMatchObject({ slug: 'hello', mode: 'derived', pending: false });
+    });
+
+    it('blocks title generation while a manual edit is in flight', async () => {
+      const pending = deferred<string>();
+      const generateSlug = vi.fn().mockReturnValueOnce(pending.promise);
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      const edit = machine.slugEdited('mine');
+      await expect(machine.titleCommitted('Changed')).resolves.toMatchObject({
+        source: 'unchanged',
+        reason: 'custom',
+      });
+
+      pending.resolve('mine');
+      await expect(edit).resolves.toEqual({ slug: 'mine', source: 'manual' });
+      expect(generateSlug).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies only the latest of overlapping manual edits', async () => {
+      const first = deferred<string>();
+      const second = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+
+      const firstEdit = machine.slugEdited('one');
+      const secondEdit = machine.slugEdited('two');
+      second.resolve('two');
+      first.resolve('one');
+
+      await expect(secondEdit).resolves.toEqual({ slug: 'two', source: 'manual' });
+      await expect(firstEdit).resolves.toEqual({
+        slug: 'two',
+        source: 'unchanged',
+        reason: 'stale',
+      });
+    });
+  });
+
+  it('stops notifying after unsubscribe', async () => {
+    const { machine } = createHarness();
+    machine.loaded({ slug: '', title: '', isNew: true });
+    const listener = vi.fn();
+    const unsubscribe = machine.subscribe(listener);
+
+    await machine.titleCommitted('One');
+    unsubscribe();
+    await machine.titleCommitted('Two');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      { slug: 'one', source: 'generated' },
+      expect.objectContaining({ slug: 'one', status: 'derived' }),
+    );
+  });
+});

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -8,16 +8,21 @@ import {
   normalizeManualSlug,
   resolveDedupedSlug,
   shouldGenerateSlug,
+  type SlugMachineState,
   type SlugProposal,
 } from './slug-machine';
 
 function createHarness(generateSlug = vi.fn((text: string) => Promise.resolve(slugify(text)))) {
   const machine = createSlugMachine({ generateSlug });
   const proposals: SlugProposal[] = [];
-  machine.subscribe((proposal) => {
-    proposals.push(proposal);
+  const events: Array<{ state: SlugMachineState; proposal: SlugProposal | null }> = [];
+  machine.subscribe((state, proposal) => {
+    events.push({ state, proposal });
+    if (proposal) {
+      proposals.push(proposal);
+    }
   });
-  return { machine, generateSlug, proposals };
+  return { machine, generateSlug, proposals, events };
 }
 
 describe('isCustomSlug', () => {
@@ -84,6 +89,7 @@ describe('resolveDedupedSlug', () => {
     ['trailing number that is a different base', 'other-2', 'other', 'whatever', 'other-2'],
     ['distinct slug', 'changed', 'changed', 'whatever', 'changed'],
     ['typed number word on current base', 'top-10', 'top 10', 'top', 'top'],
+    ['Ember parity: numeric result on an empty current slug reverts to empty', '2', '2!', '', ''],
   ])('%s', (_label, serverSlug, candidate, current, expected) => {
     expect(resolveDedupedSlug(serverSlug, candidate, current)).toBe(expected);
   });
@@ -92,38 +98,25 @@ describe('resolveDedupedSlug', () => {
 describe('createSlugMachine', () => {
   describe('loaded', () => {
     it.each([
-      ['new blank post', { slug: '', title: '', isNew: true }, 'derived', 'frozen'],
-      [
-        'saved untitled post',
-        { slug: 'untitled', title: DEFAULT_TITLE, isNew: false },
-        'derived',
-        'frozen',
-      ],
-      ['derived slug', { slug: 'hello', title: 'Hello', isNew: false }, 'derived', 'derived'],
-      ['custom slug', { slug: 'my-slug', title: 'Hello', isNew: false }, 'custom', 'custom'],
-      [
-        'deduped slug reads as custom',
-        { slug: 'hello-2', title: 'Hello', isNew: false },
-        'custom',
-        'custom',
-      ],
-      [
-        'duplicated post',
-        { slug: 'foo-copy-2', title: 'Foo (Copy)', isNew: false },
-        'derived',
-        'derived',
-      ],
+      ['new blank post', { slug: '', title: '' }, 'derived', 'frozen'],
+      ['saved untitled post', { slug: 'untitled', title: DEFAULT_TITLE }, 'derived', 'frozen'],
+      ['derived slug', { slug: 'hello', title: 'Hello' }, 'derived', 'derived'],
+      ['custom slug', { slug: 'my-slug', title: 'Hello' }, 'custom', 'custom'],
+      ['deduped slug reads as custom', { slug: 'hello-2', title: 'Hello' }, 'custom', 'custom'],
+      ['duplicated post', { slug: 'foo-copy-2', title: 'Foo (Copy)' }, 'derived', 'derived'],
     ] as const)('%s', (_label, post, mode, status) => {
-      const { machine } = createHarness();
+      const { machine, events } = createHarness();
       machine.loaded(post);
-      expect(machine.getState()).toEqual({ ...post, mode, status, pending: false });
+      const expected = { ...post, mode, status, pending: false };
+      expect(machine.getState()).toEqual(expected);
+      expect(events).toEqual([{ state: expected, proposal: null }]);
     });
   });
 
   describe('titleCommitted', () => {
     it('generates a slug from the committed title and emits it', async () => {
       const { machine, generateSlug, proposals } = createHarness();
-      machine.loaded({ slug: '', title: '', isNew: true });
+      machine.loaded({ slug: '', title: '' });
 
       const proposal = await machine.titleCommitted('  Hello World  ');
 
@@ -137,10 +130,29 @@ describe('createSlugMachine', () => {
       });
     });
 
+    it('notifies when a request starts and when it settles', async () => {
+      const pending = deferred<string>();
+      const { machine, events } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
+      machine.loaded({ slug: '', title: '' });
+      events.length = 0;
+
+      const commit = machine.titleCommitted('Hello');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ state: { pending: true }, proposal: null });
+
+      pending.resolve('hello');
+      await commit;
+      expect(events).toHaveLength(2);
+      expect(events[1]).toMatchObject({
+        state: { pending: false, slug: 'hello' },
+        proposal: { slug: 'hello', source: 'generated' },
+      });
+    });
+
     it('keeps following the title after a deduplicated response', async () => {
       const generateSlug = vi.fn().mockResolvedValueOnce('hello-2').mockResolvedValueOnce('world');
       const { machine } = createHarness(generateSlug);
-      machine.loaded({ slug: '', title: '', isNew: true });
+      machine.loaded({ slug: '', title: '' });
 
       await machine.titleCommitted('Hello');
       expect(machine.getState()).toMatchObject({ slug: 'hello-2', mode: 'derived' });
@@ -153,7 +165,7 @@ describe('createSlugMachine', () => {
 
     it('ignores an unchanged title when a slug exists', async () => {
       const { machine, generateSlug } = createHarness();
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       await expect(machine.titleCommitted('Hello ')).resolves.toEqual({
         slug: 'hello',
@@ -165,7 +177,7 @@ describe('createSlugMachine', () => {
 
     it('generates for an unchanged title when the slug is missing', async () => {
       const { machine } = createHarness();
-      machine.loaded({ slug: '', title: 'Hello', isNew: false });
+      machine.loaded({ slug: '', title: 'Hello' });
 
       await expect(machine.titleCommitted('Hello')).resolves.toEqual({
         slug: 'hello',
@@ -175,7 +187,7 @@ describe('createSlugMachine', () => {
 
     it('freezes blank titles without calling the generator', async () => {
       const { machine, generateSlug } = createHarness();
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       await expect(machine.titleCommitted('   ')).resolves.toEqual({
         slug: 'hello',
@@ -183,12 +195,12 @@ describe('createSlugMachine', () => {
         reason: 'frozen',
       });
       expect(generateSlug).not.toHaveBeenCalled();
-      expect(machine.getState()).toMatchObject({ slug: 'hello', title: '', status: 'frozen' });
+      expect(machine.getState()).toMatchObject({ slug: 'hello', title: 'Hello' });
     });
 
     it('sets the untitled slug once and never again', async () => {
       const { machine, generateSlug } = createHarness();
-      machine.loaded({ slug: '', title: '', isNew: true });
+      machine.loaded({ slug: '', title: '' });
 
       await expect(machine.titleCommitted(DEFAULT_TITLE)).resolves.toEqual({
         slug: 'untitled',
@@ -205,7 +217,7 @@ describe('createSlugMachine', () => {
 
     it('regenerates when the saved title was (Untitled)', async () => {
       const { machine } = createHarness();
-      machine.loaded({ slug: 'untitled-2', title: DEFAULT_TITLE, isNew: false });
+      machine.loaded({ slug: 'untitled-2', title: DEFAULT_TITLE });
 
       await expect(machine.titleCommitted('Real title')).resolves.toEqual({
         slug: 'real-title',
@@ -215,7 +227,7 @@ describe('createSlugMachine', () => {
 
     it('regenerates when the saved title ended with (Copy)', async () => {
       const { machine } = createHarness();
-      machine.loaded({ slug: 'foo-copy-2', title: 'Foo (Copy)', isNew: false });
+      machine.loaded({ slug: 'foo-copy-2', title: 'Foo (Copy)' });
 
       await expect(machine.titleCommitted('Bar')).resolves.toEqual({
         slug: 'bar',
@@ -225,7 +237,7 @@ describe('createSlugMachine', () => {
 
     it('never touches a custom slug detected at load', async () => {
       const { machine, generateSlug } = createHarness();
-      machine.loaded({ slug: 'my-slug', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'my-slug', title: 'Hello' });
 
       await expect(machine.titleCommitted('Changed')).resolves.toEqual({
         slug: 'my-slug',
@@ -238,7 +250,7 @@ describe('createSlugMachine', () => {
       expect(machine.getState()).toMatchObject({
         slug: 'my-slug',
         status: 'custom',
-        title: 'Foo (Copy)',
+        title: 'Hello',
       });
     });
 
@@ -250,11 +262,11 @@ describe('createSlugMachine', () => {
         .mockReturnValueOnce(first.promise)
         .mockReturnValueOnce(second.promise);
       const { machine, proposals } = createHarness(generateSlug);
-      machine.loaded({ slug: '', title: '', isNew: true });
+      machine.loaded({ slug: '', title: '' });
 
       const firstCommit = machine.titleCommitted('First');
       const secondCommit = machine.titleCommitted('Second');
-      expect(machine.getState()).toMatchObject({ pending: true, title: 'Second' });
+      expect(machine.getState()).toMatchObject({ pending: true, title: '' });
 
       second.resolve('second');
       await expect(secondCommit).resolves.toEqual({ slug: 'second', source: 'generated' });
@@ -266,7 +278,7 @@ describe('createSlugMachine', () => {
         reason: 'stale',
       });
 
-      expect(machine.getState()).toMatchObject({ slug: 'second', pending: false });
+      expect(machine.getState()).toMatchObject({ slug: 'second', title: 'Second', pending: false });
       expect(proposals.filter((p) => p.source === 'generated')).toEqual([
         { slug: 'second', source: 'generated' },
       ]);
@@ -280,7 +292,7 @@ describe('createSlugMachine', () => {
         .mockReturnValueOnce(first.promise)
         .mockReturnValueOnce(second.promise);
       const { machine } = createHarness(generateSlug);
-      machine.loaded({ slug: '', title: '', isNew: true });
+      machine.loaded({ slug: '', title: '' });
 
       const firstCommit = machine.titleCommitted('First');
       const secondCommit = machine.titleCommitted('Second');
@@ -296,10 +308,10 @@ describe('createSlugMachine', () => {
     it('discards in-flight responses when a post is loaded', async () => {
       const pending = deferred<string>();
       const { machine } = createHarness(vi.fn().mockReturnValueOnce(pending.promise));
-      machine.loaded({ slug: '', title: '', isNew: true });
+      machine.loaded({ slug: '', title: '' });
 
       const commit = machine.titleCommitted('Old post');
-      machine.loaded({ slug: 'other', title: 'Other', isNew: false });
+      machine.loaded({ slug: 'other', title: 'Other' });
       pending.resolve('old-post');
 
       await expect(commit).resolves.toEqual({
@@ -313,7 +325,7 @@ describe('createSlugMachine', () => {
     it('reports generator failures without changing the slug', async () => {
       const error = new Error('boom');
       const { machine } = createHarness(vi.fn().mockRejectedValueOnce(error));
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       await expect(machine.titleCommitted('Changed')).resolves.toEqual({
         slug: 'hello',
@@ -321,12 +333,28 @@ describe('createSlugMachine', () => {
         reason: 'error',
         error,
       });
-      expect(machine.getState()).toMatchObject({ slug: 'hello', pending: false });
+      expect(machine.getState()).toMatchObject({ slug: 'hello', title: 'Hello', pending: false });
+    });
+
+    it('retries the same title after a generator failure', async () => {
+      const generateSlug = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce('changed');
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toMatchObject({ reason: 'error' });
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'changed',
+        source: 'generated',
+      });
+      expect(generateSlug).toHaveBeenCalledTimes(2);
     });
 
     it('ignores an empty generator result', async () => {
       const { machine } = createHarness(vi.fn().mockResolvedValueOnce(''));
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       await expect(machine.titleCommitted('Changed')).resolves.toEqual({
         slug: 'hello',
@@ -344,7 +372,7 @@ describe('createSlugMachine', () => {
       ['hello  ', 'padded unchanged'],
     ])('reverts a %j (%s) edit without calling the generator', async (input) => {
       const { machine, generateSlug } = createHarness();
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       await expect(machine.slugEdited(input)).resolves.toEqual({
         slug: 'hello',
@@ -357,7 +385,7 @@ describe('createSlugMachine', () => {
 
     it('applies the server result and switches to custom', async () => {
       const { machine, generateSlug, proposals } = createHarness();
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       const proposal = await machine.slugEdited('  My Slug ');
 
@@ -368,12 +396,13 @@ describe('createSlugMachine', () => {
         slug: 'my-slug',
         mode: 'custom',
         status: 'custom',
+        title: 'Hello',
       });
     });
 
     it('never regenerates after a manual edit', async () => {
       const { machine, generateSlug } = createHarness();
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
       await machine.slugEdited('custom');
 
       await expect(machine.titleCommitted('Another title')).resolves.toEqual({
@@ -387,7 +416,7 @@ describe('createSlugMachine', () => {
 
     it('keeps the current slug when the server only appended an increment', async () => {
       const { machine } = createHarness(vi.fn().mockResolvedValueOnce('whatever-2'));
-      machine.loaded({ slug: 'whatever', title: 'Whatever', isNew: false });
+      machine.loaded({ slug: 'whatever', title: 'Whatever' });
 
       await expect(machine.slugEdited('whatever!')).resolves.toEqual({
         slug: 'whatever',
@@ -399,7 +428,7 @@ describe('createSlugMachine', () => {
 
     it('keeps the current slug when the server sanitizes back to it', async () => {
       const { machine } = createHarness(vi.fn().mockResolvedValueOnce('whatever'));
-      machine.loaded({ slug: 'whatever', title: 'Whatever', isNew: false });
+      machine.loaded({ slug: 'whatever', title: 'Whatever' });
 
       await expect(machine.slugEdited('whatever#slug')).resolves.toMatchObject({
         source: 'unchanged',
@@ -408,12 +437,14 @@ describe('createSlugMachine', () => {
       expect(machine.getState().mode).toBe('derived');
     });
 
-    it('restores the previous mode when the generator fails', async () => {
+    it('returns to derived when the generator fails', async () => {
       const error = new Error('boom');
       const { machine } = createHarness(vi.fn().mockRejectedValueOnce(error));
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
-      await expect(machine.slugEdited('changed')).resolves.toEqual({
+      const edit = machine.slugEdited('changed');
+      expect(machine.getState().mode).toBe('custom');
+      await expect(edit).resolves.toEqual({
         slug: 'hello',
         source: 'unchanged',
         reason: 'error',
@@ -422,11 +453,11 @@ describe('createSlugMachine', () => {
       expect(machine.getState()).toMatchObject({ slug: 'hello', mode: 'derived', pending: false });
     });
 
-    it('blocks title generation while a manual edit is in flight', async () => {
+    it('reads as custom while a manual edit is in flight and refuses title generation', async () => {
       const pending = deferred<string>();
       const generateSlug = vi.fn().mockReturnValueOnce(pending.promise);
       const { machine } = createHarness(generateSlug);
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       const edit = machine.slugEdited('mine');
       await expect(machine.titleCommitted('Changed')).resolves.toMatchObject({
@@ -439,6 +470,54 @@ describe('createSlugMachine', () => {
       expect(generateSlug).toHaveBeenCalledTimes(1);
     });
 
+    it('lets a refused title commit regenerate once the in-flight manual edit fails', async () => {
+      const pending = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(pending.promise)
+        .mockResolvedValueOnce('changed');
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      const edit = machine.slugEdited('mine');
+      await expect(machine.titleCommitted('Changed')).resolves.toMatchObject({ reason: 'custom' });
+
+      pending.reject(new Error('boom'));
+      await expect(edit).resolves.toMatchObject({ reason: 'error' });
+      expect(machine.getState()).toMatchObject({ mode: 'derived', slug: 'hello', title: 'Hello' });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'changed',
+        source: 'generated',
+      });
+    });
+
+    it('lets a superseded title commit regenerate once the later manual edit fails', async () => {
+      const generation = deferred<string>();
+      const edit = deferred<string>();
+      const generateSlug = vi
+        .fn()
+        .mockReturnValueOnce(generation.promise)
+        .mockReturnValueOnce(edit.promise)
+        .mockResolvedValueOnce('changed');
+      const { machine } = createHarness(generateSlug);
+      machine.loaded({ slug: 'hello', title: 'Hello' });
+
+      const commit = machine.titleCommitted('Changed');
+      const manual = machine.slugEdited('mine');
+      edit.reject(new Error('boom'));
+      generation.resolve('changed');
+
+      await expect(manual).resolves.toMatchObject({ reason: 'error' });
+      await expect(commit).resolves.toMatchObject({ reason: 'stale' });
+      expect(machine.getState()).toMatchObject({ mode: 'derived', slug: 'hello', title: 'Hello' });
+
+      await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+        slug: 'changed',
+        source: 'generated',
+      });
+    });
+
     it('applies only the latest of overlapping manual edits', async () => {
       const first = deferred<string>();
       const second = deferred<string>();
@@ -447,7 +526,7 @@ describe('createSlugMachine', () => {
         .mockReturnValueOnce(first.promise)
         .mockReturnValueOnce(second.promise);
       const { machine } = createHarness(generateSlug);
-      machine.loaded({ slug: 'hello', title: 'Hello', isNew: false });
+      machine.loaded({ slug: 'hello', title: 'Hello' });
 
       const firstEdit = machine.slugEdited('one');
       const secondEdit = machine.slugEdited('two');
@@ -460,12 +539,72 @@ describe('createSlugMachine', () => {
         source: 'unchanged',
         reason: 'stale',
       });
+      expect(machine.getState().mode).toBe('custom');
+    });
+
+    describe('overlapping manual edits where the latest does not apply', () => {
+      function overlap() {
+        const first = deferred<string>();
+        const second = deferred<string>();
+        const generateSlug = vi
+          .fn()
+          .mockReturnValueOnce(first.promise)
+          .mockReturnValueOnce(second.promise)
+          .mockResolvedValueOnce('changed');
+        const { machine } = createHarness(generateSlug);
+        machine.loaded({ slug: 'hello', title: 'Hello' });
+        const firstEdit = machine.slugEdited('one');
+        const secondEdit = machine.slugEdited('two');
+        return { first, second, firstEdit, secondEdit, machine };
+      }
+
+      async function expectDerivedAndRegenerating(
+        machine: ReturnType<typeof createHarness>['machine'],
+      ) {
+        expect(machine.getState()).toMatchObject({
+          mode: 'derived',
+          slug: 'hello',
+          pending: false,
+        });
+        await expect(machine.titleCommitted('Changed')).resolves.toEqual({
+          slug: 'changed',
+          source: 'generated',
+        });
+      }
+
+      it('latest rejects, then the earlier one resolves', async () => {
+        const { first, second, firstEdit, secondEdit, machine } = overlap();
+        second.reject(new Error('boom'));
+        await expect(secondEdit).resolves.toMatchObject({ reason: 'error' });
+        first.resolve('one');
+        await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
+        await expectDerivedAndRegenerating(machine);
+      });
+
+      it('latest sanitizes back to the current slug, then the earlier one resolves', async () => {
+        const { first, second, firstEdit, secondEdit, machine } = overlap();
+        second.resolve('hello');
+        await expect(secondEdit).resolves.toMatchObject({ reason: 'reverted' });
+        first.resolve('one');
+        await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
+        await expectDerivedAndRegenerating(machine);
+      });
+
+      it('earlier one resolves, then the latest rejects', async () => {
+        const { first, second, firstEdit, secondEdit, machine } = overlap();
+        first.resolve('one');
+        await expect(firstEdit).resolves.toMatchObject({ reason: 'stale' });
+        expect(machine.getState().mode).toBe('custom');
+        second.reject(new Error('boom'));
+        await expect(secondEdit).resolves.toMatchObject({ reason: 'error' });
+        await expectDerivedAndRegenerating(machine);
+      });
     });
   });
 
   it('stops notifying after unsubscribe', async () => {
     const { machine } = createHarness();
-    machine.loaded({ slug: '', title: '', isNew: true });
+    machine.loaded({ slug: '', title: '' });
     const listener = vi.fn();
     const unsubscribe = machine.subscribe(listener);
 
@@ -473,10 +612,10 @@ describe('createSlugMachine', () => {
     unsubscribe();
     await machine.titleCommitted('Two');
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith(
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ slug: 'one', status: 'derived', pending: false }),
       { slug: 'one', source: 'generated' },
-      expect.objectContaining({ slug: 'one', status: 'derived' }),
     );
   });
 });

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -10,8 +10,8 @@ export interface SlugMachineState {
   readonly status: SlugStatus;
   readonly mode: SlugMode;
   readonly slug: string;
+  /** The title the slug was loaded with or last generated from. */
   readonly title: string;
-  readonly isNew: boolean;
   readonly pending: boolean;
 }
 
@@ -37,7 +37,6 @@ export type SlugProposal =
 export interface LoadedPost {
   readonly slug: string;
   readonly title: string;
-  readonly isNew: boolean;
 }
 
 export interface SlugMachineOptions {
@@ -45,7 +44,8 @@ export interface SlugMachineOptions {
   generateSlug: (text: string) => Promise<string>;
 }
 
-export type SlugListener = (proposal: SlugProposal, state: SlugMachineState) => void;
+/** Called on every state change; `proposal` is null when only `pending` changed or a post loaded. */
+export type SlugListener = (state: SlugMachineState, proposal: SlugProposal | null) => void;
 
 export interface SlugMachine {
   loaded(post: LoadedPost): void;
@@ -112,30 +112,39 @@ export function resolveDedupedSlug(
 }
 
 export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMachine {
-  let mode: SlugMode = 'derived';
+  // Only load and an applied manual edit move settledMode; an in-flight manual edit reads as
+  // custom so a title commit cannot race it.
+  let settledMode: SlugMode = 'derived';
+  const pendingManual = new Set<number>();
   let slug = '';
   let title = '';
-  let isNew = true;
   let inFlight = 0;
   // Every request takes a ticket; a response applies only while its ticket is still the latest.
   let latestTicket = 0;
   const listeners = new Set<SlugListener>();
 
+  const mode = (): SlugMode => (pendingManual.size > 0 ? 'custom' : settledMode);
+
   const getState = (): SlugMachineState => {
+    const currentMode = mode();
     const status: SlugStatus =
-      mode === 'custom'
+      currentMode === 'custom'
         ? 'custom'
-        : shouldGenerateSlug({ mode, slug }, title)
+        : shouldGenerateSlug({ mode: currentMode, slug }, title)
           ? 'derived'
           : 'frozen';
-    return { status, mode, slug, title, isNew, pending: inFlight > 0 };
+    return { status, mode: currentMode, slug, title, pending: inFlight > 0 };
+  };
+
+  const notify = (proposal: SlugProposal | null): void => {
+    const state = getState();
+    for (const listener of listeners) {
+      listener(state, proposal);
+    }
   };
 
   const emit = (proposal: SlugProposal): SlugProposal => {
-    const state = getState();
-    for (const listener of listeners) {
-      listener(proposal, state);
-    }
+    notify(proposal);
     return proposal;
   };
 
@@ -144,42 +153,48 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
 
   const request = async (
     text: string,
+    manual: boolean,
   ): Promise<{ ticket: number; result?: string; error?: unknown }> => {
     latestTicket += 1;
     const ticket = latestTicket;
     inFlight += 1;
+    if (manual) {
+      pendingManual.add(ticket);
+    }
+    notify(null);
     try {
       return { ticket, result: await generateSlug(text) };
     } catch (error) {
       return { ticket, error };
     } finally {
       inFlight -= 1;
+      pendingManual.delete(ticket);
     }
   };
 
   return {
     loaded(post) {
       latestTicket += 1;
+      pendingManual.clear();
       slug = post.slug;
       title = post.title;
-      isNew = post.isNew;
-      mode = isCustomSlug(post.slug, post.title) ? 'custom' : 'derived';
+      settledMode = isCustomSlug(post.slug, post.title) ? 'custom' : 'derived';
+      notify(null);
     },
 
     async titleCommitted(rawTitle) {
       const nextTitle = rawTitle.trim();
+      if (mode() === 'custom') {
+        return unchanged('custom');
+      }
       if (nextTitle === title && slug) {
         return unchanged('same-title');
       }
-      title = nextTitle;
-      if (mode === 'custom') {
-        return unchanged('custom');
-      }
-      if (!shouldGenerateSlug({ mode, slug }, nextTitle)) {
+      if (!shouldGenerateSlug({ mode: 'derived', slug }, nextTitle)) {
         return unchanged('frozen');
       }
 
-      const { ticket, result, error } = await request(nextTitle);
+      const { ticket, result, error } = await request(nextTitle, false);
       if (ticket !== latestTicket) {
         return unchanged('stale');
       }
@@ -190,6 +205,7 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
         return unchanged('empty-result');
       }
       slug = result;
+      title = nextTitle;
       return emit({ slug, source: 'generated' });
     },
 
@@ -199,26 +215,22 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
         return unchanged('reverted');
       }
 
-      const previousMode = mode;
-      mode = 'custom';
-      const { ticket, result, error } = await request(candidate);
+      const { ticket, result, error } = await request(candidate, true);
       if (ticket !== latestTicket) {
         return unchanged('stale');
       }
       if (error !== undefined) {
-        mode = previousMode;
         return unchanged('error', error);
       }
       if (!result) {
-        mode = previousMode;
         return unchanged('empty-result');
       }
       const resolved = resolveDedupedSlug(result, candidate, slug);
       if (resolved === slug) {
-        mode = previousMode;
         return unchanged('reverted');
       }
       slug = resolved;
+      settledMode = 'custom';
       return emit({ slug, source: 'manual' });
     },
 

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -1,3 +1,39 @@
+/**
+ * Slug behavior contract
+ * ----------------------
+ *
+ * This machine owns slug intent and request ordering; callers own the input UI and persistence of
+ * emitted proposals. Its behavior follows Ember Admin unless an intentional rule below says
+ * otherwise.
+ *
+ * Ownership
+ * - A derived slug follows eligible title commits. A custom slug stops following the title.
+ * - Loading infers ownership structurally because posts do not persist slug provenance: a slug
+ *   matching `slugify(title)` is derived; a different slug is custom. `(Untitled)` and titles ending
+ *   in `(Copy)` remain derived to preserve Ember's first-real-title and duplicated-post behavior.
+ * - A successful manual edit makes the slug custom. Blank, unchanged, failed, or rejected manual
+ *   edits leave ownership unchanged.
+ *
+ * Generation
+ * - Derived slugs regenerate for non-blank committed titles. An existing slug is frozen for a blank
+ *   title or `(Untitled)` so transient editor titles cannot erase it.
+ * - The server remains authoritative for sanitization and uniqueness. Whitespace-only responses are
+ *   ignored, and an apparent uniqueness increment is ignored when it only increments the current
+ *   slug rather than representing the user's canonicalized input.
+ *
+ * Ordering
+ * - At most one slug request is sent at a time. While it is active, only the latest additional
+ *   request-requiring submission is retained and run after it settles; replaced submissions
+ *   resolve as stale.
+ * - Withdrawing a deferred manual edit does not cancel active title generation. Withdrawing an
+ *   active manual edit invalidates its result without starting another request.
+ * - `loaded()` is a document boundary: it invalidates active and deferred work from the old post.
+ *
+ * Observation
+ * - Applied, rejected, and no-op decisions emit proposals. Stale completions return a proposal to
+ *   their caller but never notify subscribers, so old work cannot look like a current state change.
+ * - Listener failures are reported and isolated from transitions and from other listeners.
+ */
 import { slugify } from '@tryghost/string';
 import { DEFAULT_TITLE } from './save-engine';
 

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -163,10 +163,17 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   const unchanged = (reason: UnchangedReason, error?: unknown): SlugProposal =>
     emit({ slug, source: 'unchanged', reason, ...(error !== undefined && { error }) });
 
+  const stale = (): SlugProposal => ({ slug, source: 'unchanged', reason: 'stale' });
+
   const request = async (
     text: string,
     manual: boolean,
-  ): Promise<{ ticket: number; result?: string; error?: unknown }> => {
+  ): Promise<{
+    ticket: number;
+    result?: string;
+    error?: unknown;
+    cleanupChangedState: boolean;
+  }> => {
     latestTicket += 1;
     const ticket = latestTicket;
     inFlightTickets.add(ticket);
@@ -174,14 +181,22 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
       pendingManual.add(ticket);
     }
     notify(null);
+    let result: string | undefined;
+    let error: unknown;
     try {
-      return { ticket, result: await generateSlug(text) };
-    } catch (error) {
-      return { ticket, error };
-    } finally {
-      inFlightTickets.delete(ticket);
-      pendingManual.delete(ticket);
+      result = await generateSlug(text);
+    } catch (requestError) {
+      error = requestError;
     }
+    const stateBeforeCleanup = getState();
+    inFlightTickets.delete(ticket);
+    pendingManual.delete(ticket);
+    const stateAfterCleanup = getState();
+    const cleanupChangedState =
+      stateBeforeCleanup.pending !== stateAfterCleanup.pending ||
+      stateBeforeCleanup.mode !== stateAfterCleanup.mode ||
+      stateBeforeCleanup.status !== stateAfterCleanup.status;
+    return { ticket, result, error, cleanupChangedState };
   };
 
   return {
@@ -203,15 +218,20 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
         return unchanged('custom');
       }
       if (nextTitle === title && slug) {
+        latestTicket += 1;
         return unchanged('same-title');
       }
       if (!shouldGenerateSlug({ mode: 'derived', slug }, nextTitle)) {
+        latestTicket += 1;
         return unchanged('frozen');
       }
 
-      const { ticket, result, error } = await request(nextTitle, false);
+      const { ticket, result, error, cleanupChangedState } = await request(nextTitle, false);
       if (ticket !== latestTicket) {
-        return unchanged('stale');
+        if (cleanupChangedState) {
+          notify(null);
+        }
+        return stale();
       }
       if (error !== undefined) {
         return unchanged('error', error);
@@ -227,12 +247,16 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
     async slugEdited(input) {
       const candidate = normalizeManualSlug(input, slug);
       if (candidate === null) {
+        latestTicket += 1;
         return unchanged('reverted');
       }
 
-      const { ticket, result, error } = await request(candidate, true);
+      const { ticket, result, error, cleanupChangedState } = await request(candidate, true);
       if (ticket !== latestTicket) {
-        return unchanged('stale');
+        if (cleanupChangedState) {
+          notify(null);
+        }
+        return stale();
       }
       if (error !== undefined) {
         return unchanged('error', error);

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -120,8 +120,16 @@ export function createSlugMachine({
   generateSlug,
   onListenerError,
 }: SlugMachineOptions): SlugMachine {
-  // Only load and an applied manual edit move settledMode; the latest request reads as custom
-  // while it is a manual edit so a title commit cannot race it. Older pending edits are stale.
+  type Submission = { kind: 'title'; value: string } | { kind: 'manual'; value: string };
+  type DeferredSubmission = {
+    submission: Submission;
+    slugAtSubmission: string;
+    resolve: (proposal: SlugProposal) => void;
+    reject: (error: unknown) => void;
+  };
+
+  // Only load and an applied manual edit move settledMode. An active manual request reads as
+  // custom until it settles, and request tickets still guard explicit invalidation and post loads.
   let settledMode: SlugMode = 'derived';
   const pendingManual = new Set<number>();
   let slug = '';
@@ -134,6 +142,12 @@ export function createSlugMachine({
   let latestManualTicket = 0;
   const inFlightTickets = new Set<number>();
   const listeners = new Set<SlugListener>();
+  // Slug requests are serialized. While one is active, only the latest deferred submission is
+  // retained so a slow response cannot create overlapping title/manual request races.
+  let nextSubmissionToken = 0;
+  let activeSubmissionToken = 0;
+  let activeSubmissionKind: Submission['kind'] | null = null;
+  let deferredSubmission: DeferredSubmission | null = null;
 
   const mode = (): SlugMode => (pendingManual.has(latestManualTicket) ? 'custom' : settledMode);
 
@@ -242,8 +256,158 @@ export function createSlugMachine({
     return { ticket, result, error, slugAtRequest };
   };
 
+  const commitTitle = async (rawTitle: string): Promise<SlugProposal> => {
+    const nextTitle = rawTitle.trim();
+    lastCommittedTitle = nextTitle;
+    if (mode() === 'custom') {
+      return unchanged('custom');
+    }
+    if (nextTitle === title && slug) {
+      invalidateTitleRequest();
+      return unchanged('same-title');
+    }
+    if (!shouldGenerateSlug({ mode: 'derived', slug }, nextTitle)) {
+      invalidateTitleRequest();
+      return unchanged('frozen');
+    }
+
+    const { ticket, result, error, slugAtRequest } = await request(nextTitle, false);
+    const cleanupChangedState = cleanupRequest(ticket);
+    if (ticket !== latestTitleTicket) {
+      if (cleanupChangedState) {
+        notify(null);
+      }
+      return stale(slugAtRequest);
+    }
+    if (error !== undefined) {
+      return unchanged('error', error);
+    }
+    if (!result?.trim()) {
+      return unchanged('empty-result');
+    }
+    slug = result;
+    title = nextTitle;
+    return emit({ slug, source: 'generated' });
+  };
+
+  const editSlug = async (input: string): Promise<SlugProposal> => {
+    const candidate = normalizeManualSlug(input, slug);
+    if (candidate === null) {
+      invalidateManualRequest();
+      return unchanged('reverted');
+    }
+
+    const { ticket, result, error, slugAtRequest } = await request(candidate, true);
+    const cleanupChangedState = cleanupRequest(ticket);
+    if (ticket !== latestManualTicket) {
+      if (cleanupChangedState) {
+        notify(null);
+      }
+      return stale(slugAtRequest);
+    }
+    if (error !== undefined) {
+      return unchanged('error', error);
+    }
+    if (!result?.trim()) {
+      return unchanged('empty-result');
+    }
+    const resolved = resolveDedupedSlug(result, candidate, slug);
+    if (resolved === slug) {
+      return unchanged('reverted');
+    }
+    slug = resolved;
+    settledMode = 'custom';
+    return emit({ slug, source: 'manual' });
+  };
+
+  const executeSubmission = (submission: Submission): Promise<SlugProposal> =>
+    submission.kind === 'title' ? commitTitle(submission.value) : editSlug(submission.value);
+
+  const finishSubmission = (token: number): void => {
+    if (token !== activeSubmissionToken) {
+      return;
+    }
+    const next = deferredSubmission;
+    deferredSubmission = null;
+    if (!next) {
+      activeSubmissionToken = 0;
+      activeSubmissionKind = null;
+      return;
+    }
+    const nextPromise = startSubmission(next.submission);
+    void nextPromise.then(next.resolve, next.reject);
+  };
+
+  const startSubmission = (submission: Submission): Promise<SlugProposal> => {
+    nextSubmissionToken += 1;
+    const token = nextSubmissionToken;
+    activeSubmissionToken = token;
+    activeSubmissionKind = submission.kind;
+    const submissionPromise = executeSubmission(submission);
+    void submissionPromise.then(
+      () => finishSubmission(token),
+      () => finishSubmission(token),
+    );
+    return submissionPromise;
+  };
+
+  const submit = (submission: Submission): Promise<SlugProposal> => {
+    if (!activeSubmissionToken) {
+      return startSubmission(submission);
+    }
+
+    // A no-op manual blur cancels a deferred manual value. If a manual request itself is active,
+    // it also withdraws that request without disturbing an active title generation.
+    if (submission.kind === 'manual' && normalizeManualSlug(submission.value, slug) === null) {
+      if (deferredSubmission?.submission.kind === 'manual') {
+        deferredSubmission.resolve(stale(deferredSubmission.slugAtSubmission));
+        deferredSubmission = null;
+      }
+      if (activeSubmissionKind === 'manual') {
+        invalidateManualRequest();
+      }
+      return Promise.resolve(unchanged('reverted'));
+    }
+
+    // A title returning to a settled/frozen value can invalidate active title generation without
+    // waiting for its physical request. Title intent behind a manual request remains deferred.
+    if (submission.kind === 'title' && activeSubmissionKind === 'title') {
+      const nextTitle = submission.value.trim();
+      lastCommittedTitle = nextTitle;
+      if (nextTitle === title && slug) {
+        if (deferredSubmission) {
+          deferredSubmission.resolve(stale(deferredSubmission.slugAtSubmission));
+          deferredSubmission = null;
+        }
+        invalidateTitleRequest();
+        return Promise.resolve(unchanged('same-title'));
+      }
+      if (!shouldGenerateSlug({ mode: 'derived', slug }, nextTitle)) {
+        if (deferredSubmission) {
+          deferredSubmission.resolve(stale(deferredSubmission.slugAtSubmission));
+          deferredSubmission = null;
+        }
+        invalidateTitleRequest();
+        return Promise.resolve(unchanged('frozen'));
+      }
+    }
+
+    if (deferredSubmission) {
+      deferredSubmission.resolve(stale(deferredSubmission.slugAtSubmission));
+    }
+    return new Promise<SlugProposal>((resolve, reject) => {
+      deferredSubmission = { submission, slugAtSubmission: slug, resolve, reject };
+    });
+  };
+
   return {
     loaded(post) {
+      activeSubmissionToken = 0;
+      activeSubmissionKind = null;
+      if (deferredSubmission) {
+        deferredSubmission.resolve(stale(deferredSubmission.slugAtSubmission));
+        deferredSubmission = null;
+      }
       latestTitleTicket = 0;
       latestManualTicket = 0;
       inFlightTickets.clear();
@@ -255,68 +419,12 @@ export function createSlugMachine({
       notify(null);
     },
 
-    async titleCommitted(rawTitle) {
-      const nextTitle = rawTitle.trim();
-      lastCommittedTitle = nextTitle;
-      if (mode() === 'custom') {
-        return unchanged('custom');
-      }
-      if (nextTitle === title && slug) {
-        invalidateTitleRequest();
-        return unchanged('same-title');
-      }
-      if (!shouldGenerateSlug({ mode: 'derived', slug }, nextTitle)) {
-        invalidateTitleRequest();
-        return unchanged('frozen');
-      }
-
-      const { ticket, result, error, slugAtRequest } = await request(nextTitle, false);
-      const cleanupChangedState = cleanupRequest(ticket);
-      if (ticket !== latestTitleTicket) {
-        if (cleanupChangedState) {
-          notify(null);
-        }
-        return stale(slugAtRequest);
-      }
-      if (error !== undefined) {
-        return unchanged('error', error);
-      }
-      if (!result?.trim()) {
-        return unchanged('empty-result');
-      }
-      slug = result;
-      title = nextTitle;
-      return emit({ slug, source: 'generated' });
+    titleCommitted(rawTitle) {
+      return submit({ kind: 'title', value: rawTitle });
     },
 
-    async slugEdited(input) {
-      const candidate = normalizeManualSlug(input, slug);
-      if (candidate === null) {
-        invalidateManualRequest();
-        return unchanged('reverted');
-      }
-
-      const { ticket, result, error, slugAtRequest } = await request(candidate, true);
-      const cleanupChangedState = cleanupRequest(ticket);
-      if (ticket !== latestManualTicket) {
-        if (cleanupChangedState) {
-          notify(null);
-        }
-        return stale(slugAtRequest);
-      }
-      if (error !== undefined) {
-        return unchanged('error', error);
-      }
-      if (!result?.trim()) {
-        return unchanged('empty-result');
-      }
-      const resolved = resolveDedupedSlug(result, candidate, slug);
-      if (resolved === slug) {
-        return unchanged('reverted');
-      }
-      slug = resolved;
-      settledMode = 'custom';
-      return emit({ slug, source: 'manual' });
+    slugEdited(input) {
+      return submit({ kind: 'manual', value: input });
     },
 
     getState,

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -14,7 +14,7 @@ export interface SlugMachineState {
   readonly title: string;
   /** The title from the latest titleCommitted call regardless of outcome; drives `status`. */
   readonly lastCommittedTitle: string;
-  /** True while a request issued since the last `loaded()` is in flight. */
+  /** True while an applicable title or manual request is in flight. */
   readonly pending: boolean;
 }
 
@@ -45,6 +45,8 @@ export interface LoadedPost {
 export interface SlugMachineOptions {
   /** Port for GET /slugs/post/:name/:id — receives the raw text, returns the deduplicated slug. */
   generateSlug: (text: string) => Promise<string>;
+  /** Listener failures are isolated from machine transitions and reported here. Must not throw. */
+  onListenerError: (error: unknown) => void;
 }
 
 /** Called on every state change; `proposal` is null when only `pending` changed or a post loaded. */
@@ -108,13 +110,16 @@ export function resolveDedupedSlug(
   }
   const tokens = serverSlug.split('-');
   const increment = Number(tokens.pop());
-  if (increment > 0 && tokens.join('-') === currentSlug && serverSlug !== candidate) {
+  if (increment > 0 && tokens.join('-') === currentSlug && serverSlug !== slugify(candidate)) {
     return currentSlug;
   }
   return serverSlug;
 }
 
-export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMachine {
+export function createSlugMachine({
+  generateSlug,
+  onListenerError,
+}: SlugMachineOptions): SlugMachine {
   // Only load and an applied manual edit move settledMode; the latest request reads as custom
   // while it is a manual edit so a title commit cannot race it. Older pending edits are stale.
   let settledMode: SlugMode = 'derived';
@@ -122,13 +127,15 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   let slug = '';
   let title = '';
   let lastCommittedTitle = '';
-  // Every request takes a ticket; a response applies only while its ticket is still the latest.
-  // loaded() clears the in-flight sets so requests from the previous post stop reading as pending.
-  let latestTicket = 0;
+  // Requests have separate applicability per intent. A manual request supersedes title generation,
+  // but a no-op manual blur only supersedes older manual work and must not cancel a title request.
+  let nextTicket = 0;
+  let latestTitleTicket = 0;
+  let latestManualTicket = 0;
   const inFlightTickets = new Set<number>();
   const listeners = new Set<SlugListener>();
 
-  const mode = (): SlugMode => (pendingManual.has(latestTicket) ? 'custom' : settledMode);
+  const mode = (): SlugMode => (pendingManual.has(latestManualTicket) ? 'custom' : settledMode);
 
   const getState = (): SlugMachineState => {
     const currentMode = mode();
@@ -144,14 +151,22 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
       slug,
       title,
       lastCommittedTitle,
-      pending: inFlightTickets.size > 0,
+      pending: inFlightTickets.has(latestTitleTicket) || inFlightTickets.has(latestManualTicket),
     };
   };
 
   const notify = (proposal: SlugProposal | null): void => {
     const state = getState();
     for (const listener of listeners) {
-      listener(state, proposal);
+      try {
+        listener(state, proposal);
+      } catch (error) {
+        try {
+          onListenerError(error);
+        } catch {
+          // Error reporting must not corrupt the state transition or prevent other listeners.
+        }
+      }
     }
   };
 
@@ -163,7 +178,34 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   const unchanged = (reason: UnchangedReason, error?: unknown): SlugProposal =>
     emit({ slug, source: 'unchanged', reason, ...(error !== undefined && { error }) });
 
-  const stale = (): SlugProposal => ({ slug, source: 'unchanged', reason: 'stale' });
+  const stale = (slugAtRequest: string): SlugProposal => ({
+    slug: slugAtRequest,
+    source: 'unchanged',
+    reason: 'stale',
+  });
+
+  const invalidateTitleRequest = (): void => {
+    inFlightTickets.delete(latestTitleTicket);
+    latestTitleTicket = 0;
+  };
+
+  const invalidateManualRequest = (): void => {
+    inFlightTickets.delete(latestManualTicket);
+    pendingManual.delete(latestManualTicket);
+    latestManualTicket = 0;
+  };
+
+  const cleanupRequest = (ticket: number): boolean => {
+    const stateBeforeCleanup = getState();
+    inFlightTickets.delete(ticket);
+    pendingManual.delete(ticket);
+    const stateAfterCleanup = getState();
+    return (
+      stateBeforeCleanup.pending !== stateAfterCleanup.pending ||
+      stateBeforeCleanup.mode !== stateAfterCleanup.mode ||
+      stateBeforeCleanup.status !== stateAfterCleanup.status
+    );
+  };
 
   const request = async (
     text: string,
@@ -172,10 +214,19 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
     ticket: number;
     result?: string;
     error?: unknown;
-    cleanupChangedState: boolean;
+    slugAtRequest: string;
   }> => {
-    latestTicket += 1;
-    const ticket = latestTicket;
+    nextTicket += 1;
+    const ticket = nextTicket;
+    const slugAtRequest = slug;
+    if (manual) {
+      invalidateTitleRequest();
+      invalidateManualRequest();
+      latestManualTicket = ticket;
+    } else {
+      invalidateTitleRequest();
+      latestTitleTicket = ticket;
+    }
     inFlightTickets.add(ticket);
     if (manual) {
       pendingManual.add(ticket);
@@ -188,20 +239,13 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
     } catch (requestError) {
       error = requestError;
     }
-    const stateBeforeCleanup = getState();
-    inFlightTickets.delete(ticket);
-    pendingManual.delete(ticket);
-    const stateAfterCleanup = getState();
-    const cleanupChangedState =
-      stateBeforeCleanup.pending !== stateAfterCleanup.pending ||
-      stateBeforeCleanup.mode !== stateAfterCleanup.mode ||
-      stateBeforeCleanup.status !== stateAfterCleanup.status;
-    return { ticket, result, error, cleanupChangedState };
+    return { ticket, result, error, slugAtRequest };
   };
 
   return {
     loaded(post) {
-      latestTicket += 1;
+      latestTitleTicket = 0;
+      latestManualTicket = 0;
       inFlightTickets.clear();
       pendingManual.clear();
       slug = post.slug;
@@ -218,25 +262,26 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
         return unchanged('custom');
       }
       if (nextTitle === title && slug) {
-        latestTicket += 1;
+        invalidateTitleRequest();
         return unchanged('same-title');
       }
       if (!shouldGenerateSlug({ mode: 'derived', slug }, nextTitle)) {
-        latestTicket += 1;
+        invalidateTitleRequest();
         return unchanged('frozen');
       }
 
-      const { ticket, result, error, cleanupChangedState } = await request(nextTitle, false);
-      if (ticket !== latestTicket) {
+      const { ticket, result, error, slugAtRequest } = await request(nextTitle, false);
+      const cleanupChangedState = cleanupRequest(ticket);
+      if (ticket !== latestTitleTicket) {
         if (cleanupChangedState) {
           notify(null);
         }
-        return stale();
+        return stale(slugAtRequest);
       }
       if (error !== undefined) {
         return unchanged('error', error);
       }
-      if (!result) {
+      if (!result?.trim()) {
         return unchanged('empty-result');
       }
       slug = result;
@@ -247,21 +292,22 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
     async slugEdited(input) {
       const candidate = normalizeManualSlug(input, slug);
       if (candidate === null) {
-        latestTicket += 1;
+        invalidateManualRequest();
         return unchanged('reverted');
       }
 
-      const { ticket, result, error, cleanupChangedState } = await request(candidate, true);
-      if (ticket !== latestTicket) {
+      const { ticket, result, error, slugAtRequest } = await request(candidate, true);
+      const cleanupChangedState = cleanupRequest(ticket);
+      if (ticket !== latestManualTicket) {
         if (cleanupChangedState) {
           notify(null);
         }
-        return stale();
+        return stale(slugAtRequest);
       }
       if (error !== undefined) {
         return unchanged('error', error);
       }
-      if (!result) {
+      if (!result?.trim()) {
         return unchanged('empty-result');
       }
       const resolved = resolveDedupedSlug(result, candidate, slug);

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -115,8 +115,8 @@ export function resolveDedupedSlug(
 }
 
 export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMachine {
-  // Only load and an applied manual edit move settledMode; an in-flight manual edit reads as
-  // custom so a title commit cannot race it.
+  // Only load and an applied manual edit move settledMode; the latest request reads as custom
+  // while it is a manual edit so a title commit cannot race it. Older pending edits are stale.
   let settledMode: SlugMode = 'derived';
   const pendingManual = new Set<number>();
   let slug = '';
@@ -128,7 +128,7 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   const inFlightTickets = new Set<number>();
   const listeners = new Set<SlugListener>();
 
-  const mode = (): SlugMode => (pendingManual.size > 0 ? 'custom' : settledMode);
+  const mode = (): SlugMode => (pendingManual.has(latestTicket) ? 'custom' : settledMode);
 
   const getState = (): SlugMachineState => {
     const currentMode = mode();

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -1,0 +1,234 @@
+import { slugify } from '@tryghost/string';
+import { DEFAULT_TITLE } from './save-engine';
+
+export const DUPLICATED_POST_TITLE_SUFFIX = '(Copy)';
+
+export type SlugMode = 'derived' | 'custom';
+export type SlugStatus = 'derived' | 'custom' | 'frozen';
+
+export interface SlugMachineState {
+  readonly status: SlugStatus;
+  readonly mode: SlugMode;
+  readonly slug: string;
+  readonly title: string;
+  readonly isNew: boolean;
+  readonly pending: boolean;
+}
+
+export type UnchangedReason =
+  | 'same-title'
+  | 'custom'
+  | 'frozen'
+  | 'stale'
+  | 'empty-result'
+  | 'reverted'
+  | 'error';
+
+export type SlugProposal =
+  | { readonly slug: string; readonly source: 'generated' }
+  | { readonly slug: string; readonly source: 'manual' }
+  | {
+      readonly slug: string;
+      readonly source: 'unchanged';
+      readonly reason: UnchangedReason;
+      readonly error?: unknown;
+    };
+
+export interface LoadedPost {
+  readonly slug: string;
+  readonly title: string;
+  readonly isNew: boolean;
+}
+
+export interface SlugMachineOptions {
+  /** Port for GET /slugs/post/:name/:id — receives the raw text, returns the deduplicated slug. */
+  generateSlug: (text: string) => Promise<string>;
+}
+
+export type SlugListener = (proposal: SlugProposal, state: SlugMachineState) => void;
+
+export interface SlugMachine {
+  loaded(post: LoadedPost): void;
+  titleCommitted(title: string): Promise<SlugProposal>;
+  slugEdited(input: string): Promise<SlugProposal>;
+  getState(): SlugMachineState;
+  subscribe(listener: SlugListener): () => void;
+}
+
+// Mirrors Ember generateSlugTask: a slug that differs from slugify(saved title) is treated as
+// custom unless the saved title is (Untitled) or ends with (Copy).
+export function isCustomSlug(slug: string, title: string): boolean {
+  if (!slug) {
+    return false;
+  }
+  if (title === DEFAULT_TITLE || title.endsWith(DUPLICATED_POST_TITLE_SUFFIX)) {
+    return false;
+  }
+  return slugify(title) !== slug;
+}
+
+export function shouldGenerateSlug(
+  state: Pick<SlugMachineState, 'mode' | 'slug'>,
+  title: string,
+): boolean {
+  if (state.mode === 'custom') {
+    return false;
+  }
+  const trimmed = title.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed === DEFAULT_TITLE && state.slug) {
+    return false;
+  }
+  return true;
+}
+
+// Returns null when the input must revert to the current slug (blank or unchanged).
+export function normalizeManualSlug(input: string, currentSlug: string): string | null {
+  const candidate = (input || currentSlug).trim();
+  if (!candidate || candidate === currentSlug) {
+    return null;
+  }
+  return candidate;
+}
+
+// Mirrors Ember updateSlugTask: keep the current slug when the server only appended an
+// incrementor to it and the user did not type that exact value.
+export function resolveDedupedSlug(
+  serverSlug: string,
+  candidate: string,
+  currentSlug: string,
+): string {
+  if (serverSlug === currentSlug) {
+    return currentSlug;
+  }
+  const tokens = serverSlug.split('-');
+  const increment = Number(tokens.pop());
+  if (increment > 0 && tokens.join('-') === currentSlug && serverSlug !== candidate) {
+    return currentSlug;
+  }
+  return serverSlug;
+}
+
+export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMachine {
+  let mode: SlugMode = 'derived';
+  let slug = '';
+  let title = '';
+  let isNew = true;
+  let inFlight = 0;
+  // Every request takes a ticket; a response applies only while its ticket is still the latest.
+  let latestTicket = 0;
+  const listeners = new Set<SlugListener>();
+
+  const getState = (): SlugMachineState => {
+    const status: SlugStatus =
+      mode === 'custom'
+        ? 'custom'
+        : shouldGenerateSlug({ mode, slug }, title)
+          ? 'derived'
+          : 'frozen';
+    return { status, mode, slug, title, isNew, pending: inFlight > 0 };
+  };
+
+  const emit = (proposal: SlugProposal): SlugProposal => {
+    const state = getState();
+    for (const listener of listeners) {
+      listener(proposal, state);
+    }
+    return proposal;
+  };
+
+  const unchanged = (reason: UnchangedReason, error?: unknown): SlugProposal =>
+    emit({ slug, source: 'unchanged', reason, ...(error !== undefined && { error }) });
+
+  const request = async (
+    text: string,
+  ): Promise<{ ticket: number; result?: string; error?: unknown }> => {
+    latestTicket += 1;
+    const ticket = latestTicket;
+    inFlight += 1;
+    try {
+      return { ticket, result: await generateSlug(text) };
+    } catch (error) {
+      return { ticket, error };
+    } finally {
+      inFlight -= 1;
+    }
+  };
+
+  return {
+    loaded(post) {
+      latestTicket += 1;
+      slug = post.slug;
+      title = post.title;
+      isNew = post.isNew;
+      mode = isCustomSlug(post.slug, post.title) ? 'custom' : 'derived';
+    },
+
+    async titleCommitted(rawTitle) {
+      const nextTitle = rawTitle.trim();
+      if (nextTitle === title && slug) {
+        return unchanged('same-title');
+      }
+      title = nextTitle;
+      if (mode === 'custom') {
+        return unchanged('custom');
+      }
+      if (!shouldGenerateSlug({ mode, slug }, nextTitle)) {
+        return unchanged('frozen');
+      }
+
+      const { ticket, result, error } = await request(nextTitle);
+      if (ticket !== latestTicket) {
+        return unchanged('stale');
+      }
+      if (error !== undefined) {
+        return unchanged('error', error);
+      }
+      if (!result) {
+        return unchanged('empty-result');
+      }
+      slug = result;
+      return emit({ slug, source: 'generated' });
+    },
+
+    async slugEdited(input) {
+      const candidate = normalizeManualSlug(input, slug);
+      if (candidate === null) {
+        return unchanged('reverted');
+      }
+
+      const previousMode = mode;
+      mode = 'custom';
+      const { ticket, result, error } = await request(candidate);
+      if (ticket !== latestTicket) {
+        return unchanged('stale');
+      }
+      if (error !== undefined) {
+        mode = previousMode;
+        return unchanged('error', error);
+      }
+      if (!result) {
+        mode = previousMode;
+        return unchanged('empty-result');
+      }
+      const resolved = resolveDedupedSlug(result, candidate, slug);
+      if (resolved === slug) {
+        mode = previousMode;
+        return unchanged('reverted');
+      }
+      slug = resolved;
+      return emit({ slug, source: 'manual' });
+    },
+
+    getState,
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -10,8 +10,11 @@ export interface SlugMachineState {
   readonly status: SlugStatus;
   readonly mode: SlugMode;
   readonly slug: string;
-  /** The title the slug was loaded with or last generated from. */
+  /** The title the slug was loaded with or last generated from; drives the same-title check. */
   readonly title: string;
+  /** The title from the latest titleCommitted call regardless of outcome; drives `status`. */
+  readonly lastCommittedTitle: string;
+  /** True while a request issued since the last `loaded()` is in flight. */
   readonly pending: boolean;
 }
 
@@ -118,9 +121,11 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   const pendingManual = new Set<number>();
   let slug = '';
   let title = '';
-  let inFlight = 0;
+  let lastCommittedTitle = '';
   // Every request takes a ticket; a response applies only while its ticket is still the latest.
+  // loaded() clears the in-flight sets so requests from the previous post stop reading as pending.
   let latestTicket = 0;
+  const inFlightTickets = new Set<number>();
   const listeners = new Set<SlugListener>();
 
   const mode = (): SlugMode => (pendingManual.size > 0 ? 'custom' : settledMode);
@@ -130,10 +135,17 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
     const status: SlugStatus =
       currentMode === 'custom'
         ? 'custom'
-        : shouldGenerateSlug({ mode: currentMode, slug }, title)
+        : shouldGenerateSlug({ mode: currentMode, slug }, lastCommittedTitle)
           ? 'derived'
           : 'frozen';
-    return { status, mode: currentMode, slug, title, pending: inFlight > 0 };
+    return {
+      status,
+      mode: currentMode,
+      slug,
+      title,
+      lastCommittedTitle,
+      pending: inFlightTickets.size > 0,
+    };
   };
 
   const notify = (proposal: SlugProposal | null): void => {
@@ -157,7 +169,7 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   ): Promise<{ ticket: number; result?: string; error?: unknown }> => {
     latestTicket += 1;
     const ticket = latestTicket;
-    inFlight += 1;
+    inFlightTickets.add(ticket);
     if (manual) {
       pendingManual.add(ticket);
     }
@@ -167,7 +179,7 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
     } catch (error) {
       return { ticket, error };
     } finally {
-      inFlight -= 1;
+      inFlightTickets.delete(ticket);
       pendingManual.delete(ticket);
     }
   };
@@ -175,15 +187,18 @@ export function createSlugMachine({ generateSlug }: SlugMachineOptions): SlugMac
   return {
     loaded(post) {
       latestTicket += 1;
+      inFlightTickets.clear();
       pendingManual.clear();
       slug = post.slug;
       title = post.title;
+      lastCommittedTitle = post.title;
       settledMode = isCustomSlug(post.slug, post.title) ? 'custom' : 'derived';
       notify(null);
     },
 
     async titleCommitted(rawTitle) {
       const nextTitle = rawTitle.trim();
+      lastCommittedTitle = nextTitle;
       if (mode() === 'custom') {
         return unchanged('custom');
       }


### PR DESCRIPTION
no ref

Adds `apps/admin/src/editor/engine/slug-machine.ts`: a framework-free port of the Ember editor's slug behaviour (`generateSlugTask`, `updateSlugTask`, the `beforeSaveTask` missing-slug path, and the slug-generator service contract), with unit tests. Nothing wires it up yet.

The module's behavior contract (state model, proposal enum, generation/manual-edit/ordering rules, Ember deltas, caller duties) is documented in `apps/admin/src/editor/engine/README.md`.

### What it does

- `loaded({slug, title})` derives the starting mode using Ember's heuristic: a slug that differs from `slugify(saved title)` is `custom`, unless the saved title is `(Untitled)` or ends with `(Copy)`.
- `titleCommitted(title)` (title blur) generates a slug through the injected `generateSlug` port and emits `{slug, source: 'generated'}`. It skips blank titles, an `(Untitled)` title when a slug already exists, unchanged titles that already have a slug, and any post in `custom` mode.
- `slugEdited(input)` (manual edit) trims, reverts blank/unchanged input, runs the candidate through the same port, applies Ember's "server only appended an incrementor" guard, then emits `{slug, source: 'manual'}` and switches to `custom` permanently.
- `getState()` reports `status` (`derived` / `custom` / `frozen`, computed from `lastCommittedTitle`, the latest blurred title regardless of outcome), the slug, `title` (the title the slug was loaded with or last generated from, which drives the same-title check), and `pending` (a request issued since the last `loaded()` is in flight). `subscribe()` listeners receive `(state, proposal | null)` on every state change, including request start and post load; `unchanged` proposals carry a `reason` so a sidebar can reset its input.
- The machine never persists. Callers route `generated`/`manual` proposals through the save queue and decide whether to autosave (drafts) or stage (published/scheduled).

Exported helpers (`isCustomSlug`, `shouldGenerateSlug`, `normalizeManualSlug`, `resolveDedupedSlug`) are pure and table-tested against the Ember cases.

### Concurrency rules

- Every request takes a ticket; a response applies only while its ticket is still the latest. A later commit, manual edit, or `loaded()` discards earlier in-flight responses, and `loaded()` also drops them from `pending`.
- Mode is derived, not stored: `custom` while any manual edit is in flight (so a title blur cannot race it), otherwise a settled mode that only `loaded()` and an applied manual edit advance. A manual edit that errors, returns empty, or sanitizes back to the current slug leaves the settled mode untouched, in every ordering of overlapping edits.
- The tracked `title` advances only when a post loads or a generation applies. A commit that is refused, discarded, or fails leaves it alone, so the next blur of the same title regenerates instead of reading as unchanged.

### Wiring contract (caller duties)

- Pre-slugify the raw title before the generator GET. Ember's slug-generator service does `encodeURIComponent(slugify(text))`; raw text with characters like a newline 404s on Pro.
- `beforeSaveTask` behaviour stays with the save engine: substitute `(Untitled)` for a blank title before saving, and call `titleCommitted` for any status when the post has no slug. Title blur itself only drives generation for drafts.
- Persist proposals through the save queue; do not save a new post on a manual slug edit (Ember defers that to the first explicit save).

### Deliberate deltas from Ember

- Overlapping generator responses apply only while their request is still the latest. Ember tolerates this race (it is the source of "draft has title set with untitled slug" Sentry reports).
- Within a session the mode is explicit. Ember re-runs the custom heuristic on every blur against the last saved title, so a server-deduplicated slug (`hello-2` for "Hello") silently becomes custom and stops following the title. The machine keeps following the title until the post is reloaded, where the load heuristic still mirrors Ember.

### Verification

- `pnpm vitest run src/editor/engine` in `apps/admin`: 78 tests, including the stale-response race and the overlapping manual-edit orderings with controlled promise resolution order.
- `pnpm lint` and `pnpm tsc -b` in `apps/admin`: clean.

