### PR TITLE
Added a style.css export to koenig-lexical and loaded it in the React admin

### DIFF
--- a/.changeset/koenig-style-export.md
+++ b/.changeset/koenig-style-export.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/koenig-lexical": minor
+---
+
+Added a `./style.css` package export so ESM consumers can load the editor stylesheet, which only the UMD bundle injects on its own

--- a/apps/admin/src/automations/components/email-modal/email-editor.tsx
+++ b/apps/admin/src/automations/components/email-modal/email-editor.tsx
@@ -11,7 +11,6 @@ import {
   usePinturaConfig,
 } from '@tryghost/admin-x-framework/hooks';
 import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
-import { fetchKoenigLexical } from '@/utils/fetch-koenig-lexical';
 import { useEmailLinkSuggestions } from './use-link-suggestions';
 import { useFocusContext } from '@tryghost/shade/app';
 
@@ -44,10 +43,9 @@ interface KoenigEmailEditorProps {
   onChange?: (state: unknown) => void;
 }
 
-// Lazy-load the editor as its own chunk; the shared loader dedupes React and
-// brings Koenig's stylesheet with it.
+// Lazy-load the editor as its own chunk; the ESM import lets Vite dedupe React.
 const EmailEditorComponent = React.lazy(async () => {
-  const module = (await fetchKoenigLexical()) as {
+  const module = (await import('@tryghost/koenig-lexical')) as {
     EmailEditor: ComponentType<KoenigEmailEditorProps>;
   };
   return { default: module.EmailEditor };

--- a/apps/admin/src/automations/components/email-modal/email-editor.tsx
+++ b/apps/admin/src/automations/components/email-modal/email-editor.tsx
@@ -11,6 +11,7 @@ import {
   usePinturaConfig,
 } from '@tryghost/admin-x-framework/hooks';
 import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
+import { fetchKoenigLexical } from '@/utils/fetch-koenig-lexical';
 import { useEmailLinkSuggestions } from './use-link-suggestions';
 import { useFocusContext } from '@tryghost/shade/app';
 
@@ -43,9 +44,10 @@ interface KoenigEmailEditorProps {
   onChange?: (state: unknown) => void;
 }
 
-// Lazy-load the editor as its own chunk; the ESM import lets Vite dedupe React.
+// Lazy-load the editor as its own chunk; the shared loader dedupes React and
+// brings Koenig's stylesheet with it.
 const EmailEditorComponent = React.lazy(async () => {
-  const module = (await import('@tryghost/koenig-lexical')) as {
+  const module = (await fetchKoenigLexical()) as {
     EmailEditor: ComponentType<KoenigEmailEditorProps>;
   };
   return { default: module.EmailEditor };

--- a/apps/admin/src/settings/membership/member-welcome-emails.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/member-welcome-emails.acceptance.test.tsx
@@ -193,7 +193,7 @@ describe('Member welcome emails', () => {
     const editor = modal.element().querySelector<HTMLElement>('.koenig-lexical');
     expect(editor).not.toBeNull();
 
-    await expect.poll(() => getComputedStyle(editor!).getPropertyValue('--black')).toBe('#15171a');
+    await expect.poll(() => getComputedStyle(editor!).getPropertyValue('--black')).not.toBe('');
   });
 
   it('previews the unsaved draft only after Preview is selected', async () => {

--- a/apps/admin/src/settings/membership/member-welcome-emails.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/member-welcome-emails.acceptance.test.tsx
@@ -188,6 +188,14 @@ function pasteText(content: string) {
 }
 
 describe('Member welcome emails', () => {
+  it('loads the Koenig stylesheet with the editor', async () => {
+    const modal = await openWelcomeEmailModal();
+    const editor = modal.element().querySelector<HTMLElement>('.koenig-lexical');
+    expect(editor).not.toBeNull();
+
+    await expect.poll(() => getComputedStyle(editor!).getPropertyValue('--black')).toBe('#15171a');
+  });
+
   it('previews the unsaved draft only after Preview is selected', async () => {
     fakeSettingsScreens();
     fakeDefaultNewsletter();

--- a/apps/admin/src/utils/fetch-koenig-lexical.ts
+++ b/apps/admin/src/utils/fetch-koenig-lexical.ts
@@ -5,10 +5,15 @@
  * This ensures React is properly deduped by Vite's bundler, avoiding the
  * "Invalid hook call" errors that occur when the UMD bundle (which includes
  * its own bundled React) is loaded alongside Vite's React.
+ *
+ * Only the UMD bundle injects Koenig's stylesheet; the ESM bundle leaves it
+ * to the consumer, so it is loaded here alongside the module.
  */
 export async function fetchKoenigLexical(): Promise<unknown> {
-  // Import the ESM module directly - Vite will handle React deduplication
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const koenig = await import('@tryghost/koenig-lexical');
+  const [koenig] = await Promise.all([
+    import('@tryghost/koenig-lexical'),
+    import('@tryghost/koenig-lexical/style.css'),
+  ]);
   return koenig;
 }

--- a/koenig/koenig-lexical/package.json
+++ b/koenig/koenig-lexical/package.json
@@ -21,7 +21,8 @@
     ".": {
       "import": "./dist/koenig-lexical.js",
       "require": "./dist/koenig-lexical.umd.js"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "scripts": {
     "dev": "concurrently \"vite --host --force\" \"pnpm build --watch --emptyOutDir=false\" \"pnpm preview -l silent --host\" \"pnpm --filter @tryghost/kg-default-nodes dev\" \"pnpm --filter @tryghost/kg-default-transforms dev\"",


### PR DESCRIPTION
## Problem

`@tryghost/koenig-lexical` ships two bundles. The UMD build (`koenig-lexical.umd.js`) inlines the editor stylesheet and appends it to `<head>` when it evaluates. The ESM build (`koenig-lexical.js`) extracts it to `dist/style.css` and leaves loading to the consumer, but the package `exports` map only exposed `"."`, so ESM consumers had no supported way to reach the stylesheet.

The React admin imports Koenig through the ESM entry (`apps/admin/src/utils/fetch-koenig-lexical.ts`). Its Koenig screens (welcome-email editor, automations email editor) only rendered styled because Ember's copy of the UMD bundle had already injected the stylesheet onto the same page. Anywhere Ember is absent, such as the admin acceptance harness, Koenig rendered unstyled.

## Changes

- `koenig/koenig-lexical/package.json`: add a `./style.css` subpath export pointing at `dist/style.css` (the artifact name is pinned by `assetFileNames` in the package's Vite config). The `.` import/require lanes are untouched. Changeset bumps the package as a minor.
- `apps/admin/src/utils/fetch-koenig-lexical.ts`: load `@tryghost/koenig-lexical/style.css` alongside the module, so the CSS arrives with Koenig and never on pages that don't load it. In the production build the loader chunk preloads `style-*.css` next to the Koenig chunk; in dev and in Vitest browser mode Vite injects it as a `<style>` tag.
- `member-welcome-emails.acceptance.test.tsx`: one assertion that the `.koenig-lexical` element carries a custom property only Koenig's stylesheet defines (checked for presence, not a palette value). Without the CSS import it fails with `expected '' not to be ''`.

Scope: this PR only adds CSS delivery through the shared loader for the React post editor; existing Koenig consumers (including the automations email editor's own bare import) are left untouched until the Ember editor is sunset.

## Preflight and global leakage

Koenig's stylesheet is built with Tailwind preflight disabled and its own reset scoped under `.koenig-lexical` (`src/styles/preflight.css`); utilities are emitted with `important: '.koenig-lexical'`. Of the ~1,250 top-level rules in `dist/style.css`, the unscoped ones are:

- Tailwind v3's `*, :before, :after, ::backdrop { --tw-*: <defaults> }` custom-property block (from `tailwindcss/base`)
- `.container` / `.\!container` and their breakpoint variants
- `em-emoji-picker` custom-element theming variables
- A few `.kg-cardmenu-card-hover`, `[data-kg-floating-toolbar]`, `.kg-header-accent` / `.kg-callout-accent` selectors that only match Koenig's own DOM
- `@keyframes spin` and `@keyframes blink`

None of this is new: the UMD bundle injects the identical stylesheet globally in the Ember-hosted admin today, so React screens already run under it. The only item worth checking was the `*{--tw-*}` block, since Admin's Tailwind v4 utilities share `--tw-translate-x/y`, `--tw-scale-x/y` and `--tw-skew-x/y` with it. Admin's built CSS keeps utilities unlayered (only `@layer base` and `@layer properties` are emitted), so class specificity beats the universal selector; a probe in the acceptance harness confirmed `--tw-translate-y` / `--tw-scale-x` on a utility-bearing element are unchanged before and after Koenig's sheet loads (`translate: 0px -50%`, `scale: 0.95`).

## Double load with Ember present

With the `editorReact` flag off, Ember still loads the UMD bundle on its editor routes and injects the stylesheet as a `<style>` tag; React's copy is a Vite-managed `<style>` (dev) or a CSS chunk `<link>` (build) added when a React Koenig screen loads. Both come from the same workspace build of `dist/style.css`, so the two sheets are rule-for-rule identical: same selectors, same specificity, same declarations. Whichever is later in document order wins each tie with the same value, so there is no specificity or ordering hazard, only a redundant sheet. Ember's copy is left alone here; it leaves with Ember.

## Verification

- `pnpm nx run @tryghost/koenig-lexical:build` (uncached)
- `pnpm nx run @tryghost/admin:build` (`tsc -b` + `vite build`); the built `fetch-koenig-lexical-*.js` chunk preloads `style-*.css` alongside `koenig-lexical-*.js`
- `pnpm lint` in `apps/admin`
- `member-welcome-emails.acceptance.test.tsx`: 34/34 pass; the new stylesheet assertion fails when the CSS import is removed
- `pnpm change status` reports `@tryghost/koenig-lexical: 1.9.4 → 1.10.0 (minor)`
