### PR TITLE
Added newsletter email sending status API

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -30,3 +30,4 @@ Newsletter Email Sending covers the preparation and submission of newsletter ema
 
 - **Portal ↔ Gift Subscriptions**: Portal presents the purchase and redemption journeys for gift subscriptions.
 - **Gift Subscriptions ↔ Gift Links**: A gift-subscription redemption link claims fixed-duration membership access; a Gift Link grants access to one protected post or page.
+- **Newsletter Email Sending ↔ Gift Subscriptions**: Newsletter Email Sending describes the status of a whole newsletter send; Gift Subscriptions' email delivery status describes one recipient's gift email.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -20,6 +20,12 @@ Path: `ghost/core/core/server/services/gift-links/CONTEXT.md`
 
 Gift Links covers shareable access to individual protected posts and pages without creating a membership.
 
+### Newsletter Email Sending
+
+Path: `ghost/core/core/server/services/email-service/CONTEXT.md`
+
+Newsletter Email Sending covers the preparation and submission of newsletter emails to the configured email provider.
+
 ## Relationships
 
 - **Portal ↔ Gift Subscriptions**: Portal presents the purchase and redemption journeys for gift subscriptions.

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -51,6 +51,19 @@ const controller = {
     },
   },
 
+  sendingStatus: {
+    headers: {
+      cacheInvalidate: false,
+    },
+    data: ['id'],
+    permissions: {
+      method: 'read',
+    },
+    async query(frame) {
+      return await emailService.controller.getSendingStatus(frame);
+    },
+  },
+
   retry: {
     headers: {
       cacheInvalidate: false,

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/emails.js
@@ -2,6 +2,12 @@ const batchMapper = require('./mappers/email-batches');
 const failureMapper = require('./mappers/email-failures');
 
 module.exports = {
+  sendingStatus(response, apiConfig, frame) {
+    frame.response = {
+      email_statuses: [response],
+    };
+  },
+
   browseBatches(response, apiConfig, frame) {
     frame.response = {};
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/emails.js
@@ -1,11 +1,12 @@
 const batchMapper = require('./mappers/email-batches');
 const failureMapper = require('./mappers/email-failures');
+const {
+  toEmailStatusesResponse,
+} = require('../../../../../services/email-service/sending-status-serializers');
 
 module.exports = {
   sendingStatus(response, apiConfig, frame) {
-    frame.response = {
-      email_statuses: [response],
-    };
+    frame.response = toEmailStatusesResponse.parse(response);
   },
 
   browseBatches(response, apiConfig, frame) {

--- a/ghost/core/core/server/lib/db-types/count.ts
+++ b/ghost/core/core/server/lib/db-types/count.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const databaseCountInput = z.union([z.number(), z.string().regex(/^\d+$/)]);
+
+/**
+ * A non-negative integer count, whichever database driver handed it back.
+ *
+ * Aggregate functions such as COUNT can return a decimal string from MySQL and
+ * a number from SQLite. Every read normalises to a safe integer so callers do
+ * not need to handle that driver difference themselves.
+ */
+export const DbCount = z.codec(
+  databaseCountInput,
+  z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+  {
+    decode: (stored) => (typeof stored === 'string' ? Number(stored) : stored),
+    encode: (value) => value,
+  },
+);

--- a/ghost/core/core/server/services/email-service/CONTEXT.md
+++ b/ghost/core/core/server/services/email-service/CONTEXT.md
@@ -1,0 +1,36 @@
+# Newsletter Email Sending
+
+Newsletter Email Sending covers the preparation and submission of newsletter emails to the configured email provider.
+
+## Language
+
+**Sending status**:
+The current progress of preparing a newsletter email and submitting its batches to the configured email provider. It is separate from any later provider-reported outcome.
+_Avoid_: Delivery status, provider outcome
+
+**Preparing**:
+The sending status covering both waiting for sending work to begin and creating the newsletter email's recipient batches.
+_Avoid_: Pending, queued
+
+**Sending progress**:
+The completed and expected recipient counts for the current sending phase. Its expected count may be corrected while preparing and is final once submitting begins.
+_Avoid_: Delivery progress
+
+**Submitted**:
+Every batch of a newsletter email has been accepted by the configured email provider. Submission does not mean that recipients have received the email.
+_Avoid_: Sent, delivered
+
+**Failed during**:
+The preparing or submitting phase in which newsletter email sending stopped. It gives meaning to the frozen progress of a failed send.
+_Avoid_: Failure step
+
+## Sending status API
+
+`GET /ghost/api/admin/emails/:id/status` exposes sending status independently
+from the email resource. The endpoint is always available; Admin decides whether
+to poll it while a send is active.
+
+The first implementation calculates progress on read from email batches and
+their recipient counts. Its rough ETA uses a rolling window of batch creation
+times while preparing and terminal batch update times while submitting. It
+returns no estimate until at least two current-attempt batches have completed.

--- a/ghost/core/core/server/services/email-service/CONTEXT.md
+++ b/ghost/core/core/server/services/email-service/CONTEXT.md
@@ -5,32 +5,33 @@ Newsletter Email Sending covers the preparation and submission of newsletter ema
 ## Language
 
 **Sending status**:
-The current progress of preparing a newsletter email and submitting its batches to the configured email provider. It is separate from any later provider-reported outcome.
+The state of a newsletter email's send: preparing, submitting, submitted, or failed. It is separate from any later provider-reported outcome.
 _Avoid_: Delivery status, provider outcome
 
+**Sending phase**:
+The open part of a send that progress and failures are reported against: preparing or submitting.
+_Avoid_: Step, stage
+
 **Preparing**:
-The sending status covering both waiting for sending work to begin and creating the newsletter email's recipient batches.
+The sending phase while none of a newsletter email's recipient batches has started submitting, including before any sending work has begun.
 _Avoid_: Pending, queued
 
+**Submitting**:
+The sending phase once at least one recipient batch has started submitting to the configured email provider and the outcome is still open.
+_Avoid_: Sending, delivering
+
 **Sending progress**:
-The completed and expected recipient counts for the current sending phase. Its expected count may be corrected while preparing and is final once submitting begins.
-_Avoid_: Delivery progress
+The completed and total recipient counts for the current sending phase.
+_Avoid_: Delivery progress, expected count
 
 **Submitted**:
 Every batch of a newsletter email has been accepted by the configured email provider. Submission does not mean that recipients have received the email.
 _Avoid_: Sent, delivered
 
+**Failed**:
+Sending stopped with an error and will not continue without a retry.
+_Avoid_: Bounced, rejected
+
 **Failed during**:
-The preparing or submitting phase in which newsletter email sending stopped. It gives meaning to the frozen progress of a failed send.
+The sending phase a failed newsletter email was in when sending stopped.
 _Avoid_: Failure step
-
-## Sending status API
-
-`GET /ghost/api/admin/emails/:id/status` exposes sending status independently
-from the email resource. The endpoint is always available; Admin decides whether
-to poll it while a send is active.
-
-The first implementation calculates progress on read from email batches and
-their recipient counts. Its rough ETA uses a rolling window of batch creation
-times while preparing and terminal batch update times while submitting. It
-returns no estimate until at least two current-attempt batches have completed.

--- a/ghost/core/core/server/services/email-service/CONTEXT.md
+++ b/ghost/core/core/server/services/email-service/CONTEXT.md
@@ -9,7 +9,7 @@ The state of a newsletter email's send: preparing, submitting, submitted, or fai
 _Avoid_: Delivery status, provider outcome
 
 **Sending phase**:
-The open part of a send that progress and failures are reported against: preparing or submitting.
+The part of a send, before it is submitted or fails, that progress and failures are reported against: preparing or submitting.
 _Avoid_: Step, stage
 
 **Preparing**:
@@ -17,7 +17,7 @@ The sending phase while none of a newsletter email's recipient batches has start
 _Avoid_: Pending, queued
 
 **Submitting**:
-The sending phase once at least one recipient batch has started submitting to the configured email provider and the outcome is still open.
+The sending phase once at least one recipient batch has started submitting to the configured email provider and the send has not yet been submitted or failed.
 _Avoid_: Sending, delivering
 
 **Sending progress**:

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -1,0 +1,40 @@
+# Email service
+
+Renders newsletter emails, splits them into recipient batches, and submits the
+batches to the configured email provider. Domain terms live in
+[CONTEXT.md](CONTEXT.md).
+
+## Sending status
+
+`SendingStatusService` derives the sending status served by the Admin API's
+`emails/:id/status` endpoint on read, from the email row and its batches with
+their recipient counts. Submitted is terminal and the batch aggregation only
+describes an open outcome, so submitted emails answer with the email's
+recipient count as both completed and total. That also keeps reads of
+long-finished emails cheap. The endpoint is always available; Admin decides
+whether to poll it while a send is active.
+
+The phase is read from the batches: an email is submitting once any batch has
+left `pending`, and preparing otherwise. Batch statuses persist across
+attempts, so a retried email reports submitting with frozen progress while it
+waits for its job, and `failed_during` is the same derivation applied to a
+failed email.
+
+The rough ETA extrapolates from a rolling window of recently completed batches:
+their creation times while preparing and their update times while submitting.
+It is `0` once nothing remains in the current phase, always `null` for failed
+emails, and otherwise `null` until at least two batches with distinct
+timestamps have completed in the current attempt. A batch that failed during
+the current attempt is only retried together with its email, so it does not
+count as remaining work; the ETA can therefore reach `0` while completed is
+still below total, and consumers should key completion on the status, never
+on the ETA.
+
+Ghost does not record when a sending attempt or phase started, so the ETA uses
+the email's `updated_at` as a proxy for the start of the current attempt: the
+sending job saves the email when it takes its status lock and, when the
+recipient count changed, again after creating batches; a retry or boot resume
+saves it when re-queuing the email. Batches completed before that timestamp
+belong to an earlier attempt and are left out of the rate window. The proxy
+only holds while nothing saves the Email model, or sets `emails.updated_at`
+through a raw update, while batches are being submitted.

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -10,9 +10,10 @@ The sending status served by the Admin API's `emails/:id/status` endpoint is
 derived on read. `sending-status.ts` owns the derivation from an email and its
 batches with their recipient counts; `SendingStatusService` reads those rows
 and `sending-status-serializers.ts` shapes the response. Submitted is terminal and the batch aggregation only
-describes an open outcome, so submitted emails answer with the email's
-recipient count as both completed and total. That also keeps reads of
-long-finished emails cheap. The endpoint is always available; Admin decides
+describes an open outcome, so submitted emails answer with the email's stored
+`email_count` as both completed and total; batch creation reconciles that
+column to the recipient rows it built. That also keeps reads of long-finished
+emails cheap, with no query over the batches or recipients. The endpoint is always available; Admin decides
 whether to poll it while a send is active.
 
 The phase is read from the batches: an email is submitting once any batch has

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -6,9 +6,10 @@ batches to the configured email provider. Domain terms live in
 
 ## Sending status
 
-`SendingStatusService` derives the sending status served by the Admin API's
-`emails/:id/status` endpoint on read, from the email row and its batches with
-their recipient counts. Submitted is terminal and the batch aggregation only
+The sending status served by the Admin API's `emails/:id/status` endpoint is
+derived on read. `sending-status.ts` owns the derivation from an email and its
+batches with their recipient counts; `SendingStatusService` reads those rows
+and `sending-status-serializers.ts` shapes the response. Submitted is terminal and the batch aggregation only
 describes an open outcome, so submitted emails answer with the email's
 recipient count as both completed and total. That also keeps reads of
 long-finished emails cheap. The endpoint is always available; Admin decides

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -10,7 +10,7 @@ The sending status served by the Admin API's `emails/:id/status` endpoint is
 derived on read. `sending-status.ts` owns the derivation from an email and its
 batches with their recipient counts; `SendingStatusService` reads those rows
 and `sending-status-serializers.ts` shapes the response. Submitted is terminal and the batch aggregation only
-describes an open outcome, so submitted emails answer with the email's stored
+describes a send that is still in progress or has failed, so submitted emails answer with the email's stored
 `email_count` as both completed and total; batch creation reconciles that
 column to the recipient rows it built. That also keeps reads of long-finished
 emails cheap, with no query over the batches or recipients. The endpoint is always available; Admin decides

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -213,6 +213,7 @@ class BatchSendingService {
 
     // Check if email is 'pending' only + change status to submitting in one transaction.
     // This allows us to have a lock around the email job that makes sure an email can only have one active job.
+    // Also stamps updated_at, which SendingStatusService reads as the attempt start; do not save the Email once batches submit.
     let email;
     try {
       email = await this.retryDb(
@@ -704,6 +705,7 @@ class BatchSendingService {
     const deliveryTimes = this.calculateDeliveryTimes(email, batches.length);
 
     // Loop batches and send them via the EmailProvider
+    // SendingStatusService treats a batch that fails in this run as finished work; never re-queue it within the run.
     let succeededCount = 0;
     const queue = batches.slice();
 

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -30,7 +30,7 @@ class EmailController {
   /**
    *
    * @param {EmailService} service
-   * @param {{models: {Post: any, Newsletter: any, Email: any}, getRequiredUrlRelations?: () => string[], sendingStatusService?: SendingStatusService}} dependencies
+   * @param {{models: {Post: any, Newsletter: any, Email: any}, getRequiredUrlRelations?: () => string[], sendingStatusService: SendingStatusService}} dependencies
    */
   constructor(service, { models, getRequiredUrlRelations = () => [], sendingStatusService }) {
     this.service = service;

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -1,6 +1,8 @@
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
+/** @typedef {import('./sending-status-service').SendingStatusService} SendingStatusService */
+
 const messages = {
   postNotFound: 'Post not found.',
   noEmailsProvided: 'No emails provided.',
@@ -23,16 +25,18 @@ class EmailController {
   service;
   models;
   getRequiredUrlRelations;
+  sendingStatusService;
 
   /**
    *
    * @param {EmailService} service
-   * @param {{models: {Post: any, Newsletter: any, Email: any}, getRequiredUrlRelations?: () => string[]}} dependencies
+   * @param {{models: {Post: any, Newsletter: any, Email: any}, getRequiredUrlRelations?: () => string[], sendingStatusService?: SendingStatusService}} dependencies
    */
-  constructor(service, { models, getRequiredUrlRelations = () => [] }) {
+  constructor(service, { models, getRequiredUrlRelations = () => [], sendingStatusService }) {
     this.service = service;
     this.models = models;
     this.getRequiredUrlRelations = getRequiredUrlRelations;
+    this.sendingStatusService = sendingStatusService;
   }
 
   async _getFrameData(frame) {
@@ -142,6 +146,18 @@ class EmailController {
     }
 
     return await this.service.retryEmail(email);
+  }
+
+  async getSendingStatus(frame) {
+    const status = await this.sendingStatusService.statusFor(frame.data.id);
+
+    if (!status) {
+      throw new errors.NotFoundError({
+        message: tpl(messages.emailNotFound),
+      });
+    }
+
+    return status;
   }
 }
 

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -128,7 +128,7 @@ class EmailServiceWrapper {
       sentry,
       getRequiredUrlRelations,
     });
-    const sendingStatusService = new SendingStatusService({ db });
+    const sendingStatusService = new SendingStatusService({ knex: db.knex });
 
     if (ghostServer) {
       // Two phases: stop claiming batches immediately, drain in-flight ones later.

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -24,6 +24,7 @@ class EmailServiceWrapper {
     const EmailRenderer = require('./email-renderer');
     const SendingService = require('./sending-service');
     const BatchSendingService = require('./batch-sending-service');
+    const { SendingStatusService } = require('./sending-status-service');
     const EmailSegmenter = require('./email-segmenter');
     const MailgunEmailProvider = require('./mailgun-email-provider');
     const { DomainWarmingService } = require('./domain-warming-service');
@@ -127,6 +128,7 @@ class EmailServiceWrapper {
       sentry,
       getRequiredUrlRelations,
     });
+    const sendingStatusService = new SendingStatusService({ db });
 
     if (ghostServer) {
       // Two phases: stop claiming batches immediately, drain in-flight ones later.
@@ -169,6 +171,7 @@ class EmailServiceWrapper {
         Email,
       },
       getRequiredUrlRelations,
+      sendingStatusService,
     });
   }
 }

--- a/ghost/core/core/server/services/email-service/sending-status-schema.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { DbCount } from '../../lib/db-types/count';
+import { DbDate } from '../../lib/db-types/date';
+
+export const StoredSendingStatus = z.enum(['pending', 'submitting', 'submitted', 'failed']);
+export type StoredSendingStatus = z.infer<typeof StoredSendingStatus>;
+
+// Projections of tables the Bookshelf models own, not full rows, so there is no knex table
+// augmentation here: typing `emails` by these columns alone would mistype every other read.
+export const DbEmailSendingRow = z.object({
+  id: z.string(),
+  status: StoredSendingStatus,
+  email_count: DbCount,
+  updated_at: DbDate.nullable(),
+});
+export type DbEmailSendingRow = z.output<typeof DbEmailSendingRow>;
+
+export const DbBatchSendingRow = z.object({
+  status: StoredSendingStatus,
+  created_at: DbDate,
+  updated_at: DbDate,
+  recipient_count: DbCount,
+});
+export type DbBatchSendingRow = z.output<typeof DbBatchSendingRow>;

--- a/ghost/core/core/server/services/email-service/sending-status-serializers.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-serializers.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { snakeKeys } from '../../lib/case-keys';
-import { EmailStatus } from './sending-status';
+import { EmailSendingStatus } from './sending-status';
 
 const SendingPhaseResource = z.enum(['preparing', 'submitting']);
 
@@ -21,7 +21,7 @@ const EmailStatusResource = z.object({
 
 const EmailStatusesResponse = z.object({ email_statuses: z.array(EmailStatusResource) });
 
-export const toEmailStatusesResponse = EmailStatus.transform(
+export const toEmailStatusesResponse = EmailSendingStatus.transform(
   ({ id, sending }): z.input<typeof EmailStatusesResponse> => ({
     email_statuses: [
       {

--- a/ghost/core/core/server/services/email-service/sending-status-serializers.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-serializers.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { snakeKeys } from '../../lib/case-keys';
+import { EmailSendingStatus } from './sending-status';
+
+const SendingPhaseResource = z.enum(['preparing', 'submitting']);
+
+const SendingResource = z.object({
+  status: z.enum(['preparing', 'submitting', 'submitted', 'failed']),
+  progress: z.object({
+    completed: z.number(),
+    total: z.number(),
+    estimated_seconds_remaining: z.number().nullable(),
+  }),
+  failed_during: SendingPhaseResource.optional(),
+});
+
+const EmailStatusResource = z.object({
+  id: z.string(),
+  sending: SendingResource,
+});
+
+const EmailStatusesResponse = z.object({ email_statuses: z.array(EmailStatusResource) });
+
+export const toEmailStatusesResponse = EmailSendingStatus.transform(
+  ({ id, sending }): z.input<typeof EmailStatusesResponse> => ({
+    email_statuses: [
+      {
+        id,
+        sending: {
+          status: sending.status,
+          progress: snakeKeys(sending.progress),
+          ...(sending.status === 'failed' ? { failed_during: sending.failedDuring } : {}),
+        },
+      },
+    ],
+  }),
+).pipe(EmailStatusesResponse);

--- a/ghost/core/core/server/services/email-service/sending-status-serializers.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-serializers.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { snakeKeys } from '../../lib/case-keys';
-import { EmailSendingStatus } from './sending-status';
+import { EmailStatus } from './sending-status';
 
 const SendingPhaseResource = z.enum(['preparing', 'submitting']);
 
@@ -21,7 +21,7 @@ const EmailStatusResource = z.object({
 
 const EmailStatusesResponse = z.object({ email_statuses: z.array(EmailStatusResource) });
 
-export const toEmailStatusesResponse = EmailSendingStatus.transform(
+export const toEmailStatusesResponse = EmailStatus.transform(
   ({ id, sending }): z.input<typeof EmailStatusesResponse> => ({
     email_statuses: [
       {

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -5,7 +5,10 @@ import { DbDate } from '../../lib/db-types/date';
 const ETA_BATCH_WINDOW = 20;
 
 const StoredStatus = z.enum(['pending', 'submitting', 'submitted', 'failed']);
-const DbCount = z.number().int().nonnegative();
+const DbCount = z.preprocess(
+  (value) => (typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value),
+  z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+);
 
 const EmailRow = z.object({
   id: z.string(),

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -1,32 +1,34 @@
 import type { Knex } from 'knex';
+import { z } from 'zod';
+import { DbDate } from '../../lib/db-types/date';
 
 const ETA_BATCH_WINDOW = 20;
 
+const StoredStatus = z.enum(['pending', 'submitting', 'submitted', 'failed']);
+const DbCount = z.number().int().nonnegative();
+
+const EmailRow = z.object({
+  id: z.string(),
+  status: StoredStatus,
+  email_count: DbCount,
+  updated_at: DbDate.nullable(),
+});
+
+const BatchRows = z.array(
+  z.object({
+    status: StoredStatus,
+    created_at: DbDate,
+    updated_at: DbDate,
+    recipient_count: DbCount,
+  }),
+);
+
+type EmailRow = z.output<typeof EmailRow>;
+type Batch = z.output<typeof BatchRows>[number];
+type BatchSample = { recipientCount: number; timestamp: number };
+
 type SendingPhase = 'preparing' | 'submitting';
 type SendingStatus = SendingPhase | 'submitted' | 'failed';
-type StoredEmailStatus = 'pending' | 'submitting' | 'submitted' | 'failed';
-type StoredBatchStatus = 'pending' | 'submitting' | 'submitted' | 'failed';
-
-type EmailRow = {
-  id: string;
-  status: StoredEmailStatus;
-  email_count: number;
-  updated_at: Date | string | null;
-};
-
-type BatchRow = {
-  status: StoredBatchStatus;
-  recipient_count: number | string;
-  created_at: Date | string;
-  updated_at: Date | string;
-};
-
-type Batch = {
-  status: StoredBatchStatus;
-  recipientCount: number;
-  createdAt: Date | string;
-  updatedAt: Date | string;
-};
 
 type SendingProgress = {
   completed: number;
@@ -34,153 +36,157 @@ type SendingProgress = {
   estimated_seconds_remaining: number | null;
 };
 
-export type EmailSendingStatus = {
-  id: string;
-  sending: {
-    status: SendingStatus;
-    progress: SendingProgress;
-    failed_during?: SendingPhase;
-  };
+type Sending = {
+  status: SendingStatus;
+  progress: SendingProgress;
+  failed_during?: SendingPhase;
 };
 
-type Database = {
-  knex: Knex;
+export type EmailSendingStatus = {
+  id: string;
+  sending: Sending;
 };
 
 export class SendingStatusService {
-  #db: Database;
+  #knex: Knex;
 
-  constructor({ db }: { db: Database }) {
-    this.#db = db;
+  constructor({ knex }: { knex: Knex }) {
+    this.#knex = knex;
   }
 
   async statusFor(emailId: string): Promise<EmailSendingStatus | null> {
-    const email = await this.#db
-      .knex<EmailRow>('emails')
+    const emailRow = await this.#knex('emails')
       .select('id', 'status', 'email_count', 'updated_at')
       .where('id', emailId)
       .first();
 
-    if (!email) {
+    if (!emailRow) {
       return null;
     }
 
-    const recipientCount = this.#db
-      .knex('email_recipients as recipient')
-      .count('recipient.id')
+    const email = EmailRow.parse(emailRow);
+    const sending =
+      email.status === 'submitted'
+        ? await this.#submittedSending(emailId)
+        : openSending(email, await this.#batchesFor(emailId));
+
+    return { id: email.id, sending };
+  }
+
+  async #batchesFor(emailId: string): Promise<Batch[]> {
+    // Correlated per-batch count stays on the batch_id index; grouping recipients by email_id scans every recipient row.
+    const recipientCount = this.#knex('email_recipients as recipient')
+      .count('*')
       .whereRaw('recipient.batch_id = batch.id');
-    const batchRows = await this.#db
-      .knex<BatchRow>('email_batches as batch')
+    const rows = await this.#knex('email_batches as batch')
       .select('batch.status', 'batch.created_at', 'batch.updated_at')
       .select(recipientCount.as('recipient_count'))
       .where('batch.email_id', emailId);
-    const batches = batchRows.map((batch) => ({
-      status: batch.status,
-      recipientCount: Number(batch.recipient_count),
-      createdAt: batch.created_at,
-      updatedAt: batch.updated_at,
-    }));
 
-    return this.#buildStatus(email, batches);
+    return BatchRows.parse(rows);
   }
 
-  #buildStatus(email: EmailRow, batches: Batch[]): EmailSendingStatus {
-    const submissionStarted = batches.some((batch) => batch.status !== 'pending');
-    const failedDuring = submissionStarted ? 'submitting' : 'preparing';
-    const status =
-      email.status === 'submitted' || email.status === 'failed'
-        ? email.status
-        : submissionStarted
-          ? 'submitting'
-          : 'preparing';
-    const progressStatus = status === 'failed' ? failedDuring : status;
-
-    const preparedCount = batches.reduce((total, batch) => total + batch.recipientCount, 0);
-    const submittedCount = batches
-      .filter((batch) => batch.status === 'submitted')
-      .reduce((total, batch) => total + batch.recipientCount, 0);
-    const completed = progressStatus === 'preparing' ? preparedCount : submittedCount;
-    const total = Math.max(Number(email.email_count), completed);
-
-    const sending: EmailSendingStatus['sending'] = {
-      status,
-      progress: {
-        completed,
-        total,
-        estimated_seconds_remaining: this.#estimateSecondsRemaining({
-          status,
-          batches,
-          completed,
-          total,
-          attemptStartedAt: email.updated_at,
-        }),
-      },
-    };
-
-    if (status === 'failed') {
-      sending.failed_during = failedDuring;
-    }
+  async #submittedSending(emailId: string): Promise<Sending> {
+    const [countRow] = await this.#knex('email_recipients')
+      .count({ count: '*' })
+      .where('email_id', emailId);
+    const count = DbCount.parse(countRow.count);
 
     return {
-      id: email.id,
-      sending,
+      status: 'submitted',
+      progress: { completed: count, total: count, estimated_seconds_remaining: 0 },
+    };
+  }
+}
+
+function openSending(email: EmailRow, batches: Batch[]): Sending {
+  const phase: SendingPhase = batches.some((batch) => batch.status !== 'pending')
+    ? 'submitting'
+    : 'preparing';
+  const attemptStartedAt = email.updated_at?.getTime() ?? null;
+
+  const preparedCount = sumRecipients(batches);
+  const completedBatches =
+    phase === 'preparing' ? batches : batches.filter((batch) => batch.status === 'submitted');
+  const completed = sumRecipients(completedBatches);
+  const total = phase === 'preparing' ? Math.max(email.email_count, preparedCount) : preparedCount;
+
+  if (email.status === 'failed') {
+    return {
+      status: 'failed',
+      progress: { completed, total, estimated_seconds_remaining: null },
+      failed_during: phase,
     };
   }
 
-  #estimateSecondsRemaining({
-    status,
-    batches,
-    completed,
-    total,
-    attemptStartedAt,
-  }: {
-    status: SendingStatus;
-    batches: Batch[];
-    completed: number;
-    total: number;
-    attemptStartedAt: Date | string | null;
-  }): number | null {
-    if (status === 'submitted') {
-      return 0;
-    }
-    if (status === 'failed') {
-      return null;
-    }
+  const failedThisAttempt = batches.filter((batch) => failedDuringAttempt(batch, attemptStartedAt));
+  const remaining = total - completed - sumRecipients(failedThisAttempt);
+  const samples = completedBatches.map((batch) => ({
+    recipientCount: batch.recipient_count,
+    timestamp: (phase === 'preparing' ? batch.created_at : batch.updated_at).getTime(),
+  }));
 
-    const timestampField = status === 'preparing' ? 'createdAt' : 'updatedAt';
-    const attemptStarted = attemptStartedAt ? new Date(attemptStartedAt).getTime() : null;
-    const completedBatches = batches
-      .filter((batch) => status === 'preparing' || batch.status === 'submitted')
-      .map((batch) => ({
-        recipientCount: batch.recipientCount,
-        timestamp: new Date(batch[timestampField]).getTime(),
-      }))
-      .filter(
-        (batch) =>
-          Number.isFinite(batch.timestamp) &&
-          batch.recipientCount > 0 &&
-          (attemptStarted === null || batch.timestamp >= attemptStarted),
-      )
-      .sort((a, b) => a.timestamp - b.timestamp)
-      .slice(-ETA_BATCH_WINDOW);
+  return {
+    status: phase,
+    progress: {
+      completed,
+      total,
+      estimated_seconds_remaining: estimateSecondsRemaining({
+        remaining,
+        samples,
+        attemptStartedAt,
+      }),
+    },
+  };
+}
 
-    if (completedBatches.length < 2) {
-      return null;
-    }
+function sumRecipients(batches: Batch[]): number {
+  return batches.reduce((sum, batch) => sum + batch.recipient_count, 0);
+}
 
-    const firstTimestamp = completedBatches[0].timestamp;
-    const lastTimestamp = completedBatches[completedBatches.length - 1].timestamp;
-    const elapsedSeconds = (lastTimestamp - firstTimestamp) / 1000;
-    if (elapsedSeconds <= 0) {
-      return null;
-    }
+// A batch that fails is only retried together with its email, so within an attempt it is finished work.
+function failedDuringAttempt(batch: Batch, attemptStartedAt: number | null): boolean {
+  return (
+    batch.status === 'failed' &&
+    attemptStartedAt !== null &&
+    batch.updated_at.getTime() >= attemptStartedAt
+  );
+}
 
-    const averageRecipientsPerBatch =
-      completedBatches.reduce((sum, batch) => sum + batch.recipientCount, 0) /
-      completedBatches.length;
-    const recipientsPerSecond =
-      (averageRecipientsPerBatch * (completedBatches.length - 1)) / elapsedSeconds;
-
-    return Math.ceil(Math.max(total - completed, 0) / recipientsPerSecond);
+function estimateSecondsRemaining({
+  remaining,
+  samples,
+  attemptStartedAt,
+}: {
+  remaining: number;
+  samples: BatchSample[];
+  attemptStartedAt: number | null;
+}): number | null {
+  if (remaining <= 0) {
+    return 0;
   }
+
+  const window = samples
+    .filter(
+      (sample) =>
+        sample.recipientCount > 0 &&
+        (attemptStartedAt === null || sample.timestamp >= attemptStartedAt),
+    )
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .slice(-ETA_BATCH_WINDOW);
+
+  if (window.length < 2) {
+    return null;
+  }
+
+  const elapsedSeconds = (window[window.length - 1].timestamp - window[0].timestamp) / 1000;
+  if (elapsedSeconds <= 0) {
+    return null;
+  }
+
+  const averageRecipientsPerBatch =
+    window.reduce((sum, sample) => sum + sample.recipientCount, 0) / window.length;
+  const recipientsPerSecond = (averageRecipientsPerBatch * (window.length - 1)) / elapsedSeconds;
+
+  return Math.ceil(remaining / recipientsPerSecond);
 }

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -4,11 +4,11 @@ import { DbBatchSendingRow, DbEmailSendingRow } from './sending-status-schema';
 import {
   sendingStatusForSubmittedEmail,
   sendingStatusFromBatches,
-  type EmailStatus,
+  type EmailSendingStatus,
   type SendingBatch,
 } from './sending-status';
 
-export type { EmailStatus } from './sending-status';
+export type { EmailSendingStatus } from './sending-status';
 
 export class SendingStatusService {
   #knex: Knex;
@@ -17,7 +17,7 @@ export class SendingStatusService {
     this.#knex = knex;
   }
 
-  async statusFor(emailId: string): Promise<EmailStatus | null> {
+  async statusFor(emailId: string): Promise<EmailSendingStatus | null> {
     const row = await this.#knex('emails')
       .select('id', 'status', 'email_count', 'updated_at')
       .where('id', emailId)
@@ -30,21 +30,21 @@ export class SendingStatusService {
     const email = DbEmailSendingRow.parse(row);
     // Batch creation reconciles email_count to the recipient rows it built, so a submitted
     // email's stored count is its recipient count without a query over email_recipients.
-    const sending =
-      email.status === 'submitted'
-        ? sendingStatusForSubmittedEmail(email.email_count)
-        : sendingStatusFromBatches(
-            {
-              status: email.status,
-              recipientCount: email.email_count,
-              // The sending job saves the email when it takes its status lock, so updated_at
-              // stands in for the attempt start that Ghost does not record.
-              attemptStartedAt: email.updated_at,
-            },
-            await this.#batchesFor(emailId),
-          );
+    if (email.status === 'submitted') {
+      return sendingStatusForSubmittedEmail({ id: email.id, recipientCount: email.email_count });
+    }
 
-    return { id: email.id, sending };
+    return sendingStatusFromBatches(
+      {
+        id: email.id,
+        status: email.status,
+        recipientCount: email.email_count,
+        // The sending job saves the email when it takes its status lock, so updated_at
+        // stands in for the attempt start that Ghost does not record.
+        attemptStartedAt: email.updated_at,
+      },
+      await this.#batchesFor(emailId),
+    );
   }
 
   async #batchesFor(emailId: string): Promise<SendingBatch[]> {

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -1,6 +1,5 @@
 import type { Knex } from 'knex';
 import { camelKeys } from '../../lib/case-keys';
-import { DbCount } from '../../lib/db-types/count';
 import { DbBatchSendingRow, DbEmailSendingRow } from './sending-status-schema';
 import {
   openSending,
@@ -29,9 +28,11 @@ export class SendingStatusService {
     }
 
     const email = DbEmailSendingRow.parse(row);
+    // Batch creation reconciles email_count to the recipient rows it built, so a submitted
+    // email's stored count is its recipient count without a query over email_recipients.
     const sending =
       email.status === 'submitted'
-        ? submittedSending(await this.#recipientCountFor(emailId))
+        ? submittedSending(email.email_count)
         : openSending(
             {
               status: email.status,
@@ -57,13 +58,5 @@ export class SendingStatusService {
       .where('batch.email_id', emailId);
 
     return rows.map((batchRow) => camelKeys(DbBatchSendingRow.parse(batchRow)));
-  }
-
-  async #recipientCountFor(emailId: string): Promise<number> {
-    const [countRow] = await this.#knex('email_recipients')
-      .count({ count: '*' })
-      .where('email_id', emailId);
-
-    return DbCount.parse(countRow.count);
   }
 }

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -1,0 +1,186 @@
+import type { Knex } from 'knex';
+
+const ETA_BATCH_WINDOW = 20;
+
+type SendingPhase = 'preparing' | 'submitting';
+type SendingStatus = SendingPhase | 'submitted' | 'failed';
+type StoredEmailStatus = 'pending' | 'submitting' | 'submitted' | 'failed';
+type StoredBatchStatus = 'pending' | 'submitting' | 'submitted' | 'failed';
+
+type EmailRow = {
+  id: string;
+  status: StoredEmailStatus;
+  email_count: number;
+  updated_at: Date | string | null;
+};
+
+type BatchRow = {
+  status: StoredBatchStatus;
+  recipient_count: number | string;
+  created_at: Date | string;
+  updated_at: Date | string;
+};
+
+type Batch = {
+  status: StoredBatchStatus;
+  recipientCount: number;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+};
+
+type SendingProgress = {
+  completed: number;
+  total: number;
+  estimated_seconds_remaining: number | null;
+};
+
+export type EmailSendingStatus = {
+  id: string;
+  sending: {
+    status: SendingStatus;
+    progress: SendingProgress;
+    failed_during?: SendingPhase;
+  };
+};
+
+type Database = {
+  knex: Knex;
+};
+
+export class SendingStatusService {
+  #db: Database;
+
+  constructor({ db }: { db: Database }) {
+    this.#db = db;
+  }
+
+  async statusFor(emailId: string): Promise<EmailSendingStatus | null> {
+    const email = await this.#db
+      .knex<EmailRow>('emails')
+      .select('id', 'status', 'email_count', 'updated_at')
+      .where('id', emailId)
+      .first();
+
+    if (!email) {
+      return null;
+    }
+
+    const recipientCount = this.#db
+      .knex('email_recipients as recipient')
+      .count('recipient.id')
+      .whereRaw('recipient.batch_id = batch.id');
+    const batchRows = await this.#db
+      .knex<BatchRow>('email_batches as batch')
+      .select('batch.status', 'batch.created_at', 'batch.updated_at')
+      .select(recipientCount.as('recipient_count'))
+      .where('batch.email_id', emailId);
+    const batches = batchRows.map((batch) => ({
+      status: batch.status,
+      recipientCount: Number(batch.recipient_count),
+      createdAt: batch.created_at,
+      updatedAt: batch.updated_at,
+    }));
+
+    return this.#buildStatus(email, batches);
+  }
+
+  #buildStatus(email: EmailRow, batches: Batch[]): EmailSendingStatus {
+    const submissionStarted = batches.some((batch) => batch.status !== 'pending');
+    const failedDuring = submissionStarted ? 'submitting' : 'preparing';
+    const status =
+      email.status === 'submitted' || email.status === 'failed'
+        ? email.status
+        : submissionStarted
+          ? 'submitting'
+          : 'preparing';
+    const progressStatus = status === 'failed' ? failedDuring : status;
+
+    const preparedCount = batches.reduce((total, batch) => total + batch.recipientCount, 0);
+    const submittedCount = batches
+      .filter((batch) => batch.status === 'submitted')
+      .reduce((total, batch) => total + batch.recipientCount, 0);
+    const completed = progressStatus === 'preparing' ? preparedCount : submittedCount;
+    const total = Math.max(Number(email.email_count), completed);
+
+    const sending: EmailSendingStatus['sending'] = {
+      status,
+      progress: {
+        completed,
+        total,
+        estimated_seconds_remaining: this.#estimateSecondsRemaining({
+          status,
+          batches,
+          completed,
+          total,
+          attemptStartedAt: email.updated_at,
+        }),
+      },
+    };
+
+    if (status === 'failed') {
+      sending.failed_during = failedDuring;
+    }
+
+    return {
+      id: email.id,
+      sending,
+    };
+  }
+
+  #estimateSecondsRemaining({
+    status,
+    batches,
+    completed,
+    total,
+    attemptStartedAt,
+  }: {
+    status: SendingStatus;
+    batches: Batch[];
+    completed: number;
+    total: number;
+    attemptStartedAt: Date | string | null;
+  }): number | null {
+    if (status === 'submitted') {
+      return 0;
+    }
+    if (status === 'failed') {
+      return null;
+    }
+
+    const timestampField = status === 'preparing' ? 'createdAt' : 'updatedAt';
+    const attemptStarted = attemptStartedAt ? new Date(attemptStartedAt).getTime() : null;
+    const completedBatches = batches
+      .filter((batch) => status === 'preparing' || batch.status === 'submitted')
+      .map((batch) => ({
+        recipientCount: batch.recipientCount,
+        timestamp: new Date(batch[timestampField]).getTime(),
+      }))
+      .filter(
+        (batch) =>
+          Number.isFinite(batch.timestamp) &&
+          batch.recipientCount > 0 &&
+          (attemptStarted === null || batch.timestamp >= attemptStarted),
+      )
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .slice(-ETA_BATCH_WINDOW);
+
+    if (completedBatches.length < 2) {
+      return null;
+    }
+
+    const firstTimestamp = completedBatches[0].timestamp;
+    const lastTimestamp = completedBatches[completedBatches.length - 1].timestamp;
+    const elapsedSeconds = (lastTimestamp - firstTimestamp) / 1000;
+    if (elapsedSeconds <= 0) {
+      return null;
+    }
+
+    const averageRecipientsPerBatch =
+      completedBatches.reduce((sum, batch) => sum + batch.recipientCount, 0) /
+      completedBatches.length;
+    const recipientsPerSecond =
+      (averageRecipientsPerBatch * (completedBatches.length - 1)) / elapsedSeconds;
+
+    return Math.ceil(Math.max(total - completed, 0) / recipientsPerSecond);
+  }
+}

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -1,12 +1,7 @@
 import type { Knex } from 'knex';
 import { camelKeys } from '../../lib/case-keys';
 import { DbBatchSendingRow, DbEmailSendingRow } from './sending-status-schema';
-import {
-  emailSendingStatusWhenSubmitted,
-  emailSendingStatusFromBatches,
-  type EmailSendingStatus,
-  type SendingBatch,
-} from './sending-status';
+import { buildSendingStatus, type EmailSendingStatus, type SendingBatch } from './sending-status';
 
 export type { EmailSendingStatus } from './sending-status';
 
@@ -28,23 +23,23 @@ export class SendingStatusService {
     }
 
     const email = DbEmailSendingRow.parse(row);
-    // Batch creation reconciles email_count to the recipient rows it built, so a submitted
-    // email's stored count is its recipient count without a query over email_recipients.
-    if (email.status === 'submitted') {
-      return emailSendingStatusWhenSubmitted({ id: email.id, recipientCount: email.email_count });
-    }
+    // A submitted email answers from its own count, and batch creation reconciles email_count
+    // to the recipient rows it built, so the batch query is skipped rather than run and ignored.
+    const batches = email.status === 'submitted' ? [] : await this.#batchesFor(emailId);
 
-    return emailSendingStatusFromBatches(
-      {
-        id: email.id,
-        status: email.status,
-        recipientCount: email.email_count,
-        // The sending job saves the email when it takes its status lock, so updated_at
-        // stands in for the attempt start that Ghost does not record.
-        attemptStartedAt: email.updated_at,
-      },
-      await this.#batchesFor(emailId),
-    );
+    return {
+      id: email.id,
+      sending: buildSendingStatus(
+        {
+          status: email.status,
+          recipientCount: email.email_count,
+          // The sending job saves the email when it takes its status lock, so updated_at
+          // stands in for the attempt start that Ghost does not record.
+          attemptStartedAt: email.updated_at,
+        },
+        batches,
+      ),
+    };
   }
 
   async #batchesFor(emailId: string): Promise<SendingBatch[]> {

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -1,51 +1,15 @@
 import type { Knex } from 'knex';
-import { z } from 'zod';
+import { camelKeys } from '../../lib/case-keys';
 import { DbCount } from '../../lib/db-types/count';
-import { DbDate } from '../../lib/db-types/date';
+import { DbBatchSendingRow, DbEmailSendingRow } from './sending-status-schema';
+import {
+  openSending,
+  submittedSending,
+  type EmailSendingStatus,
+  type SendingBatch,
+} from './sending-status';
 
-const ETA_BATCH_WINDOW = 20;
-
-const StoredStatus = z.enum(['pending', 'submitting', 'submitted', 'failed']);
-
-const EmailRow = z.object({
-  id: z.string(),
-  status: StoredStatus,
-  email_count: DbCount,
-  updated_at: DbDate.nullable(),
-});
-
-const BatchRows = z.array(
-  z.object({
-    status: StoredStatus,
-    created_at: DbDate,
-    updated_at: DbDate,
-    recipient_count: DbCount,
-  }),
-);
-
-type EmailRow = z.output<typeof EmailRow>;
-type Batch = z.output<typeof BatchRows>[number];
-type BatchSample = { recipientCount: number; timestamp: number };
-
-type SendingPhase = 'preparing' | 'submitting';
-type SendingStatus = SendingPhase | 'submitted' | 'failed';
-
-type SendingProgress = {
-  completed: number;
-  total: number;
-  estimated_seconds_remaining: number | null;
-};
-
-type Sending = {
-  status: SendingStatus;
-  progress: SendingProgress;
-  failed_during?: SendingPhase;
-};
-
-export type EmailSendingStatus = {
-  id: string;
-  sending: Sending;
-};
+export type { EmailSendingStatus } from './sending-status';
 
 export class SendingStatusService {
   #knex: Knex;
@@ -55,25 +19,34 @@ export class SendingStatusService {
   }
 
   async statusFor(emailId: string): Promise<EmailSendingStatus | null> {
-    const emailRow = await this.#knex('emails')
+    const row = await this.#knex('emails')
       .select('id', 'status', 'email_count', 'updated_at')
       .where('id', emailId)
       .first();
 
-    if (!emailRow) {
+    if (!row) {
       return null;
     }
 
-    const email = EmailRow.parse(emailRow);
+    const email = DbEmailSendingRow.parse(row);
     const sending =
       email.status === 'submitted'
-        ? await this.#submittedSending(emailId)
-        : openSending(email, await this.#batchesFor(emailId));
+        ? submittedSending(await this.#recipientCountFor(emailId))
+        : openSending(
+            {
+              status: email.status,
+              recipientCount: email.email_count,
+              // The sending job saves the email when it takes its status lock, so updated_at
+              // stands in for the attempt start that Ghost does not record.
+              attemptStartedAt: email.updated_at,
+            },
+            await this.#batchesFor(emailId),
+          );
 
     return { id: email.id, sending };
   }
 
-  async #batchesFor(emailId: string): Promise<Batch[]> {
+  async #batchesFor(emailId: string): Promise<SendingBatch[]> {
     // Correlated per-batch count stays on the batch_id index; grouping recipients by email_id scans every recipient row.
     const recipientCount = this.#knex('email_recipients as recipient')
       .count('*')
@@ -83,110 +56,14 @@ export class SendingStatusService {
       .select(recipientCount.as('recipient_count'))
       .where('batch.email_id', emailId);
 
-    return BatchRows.parse(rows);
+    return rows.map((batchRow) => camelKeys(DbBatchSendingRow.parse(batchRow)));
   }
 
-  async #submittedSending(emailId: string): Promise<Sending> {
+  async #recipientCountFor(emailId: string): Promise<number> {
     const [countRow] = await this.#knex('email_recipients')
       .count({ count: '*' })
       .where('email_id', emailId);
-    const count = DbCount.parse(countRow.count);
 
-    return {
-      status: 'submitted',
-      progress: { completed: count, total: count, estimated_seconds_remaining: 0 },
-    };
+    return DbCount.parse(countRow.count);
   }
-}
-
-function openSending(email: EmailRow, batches: Batch[]): Sending {
-  const phase: SendingPhase = batches.some((batch) => batch.status !== 'pending')
-    ? 'submitting'
-    : 'preparing';
-  const attemptStartedAt = email.updated_at?.getTime() ?? null;
-
-  const preparedCount = sumRecipients(batches);
-  const completedBatches =
-    phase === 'preparing' ? batches : batches.filter((batch) => batch.status === 'submitted');
-  const completed = sumRecipients(completedBatches);
-  const total = phase === 'preparing' ? Math.max(email.email_count, preparedCount) : preparedCount;
-
-  if (email.status === 'failed') {
-    return {
-      status: 'failed',
-      progress: { completed, total, estimated_seconds_remaining: null },
-      failed_during: phase,
-    };
-  }
-
-  const failedThisAttempt = batches.filter((batch) => failedDuringAttempt(batch, attemptStartedAt));
-  const remaining = total - completed - sumRecipients(failedThisAttempt);
-  const samples = completedBatches.map((batch) => ({
-    recipientCount: batch.recipient_count,
-    timestamp: (phase === 'preparing' ? batch.created_at : batch.updated_at).getTime(),
-  }));
-
-  return {
-    status: phase,
-    progress: {
-      completed,
-      total,
-      estimated_seconds_remaining: estimateSecondsRemaining({
-        remaining,
-        samples,
-        attemptStartedAt,
-      }),
-    },
-  };
-}
-
-function sumRecipients(batches: Batch[]): number {
-  return batches.reduce((sum, batch) => sum + batch.recipient_count, 0);
-}
-
-// A batch that fails is only retried together with its email, so within an attempt it is finished work.
-function failedDuringAttempt(batch: Batch, attemptStartedAt: number | null): boolean {
-  return (
-    batch.status === 'failed' &&
-    attemptStartedAt !== null &&
-    batch.updated_at.getTime() >= attemptStartedAt
-  );
-}
-
-function estimateSecondsRemaining({
-  remaining,
-  samples,
-  attemptStartedAt,
-}: {
-  remaining: number;
-  samples: BatchSample[];
-  attemptStartedAt: number | null;
-}): number | null {
-  if (remaining <= 0) {
-    return 0;
-  }
-
-  const window = samples
-    .filter(
-      (sample) =>
-        sample.recipientCount > 0 &&
-        (attemptStartedAt === null || sample.timestamp >= attemptStartedAt),
-    )
-    .sort((a, b) => a.timestamp - b.timestamp)
-    .slice(-ETA_BATCH_WINDOW);
-
-  if (window.length < 2) {
-    return null;
-  }
-
-  const elapsedSeconds = (window[window.length - 1].timestamp - window[0].timestamp) / 1000;
-  if (elapsedSeconds <= 0) {
-    return null;
-  }
-
-  const averageRecipientsPerBatch =
-    window.reduce((sum, sample) => sum + sample.recipientCount, 0) / window.length;
-  const recipientsPerSecond = (averageRecipientsPerBatch * (window.length - 1)) / elapsedSeconds;
-
-  return Math.ceil(remaining / recipientsPerSecond);
 }

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -1,14 +1,11 @@
 import type { Knex } from 'knex';
 import { z } from 'zod';
+import { DbCount } from '../../lib/db-types/count';
 import { DbDate } from '../../lib/db-types/date';
 
 const ETA_BATCH_WINDOW = 20;
 
 const StoredStatus = z.enum(['pending', 'submitting', 'submitted', 'failed']);
-const DbCount = z.preprocess(
-  (value) => (typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value),
-  z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
-);
 
 const EmailRow = z.object({
   id: z.string(),

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -2,8 +2,8 @@ import type { Knex } from 'knex';
 import { camelKeys } from '../../lib/case-keys';
 import { DbBatchSendingRow, DbEmailSendingRow } from './sending-status-schema';
 import {
-  sendingStatusForSubmittedEmail,
-  sendingStatusFromBatches,
+  emailSendingStatusWhenSubmitted,
+  emailSendingStatusFromBatches,
   type EmailSendingStatus,
   type SendingBatch,
 } from './sending-status';
@@ -31,10 +31,10 @@ export class SendingStatusService {
     // Batch creation reconciles email_count to the recipient rows it built, so a submitted
     // email's stored count is its recipient count without a query over email_recipients.
     if (email.status === 'submitted') {
-      return sendingStatusForSubmittedEmail({ id: email.id, recipientCount: email.email_count });
+      return emailSendingStatusWhenSubmitted({ id: email.id, recipientCount: email.email_count });
     }
 
-    return sendingStatusFromBatches(
+    return emailSendingStatusFromBatches(
       {
         id: email.id,
         status: email.status,

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -2,13 +2,13 @@ import type { Knex } from 'knex';
 import { camelKeys } from '../../lib/case-keys';
 import { DbBatchSendingRow, DbEmailSendingRow } from './sending-status-schema';
 import {
-  openSending,
-  submittedSending,
-  type EmailSendingStatus,
+  sendingStatusForSubmittedEmail,
+  sendingStatusFromBatches,
+  type EmailStatus,
   type SendingBatch,
 } from './sending-status';
 
-export type { EmailSendingStatus } from './sending-status';
+export type { EmailStatus } from './sending-status';
 
 export class SendingStatusService {
   #knex: Knex;
@@ -17,7 +17,7 @@ export class SendingStatusService {
     this.#knex = knex;
   }
 
-  async statusFor(emailId: string): Promise<EmailSendingStatus | null> {
+  async statusFor(emailId: string): Promise<EmailStatus | null> {
     const row = await this.#knex('emails')
       .select('id', 'status', 'email_count', 'updated_at')
       .where('id', emailId)
@@ -32,8 +32,8 @@ export class SendingStatusService {
     // email's stored count is its recipient count without a query over email_recipients.
     const sending =
       email.status === 'submitted'
-        ? submittedSending(email.email_count)
-        : openSending(
+        ? sendingStatusForSubmittedEmail(email.email_count)
+        : sendingStatusFromBatches(
             {
               status: email.status,
               recipientCount: email.email_count,

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -28,7 +28,6 @@ export type EmailSendingStatus = z.infer<typeof EmailSendingStatus>;
 
 /** The email as the derivation reads it: its stored status, the recipient count it expects, and when the current attempt started. */
 export interface SendingEmail {
-  id: string;
   status: StoredSendingStatus;
   recipientCount: number;
   attemptStartedAt: Date | null;
@@ -43,24 +42,20 @@ export interface SendingBatch {
 
 type BatchSample = { recipientCount: number; timestamp: number };
 
-export function emailSendingStatusWhenSubmitted(email: {
-  id: string;
-  recipientCount: number;
-}): EmailSendingStatus {
-  const { recipientCount } = email;
-  return {
-    id: email.id,
-    sending: {
+export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[]): SendingStatus {
+  // Submitted is terminal: every batch was accepted, so the email's own recipient count is the
+  // answer and the batch aggregation below, which describes a send still in progress, does not apply.
+  if (email.status === 'submitted') {
+    return {
       status: 'submitted',
-      progress: { completed: recipientCount, total: recipientCount, estimatedSecondsRemaining: 0 },
-    },
-  };
-}
+      progress: {
+        completed: email.recipientCount,
+        total: email.recipientCount,
+        estimatedSecondsRemaining: 0,
+      },
+    };
+  }
 
-export function emailSendingStatusFromBatches(
-  email: SendingEmail,
-  batches: SendingBatch[],
-): EmailSendingStatus {
   const phase: SendingPhase = batches.some((batch) => batch.status !== 'pending')
     ? 'submitting'
     : 'preparing';
@@ -75,12 +70,9 @@ export function emailSendingStatusFromBatches(
 
   if (email.status === 'failed') {
     return {
-      id: email.id,
-      sending: {
-        status: 'failed',
-        progress: { completed, total, estimatedSecondsRemaining: null },
-        failedDuring: phase,
-      },
+      status: 'failed',
+      progress: { completed, total, estimatedSecondsRemaining: null },
+      failedDuring: phase,
     };
   }
 
@@ -92,18 +84,15 @@ export function emailSendingStatusFromBatches(
   }));
 
   return {
-    id: email.id,
-    sending: {
-      status: phase,
-      progress: {
-        completed,
-        total,
-        estimatedSecondsRemaining: estimateSecondsRemaining({
-          remaining,
-          samples,
-          attemptStartedAt,
-        }),
-      },
+    status: phase,
+    progress: {
+      completed,
+      total,
+      estimatedSecondsRemaining: estimateSecondsRemaining({
+        remaining,
+        samples,
+        attemptStartedAt,
+      }),
     },
   };
 }

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -13,22 +13,23 @@ export const SendingProgress = z.object({
 });
 export type SendingProgress = z.infer<typeof SendingProgress>;
 
-export const SendingStatus = z.discriminatedUnion('status', [
-  z.object({ status: SendingPhase, progress: SendingProgress }),
-  z.object({ status: z.literal('submitted'), progress: SendingProgress }),
-  z.object({ status: z.literal('failed'), progress: SendingProgress, failedDuring: SendingPhase }),
-]);
-export type SendingStatus = z.infer<typeof SendingStatus>;
-
-/** One email's status; sending is its first facet, delivery joins it later. */
-export const EmailStatus = z.object({
+export const EmailSendingStatus = z.object({
   id: z.string(),
-  sending: SendingStatus,
+  sending: z.discriminatedUnion('status', [
+    z.object({ status: SendingPhase, progress: SendingProgress }),
+    z.object({ status: z.literal('submitted'), progress: SendingProgress }),
+    z.object({
+      status: z.literal('failed'),
+      progress: SendingProgress,
+      failedDuring: SendingPhase,
+    }),
+  ]),
 });
-export type EmailStatus = z.infer<typeof EmailStatus>;
+export type EmailSendingStatus = z.infer<typeof EmailSendingStatus>;
 
 /** The email as the derivation reads it: its stored status, the recipient count it expects, and when the current attempt started. */
 export interface SendingEmail {
+  id: string;
   status: StoredSendingStatus;
   recipientCount: number;
   attemptStartedAt: Date | null;
@@ -43,17 +44,24 @@ export interface SendingBatch {
 
 type BatchSample = { recipientCount: number; timestamp: number };
 
-export function sendingStatusForSubmittedEmail(recipientCount: number): SendingStatus {
+export function sendingStatusForSubmittedEmail(email: {
+  id: string;
+  recipientCount: number;
+}): EmailSendingStatus {
+  const { recipientCount } = email;
   return {
-    status: 'submitted',
-    progress: { completed: recipientCount, total: recipientCount, estimatedSecondsRemaining: 0 },
+    id: email.id,
+    sending: {
+      status: 'submitted',
+      progress: { completed: recipientCount, total: recipientCount, estimatedSecondsRemaining: 0 },
+    },
   };
 }
 
 export function sendingStatusFromBatches(
   email: SendingEmail,
   batches: SendingBatch[],
-): SendingStatus {
+): EmailSendingStatus {
   const phase: SendingPhase = batches.some((batch) => batch.status !== 'pending')
     ? 'submitting'
     : 'preparing';
@@ -68,9 +76,12 @@ export function sendingStatusFromBatches(
 
   if (email.status === 'failed') {
     return {
-      status: 'failed',
-      progress: { completed, total, estimatedSecondsRemaining: null },
-      failedDuring: phase,
+      id: email.id,
+      sending: {
+        status: 'failed',
+        progress: { completed, total, estimatedSecondsRemaining: null },
+        failedDuring: phase,
+      },
     };
   }
 
@@ -82,15 +93,18 @@ export function sendingStatusFromBatches(
   }));
 
   return {
-    status: phase,
-    progress: {
-      completed,
-      total,
-      estimatedSecondsRemaining: estimateSecondsRemaining({
-        remaining,
-        samples,
-        attemptStartedAt,
-      }),
+    id: email.id,
+    sending: {
+      status: phase,
+      progress: {
+        completed,
+        total,
+        estimatedSecondsRemaining: estimateSecondsRemaining({
+          remaining,
+          samples,
+          attemptStartedAt,
+        }),
+      },
     },
   };
 }

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -13,18 +13,19 @@ export const SendingProgress = z.object({
 });
 export type SendingProgress = z.infer<typeof SendingProgress>;
 
-export const Sending = z.discriminatedUnion('status', [
+export const SendingStatus = z.discriminatedUnion('status', [
   z.object({ status: SendingPhase, progress: SendingProgress }),
   z.object({ status: z.literal('submitted'), progress: SendingProgress }),
   z.object({ status: z.literal('failed'), progress: SendingProgress, failedDuring: SendingPhase }),
 ]);
-export type Sending = z.infer<typeof Sending>;
+export type SendingStatus = z.infer<typeof SendingStatus>;
 
-export const EmailSendingStatus = z.object({
+/** One email's status; sending is its first facet, delivery joins it later. */
+export const EmailStatus = z.object({
   id: z.string(),
-  sending: Sending,
+  sending: SendingStatus,
 });
-export type EmailSendingStatus = z.infer<typeof EmailSendingStatus>;
+export type EmailStatus = z.infer<typeof EmailStatus>;
 
 /** The email as the derivation reads it: its stored status, the recipient count it expects, and when the current attempt started. */
 export interface SendingEmail {
@@ -42,14 +43,17 @@ export interface SendingBatch {
 
 type BatchSample = { recipientCount: number; timestamp: number };
 
-export function submittedSending(recipientCount: number): Sending {
+export function sendingStatusForSubmittedEmail(recipientCount: number): SendingStatus {
   return {
     status: 'submitted',
     progress: { completed: recipientCount, total: recipientCount, estimatedSecondsRemaining: 0 },
   };
 }
 
-export function openSending(email: SendingEmail, batches: SendingBatch[]): Sending {
+export function sendingStatusFromBatches(
+  email: SendingEmail,
+  batches: SendingBatch[],
+): SendingStatus {
   const phase: SendingPhase = batches.some((batch) => batch.status !== 'pending')
     ? 'submitting'
     : 'preparing';

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -13,17 +13,16 @@ export const SendingProgress = z.object({
 });
 export type SendingProgress = z.infer<typeof SendingProgress>;
 
+export const SendingStatus = z.discriminatedUnion('status', [
+  z.object({ status: SendingPhase, progress: SendingProgress }),
+  z.object({ status: z.literal('submitted'), progress: SendingProgress }),
+  z.object({ status: z.literal('failed'), progress: SendingProgress, failedDuring: SendingPhase }),
+]);
+export type SendingStatus = z.infer<typeof SendingStatus>;
+
 export const EmailSendingStatus = z.object({
   id: z.string(),
-  sending: z.discriminatedUnion('status', [
-    z.object({ status: SendingPhase, progress: SendingProgress }),
-    z.object({ status: z.literal('submitted'), progress: SendingProgress }),
-    z.object({
-      status: z.literal('failed'),
-      progress: SendingProgress,
-      failedDuring: SendingPhase,
-    }),
-  ]),
+  sending: SendingStatus,
 });
 export type EmailSendingStatus = z.infer<typeof EmailSendingStatus>;
 

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+import type { StoredSendingStatus } from './sending-status-schema';
+
+const ETA_BATCH_WINDOW = 20;
+
+export const SendingPhase = z.enum(['preparing', 'submitting']);
+export type SendingPhase = z.infer<typeof SendingPhase>;
+
+export const SendingProgress = z.object({
+  completed: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+  estimatedSecondsRemaining: z.number().int().nonnegative().nullable(),
+});
+export type SendingProgress = z.infer<typeof SendingProgress>;
+
+export const Sending = z.discriminatedUnion('status', [
+  z.object({ status: SendingPhase, progress: SendingProgress }),
+  z.object({ status: z.literal('submitted'), progress: SendingProgress }),
+  z.object({ status: z.literal('failed'), progress: SendingProgress, failedDuring: SendingPhase }),
+]);
+export type Sending = z.infer<typeof Sending>;
+
+export const EmailSendingStatus = z.object({
+  id: z.string(),
+  sending: Sending,
+});
+export type EmailSendingStatus = z.infer<typeof EmailSendingStatus>;
+
+/** The email as the derivation reads it: its stored status, the recipient count it expects, and when the current attempt started. */
+export interface SendingEmail {
+  status: StoredSendingStatus;
+  recipientCount: number;
+  attemptStartedAt: Date | null;
+}
+
+export interface SendingBatch {
+  status: StoredSendingStatus;
+  recipientCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type BatchSample = { recipientCount: number; timestamp: number };
+
+export function submittedSending(recipientCount: number): Sending {
+  return {
+    status: 'submitted',
+    progress: { completed: recipientCount, total: recipientCount, estimatedSecondsRemaining: 0 },
+  };
+}
+
+export function openSending(email: SendingEmail, batches: SendingBatch[]): Sending {
+  const phase: SendingPhase = batches.some((batch) => batch.status !== 'pending')
+    ? 'submitting'
+    : 'preparing';
+  const attemptStartedAt = email.attemptStartedAt?.getTime() ?? null;
+
+  const preparedCount = sumRecipients(batches);
+  const completedBatches =
+    phase === 'preparing' ? batches : batches.filter((batch) => batch.status === 'submitted');
+  const completed = sumRecipients(completedBatches);
+  const total =
+    phase === 'preparing' ? Math.max(email.recipientCount, preparedCount) : preparedCount;
+
+  if (email.status === 'failed') {
+    return {
+      status: 'failed',
+      progress: { completed, total, estimatedSecondsRemaining: null },
+      failedDuring: phase,
+    };
+  }
+
+  const failedThisAttempt = batches.filter((batch) => failedDuringAttempt(batch, attemptStartedAt));
+  const remaining = total - completed - sumRecipients(failedThisAttempt);
+  const samples = completedBatches.map((batch) => ({
+    recipientCount: batch.recipientCount,
+    timestamp: (phase === 'preparing' ? batch.createdAt : batch.updatedAt).getTime(),
+  }));
+
+  return {
+    status: phase,
+    progress: {
+      completed,
+      total,
+      estimatedSecondsRemaining: estimateSecondsRemaining({
+        remaining,
+        samples,
+        attemptStartedAt,
+      }),
+    },
+  };
+}
+
+function sumRecipients(batches: SendingBatch[]): number {
+  return batches.reduce((sum, batch) => sum + batch.recipientCount, 0);
+}
+
+// A batch that fails is only retried together with its email, so within an attempt it is finished work.
+function failedDuringAttempt(batch: SendingBatch, attemptStartedAt: number | null): boolean {
+  return (
+    batch.status === 'failed' &&
+    attemptStartedAt !== null &&
+    batch.updatedAt.getTime() >= attemptStartedAt
+  );
+}
+
+function estimateSecondsRemaining({
+  remaining,
+  samples,
+  attemptStartedAt,
+}: {
+  remaining: number;
+  samples: BatchSample[];
+  attemptStartedAt: number | null;
+}): number | null {
+  if (remaining <= 0) {
+    return 0;
+  }
+
+  const window = samples
+    .filter(
+      (sample) =>
+        sample.recipientCount > 0 &&
+        (attemptStartedAt === null || sample.timestamp >= attemptStartedAt),
+    )
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .slice(-ETA_BATCH_WINDOW);
+
+  if (window.length < 2) {
+    return null;
+  }
+
+  const elapsedSeconds = (window[window.length - 1].timestamp - window[0].timestamp) / 1000;
+  if (elapsedSeconds <= 0) {
+    return null;
+  }
+
+  const averageRecipientsPerBatch =
+    window.reduce((sum, sample) => sum + sample.recipientCount, 0) / window.length;
+  const recipientsPerSecond = (averageRecipientsPerBatch * (window.length - 1)) / elapsedSeconds;
+
+  return Math.ceil(remaining / recipientsPerSecond);
+}

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -43,7 +43,7 @@ export interface SendingBatch {
 
 type BatchSample = { recipientCount: number; timestamp: number };
 
-export function sendingStatusForSubmittedEmail(email: {
+export function emailSendingStatusWhenSubmitted(email: {
   id: string;
   recipientCount: number;
 }): EmailSendingStatus {
@@ -57,7 +57,7 @@ export function sendingStatusForSubmittedEmail(email: {
   };
 }
 
-export function sendingStatusFromBatches(
+export function emailSendingStatusFromBatches(
   email: SendingEmail,
   batches: SendingBatch[],
 ): EmailSendingStatus {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -521,6 +521,7 @@ module.exports = function apiRoutes() {
   // ## Emails
   router.get('/emails', mw.authAdminApi, http(api.emails.browse));
   router.get('/emails/:id', mw.authAdminApi, http(api.emails.read));
+  router.get('/emails/:id/status', mw.authAdminApi, http(api.emails.sendingStatus));
   router.put('/emails/:id/retry', mw.authAdminApi, http(api.emails.retry));
   router.get('/emails/:id/batches', mw.authAdminApi, http(api.emails.browseBatches));
   router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/emails.test.js.snap
@@ -734,6 +734,100 @@ Object {
 }
 `;
 
+exports[`Emails API Can read the sending status of a failed email 1: [body] 1`] = `
+Object {
+  "email_statuses": Array [
+    Object {
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "sending": Object {
+        "failed_during": "preparing",
+        "progress": Object {
+          "completed": 0,
+          "estimated_seconds_remaining": null,
+          "total": 3,
+        },
+        "status": "failed",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Emails API Can read the sending status of a failed email 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "184",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Emails API Can read the sending status of a submitted email 1: [body] 1`] = `
+Object {
+  "email_statuses": Array [
+    Object {
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "sending": Object {
+        "progress": Object {
+          "completed": 6,
+          "estimated_seconds_remaining": 0,
+          "total": 6,
+        },
+        "status": "submitted",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Emails API Can read the sending status of a submitted email 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "156",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Emails API Can read the sending status of an email that is still submitting 1: [body] 1`] = `
+Object {
+  "email_statuses": Array [
+    Object {
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "sending": Object {
+        "progress": Object {
+          "completed": 6,
+          "estimated_seconds_remaining": null,
+          "total": 8,
+        },
+        "status": "submitting",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Emails API Can read the sending status of an email that is still submitting 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "160",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Emails API Can retry a failed email 1: [body] 1`] = `
 Object {
   "emails": Array [
@@ -774,6 +868,37 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "711",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Emails API Cannot read the sending status of a missing email 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Email not found.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Emails API Cannot read the sending status of a missing email 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "202",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/emails.test.js
+++ b/ghost/core/test/e2e-api/admin/emails.test.js
@@ -4,12 +4,21 @@ const {
   matchers,
   mockManager,
 } = require('../../utils/e2e-framework');
-const { nullable, anyContentVersion, anyEtag, anyObjectId, anyUuid, anyISODateTime, anyString } =
-  matchers;
+const {
+  nullable,
+  anyContentVersion,
+  anyEtag,
+  anyErrorId,
+  anyObjectId,
+  anyUuid,
+  anyISODateTime,
+  anyString,
+} = matchers;
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const jobManager = require('../../../core/server/services/jobs/job-service');
 const models = require('../../../core/server/models');
+const db = require('../../../core/server/data/db');
 const settingsHelpers = require('../../../core/server/services/settings-helpers');
 
 const matchEmail = {
@@ -84,29 +93,90 @@ describe('Emails API', function () {
       });
   });
 
-  it('Can read an email sending status', async function () {
+  it('Can read the sending status of a submitted email', async function () {
     const email = fixtureManager.get('emails', 0);
-    const { body } = await agent.get(`emails/${email.id}/status/`).expectStatus(200);
-
-    assert.deepEqual(body, {
-      email_statuses: [
-        {
-          id: email.id,
-          sending: {
-            status: 'submitted',
-            progress: {
-              completed: 6,
-              total: 6,
-              estimated_seconds_remaining: 0,
-            },
-          },
-        },
-      ],
-    });
+    await agent
+      .get(`emails/${email.id}/status/`)
+      .expectStatus(200)
+      .matchBodySnapshot({
+        email_statuses: [{ id: anyObjectId }],
+      })
+      .matchHeaderSnapshot({
+        'content-version': anyContentVersion,
+        etag: anyEtag,
+      })
+      .expect(({ body }) => {
+        assert.equal(body.email_statuses[0].id, email.id);
+      });
   });
 
-  it('Returns 404 when reading sending status for a missing email', async function () {
-    await agent.get('emails/123456789012345678901234/status/').expectStatus(404);
+  it('Can read the sending status of an email that is still submitting', async function () {
+    const email = fixtureManager.get('emails', 0);
+    const member = fixtureManager.get('members', 0);
+    let pendingBatch;
+    try {
+      pendingBatch = await models.EmailBatch.add({ email_id: email.id });
+      for (let index = 0; index < 2; index += 1) {
+        await models.EmailRecipient.add({
+          email_id: email.id,
+          batch_id: pendingBatch.id,
+          member_id: member.id,
+          member_uuid: member.uuid,
+          member_email: member.email,
+        });
+      }
+      await db.knex('emails').where('id', email.id).update({ status: 'submitting' });
+
+      await agent
+        .get(`emails/${email.id}/status/`)
+        .expectStatus(200)
+        .matchBodySnapshot({
+          email_statuses: [{ id: anyObjectId }],
+        })
+        .matchHeaderSnapshot({
+          'content-version': anyContentVersion,
+          etag: anyEtag,
+        })
+        .expect(({ body }) => {
+          assert.equal(body.email_statuses[0].id, email.id);
+        });
+    } finally {
+      if (pendingBatch) {
+        await db.knex('email_recipients').where('batch_id', pendingBatch.id).del();
+        await db.knex('email_batches').where('id', pendingBatch.id).del();
+      }
+      await db.knex('emails').where('id', email.id).update({ status: 'submitted' });
+    }
+  });
+
+  it('Can read the sending status of a failed email', async function () {
+    const email = fixtureManager.get('emails', 1);
+    await agent
+      .get(`emails/${email.id}/status/`)
+      .expectStatus(200)
+      .matchBodySnapshot({
+        email_statuses: [{ id: anyObjectId }],
+      })
+      .matchHeaderSnapshot({
+        'content-version': anyContentVersion,
+        etag: anyEtag,
+      })
+      .expect(({ body }) => {
+        assert.equal(body.email_statuses[0].id, email.id);
+      });
+  });
+
+  it('Cannot read the sending status of a missing email', async function () {
+    await agent
+      .get('emails/123456789012345678901234/status/')
+      .expectStatus(404)
+      .matchBodySnapshot({
+        errors: [{ id: anyErrorId }],
+      })
+      .matchHeaderSnapshot({
+        'content-version': anyContentVersion,
+        etag: anyEtag,
+      });
   });
 
   it('Can retry a failed email', async function () {

--- a/ghost/core/test/e2e-api/admin/emails.test.js
+++ b/ghost/core/test/e2e-api/admin/emails.test.js
@@ -84,6 +84,31 @@ describe('Emails API', function () {
       });
   });
 
+  it('Can read an email sending status', async function () {
+    const email = fixtureManager.get('emails', 0);
+    const { body } = await agent.get(`emails/${email.id}/status/`).expectStatus(200);
+
+    assert.deepEqual(body, {
+      email_statuses: [
+        {
+          id: email.id,
+          sending: {
+            status: 'submitted',
+            progress: {
+              completed: 6,
+              total: 6,
+              estimated_seconds_remaining: 0,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it('Returns 404 when reading sending status for a missing email', async function () {
+    await agent.get('emails/123456789012345678901234/status/').expectStatus(404);
+  });
+
   it('Can retry a failed email', async function () {
     await agent
       .put(`emails/${fixtureManager.get('emails', 1).id}/retry`)

--- a/ghost/core/test/e2e-api/admin/emails.test.js
+++ b/ghost/core/test/e2e-api/admin/emails.test.js
@@ -95,19 +95,27 @@ describe('Emails API', function () {
 
   it('Can read the sending status of a submitted email', async function () {
     const email = fixtureManager.get('emails', 0);
-    await agent
-      .get(`emails/${email.id}/status/`)
-      .expectStatus(200)
-      .matchBodySnapshot({
-        email_statuses: [{ id: anyObjectId }],
-      })
-      .matchHeaderSnapshot({
-        'content-version': anyContentVersion,
-        etag: anyEtag,
-      })
-      .expect(({ body }) => {
-        assert.equal(body.email_statuses[0].id, email.id);
-      });
+    // The fixture stores email_count 0 against its recipient rows; batch creation
+    // reconciles the column to those rows before an email can be submitted.
+    try {
+      await db.knex('emails').where('id', email.id).update({ email_count: 6 });
+
+      await agent
+        .get(`emails/${email.id}/status/`)
+        .expectStatus(200)
+        .matchBodySnapshot({
+          email_statuses: [{ id: anyObjectId }],
+        })
+        .matchHeaderSnapshot({
+          'content-version': anyContentVersion,
+          etag: anyEtag,
+        })
+        .expect(({ body }) => {
+          assert.equal(body.email_statuses[0].id, email.id);
+        });
+    } finally {
+      await db.knex('emails').where('id', email.id).update({ email_count: email.email_count });
+    }
   });
 
   it('Can read the sending status of an email that is still submitting', async function () {

--- a/ghost/core/test/unit/server/lib/db-types/count.test.ts
+++ b/ghost/core/test/unit/server/lib/db-types/count.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { DbCount } from '../../../../../core/server/lib/db-types/count';
+
+describe('DbCount', function () {
+  describe('decode', function () {
+    it('reads numeric counts', function () {
+      assert.strictEqual(DbCount.decode(0), 0);
+      assert.strictEqual(DbCount.decode(42), 42);
+      assert.strictEqual(DbCount.decode(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER);
+    });
+
+    it('reads decimal string counts', function () {
+      assert.strictEqual(DbCount.decode('0'), 0);
+      assert.strictEqual(DbCount.decode('42'), 42);
+      assert.strictEqual(DbCount.decode(String(Number.MAX_SAFE_INTEGER)), Number.MAX_SAFE_INTEGER);
+    });
+
+    it('rejects values that are not non-negative safe integers', function () {
+      for (const stored of [
+        -1,
+        1.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        '-1',
+        '1.5',
+        String(Number.MAX_SAFE_INTEGER + 1),
+        '',
+        'not-a-count',
+        null,
+        undefined,
+        {},
+      ]) {
+        assert.throws(() => DbCount.decode(stored as never));
+      }
+    });
+  });
+
+  describe('encode', function () {
+    it('writes counts unchanged', function () {
+      assert.strictEqual(DbCount.encode(0), 0);
+      assert.strictEqual(DbCount.encode(42), 42);
+    });
+  });
+});

--- a/ghost/core/test/unit/server/services/email-service/email-controller.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-controller.test.js
@@ -583,4 +583,46 @@ describe('Email Controller', function () {
       assert.equal(result.get('status'), 'failed');
     });
   });
+
+  describe('getSendingStatus', function () {
+    it('throws if email not found', async function () {
+      const sendingStatusService = {
+        statusFor: sinon.stub().resolves(null),
+      };
+      const controller = new EmailController({}, { models: {}, sendingStatusService });
+
+      await assert.rejects(
+        controller.getSendingStatus({
+          options: {},
+          data: {
+            id: '123',
+          },
+        }),
+        /Email not found/,
+      );
+    });
+
+    it('returns the status from the sending status service', async function () {
+      const expectedStatus = {
+        id: '123',
+        sending: {
+          status: 'preparing',
+        },
+      };
+      const sendingStatusService = {
+        statusFor: sinon.stub().resolves(expectedStatus),
+      };
+      const controller = new EmailController({}, { models: {}, sendingStatusService });
+
+      const result = await controller.getSendingStatus({
+        options: {},
+        data: {
+          id: '123',
+        },
+      });
+
+      assert.deepEqual(result, expectedStatus);
+      sinon.assert.calledOnceWithExactly(sendingStatusService.statusFor, '123');
+    });
+  });
 });

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -6,14 +6,33 @@ describe('SendingStatusService', function () {
   let knex: Knex;
   let service: SendingStatusService;
   let batchCount: number;
+  let aggregateCountsAsStrings: boolean;
 
   beforeEach(async function () {
+    aggregateCountsAsStrings = false;
     knex = createKnex({
       client: 'better-sqlite3',
       connection: {
         filename: ':memory:',
       },
       useNullAsDefault: true,
+      postProcessResponse(result) {
+        if (!aggregateCountsAsStrings || !Array.isArray(result)) {
+          return result;
+        }
+
+        return result.map((row) => {
+          if (row && typeof row === 'object') {
+            for (const key of ['count', 'recipient_count']) {
+              const value = Reflect.get(row, key);
+              if (typeof value === 'number') {
+                Reflect.set(row, key, String(value));
+              }
+            }
+          }
+          return row;
+        });
+      },
     });
 
     await knex.schema.createTable('emails', (table) => {
@@ -291,6 +310,29 @@ describe('SendingStatusService', function () {
       updatedAt: '2026-09-02 12:01:00',
     });
 
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'submitted',
+        progress: { completed: 10, total: 10, estimated_seconds_remaining: 0 },
+      },
+    });
+  });
+
+  it('accepts aggregate counts returned as decimal strings', async function () {
+    await addEmail({ status: 'submitting', emailCount: 10 });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
+    aggregateCountsAsStrings = true;
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'preparing',
+        progress: { completed: 10, total: 10, estimated_seconds_remaining: 0 },
+      },
+    });
+
+    await knex('emails').where('id', 'email-id').update({ status: 'submitted' });
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -115,7 +115,7 @@ describe('SendingStatusService', function () {
     assert.equal(await service.statusFor('missing-email'), null);
   });
 
-  it('derives an open send from the email and its batches with their recipient counts', async function () {
+  it('derives the sending status of an unsubmitted email from its batches and their recipient counts', async function () {
     await addEmail({ status: 'submitting', emailCount: 50, updatedAt: '2026-09-02 12:01:00' });
     await addBatch({
       status: 'submitted',

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -1,0 +1,276 @@
+import assert from 'node:assert/strict';
+import createKnex, { type Knex } from 'knex';
+import { SendingStatusService } from '../../../../../core/server/services/email-service/sending-status-service';
+
+describe('SendingStatusService', function () {
+  let knex: Knex;
+  let service: SendingStatusService;
+  let recipientSequence: number;
+
+  beforeEach(async function () {
+    knex = createKnex({
+      client: 'better-sqlite3',
+      connection: {
+        filename: ':memory:',
+      },
+      useNullAsDefault: true,
+    });
+    recipientSequence = 0;
+
+    await knex.schema.createTable('emails', (table) => {
+      table.string('id').primary();
+      table.string('status').notNullable();
+      table.integer('email_count').notNullable();
+      table.dateTime('updated_at').nullable();
+    });
+    await knex.schema.createTable('email_batches', (table) => {
+      table.string('id').primary();
+      table.string('email_id').notNullable().index();
+      table.string('status').notNullable();
+      table.dateTime('created_at').notNullable();
+      table.dateTime('updated_at').notNullable();
+    });
+    await knex.schema.createTable('email_recipients', (table) => {
+      table.string('id').primary();
+      table.string('batch_id').notNullable().index();
+    });
+
+    service = new SendingStatusService({ db: { knex } });
+  });
+
+  afterEach(async function () {
+    await knex.destroy();
+  });
+
+  async function addEmail({
+    status,
+    emailCount,
+    updatedAt,
+  }: {
+    status: string;
+    emailCount: number;
+    updatedAt: string;
+  }) {
+    await knex('emails').insert({
+      id: 'email-id',
+      status,
+      email_count: emailCount,
+      updated_at: updatedAt,
+    });
+  }
+
+  async function addBatch({
+    id,
+    status,
+    createdAt,
+    updatedAt,
+    recipientCount = 10,
+  }: {
+    id: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    recipientCount?: number;
+  }) {
+    await knex('email_batches').insert({
+      id,
+      email_id: 'email-id',
+      status,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    });
+    await knex('email_recipients').insert(
+      Array.from({ length: recipientCount }, () => {
+        const recipientId = `recipient-${recipientSequence}`;
+        recipientSequence += 1;
+        return {
+          id: recipientId,
+          batch_id: id,
+        };
+      }),
+    );
+  }
+
+  it('returns null when the email does not exist', async function () {
+    assert.equal(await service.statusFor('missing-email'), null);
+  });
+
+  it('reports preparation progress and estimates from batch creation times', async function () {
+    await addEmail({
+      status: 'submitting',
+      emailCount: 100,
+      updatedAt: '2026-09-02T11:59:59Z',
+    });
+    await addBatch({
+      id: 'batch-1',
+      status: 'pending',
+      createdAt: '2026-09-02T12:00:00Z',
+      updatedAt: '2026-09-02T12:00:00Z',
+    });
+    await addBatch({
+      id: 'batch-2',
+      status: 'pending',
+      createdAt: '2026-09-02T12:00:10Z',
+      updatedAt: '2026-09-02T12:00:10Z',
+    });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'preparing',
+        progress: {
+          completed: 20,
+          total: 100,
+          estimated_seconds_remaining: 80,
+        },
+      },
+    });
+  });
+
+  it('reports submission progress and estimates from submitted batch updates', async function () {
+    await addEmail({
+      status: 'submitting',
+      emailCount: 30,
+      updatedAt: '2026-09-02T12:01:00Z',
+    });
+    await addBatch({
+      id: 'batch-1',
+      status: 'submitted',
+      createdAt: '2026-09-02T12:00:00Z',
+      updatedAt: '2026-09-02T12:01:10Z',
+    });
+    await addBatch({
+      id: 'batch-2',
+      status: 'submitted',
+      createdAt: '2026-09-02T12:00:10Z',
+      updatedAt: '2026-09-02T12:01:20Z',
+    });
+    await addBatch({
+      id: 'batch-3',
+      status: 'pending',
+      createdAt: '2026-09-02T12:00:20Z',
+      updatedAt: '2026-09-02T12:00:20Z',
+    });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'submitting',
+        progress: {
+          completed: 20,
+          total: 30,
+          estimated_seconds_remaining: 10,
+        },
+      },
+    });
+  });
+
+  it('reports the phase and frozen progress for a failed send', async function () {
+    await addEmail({
+      status: 'failed',
+      emailCount: 20,
+      updatedAt: '2026-09-02T12:01:20Z',
+    });
+    await addBatch({
+      id: 'batch-1',
+      status: 'submitted',
+      createdAt: '2026-09-02T12:00:00Z',
+      updatedAt: '2026-09-02T12:01:10Z',
+    });
+    await addBatch({
+      id: 'batch-2',
+      status: 'failed',
+      createdAt: '2026-09-02T12:00:10Z',
+      updatedAt: '2026-09-02T12:01:20Z',
+    });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'failed',
+        progress: {
+          completed: 10,
+          total: 20,
+          estimated_seconds_remaining: null,
+        },
+        failed_during: 'submitting',
+      },
+    });
+  });
+
+  it('reports a failure during preparation when no batch started submitting', async function () {
+    await addEmail({
+      status: 'failed',
+      emailCount: 20,
+      updatedAt: '2026-09-02T12:00:01Z',
+    });
+    await addBatch({
+      id: 'batch-1',
+      status: 'pending',
+      createdAt: '2026-09-02T12:00:00Z',
+      updatedAt: '2026-09-02T12:00:00Z',
+    });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'failed',
+        progress: {
+          completed: 10,
+          total: 20,
+          estimated_seconds_remaining: null,
+        },
+        failed_during: 'preparing',
+      },
+    });
+  });
+
+  it('reports submitted sends as complete', async function () {
+    await addEmail({
+      status: 'submitted',
+      emailCount: 10,
+      updatedAt: '2026-09-02T12:01:00Z',
+    });
+    await addBatch({
+      id: 'batch-1',
+      status: 'submitted',
+      createdAt: '2026-09-02T12:00:00Z',
+      updatedAt: '2026-09-02T12:01:00Z',
+    });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'submitted',
+        progress: {
+          completed: 10,
+          total: 10,
+          estimated_seconds_remaining: 0,
+        },
+      },
+    });
+  });
+
+  it('returns no estimate until two batches complete in the current attempt', async function () {
+    await addEmail({
+      status: 'submitting',
+      emailCount: 30,
+      updatedAt: '2026-09-02T12:02:00Z',
+    });
+    await addBatch({
+      id: 'batch-1',
+      status: 'submitted',
+      createdAt: '2026-09-02T12:00:00Z',
+      updatedAt: '2026-09-02T12:01:00Z',
+    });
+    await addBatch({
+      id: 'batch-2',
+      status: 'submitted',
+      createdAt: '2026-09-02T12:00:10Z',
+      updatedAt: '2026-09-02T12:02:10Z',
+    });
+
+    const result = await service.statusFor('email-id');
+    assert.equal(result?.sending.progress.estimated_seconds_remaining, null);
+  });
+});

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -115,59 +115,7 @@ describe('SendingStatusService', function () {
     assert.equal(await service.statusFor('missing-email'), null);
   });
 
-  it('reports a pending email as preparing', async function () {
-    await addEmail({ status: 'pending', emailCount: 100 });
-
-    assert.deepEqual(await service.statusFor('email-id'), {
-      id: 'email-id',
-      sending: {
-        status: 'preparing',
-        progress: { completed: 0, total: 100, estimated_seconds_remaining: null },
-      },
-    });
-  });
-
-  it('reports preparation progress and estimates from batch creation times', async function () {
-    await addEmail({ status: 'submitting', emailCount: 100 });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
-
-    assert.deepEqual(await service.statusFor('email-id'), {
-      id: 'email-id',
-      sending: {
-        status: 'preparing',
-        progress: { completed: 20, total: 100, estimated_seconds_remaining: 80 },
-      },
-    });
-  });
-
-  it('grows the total when more recipients are prepared than estimated', async function () {
-    await addEmail({ status: 'submitting', emailCount: 15 });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
-
-    const result = await service.statusFor('email-id');
-    assert.deepEqual(result?.sending.progress, {
-      completed: 20,
-      total: 20,
-      estimated_seconds_remaining: 0,
-    });
-  });
-
-  it('excludes batches created before the current attempt from the preparing estimate', async function () {
-    await addEmail({ status: 'submitting', emailCount: 30, updatedAt: '2026-09-02 12:00:11' });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
-
-    const result = await service.statusFor('email-id');
-    assert.deepEqual(result?.sending.progress, {
-      completed: 20,
-      total: 30,
-      estimated_seconds_remaining: null,
-    });
-  });
-
-  it('reports submission progress and estimates from submitted batch updates', async function () {
+  it('derives an open send from the email and its batches with their recipient counts', async function () {
     await addEmail({ status: 'submitting', emailCount: 50, updatedAt: '2026-09-02 12:01:00' });
     await addBatch({
       status: 'submitted',
@@ -179,142 +127,26 @@ describe('SendingStatusService', function () {
       createdAt: '2026-09-02 12:00:10',
       updatedAt: '2026-09-02 12:01:20',
     });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20' });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20', recipientCount: 5 });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'submitting',
-        progress: { completed: 20, total: 30, estimated_seconds_remaining: 10 },
+        progress: { completed: 20, total: 25, estimatedSecondsRemaining: 5 },
       },
     });
   });
 
-  it('excludes batches that failed during the current attempt from the remaining work', async function () {
-    await addEmail({ status: 'submitting', emailCount: 40, updatedAt: '2026-09-02 12:00:30' });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:00',
-      updatedAt: '2026-09-02 12:01:00',
-    });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:10',
-      updatedAt: '2026-09-02 12:01:10',
-    });
-    await addBatch({
-      status: 'failed',
-      createdAt: '2026-09-02 12:00:20',
-      updatedAt: '2026-09-02 12:01:15',
-    });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:30' });
-
-    const result = await service.statusFor('email-id');
-    assert.deepEqual(result?.sending.progress, {
-      completed: 20,
-      total: 40,
-      estimated_seconds_remaining: 10,
-    });
-  });
-
-  it('reports no remaining time once only batches that failed during the attempt are left', async function () {
-    await addEmail({ status: 'submitting', emailCount: 30, updatedAt: '2026-09-02 12:00:30' });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:00',
-      updatedAt: '2026-09-02 12:01:00',
-    });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:10',
-      updatedAt: '2026-09-02 12:01:10',
-    });
-    await addBatch({
-      status: 'failed',
-      createdAt: '2026-09-02 12:00:20',
-      updatedAt: '2026-09-02 12:01:15',
-    });
-
-    const result = await service.statusFor('email-id');
-    assert.deepEqual(result?.sending.progress, {
-      completed: 20,
-      total: 30,
-      estimated_seconds_remaining: 0,
-    });
-  });
-
-  it('reports the phase and frozen progress for a failed send', async function () {
-    await addEmail({ status: 'failed', emailCount: 20, updatedAt: '2026-09-02 12:01:20' });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:00',
-      updatedAt: '2026-09-02 12:01:10',
-    });
-    await addBatch({
-      status: 'failed',
-      createdAt: '2026-09-02 12:00:10',
-      updatedAt: '2026-09-02 12:01:20',
-    });
-
-    assert.deepEqual(await service.statusFor('email-id'), {
-      id: 'email-id',
-      sending: {
-        status: 'failed',
-        progress: { completed: 10, total: 20, estimated_seconds_remaining: null },
-        failed_during: 'submitting',
-      },
-    });
-  });
-
-  it('reports a failure during preparation when no batch started submitting', async function () {
-    await addEmail({ status: 'failed', emailCount: 20, updatedAt: '2026-09-02 12:00:01' });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
-
-    assert.deepEqual(await service.statusFor('email-id'), {
-      id: 'email-id',
-      sending: {
-        status: 'failed',
-        progress: { completed: 10, total: 20, estimated_seconds_remaining: null },
-        failed_during: 'preparing',
-      },
-    });
-  });
-
-  it('keeps the frozen submission progress of a retried email while it waits for its job', async function () {
-    await addEmail({ status: 'pending', emailCount: 20, updatedAt: '2026-09-02 12:05:00' });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:00',
-      updatedAt: '2026-09-02 12:01:10',
-    });
-    await addBatch({
-      status: 'failed',
-      createdAt: '2026-09-02 12:00:10',
-      updatedAt: '2026-09-02 12:01:20',
-    });
-
-    assert.deepEqual(await service.statusFor('email-id'), {
-      id: 'email-id',
-      sending: {
-        status: 'submitting',
-        progress: { completed: 10, total: 20, estimated_seconds_remaining: null },
-      },
-    });
-  });
-
-  it('reports submitted sends as complete from their recipient count', async function () {
-    await addEmail({ status: 'submitted', emailCount: 0, updatedAt: '2026-09-02 12:01:00' });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:00',
-      updatedAt: '2026-09-02 12:01:00',
-    });
+  it('derives a submitted send from its recipient count', async function () {
+    await addEmail({ status: 'submitted', emailCount: 0 });
+    await addBatch({ status: 'submitted', createdAt: '2026-09-02 12:00:00' });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'submitted',
-        progress: { completed: 10, total: 10, estimated_seconds_remaining: 0 },
+        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
       },
     });
   });
@@ -328,7 +160,7 @@ describe('SendingStatusService', function () {
       id: 'email-id',
       sending: {
         status: 'preparing',
-        progress: { completed: 10, total: 10, estimated_seconds_remaining: 0 },
+        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
       },
     });
 
@@ -337,39 +169,8 @@ describe('SendingStatusService', function () {
       id: 'email-id',
       sending: {
         status: 'submitted',
-        progress: { completed: 10, total: 10, estimated_seconds_remaining: 0 },
+        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
       },
-    });
-  });
-
-  it('excludes batches submitted before the current attempt from the submitting estimate', async function () {
-    await addEmail({ status: 'submitting', emailCount: 30, updatedAt: '2026-09-02 12:02:00' });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:00',
-      updatedAt: '2026-09-02 12:01:00',
-    });
-    await addBatch({
-      status: 'submitted',
-      createdAt: '2026-09-02 12:00:10',
-      updatedAt: '2026-09-02 12:02:10',
-    });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20' });
-
-    const result = await service.statusFor('email-id');
-    assert.equal(result?.sending.progress.estimated_seconds_remaining, null);
-  });
-
-  it('ignores batches without recipients when estimating', async function () {
-    await addEmail({ status: 'submitting', emailCount: 30 });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00', recipientCount: 0 });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
-
-    const result = await service.statusFor('email-id');
-    assert.deepEqual(result?.sending.progress, {
-      completed: 10,
-      total: 30,
-      estimated_seconds_remaining: null,
     });
   });
 });

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -5,7 +5,7 @@ import { SendingStatusService } from '../../../../../core/server/services/email-
 describe('SendingStatusService', function () {
   let knex: Knex;
   let service: SendingStatusService;
-  let recipientSequence: number;
+  let batchCount: number;
 
   beforeEach(async function () {
     knex = createKnex({
@@ -15,7 +15,6 @@ describe('SendingStatusService', function () {
       },
       useNullAsDefault: true,
     });
-    recipientSequence = 0;
 
     await knex.schema.createTable('emails', (table) => {
       table.string('id').primary();
@@ -25,17 +24,19 @@ describe('SendingStatusService', function () {
     });
     await knex.schema.createTable('email_batches', (table) => {
       table.string('id').primary();
-      table.string('email_id').notNullable().index();
+      table.string('email_id').notNullable();
       table.string('status').notNullable();
       table.dateTime('created_at').notNullable();
       table.dateTime('updated_at').notNullable();
     });
     await knex.schema.createTable('email_recipients', (table) => {
       table.string('id').primary();
-      table.string('batch_id').notNullable().index();
+      table.string('email_id').notNullable();
+      table.string('batch_id').notNullable();
     });
 
-    service = new SendingStatusService({ db: { knex } });
+    service = new SendingStatusService({ knex });
+    batchCount = 0;
   });
 
   afterEach(async function () {
@@ -45,11 +46,11 @@ describe('SendingStatusService', function () {
   async function addEmail({
     status,
     emailCount,
-    updatedAt,
+    updatedAt = '2026-09-02 11:59:59',
   }: {
     status: string;
     emailCount: number;
-    updatedAt: string;
+    updatedAt?: string;
   }) {
     await knex('emails').insert({
       id: 'email-id',
@@ -60,18 +61,18 @@ describe('SendingStatusService', function () {
   }
 
   async function addBatch({
-    id,
     status,
     createdAt,
-    updatedAt,
+    updatedAt = createdAt,
     recipientCount = 10,
   }: {
-    id: string;
     status: string;
     createdAt: string;
-    updatedAt: string;
+    updatedAt?: string;
     recipientCount?: number;
   }) {
+    batchCount += 1;
+    const id = `batch-${batchCount}`;
     await knex('email_batches').insert({
       id,
       email_id: 'email-id',
@@ -79,15 +80,15 @@ describe('SendingStatusService', function () {
       created_at: createdAt,
       updated_at: updatedAt,
     });
+    if (recipientCount === 0) {
+      return;
+    }
     await knex('email_recipients').insert(
-      Array.from({ length: recipientCount }, () => {
-        const recipientId = `recipient-${recipientSequence}`;
-        recipientSequence += 1;
-        return {
-          id: recipientId,
-          batch_id: id,
-        };
-      }),
+      Array.from({ length: recipientCount }, (_, index) => ({
+        id: `${id}-recipient-${index}`,
+        email_id: 'email-id',
+        batch_id: id,
+      })),
     );
   }
 
@@ -95,182 +96,238 @@ describe('SendingStatusService', function () {
     assert.equal(await service.statusFor('missing-email'), null);
   });
 
-  it('reports preparation progress and estimates from batch creation times', async function () {
-    await addEmail({
-      status: 'submitting',
-      emailCount: 100,
-      updatedAt: '2026-09-02T11:59:59Z',
-    });
-    await addBatch({
-      id: 'batch-1',
-      status: 'pending',
-      createdAt: '2026-09-02T12:00:00Z',
-      updatedAt: '2026-09-02T12:00:00Z',
-    });
-    await addBatch({
-      id: 'batch-2',
-      status: 'pending',
-      createdAt: '2026-09-02T12:00:10Z',
-      updatedAt: '2026-09-02T12:00:10Z',
-    });
+  it('reports a pending email as preparing', async function () {
+    await addEmail({ status: 'pending', emailCount: 100 });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'preparing',
-        progress: {
-          completed: 20,
-          total: 100,
-          estimated_seconds_remaining: 80,
-        },
+        progress: { completed: 0, total: 100, estimated_seconds_remaining: null },
       },
     });
   });
 
+  it('reports preparation progress and estimates from batch creation times', async function () {
+    await addEmail({ status: 'submitting', emailCount: 100 });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'preparing',
+        progress: { completed: 20, total: 100, estimated_seconds_remaining: 80 },
+      },
+    });
+  });
+
+  it('grows the total when more recipients are prepared than estimated', async function () {
+    await addEmail({ status: 'submitting', emailCount: 15 });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
+
+    const result = await service.statusFor('email-id');
+    assert.deepEqual(result?.sending.progress, {
+      completed: 20,
+      total: 20,
+      estimated_seconds_remaining: 0,
+    });
+  });
+
+  it('excludes batches created before the current attempt from the preparing estimate', async function () {
+    await addEmail({ status: 'submitting', emailCount: 30, updatedAt: '2026-09-02 12:00:11' });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
+
+    const result = await service.statusFor('email-id');
+    assert.deepEqual(result?.sending.progress, {
+      completed: 20,
+      total: 30,
+      estimated_seconds_remaining: null,
+    });
+  });
+
   it('reports submission progress and estimates from submitted batch updates', async function () {
-    await addEmail({
-      status: 'submitting',
-      emailCount: 30,
-      updatedAt: '2026-09-02T12:01:00Z',
-    });
+    await addEmail({ status: 'submitting', emailCount: 50, updatedAt: '2026-09-02 12:01:00' });
     await addBatch({
-      id: 'batch-1',
       status: 'submitted',
-      createdAt: '2026-09-02T12:00:00Z',
-      updatedAt: '2026-09-02T12:01:10Z',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:10',
     });
     await addBatch({
-      id: 'batch-2',
       status: 'submitted',
-      createdAt: '2026-09-02T12:00:10Z',
-      updatedAt: '2026-09-02T12:01:20Z',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:01:20',
     });
-    await addBatch({
-      id: 'batch-3',
-      status: 'pending',
-      createdAt: '2026-09-02T12:00:20Z',
-      updatedAt: '2026-09-02T12:00:20Z',
-    });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20' });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'submitting',
-        progress: {
-          completed: 20,
-          total: 30,
-          estimated_seconds_remaining: 10,
-        },
+        progress: { completed: 20, total: 30, estimated_seconds_remaining: 10 },
       },
     });
   });
 
-  it('reports the phase and frozen progress for a failed send', async function () {
-    await addEmail({
-      status: 'failed',
-      emailCount: 20,
-      updatedAt: '2026-09-02T12:01:20Z',
-    });
+  it('excludes batches that failed during the current attempt from the remaining work', async function () {
+    await addEmail({ status: 'submitting', emailCount: 40, updatedAt: '2026-09-02 12:00:30' });
     await addBatch({
-      id: 'batch-1',
       status: 'submitted',
-      createdAt: '2026-09-02T12:00:00Z',
-      updatedAt: '2026-09-02T12:01:10Z',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:00',
     });
     await addBatch({
-      id: 'batch-2',
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:01:10',
+    });
+    await addBatch({
       status: 'failed',
-      createdAt: '2026-09-02T12:00:10Z',
-      updatedAt: '2026-09-02T12:01:20Z',
+      createdAt: '2026-09-02 12:00:20',
+      updatedAt: '2026-09-02 12:01:15',
+    });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:30' });
+
+    const result = await service.statusFor('email-id');
+    assert.deepEqual(result?.sending.progress, {
+      completed: 20,
+      total: 40,
+      estimated_seconds_remaining: 10,
+    });
+  });
+
+  it('reports no remaining time once only batches that failed during the attempt are left', async function () {
+    await addEmail({ status: 'submitting', emailCount: 30, updatedAt: '2026-09-02 12:00:30' });
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:00',
+    });
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:01:10',
+    });
+    await addBatch({
+      status: 'failed',
+      createdAt: '2026-09-02 12:00:20',
+      updatedAt: '2026-09-02 12:01:15',
+    });
+
+    const result = await service.statusFor('email-id');
+    assert.deepEqual(result?.sending.progress, {
+      completed: 20,
+      total: 30,
+      estimated_seconds_remaining: 0,
+    });
+  });
+
+  it('reports the phase and frozen progress for a failed send', async function () {
+    await addEmail({ status: 'failed', emailCount: 20, updatedAt: '2026-09-02 12:01:20' });
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:10',
+    });
+    await addBatch({
+      status: 'failed',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:01:20',
     });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'failed',
-        progress: {
-          completed: 10,
-          total: 20,
-          estimated_seconds_remaining: null,
-        },
+        progress: { completed: 10, total: 20, estimated_seconds_remaining: null },
         failed_during: 'submitting',
       },
     });
   });
 
   it('reports a failure during preparation when no batch started submitting', async function () {
-    await addEmail({
-      status: 'failed',
-      emailCount: 20,
-      updatedAt: '2026-09-02T12:00:01Z',
-    });
-    await addBatch({
-      id: 'batch-1',
-      status: 'pending',
-      createdAt: '2026-09-02T12:00:00Z',
-      updatedAt: '2026-09-02T12:00:00Z',
-    });
+    await addEmail({ status: 'failed', emailCount: 20, updatedAt: '2026-09-02 12:00:01' });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00' });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'failed',
-        progress: {
-          completed: 10,
-          total: 20,
-          estimated_seconds_remaining: null,
-        },
+        progress: { completed: 10, total: 20, estimated_seconds_remaining: null },
         failed_during: 'preparing',
       },
     });
   });
 
-  it('reports submitted sends as complete', async function () {
-    await addEmail({
+  it('keeps the frozen submission progress of a retried email while it waits for its job', async function () {
+    await addEmail({ status: 'pending', emailCount: 20, updatedAt: '2026-09-02 12:05:00' });
+    await addBatch({
       status: 'submitted',
-      emailCount: 10,
-      updatedAt: '2026-09-02T12:01:00Z',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:10',
     });
     await addBatch({
-      id: 'batch-1',
+      status: 'failed',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:01:20',
+    });
+
+    assert.deepEqual(await service.statusFor('email-id'), {
+      id: 'email-id',
+      sending: {
+        status: 'submitting',
+        progress: { completed: 10, total: 20, estimated_seconds_remaining: null },
+      },
+    });
+  });
+
+  it('reports submitted sends as complete from their recipient count', async function () {
+    await addEmail({ status: 'submitted', emailCount: 0, updatedAt: '2026-09-02 12:01:00' });
+    await addBatch({
       status: 'submitted',
-      createdAt: '2026-09-02T12:00:00Z',
-      updatedAt: '2026-09-02T12:01:00Z',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:00',
     });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
       sending: {
         status: 'submitted',
-        progress: {
-          completed: 10,
-          total: 10,
-          estimated_seconds_remaining: 0,
-        },
+        progress: { completed: 10, total: 10, estimated_seconds_remaining: 0 },
       },
     });
   });
 
-  it('returns no estimate until two batches complete in the current attempt', async function () {
-    await addEmail({
-      status: 'submitting',
-      emailCount: 30,
-      updatedAt: '2026-09-02T12:02:00Z',
+  it('excludes batches submitted before the current attempt from the submitting estimate', async function () {
+    await addEmail({ status: 'submitting', emailCount: 30, updatedAt: '2026-09-02 12:02:00' });
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:00',
     });
     await addBatch({
-      id: 'batch-1',
       status: 'submitted',
-      createdAt: '2026-09-02T12:00:00Z',
-      updatedAt: '2026-09-02T12:01:00Z',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:02:10',
     });
-    await addBatch({
-      id: 'batch-2',
-      status: 'submitted',
-      createdAt: '2026-09-02T12:00:10Z',
-      updatedAt: '2026-09-02T12:02:10Z',
-    });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20' });
 
     const result = await service.statusFor('email-id');
     assert.equal(result?.sending.progress.estimated_seconds_remaining, null);
+  });
+
+  it('ignores batches without recipients when estimating', async function () {
+    await addEmail({ status: 'submitting', emailCount: 30 });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:00', recipientCount: 0 });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:10' });
+
+    const result = await service.statusFor('email-id');
+    assert.deepEqual(result?.sending.progress, {
+      completed: 10,
+      total: 30,
+      estimated_seconds_remaining: null,
+    });
   });
 });

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -23,7 +23,7 @@ describe('SendingStatusService', function () {
 
         return result.map((row) => {
           if (row && typeof row === 'object') {
-            for (const key of ['count', 'recipient_count']) {
+            for (const key of ['recipient_count']) {
               const value = Reflect.get(row, key);
               if (typeof value === 'number') {
                 Reflect.set(row, key, String(value));
@@ -138,9 +138,8 @@ describe('SendingStatusService', function () {
     });
   });
 
-  it('derives a submitted send from its recipient count', async function () {
-    await addEmail({ status: 'submitted', emailCount: 0 });
-    await addBatch({ status: 'submitted', createdAt: '2026-09-02 12:00:00' });
+  it('derives a submitted send from the stored email count without reading its batches', async function () {
+    await addEmail({ status: 'submitted', emailCount: 10 });
 
     assert.deepEqual(await service.statusFor('email-id'), {
       id: 'email-id',
@@ -160,15 +159,6 @@ describe('SendingStatusService', function () {
       id: 'email-id',
       sending: {
         status: 'preparing',
-        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
-      },
-    });
-
-    await knex('emails').where('id', 'email-id').update({ status: 'submitted' });
-    assert.deepEqual(await service.statusFor('email-id'), {
-      id: 'email-id',
-      sending: {
-        status: 'submitted',
         progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
       },
     });

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {
-  openSending,
-  submittedSending,
+  sendingStatusForSubmittedEmail,
+  sendingStatusFromBatches,
   type SendingBatch,
   type SendingEmail,
 } from '../../../../../core/server/services/email-service/sending-status';
@@ -35,12 +35,15 @@ function batch({
 }
 
 describe('sending status', function () {
-  describe('openSending', function () {
+  describe('sendingStatusFromBatches', function () {
     it('reports a pending email without batches as preparing', function () {
-      assert.deepEqual(openSending(email({ status: 'pending', recipientCount: 100 }), []), {
-        status: 'preparing',
-        progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
-      });
+      assert.deepEqual(
+        sendingStatusFromBatches(email({ status: 'pending', recipientCount: 100 }), []),
+        {
+          status: 'preparing',
+          progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
+        },
+      );
     });
 
     it('reports preparation progress and estimates from batch creation times', function () {
@@ -49,7 +52,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(openSending(email({ recipientCount: 100 }), batches), {
+      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 100 }), batches), {
         status: 'preparing',
         progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
       });
@@ -61,7 +64,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(openSending(email({ recipientCount: 15 }), batches).progress, {
+      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 15 }), batches).progress, {
         completed: 20,
         total: 20,
         estimatedSecondsRemaining: 0,
@@ -74,7 +77,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      const result = openSending(
+      const result = sendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: at('12:00:11') }),
         batches,
       );
@@ -93,7 +96,10 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        openSending(email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }), batches),
+        sendingStatusFromBatches(
+          email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }),
+          batches,
+        ),
         {
           status: 'submitting',
           progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
@@ -109,7 +115,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:30' }),
       ];
 
-      const result = openSending(
+      const result = sendingStatusFromBatches(
         email({ recipientCount: 40, attemptStartedAt: at('12:00:30') }),
         batches,
       );
@@ -127,7 +133,7 @@ describe('sending status', function () {
         batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
       ];
 
-      const result = openSending(
+      const result = sendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: at('12:00:30') }),
         batches,
       );
@@ -145,7 +151,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        openSending(
+        sendingStatusFromBatches(
           email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:01:20') }),
           batches,
         ),
@@ -161,7 +167,7 @@ describe('sending status', function () {
       const batches = [batch({ status: 'pending', createdAt: '12:00:00' })];
 
       assert.deepEqual(
-        openSending(
+        sendingStatusFromBatches(
           email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:00:01') }),
           batches,
         ),
@@ -180,7 +186,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        openSending(
+        sendingStatusFromBatches(
           email({ status: 'pending', recipientCount: 20, attemptStartedAt: at('12:05:00') }),
           batches,
         ),
@@ -198,7 +204,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:20' }),
       ];
 
-      const result = openSending(
+      const result = sendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: at('12:02:00') }),
         batches,
       );
@@ -211,7 +217,10 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      const result = openSending(email({ recipientCount: 30, attemptStartedAt: null }), batches);
+      const result = sendingStatusFromBatches(
+        email({ recipientCount: 30, attemptStartedAt: null }),
+        batches,
+      );
       assert.equal(result.progress.estimatedSecondsRemaining, 10);
     });
 
@@ -221,7 +230,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(openSending(email({ recipientCount: 30 }), batches).progress, {
+      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 30 }), batches).progress, {
         completed: 10,
         total: 30,
         estimatedSecondsRemaining: null,
@@ -229,9 +238,9 @@ describe('sending status', function () {
     });
   });
 
-  describe('submittedSending', function () {
+  describe('sendingStatusForSubmittedEmail', function () {
     it('reports submitted sends as complete from their recipient count', function () {
-      assert.deepEqual(submittedSending(10), {
+      assert.deepEqual(sendingStatusForSubmittedEmail(10), {
         status: 'submitted',
         progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
       });

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -17,7 +17,7 @@ function email({
   recipientCount: number;
   attemptStartedAt?: Date | null;
 }): SendingEmail {
-  return { status, recipientCount, attemptStartedAt };
+  return { id: 'email-id', status, recipientCount, attemptStartedAt };
 }
 
 function batch({
@@ -40,8 +40,11 @@ describe('sending status', function () {
       assert.deepEqual(
         sendingStatusFromBatches(email({ status: 'pending', recipientCount: 100 }), []),
         {
-          status: 'preparing',
-          progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
+          id: 'email-id',
+          sending: {
+            status: 'preparing',
+            progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
+          },
         },
       );
     });
@@ -52,7 +55,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 100 }), batches), {
+      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 100 }), batches).sending, {
         status: 'preparing',
         progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
       });
@@ -64,11 +67,14 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 15 }), batches).progress, {
-        completed: 20,
-        total: 20,
-        estimatedSecondsRemaining: 0,
-      });
+      assert.deepEqual(
+        sendingStatusFromBatches(email({ recipientCount: 15 }), batches).sending.progress,
+        {
+          completed: 20,
+          total: 20,
+          estimatedSecondsRemaining: 0,
+        },
+      );
     });
 
     it('excludes batches created before the current attempt from the preparing estimate', function () {
@@ -81,7 +87,7 @@ describe('sending status', function () {
         email({ recipientCount: 30, attemptStartedAt: at('12:00:11') }),
         batches,
       );
-      assert.deepEqual(result.progress, {
+      assert.deepEqual(result.sending.progress, {
         completed: 20,
         total: 30,
         estimatedSecondsRemaining: null,
@@ -101,8 +107,11 @@ describe('sending status', function () {
           batches,
         ),
         {
-          status: 'submitting',
-          progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
+          id: 'email-id',
+          sending: {
+            status: 'submitting',
+            progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
+          },
         },
       );
     });
@@ -119,7 +128,7 @@ describe('sending status', function () {
         email({ recipientCount: 40, attemptStartedAt: at('12:00:30') }),
         batches,
       );
-      assert.deepEqual(result.progress, {
+      assert.deepEqual(result.sending.progress, {
         completed: 20,
         total: 40,
         estimatedSecondsRemaining: 10,
@@ -137,7 +146,7 @@ describe('sending status', function () {
         email({ recipientCount: 30, attemptStartedAt: at('12:00:30') }),
         batches,
       );
-      assert.deepEqual(result.progress, {
+      assert.deepEqual(result.sending.progress, {
         completed: 20,
         total: 30,
         estimatedSecondsRemaining: 0,
@@ -154,7 +163,7 @@ describe('sending status', function () {
         sendingStatusFromBatches(
           email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:01:20') }),
           batches,
-        ),
+        ).sending,
         {
           status: 'failed',
           progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
@@ -170,7 +179,7 @@ describe('sending status', function () {
         sendingStatusFromBatches(
           email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:00:01') }),
           batches,
-        ),
+        ).sending,
         {
           status: 'failed',
           progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
@@ -189,7 +198,7 @@ describe('sending status', function () {
         sendingStatusFromBatches(
           email({ status: 'pending', recipientCount: 20, attemptStartedAt: at('12:05:00') }),
           batches,
-        ),
+        ).sending,
         {
           status: 'submitting',
           progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
@@ -208,7 +217,7 @@ describe('sending status', function () {
         email({ recipientCount: 30, attemptStartedAt: at('12:02:00') }),
         batches,
       );
-      assert.equal(result.progress.estimatedSecondsRemaining, null);
+      assert.equal(result.sending.progress.estimatedSecondsRemaining, null);
     });
 
     it('estimates without an attempt start when the email has never been saved', function () {
@@ -221,7 +230,7 @@ describe('sending status', function () {
         email({ recipientCount: 30, attemptStartedAt: null }),
         batches,
       );
-      assert.equal(result.progress.estimatedSecondsRemaining, 10);
+      assert.equal(result.sending.progress.estimatedSecondsRemaining, 10);
     });
 
     it('ignores batches without recipients when estimating', function () {
@@ -230,19 +239,25 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 30 }), batches).progress, {
-        completed: 10,
-        total: 30,
-        estimatedSecondsRemaining: null,
-      });
+      assert.deepEqual(
+        sendingStatusFromBatches(email({ recipientCount: 30 }), batches).sending.progress,
+        {
+          completed: 10,
+          total: 30,
+          estimatedSecondsRemaining: null,
+        },
+      );
     });
   });
 
   describe('sendingStatusForSubmittedEmail', function () {
     it('reports submitted sends as complete from their recipient count', function () {
-      assert.deepEqual(sendingStatusForSubmittedEmail(10), {
-        status: 'submitted',
-        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
+      assert.deepEqual(sendingStatusForSubmittedEmail({ id: 'email-id', recipientCount: 10 }), {
+        id: 'email-id',
+        sending: {
+          status: 'submitted',
+          progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
+        },
       });
     });
   });

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import {
+  openSending,
+  submittedSending,
+  type SendingBatch,
+  type SendingEmail,
+} from '../../../../../core/server/services/email-service/sending-status';
+
+const at = (time: string) => new Date(`2026-09-02T${time}Z`);
+
+function email({
+  status = 'submitting',
+  recipientCount,
+  attemptStartedAt = at('11:59:59'),
+}: {
+  status?: SendingEmail['status'];
+  recipientCount: number;
+  attemptStartedAt?: Date | null;
+}): SendingEmail {
+  return { status, recipientCount, attemptStartedAt };
+}
+
+function batch({
+  status,
+  createdAt,
+  updatedAt = createdAt,
+  recipientCount = 10,
+}: {
+  status: SendingBatch['status'];
+  createdAt: string;
+  updatedAt?: string;
+  recipientCount?: number;
+}): SendingBatch {
+  return { status, recipientCount, createdAt: at(createdAt), updatedAt: at(updatedAt) };
+}
+
+describe('sending status', function () {
+  describe('openSending', function () {
+    it('reports a pending email without batches as preparing', function () {
+      assert.deepEqual(openSending(email({ status: 'pending', recipientCount: 100 }), []), {
+        status: 'preparing',
+        progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
+      });
+    });
+
+    it('reports preparation progress and estimates from batch creation times', function () {
+      const batches = [
+        batch({ status: 'pending', createdAt: '12:00:00' }),
+        batch({ status: 'pending', createdAt: '12:00:10' }),
+      ];
+
+      assert.deepEqual(openSending(email({ recipientCount: 100 }), batches), {
+        status: 'preparing',
+        progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
+      });
+    });
+
+    it('grows the total when more recipients are prepared than estimated', function () {
+      const batches = [
+        batch({ status: 'pending', createdAt: '12:00:00' }),
+        batch({ status: 'pending', createdAt: '12:00:10' }),
+      ];
+
+      assert.deepEqual(openSending(email({ recipientCount: 15 }), batches).progress, {
+        completed: 20,
+        total: 20,
+        estimatedSecondsRemaining: 0,
+      });
+    });
+
+    it('excludes batches created before the current attempt from the preparing estimate', function () {
+      const batches = [
+        batch({ status: 'pending', createdAt: '12:00:00' }),
+        batch({ status: 'pending', createdAt: '12:00:10' }),
+      ];
+
+      const result = openSending(
+        email({ recipientCount: 30, attemptStartedAt: at('12:00:11') }),
+        batches,
+      );
+      assert.deepEqual(result.progress, {
+        completed: 20,
+        total: 30,
+        estimatedSecondsRemaining: null,
+      });
+    });
+
+    it('reports submission progress and estimates from submitted batch updates', function () {
+      const batches = [
+        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+        batch({ status: 'pending', createdAt: '12:00:20' }),
+      ];
+
+      assert.deepEqual(
+        openSending(email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }), batches),
+        {
+          status: 'submitting',
+          progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
+        },
+      );
+    });
+
+    it('excludes batches that failed during the current attempt from the remaining work', function () {
+      const batches = [
+        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
+        batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
+        batch({ status: 'pending', createdAt: '12:00:30' }),
+      ];
+
+      const result = openSending(
+        email({ recipientCount: 40, attemptStartedAt: at('12:00:30') }),
+        batches,
+      );
+      assert.deepEqual(result.progress, {
+        completed: 20,
+        total: 40,
+        estimatedSecondsRemaining: 10,
+      });
+    });
+
+    it('reports no remaining time once only batches that failed during the attempt are left', function () {
+      const batches = [
+        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
+        batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
+      ];
+
+      const result = openSending(
+        email({ recipientCount: 30, attemptStartedAt: at('12:00:30') }),
+        batches,
+      );
+      assert.deepEqual(result.progress, {
+        completed: 20,
+        total: 30,
+        estimatedSecondsRemaining: 0,
+      });
+    });
+
+    it('reports the phase and frozen progress for a failed send', function () {
+      const batches = [
+        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+        batch({ status: 'failed', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+      ];
+
+      assert.deepEqual(
+        openSending(
+          email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:01:20') }),
+          batches,
+        ),
+        {
+          status: 'failed',
+          progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
+          failedDuring: 'submitting',
+        },
+      );
+    });
+
+    it('reports a failure during preparation when no batch started submitting', function () {
+      const batches = [batch({ status: 'pending', createdAt: '12:00:00' })];
+
+      assert.deepEqual(
+        openSending(
+          email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:00:01') }),
+          batches,
+        ),
+        {
+          status: 'failed',
+          progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
+          failedDuring: 'preparing',
+        },
+      );
+    });
+
+    it('keeps the frozen submission progress of a retried email while it waits for its job', function () {
+      const batches = [
+        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+        batch({ status: 'failed', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+      ];
+
+      assert.deepEqual(
+        openSending(
+          email({ status: 'pending', recipientCount: 20, attemptStartedAt: at('12:05:00') }),
+          batches,
+        ),
+        {
+          status: 'submitting',
+          progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
+        },
+      );
+    });
+
+    it('excludes batches submitted before the current attempt from the submitting estimate', function () {
+      const batches = [
+        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:02:10' }),
+        batch({ status: 'pending', createdAt: '12:00:20' }),
+      ];
+
+      const result = openSending(
+        email({ recipientCount: 30, attemptStartedAt: at('12:02:00') }),
+        batches,
+      );
+      assert.equal(result.progress.estimatedSecondsRemaining, null);
+    });
+
+    it('estimates without an attempt start when the email has never been saved', function () {
+      const batches = [
+        batch({ status: 'pending', createdAt: '12:00:00' }),
+        batch({ status: 'pending', createdAt: '12:00:10' }),
+      ];
+
+      const result = openSending(email({ recipientCount: 30, attemptStartedAt: null }), batches);
+      assert.equal(result.progress.estimatedSecondsRemaining, 10);
+    });
+
+    it('ignores batches without recipients when estimating', function () {
+      const batches = [
+        batch({ status: 'pending', createdAt: '12:00:00', recipientCount: 0 }),
+        batch({ status: 'pending', createdAt: '12:00:10' }),
+      ];
+
+      assert.deepEqual(openSending(email({ recipientCount: 30 }), batches).progress, {
+        completed: 10,
+        total: 30,
+        estimatedSecondsRemaining: null,
+      });
+    });
+  });
+
+  describe('submittedSending', function () {
+    it('reports submitted sends as complete from their recipient count', function () {
+      assert.deepEqual(submittedSending(10), {
+        status: 'submitted',
+        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
+      });
+    });
+  });
+});

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {
-  sendingStatusForSubmittedEmail,
-  sendingStatusFromBatches,
+  emailSendingStatusWhenSubmitted,
+  emailSendingStatusFromBatches,
   type SendingBatch,
   type SendingEmail,
 } from '../../../../../core/server/services/email-service/sending-status';
@@ -35,10 +35,10 @@ function batch({
 }
 
 describe('sending status', function () {
-  describe('sendingStatusFromBatches', function () {
+  describe('emailSendingStatusFromBatches', function () {
     it('reports a pending email without batches as preparing', function () {
       assert.deepEqual(
-        sendingStatusFromBatches(email({ status: 'pending', recipientCount: 100 }), []),
+        emailSendingStatusFromBatches(email({ status: 'pending', recipientCount: 100 }), []),
         {
           id: 'email-id',
           sending: {
@@ -55,10 +55,13 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      assert.deepEqual(sendingStatusFromBatches(email({ recipientCount: 100 }), batches).sending, {
-        status: 'preparing',
-        progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
-      });
+      assert.deepEqual(
+        emailSendingStatusFromBatches(email({ recipientCount: 100 }), batches).sending,
+        {
+          status: 'preparing',
+          progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
+        },
+      );
     });
 
     it('grows the total when more recipients are prepared than estimated', function () {
@@ -68,7 +71,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        sendingStatusFromBatches(email({ recipientCount: 15 }), batches).sending.progress,
+        emailSendingStatusFromBatches(email({ recipientCount: 15 }), batches).sending.progress,
         {
           completed: 20,
           total: 20,
@@ -83,7 +86,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      const result = sendingStatusFromBatches(
+      const result = emailSendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: at('12:00:11') }),
         batches,
       );
@@ -102,7 +105,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        sendingStatusFromBatches(
+        emailSendingStatusFromBatches(
           email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }),
           batches,
         ),
@@ -124,7 +127,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:30' }),
       ];
 
-      const result = sendingStatusFromBatches(
+      const result = emailSendingStatusFromBatches(
         email({ recipientCount: 40, attemptStartedAt: at('12:00:30') }),
         batches,
       );
@@ -142,7 +145,7 @@ describe('sending status', function () {
         batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
       ];
 
-      const result = sendingStatusFromBatches(
+      const result = emailSendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: at('12:00:30') }),
         batches,
       );
@@ -160,7 +163,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        sendingStatusFromBatches(
+        emailSendingStatusFromBatches(
           email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:01:20') }),
           batches,
         ).sending,
@@ -176,7 +179,7 @@ describe('sending status', function () {
       const batches = [batch({ status: 'pending', createdAt: '12:00:00' })];
 
       assert.deepEqual(
-        sendingStatusFromBatches(
+        emailSendingStatusFromBatches(
           email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:00:01') }),
           batches,
         ).sending,
@@ -195,7 +198,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        sendingStatusFromBatches(
+        emailSendingStatusFromBatches(
           email({ status: 'pending', recipientCount: 20, attemptStartedAt: at('12:05:00') }),
           batches,
         ).sending,
@@ -213,7 +216,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:20' }),
       ];
 
-      const result = sendingStatusFromBatches(
+      const result = emailSendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: at('12:02:00') }),
         batches,
       );
@@ -226,7 +229,7 @@ describe('sending status', function () {
         batch({ status: 'pending', createdAt: '12:00:10' }),
       ];
 
-      const result = sendingStatusFromBatches(
+      const result = emailSendingStatusFromBatches(
         email({ recipientCount: 30, attemptStartedAt: null }),
         batches,
       );
@@ -240,7 +243,7 @@ describe('sending status', function () {
       ];
 
       assert.deepEqual(
-        sendingStatusFromBatches(email({ recipientCount: 30 }), batches).sending.progress,
+        emailSendingStatusFromBatches(email({ recipientCount: 30 }), batches).sending.progress,
         {
           completed: 10,
           total: 30,
@@ -250,9 +253,9 @@ describe('sending status', function () {
     });
   });
 
-  describe('sendingStatusForSubmittedEmail', function () {
+  describe('emailSendingStatusWhenSubmitted', function () {
     it('reports submitted sends as complete from their recipient count', function () {
-      assert.deepEqual(sendingStatusForSubmittedEmail({ id: 'email-id', recipientCount: 10 }), {
+      assert.deepEqual(emailSendingStatusWhenSubmitted({ id: 'email-id', recipientCount: 10 }), {
         id: 'email-id',
         sending: {
           status: 'submitted',

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import {
-  emailSendingStatusWhenSubmitted,
-  emailSendingStatusFromBatches,
+  buildSendingStatus,
   type SendingBatch,
   type SendingEmail,
 } from '../../../../../core/server/services/email-service/sending-status';
@@ -17,7 +16,7 @@ function email({
   recipientCount: number;
   attemptStartedAt?: Date | null;
 }): SendingEmail {
-  return { id: 'email-id', status, recipientCount, attemptStartedAt };
+  return { status, recipientCount, attemptStartedAt };
 }
 
 function batch({
@@ -34,234 +33,211 @@ function batch({
   return { status, recipientCount, createdAt: at(createdAt), updatedAt: at(updatedAt) };
 }
 
-describe('sending status', function () {
-  describe('emailSendingStatusFromBatches', function () {
-    it('reports a pending email without batches as preparing', function () {
-      assert.deepEqual(
-        emailSendingStatusFromBatches(email({ status: 'pending', recipientCount: 100 }), []),
-        {
-          id: 'email-id',
-          sending: {
-            status: 'preparing',
-            progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
-          },
-        },
-      );
-    });
-
-    it('reports preparation progress and estimates from batch creation times', function () {
-      const batches = [
-        batch({ status: 'pending', createdAt: '12:00:00' }),
-        batch({ status: 'pending', createdAt: '12:00:10' }),
-      ];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(email({ recipientCount: 100 }), batches).sending,
-        {
-          status: 'preparing',
-          progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
-        },
-      );
-    });
-
-    it('grows the total when more recipients are prepared than estimated', function () {
-      const batches = [
-        batch({ status: 'pending', createdAt: '12:00:00' }),
-        batch({ status: 'pending', createdAt: '12:00:10' }),
-      ];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(email({ recipientCount: 15 }), batches).sending.progress,
-        {
-          completed: 20,
-          total: 20,
-          estimatedSecondsRemaining: 0,
-        },
-      );
-    });
-
-    it('excludes batches created before the current attempt from the preparing estimate', function () {
-      const batches = [
-        batch({ status: 'pending', createdAt: '12:00:00' }),
-        batch({ status: 'pending', createdAt: '12:00:10' }),
-      ];
-
-      const result = emailSendingStatusFromBatches(
-        email({ recipientCount: 30, attemptStartedAt: at('12:00:11') }),
-        batches,
-      );
-      assert.deepEqual(result.sending.progress, {
-        completed: 20,
-        total: 30,
-        estimatedSecondsRemaining: null,
-      });
-    });
-
-    it('reports submission progress and estimates from submitted batch updates', function () {
-      const batches = [
-        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
-        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:20' }),
-        batch({ status: 'pending', createdAt: '12:00:20' }),
-      ];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(
-          email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }),
-          batches,
-        ),
-        {
-          id: 'email-id',
-          sending: {
-            status: 'submitting',
-            progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
-          },
-        },
-      );
-    });
-
-    it('excludes batches that failed during the current attempt from the remaining work', function () {
-      const batches = [
-        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
-        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
-        batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
-        batch({ status: 'pending', createdAt: '12:00:30' }),
-      ];
-
-      const result = emailSendingStatusFromBatches(
-        email({ recipientCount: 40, attemptStartedAt: at('12:00:30') }),
-        batches,
-      );
-      assert.deepEqual(result.sending.progress, {
-        completed: 20,
-        total: 40,
-        estimatedSecondsRemaining: 10,
-      });
-    });
-
-    it('reports no remaining time once only batches that failed during the attempt are left', function () {
-      const batches = [
-        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
-        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
-        batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
-      ];
-
-      const result = emailSendingStatusFromBatches(
-        email({ recipientCount: 30, attemptStartedAt: at('12:00:30') }),
-        batches,
-      );
-      assert.deepEqual(result.sending.progress, {
-        completed: 20,
-        total: 30,
-        estimatedSecondsRemaining: 0,
-      });
-    });
-
-    it('reports the phase and frozen progress for a failed send', function () {
-      const batches = [
-        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
-        batch({ status: 'failed', createdAt: '12:00:10', updatedAt: '12:01:20' }),
-      ];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(
-          email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:01:20') }),
-          batches,
-        ).sending,
-        {
-          status: 'failed',
-          progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
-          failedDuring: 'submitting',
-        },
-      );
-    });
-
-    it('reports a failure during preparation when no batch started submitting', function () {
-      const batches = [batch({ status: 'pending', createdAt: '12:00:00' })];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(
-          email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:00:01') }),
-          batches,
-        ).sending,
-        {
-          status: 'failed',
-          progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
-          failedDuring: 'preparing',
-        },
-      );
-    });
-
-    it('keeps the frozen submission progress of a retried email while it waits for its job', function () {
-      const batches = [
-        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
-        batch({ status: 'failed', createdAt: '12:00:10', updatedAt: '12:01:20' }),
-      ];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(
-          email({ status: 'pending', recipientCount: 20, attemptStartedAt: at('12:05:00') }),
-          batches,
-        ).sending,
-        {
-          status: 'submitting',
-          progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
-        },
-      );
-    });
-
-    it('excludes batches submitted before the current attempt from the submitting estimate', function () {
-      const batches = [
-        batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
-        batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:02:10' }),
-        batch({ status: 'pending', createdAt: '12:00:20' }),
-      ];
-
-      const result = emailSendingStatusFromBatches(
-        email({ recipientCount: 30, attemptStartedAt: at('12:02:00') }),
-        batches,
-      );
-      assert.equal(result.sending.progress.estimatedSecondsRemaining, null);
-    });
-
-    it('estimates without an attempt start when the email has never been saved', function () {
-      const batches = [
-        batch({ status: 'pending', createdAt: '12:00:00' }),
-        batch({ status: 'pending', createdAt: '12:00:10' }),
-      ];
-
-      const result = emailSendingStatusFromBatches(
-        email({ recipientCount: 30, attemptStartedAt: null }),
-        batches,
-      );
-      assert.equal(result.sending.progress.estimatedSecondsRemaining, 10);
-    });
-
-    it('ignores batches without recipients when estimating', function () {
-      const batches = [
-        batch({ status: 'pending', createdAt: '12:00:00', recipientCount: 0 }),
-        batch({ status: 'pending', createdAt: '12:00:10' }),
-      ];
-
-      assert.deepEqual(
-        emailSendingStatusFromBatches(email({ recipientCount: 30 }), batches).sending.progress,
-        {
-          completed: 10,
-          total: 30,
-          estimatedSecondsRemaining: null,
-        },
-      );
+describe('buildSendingStatus', function () {
+  it('reports a pending email without batches as preparing', function () {
+    assert.deepEqual(buildSendingStatus(email({ status: 'pending', recipientCount: 100 }), []), {
+      status: 'preparing',
+      progress: { completed: 0, total: 100, estimatedSecondsRemaining: null },
     });
   });
 
-  describe('emailSendingStatusWhenSubmitted', function () {
-    it('reports submitted sends as complete from their recipient count', function () {
-      assert.deepEqual(emailSendingStatusWhenSubmitted({ id: 'email-id', recipientCount: 10 }), {
-        id: 'email-id',
-        sending: {
-          status: 'submitted',
-          progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
-        },
-      });
+  it('reports preparation progress and estimates from batch creation times', function () {
+    const batches = [
+      batch({ status: 'pending', createdAt: '12:00:00' }),
+      batch({ status: 'pending', createdAt: '12:00:10' }),
+    ];
+
+    assert.deepEqual(buildSendingStatus(email({ recipientCount: 100 }), batches), {
+      status: 'preparing',
+      progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
     });
+  });
+
+  it('grows the total when more recipients are prepared than estimated', function () {
+    const batches = [
+      batch({ status: 'pending', createdAt: '12:00:00' }),
+      batch({ status: 'pending', createdAt: '12:00:10' }),
+    ];
+
+    assert.deepEqual(buildSendingStatus(email({ recipientCount: 15 }), batches).progress, {
+      completed: 20,
+      total: 20,
+      estimatedSecondsRemaining: 0,
+    });
+  });
+
+  it('excludes batches created before the current attempt from the preparing estimate', function () {
+    const batches = [
+      batch({ status: 'pending', createdAt: '12:00:00' }),
+      batch({ status: 'pending', createdAt: '12:00:10' }),
+    ];
+
+    const result = buildSendingStatus(
+      email({ recipientCount: 30, attemptStartedAt: at('12:00:11') }),
+      batches,
+    );
+    assert.deepEqual(result.progress, {
+      completed: 20,
+      total: 30,
+      estimatedSecondsRemaining: null,
+    });
+  });
+
+  it('reports submission progress and estimates from submitted batch updates', function () {
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+      batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+      batch({ status: 'pending', createdAt: '12:00:20' }),
+    ];
+
+    assert.deepEqual(
+      buildSendingStatus(email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }), batches),
+      {
+        status: 'submitting',
+        progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
+      },
+    );
+  });
+
+  it('excludes batches that failed during the current attempt from the remaining work', function () {
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+      batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
+      batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
+      batch({ status: 'pending', createdAt: '12:00:30' }),
+    ];
+
+    const result = buildSendingStatus(
+      email({ recipientCount: 40, attemptStartedAt: at('12:00:30') }),
+      batches,
+    );
+    assert.deepEqual(result.progress, {
+      completed: 20,
+      total: 40,
+      estimatedSecondsRemaining: 10,
+    });
+  });
+
+  it('reports no remaining time once only batches that failed during the attempt are left', function () {
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+      batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
+      batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
+    ];
+
+    const result = buildSendingStatus(
+      email({ recipientCount: 30, attemptStartedAt: at('12:00:30') }),
+      batches,
+    );
+    assert.deepEqual(result.progress, {
+      completed: 20,
+      total: 30,
+      estimatedSecondsRemaining: 0,
+    });
+  });
+
+  it('reports the phase and frozen progress for a failed send', function () {
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+      batch({ status: 'failed', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+    ];
+
+    assert.deepEqual(
+      buildSendingStatus(
+        email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:01:20') }),
+        batches,
+      ),
+      {
+        status: 'failed',
+        progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
+        failedDuring: 'submitting',
+      },
+    );
+  });
+
+  it('reports a failure during preparation when no batch started submitting', function () {
+    const batches = [batch({ status: 'pending', createdAt: '12:00:00' })];
+
+    assert.deepEqual(
+      buildSendingStatus(
+        email({ status: 'failed', recipientCount: 20, attemptStartedAt: at('12:00:01') }),
+        batches,
+      ),
+      {
+        status: 'failed',
+        progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
+        failedDuring: 'preparing',
+      },
+    );
+  });
+
+  it('keeps the frozen submission progress of a retried email while it waits for its job', function () {
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+      batch({ status: 'failed', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+    ];
+
+    assert.deepEqual(
+      buildSendingStatus(
+        email({ status: 'pending', recipientCount: 20, attemptStartedAt: at('12:05:00') }),
+        batches,
+      ),
+      {
+        status: 'submitting',
+        progress: { completed: 10, total: 20, estimatedSecondsRemaining: null },
+      },
+    );
+  });
+
+  it('excludes batches submitted before the current attempt from the submitting estimate', function () {
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+      batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:02:10' }),
+      batch({ status: 'pending', createdAt: '12:00:20' }),
+    ];
+
+    const result = buildSendingStatus(
+      email({ recipientCount: 30, attemptStartedAt: at('12:02:00') }),
+      batches,
+    );
+    assert.equal(result.progress.estimatedSecondsRemaining, null);
+  });
+
+  it('estimates without an attempt start when the email has never been saved', function () {
+    const batches = [
+      batch({ status: 'pending', createdAt: '12:00:00' }),
+      batch({ status: 'pending', createdAt: '12:00:10' }),
+    ];
+
+    const result = buildSendingStatus(
+      email({ recipientCount: 30, attemptStartedAt: null }),
+      batches,
+    );
+    assert.equal(result.progress.estimatedSecondsRemaining, 10);
+  });
+
+  it('ignores batches without recipients when estimating', function () {
+    const batches = [
+      batch({ status: 'pending', createdAt: '12:00:00', recipientCount: 0 }),
+      batch({ status: 'pending', createdAt: '12:00:10' }),
+    ];
+
+    assert.deepEqual(buildSendingStatus(email({ recipientCount: 30 }), batches).progress, {
+      completed: 10,
+      total: 30,
+      estimatedSecondsRemaining: null,
+    });
+  });
+
+  it('answers a submitted email from its recipient count without the batches', function () {
+    const batches = [batch({ status: 'submitted', createdAt: '12:00:00', recipientCount: 4 })];
+
+    assert.deepEqual(
+      buildSendingStatus(email({ status: 'submitted', recipientCount: 10 }), batches),
+      {
+        status: 'submitted',
+        progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
+      },
+    );
   });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3920/

## What changed

Adds `GET /ghost/api/admin/emails/:id/status` so Admin can poll newsletter email preparation and provider submission progress independently from the email resource.

The response exposes:

- sending status: `preparing`, `submitting`, `submitted`, or `failed`
- completed and total recipient counts
- a rough estimated number of seconds remaining
- the phase in which a failed send stopped

## Implementation

The endpoint is gate-free so Admin can feature-detect and selectively enable the UI. A dedicated sending status service derives progress and ETA from existing email, batch, and recipient data using Knex, avoiding schema changes for this initial proof of concept.