### PR TITLE
Added a host limit that can switch custom member fields off per site

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -74,6 +74,10 @@ export type Config = {
         disabled: boolean;
         error?: string;
       };
+      limitCustomFields?: {
+        disabled: boolean;
+        error?: string;
+      };
       publicSiteAccess?: {
         disabled: boolean;
         // Copy shown in the pre-launch banner when public site access is disabled.

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -54,6 +54,7 @@ import { memberCustomFieldCsvColumns } from '@tryghost/admin-x-framework/api/mem
 import { useCustomFieldDefinitions } from '@/shared/member-custom-fields/use-definitions';
 import { parseCSV } from '@/members/components/bulk-action-modals/import-members/csv';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useLabelPicker } from '@/members/hooks/use-label-picker';
 
@@ -75,7 +76,7 @@ export function ImportMembersModal({
   const { mutateAsync: importMembers } = useImportMembers();
   const importMemberTier = useFeatureFlag('importMemberTier');
 
-  const canCreateCustomFields = useFeatureFlag('membersCustomFields');
+  const canCreateCustomFields = useCustomFieldsAvailable();
   const { data: customFieldsData, isError: customFieldsFailed } = useCustomFieldDefinitions();
   // A field created from the mapping step is in here the moment it is created: the create
   // mutation puts it into the cached list, so there is no window where a row points at a

--- a/apps/admin/src/settings/layout/sidebar.tsx
+++ b/apps/admin/src/settings/layout/sidebar.tsx
@@ -31,6 +31,7 @@ import { searchKeywords as growthSearchKeywords } from '@/settings/growth/search
 import { searchKeywords as membershipSearchKeywords } from '@/settings/membership/search-keywords';
 import { searchKeywords as siteSearchKeywords } from '@/settings/site/search-keywords';
 
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useGlobalData } from '@/settings/providers/global-data-context';
 import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
@@ -124,7 +125,7 @@ const Sidebar: React.FC = () => {
   const paidMembersEnabled = usePaidMembersEnabled();
   const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
   const hasAutomations = useFeatureFlag('automations');
-  const hasCustomFields = useFeatureFlag('membersCustomFields');
+  const hasCustomFields = useCustomFieldsAvailable();
   const hasNewslettersEnabled = useNewslettersEnabled() === true;
   const mailgunIsConfigured = Boolean(config.mailgunIsConfigured);
   const hasMailgun = hasNewslettersEnabled && !mailgunIsConfigured;

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
+  configResponse,
   fakeAdminEndpoint,
   fakeMemberCustomFields,
   fakeSettingsScreens,
@@ -63,6 +64,42 @@ describe('Custom fields', () => {
 
     await expect(settingsScreen.customFields()).toHaveCount(0);
     expect(customFieldsApi.requests).toHaveLength(0);
+  });
+
+  // A host can switch custom fields off for a site separately from the flag, so the
+  // feature can be sold with a plan. Settings is where a publisher would go to set fields
+  // up, so a limited site is offered nothing to set up. Reading definitions stays open on
+  // the server, so this is the check that stops a limited site being shown a section whose
+  // every save would come back refused.
+  it('stays hidden when the host limit disables the feature', async () => {
+    fakeSettingsScreens();
+    const customFieldsApi = fakeCustomFields();
+    const config = configResponse({ labs: { membersCustomFields: true } });
+    config.config.hostSettings = {
+      limits: { limitCustomFields: { disabled: true } },
+    };
+    await renderAdminApp('/settings', {
+      ...flagOn,
+      boot: { browseConfig: { response: config } },
+    });
+
+    await expect(settingsScreen.customFields()).toHaveCount(0);
+    expect(customFieldsApi.requests).toHaveLength(0);
+  });
+
+  it('stays visible when the host sets the limit but leaves it enabled', async () => {
+    fakeSettingsScreens();
+    fakeCustomFields();
+    const config = configResponse({ labs: { membersCustomFields: true } });
+    config.config.hostSettings = {
+      limits: { limitCustomFields: { disabled: false } },
+    };
+    await renderAdminApp('/settings', {
+      ...flagOn,
+      boot: { browseConfig: { response: config } },
+    });
+
+    await expect.element(settingsScreen.customFields()).toBeVisible();
   });
 
   it('lists each field with its user-facing type, opting into archived fields', async () => {

--- a/apps/admin/src/settings/membership/custom-fields.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.tsx
@@ -28,7 +28,8 @@ import {
   useReorderMemberCustomFields,
   userTypeForField,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
-import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { useQueryClient } from '@tryghost/admin-x-framework';
 import { withErrorBoundary } from '@/settings/components/with-error-boundary';
 import type { MemberCustomField } from '@tryghost/admin-x-framework/api/member-custom-fields';
@@ -182,11 +183,11 @@ const FieldList: React.FC<{
 };
 
 const CustomFields: React.FC<{ keywords: string[] }> = ({ keywords }) => {
-  // The endpoint is closed (404s) while the flag is off, so keep the query in
-  // step with the flag rather than firing it into a wall. Settings is the one
-  // place that manages archived fields too, so it uses the include-archived
+  // Nothing to fetch when the site cannot use custom fields at all, so keep the
+  // query in step with availability rather than firing it into a wall. Settings is
+  // the one place that manages archived fields too, so it uses the include-archived
   // variant rather than the default active-only browse.
-  const hasCustomFields = useFeatureFlag('membersCustomFields');
+  const hasCustomFields = useCustomFieldsAvailable();
   const { data } = useBrowseMemberCustomFieldsIncludingArchived({
     enabled: hasCustomFields,
   });

--- a/apps/admin/src/settings/membership/membership-settings.tsx
+++ b/apps/admin/src/settings/membership/membership-settings.tsx
@@ -14,6 +14,7 @@ import {
   usePaidMembersEnabled,
 } from '@tryghost/admin-x-framework/api/settings';
 import { searchKeywords } from './search-keywords';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useGlobalData } from '@/settings/providers/global-data-context';
 
@@ -23,7 +24,7 @@ const MembershipSettings: React.FC = () => {
   const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
   const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
   const hasAutomations = useFeatureFlag('automations');
-  const hasCustomFields = useFeatureFlag('membersCustomFields');
+  const hasCustomFields = useCustomFieldsAvailable();
   const visibleSearchKeywords = [
     searchKeywords.access,
     searchKeywords.tiers,

--- a/apps/admin/src/settings/membership/tiers/tier-checkout-collection.tsx
+++ b/apps/admin/src/settings/membership/tiers/tier-checkout-collection.tsx
@@ -30,11 +30,8 @@ import {
   type StripePort,
 } from '@tryghost/checkout';
 import { JSONError, getErrorMessage } from '@tryghost/admin-x-framework/errors';
-import {
-  type ErrorMessages,
-  useFeatureFlag,
-  useHandleError,
-} from '@tryghost/admin-x-framework/hooks';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
+import { type ErrorMessages, useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { Text } from '@tryghost/shade/primitives';
 import {
   type MemberCustomField,
@@ -297,7 +294,7 @@ const TierCheckoutCollection = forwardRef<
   const { mutateAsync: editCheckoutConfig } = useEditTierCheckoutConfig();
   const handleError = useHandleError();
 
-  const canManageFields = useFeatureFlag('membersCustomFields');
+  const canManageFields = useCustomFieldsAvailable();
   const { data: fieldsData } = useBrowseMemberCustomFields({ enabled: canManageFields });
   const allFields = fieldsData ?? [];
   // What each collected value may be kept in is the server's rule, so it is read from the

--- a/apps/admin/src/shared/member-custom-fields/use-availability.ts
+++ b/apps/admin/src/shared/member-custom-fields/use-availability.ts
@@ -1,0 +1,24 @@
+import { useFeatureFlag, useHostLimits } from '@tryghost/admin-x-framework/hooks';
+
+/**
+ * Whether this site may use custom member fields.
+ *
+ * Two separate things can withhold them, and one place answers for both, so a screen
+ * cannot be left checking one and forgetting the other. The labs flag says whether this
+ * build of Ghost offers the feature at all; the host limit says whether this site's plan
+ * includes it. When the flag goes at GA only this function changes.
+ *
+ * The limit is unset on every self-hosted site and on any plan that includes the feature,
+ * which is every site today.
+ *
+ * A boolean because that is all any screen needs so far. The server does distinguish the
+ * two refusals, answering "not found" for the flag and "forbidden" for the limit, so a
+ * screen that offers an upgrade will want to know which applies. Nothing offers one yet,
+ * so the reason is not reported until something reads it.
+ */
+export const useCustomFieldsAvailable = (): boolean => {
+  const hasFlag = useFeatureFlag('membersCustomFields');
+  const limit = useHostLimits()?.limitCustomFields;
+
+  return hasFlag && limit?.disabled !== true;
+};

--- a/ghost/core/core/server/services/limits.js
+++ b/ghost/core/core/server/services/limits.js
@@ -1,3 +1,4 @@
+const camelCase = require('lodash/camelCase');
 const errors = require('@tryghost/errors');
 const config = require('../../shared/config');
 const db = require('../data/db');
@@ -47,6 +48,90 @@ const init = () => {
   }
 };
 
+/**
+ * Read a flag limit straight from host config, in the same `{disabled, error}` shape a
+ * FlagLimit is configured with.
+ *
+ * The limit service only recognises limit names present in the published
+ * `@tryghost/limit-service` allowlist, so a name it does not know is dropped when limits
+ * load and every check on it silently passes. Reading config directly keeps a new flag
+ * limit switchable by host config alone. The name is matched the way the limit service
+ * matches it, so config written for one path is read the same way by the other, and these
+ * helpers can delegate to it once the name ships in the package.
+ *
+ * @param {string} limitName
+ * @returns {{disabled?: boolean, error?: string}|undefined}
+ */
+const featureLimit = (limitName) => {
+  const configured = config.get('hostSettings:limits') || {};
+
+  // The limit service camelCases every configured name before matching it, so
+  // `limit_custom_fields` and `limit-custom-fields` reach the same limit there. Matching
+  // the same way keeps a host that writes either spelling from silently going ungated.
+  const match = Object.keys(configured).find((name) => camelCase(name) === camelCase(limitName));
+  const limit = match === undefined ? undefined : configured[match];
+
+  if (!limit || typeof limit !== 'object' || Array.isArray(limit)) {
+    return undefined;
+  }
+
+  return limit;
+};
+
+/**
+ * Whether host config turns this feature off. False everywhere the limit is unset, which
+ * is every self-hosted site and every plan the limit does not apply to.
+ *
+ * Truthiness rather than a strict `true`, because that is what the limit service tests,
+ * and a host that writes the string "true" means the same thing by it.
+ *
+ * @param {string} limitName
+ * @returns {boolean}
+ */
+const isFeatureDisabled = (limitName) => {
+  return Boolean(featureLimit(limitName)?.disabled);
+};
+
+/**
+ * The error a withheld feature is refused with: 403, carrying the host's own copy and its
+ * upgrade link, so a caller can tell "your plan does not include this" apart from the 404
+ * a labs flag gives for "this does not exist here".
+ *
+ * Shaped the way the limit service shapes its own errors, so a client reading one does not
+ * have to tell the two apart, and so moving onto the package later changes nothing a
+ * caller sees.
+ *
+ * @param {string} limitName
+ */
+const featureDisabledError = (limitName) => {
+  const helpLink =
+    config.get('hostSettings:billing:enabled') === true && config.get('hostSettings:billing:url')
+      ? config.get('hostSettings:billing:url')
+      : 'https://ghost.org/help/';
+
+  return new errors.HostLimitError({
+    message: featureLimit(limitName)?.error || 'Your plan does not support this feature.',
+    errorDetails: { name: limitName },
+    help: helpLink,
+  });
+};
+
+/**
+ * Route guard for a feature the host can switch off.
+ *
+ * @param {string} limitName
+ * @returns {import('express').RequestHandler}
+ */
+const requireFeature = (limitName) =>
+  function requireFeatureMw(req, res, next) {
+    if (!isFeatureDisabled(limitName)) {
+      return next();
+    }
+
+    return next(featureDisabledError(limitName));
+  };
+
 module.exports = limitService;
 
 module.exports.init = init;
+module.exports.requireFeature = requireFeature;

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -5,6 +5,7 @@ const auth = require('../../../../services/auth');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
 const labs = require('../../../../../shared/labs');
+const limits = require('../../../../services/limits');
 
 const shared = require('../../../shared');
 
@@ -197,19 +198,22 @@ module.exports = function apiRoutes() {
 
   // Reading definitions is deliberately not behind the feature flag: Admin asks every site
   // for them, and a site without the flag simply has none, so the answer is an empty list
-  // rather than a 404. Creating and changing them is flagged. Registered before /members/:id
-  // so the literal path is not captured as an id.
+  // rather than a 404. Creating and changing them is flagged, and separately gated on the
+  // host limit so a site whose plan drops keeps reading the fields it already has.
+  // Registered before /members/:id so the literal path is not captured as an id.
   router.get('/members/metafields/:namespace', mw.authAdminApi, http(api.membersMetafields.browse));
   router.post(
     '/members/metafields/:namespace',
     mw.authAdminApi,
     labs.enabledMiddleware('membersCustomFields'),
+    limits.requireFeature('limitCustomFields'),
     http(api.membersMetafields.add),
   );
   router.put(
     '/members/metafields/:namespace',
     mw.authAdminApi,
     labs.enabledMiddleware('membersCustomFields'),
+    limits.requireFeature('limitCustomFields'),
     http(api.membersMetafields.reorder),
   );
   router.get(
@@ -221,12 +225,14 @@ module.exports = function apiRoutes() {
     '/members/metafields/:namespace/:key',
     mw.authAdminApi,
     labs.enabledMiddleware('membersCustomFields'),
+    limits.requireFeature('limitCustomFields'),
     http(api.membersMetafields.edit),
   );
   router.delete(
     '/members/metafields/:namespace/:key',
     mw.authAdminApi,
     labs.enabledMiddleware('membersCustomFields'),
+    limits.requireFeature('limitCustomFields'),
     http(api.membersMetafields.destroy),
   );
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -196,45 +196,38 @@ module.exports = function apiRoutes() {
 
   router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
 
-  // Reading definitions is deliberately not behind the feature flag: Admin asks every site
-  // for them, and a site without the flag simply has none, so the answer is an empty list
-  // rather than a 404. Creating and changing them is flagged, and separately gated on the
-  // host limit so a site whose plan drops keeps reading the fields it already has.
-  // Registered before /members/:id so the literal path is not captured as an id.
-  router.get('/members/metafields/:namespace', mw.authAdminApi, http(api.membersMetafields.browse));
-  router.post(
-    '/members/metafields/:namespace',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    limits.requireFeature('limitCustomFields'),
-    http(api.membersMetafields.add),
-  );
-  router.put(
-    '/members/metafields/:namespace',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    limits.requireFeature('limitCustomFields'),
-    http(api.membersMetafields.reorder),
-  );
-  router.get(
-    '/members/metafields/:namespace/:key',
-    mw.authAdminApi,
-    http(api.membersMetafields.read),
-  );
-  router.put(
-    '/members/metafields/:namespace/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    limits.requireFeature('limitCustomFields'),
-    http(api.membersMetafields.edit),
-  );
-  router.delete(
-    '/members/metafields/:namespace/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    limits.requireFeature('limitCustomFields'),
-    http(api.membersMetafields.destroy),
-  );
+  // Custom field definitions. Mounted rather than listed so every route under it is
+  // reached the same way, and so the guards are stated once each instead of on every
+  // route that needs them.
+  //
+  // Order carries the rule here, the way Express reads it: a request walks this stack
+  // from the top, so the reads below are answered before the guards are reached, and
+  // everything registered after them passes through both. A route added at the end is
+  // guarded by being there, which is the safer way round to forget.
+  //
+  // Mounted before /members/:id so the literal path is not captured as an id.
+  const metafieldsRouter = express.Router('admin api members metafields');
+  router.use('/members/metafields', metafieldsRouter);
+
+  metafieldsRouter.use(mw.authAdminApi);
+
+  // Reading is deliberately open: Admin asks every site for its definitions to draw
+  // screens it renders either way, and a site that has none simply answers with an empty
+  // list rather than a 404.
+  metafieldsRouter.get('/:namespace', http(api.membersMetafields.browse));
+  metafieldsRouter.get('/:namespace/:key', http(api.membersMetafields.read));
+
+  // Changing one needs the feature to exist in this build and the site's plan to include
+  // it. Two separate questions, asked once each: a 404 says the feature is not here, a 403
+  // says the plan does not cover it, and only the second is something a publisher can act
+  // on.
+  metafieldsRouter.use(labs.enabledMiddleware('membersCustomFields'));
+  metafieldsRouter.use(limits.requireFeature('limitCustomFields'));
+
+  metafieldsRouter.post('/:namespace', http(api.membersMetafields.add));
+  metafieldsRouter.put('/:namespace', http(api.membersMetafields.reorder));
+  metafieldsRouter.put('/:namespace/:key', http(api.membersMetafields.edit));
+  metafieldsRouter.delete('/:namespace/:key', http(api.membersMetafields.destroy));
 
   router.get('/members/:id', mw.authAdminApi, http(api.members.read));
   router.put('/members/:id', mw.authAdminApi, http(api.members.edit));

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -2311,4 +2311,157 @@ describe('Member Custom Fields Admin API', function () {
       await agent.delete('members/metafields/custom/company/').expectStatus(404);
     });
   });
+
+  // Custom fields can be switched off for a site by its host, separately from the flag,
+  // so the feature can be sold with a plan. The limit is unset everywhere today, which is
+  // what the first test pins: nothing changes for a site nobody has limited. When it is
+  // set, changing definitions answers 403 with the host's copy, distinct from the 404 the
+  // flag gives, because "your plan does not include this" is a different thing to tell a
+  // caller than "this does not exist here". Reading stays open either way, so a site whose
+  // plan drops can still see and export the fields it already has.
+  describe('Host limit', function () {
+    afterEach(async function () {
+      await configUtils.restore();
+    });
+
+    it('leaves every route alone when the limit is unset', async function () {
+      const field = await createField({ name: 'Unlimited' });
+
+      await agent.get('members/metafields/custom/').expectStatus(200);
+      await agent
+        .put(`members/metafields/custom/${field.key}/`)
+        .body({ members_metafields: [{ name: 'Still unlimited' }] })
+        .expectStatus(200);
+      // Deleting is only offered on an archived field, so archiving is the step
+      // that proves the edit route is open, and the delete that follows it too.
+      await setStatus(field.key, 'archived');
+      await agent.delete(`members/metafields/custom/${field.key}/`).expectStatus(204);
+    });
+
+    it('leaves every route alone when the limit is present but not disabled', async function () {
+      configUtils.set('hostSettings:limits:limitCustomFields', { disabled: false });
+
+      const field = await createField({ name: 'Permitted' });
+      await setStatus(field.key, 'archived');
+      await agent.delete(`members/metafields/custom/${field.key}/`).expectStatus(204);
+    });
+
+    describe('when the host disables the feature', function () {
+      let existingKey: string;
+
+      beforeEach(async function () {
+        // Created before the limit goes on, standing in for a site that had the feature
+        // and then dropped below the plan that includes it.
+        existingKey = (await createField({ name: 'Bought earlier' })).key;
+        configUtils.set('hostSettings:limits:limitCustomFields', {
+          disabled: true,
+          error: 'Custom fields are available on the Publisher plan and above.',
+        });
+      });
+
+      it('still lists the fields the site already has', async function () {
+        const { body } = await agent.get('members/metafields/custom/').expectStatus(200);
+        assert.equal(
+          body.members_metafields.some((field: { key: string }) => field.key === existingKey),
+          true,
+        );
+      });
+
+      it('still reads a single field', async function () {
+        await agent.get(`members/metafields/custom/${existingKey}/`).expectStatus(200);
+      });
+
+      it('403s the create endpoint, with the host copy', async function () {
+        const { body } = await agent
+          .post('members/metafields/custom/')
+          .body({ members_metafields: [{ name: 'Company', type: 'short_text' }] })
+          .expectStatus(403);
+
+        assert.equal(
+          body.errors[0].message,
+          'Custom fields are available on the Publisher plan and above.',
+        );
+      });
+
+      it('403s the reorder endpoint', async function () {
+        await agent
+          .put('members/metafields/custom/')
+          .body({ members_metafields: [{ key: existingKey }] })
+          .expectStatus(403);
+      });
+
+      it('403s the edit endpoint', async function () {
+        await agent
+          .put(`members/metafields/custom/${existingKey}/`)
+          .body({ members_metafields: [{ name: 'Employer' }] })
+          .expectStatus(403);
+      });
+
+      it('403s the delete endpoint', async function () {
+        await agent.delete(`members/metafields/custom/${existingKey}/`).expectStatus(403);
+      });
+
+      // Turning checkout collection on makes the field the collected value lands in, so
+      // this route creates definitions without going near the routes above. That is
+      // deliberate and stays allowed: the publisher is not managing custom fields here,
+      // they are turning on shipping, and the field is the machinery that serves it.
+      //
+      // What makes it safe is the packaging, not anything enforced along the way. Only one
+      // plan limit is involved at all: limitStripeConnect, which withholds Stripe, without
+      // which there is nothing to charge for and so no reason to have a paid tier. Admin
+      // then offers a checkout configuration only on a paid tier. The plan that includes
+      // Stripe is the plan that will include custom fields, so a site that reaches here is
+      // entitled to what it provisions.
+      //
+      // That chain holds by coincidence of pricing, and only its first link is enforced.
+      // The last one is a convention of the interface: this route accepts a free tier, and
+      // checks neither the tier's type nor whether Stripe is connected. Nor does the
+      // stripeCheckoutCollection flag stand in for any of it, being a rollout switch with
+      // no view on what a site pays for.
+      //
+      // So this pins a decision, not a mechanism. If checkout collection is ever sold
+      // apart from custom fields, this route needs a limit of its own rather than
+      // borrowing this one, because what it governs is what a checkout may collect.
+      it('still provisions the field a checkout collection needs', async function () {
+        const { body: tiers } = await agent
+          .get('tiers/?limit=1&filter=type:paid')
+          .expectStatus(200);
+
+        await agent
+          .put(`tiers/${tiers.tiers[0].id}/checkout_config/`)
+          .body({
+            tiers_checkout_config: [
+              {
+                shipping: {
+                  collect: true,
+                  allowed_countries: ['GB'],
+                  name: { custom_field_key: 'shipping_name' },
+                  address: { custom_field_key: 'shipping_address' },
+                },
+              },
+            ],
+          })
+          .expectStatus(200);
+
+        const { body } = await agent.get('members/metafields/custom/').expectStatus(200);
+        assert.equal(
+          body.members_metafields.some(
+            (field: { key: string }) => field.key === 'shipping_address',
+          ),
+          true,
+        );
+      });
+
+      it('falls back to generic copy when the host sets no message', async function () {
+        configUtils.set('hostSettings:limits:limitCustomFields', { disabled: true });
+
+        const { body } = await agent
+          .post('members/metafields/custom/')
+          .body({ members_metafields: [{ name: 'Company', type: 'short_text' }] })
+          .expectStatus(403);
+
+        assert.equal(body.errors[0].message, 'Your plan does not support this feature.');
+      });
+    });
+  });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3797/gate-custom-member-fields-to-the-publisher-tier-and-above

## Problem

Ghost's hosted service sells several plans. Custom member fields, which let a publisher add their own questions to a member's record, is meant to be included in the more expensive plans and withheld from the cheaper ones.

Ghost cannot currently express that. The only switch that hides this feature is the private flag used while it is being built, and that flag answers a different question: whether a given version of Ghost carries the feature at all. Its answer is the same for every site running that version, so it cannot allow the feature on one site and withhold it from another. Until something can make that distinction, the feature cannot be sold as part of a plan.

## Solution

A second switch, held separately from the flag, that the hosting service sets for one site at a time.

No site has it set, so nothing changes for anyone when this lands. Once the pricing decision is made, applying it is a change to the hosting service's own settings, as is revising it later. Ghost itself does not have to change again.

Where the switch is on, a publisher cannot add a custom field or alter an existing one, and Admin stops offering to. Fields the site already has remain fully usable: still visible on member records, still available to search and export by. A publisher who moves to a cheaper plan therefore keeps everything they have already collected.

A request refused for this reason says that the plan does not cover the feature, rather than that the feature does not exist. Only the first of those is something a publisher can act on. The refusal also repeats whatever wording the hosting service supplies, so it can name the plan and point the publisher somewhere useful.

## One decision worth a second opinion

Every other per-site limit is read through a shared library, and this one is not.

That library only recognises limit names published in its own releases, and quietly ignores any it does not know. Reading through it would therefore leave the new switch doing nothing, with no error to explain why, until a release of that library carries the name. Reading the setting directly makes the switch work now. It can move onto the library later without the hosting service having to change anything it sets.

## Not included

A publisher on a plan without custom member fields is shown nothing in place of them. What they should see instead, and whether to invite them to upgrade, is a design question rather than a technical one. The same decision was made once already for traffic analytics ([NY-144](https://linear.app/ghost/issue/NY-144)) and that work is the natural precedent to follow.
