### PR TITLE
Added a slug generation hook to the admin framework

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -79,6 +79,7 @@
     "@tryghost/limit-service": "catalog:",
     "@tryghost/nql-string": "workspace:*",
     "@tryghost/shade": "workspace:*",
+    "@tryghost/string": "catalog:",
     "bson-objectid": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/admin-x-framework/src/api/slugs.ts
+++ b/apps/admin-x-framework/src/api/slugs.ts
@@ -1,0 +1,35 @@
+import { slugify } from '@tryghost/string';
+import { useCallback } from 'react';
+import { apiUrl, useFetchApi } from '../utils/api/fetch-api';
+
+export interface SlugsResponseType {
+  slugs: Array<{ slug: string }>;
+}
+
+export interface GenerateSlugParams {
+  /** Pages share the posts table, so they dedupe under `post` */
+  type: 'post' | 'tag' | 'user';
+  text: string;
+  /** The record being edited, so its own current slug is not counted as a collision */
+  id?: string;
+}
+
+export const useGenerateSlug = () => {
+  const fetchApi = useFetchApi();
+
+  return useCallback(
+    async ({ type, text, id }: GenerateSlugParams): Promise<string> => {
+      if (!text) {
+        return '';
+      }
+
+      // Slugified client-side first: raw reserved characters in the path (a newline as %0A) 404 at the CDN before reaching Ghost
+      const name = encodeURIComponent(slugify(text));
+      const path = id ? `/slugs/${type}/${name}/${id}/` : `/slugs/${type}/${name}/`;
+      const data = await fetchApi<SlugsResponseType>(apiUrl(path));
+
+      return data.slugs[0].slug;
+    },
+    [fetchApi],
+  );
+};

--- a/apps/admin-x-framework/src/string.d.ts
+++ b/apps/admin-x-framework/src/string.d.ts
@@ -1,0 +1,3 @@
+declare module '@tryghost/string' {
+  export function slugify(string: string, options?: { requiredChangesOnly?: boolean }): string;
+}

--- a/apps/admin-x-framework/test/unit/api/slugs.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/slugs.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '../../../src/test/test-utils';
+import { useGenerateSlug } from '../../../src/api/slugs';
+import { withMockFetch } from '../../utils/mock-fetch';
+
+const slugResponse = {
+  json: { slugs: [{ slug: 'hello-world-cafe-quotes-1-100-2' }] },
+  headers: { 'content-type': 'application/json' },
+};
+
+describe('slugs api', () => {
+  it('slugifies and encodes the text client-side, then returns the deduplicated server slug', async () => {
+    await withMockFetch(slugResponse, async (mock) => {
+      const { result } = renderHookWithProviders(() => useGenerateSlug());
+
+      const slug = await result.current({
+        type: 'post',
+        text: 'Hello World! Café & "Quotes" #1 / 100%',
+      });
+
+      expect(mock.calls[0][0]).toBe(
+        'http://localhost:3000/ghost/api/admin/slugs/post/hello-world-cafe-quotes-1-100/',
+      );
+      expect(mock.calls[0][1].method).toBe('GET');
+      expect(slug).toBe('hello-world-cafe-quotes-1-100-2');
+    });
+  });
+
+  it('strips characters that would otherwise be sent as raw path escapes', async () => {
+    await withMockFetch(slugResponse, async (mock) => {
+      const { result } = renderHookWithProviders(() => useGenerateSlug());
+
+      await result.current({ type: 'post', text: 'Line one\nLine two' });
+      await result.current({ type: 'post', text: '  Ünïcode — dash… 50% off?  ' });
+
+      expect(mock.calls[0][0]).toBe(
+        'http://localhost:3000/ghost/api/admin/slugs/post/line-oneline-two/',
+      );
+      expect(mock.calls[1][0]).toBe(
+        'http://localhost:3000/ghost/api/admin/slugs/post/unicode-dash-50-off/',
+      );
+    });
+  });
+
+  it('appends the record id so its own slug is not counted as a collision', async () => {
+    await withMockFetch(slugResponse, async (mock) => {
+      const { result } = renderHookWithProviders(() => useGenerateSlug());
+
+      await result.current({ type: 'post', text: 'Hello world', id: '64f1c0ffee0000000000abcd' });
+
+      expect(mock.calls[0][0]).toBe(
+        'http://localhost:3000/ghost/api/admin/slugs/post/hello-world/64f1c0ffee0000000000abcd/',
+      );
+    });
+  });
+
+  it('resolves an empty slug for empty text without calling the API', async () => {
+    await withMockFetch(slugResponse, async (mock) => {
+      const { result } = renderHookWithProviders(() => useGenerateSlug());
+
+      await expect(result.current({ type: 'post', text: '' })).resolves.toBe('');
+
+      expect(mock.calls).toHaveLength(0);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1136,6 +1136,9 @@ importers:
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade
+      '@tryghost/string':
+        specifier: 'catalog:'
+        version: 0.3.5
       bson-objectid:
         specifier: 'catalog:'
         version: 2.0.4


### PR DESCRIPTION
no ref

The React post editor needs to ask the server for a deduplicated slug when the title or slug changes. Ember does this through its `slug-generator` service; the framework had no equivalent.

- `useGenerateSlug` — returns an imperative async function (same shape as `useFindLabelByName`) because the editor calls it from a state machine rather than rendering its result. It calls `GET /slugs/:type/:name/` (or `/slugs/:type/:name/:id/` when the record being edited is known, so its own slug is not counted as a collision) and resolves `slugs[0].slug`. Text is run through `@tryghost/string` `slugify` and `encodeURIComponent` client-side first, as Ember does, so raw reserved characters never reach the URL path. Empty text resolves `''` without a request.
- Accepted `type` values follow the server (`post`, `tag`, `user`); pages share the posts table and dedupe under `post`.

`@tryghost/string` is added as a framework dependency from the catalog with a local ambient declaration, matching how `apps/admin` already types it.

### Verification

- `pnpm run lint` in `apps/admin-x-framework`
- `pnpm nx run @tryghost/admin-x-framework:test:types`
- `pnpm nx run @tryghost/admin-x-framework:test:unit` — new tests pin the request URL and method, the record-id path form, the empty-text short circuit, and slug encoding for text with spaces, unicode, reserved characters and a newline
- `pnpm nx run @tryghost/admin:build`
