### PR TITLE
[WIP, NO MERGE]: Added recurring job to sync automation runs to Tinybird

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -473,93 +473,6 @@ async function initBackgroundServices({ config }) {
     return;
   }
 
-  const tinybirdConfig = config.get('tinybird:stats');
-  const tinybirdEndpoint = tinybirdConfig?.local?.enabled
-    ? tinybirdConfig.local.endpoint
-    : tinybirdConfig?.endpoint;
-
-  if (tinybirdEndpoint && Math.random() === 100) {
-    const db = require('./server/data/db');
-    const logging = require('@tryghost/logging');
-    const settingsCache = require('./shared/settings-cache');
-    const token = config.get('tinybird:adminToken');
-    const siteUuid = tinybirdConfig.id || settingsCache.get('site_uuid');
-    const batchSize = 10_000;
-
-    const syncAutomationEvents = async ({ table, datasource, name }) => {
-      try {
-        if (!token) {
-          logging.info(`Skipping ${name} sync to Tinybird: no admin token configured`);
-          return;
-        }
-
-        let lastId;
-        let totalSent = 0;
-
-        while (true) {
-          const query = db.knex(table).select('*').orderBy('id').limit(batchSize);
-          if (lastId) {
-            query.where('id', '>', lastId);
-          }
-
-          const rows = await query;
-          if (!rows.length) {
-            if (!totalSent) {
-              logging.info(`Skipping ${name} sync to Tinybird: no ${name}s found`);
-            }
-            return;
-          }
-
-          const events = rows.map((row) => ({
-            site_uuid: siteUuid,
-            id: row.id,
-            updated_at: row.updated_at,
-            payload: {
-              ...row,
-              site_uuid: siteUuid,
-            },
-          }));
-
-          logging.info(`Sending ${events.length} ${name} events to Tinybird`);
-
-          const response = await fetch(`${tinybirdEndpoint}/v0/events?name=${datasource}`, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${token}`,
-              'Content-Type': 'application/x-ndjson',
-            },
-            body: events.map((event) => JSON.stringify(event)).join('\n'),
-          });
-
-          if (!response.ok) {
-            // I don't care
-            // eslint-disable-next-line
-            throw new Error(`Tinybird API error: ${response.status} - ${await response.text()}`);
-          }
-
-          totalSent += events.length;
-          lastId = rows.at(-1).id;
-          logging.info(`Sent ${totalSent} ${name} events to Tinybird`);
-        }
-      } catch (err) {
-        logging.error(err);
-      }
-    };
-
-    setTimeout(async () => {
-      await syncAutomationEvents({
-        table: 'automation_runs',
-        datasource: 'automation_run_events',
-        name: 'automation run',
-      });
-      await syncAutomationEvents({
-        table: 'automation_run_steps',
-        datasource: 'automation_run_step_events',
-        name: 'automation run step',
-      });
-    }, 10_000);
-  }
-
   // Resume any newsletter sends interrupted by a prior container shutdown.
   // Runs before activitypub.init so an activitypub failure can't disable recovery.
   try {
@@ -606,6 +519,16 @@ async function initBackgroundServices({ config }) {
   } catch (err) {
     const logging = require('@tryghost/logging');
     logging.error(err);
+  }
+
+  if (config.get('backgroundJobs:tinybirdSync')) {
+    try {
+      const tinybirdSync = require('./server/services/tinybird-sync');
+      await tinybirdSync.scheduleTinybirdSyncJob(jobsService);
+    } catch (err) {
+      const logging = require('@tryghost/logging');
+      logging.error(err);
+    }
   }
 
   const activitypub = require('./server/services/activitypub');

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -76,6 +76,7 @@ const BACKUP_TABLES = [
   'automation_runs',
   'welcome_email_automation_runs',
   'welcome_email_automated_emails',
+  'tinybird_syncs',
 ];
 
 // NOTE: exposing only tables which are going to be included in a "default" export file

--- a/ghost/core/core/server/data/migrations/versions/6.63/2026-09-02-18-23-36-add-tinybird-syncs-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.63/2026-09-02-18-23-36-add-tinybird-syncs-table.js
@@ -1,0 +1,9 @@
+const { addTable } = require('../../utils');
+
+module.exports = addTable('tinybird_syncs', {
+  id: { type: 'string', maxlength: 24, nullable: false, primary: true },
+  table_name: { type: 'string', maxlength: 191, nullable: false, unique: true },
+  last_synced_updated_at: { type: 'dateTime', nullable: false },
+  created_at: { type: 'dateTime', nullable: false },
+  updated_at: { type: 'dateTime', nullable: true },
+});

--- a/ghost/core/core/server/data/migrations/versions/6.63/2026-09-02-18-24-50-add-automation-updated-at-indexes.js
+++ b/ghost/core/core/server/data/migrations/versions/6.63/2026-09-02-18-24-50-add-automation-updated-at-indexes.js
@@ -1,0 +1,6 @@
+const { combineTransactionalMigrations, createAddIndexMigration } = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+  createAddIndexMigration('automation_runs', ['updated_at']),
+  createAddIndexMigration('automation_run_steps', ['updated_at']),
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -2258,7 +2258,7 @@ module.exports = {
       nullable: false,
       validations: { isEmail: true },
     },
-    '@@INDEXES@@': [['automation_id', 'created_at']],
+    '@@INDEXES@@': [['automation_id', 'created_at'], ['updated_at']],
   },
   automation_run_steps: {
     id: { type: 'string', maxlength: 24, nullable: false, primary: true },
@@ -2302,7 +2302,14 @@ module.exports = {
     },
     locked_by: { type: 'string', maxlength: 191, nullable: true },
     locked_at: { type: 'dateTime', nullable: true },
-    '@@INDEXES@@': [['status', 'ready_at', 'created_at', 'id']],
+    '@@INDEXES@@': [['status', 'ready_at', 'created_at', 'id'], ['updated_at']],
+  },
+  tinybird_syncs: {
+    id: { type: 'string', maxlength: 24, nullable: false, primary: true },
+    table_name: { type: 'string', maxlength: 191, nullable: false, unique: true },
+    last_synced_updated_at: { type: 'dateTime', nullable: false },
+    created_at: { type: 'dateTime', nullable: false },
+    updated_at: { type: 'dateTime', nullable: true },
   },
   welcome_email_automated_emails: {
     id: { type: 'string', maxlength: 24, nullable: false, primary: true },

--- a/ghost/core/core/server/data/tinybird/README.md
+++ b/ghost/core/core/server/data/tinybird/README.md
@@ -108,6 +108,18 @@ Keep in mind that as you update fixtures, it will rebuild data, but materialized
 data will not be cleared from them. One way to approach this to make sure data is consistent is to truncate all data
 sources before adding test data to it.
 
+### Automation data sync
+
+Ghost copies `automation_runs` and `automation_run_steps` into the `automation_run_events` and
+`automation_run_step_events` data sources with a recurring job (`core/server/services/tinybird-sync`).
+It runs every five minutes when Tinybird is configured, sending only rows updated since the
+watermark stored in the `tinybird_syncs` table. Set `backgroundJobs.tinybirdSync` to `false` in config
+to turn the job off.
+
+To force a full backfill, for example after pointing Ghost at a different Tinybird workspace or
+truncating the data sources, delete the matching rows from `tinybird_syncs`; the next run starts from
+the beginning.
+
 ### Architecture
 
 [See full documentation regarding analytics architecture in following document](ARCHITECTURE.md)

--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -11,9 +11,7 @@ const { knex } = require('../../data/db');
 const domainEvents = require('@tryghost/domain-events');
 const labs = require('../../../shared/labs');
 const config = require('../../../shared/config');
-const settingsCache = require('../../../shared/settings-cache');
 const lexicalLib = require('../../lib/lexical');
-const TinybirdServiceWrapper = require('../tinybird');
 
 const MAX_AUTOMATION_ACTIONS = 20;
 
@@ -75,58 +73,7 @@ const repository = createDatabaseAutomationsRepository({
 });
 
 export async function browse() {
-  console.time('@@@@ full browse')
-  const result = await repository.browse();
-  const tinybirdConfig = config.get('tinybird:stats');
-  const endpoint = tinybirdConfig.local?.enabled
-    ? tinybirdConfig.local.endpoint
-    : tinybirdConfig.endpoint;
-  const siteUuid = tinybirdConfig.id || settingsCache.get('site_uuid');
-
-  TinybirdServiceWrapper.init();
-  const token = TinybirdServiceWrapper.instance.getToken().token;
-
-  console.time('@@@@ tinybird req')
-  const response = await fetch(
-    `${endpoint}/v0/pipes/api_automation_browse_stats.json?site_uuid=${siteUuid}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
-  );
-  console.timeEnd('@@@@ tinybird req')
-
-  if (!response.ok) {
-    throw new errors.InternalServerError({
-      message: `Tinybird API error: ${response.status} - ${await response.text()}`,
-    });
-  }
-
-  const { data } = (await response.json()) as {
-    data: Array<{
-      automation_id: string;
-      last_run_created_at: string;
-      total_run_count: number | string;
-      in_progress_run_count: number | string;
-    }>;
-  };
-  const statsByAutomationId = new Map(data.map((stats) => [stats.automation_id, stats]));
-
-  result.data = result.data.map((automation) => {
-    const stats = statsByAutomationId.get(automation.id);
-    return {
-      ...automation,
-      stats: {
-        last_run_created_at: stats ? new Date(stats.last_run_created_at) : null,
-        total_run_count: Number(stats?.total_run_count ?? 0),
-        in_progress_run_count: Number(stats?.in_progress_run_count ?? 0),
-      },
-    };
-  });
-
-  console.timeEnd('@@@@ full browse')
-  return result;
+  return await repository.browse();
 }
 
 export async function read(automationId: string) {

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -62,6 +62,12 @@ interface AutomationRow {
   updated_at: DatabaseDate;
 }
 
+interface AutomationBrowseRow extends AutomationRow {
+  last_run_created_at: DatabaseDate | null;
+  total_run_count: string | number | null;
+  in_progress_run_count: string | number | null;
+}
+
 interface ActionRow {
   id: string;
   type: 'wait' | 'send_email';
@@ -1064,9 +1070,32 @@ async function loadAutomationBySlug(
   return row ?? null;
 }
 
-async function loadAutomations(trx: Knex.Transaction): Promise<AutomationRow[]> {
+async function loadAutomations(trx: Knex.Transaction): Promise<AutomationBrowseRow[]> {
+  const inProgressRuns = trx('automation_run_steps')
+    .distinct('automation_run_id')
+    .where('status', 'pending')
+    .as('in_progress_runs');
+  const runStats = trx('automation_runs')
+    .select('automation_runs.automation_id')
+    .max({ last_run_created_at: 'automation_runs.created_at' })
+    .count({ total_run_count: '*' })
+    .count({ in_progress_run_count: 'in_progress_runs.automation_run_id' })
+    .leftJoin(inProgressRuns, 'automation_runs.id', 'in_progress_runs.automation_run_id')
+    .groupBy('automation_runs.automation_id')
+    .as('run_stats');
   return await trx('automations')
-    .select('id', 'slug', 'name', 'status', 'created_at', 'updated_at')
+    .select(
+      'automations.id',
+      'automations.slug',
+      'automations.name',
+      'automations.status',
+      'automations.created_at',
+      'automations.updated_at',
+      'run_stats.last_run_created_at',
+      'run_stats.total_run_count',
+      'run_stats.in_progress_run_count',
+    )
+    .leftJoin(runStats, 'automations.id', 'run_stats.automation_id')
     .orderBy('automations.name');
 }
 
@@ -1465,8 +1494,17 @@ function buildAutomationSummary(automation: AutomationRow): AutomationSummary {
   };
 }
 
-function buildAutomationBrowseResult(automation: AutomationRow): AutomationBrowseResult {
-  return buildAutomationSummary(automation);
+function buildAutomationBrowseResult(automation: AutomationBrowseRow): AutomationBrowseResult {
+  return {
+    ...buildAutomationSummary(automation),
+    stats: {
+      last_run_created_at: automation.last_run_created_at
+        ? fromDatabaseDate(automation.last_run_created_at)
+        : null,
+      total_run_count: Number(automation.total_run_count ?? 0),
+      in_progress_run_count: Number(automation.in_progress_run_count ?? 0),
+    },
+  };
 }
 
 function serializeDate(date: DatabaseDate) {

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -152,16 +152,16 @@ const processStep = async ({
   // NOTE: This will change once we support additional automation triggers.
   const memberStatus = slugToMemberStatus.get(step.automation_slug);
   if (!memberStatus) {
-    // logging.error(
-    //   {
-    //     system: {
-    //       event: 'automations.poll.unknown_slug',
-    //       slug: step.automation_slug,
-    //       step_id: step.id,
-    //     },
-    //   },
-    //   `[AUTOMATIONS] Unknown automation slug: ${step.automation_slug}`,
-    // );
+    logging.error(
+      {
+        system: {
+          event: 'automations.poll.unknown_slug',
+          slug: step.automation_slug,
+          step_id: step.id,
+        },
+      },
+      `[AUTOMATIONS] Unknown automation slug: ${step.automation_slug}`,
+    );
     await automationsApi.markStepTerminal(step, 'failed');
     return null;
   }

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -10,6 +10,8 @@ import * as contentImport from '../content-import';
 import UpdateCheckJob from '../update-check/jobs/update-check-job';
 import type MentionController from '../mentions/mention-controller';
 import ProcessWebmentionJob from '../mentions/process-webmention-job';
+import TinybirdSyncJob from '../tinybird-sync/tinybird-sync-job';
+import * as tinybirdSync from '../tinybird-sync';
 
 const updateCheck = require('../update-check');
 
@@ -57,5 +59,9 @@ export default function registerJobHandlers({
 
   jobsService.handle(ProcessWebmentionJob, async (job) => {
     await mentionsController.processWebmention(job);
+  });
+
+  jobsService.handle(TinybirdSyncJob, async () => {
+    await tinybirdSync.run();
   });
 }

--- a/ghost/core/core/server/services/tinybird-sync/index.ts
+++ b/ghost/core/core/server/services/tinybird-sync/index.ts
@@ -1,0 +1,94 @@
+import type { JobsService } from '../jobs-service/jobs-service';
+import TinybirdSyncJob from './tinybird-sync-job';
+import { AUTOMATION_SYNC_TARGETS, syncTableToTinybird } from './sync-table-to-tinybird';
+
+const logging = require('@tryghost/logging');
+
+interface IngestConfig {
+  endpoint: string;
+  token: string;
+  siteUuid: string;
+}
+
+function getIngestConfig(): IngestConfig | null {
+  const config = require('../../../shared/config');
+  const settingsCache = require('../../../shared/settings-cache');
+
+  const stats = config.get('tinybird:stats');
+  if (!stats) {
+    return null;
+  }
+
+  const local = stats.local?.enabled ? stats.local : null;
+  const endpoint = local ? local.endpoint : stats.endpoint;
+  const token = local ? local.token : config.get('tinybird:adminToken');
+  const siteUuid = stats.id || settingsCache.get('site_uuid');
+
+  return endpoint && token && siteUuid ? { endpoint, token, siteUuid } : null;
+}
+
+const randomBelow = (max: number) => Math.floor(Math.random() * max);
+
+// Every five minutes, offset per process so sites don't all hit Tinybird at the same instant.
+const randomFiveMinuteCron = () => `${randomBelow(60)} ${randomBelow(5)}/5 * * * *`;
+
+let hasScheduled = false;
+
+export async function scheduleTinybirdSyncJob(
+  jobsService: Pick<JobsService, 'scheduleRecurring'>,
+): Promise<void> {
+  if (hasScheduled || process.env.NODE_ENV?.startsWith('test')) {
+    return;
+  }
+  if (!getIngestConfig()) {
+    logging.info('[Background Job] tinybird-sync not scheduled: Tinybird is not configured');
+    return;
+  }
+
+  const cron = randomFiveMinuteCron();
+  logging.info(`[Background Job] tinybird-sync scheduled at ${cron}`);
+  await jobsService.scheduleRecurring(new TinybirdSyncJob(), { cron });
+
+  hasScheduled = true;
+}
+
+async function syncAll(): Promise<void> {
+  const ingest = getIngestConfig();
+  if (!ingest) {
+    return;
+  }
+
+  const { knex } = require('../../data/db');
+
+  const results = await Promise.allSettled(
+    AUTOMATION_SYNC_TARGETS.map(async (target) => {
+      const sent = await syncTableToTinybird(target, { knex, ...ingest });
+      if (sent) {
+        logging.info(
+          { system: { event: 'tinybird.sync.completed', table: target.table, sent } },
+          `[Tinybird sync] ${target.table}: sent ${sent} rows`,
+        );
+      }
+    }),
+  );
+
+  const failures = results.filter((result) => result.status === 'rejected');
+  // Log every failure so neither table's error is lost, then let the first one fail the job.
+  for (const failure of failures.slice(1)) {
+    logging.error(failure.reason);
+  }
+  if (failures.length) {
+    throw failures[0].reason;
+  }
+}
+
+let inFlight: Promise<void> | null = null;
+
+// A run can outlast the five-minute interval on a large backlog; the jobs backend
+// processes concurrently, so overlapping runs would race on the watermark.
+export function run(): Promise<void> {
+  inFlight ??= syncAll().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}

--- a/ghost/core/core/server/services/tinybird-sync/sync-table-to-tinybird.ts
+++ b/ghost/core/core/server/services/tinybird-sync/sync-table-to-tinybird.ts
@@ -1,0 +1,220 @@
+import ObjectId from 'bson-objectid';
+import type { Knex } from 'knex';
+import { toDatabaseDate, type DatabaseDate } from '../../lib/db-types/date';
+
+const errors = require('@tryghost/errors');
+
+export interface TinybirdSyncTarget {
+  table: string;
+  datasource: string;
+  columns: string[];
+}
+
+export interface TinybirdSyncOptions {
+  knex: Knex;
+  endpoint: string;
+  token: string;
+  siteUuid: string;
+  now?: () => Date;
+  batchSize?: number;
+  maxPayloadBytes?: number;
+  requestTimeoutMs?: number;
+}
+
+// Only what the Tinybird materialized views read. Member identity and lock bookkeeping
+// stay in MySQL.
+export const AUTOMATION_SYNC_TARGETS: TinybirdSyncTarget[] = [
+  {
+    table: 'automation_runs',
+    datasource: 'automation_run_events',
+    columns: ['id', 'automation_id', 'created_at', 'updated_at'],
+  },
+  {
+    table: 'automation_run_steps',
+    datasource: 'automation_run_step_events',
+    columns: [
+      'id',
+      'automation_run_id',
+      'automation_action_revision_id',
+      'status',
+      'step_attempts',
+      'ready_at',
+      'started_at',
+      'finished_at',
+      'created_at',
+      'updated_at',
+    ],
+  },
+];
+
+const DEFAULT_BATCH_SIZE = 5000;
+// Tinybird's Events API rejects request bodies over 10MB.
+const DEFAULT_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS = 60 * 1000;
+// A row's updated_at is assigned before its transaction commits, so a row can become
+// visible after rows with later timestamps. Holding back the newest rows keeps the
+// watermark from moving past a row whose transaction is still open.
+export const SAFETY_LAG_MS = 60 * 1000;
+
+type Row = Record<string, unknown> & { id: string; updated_at: DatabaseDate };
+
+interface Cursor {
+  updatedAt: string;
+  id: string;
+}
+
+const serializeValue = (value: unknown): unknown =>
+  value instanceof Date ? toDatabaseDate(value) : value;
+
+const toEventLine = (row: Row, siteUuid: string): string => {
+  const payload = Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, serializeValue(value)]),
+  );
+  return JSON.stringify({
+    site_uuid: siteUuid,
+    id: row.id,
+    updated_at: toDatabaseDate(row.updated_at),
+    payload: { ...payload, site_uuid: siteUuid },
+  });
+};
+
+export function chunkByBytes(lines: string[], maxBytes: number): string[][] {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+
+  for (const line of lines) {
+    const bytes = Buffer.byteLength(line) + '\n'.length;
+    if (current.length && currentBytes + bytes > maxBytes) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(line);
+    currentBytes += bytes;
+  }
+
+  if (current.length) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+async function postEvents(
+  lines: string[],
+  { datasource }: TinybirdSyncTarget,
+  { endpoint, token, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS }: TinybirdSyncOptions,
+): Promise<void> {
+  // wait=true makes Tinybird acknowledge only once the rows are committed.
+  const url = `${endpoint}/v0/events?name=${encodeURIComponent(datasource)}&wait=true`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/x-ndjson',
+    },
+    body: lines.join('\n'),
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new errors.InternalServerError({
+      message: `Tinybird Events API returned ${response.status} for ${datasource}: ${await response.text()}`,
+    });
+  }
+
+  const body: { quarantined_rows?: unknown } = await response.json().catch(() => ({}));
+  if (typeof body.quarantined_rows === 'number' && body.quarantined_rows > 0) {
+    throw new errors.InternalServerError({
+      message: `Tinybird quarantined ${body.quarantined_rows} ${datasource} rows`,
+    });
+  }
+}
+
+async function readWatermark(knex: Knex, table: string): Promise<string | null> {
+  const row = await knex('tinybird_syncs')
+    .select('last_synced_updated_at')
+    .where({ table_name: table })
+    .first();
+  return row ? toDatabaseDate(row.last_synced_updated_at) : null;
+}
+
+async function writeWatermark(knex: Knex, table: string, value: string): Promise<void> {
+  const now = toDatabaseDate(new Date());
+  const updated = await knex('tinybird_syncs')
+    .where({ table_name: table })
+    .update({ last_synced_updated_at: value, updated_at: now });
+  if (!updated) {
+    await knex('tinybird_syncs').insert({
+      id: ObjectId().toHexString(),
+      table_name: table,
+      last_synced_updated_at: value,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+}
+
+async function readBatch(
+  { table, columns }: TinybirdSyncTarget,
+  { knex, batchSize = DEFAULT_BATCH_SIZE }: TinybirdSyncOptions,
+  cursor: Cursor | null,
+  cutoff: string,
+): Promise<Row[]> {
+  const query = knex(table)
+    .select(columns)
+    .where('updated_at', '<', cutoff)
+    .orderBy([{ column: 'updated_at' }, { column: 'id' }])
+    .limit(batchSize);
+
+  if (cursor) {
+    query.andWhere((builder) =>
+      builder
+        .where('updated_at', '>', cursor.updatedAt)
+        .orWhere((tie) => tie.where('updated_at', cursor.updatedAt).andWhere('id', '>', cursor.id)),
+    );
+  }
+
+  return await query;
+}
+
+export async function syncTableToTinybird(
+  target: TinybirdSyncTarget,
+  options: TinybirdSyncOptions,
+): Promise<number> {
+  const {
+    knex,
+    siteUuid,
+    now = () => new Date(),
+    batchSize = DEFAULT_BATCH_SIZE,
+    maxPayloadBytes = DEFAULT_MAX_PAYLOAD_BYTES,
+  } = options;
+  const cutoff = toDatabaseDate(new Date(now().getTime() - SAFETY_LAG_MS));
+  const watermark = await readWatermark(knex, target.table);
+  // The empty id makes the first page inclusive of the watermark second, so rows that
+  // landed in that second after the previous run are re-sent rather than skipped.
+  let cursor: Cursor | null = watermark ? { updatedAt: watermark, id: '' } : null;
+  let sent = 0;
+
+  while (true) {
+    const rows = await readBatch(target, options, cursor, cutoff);
+    if (!rows.length) {
+      return sent;
+    }
+
+    const lines = rows.map((row) => toEventLine(row, siteUuid));
+    for (const chunk of chunkByBytes(lines, maxPayloadBytes)) {
+      await postEvents(chunk, target, options);
+    }
+
+    const last = rows[rows.length - 1];
+    cursor = { updatedAt: toDatabaseDate(last.updated_at), id: last.id };
+    await writeWatermark(knex, target.table, cursor.updatedAt);
+    sent += rows.length;
+
+    if (rows.length < batchSize) {
+      return sent;
+    }
+  }
+}

--- a/ghost/core/core/server/services/tinybird-sync/tinybird-sync-job.ts
+++ b/ghost/core/core/server/services/tinybird-sync/tinybird-sync-job.ts
@@ -1,0 +1,5 @@
+import { Job } from '../jobs-service/job';
+
+export default class TinybirdSyncJob extends Job {
+  static type = 'tinybird-sync';
+}

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -311,7 +311,8 @@
   "linkClickTrackingCacheMemberUuid": false,
   "backgroundJobs": {
     "emailAnalytics": true,
-    "clickTrackingLastSeenAtUpdater": true
+    "clickTrackingLastSeenAtUpdater": true,
+    "tinybirdSync": true
   },
   "portal": {
     "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.62.1-rc.0",
+  "version": "6.63.0-rc.0",
   "description": "The professional publishing platform",
   "keywords": [
     "blog",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = '0d83dfdf9142d606e0660871c5adcf1a';
+  const currentSchemaHash = '939c2e58e9c633276f4f784e7e3a80a6';
   const currentFixturesHash = '1727a789194847da33d68dd95301b416';
   const currentSettingsHash = '6ea42a00cca61a1ba87f66eb6e25a78a';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';

--- a/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
+++ b/ghost/core/test/unit/server/services/jobs-service/register-job-handlers.test.ts
@@ -7,6 +7,7 @@ import ExternalMediaInlinerJob from '../../../../../core/server/services/media-i
 import ContentCSVImportJob from '../../../../../core/server/services/content-import/jobs/content-csv-import-job';
 import UpdateCheckJob from '../../../../../core/server/services/update-check/jobs/update-check-job';
 import ProcessWebmentionJob from '../../../../../core/server/services/mentions/process-webmention-job';
+import TinybirdSyncJob from '../../../../../core/server/services/tinybird-sync/tinybird-sync-job';
 
 const registerJobHandlers =
   require('../../../../../core/server/services/jobs-service/register-job-handlers').default;
@@ -121,6 +122,14 @@ describe('register-job-handlers', function () {
     const updateCheckHandler = handlerFor('update-check');
 
     await updateCheckHandler(new UpdateCheckJob());
+  });
+
+  // Tinybird is not configured under the test env, so the sync exits before
+  // touching the database or the network.
+  it('registers the tinybird-sync handler', async function () {
+    const tinybirdSyncHandler = handlerFor('tinybird-sync');
+
+    await tinybirdSyncHandler(new TinybirdSyncJob());
   });
 
   it('runs process-webmention with the injected mentions controller', async function () {

--- a/ghost/core/test/unit/server/services/tinybird-sync/schedule.test.ts
+++ b/ghost/core/test/unit/server/services/tinybird-sync/schedule.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import logging from '@tryghost/logging';
+import { scheduleTinybirdSyncJob } from '../../../../../core/server/services/tinybird-sync';
+import TinybirdSyncJob from '../../../../../core/server/services/tinybird-sync/tinybird-sync-job';
+
+// require, not import: these must be the same CommonJS instances the service
+// under test loads lazily, so the stubs below are the ones it reads.
+const config = require('../../../../../core/shared/config');
+const settingsCache = require('../../../../../core/shared/settings-cache');
+
+describe('tinybird-sync scheduling', function () {
+  let jobsService: { scheduleRecurring: sinon.SinonStub };
+  let originalEnv: string | undefined;
+
+  beforeEach(function () {
+    jobsService = { scheduleRecurring: sinon.stub().resolves() };
+    originalEnv = process.env.NODE_ENV;
+    sinon.stub(logging, 'info');
+  });
+
+  afterEach(function () {
+    process.env.NODE_ENV = originalEnv;
+    sinon.restore();
+  });
+
+  it('does not schedule under the test environment', async function () {
+    await scheduleTinybirdSyncJob(jobsService);
+
+    assert.ok(jobsService.scheduleRecurring.notCalled);
+  });
+
+  it('does not schedule when Tinybird is not configured', async function () {
+    process.env.NODE_ENV = 'production';
+    sinon.stub(config, 'get').withArgs('tinybird:stats').returns(undefined);
+
+    await scheduleTinybirdSyncJob(jobsService);
+
+    assert.ok(jobsService.scheduleRecurring.notCalled);
+  });
+
+  it('schedules a single five-minute job with a random offset when Tinybird is configured', async function () {
+    process.env.NODE_ENV = 'production';
+    const get = sinon.stub(config, 'get');
+    get.withArgs('tinybird:stats').returns({ endpoint: 'https://api.tinybird.co' });
+    get.withArgs('tinybird:adminToken').returns('admin-token');
+    sinon.stub(settingsCache, 'get').withArgs('site_uuid').returns('site-uuid');
+
+    await scheduleTinybirdSyncJob(jobsService);
+    await scheduleTinybirdSyncJob(jobsService);
+
+    assert.ok(jobsService.scheduleRecurring.calledOnce);
+    const [job, schedule] = jobsService.scheduleRecurring.firstCall.args;
+    assert.ok(job instanceof TinybirdSyncJob);
+    assert.match(schedule.cron, /^\d{1,2} [0-4]\/5 \* \* \* \*$/);
+  });
+});

--- a/ghost/core/test/unit/server/services/tinybird-sync/sync-table-to-tinybird.test.ts
+++ b/ghost/core/test/unit/server/services/tinybird-sync/sync-table-to-tinybird.test.ts
@@ -1,0 +1,293 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+import createKnex, { type Knex } from 'knex';
+import ObjectId from 'bson-objectid';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  AUTOMATION_SYNC_TARGETS,
+  SAFETY_LAG_MS,
+  chunkByBytes,
+  syncTableToTinybird,
+} from '../../../../../core/server/services/tinybird-sync/sync-table-to-tinybird';
+import { toDatabaseDate } from '../../../../../core/server/lib/db-types/date';
+
+const SITE_UUID = 'bd05ceed-1df9-4af7-832a-d3b5faa7ca1d';
+const TOKEN = 'admin-token';
+const TARGET = AUTOMATION_SYNC_TARGETS.find((target) => target.table === 'automation_runs')!;
+const NOW = new Date('2026-03-01T12:00:00.000Z');
+
+interface EventLine {
+  site_uuid: string;
+  id: string;
+  updated_at: string;
+  payload: Record<string, unknown>;
+}
+
+interface ReceivedRequest {
+  url: string;
+  authorization: string | undefined;
+  contentType: string | undefined;
+  lines: EventLine[];
+}
+
+let server: Server;
+let endpoint: string;
+let received: ReceivedRequest[];
+let respondWith: { status: number; body: unknown } | 'hang';
+let knex: Knex;
+
+const createDatabase = async (): Promise<Knex> => {
+  const database = createKnex({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    pool: { min: 1, max: 1 },
+    useNullAsDefault: true,
+  });
+
+  await database.schema.createTable('automation_runs', (table) => {
+    table.text('id').primary();
+    table.text('created_at').notNullable();
+    table.text('updated_at').notNullable();
+    table.text('automation_id').notNullable();
+    table.text('member_id');
+    table.text('member_email').notNullable();
+  });
+
+  await database.schema.createTable('tinybird_syncs', (table) => {
+    table.text('id').primary();
+    table.text('table_name').notNullable().unique();
+    table.text('last_synced_updated_at').notNullable();
+    table.text('created_at').notNullable();
+    table.text('updated_at');
+  });
+
+  return database;
+};
+
+const insertRun = async (updatedAt: Date, overrides: Record<string, unknown> = {}) => {
+  const id = ObjectId().toHexString();
+  await knex('automation_runs').insert({
+    id,
+    created_at: toDatabaseDate(updatedAt),
+    updated_at: toDatabaseDate(updatedAt),
+    automation_id: 'automation-1',
+    member_id: 'member-1',
+    member_email: 'member@example.com',
+    ...overrides,
+  });
+  return id;
+};
+
+const minutesBeforeNow = (minutes: number) => new Date(NOW.getTime() - minutes * 60 * 1000);
+
+const sync = (options: Partial<Parameters<typeof syncTableToTinybird>[1]> = {}) =>
+  syncTableToTinybird(TARGET, {
+    knex,
+    endpoint,
+    token: TOKEN,
+    siteUuid: SITE_UUID,
+    now: () => NOW,
+    ...options,
+  });
+
+const receivedIds = () => received.flatMap((request) => request.lines.map((line) => line.id));
+
+const watermark = async () => {
+  const row = await knex('tinybird_syncs').where({ table_name: TARGET.table }).first();
+  return row?.last_synced_updated_at ?? null;
+};
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.text({ type: 'application/x-ndjson', limit: '20mb' }));
+  app.post('/v0/events', (req, res) => {
+    received.push({
+      url: req.originalUrl,
+      authorization: req.get('authorization'),
+      contentType: req.get('content-type'),
+      lines: String(req.body)
+        .split('\n')
+        .map((line) => JSON.parse(line) as EventLine),
+    });
+    if (respondWith === 'hang') {
+      return;
+    }
+    res.status(respondWith.status).json(respondWith.body);
+  });
+  server = app.listen(0);
+  await once(server, 'listening');
+  endpoint = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  server.closeAllConnections();
+  server.close();
+  await once(server, 'close');
+});
+
+beforeEach(async () => {
+  received = [];
+  respondWith = { status: 200, body: { successful_rows: 0, quarantined_rows: 0 } };
+  knex = await createDatabase();
+});
+
+afterEach(async () => {
+  await knex.destroy();
+});
+
+describe('syncTableToTinybird', () => {
+  it('sends allowlisted columns to the Events API as acknowledged NDJSON events', async () => {
+    const updatedAt = minutesBeforeNow(10);
+    const id = await insertRun(updatedAt);
+
+    const sent = await sync();
+
+    assert.equal(sent, 1);
+    assert.equal(received.length, 1);
+    const [request] = received;
+    assert.equal(request.url, '/v0/events?name=automation_run_events&wait=true');
+    assert.equal(request.authorization, `Bearer ${TOKEN}`);
+    assert.equal(request.contentType, 'application/x-ndjson');
+    assert.deepEqual(request.lines, [
+      {
+        site_uuid: SITE_UUID,
+        id,
+        updated_at: '2026-03-01 11:50:00',
+        payload: {
+          site_uuid: SITE_UUID,
+          id,
+          automation_id: 'automation-1',
+          created_at: '2026-03-01 11:50:00',
+          updated_at: '2026-03-01 11:50:00',
+        },
+      },
+    ]);
+  });
+
+  it('never sends member identity columns', async () => {
+    await insertRun(minutesBeforeNow(10));
+
+    await sync();
+
+    const [line] = received[0].lines;
+    assert.ok(!('member_email' in line.payload));
+    assert.ok(!('member_id' in line.payload));
+  });
+
+  it('sends nothing and records no watermark when there are no rows', async () => {
+    const sent = await sync();
+
+    assert.equal(sent, 0);
+    assert.equal(received.length, 0);
+    assert.equal(await watermark(), null);
+  });
+
+  it('records the newest synced updated_at as the watermark', async () => {
+    await insertRun(minutesBeforeNow(30));
+    await insertRun(minutesBeforeNow(20));
+
+    await sync();
+
+    assert.equal(await watermark(), '2026-03-01 11:40:00');
+  });
+
+  it('only sends rows at or after the watermark on later runs', async () => {
+    await insertRun(minutesBeforeNow(30));
+    const boundaryId = await insertRun(minutesBeforeNow(20));
+    await sync();
+    received = [];
+
+    const newerId = await insertRun(minutesBeforeNow(10));
+    await insertRun(minutesBeforeNow(40));
+    const sent = await sync();
+
+    assert.equal(sent, 2);
+    assert.deepEqual(receivedIds().sort(), [boundaryId, newerId].sort());
+  });
+
+  it('holds back rows updated within the safety lag until a later run', async () => {
+    const oldId = await insertRun(new Date(NOW.getTime() - SAFETY_LAG_MS - 1000));
+    const freshId = await insertRun(new Date(NOW.getTime() - SAFETY_LAG_MS + 1000));
+
+    await sync();
+    assert.deepEqual(receivedIds(), [oldId]);
+
+    received = [];
+    await sync({ now: () => new Date(NOW.getTime() + SAFETY_LAG_MS) });
+    assert.deepEqual(receivedIds(), [oldId, freshId]);
+  });
+
+  it('pages through rows in batches ordered by updated_at then id', async () => {
+    for (let i = 0; i < 5; i++) {
+      await insertRun(minutesBeforeNow(10), { id: `run-${i}` });
+    }
+    await insertRun(minutesBeforeNow(5), { id: 'run-later' });
+
+    const sent = await sync({ batchSize: 2 });
+
+    assert.equal(sent, 6);
+    assert.equal(received.length, 3);
+    assert.deepEqual(receivedIds(), ['run-0', 'run-1', 'run-2', 'run-3', 'run-4', 'run-later']);
+    assert.equal(await watermark(), '2026-03-01 11:55:00');
+  });
+
+  it('splits a batch into multiple requests when it exceeds the payload size in bytes', async () => {
+    // 1000 characters but 2000 bytes: measured by string length, three lines would fit.
+    const twoByteCharacters = 'ü'.repeat(1000);
+    for (let i = 0; i < 3; i++) {
+      await insertRun(minutesBeforeNow(10), { id: `run-${i}`, automation_id: twoByteCharacters });
+    }
+
+    await sync({ maxPayloadBytes: 5000 });
+
+    assert.deepEqual(
+      received.map((request) => request.lines.length),
+      [2, 1],
+    );
+    for (const request of received) {
+      assert.ok(request.lines.every((line) => line.payload.automation_id === twoByteCharacters));
+    }
+  });
+
+  it('throws and leaves the watermark alone when the Events API rejects a request', async () => {
+    await insertRun(minutesBeforeNow(10));
+    respondWith = { status: 403, body: { error: 'forbidden' } };
+
+    await assert.rejects(sync(), /Tinybird Events API returned 403 for automation_run_events/);
+    assert.equal(await watermark(), null);
+  });
+
+  it('throws and leaves the watermark alone when rows are quarantined', async () => {
+    await insertRun(minutesBeforeNow(10));
+    respondWith = { status: 200, body: { successful_rows: 0, quarantined_rows: 1 } };
+
+    await assert.rejects(sync(), /Tinybird quarantined 1 automation_run_events rows/);
+    assert.equal(await watermark(), null);
+  });
+
+  it('throws and leaves the watermark alone when the request times out', async () => {
+    await insertRun(minutesBeforeNow(10));
+    respondWith = 'hang';
+
+    await assert.rejects(sync({ requestTimeoutMs: 50 }), { name: 'TimeoutError' });
+    assert.equal(await watermark(), null);
+  });
+});
+
+describe('chunkByBytes', () => {
+  it('measures lines in UTF-8 bytes, not string length', () => {
+    const ascii = 'aaaa';
+    const multibyte = 'ääää';
+    assert.equal(ascii.length, multibyte.length);
+
+    assert.deepEqual(chunkByBytes([ascii, ascii], 10), [[ascii, ascii]]);
+    assert.deepEqual(chunkByBytes([multibyte, multibyte], 10), [[multibyte], [multibyte]]);
+  });
+
+  it('never splits a single line, even when it is over the limit', () => {
+    assert.deepEqual(chunkByBytes(['0123456789'], 2), [['0123456789']]);
+  });
+});

--- a/ghost/core/test/unit/server/services/tinybird-sync/sync-targets.test.ts
+++ b/ghost/core/test/unit/server/services/tinybird-sync/sync-targets.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'vitest';
+import { AUTOMATION_SYNC_TARGETS } from '../../../../../core/server/services/tinybird-sync/sync-table-to-tinybird';
+
+const tinybirdDir = path.resolve(__dirname, '../../../../../core/server/data/tinybird');
+
+// The sync targets must line up with the Tinybird datafiles, or rows get quarantined at runtime.
+describe('AUTOMATION_SYNC_TARGETS', () => {
+  for (const target of AUTOMATION_SYNC_TARGETS) {
+    describe(target.datasource, () => {
+      it('has a datasource file', () => {
+        assert.ok(
+          existsSync(path.join(tinybirdDir, 'datasources', `${target.datasource}.datasource`)),
+        );
+      });
+
+      it('sends every payload column the fixtures rely on', () => {
+        const fixture = readFileSync(
+          path.join(tinybirdDir, 'fixtures', `${target.datasource}.ndjson`),
+          'utf8',
+        );
+        const payloadKeys = new Set(
+          fixture
+            .trim()
+            .split('\n')
+            .flatMap((line) => Object.keys(JSON.parse(line).payload))
+            .filter((key) => key !== 'site_uuid'),
+        );
+
+        for (const key of payloadKeys) {
+          assert.ok(target.columns.includes(key), `${target.table} must send ${key}`);
+        }
+      });
+
+      it('always sends the id and updated_at used as the sync cursor', () => {
+        assert.ok(target.columns.includes('id'));
+        assert.ok(target.columns.includes('updated_at'));
+      });
+    });
+  }
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1559/ghost-backend-send-events-to-traffic-analytics-service-with-recurring

This cannot be merged as-is because it includes database migrations, so it will need to be broken up further before review.

This _probably_ will actually replace its parent pr #30441 instead of getting merged into it, but i wanted to take it one step at a time and leave the stack we were working from intact for now. 


- Replaces the boot.js proof of concept with a tinybird-sync service scheduled through the jobs service every five minutes, with a per-process random offset
- Adds a tinybird_syncs table storing a per-table watermark (last_synced_updated_at), plus updated_at indexes on automation_runs and automation_run_steps so each run only scans recently changed rows
- Sends only the columns the Tinybird materialized views read; member id, member email, and lock bookkeeping never leave MySQL
- Reads rows in keyset-paginated batches and splits requests by UTF-8 byte size under Tinybird's Events API limit
- Uses wait=true so Tinybird acknowledges committed rows, fails the job on quarantined rows or HTTP errors without advancing the watermark, and aborts stalled requests after a timeout
- Holds back rows updated within the last minute so a still-open transaction cannot be skipped by the watermark
- Syncs both tables concurrently and guards against overlapping runs
- Adds a backgroundJobs.tinybirdSync config flag to disable the job
- Reverts the WIP changes that read stats from Tinybird; that work belongs to NY-1560
- Covers the sync logic with unit tests against an in-memory SQLite database and a fake Tinybird Express server