### PR TITLE
Added the editor email confirmation poller as a pure module

### DIFF
--- a/apps/admin/src/editor/publish/email-confirmation.test.ts
+++ b/apps/admin/src/editor/publish/email-confirmation.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CONFIRM_EMAIL_MAX_POLL_LENGTH,
+  CONFIRM_EMAIL_POLL_LENGTH,
+  type EmailConfirmationPost,
+  createEmailConfirmation,
+  isPartialEmailFailure,
+} from './email-confirmation';
+
+const MAX_ATTEMPTS = CONFIRM_EMAIL_MAX_POLL_LENGTH / CONFIRM_EMAIL_POLL_LENGTH;
+
+function published(email: EmailConfirmationPost['email']): EmailConfirmationPost {
+  return { status: 'published', email };
+}
+
+const pending = published({ status: 'pending', opened_count: 0, email_count: 1 });
+const submitted = published({ status: 'submitted', opened_count: 0, email_count: 1 });
+
+function failed(error: string | null) {
+  return published({ status: 'failed', error, opened_count: 0, email_count: 1 });
+}
+
+function setup(reloads: EmailConfirmationPost[]) {
+  const reload = vi.fn(() =>
+    Promise.resolve(reloads[Math.min(reload.mock.calls.length, reloads.length) - 1]),
+  );
+  const retry = vi.fn(() => Promise.resolve());
+
+  return { reload, retry, confirmation: createEmailConfirmation({ reload, retry }) };
+}
+
+async function advance(times: number) {
+  for (let index = 0; index < times; index += 1) {
+    await vi.advanceTimersByTimeAsync(CONFIRM_EMAIL_POLL_LENGTH);
+  }
+}
+
+describe('createEmailConfirmation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls once a second for at most fifteen seconds', () => {
+    expect(CONFIRM_EMAIL_POLL_LENGTH).toBe(1000);
+    expect(CONFIRM_EMAIL_MAX_POLL_LENGTH).toBe(15000);
+  });
+
+  it('polls until the email is submitted', async () => {
+    const { reload, confirmation } = setup([pending, pending, submitted]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(3);
+
+    await expect(result).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).toHaveBeenCalledTimes(3);
+    expect(reload).toHaveBeenCalledWith('post-1');
+  });
+
+  it('does not poll when the supplied post already has a submitted email', async () => {
+    const { reload, confirmation } = setup([submitted]);
+
+    await expect(confirmation.confirm('post-1', submitted)).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not poll when the supplied post has no email', async () => {
+    const { reload, confirmation } = setup([submitted]);
+
+    await expect(confirmation.confirm('post-1', { status: 'published' })).resolves.toEqual({
+      kind: 'submitted',
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reports a full failure with the email error', async () => {
+    const { confirmation } = setup([failed('The email service returned an error.')]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+
+    await expect(result).resolves.toEqual({
+      kind: 'failed',
+      error: 'The email service returned an error.',
+      partial: false,
+    });
+  });
+
+  it('reports a partial failure when the error message says partially', async () => {
+    const { confirmation } = setup([failed('Email was partially sent to 3 of 10 members.')]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+
+    await expect(result).resolves.toEqual({
+      kind: 'failed',
+      error: 'Email was partially sent to 3 of 10 members.',
+      partial: true,
+    });
+  });
+
+  it('reports a failure with a null error when the email has none', async () => {
+    const { confirmation } = setup([failed(null)]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+
+    await expect(result).resolves.toEqual({ kind: 'failed', error: null, partial: false });
+  });
+
+  it('times out after the maximum number of attempts', async () => {
+    const { reload, confirmation } = setup([pending]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(MAX_ATTEMPTS);
+
+    await expect(result).resolves.toEqual({ kind: 'timeout' });
+    expect(reload).toHaveBeenCalledTimes(15);
+  });
+
+  it('is still polling one attempt before the timeout', async () => {
+    const { confirmation } = setup([pending]);
+    const settled = vi.fn();
+
+    void confirmation.confirm('post-1').then(settled);
+    await advance(MAX_ATTEMPTS - 1);
+
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it('stops polling once the post is no longer published or sent', async () => {
+    const { reload, confirmation } = setup([{ status: 'draft', email: pending.email }, pending]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(2);
+
+    await expect(result).resolves.toEqual({ kind: 'timeout' });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a sent post as still emailing', async () => {
+    const { confirmation } = setup([{ status: 'sent', email: submitted.email }]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+
+    await expect(result).resolves.toEqual({ kind: 'submitted' });
+  });
+
+  it('rejects when a reload fails instead of continuing to poll', async () => {
+    const transportError = new Error('Network request failed');
+    const reload = vi.fn().mockRejectedValue(transportError);
+    const retry = vi.fn(() => Promise.resolve());
+    const confirmation = createEmailConfirmation({ reload, retry });
+
+    const result = confirmation.confirm('post-1');
+    const assertion = expect(result).rejects.toBe(transportError);
+    await advance(MAX_ATTEMPTS);
+
+    await assertion;
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the email and then polls for submission', async () => {
+    const { reload, retry, confirmation } = setup([pending, submitted]);
+
+    const result = confirmation.retryAndConfirm('post-1', 'email-1');
+    await advance(2);
+
+    await expect(result).resolves.toEqual({ kind: 'submitted' });
+    expect(retry).toHaveBeenCalledWith('email-1');
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a failed retry with partial detection', async () => {
+    const { confirmation } = setup([failed('Email was partially sent.')]);
+
+    const result = confirmation.retryAndConfirm('post-1', 'email-1');
+    await advance(1);
+
+    await expect(result).resolves.toEqual({
+      kind: 'failed',
+      error: 'Email was partially sent.',
+      partial: true,
+    });
+  });
+
+  it('keeps polling a retry even when the post is no longer published', async () => {
+    const { reload, confirmation } = setup([
+      { status: 'draft', email: pending.email },
+      { status: 'draft', email: submitted.email },
+    ]);
+
+    const result = confirmation.retryAndConfirm('post-1', 'email-1');
+    await advance(2);
+
+    await expect(result).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects when the retry request fails', async () => {
+    const transportError = new Error('Unable to connect');
+    const reload = vi.fn(() => Promise.resolve(pending));
+    const retry = vi.fn().mockRejectedValue(transportError);
+    const confirmation = createEmailConfirmation({ reload, retry });
+
+    await expect(confirmation.retryAndConfirm('post-1', 'email-1')).rejects.toBe(transportError);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('settles as cancelled and clears the pending timer when cancelled mid-poll', async () => {
+    const { reload, retry } = setup([pending]);
+    const clearedHandles: unknown[] = [];
+    const confirmation = createEmailConfirmation({
+      reload,
+      retry,
+      setTimeout: (callback, delay) => setTimeout(callback, delay),
+      clearTimeout: (handle) => {
+        clearedHandles.push(handle);
+        clearTimeout(handle as Parameters<typeof clearTimeout>[0]);
+      },
+    });
+
+    const result = confirmation.confirm('post-1');
+    await advance(2);
+    confirmation.cancel();
+
+    await expect(result).resolves.toEqual({ kind: 'cancelled' });
+    expect(clearedHandles).toHaveLength(1);
+
+    await advance(MAX_ATTEMPTS);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('settles as cancelled when cancelled while a reload is in flight', async () => {
+    let releaseReload: (post: EmailConfirmationPost) => void = () => {};
+    const reload = vi.fn(
+      () =>
+        new Promise<EmailConfirmationPost>((resolve) => {
+          releaseReload = resolve;
+        }),
+    );
+    const confirmation = createEmailConfirmation({ reload, retry: () => Promise.resolve() });
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+    confirmation.cancel();
+    releaseReload(submitted);
+
+    await expect(result).resolves.toEqual({ kind: 'cancelled' });
+  });
+
+  it('runs a single confirmation at a time', async () => {
+    const { reload, confirmation } = setup([pending, submitted]);
+
+    const first = confirmation.confirm('post-1');
+    const second = confirmation.confirm('post-1');
+    expect(second).toBe(first);
+
+    await advance(2);
+
+    await expect(first).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows a new run once the previous one has settled', async () => {
+    const { reload, confirmation } = setup([submitted]);
+
+    const first = confirmation.confirm('post-1');
+    await advance(1);
+    await first;
+
+    const second = confirmation.confirm('post-1');
+    expect(second).not.toBe(first);
+    await advance(1);
+
+    await expect(second).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isPartialEmailFailure', () => {
+  it.each([
+    ['Email was partially sent.', true],
+    ['partially', true],
+    ['The email failed to send.', false],
+    ['', false],
+    [null, false],
+    [undefined, false],
+  ])('reads %j as %s', (error, expected) => {
+    expect(isPartialEmailFailure(error)).toBe(expected);
+  });
+});

--- a/apps/admin/src/editor/publish/email-confirmation.test.ts
+++ b/apps/admin/src/editor/publish/email-confirmation.test.ts
@@ -272,9 +272,9 @@ describe('createEmailConfirmation', () => {
     const result = confirmation.confirm('post-1');
     await advance(1);
     confirmation.cancel();
-    releaseReload(submitted);
 
     await expect(result).resolves.toEqual({ kind: 'cancelled' });
+    releaseReload(submitted);
   });
 
   it('settles as cancelled when cancelled during the retry request', async () => {
@@ -290,10 +290,29 @@ describe('createEmailConfirmation', () => {
 
     const result = confirmation.retryAndConfirm('post-1', 'email-1');
     confirmation.cancel();
-    releaseRetry();
 
     await expect(result).resolves.toEqual({ kind: 'cancelled' });
+    releaseRetry();
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not reject when an abandoned reload fails after cancellation', async () => {
+    let rejectReload: (error: Error) => void = () => {};
+    const transportError = new Error('Late network failure');
+    const reload = vi.fn(
+      () =>
+        new Promise<EmailConfirmationPost>((_resolve, reject) => {
+          rejectReload = reject;
+        }),
+    );
+    const confirmation = createEmailConfirmation({ reload, retry: () => Promise.resolve() });
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+    confirmation.cancel();
+    rejectReload(transportError);
+
+    await expect(result).resolves.toEqual({ kind: 'cancelled' });
   });
 
   it('accepts a new confirmation immediately after cancelling a stuck one', async () => {
@@ -316,12 +335,12 @@ describe('createEmailConfirmation', () => {
     const restarted = confirmation.confirm('post-1');
     expect(restarted).not.toBe(abandoned);
 
-    releaseStuckReload(submitted);
     await advance(1);
 
     await expect(restarted).resolves.toEqual({ kind: 'submitted' });
     await expect(abandoned).resolves.toEqual({ kind: 'cancelled' });
     expect(reload).toHaveBeenCalledTimes(2);
+    releaseStuckReload(submitted);
   });
 
   it('coalesces a repeat confirmation of the same post', async () => {

--- a/apps/admin/src/editor/publish/email-confirmation.test.ts
+++ b/apps/admin/src/editor/publish/email-confirmation.test.ts
@@ -44,7 +44,7 @@ describe('createEmailConfirmation', () => {
     vi.useRealTimers();
   });
 
-  it('polls once a second for at most fifteen seconds', () => {
+  it('pins the poll interval to a second and the poll window to fifteen seconds', () => {
     expect(CONFIRM_EMAIL_POLL_LENGTH).toBe(1000);
     expect(CONFIRM_EMAIL_MAX_POLL_LENGTH).toBe(15000);
   });
@@ -67,13 +67,36 @@ describe('createEmailConfirmation', () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('does not poll when the supplied post has no email', async () => {
+  it('reports the supplied post having no email as nothing to confirm', async () => {
     const { reload, confirmation } = setup([submitted]);
 
     await expect(confirmation.confirm('post-1', { status: 'published' })).resolves.toEqual({
-      kind: 'submitted',
+      kind: 'not-needed',
     });
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reports a reloaded post having no email as nothing to confirm', async () => {
+    const { reload, confirmation } = setup([{ status: 'published' }]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(1);
+
+    await expect(result).resolves.toEqual({ kind: 'not-needed' });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps polling while the email is still submitting', async () => {
+    const { reload, confirmation } = setup([
+      published({ status: 'submitting', opened_count: 0, email_count: 1 }),
+      submitted,
+    ]);
+
+    const result = confirmation.confirm('post-1');
+    await advance(2);
+
+    await expect(result).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).toHaveBeenCalledTimes(2);
   });
 
   it('reports a full failure with the email error', async () => {
@@ -137,7 +160,7 @@ describe('createEmailConfirmation', () => {
     const result = confirmation.confirm('post-1');
     await advance(2);
 
-    await expect(result).resolves.toEqual({ kind: 'timeout' });
+    await expect(result).resolves.toEqual({ kind: 'unpublished' });
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
@@ -230,6 +253,7 @@ describe('createEmailConfirmation', () => {
 
     await expect(result).resolves.toEqual({ kind: 'cancelled' });
     expect(clearedHandles).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
 
     await advance(MAX_ATTEMPTS);
     expect(reload).toHaveBeenCalledTimes(2);
@@ -253,7 +277,54 @@ describe('createEmailConfirmation', () => {
     await expect(result).resolves.toEqual({ kind: 'cancelled' });
   });
 
-  it('runs a single confirmation at a time', async () => {
+  it('settles as cancelled when cancelled during the retry request', async () => {
+    let releaseRetry: () => void = () => {};
+    const { reload } = setup([submitted]);
+    const retry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRetry = resolve;
+        }),
+    );
+    const confirmation = createEmailConfirmation({ reload, retry });
+
+    const result = confirmation.retryAndConfirm('post-1', 'email-1');
+    confirmation.cancel();
+    releaseRetry();
+
+    await expect(result).resolves.toEqual({ kind: 'cancelled' });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('accepts a new confirmation immediately after cancelling a stuck one', async () => {
+    let releaseStuckReload: (post: EmailConfirmationPost) => void = () => {};
+    const reload = vi.fn(() => {
+      if (reload.mock.calls.length > 1) {
+        return Promise.resolve(submitted);
+      }
+
+      return new Promise<EmailConfirmationPost>((resolve) => {
+        releaseStuckReload = resolve;
+      });
+    });
+    const confirmation = createEmailConfirmation({ reload, retry: () => Promise.resolve() });
+
+    const abandoned = confirmation.confirm('post-1');
+    await advance(1);
+    confirmation.cancel();
+
+    const restarted = confirmation.confirm('post-1');
+    expect(restarted).not.toBe(abandoned);
+
+    releaseStuckReload(submitted);
+    await advance(1);
+
+    await expect(restarted).resolves.toEqual({ kind: 'submitted' });
+    await expect(abandoned).resolves.toEqual({ kind: 'cancelled' });
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces a repeat confirmation of the same post', async () => {
     const { reload, confirmation } = setup([pending, submitted]);
 
     const first = confirmation.confirm('post-1');
@@ -264,6 +335,55 @@ describe('createEmailConfirmation', () => {
 
     await expect(first).resolves.toEqual({ kind: 'submitted' });
     expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('abandons the run in progress when a different post is confirmed', async () => {
+    const posts: Record<string, EmailConfirmationPost> = {
+      'post-1': pending,
+      'post-2': submitted,
+    };
+    const reload = vi.fn((postId: string) => Promise.resolve(posts[postId]));
+    const confirmation = createEmailConfirmation({ reload, retry: () => Promise.resolve() });
+
+    const abandoned = confirmation.confirm('post-1');
+    await advance(1);
+
+    const started = confirmation.confirm('post-2');
+    expect(started).not.toBe(abandoned);
+    await advance(1);
+
+    await expect(abandoned).resolves.toEqual({ kind: 'cancelled' });
+    await expect(started).resolves.toEqual({ kind: 'submitted' });
+    expect(reload).toHaveBeenCalledWith('post-2');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('abandons a confirmation in progress when the same post is retried', async () => {
+    const { retry, confirmation } = setup([pending, submitted]);
+
+    const abandoned = confirmation.confirm('post-1');
+    await advance(1);
+
+    const started = confirmation.retryAndConfirm('post-1', 'email-1');
+    expect(started).not.toBe(abandoned);
+    await advance(1);
+
+    await expect(abandoned).resolves.toEqual({ kind: 'cancelled' });
+    await expect(started).resolves.toEqual({ kind: 'submitted' });
+    expect(retry).toHaveBeenCalledWith('email-1');
+  });
+
+  it('coalesces a repeat retry of the same post', async () => {
+    const { retry, confirmation } = setup([submitted]);
+
+    const first = confirmation.retryAndConfirm('post-1', 'email-1');
+    const second = confirmation.retryAndConfirm('post-1', 'email-1');
+    expect(second).toBe(first);
+
+    await advance(1);
+
+    await expect(first).resolves.toEqual({ kind: 'submitted' });
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 
   it('allows a new run once the previous one has settled', async () => {

--- a/apps/admin/src/editor/publish/email-confirmation.ts
+++ b/apps/admin/src/editor/publish/email-confirmation.ts
@@ -1,0 +1,163 @@
+import type { Email, PostStatus } from '@tryghost/admin-x-framework/api/posts';
+
+export const CONFIRM_EMAIL_POLL_LENGTH = 1000;
+export const CONFIRM_EMAIL_MAX_POLL_LENGTH = 15 * 1000;
+
+export interface EmailConfirmationPost {
+  status?: PostStatus;
+  email?: Email | null;
+}
+
+export type EmailConfirmationOutcome =
+  | { kind: 'submitted' }
+  | { kind: 'failed'; error: string | null; partial: boolean }
+  | { kind: 'timeout' }
+  | { kind: 'cancelled' };
+
+export type TimerHandle = unknown;
+
+export interface EmailConfirmationOptions {
+  reload: (postId: string) => Promise<EmailConfirmationPost>;
+  retry: (emailId: string) => Promise<void>;
+  setTimeout?: (callback: () => void, delay: number) => TimerHandle;
+  clearTimeout?: (handle: TimerHandle) => void;
+}
+
+export interface EmailConfirmation {
+  confirm(postId: string, currentPost?: EmailConfirmationPost): Promise<EmailConfirmationOutcome>;
+  retryAndConfirm(postId: string, emailId: string): Promise<EmailConfirmationOutcome>;
+  cancel(): void;
+}
+
+// A partially delivered send is only distinguishable by the word "partially"
+// appearing in the error message the API stores on the email.
+export function isPartialEmailFailure(error?: string | null): boolean {
+  return !!error && error.includes('partially');
+}
+
+function failureOutcome(email?: Email | null): EmailConfirmationOutcome {
+  const error = email?.error ?? null;
+  return { kind: 'failed', error, partial: isPartialEmailFailure(error) };
+}
+
+export function createEmailConfirmation(options: EmailConfirmationOptions): EmailConfirmation {
+  const { reload, retry } = options;
+  const schedule =
+    options.setTimeout ?? ((callback: () => void, delay: number) => setTimeout(callback, delay));
+  const unschedule =
+    options.clearTimeout ??
+    ((handle: TimerHandle) => clearTimeout(handle as Parameters<typeof clearTimeout>[0]));
+
+  let inFlight: Promise<EmailConfirmationOutcome> | null = null;
+  let cancelled = false;
+  let pendingTimer: TimerHandle = null;
+  let releasePendingWait: (() => void) | null = null;
+
+  function wait(delay: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      releasePendingWait = resolve;
+      pendingTimer = schedule(() => {
+        pendingTimer = null;
+        releasePendingWait = null;
+        resolve();
+      }, delay);
+    });
+  }
+
+  function cancel(): void {
+    cancelled = true;
+
+    if (pendingTimer !== null) {
+      unschedule(pendingTimer);
+      pendingTimer = null;
+    }
+
+    releasePendingWait?.();
+    releasePendingWait = null;
+  }
+
+  async function poll(
+    postId: string,
+    { stopWhenUnpublished }: { stopWhenUnpublished: boolean },
+  ): Promise<EmailConfirmationOutcome> {
+    let pollTimeout = 0;
+
+    while (pollTimeout < CONFIRM_EMAIL_MAX_POLL_LENGTH) {
+      await wait(CONFIRM_EMAIL_POLL_LENGTH);
+
+      if (cancelled) {
+        return { kind: 'cancelled' };
+      }
+
+      pollTimeout += CONFIRM_EMAIL_POLL_LENGTH;
+
+      const post = await reload(postId);
+
+      if (cancelled) {
+        return { kind: 'cancelled' };
+      }
+
+      // A post that is no longer published or sent never sends or retries an
+      // email, so give up the same way as running out of attempts.
+      if (stopWhenUnpublished && post.status !== 'sent' && post.status !== 'published') {
+        return { kind: 'timeout' };
+      }
+
+      if (post.email?.status === 'submitted') {
+        return { kind: 'submitted' };
+      }
+
+      if (post.email?.status === 'failed') {
+        return failureOutcome(post.email);
+      }
+    }
+
+    return { kind: 'timeout' };
+  }
+
+  function run(work: () => Promise<EmailConfirmationOutcome>): Promise<EmailConfirmationOutcome> {
+    if (inFlight) {
+      return inFlight;
+    }
+
+    cancelled = false;
+
+    const started = work();
+    const settle = () => {
+      if (inFlight === started) {
+        inFlight = null;
+      }
+    };
+
+    inFlight = started;
+    started.then(settle, settle);
+
+    return started;
+  }
+
+  return {
+    confirm(postId, currentPost) {
+      return run(async () => {
+        if (currentPost && (!currentPost.email || currentPost.email.status === 'submitted')) {
+          return { kind: 'submitted' };
+        }
+
+        return poll(postId, { stopWhenUnpublished: true });
+      });
+    },
+
+    retryAndConfirm(postId, emailId) {
+      return run(async () => {
+        await retry(emailId);
+
+        if (cancelled) {
+          return { kind: 'cancelled' };
+        }
+
+        return poll(postId, { stopWhenUnpublished: false });
+      });
+    },
+
+    cancel,
+  };
+}

--- a/apps/admin/src/editor/publish/email-confirmation.ts
+++ b/apps/admin/src/editor/publish/email-confirmation.ts
@@ -11,7 +11,9 @@ export interface EmailConfirmationPost {
 export type EmailConfirmationOutcome =
   | { kind: 'submitted' }
   | { kind: 'failed'; error: string | null; partial: boolean }
+  | { kind: 'unpublished' }
   | { kind: 'timeout' }
+  | { kind: 'not-needed' }
   | { kind: 'cancelled' };
 
 export type TimerHandle = unknown;
@@ -27,6 +29,16 @@ export interface EmailConfirmation {
   confirm(postId: string, currentPost?: EmailConfirmationPost): Promise<EmailConfirmationOutcome>;
   retryAndConfirm(postId: string, emailId: string): Promise<EmailConfirmationOutcome>;
   cancel(): void;
+}
+
+type RunOperation = 'confirm' | 'retry';
+
+interface RunState {
+  operation: RunOperation;
+  postId: string;
+  cancelled: boolean;
+  timer: TimerHandle;
+  release: (() => void) | null;
 }
 
 // A partially delivered send is only distinguishable by the word "partially"
@@ -48,66 +60,91 @@ export function createEmailConfirmation(options: EmailConfirmationOptions): Emai
     options.clearTimeout ??
     ((handle: TimerHandle) => clearTimeout(handle as Parameters<typeof clearTimeout>[0]));
 
-  let inFlight: Promise<EmailConfirmationOutcome> | null = null;
-  let cancelled = false;
-  let pendingTimer: TimerHandle = null;
-  let releasePendingWait: (() => void) | null = null;
+  let current: { state: RunState; promise: Promise<EmailConfirmationOutcome> } | null = null;
 
-  function wait(delay: number): Promise<void> {
+  function wait(state: RunState, delay: number): Promise<void> {
     return new Promise<void>((resolve) => {
-      releasePendingWait = resolve;
-      pendingTimer = schedule(() => {
-        pendingTimer = null;
-        releasePendingWait = null;
+      let fired = false;
+      const release = () => {
+        if (fired) {
+          return;
+        }
+
+        fired = true;
+        state.timer = null;
+        state.release = null;
         resolve();
-      }, delay);
+      };
+
+      state.release = release;
+
+      const handle = schedule(release, delay);
+
+      // Only keep a handle that is still pending: a scheduler that runs its
+      // callback synchronously has already finished with this one.
+      if (!fired) {
+        state.timer = handle;
+      }
     });
   }
 
-  function cancel(): void {
-    cancelled = true;
+  function stop(state: RunState): void {
+    state.cancelled = true;
 
-    if (pendingTimer !== null) {
-      unschedule(pendingTimer);
-      pendingTimer = null;
+    if (state.timer !== null) {
+      unschedule(state.timer);
+      state.timer = null;
     }
 
-    releasePendingWait?.();
-    releasePendingWait = null;
+    state.release?.();
+    state.release = null;
+  }
+
+  function cancel(): void {
+    if (!current) {
+      return;
+    }
+
+    stop(current.state);
+    current = null;
   }
 
   async function poll(
-    postId: string,
+    state: RunState,
     { stopWhenUnpublished }: { stopWhenUnpublished: boolean },
   ): Promise<EmailConfirmationOutcome> {
     let pollTimeout = 0;
 
     while (pollTimeout < CONFIRM_EMAIL_MAX_POLL_LENGTH) {
-      await wait(CONFIRM_EMAIL_POLL_LENGTH);
+      await wait(state, CONFIRM_EMAIL_POLL_LENGTH);
 
-      if (cancelled) {
+      if (state.cancelled) {
         return { kind: 'cancelled' };
       }
 
       pollTimeout += CONFIRM_EMAIL_POLL_LENGTH;
 
-      const post = await reload(postId);
+      const post = await reload(state.postId);
 
-      if (cancelled) {
+      if (state.cancelled) {
         return { kind: 'cancelled' };
       }
 
       // A post that is no longer published or sent never sends or retries an
-      // email, so give up the same way as running out of attempts.
+      // email, so there is nothing left to wait for.
       if (stopWhenUnpublished && post.status !== 'sent' && post.status !== 'published') {
-        return { kind: 'timeout' };
+        return { kind: 'unpublished' };
       }
 
-      if (post.email?.status === 'submitted') {
+      if (!post.email) {
+        return { kind: 'not-needed' };
+      }
+
+      if (post.email.status === 'submitted') {
         return { kind: 'submitted' };
       }
 
-      if (post.email?.status === 'failed') {
+      if (post.email.status === 'failed') {
         return failureOutcome(post.email);
       }
     }
@@ -115,46 +152,60 @@ export function createEmailConfirmation(options: EmailConfirmationOptions): Emai
     return { kind: 'timeout' };
   }
 
-  function run(work: () => Promise<EmailConfirmationOutcome>): Promise<EmailConfirmationOutcome> {
-    if (inFlight) {
-      return inFlight;
+  function run(
+    operation: RunOperation,
+    postId: string,
+    work: (state: RunState) => Promise<EmailConfirmationOutcome>,
+  ): Promise<EmailConfirmationOutcome> {
+    if (current) {
+      if (current.state.operation === operation && current.state.postId === postId) {
+        return current.promise;
+      }
+
+      // A run belongs to one operation on one post, so only an identical
+      // repeat coalesces; anything else abandons the run in progress.
+      stop(current.state);
+      current = null;
     }
 
-    cancelled = false;
-
-    const started = work();
+    const state: RunState = { operation, postId, cancelled: false, timer: null, release: null };
+    const promise = work(state);
     const settle = () => {
-      if (inFlight === started) {
-        inFlight = null;
+      if (current?.state === state) {
+        current = null;
       }
     };
 
-    inFlight = started;
-    started.then(settle, settle);
+    current = { state, promise };
+    promise.then(settle, settle);
 
-    return started;
+    return promise;
   }
 
   return {
     confirm(postId, currentPost) {
-      return run(async () => {
-        if (currentPost && (!currentPost.email || currentPost.email.status === 'submitted')) {
-          return { kind: 'submitted' };
+      return run('confirm', postId, (state) => {
+        if (currentPost && !currentPost.email) {
+          return Promise.resolve({ kind: 'not-needed' });
         }
 
-        return poll(postId, { stopWhenUnpublished: true });
+        if (currentPost?.email?.status === 'submitted') {
+          return Promise.resolve({ kind: 'submitted' });
+        }
+
+        return poll(state, { stopWhenUnpublished: true });
       });
     },
 
     retryAndConfirm(postId, emailId) {
-      return run(async () => {
+      return run('retry', postId, async (state) => {
         await retry(emailId);
 
-        if (cancelled) {
+        if (state.cancelled) {
           return { kind: 'cancelled' };
         }
 
-        return poll(postId, { stopWhenUnpublished: false });
+        return poll(state, { stopWhenUnpublished: false });
       });
     },
 

--- a/apps/admin/src/editor/publish/email-confirmation.ts
+++ b/apps/admin/src/editor/publish/email-confirmation.ts
@@ -39,6 +39,7 @@ interface RunState {
   cancelled: boolean;
   timer: TimerHandle;
   release: (() => void) | null;
+  settleCancelled: () => void;
 }
 
 // A partially delivered send is only distinguishable by the word "partially"
@@ -98,6 +99,7 @@ export function createEmailConfirmation(options: EmailConfirmationOptions): Emai
 
     state.release?.();
     state.release = null;
+    state.settleCancelled();
   }
 
   function cancel(): void {
@@ -168,8 +170,19 @@ export function createEmailConfirmation(options: EmailConfirmationOptions): Emai
       current = null;
     }
 
-    const state: RunState = { operation, postId, cancelled: false, timer: null, release: null };
-    const promise = work(state);
+    let settleCancelled: () => void = () => {};
+    const cancellation = new Promise<EmailConfirmationOutcome>((resolve) => {
+      settleCancelled = () => resolve({ kind: 'cancelled' });
+    });
+    const state: RunState = {
+      operation,
+      postId,
+      cancelled: false,
+      timer: null,
+      release: null,
+      settleCancelled,
+    };
+    const promise = Promise.race([work(state), cancellation]);
     const settle = () => {
       if (current?.state === state) {
         current = null;


### PR DESCRIPTION
## What

Adds `apps/admin/src/editor/publish/email-confirmation.ts`: the post-publish wait that watches an email leave the `pending` state, as a dependency-free TypeScript module with unit tests. No React, no UI, no wiring yet.

Publishing a post with an immediate email returns before the email has actually been handed to the delivery service. The editor has to keep checking until the email reports `submitted`, so it can either close out the publish flow or show the failure state. This module owns that loop.

## Shape

```ts
const confirmation = createEmailConfirmation({ reload, retry });

await confirmation.confirm(postId, currentPost);
await confirmation.retryAndConfirm(postId, emailId);
confirmation.cancel();
```

- Network access arrives as injected ports — `reload(postId)` returns the post with its embedded email, `retry(emailId)` re-sends. `setTimeout`/`clearTimeout` are injectable and default to the globals.
- Both entry points resolve to a typed outcome rather than throwing: `submitted`, `failed` (with `error` and `partial`), `unpublished`, `timeout`, `not-needed`, `cancelled`. The caller decides what each one looks like on screen.
- A transport error from `reload` or `retry` rejects the returned promise instead of being folded into an outcome, so the caller's existing API-error handling still applies.
- A run is bound to one operation on one post. Repeating the same call while it is in flight returns the same promise; confirming a different post, or retrying while a confirmation is running, abandons the previous run (which settles as `cancelled`) and starts a fresh one. `cancel()` does the same for unmount, releasing the slot so the next call always starts clean even if a reload never settled.

## Behaviour worth calling out

- Polls every second, giving up after fifteen seconds (`CONFIRM_EMAIL_POLL_LENGTH` and `CONFIRM_EMAIL_MAX_POLL_LENGTH` are exported and pinned by a test). The delay comes before the first reload, so a fifteen-second window is exactly fifteen reloads.
- Outcomes are kept distinct where the UI story differs: `timeout` means still sending after the full window, `unpublished` means the post left the `published`/`sent` states so nothing will send or retry, and `not-needed` means there is no email to wait on at all. The no-email check applies both to a post handed in and to one that comes back from a reload.
- Passing the already-loaded post to `confirm` skips the first delay when its email is already submitted or absent.
- `retryAndConfirm` keeps polling regardless of post status, matching the retry path it replaces.
- A partially delivered send is only distinguishable by the word `partially` appearing in the error message the API stores on the email. That check is preserved and flagged in a comment, and the `partial` flag on the failed outcome carries it.
- Every exit path leaves no live timer, including cancellation and abandonment.

## Testing

33 unit tests with fake timers cover: submission on the nth poll, `submitting` treated as still in progress, full vs. partial failure detection, the exact attempt count at timeout, the unpublished stop, both no-email paths, retry-then-success, retry that keeps polling past a status change, cancellation mid-poll, mid-reload and mid-retry, cancel-then-restart, cross-post and cross-operation handover, coalescing of identical repeats, and transport-error rejection on both ports.

`apps/admin` lint, `tsc -b`, and the full unit suite (2637 tests) pass.