### PR TITLE
Added the editor publish options as a pure module

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -46,6 +46,11 @@
       "import": "./dist/utils/get-site-timezone.js",
       "require": "./dist/utils/get-site-timezone.cjs"
     },
+    "./utils/recipient-filter": {
+      "types": "./types/utils/recipient-filter.d.ts",
+      "import": "./dist/utils/recipient-filter.js",
+      "require": "./dist/utils/recipient-filter.cjs"
+    },
     "./vite": {
       "types": "./types/vite.d.ts",
       "import": "./dist/vite.js",

--- a/apps/admin/src/editor/publish/README.md
+++ b/apps/admin/src/editor/publish/README.md
@@ -93,7 +93,7 @@ Core represents the special segments as `all` and `none`. Inputs and explicit se
 
 ## Whether the post emails
 
-`willEmail` requires a selected newsletter and email that is not disabled — without those there is nothing to send and nothing to send it with. Given both, it is true when either holds:
+`willEmail` requires a selected newsletter and email that is not disabled. Fresh emails must also be available; a failed-email draft is the only unavailable state allowed through because it retries an existing email. Given those prerequisites, it is true when either holds:
 
 - the type is not `publish`, a recipient filter is set, the post is still a draft, and it has no email record; or
 - the post is a draft whose email record failed. A failed send is retried regardless of the selected type or filter.

--- a/apps/admin/src/editor/publish/README.md
+++ b/apps/admin/src/editor/publish/README.md
@@ -16,13 +16,13 @@ It is pure TypeScript. It imports no React and performs no network calls; every 
 
 Inputs are read once, at creation: the machine is built after the data it needs has loaded, and replaced rather than updated when the post changes.
 
-`memberCount` is `null` when the count could not be read — an editor, author or contributor cannot browse members — and a `null` count counts as "has members" so email is not disabled for the wrong reason.
+`memberCount` is read for admins only, because nobody else can browse members. A count of `null` — not read, or not readable — counts as "has members" so email is never disabled for the wrong reason.
 
-Only newsletters with `status: 'active'` are selectable; they are ordered by `sortOrder`, and the first is selected by default.
+Only newsletters with `status: 'active'` are selectable; they are ordered by `sortOrder`, and the first is selected by default. `onlyDefaultNewsletter` reports whether there is exactly one, which is what decides whether the flow offers a newsletter picker at all.
 
 ## Publish types
 
-Three types, and the flow shows all three whenever the type picker is shown at all:
+Three types:
 
 | Value          | Label             | Effect                                       |
 | -------------- | ----------------- | -------------------------------------------- |
@@ -38,7 +38,15 @@ The initial type is `publish+send`, narrowed in order:
 2. `publish` when the site's default recipients are "usually nobody" (a `filter` default with no filter). Recipients still follow post visibility, so turning email on is a single click.
 3. `send` for a post that has already been sent, whatever the two rules above decided.
 
-`setPublishType()` does not validate: the caller may select a disabled type, and `availablePublishTypes` tells the UI which ones to offer.
+`setPublishType()` does not validate, so `availablePublishTypes` is what tells the UI which types to offer:
+
+| State             | `availablePublishTypes`           |
+| ----------------- | --------------------------------- |
+| Email available   | `publish+send`, `publish`, `send` |
+| Email disabled    | `publish`                         |
+| Email unavailable | `publish`                         |
+
+Selecting a type that is not on offer never produces an email: the post-emails rules below gate on availability, not on the selection alone.
 
 ## Email availability
 
@@ -54,12 +62,13 @@ Two separate states, because they have different UI consequences.
 
 **Disabled** shows the picker with the two email types disabled. `emailDisabledReason` names the first reason that applies:
 
-| Reason               | Condition                                         |
-| -------------------- | ------------------------------------------------- |
-| `no-mailgun`         | No bulk email provider is configured              |
-| `no-members`         | The member count is exactly `0`                   |
-| `sending-limit`      | The host's email limit would be exceeded          |
-| `email-verification` | Sending is on hold while the account is in review |
+| Reason               | Condition                                           |
+| -------------------- | --------------------------------------------------- |
+| `no-mailgun`         | No bulk email provider is configured                |
+| `no-members`         | The member count is exactly `0`                     |
+| `no-newsletter`      | No newsletter is selected, so no email can be built |
+| `sending-limit`      | The host's email limit would be exceeded            |
+| `email-verification` | Sending is on hold while the account is in review   |
 
 The last two are set by `checkLimits()`.
 
@@ -82,7 +91,7 @@ Following visibility maps a public or members-only post to everyone (`status:fre
 
 ## Whether the post emails
 
-`willEmail` is true when either holds:
+`willEmail` requires a selected newsletter and email that is not disabled — without those there is nothing to send and nothing to send it with. Given both, it is true when either holds:
 
 - the type is not `publish`, a recipient filter is set, the post is still a draft, and it has no email record; or
 - the post is a draft whose email record failed. A failed send is retried regardless of the selected type or filter.
@@ -111,7 +120,7 @@ Times are ISO 8601 strings with milliseconds zeroed, because the API stores seco
 
 Email extras ride on the command only when `willEmail` is true: `emailOnly` (true only for `send`), the selected newsletter's slug, and the recipient filter as `emailSegment`. An empty filter sends the newsletter with no segment. `toRevertDispatch()` returns `{kind: 'revert'}` for any status; the engine derives the rest of that transition (clearing the publish time only when unscheduling, and always clearing `emailOnly`).
 
-The machine never mutates a post, so it needs no snapshot-and-rollback around a failed save: the save engine builds each request from its own snapshot, and the change tracker adopts the acknowledged status only once the server confirms it. A failed publish leaves both the post and these options exactly as they were, ready to dispatch again.
+The machine never mutates a post, so it needs no snapshot-and-rollback around a failed save: the save engine builds each request from its own snapshot and adopts the acknowledged status only once the server confirms it. A failed publish leaves both the post and these options exactly as they were, ready to dispatch again.
 
 ## Limits
 
@@ -121,8 +130,10 @@ The sending check awaits `refreshSettings()` before anything else, so a hold app
 
 The publishing check runs for admins only, since nobody else can read the member count. A rejection becomes a `host-limit` block with the host's message split into `parts`, where the segment marked `upgrade` is the phrase to render as an upgrade link. The message is returned as data, never as markup.
 
-Both blocks feed the state directly: an email block disables the email publish types, and — unless the user has already chosen a type — the initial-type rules are re-applied so the selection falls back to `publish`.
+Both blocks feed the state directly. An email block disables the email publish types and re-applies the initial-type rules, so the selection falls back to `publish`; that demotion also applies to a type the user picked before the block landed, since a block that arrives late must not leave an unsendable type selected.
 
 ## Dirty state and reset
 
-`isDirty` compares the publish type, scheduling, scheduled time, newsletter and recipient filter against the values the machine started with. Selecting the value that was already there is not a change. `reset()` restores all of them, and re-arms the automatic type fallback that `setPublishType()` disables.
+`isDirty` compares the publish type, scheduling, newsletter and recipient filter against the values the machine started with; selecting the value that was already there is not a change. The scheduled time counts only while scheduling is on or the user has actually chosen a time, so turning scheduling on and back off leaves the state clean.
+
+`reset()` restores every option and re-arms the automatic type fallback that `setPublishType()` disables. It takes a fresh scheduled time from the current clock, since the floor the machine was created with may itself have passed.

--- a/apps/admin/src/editor/publish/README.md
+++ b/apps/admin/src/editor/publish/README.md
@@ -18,7 +18,7 @@ Inputs are read once, at creation: the machine is built after the data it needs 
 
 `memberCount` is read for admins only, because nobody else can browse members. A count of `null` — not read, or not readable — counts as "has members" so email is never disabled for the wrong reason.
 
-Only newsletters with `status: 'active'` are selectable; they are ordered by `sortOrder`, and the first is selected by default. `onlyDefaultNewsletter` reports whether there is exactly one, which is what decides whether the flow offers a newsletter picker at all.
+Only newsletters with `status: 'active'` are selectable; they are ordered by `sortOrder`. The post's persisted active newsletter is selected initially when it is present, otherwise the first active newsletter is the default. A failed-email retry also retains its persisted newsletter even when it is no longer selectable. `onlyDefaultNewsletter` reports whether there is exactly one active newsletter, which is what decides whether the flow offers a newsletter picker at all.
 
 ## Publish types
 
@@ -87,6 +87,8 @@ Following visibility maps a public or members-only post to everyone (`status:fre
 
 `setRecipientFilter(null)` is a real choice — "no recipients" — and is distinct from never having chosen.
 
+Core represents the special segments as `all` and `none`. Inputs and explicit selections normalize those API sentinels to the editor's expanded everyone filter and `null`, matching the legacy Admin transform.
+
 `fullRecipientFilter` is what the email service receives: the newsletter's own audience filter (subscribed to that newsletter, email not disabled, plus paid-only for a paid newsletter), AND-ed with the recipient filter when there is one. It is `null` while no newsletter is selected.
 
 ## Whether the post emails
@@ -112,13 +114,14 @@ Times are ISO 8601 strings with milliseconds zeroed, because the API stores seco
 
 `toDispatch()` returns the status command for the current options, shaped exactly as the save engine accepts it:
 
-| Options     | Command                                                                                                |
-| ----------- | ------------------------------------------------------------------------------------------------------ |
-| Unscheduled | `{kind: 'publish', options}` — no publish time, so the post keeps the one it has                       |
-| Scheduled   | `{kind: 'schedule', options}` with `publishedAt` set to the scheduled time                             |
-| Not a draft | `null` — publishing and scheduling are draft-only transitions, and `canPublish` reports the same thing |
+| Options                                | Command                                                                                                |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Unscheduled                            | `{kind: 'publish', options}` — no publish time, so the post keeps the one it has                       |
+| Scheduled                              | `{kind: 'schedule', options}` with `publishedAt` set to the scheduled time                             |
+| Not a draft                            | `null` — publishing and scheduling are draft-only transitions, and `canPublish` reports the same thing |
+| Email-only without an executable email | `null` — an invalid email choice must never fall through to a public publish                           |
 
-Email extras ride on the command only when `willEmail` is true: `emailOnly` (true only for `send`), the selected newsletter's slug, and the recipient filter as `emailSegment`. An empty filter sends the newsletter with no segment. `toRevertDispatch()` returns `{kind: 'revert'}` for any status; the engine derives the rest of that transition (clearing the publish time only when unscheduling, and always clearing `emailOnly`).
+Email extras ride on the command only when `willEmail` is true: `emailOnly` (true only for `send`), the selected newsletter's slug, and the recipient filter as `emailSegment`. Failed-email retries omit the newsletter and segment overrides so Core validates and retries the durable email against the values it was created with. `toRevertDispatch()` returns `{kind: 'revert'}` for any status; the engine derives the rest of that transition (clearing the publish time only when unscheduling, and always clearing `emailOnly`).
 
 The machine never mutates a post, so it needs no snapshot-and-rollback around a failed save: the save engine builds each request from its own snapshot and adopts the acknowledged status only once the server confirms it. A failed publish leaves both the post and these options exactly as they were, ready to dispatch again.
 

--- a/apps/admin/src/editor/publish/README.md
+++ b/apps/admin/src/editor/publish/README.md
@@ -1,0 +1,128 @@
+# Publish options
+
+`createPublishOptions()` is the state machine behind the editor's publish flow: it holds the choices a user makes in that flow (publish type, schedule, newsletter, recipients) and turns them into the save command that changes a post's status.
+
+It is pure TypeScript. It imports no React and performs no network calls; every input is plain data supplied by the caller, and the only asynchronous work goes through injected limit ports. Every transition is synchronous and caller-driven, so there is no subscription: call a transition, then read `getState()`.
+
+## Inputs
+
+| Input    | Contents                                                                                                                                     |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `post`   | `status`, `isPage`, `visibility`, `tiers`, the persisted `newsletter` slug and `emailSegment`, and the post's `email` record when one exists |
+| `site`   | `membersEnabled`, `mailgunConfigured`, `editorDefaultEmailRecipients` and its filter, `memberCount`, and the full `newsletters` list         |
+| `user`   | `isAdmin` and `isAuthorOrContributor`, which decide whether each limit is evaluated                                                          |
+| `limits` | Optional ports for the sending and publishing limit checks                                                                                   |
+| `now`    | Optional clock, injected for tests                                                                                                           |
+
+Inputs are read once, at creation: the machine is built after the data it needs has loaded, and replaced rather than updated when the post changes.
+
+`memberCount` is `null` when the count could not be read — an editor, author or contributor cannot browse members — and a `null` count counts as "has members" so email is not disabled for the wrong reason.
+
+Only newsletters with `status: 'active'` are selectable; they are ordered by `sortOrder`, and the first is selected by default.
+
+## Publish types
+
+Three types, and the flow shows all three whenever the type picker is shown at all:
+
+| Value          | Label             | Effect                                       |
+| -------------- | ----------------- | -------------------------------------------- |
+| `publish+send` | Publish and email | Publishes and emails the selected recipients |
+| `publish`      | Publish only      | Publishes without emailing                   |
+| `send`         | Email only        | Emails without listing the post publicly     |
+
+`willPublish` is every type but `send`; `willOnlyEmail` is only `send`.
+
+The initial type is `publish+send`, narrowed in order:
+
+1. `publish` when email is unavailable or disabled.
+2. `publish` when the site's default recipients are "usually nobody" (a `filter` default with no filter). Recipients still follow post visibility, so turning email on is a single click.
+3. `send` for a post that has already been sent, whatever the two rules above decided.
+
+`setPublishType()` does not validate: the caller may select a disabled type, and `availablePublishTypes` tells the UI which ones to offer.
+
+## Email availability
+
+Two separate states, because they have different UI consequences.
+
+**Unavailable** hides the type picker entirely. `emailUnavailableReason` names the first reason that applies:
+
+| Reason                 | Condition                                                    |
+| ---------------------- | ------------------------------------------------------------ |
+| `page`                 | The post is a page                                           |
+| `already-emailed`      | The post already has an email record, including a failed one |
+| `disabled-in-settings` | Default recipients are `disabled`, or members are turned off |
+
+**Disabled** shows the picker with the two email types disabled. `emailDisabledReason` names the first reason that applies:
+
+| Reason               | Condition                                         |
+| -------------------- | ------------------------------------------------- |
+| `no-mailgun`         | No bulk email provider is configured              |
+| `no-members`         | The member count is exactly `0`                   |
+| `sending-limit`      | The host's email limit would be exceeded          |
+| `email-verification` | Sending is on hold while the account is in review |
+
+The last two are set by `checkLimits()`.
+
+## Recipients
+
+`recipientFilter` is the member filter the email targets. Until the user picks one it is the post's own `emailSegment` (only when the post also carries a newsletter), otherwise the site default:
+
+| Default recipients setting                 | Filter                            |
+| ------------------------------------------ | --------------------------------- |
+| `disabled`                                 | none                              |
+| `filter` with a filter                     | that filter                       |
+| `filter` with no filter ("usually nobody") | follows post visibility, as below |
+| `visibility`                               | follows post visibility           |
+
+Following visibility maps a public or members-only post to everyone (`status:free,status:-free`), a paid post to `status:-free`, and a tiers-restricted post to its tier segments (`tier:<slug>` joined by commas, or no filter when it has no tiers). Any other visibility value is used verbatim as the filter.
+
+`setRecipientFilter(null)` is a real choice — "no recipients" — and is distinct from never having chosen.
+
+`fullRecipientFilter` is what the email service receives: the newsletter's own audience filter (subscribed to that newsletter, email not disabled, plus paid-only for a paid newsletter), AND-ed with the recipient filter when there is one. It is `null` while no newsletter is selected.
+
+## Whether the post emails
+
+`willEmail` is true when either holds:
+
+- the type is not `publish`, a recipient filter is set, the post is still a draft, and it has no email record; or
+- the post is a draft whose email record failed. A failed send is retried regardless of the selected type or filter.
+
+`willEmailImmediately` is `willEmail` on an unscheduled post — the flow's confirmation copy and any post-save email polling hang off it.
+
+## Scheduling
+
+Times are ISO 8601 strings with milliseconds zeroed, because the API stores seconds and a non-zero millisecond value can fail validation when a scheduled post is updated.
+
+- `minScheduledAt` is five seconds ahead of now and is recomputed on every read; it is the floor the picker enforces.
+- `scheduledAt` starts at that floor.
+- `setIsScheduled(true)` snaps a time that is earlier than ten minutes ahead of now forward to exactly that default; calling it with no argument toggles.
+- `setScheduledAt()` zeroes milliseconds and clamps anything before the floor up to it. An unparseable date is ignored.
+- `resetPastScheduledAt()` turns scheduling off when the chosen time has fallen into the past. It leaves the stale time in place: re-enabling scheduling snaps it forward to the default, so the stale value is never offered.
+
+## Producing a save command
+
+`toDispatch()` returns the status command for the current options, shaped exactly as the save engine accepts it:
+
+| Options     | Command                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------ |
+| Unscheduled | `{kind: 'publish', options}` — no publish time, so the post keeps the one it has                       |
+| Scheduled   | `{kind: 'schedule', options}` with `publishedAt` set to the scheduled time                             |
+| Not a draft | `null` — publishing and scheduling are draft-only transitions, and `canPublish` reports the same thing |
+
+Email extras ride on the command only when `willEmail` is true: `emailOnly` (true only for `send`), the selected newsletter's slug, and the recipient filter as `emailSegment`. An empty filter sends the newsletter with no segment. `toRevertDispatch()` returns `{kind: 'revert'}` for any status; the engine derives the rest of that transition (clearing the publish time only when unscheduling, and always clearing `emailOnly`).
+
+The machine never mutates a post, so it needs no snapshot-and-rollback around a failed save: the save engine builds each request from its own snapshot, and the change tracker adopts the acknowledged status only once the server confirms it. A failed publish leaves both the post and these options exactly as they were, ready to dispatch again.
+
+## Limits
+
+`checkLimits()` runs the two host checks concurrently and returns — and stores — a typed result. It clears any result from a previous run first.
+
+The sending check awaits `refreshSettings()` before anything else, so a hold applied since the editor opened is seen; a failed refresh rejects `checkLimits()`. It then evaluates the email limit, skipping it for authors and contributors, who cannot read email counts. A rejection becomes a `sending-limit` block carrying the host's message. Only if the limit passes is the verification hold read, so a site under its email limit still surfaces a hold; a hold without host-specific copy uses the default message.
+
+The publishing check runs for admins only, since nobody else can read the member count. A rejection becomes a `host-limit` block with the host's message split into `parts`, where the segment marked `upgrade` is the phrase to render as an upgrade link. The message is returned as data, never as markup.
+
+Both blocks feed the state directly: an email block disables the email publish types, and — unless the user has already chosen a type — the initial-type rules are re-applied so the selection falls back to `publish`.
+
+## Dirty state and reset
+
+`isDirty` compares the publish type, scheduling, scheduled time, newsletter and recipient filter against the values the machine started with. Selecting the value that was already there is not a change. `reset()` restores all of them, and re-arms the automatic type fallback that `setPublishType()` disables.

--- a/apps/admin/src/editor/publish/publish-options.test.ts
+++ b/apps/admin/src/editor/publish/publish-options.test.ts
@@ -8,6 +8,7 @@ import {
   getEmailDisabledReason,
   getEmailUnavailableReason,
   getInitialPublishType,
+  normalizeRecipientFilter,
   selectableNewsletters,
   splitUpgradeMessage,
   tiersSegment,
@@ -101,6 +102,17 @@ describe('tiersSegment', () => {
   });
 });
 
+describe('normalizeRecipientFilter', () => {
+  it.each([
+    ['all', EVERYONE],
+    ['none', null],
+    [null, null],
+    ['label:vip', 'label:vip'],
+  ])('normalizes %j to %j', (filter, expected) => {
+    expect(normalizeRecipientFilter(filter)).toBe(expected);
+  });
+});
+
 describe('getEmailUnavailableReason', () => {
   it.each([
     ['post with members and email settings on', {}, {}, null],
@@ -174,6 +186,16 @@ describe('getInitialPublishType', () => {
       'usually nobody',
       {},
       { editorDefaultEmailRecipients: 'filter' as const, editorDefaultEmailRecipientsFilter: null },
+      { emailUnavailable: false, emailDisabled: false },
+      'publish',
+    ],
+    [
+      'usually nobody from the API sentinel',
+      {},
+      {
+        editorDefaultEmailRecipients: 'filter' as const,
+        editorDefaultEmailRecipientsFilter: 'none',
+      },
       { emailUnavailable: false, emailDisabled: false },
       'publish',
     ],
@@ -273,6 +295,15 @@ describe('publish type availability', () => {
     expect(many.onlyDefaultNewsletter).toBe(false);
   });
 
+  it('starts with the active newsletter persisted on the post', () => {
+    const state = create({
+      post: createPost({ newsletter: 'paid-only' }),
+      site: createSite({ newsletters: [WEEKLY, PAID_NEWSLETTER] }),
+    }).getState();
+
+    expect(state.newsletter?.slug).toBe('paid-only');
+  });
+
   it('trusts a member count of zero only from an admin', () => {
     const site = createSite({ memberCount: 0 });
 
@@ -297,15 +328,23 @@ describe('without a newsletter to send', () => {
     expect(state.fullRecipientFilter).toBeNull();
   });
 
-  it.each([
-    ['a chosen send type', createPost(), 'send' as const],
-    ['a failed email retry', createPost({ email: { status: 'failed' } }), 'publish' as const],
-  ])('emits no email options for %s', (_name, post, publishType) => {
-    const machine = create({ post, site });
+  it('does not dispatch a chosen send type', () => {
+    const machine = create({ site });
 
-    machine.setPublishType(publishType);
+    machine.setPublishType('send');
 
     expect(machine.getState().willEmail).toBe(false);
+    expect(machine.getState().canPublish).toBe(false);
+    expect(machine.toDispatch()).toBeNull();
+  });
+
+  it('emits no email options for a failed email retry', () => {
+    const machine = create({ post: createPost({ email: { status: 'failed' } }), site });
+
+    machine.setPublishType('publish');
+
+    expect(machine.getState().willEmail).toBe(false);
+    expect(machine.getState().canPublish).toBe(true);
     expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
   });
 
@@ -551,6 +590,24 @@ describe('getDefaultRecipientFilter', () => {
       },
       'status:-free',
     ],
+    [
+      'raw all sentinel expands to everyone',
+      { visibility: 'paid' },
+      {
+        editorDefaultEmailRecipients: 'filter' as const,
+        editorDefaultEmailRecipientsFilter: 'all',
+      },
+      EVERYONE,
+    ],
+    [
+      'raw none sentinel follows visibility',
+      { visibility: 'paid' },
+      {
+        editorDefaultEmailRecipients: 'filter' as const,
+        editorDefaultEmailRecipientsFilter: 'none',
+      },
+      'status:-free',
+    ],
   ])('%s', (_name, post, site, expected) => {
     expect(getDefaultRecipientFilter(createPost(post), createSite(site))).toBe(expected);
   });
@@ -568,6 +625,7 @@ describe('recipient filter', () => {
   it.each([
     ['no newsletter on the post', { newsletter: null, emailSegment: 'label:vip' }],
     ['no segment on the post', { newsletter: 'weekly', emailSegment: null }],
+    ['raw none segment on the post', { newsletter: 'weekly', emailSegment: 'none' }],
   ])('falls back to the site default with %s', (_name, post) => {
     expect(create({ post: createPost(post) }).getState().recipientFilter).toBe(EVERYONE);
   });
@@ -579,6 +637,17 @@ describe('recipient filter', () => {
     expect(machine.getState().recipientFilter).toBe('label:vip');
 
     machine.setRecipientFilter(null);
+    expect(machine.getState().recipientFilter).toBeNull();
+  });
+
+  it('normalizes raw sentinels from the post and explicit selections', () => {
+    const machine = create({
+      post: createPost({ newsletter: 'weekly', emailSegment: 'all' }),
+    });
+
+    expect(machine.getState().recipientFilter).toBe(EVERYONE);
+
+    machine.setRecipientFilter('none');
     expect(machine.getState().recipientFilter).toBeNull();
   });
 
@@ -702,15 +771,53 @@ describe('toDispatch', () => {
     });
   });
 
-  it('sends the newsletter without a segment when the filter is empty', () => {
-    const machine = create({ post: createPost({ email: { status: 'failed' } }) });
+  it('uses the persisted newsletter and segment when retrying a failed email', () => {
+    const machine = create({
+      post: createPost({
+        newsletter: 'paid-only',
+        emailSegment: 'label:vip',
+        email: { status: 'failed' },
+      }),
+      site: createSite({ newsletters: [WEEKLY, PAID_NEWSLETTER] }),
+    });
 
     machine.setRecipientFilter(null);
 
+    expect(machine.getState().newsletter?.slug).toBe('paid-only');
     expect(machine.toDispatch()).toEqual({
       kind: 'publish',
-      options: { emailOnly: false, newsletter: 'weekly' },
+      options: { emailOnly: false },
     });
+  });
+
+  it.each([
+    ['archived', [{ ...WEEKLY }, { ...PAID_NEWSLETTER, status: 'archived' }]],
+    ['missing', [WEEKLY]],
+  ])(
+    'does not override the durable newsletter for a %s failed-email retry',
+    (_name, newsletters) => {
+      const machine = create({
+        post: createPost({ newsletter: 'paid-only', email: { status: 'failed' } }),
+        site: createSite({ newsletters }),
+      });
+
+      expect(machine.getState().newsletter?.slug).toBe('paid-only');
+      expect(machine.toDispatch()).toEqual({
+        kind: 'publish',
+        options: { emailOnly: false },
+      });
+    },
+  );
+
+  it('does not dispatch email-only when there are no recipients', () => {
+    const machine = create();
+
+    machine.setPublishType('send');
+    machine.setRecipientFilter(null);
+
+    expect(machine.getState().willEmail).toBe(false);
+    expect(machine.getState().canPublish).toBe(false);
+    expect(machine.toDispatch()).toBeNull();
   });
 
   it('omits email options when the post will not email', () => {
@@ -957,7 +1064,8 @@ describe('checkLimits', () => {
     machine.setPublishType('send');
 
     expect(machine.getState().willEmail).toBe(false);
-    expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
+    expect(machine.getState().canPublish).toBe(false);
+    expect(machine.toDispatch()).toBeNull();
   });
 
   it('keeps send for a sent post', async () => {

--- a/apps/admin/src/editor/publish/publish-options.test.ts
+++ b/apps/admin/src/editor/publish/publish-options.test.ts
@@ -283,6 +283,24 @@ describe('publish type availability', () => {
     expect(machine.getState().emailDisabled).toBe(true);
   });
 
+  it.each([
+    ['page draft', { isPage: true }, {}],
+    ['members disabled', {}, { membersEnabled: false }],
+    ['recipients disabled', {}, { editorDefaultEmailRecipients: 'disabled' as const }],
+  ])('rejects a forced send for a %s', (_name, post, site) => {
+    const machine = create({ post: createPost(post), site: createSite(site) });
+
+    machine.setRecipientFilter('label:vip');
+    machine.setPublishType('send');
+
+    const state = machine.getState();
+
+    expect(state.emailUnavailable).toBe(true);
+    expect(state.willEmail).toBe(false);
+    expect(state.canPublish).toBe(false);
+    expect(machine.toDispatch()).toBeNull();
+  });
+
   it('reports the newsletter selection', () => {
     const single = create().getState();
     const many = create({
@@ -446,6 +464,7 @@ describe('will* matrix', () => {
 
     machine.setRecipientFilter(null);
 
+    expect(machine.getState().emailUnavailable).toBe(true);
     expect(machine.getState().willEmail).toBe(true);
   });
 });

--- a/apps/admin/src/editor/publish/publish-options.test.ts
+++ b/apps/admin/src/editor/publish/publish-options.test.ts
@@ -127,25 +127,41 @@ describe('getEmailUnavailableReason', () => {
 
 describe('getEmailDisabledReason', () => {
   it.each([
-    ['configured with members', {}, null, null],
-    ['no mailgun', { mailgunConfigured: false }, null, 'no-mailgun'],
-    ['no members', { memberCount: 0 }, null, 'no-members'],
-    ['unknown member count', { memberCount: null }, null, null],
-    ['sending limit', {}, { kind: 'sending-limit' as const, message: 'over' }, 'sending-limit'],
+    ['configured with members', {}, null, true, null],
+    ['no mailgun', { mailgunConfigured: false }, null, true, 'no-mailgun'],
+    ['no members', { memberCount: 0 }, null, true, 'no-members'],
+    ['unknown member count', { memberCount: null }, null, true, null],
+    ['no newsletter to send', {}, null, false, 'no-newsletter'],
+    [
+      'sending limit',
+      {},
+      { kind: 'sending-limit' as const, message: 'over' },
+      true,
+      'sending-limit',
+    ],
     [
       'verification hold',
       {},
       { kind: 'email-verification' as const, message: 'in review' },
+      true,
       'email-verification',
     ],
     [
       'mailgun wins over a block',
       { mailgunConfigured: false },
       { kind: 'sending-limit' as const, message: 'over' },
+      true,
       'no-mailgun',
     ],
-  ])('%s', (_name, site, block, expected) => {
-    expect(getEmailDisabledReason(createSite(site), block)).toBe(expected);
+    [
+      'a missing newsletter wins over a block',
+      {},
+      { kind: 'sending-limit' as const, message: 'over' },
+      false,
+      'no-newsletter',
+    ],
+  ])('%s', (_name, site, block, hasNewsletter, expected) => {
+    expect(getEmailDisabledReason(createSite(site), block, hasNewsletter)).toBe(expected);
   });
 });
 
@@ -195,35 +211,24 @@ describe('publish type availability', () => {
       'publish+send',
       ['publish+send', 'publish', 'send'],
     ],
-    [
-      'members disabled',
-      {},
-      { membersEnabled: false },
-      'publish',
-      ['publish+send', 'publish', 'send'],
-    ],
+    ['members disabled', {}, { membersEnabled: false }, 'publish', ['publish']],
     [
       'recipients disabled',
       {},
       { editorDefaultEmailRecipients: 'disabled' as const },
       'publish',
-      ['publish+send', 'publish', 'send'],
+      ['publish'],
     ],
-    ['page', { isPage: true }, {}, 'publish', ['publish+send', 'publish', 'send']],
-    [
-      'already emailed post',
-      { email: { status: 'submitted' } },
-      {},
-      'publish',
-      ['publish+send', 'publish', 'send'],
-    ],
+    ['page', { isPage: true }, {}, 'publish', ['publish']],
+    ['already emailed post', { email: { status: 'submitted' } }, {}, 'publish', ['publish']],
     ['sent post', { status: 'sent' as const }, {}, 'send', ['publish+send', 'publish', 'send']],
+    ['no active newsletters', {}, { newsletters: [] }, 'publish', ['publish']],
     [
-      'no newsletters',
+      'only archived newsletters',
       {},
-      { newsletters: [] },
-      'publish+send',
-      ['publish+send', 'publish', 'send'],
+      { newsletters: [{ slug: 'old', status: 'archived' }] },
+      'publish',
+      ['publish'],
     ],
   ])('%s', (_name, post, site, publishType, available) => {
     const state = create({ post: createPost(post), site: createSite(site) }).getState();
@@ -266,6 +271,52 @@ describe('publish type availability', () => {
     expect(single.onlyDefaultNewsletter).toBe(true);
     expect(many.newsletter?.slug).toBe('weekly');
     expect(many.onlyDefaultNewsletter).toBe(false);
+  });
+
+  it('trusts a member count of zero only from an admin', () => {
+    const site = createSite({ memberCount: 0 });
+
+    expect(create({ site }).getState().emailDisabledReason).toBe('no-members');
+    expect(
+      create({ site, user: createUser({ isAdmin: false }) }).getState().emailDisabledReason,
+    ).toBeNull();
+  });
+});
+
+describe('without a newsletter to send', () => {
+  const site = createSite({ newsletters: [] });
+
+  it('disables email rather than offering a send with no newsletter', () => {
+    const state = create({ site }).getState();
+
+    expect(state.newsletter).toBeNull();
+    expect(state.emailDisabled).toBe(true);
+    expect(state.emailDisabledReason).toBe('no-newsletter');
+    expect(state.willEmail).toBe(false);
+    expect(state.willEmailImmediately).toBe(false);
+    expect(state.fullRecipientFilter).toBeNull();
+  });
+
+  it.each([
+    ['a chosen send type', createPost(), 'send' as const],
+    ['a failed email retry', createPost({ email: { status: 'failed' } }), 'publish' as const],
+  ])('emits no email options for %s', (_name, post, publishType) => {
+    const machine = create({ post, site });
+
+    machine.setPublishType(publishType);
+
+    expect(machine.getState().willEmail).toBe(false);
+    expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
+  });
+
+  it('disables email when the selected newsletter is cleared', () => {
+    const machine = create();
+
+    machine.setNewsletter(null);
+
+    expect(machine.getState().emailDisabledReason).toBe('no-newsletter');
+    expect(machine.getState().willEmail).toBe(false);
+    expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
   });
 });
 
@@ -435,6 +486,20 @@ describe('scheduling', () => {
 
     machine.setIsScheduled(true);
     expect(machine.getState().scheduledAt).toBe('2026-09-02T11:10:00.000Z');
+  });
+
+  it('resets to a floor taken from the current time, not from creation', () => {
+    let now = NOW;
+    const machine = create({ now: () => now });
+
+    machine.setScheduledAt('2026-09-02T10:30:00.000Z');
+    machine.setIsScheduled(true);
+
+    now = new Date('2026-09-02T11:00:00.000Z');
+    machine.reset();
+
+    expect(machine.getState().scheduledAt).toBe('2026-09-02T11:00:05.000Z');
+    expect(machine.getState().isDirty).toBe(false);
   });
 
   it('keeps a future schedule untouched', () => {
@@ -862,14 +927,37 @@ describe('checkLimits', () => {
     expect(state.isDirty).toBe(false);
   });
 
-  it('keeps a type the user already chose', async () => {
+  it('demotes an email type the user chose before the block landed', async () => {
     const limits = ports({ getEmailVerification: vi.fn(() => ({ required: true })) });
     const machine = create({ limits });
 
     machine.setPublishType('send');
     await machine.checkLimits();
 
-    expect(machine.getState().publishType).toBe('send');
+    expect(machine.getState().publishType).toBe('publish');
+    expect(machine.getState().willEmail).toBe(false);
+    expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
+  });
+
+  it('keeps a type the user chose while email stays available', async () => {
+    const limits = ports();
+    const machine = create({ limits });
+
+    machine.setPublishType('publish');
+    await machine.checkLimits();
+
+    expect(machine.getState().publishType).toBe('publish');
+  });
+
+  it('emits no email options for a send type chosen after a block', async () => {
+    const limits = ports({ getEmailVerification: vi.fn(() => ({ required: true })) });
+    const machine = create({ limits });
+
+    await machine.checkLimits();
+    machine.setPublishType('send');
+
+    expect(machine.getState().willEmail).toBe(false);
+    expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
   });
 
   it('keeps send for a sent post', async () => {
@@ -932,6 +1020,27 @@ describe('dirty tracking and reset', () => {
     change(machine);
 
     expect(machine.getState().isDirty).toBe(expected);
+  });
+
+  it('is clean again once scheduling is turned back off', () => {
+    const machine = create();
+
+    machine.setIsScheduled(true);
+    expect(machine.getState().isDirty).toBe(true);
+
+    machine.setIsScheduled(false);
+    expect(machine.getState().isDirty).toBe(false);
+  });
+
+  it('stays dirty when a chosen time survives unscheduling', () => {
+    const machine = create();
+
+    machine.setScheduledAt('2026-09-03T09:00:00.000Z');
+    machine.setIsScheduled(true);
+    machine.setIsScheduled(false);
+
+    expect(machine.getState().scheduledAt).toBe('2026-09-03T09:00:00.000Z');
+    expect(machine.getState().isDirty).toBe(true);
   });
 
   it('is dirty when the newsletter changes', () => {

--- a/apps/admin/src/editor/publish/publish-options.test.ts
+++ b/apps/admin/src/editor/publish/publish-options.test.ts
@@ -1,0 +1,964 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_SCHEDULE_LEAD_MS,
+  EMAIL_VERIFICATION_HOLD_MESSAGE,
+  MIN_SCHEDULE_LEAD_MS,
+  createPublishOptions,
+  getDefaultRecipientFilter,
+  getEmailDisabledReason,
+  getEmailUnavailableReason,
+  getInitialPublishType,
+  selectableNewsletters,
+  splitUpgradeMessage,
+  tiersSegment,
+  type NewsletterInput,
+  type PublishOptionsInputs,
+  type PublishPostInput,
+  type PublishSiteInput,
+  type PublishUserInput,
+} from './publish-options';
+
+const NOW = new Date('2026-09-02T10:00:00.000Z');
+const MIN_SCHEDULED_AT = '2026-09-02T10:00:05.000Z';
+const DEFAULT_SCHEDULED_AT = '2026-09-02T10:10:00.000Z';
+const EVERYONE = 'status:free,status:-free';
+
+const WEEKLY: NewsletterInput = {
+  slug: 'weekly',
+  name: 'Weekly',
+  status: 'active',
+  visibility: 'members',
+  sortOrder: 0,
+};
+
+const PAID_NEWSLETTER: NewsletterInput = {
+  slug: 'paid-only',
+  name: 'Paid only',
+  status: 'active',
+  visibility: 'paid',
+  sortOrder: 1,
+};
+
+function createPost(overrides: Partial<PublishPostInput> = {}): PublishPostInput {
+  return {
+    status: 'draft',
+    isPage: false,
+    visibility: 'public',
+    tiers: [],
+    newsletter: null,
+    emailSegment: null,
+    email: null,
+    ...overrides,
+  };
+}
+
+function createSite(overrides: Partial<PublishSiteInput> = {}): PublishSiteInput {
+  return {
+    membersEnabled: true,
+    mailgunConfigured: true,
+    editorDefaultEmailRecipients: 'visibility',
+    editorDefaultEmailRecipientsFilter: null,
+    memberCount: 100,
+    newsletters: [WEEKLY],
+    ...overrides,
+  };
+}
+
+function createUser(overrides: Partial<PublishUserInput> = {}): PublishUserInput {
+  return { isAdmin: true, isAuthorOrContributor: false, ...overrides };
+}
+
+function create(overrides: Partial<PublishOptionsInputs> = {}) {
+  return createPublishOptions({
+    post: createPost(),
+    site: createSite(),
+    user: createUser(),
+    now: () => NOW,
+    ...overrides,
+  });
+}
+
+describe('selectableNewsletters', () => {
+  it('keeps active newsletters in sort order', () => {
+    const archived = { slug: 'old', status: 'archived', sortOrder: 0 };
+    const second = { slug: 'second', status: 'active', sortOrder: 2 };
+    const first = { slug: 'first', status: 'active', sortOrder: 1 };
+
+    expect(selectableNewsletters([archived, second, first]).map((n) => n.slug)).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+});
+
+describe('tiersSegment', () => {
+  it.each([
+    [[], null],
+    [[{ slug: 'gold' }], 'tier:gold'],
+    [[{ slug: 'gold' }, { slug: 'silver' }], 'tier:gold,tier:silver'],
+  ])('%j → %j', (tiers, expected) => {
+    expect(tiersSegment(tiers)).toBe(expected);
+  });
+});
+
+describe('getEmailUnavailableReason', () => {
+  it.each([
+    ['post with members and email settings on', {}, {}, null],
+    ['page', { isPage: true }, {}, 'page'],
+    ['already emailed', { email: { status: 'submitted' } }, {}, 'already-emailed'],
+    [
+      'failed email still counts as emailed',
+      { email: { status: 'failed' } },
+      {},
+      'already-emailed',
+    ],
+    [
+      'recipients disabled',
+      {},
+      { editorDefaultEmailRecipients: 'disabled' as const },
+      'disabled-in-settings',
+    ],
+    ['members off', {}, { membersEnabled: false }, 'disabled-in-settings'],
+    ['page wins over settings', { isPage: true }, { membersEnabled: false }, 'page'],
+  ])('%s', (_name, post, site, expected) => {
+    expect(getEmailUnavailableReason(createPost(post), createSite(site))).toBe(expected);
+  });
+});
+
+describe('getEmailDisabledReason', () => {
+  it.each([
+    ['configured with members', {}, null, null],
+    ['no mailgun', { mailgunConfigured: false }, null, 'no-mailgun'],
+    ['no members', { memberCount: 0 }, null, 'no-members'],
+    ['unknown member count', { memberCount: null }, null, null],
+    ['sending limit', {}, { kind: 'sending-limit' as const, message: 'over' }, 'sending-limit'],
+    [
+      'verification hold',
+      {},
+      { kind: 'email-verification' as const, message: 'in review' },
+      'email-verification',
+    ],
+    [
+      'mailgun wins over a block',
+      { mailgunConfigured: false },
+      { kind: 'sending-limit' as const, message: 'over' },
+      'no-mailgun',
+    ],
+  ])('%s', (_name, site, block, expected) => {
+    expect(getEmailDisabledReason(createSite(site), block)).toBe(expected);
+  });
+});
+
+describe('getInitialPublishType', () => {
+  it.each([
+    ['email available', {}, {}, { emailUnavailable: false, emailDisabled: false }, 'publish+send'],
+    ['email unavailable', {}, {}, { emailUnavailable: true, emailDisabled: false }, 'publish'],
+    ['email disabled', {}, {}, { emailUnavailable: false, emailDisabled: true }, 'publish'],
+    [
+      'usually nobody',
+      {},
+      { editorDefaultEmailRecipients: 'filter' as const, editorDefaultEmailRecipientsFilter: null },
+      { emailUnavailable: false, emailDisabled: false },
+      'publish',
+    ],
+    [
+      'explicit default filter',
+      {},
+      {
+        editorDefaultEmailRecipients: 'filter' as const,
+        editorDefaultEmailRecipientsFilter: 'label:vip',
+      },
+      { emailUnavailable: false, emailDisabled: false },
+      'publish+send',
+    ],
+    [
+      'sent post overrides everything',
+      { status: 'sent' as const },
+      {},
+      { emailUnavailable: true, emailDisabled: true },
+      'send',
+    ],
+  ])('%s', (_name, post, site, availability, expected) => {
+    expect(getInitialPublishType(createPost(post), createSite(site), availability)).toBe(expected);
+  });
+});
+
+describe('publish type availability', () => {
+  it.each([
+    ['default site', {}, {}, 'publish+send', ['publish+send', 'publish', 'send']],
+    ['mailgun missing', {}, { mailgunConfigured: false }, 'publish', ['publish']],
+    ['no members', {}, { memberCount: 0 }, 'publish', ['publish']],
+    [
+      'member count unknown',
+      {},
+      { memberCount: null },
+      'publish+send',
+      ['publish+send', 'publish', 'send'],
+    ],
+    [
+      'members disabled',
+      {},
+      { membersEnabled: false },
+      'publish',
+      ['publish+send', 'publish', 'send'],
+    ],
+    [
+      'recipients disabled',
+      {},
+      { editorDefaultEmailRecipients: 'disabled' as const },
+      'publish',
+      ['publish+send', 'publish', 'send'],
+    ],
+    ['page', { isPage: true }, {}, 'publish', ['publish+send', 'publish', 'send']],
+    [
+      'already emailed post',
+      { email: { status: 'submitted' } },
+      {},
+      'publish',
+      ['publish+send', 'publish', 'send'],
+    ],
+    ['sent post', { status: 'sent' as const }, {}, 'send', ['publish+send', 'publish', 'send']],
+    [
+      'no newsletters',
+      {},
+      { newsletters: [] },
+      'publish+send',
+      ['publish+send', 'publish', 'send'],
+    ],
+  ])('%s', (_name, post, site, publishType, available) => {
+    const state = create({ post: createPost(post), site: createSite(site) }).getState();
+
+    expect(state.publishType).toBe(publishType);
+    expect(state.availablePublishTypes).toEqual(available);
+  });
+
+  it('exposes the option labels the flow renders', () => {
+    expect(
+      create({ site: createSite({ mailgunConfigured: false }) }).getState().publishTypeOptions,
+    ).toEqual([
+      {
+        value: 'publish+send',
+        label: 'Publish and email',
+        display: 'Publish and email',
+        disabled: true,
+      },
+      { value: 'publish', label: 'Publish only', display: 'Publish', disabled: false },
+      { value: 'send', label: 'Email only', display: 'Email', disabled: true },
+    ]);
+  });
+
+  it('does not validate the type being set', () => {
+    const machine = create({ site: createSite({ memberCount: 0 }) });
+
+    machine.setPublishType('send');
+
+    expect(machine.getState().publishType).toBe('send');
+    expect(machine.getState().emailDisabled).toBe(true);
+  });
+
+  it('reports the newsletter selection', () => {
+    const single = create().getState();
+    const many = create({
+      site: createSite({ newsletters: [WEEKLY, PAID_NEWSLETTER] }),
+    }).getState();
+
+    expect(single.newsletter?.slug).toBe('weekly');
+    expect(single.onlyDefaultNewsletter).toBe(true);
+    expect(many.newsletter?.slug).toBe('weekly');
+    expect(many.onlyDefaultNewsletter).toBe(false);
+  });
+});
+
+describe('will* matrix', () => {
+  it.each([
+    ['publish+send draft', {}, 'publish+send' as const, false, true, true, false, true],
+    ['publish draft', {}, 'publish' as const, false, false, true, false, false],
+    ['send draft', {}, 'send' as const, false, true, false, true, true],
+    ['publish+send scheduled', {}, 'publish+send' as const, true, true, true, false, false],
+    ['send scheduled', {}, 'send' as const, true, true, false, true, false],
+    [
+      'published post',
+      { status: 'published' as const },
+      'publish+send' as const,
+      false,
+      false,
+      true,
+      false,
+      false,
+    ],
+    ['sent post', { status: 'sent' as const }, 'send' as const, false, false, false, true, false],
+    [
+      'draft that already emailed',
+      { email: { status: 'submitted' } },
+      'publish+send' as const,
+      false,
+      false,
+      true,
+      false,
+      false,
+    ],
+    [
+      'draft whose email failed',
+      { email: { status: 'failed' } },
+      'publish' as const,
+      false,
+      true,
+      true,
+      false,
+      true,
+    ],
+    [
+      'draft whose email failed, scheduled',
+      { email: { status: 'failed' } },
+      'publish' as const,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ],
+  ])(
+    '%s',
+    (
+      _name,
+      post,
+      publishType,
+      scheduled,
+      willEmail,
+      willPublish,
+      willOnlyEmail,
+      willEmailImmediately,
+    ) => {
+      const machine = create({ post: createPost(post) });
+
+      machine.setPublishType(publishType);
+      machine.setIsScheduled(scheduled);
+
+      const state = machine.getState();
+
+      expect(state.willEmail).toBe(willEmail);
+      expect(state.willPublish).toBe(willPublish);
+      expect(state.willOnlyEmail).toBe(willOnlyEmail);
+      expect(state.willEmailImmediately).toBe(willEmailImmediately);
+    },
+  );
+
+  it('does not email without a recipient filter', () => {
+    const machine = create();
+
+    machine.setRecipientFilter(null);
+
+    expect(machine.getState().willEmail).toBe(false);
+  });
+
+  it('emails a failed-email draft even without a recipient filter', () => {
+    const machine = create({ post: createPost({ email: { status: 'failed' } }) });
+
+    machine.setRecipientFilter(null);
+
+    expect(machine.getState().willEmail).toBe(true);
+  });
+});
+
+describe('scheduling', () => {
+  it('starts unscheduled at the earliest allowed time', () => {
+    const state = create().getState();
+
+    expect(state.isScheduled).toBe(false);
+    expect(state.scheduledAt).toBe(MIN_SCHEDULED_AT);
+    expect(state.minScheduledAt).toBe(MIN_SCHEDULED_AT);
+    expect(MIN_SCHEDULE_LEAD_MS).toBe(5000);
+    expect(DEFAULT_SCHEDULE_LEAD_MS).toBe(600000);
+  });
+
+  it('snaps a stale time forward to the default when scheduling is turned on', () => {
+    const machine = create();
+
+    machine.setIsScheduled(true);
+
+    expect(machine.getState().scheduledAt).toBe(DEFAULT_SCHEDULED_AT);
+  });
+
+  it('keeps a later time when scheduling is turned on', () => {
+    const machine = create();
+
+    machine.setScheduledAt('2026-09-03T09:00:00.000Z');
+    machine.setIsScheduled(true);
+
+    expect(machine.getState().scheduledAt).toBe('2026-09-03T09:00:00.000Z');
+  });
+
+  it('toggles when no value is given', () => {
+    const machine = create();
+
+    machine.setIsScheduled();
+    expect(machine.getState().isScheduled).toBe(true);
+
+    machine.setIsScheduled();
+    expect(machine.getState().isScheduled).toBe(false);
+  });
+
+  it.each([
+    ['zeroes milliseconds', '2026-09-03T09:00:00.789Z', '2026-09-03T09:00:00.000Z'],
+    ['accepts a Date', new Date('2026-09-03T09:00:00.456Z'), '2026-09-03T09:00:00.000Z'],
+    ['floors a past time to the minimum', '2026-09-01T09:00:00.000Z', MIN_SCHEDULED_AT],
+    ['floors a time inside the lead window', '2026-09-02T10:00:01.000Z', MIN_SCHEDULED_AT],
+    ['accepts the minimum itself', MIN_SCHEDULED_AT, MIN_SCHEDULED_AT],
+  ])('%s', (_name, input, expected) => {
+    const machine = create();
+
+    machine.setScheduledAt(input);
+
+    expect(machine.getState().scheduledAt).toBe(expected);
+  });
+
+  it('ignores an unparseable date', () => {
+    const machine = create();
+
+    machine.setScheduledAt('not a date');
+
+    expect(machine.getState().scheduledAt).toBe(MIN_SCHEDULED_AT);
+  });
+
+  it('unschedules a time that fell into the past, keeping the stale time', () => {
+    let now = NOW;
+    const machine = create({ now: () => now });
+
+    machine.setScheduledAt('2026-09-02T10:30:00.000Z');
+    machine.setIsScheduled(true);
+
+    now = new Date('2026-09-02T11:00:00.000Z');
+    machine.resetPastScheduledAt();
+
+    expect(machine.getState().isScheduled).toBe(false);
+    expect(machine.getState().scheduledAt).toBe('2026-09-02T10:30:00.000Z');
+
+    machine.setIsScheduled(true);
+    expect(machine.getState().scheduledAt).toBe('2026-09-02T11:10:00.000Z');
+  });
+
+  it('keeps a future schedule untouched', () => {
+    const machine = create();
+
+    machine.setScheduledAt('2026-09-03T09:00:00.000Z');
+    machine.setIsScheduled(true);
+    machine.resetPastScheduledAt();
+
+    expect(machine.getState().isScheduled).toBe(true);
+    expect(machine.getState().scheduledAt).toBe('2026-09-03T09:00:00.000Z');
+  });
+});
+
+describe('getDefaultRecipientFilter', () => {
+  it.each([
+    ['visibility, public post', { visibility: 'public' }, {}, EVERYONE],
+    ['visibility, members post', { visibility: 'members' }, {}, EVERYONE],
+    ['visibility, paid post', { visibility: 'paid' }, {}, 'status:-free'],
+    [
+      'visibility, tiers post',
+      { visibility: 'tiers', tiers: [{ slug: 'gold' }, { slug: 'silver' }] },
+      {},
+      'tier:gold,tier:silver',
+    ],
+    ['visibility, tiers post without tiers', { visibility: 'tiers' }, {}, null],
+    ['visibility, unknown visibility', { visibility: 'custom' }, {}, 'custom'],
+    [
+      'disabled',
+      { visibility: 'public' },
+      { editorDefaultEmailRecipients: 'disabled' as const },
+      null,
+    ],
+    [
+      'explicit filter',
+      { visibility: 'public' },
+      {
+        editorDefaultEmailRecipients: 'filter' as const,
+        editorDefaultEmailRecipientsFilter: 'label:vip',
+      },
+      'label:vip',
+    ],
+    [
+      'usually nobody follows visibility',
+      { visibility: 'paid' },
+      {
+        editorDefaultEmailRecipients: 'filter' as const,
+        editorDefaultEmailRecipientsFilter: null,
+      },
+      'status:-free',
+    ],
+  ])('%s', (_name, post, site, expected) => {
+    expect(getDefaultRecipientFilter(createPost(post), createSite(site))).toBe(expected);
+  });
+});
+
+describe('recipient filter', () => {
+  it('prefers the segment the post was saved with', () => {
+    const state = create({
+      post: createPost({ newsletter: 'weekly', emailSegment: 'label:vip' }),
+    }).getState();
+
+    expect(state.recipientFilter).toBe('label:vip');
+  });
+
+  it.each([
+    ['no newsletter on the post', { newsletter: null, emailSegment: 'label:vip' }],
+    ['no segment on the post', { newsletter: 'weekly', emailSegment: null }],
+  ])('falls back to the site default with %s', (_name, post) => {
+    expect(create({ post: createPost(post) }).getState().recipientFilter).toBe(EVERYONE);
+  });
+
+  it('follows an explicit selection, including clearing it', () => {
+    const machine = create();
+
+    machine.setRecipientFilter('label:vip');
+    expect(machine.getState().recipientFilter).toBe('label:vip');
+
+    machine.setRecipientFilter(null);
+    expect(machine.getState().recipientFilter).toBeNull();
+  });
+
+  it.each([
+    [
+      'members newsletter with a filter',
+      [WEEKLY],
+      EVERYONE,
+      'newsletters.slug:weekly+email_disabled:0+(status:free,status:-free)',
+    ],
+    [
+      'paid newsletter with a filter',
+      [PAID_NEWSLETTER],
+      EVERYONE,
+      'newsletters.slug:paid-only+email_disabled:0+status:-free+(status:free,status:-free)',
+    ],
+    [
+      'members newsletter without a filter',
+      [WEEKLY],
+      null,
+      'newsletters.slug:weekly+email_disabled:0',
+    ],
+  ])('composes the full filter: %s', (_name, newsletters, filter, expected) => {
+    const machine = create({ site: createSite({ newsletters }) });
+
+    machine.setRecipientFilter(filter);
+
+    expect(machine.getState().fullRecipientFilter).toBe(expected);
+  });
+
+  it('has no full filter without a newsletter', () => {
+    expect(
+      create({ site: createSite({ newsletters: [] }) }).getState().fullRecipientFilter,
+    ).toBeNull();
+  });
+
+  it('recomposes when the newsletter changes', () => {
+    const machine = create({ site: createSite({ newsletters: [WEEKLY, PAID_NEWSLETTER] }) });
+
+    machine.setNewsletter(PAID_NEWSLETTER);
+
+    expect(machine.getState().newsletter?.slug).toBe('paid-only');
+    expect(machine.getState().fullRecipientFilter).toBe(
+      'newsletters.slug:paid-only+email_disabled:0+status:-free+(status:free,status:-free)',
+    );
+  });
+});
+
+describe('toDispatch', () => {
+  it.each([
+    [
+      'publish+send',
+      'publish+send' as const,
+      false,
+      {
+        kind: 'publish',
+        options: { emailOnly: false, newsletter: 'weekly', emailSegment: EVERYONE },
+      },
+    ],
+    [
+      'publish+send scheduled',
+      'publish+send' as const,
+      true,
+      {
+        kind: 'schedule',
+        options: {
+          emailOnly: false,
+          newsletter: 'weekly',
+          emailSegment: EVERYONE,
+          publishedAt: DEFAULT_SCHEDULED_AT,
+        },
+      },
+    ],
+    ['publish', 'publish' as const, false, { kind: 'publish', options: {} }],
+    [
+      'publish scheduled',
+      'publish' as const,
+      true,
+      { kind: 'schedule', options: { publishedAt: DEFAULT_SCHEDULED_AT } },
+    ],
+    [
+      'send',
+      'send' as const,
+      false,
+      {
+        kind: 'publish',
+        options: { emailOnly: true, newsletter: 'weekly', emailSegment: EVERYONE },
+      },
+    ],
+    [
+      'send scheduled',
+      'send' as const,
+      true,
+      {
+        kind: 'schedule',
+        options: {
+          emailOnly: true,
+          newsletter: 'weekly',
+          emailSegment: EVERYONE,
+          publishedAt: DEFAULT_SCHEDULED_AT,
+        },
+      },
+    ],
+  ])('%s', (_name, publishType, scheduled, expected) => {
+    const machine = create();
+
+    machine.setPublishType(publishType);
+    machine.setIsScheduled(scheduled);
+
+    expect(machine.toDispatch()).toEqual(expected);
+  });
+
+  it('carries the selected segment', () => {
+    const machine = create();
+
+    machine.setRecipientFilter('label:vip');
+
+    expect(machine.toDispatch()).toEqual({
+      kind: 'publish',
+      options: { emailOnly: false, newsletter: 'weekly', emailSegment: 'label:vip' },
+    });
+  });
+
+  it('sends the newsletter without a segment when the filter is empty', () => {
+    const machine = create({ post: createPost({ email: { status: 'failed' } }) });
+
+    machine.setRecipientFilter(null);
+
+    expect(machine.toDispatch()).toEqual({
+      kind: 'publish',
+      options: { emailOnly: false, newsletter: 'weekly' },
+    });
+  });
+
+  it('omits email options when the post will not email', () => {
+    const machine = create({ post: createPost({ email: { status: 'submitted' } }) });
+
+    machine.setPublishType('publish+send');
+
+    expect(machine.toDispatch()).toEqual({ kind: 'publish', options: {} });
+  });
+
+  it.each([
+    ['published', 'published' as const],
+    ['scheduled', 'scheduled' as const],
+    ['sent', 'sent' as const],
+  ])('offers no transition for a %s post', (_name, status) => {
+    const machine = create({ post: createPost({ status }) });
+
+    expect(machine.getState().canPublish).toBe(false);
+    expect(machine.toDispatch()).toBeNull();
+  });
+
+  it.each([
+    ['draft', 'draft' as const],
+    ['published', 'published' as const],
+    ['scheduled', 'scheduled' as const],
+    ['sent', 'sent' as const],
+  ])('reverts a %s post without options', (_name, status) => {
+    expect(create({ post: createPost({ status }) }).toRevertDispatch()).toEqual({ kind: 'revert' });
+  });
+});
+
+describe('splitUpgradeMessage', () => {
+  it.each([
+    [
+      'no phrase',
+      'You are over your member limit.',
+      [{ text: 'You are over your member limit.', kind: 'text' }],
+    ],
+    [
+      'phrase in the middle',
+      'Your plan is full, please upgrade to continue.',
+      [
+        { text: 'Your plan is full, ', kind: 'text' },
+        { text: 'please upgrade', kind: 'upgrade' },
+        { text: ' to continue.', kind: 'text' },
+      ],
+    ],
+    [
+      'phrase at the start',
+      'Please upgrade your plan.',
+      [
+        { text: 'Please upgrade', kind: 'upgrade' },
+        { text: ' your plan.', kind: 'text' },
+      ],
+    ],
+    ['phrase alone', 'please upgrade', [{ text: 'please upgrade', kind: 'upgrade' }]],
+    [
+      'only the first phrase links',
+      'please upgrade or please upgrade',
+      [
+        { text: 'please upgrade', kind: 'upgrade' },
+        { text: ' or please upgrade', kind: 'text' },
+      ],
+    ],
+  ])('%s', (_name, message, expected) => {
+    expect(splitUpgradeMessage(message)).toEqual(expected);
+  });
+});
+
+describe('checkLimits', () => {
+  function ports(overrides = {}) {
+    return {
+      refreshSettings: vi.fn(() => Promise.resolve()),
+      checkSendingLimit: vi.fn(() => Promise.resolve()),
+      checkPublishingLimit: vi.fn(() => Promise.resolve()),
+      getEmailVerification: vi.fn(() => ({ required: false })),
+      ...overrides,
+    };
+  }
+
+  it('reports no blocks when every check passes', async () => {
+    const limits = ports();
+
+    await expect(create({ limits }).checkLimits()).resolves.toEqual({
+      emailBlock: null,
+      publishBlock: null,
+    });
+  });
+
+  it('refreshes settings before reading the sending limit', async () => {
+    const calls: string[] = [];
+    const limits = ports({
+      refreshSettings: vi.fn(() => {
+        calls.push('refresh');
+        return Promise.resolve();
+      }),
+      checkSendingLimit: vi.fn(() => {
+        calls.push('sending');
+        return Promise.resolve();
+      }),
+      getEmailVerification: vi.fn(() => {
+        calls.push('verification');
+        return { required: false };
+      }),
+    });
+
+    await create({ limits }).checkLimits();
+
+    expect(calls).toEqual(['refresh', 'sending', 'verification']);
+  });
+
+  it('rejects when the settings refresh fails', async () => {
+    const limits = ports({
+      refreshSettings: vi.fn(() => Promise.reject(new Error('offline'))),
+    });
+
+    await expect(create({ limits }).checkLimits()).rejects.toThrow('offline');
+  });
+
+  it('blocks email on the sending limit and skips the verification read', async () => {
+    const limits = ports({
+      checkSendingLimit: vi.fn(() =>
+        Promise.reject(new Error('Your plan is over its email limit, please upgrade.')),
+      ),
+    });
+
+    const result = await create({ limits }).checkLimits();
+
+    expect(result.emailBlock).toEqual({
+      kind: 'sending-limit',
+      message: 'Your plan is over its email limit, please upgrade.',
+    });
+    expect(limits.getEmailVerification).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'host message',
+      { required: true, message: 'Sending is paused for review.' },
+      'Sending is paused for review.',
+    ],
+    ['default message', { required: true }, EMAIL_VERIFICATION_HOLD_MESSAGE],
+    ['blank host message', { required: true, message: '' }, EMAIL_VERIFICATION_HOLD_MESSAGE],
+  ])('holds email on verification with the %s', async (_name, hold, message) => {
+    const limits = ports({ getEmailVerification: vi.fn(() => hold) });
+
+    const result = await create({ limits }).checkLimits();
+
+    expect(result.emailBlock).toEqual({ kind: 'email-verification', message });
+  });
+
+  it('does not evaluate the sending limit for authors and contributors', async () => {
+    const limits = ports({
+      checkSendingLimit: vi.fn(() => Promise.reject(new Error('over limit'))),
+      getEmailVerification: vi.fn(() => ({ required: true, message: 'in review' })),
+    });
+
+    const result = await create({
+      limits,
+      user: createUser({ isAdmin: false, isAuthorOrContributor: true }),
+    }).checkLimits();
+
+    expect(limits.checkSendingLimit).not.toHaveBeenCalled();
+    expect(result.emailBlock).toEqual({ kind: 'email-verification', message: 'in review' });
+  });
+
+  it('does not evaluate the publishing limit for non-admins', async () => {
+    const limits = ports({
+      checkPublishingLimit: vi.fn(() => Promise.reject(new Error('over member limit'))),
+    });
+
+    const result = await create({ limits, user: createUser({ isAdmin: false }) }).checkLimits();
+
+    expect(limits.checkPublishingLimit).not.toHaveBeenCalled();
+    expect(result.publishBlock).toBeNull();
+  });
+
+  it('returns the publishing limit as linkable parts', async () => {
+    const limits = ports({
+      checkPublishingLimit: vi.fn(() =>
+        Promise.reject(new Error('You have reached your member limit, please upgrade your plan.')),
+      ),
+    });
+
+    const machine = create({ limits });
+    const result = await machine.checkLimits();
+
+    expect(result.publishBlock).toEqual({
+      kind: 'host-limit',
+      message: 'You have reached your member limit, please upgrade your plan.',
+      parts: [
+        { text: 'You have reached your member limit, ', kind: 'text' },
+        { text: 'please upgrade', kind: 'upgrade' },
+        { text: ' your plan.', kind: 'text' },
+      ],
+    });
+    expect(machine.getState().emailDisabled).toBe(false);
+  });
+
+  it('disables the email types and falls back to publish only', async () => {
+    const limits = ports({ getEmailVerification: vi.fn(() => ({ required: true })) });
+    const machine = create({ limits });
+
+    expect(machine.getState().publishType).toBe('publish+send');
+
+    await machine.checkLimits();
+
+    const state = machine.getState();
+
+    expect(state.emailDisabled).toBe(true);
+    expect(state.emailDisabledReason).toBe('email-verification');
+    expect(state.availablePublishTypes).toEqual(['publish']);
+    expect(state.publishType).toBe('publish');
+    expect(state.isDirty).toBe(false);
+  });
+
+  it('keeps a type the user already chose', async () => {
+    const limits = ports({ getEmailVerification: vi.fn(() => ({ required: true })) });
+    const machine = create({ limits });
+
+    machine.setPublishType('send');
+    await machine.checkLimits();
+
+    expect(machine.getState().publishType).toBe('send');
+  });
+
+  it('keeps send for a sent post', async () => {
+    const limits = ports({ getEmailVerification: vi.fn(() => ({ required: true })) });
+    const machine = create({ limits, post: createPost({ status: 'sent' }) });
+
+    await machine.checkLimits();
+
+    expect(machine.getState().publishType).toBe('send');
+  });
+
+  it('clears blocks from an earlier run', async () => {
+    let required = true;
+    const limits = ports({ getEmailVerification: vi.fn(() => ({ required })) });
+    const machine = create({ limits });
+
+    await machine.checkLimits();
+    expect(machine.getState().emailBlock).not.toBeNull();
+
+    required = false;
+    await machine.checkLimits();
+
+    expect(machine.getState().emailBlock).toBeNull();
+    expect(machine.getState().publishType).toBe('publish+send');
+  });
+});
+
+describe('dirty tracking and reset', () => {
+  it('starts clean', () => {
+    expect(create().getState().isDirty).toBe(false);
+  });
+
+  it.each([
+    ['publish type', (m: ReturnType<typeof create>) => m.setPublishType('send'), true],
+    [
+      'same publish type',
+      (m: ReturnType<typeof create>) => m.setPublishType('publish+send'),
+      false,
+    ],
+    ['scheduling', (m: ReturnType<typeof create>) => m.setIsScheduled(true), true],
+    [
+      'scheduled time',
+      (m: ReturnType<typeof create>) => m.setScheduledAt('2026-09-03T09:00:00.000Z'),
+      true,
+    ],
+    ['recipient filter', (m: ReturnType<typeof create>) => m.setRecipientFilter('label:vip'), true],
+    [
+      'same recipient filter',
+      (m: ReturnType<typeof create>) => m.setRecipientFilter(EVERYONE),
+      false,
+    ],
+    [
+      'cleared recipient filter',
+      (m: ReturnType<typeof create>) => m.setRecipientFilter(null),
+      true,
+    ],
+  ])('changing the %s → dirty: %s', (_name, change, expected) => {
+    const machine = create();
+
+    change(machine);
+
+    expect(machine.getState().isDirty).toBe(expected);
+  });
+
+  it('is dirty when the newsletter changes', () => {
+    const machine = create({ site: createSite({ newsletters: [WEEKLY, PAID_NEWSLETTER] }) });
+
+    machine.setNewsletter(PAID_NEWSLETTER);
+
+    expect(machine.getState().isDirty).toBe(true);
+  });
+
+  it('restores every option', () => {
+    const machine = create({ site: createSite({ newsletters: [WEEKLY, PAID_NEWSLETTER] }) });
+
+    machine.setPublishType('send');
+    machine.setIsScheduled(true);
+    machine.setNewsletter(PAID_NEWSLETTER);
+    machine.setRecipientFilter('label:vip');
+
+    machine.reset();
+
+    const state = machine.getState();
+
+    expect(state.publishType).toBe('publish+send');
+    expect(state.isScheduled).toBe(false);
+    expect(state.scheduledAt).toBe(MIN_SCHEDULED_AT);
+    expect(state.newsletter?.slug).toBe('weekly');
+    expect(state.recipientFilter).toBe(EVERYONE);
+    expect(state.isDirty).toBe(false);
+  });
+});

--- a/apps/admin/src/editor/publish/publish-options.ts
+++ b/apps/admin/src/editor/publish/publish-options.ts
@@ -411,8 +411,8 @@ export function createPublishOptions({
   };
 
   const willEmail = (): boolean => {
-    // No newsletter means no email can be built at all, whatever the type says.
-    if (!newsletter || emailDisabled()) {
+    // Failed emails are unavailable for a fresh send but must remain retryable.
+    if (!newsletter || emailDisabled() || (emailUnavailable && !retryingFailedEmail)) {
       return false;
     }
 

--- a/apps/admin/src/editor/publish/publish-options.ts
+++ b/apps/admin/src/editor/publish/publish-options.ts
@@ -1,0 +1,577 @@
+import {
+  EVERYONE_RECIPIENT_FILTER,
+  PAID_SEGMENT,
+  getFullRecipientFilter,
+  getNewsletterRecipientFilter,
+} from '@tryghost/admin-x-framework';
+import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
+import type {
+  PublishOptions as PublishCommandOptions,
+  ScheduleOptions as ScheduleCommandOptions,
+} from '@/editor/engine/save-engine';
+
+/** The server rejects a schedule in the past; the picker floor sits just ahead of now. */
+export const MIN_SCHEDULE_LEAD_MS = 5 * 1000;
+export const DEFAULT_SCHEDULE_LEAD_MS = 10 * 60 * 1000;
+
+export const EMAIL_VERIFICATION_HOLD_MESSAGE =
+  'Email sending is temporarily disabled because your account is currently in review. You should have an email about this from us already, but you can also reach us any time at support@ghost.org.';
+
+const UPGRADE_PHRASE = /please upgrade/i;
+
+export type PublishType = 'publish+send' | 'publish' | 'send';
+
+export interface PublishTypeOption {
+  value: PublishType;
+  /** Shown in the expanded options list. */
+  label: string;
+  /** Shown in the collapsed option title. */
+  display: string;
+  disabled: boolean;
+}
+
+export interface PublishPostInput {
+  status: PostStatus;
+  /** Pages never email. */
+  isPage?: boolean;
+  visibility?: string | null;
+  tiers?: ReadonlyArray<{ slug: string }>;
+  /** The post's persisted newsletter slug; pairs with `emailSegment` for the initial filter. */
+  newsletter?: string | null;
+  emailSegment?: string | null;
+  /** The post's email record, if one was ever created. */
+  email?: { status?: string | null } | null;
+}
+
+export interface NewsletterInput {
+  slug: string;
+  name?: string;
+  /** Only `active` newsletters are selectable. */
+  status?: string;
+  visibility?: string;
+  sortOrder?: number;
+}
+
+export type DefaultEmailRecipients = 'disabled' | 'visibility' | 'filter';
+
+export interface PublishSiteInput {
+  /** False when members signup access is `none`. */
+  membersEnabled: boolean;
+  mailgunConfigured: boolean;
+  editorDefaultEmailRecipients: DefaultEmailRecipients;
+  editorDefaultEmailRecipientsFilter: string | null;
+  /** Null when the count could not be read; treated as "has members". */
+  memberCount: number | null;
+  newsletters: ReadonlyArray<NewsletterInput>;
+}
+
+export interface PublishUserInput {
+  /** Only admins and owners can read the member count and the publishing limit. */
+  isAdmin: boolean;
+  /** Authors and contributors cannot browse emails, so the sending limit is not evaluated for them. */
+  isAuthorOrContributor: boolean;
+}
+
+export interface EmailVerificationHold {
+  required: boolean;
+  /** Host-specific copy; the default hold message is used when absent. */
+  message?: string | null;
+}
+
+export interface PublishLimitPorts {
+  /** Awaited before the sending checks so a fresh hold is seen. A rejection propagates. */
+  refreshSettings?: () => Promise<void>;
+  /** Resolves when sending is allowed; rejects with the host's message when the email limit would be exceeded. */
+  checkSendingLimit?: () => Promise<void>;
+  /** Resolves when publishing is allowed; rejects with the host's message when over the member limit. */
+  checkPublishingLimit?: () => Promise<void>;
+  /** Read after `refreshSettings`. */
+  getEmailVerification?: () => EmailVerificationHold;
+}
+
+export interface LimitMessagePart {
+  text: string;
+  /** `upgrade` marks the phrase to render as an upgrade link. */
+  kind: 'text' | 'upgrade';
+}
+
+export interface EmailBlock {
+  kind: 'sending-limit' | 'email-verification';
+  message: string;
+}
+
+export interface PublishBlock {
+  kind: 'host-limit';
+  message: string;
+  parts: LimitMessagePart[];
+}
+
+export interface PublishLimits {
+  emailBlock: EmailBlock | null;
+  publishBlock: PublishBlock | null;
+}
+
+export type EmailUnavailableReason = 'page' | 'already-emailed' | 'disabled-in-settings';
+
+export type EmailDisabledReason =
+  | 'no-mailgun'
+  | 'no-members'
+  | 'sending-limit'
+  | 'email-verification';
+
+export interface PublishOptionsState {
+  readonly publishType: PublishType;
+  readonly publishTypeOptions: readonly PublishTypeOption[];
+  readonly availablePublishTypes: readonly PublishType[];
+  readonly isScheduled: boolean;
+  /** ISO 8601, milliseconds zeroed. */
+  readonly scheduledAt: string;
+  /** The earliest time the picker may offer, recomputed on every read. */
+  readonly minScheduledAt: string;
+  readonly newsletter: NewsletterInput | null;
+  /** Active newsletters in sort order. */
+  readonly newsletters: readonly NewsletterInput[];
+  readonly onlyDefaultNewsletter: boolean;
+  readonly recipientFilter: string | null;
+  /** The newsletter audience AND-ed with the recipient filter; null without a newsletter. */
+  readonly fullRecipientFilter: string | null;
+  readonly willEmail: boolean;
+  readonly willEmailImmediately: boolean;
+  readonly willPublish: boolean;
+  readonly willOnlyEmail: boolean;
+  readonly emailUnavailable: boolean;
+  readonly emailUnavailableReason: EmailUnavailableReason | null;
+  readonly emailDisabled: boolean;
+  readonly emailDisabledReason: EmailDisabledReason | null;
+  readonly emailBlock: EmailBlock | null;
+  readonly publishBlock: PublishBlock | null;
+  /** Publishing and scheduling are draft-only transitions. */
+  readonly canPublish: boolean;
+  readonly isDirty: boolean;
+}
+
+export type PublishDispatch =
+  | { kind: 'publish'; options: PublishCommandOptions }
+  | { kind: 'schedule'; options: ScheduleCommandOptions }
+  | { kind: 'revert' };
+
+export interface PublishOptionsMachine {
+  getState(): PublishOptionsState;
+  setPublishType(publishType: PublishType): void;
+  setIsScheduled(shouldSchedule?: boolean): void;
+  setScheduledAt(date: string | Date): void;
+  resetPastScheduledAt(): void;
+  setNewsletter(newsletter: NewsletterInput | null): void;
+  setRecipientFilter(filter: string | null): void;
+  reset(): void;
+  checkLimits(): Promise<PublishLimits>;
+  /** Null when the post is not a draft: no status transition is on offer. */
+  toDispatch(): PublishDispatch | null;
+  toRevertDispatch(): PublishDispatch;
+}
+
+export interface PublishOptionsInputs {
+  post: PublishPostInput;
+  site: PublishSiteInput;
+  user: PublishUserInput;
+  limits?: PublishLimitPorts;
+  now?: () => Date;
+}
+
+function zeroMilliseconds(time: number): string {
+  return new Date(time - (time % 1000)).toISOString();
+}
+
+function isBefore(iso: string, other: string): boolean {
+  return Date.parse(iso) < Date.parse(other);
+}
+
+export function selectableNewsletters(
+  newsletters: ReadonlyArray<NewsletterInput>,
+): NewsletterInput[] {
+  return newsletters
+    .filter((newsletter) => newsletter.status === 'active')
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+}
+
+/** The tier list spelled as a recipient filter; null when the post has no tiers. */
+export function tiersSegment(tiers: ReadonlyArray<{ slug: string }>): string | null {
+  return tiers.map((tier) => `tier:${tier.slug}`).join(',') || null;
+}
+
+export function getDefaultRecipientFilter(
+  post: PublishPostInput,
+  site: Pick<
+    PublishSiteInput,
+    'editorDefaultEmailRecipients' | 'editorDefaultEmailRecipientsFilter'
+  >,
+): string | null {
+  const recipients = site.editorDefaultEmailRecipients;
+  const filter = site.editorDefaultEmailRecipientsFilter;
+  const usuallyNobody = recipients === 'filter' && filter === null;
+
+  if (recipients === 'disabled') {
+    return null;
+  }
+
+  if (recipients === 'visibility' || usuallyNobody) {
+    switch (post.visibility) {
+      case 'public':
+      case 'members':
+        return EVERYONE_RECIPIENT_FILTER;
+      case 'paid':
+        return PAID_SEGMENT;
+      case 'tiers':
+        return tiersSegment(post.tiers ?? []);
+      default:
+        return post.visibility ?? null;
+    }
+  }
+
+  return filter;
+}
+
+export function getEmailUnavailableReason(
+  post: PublishPostInput,
+  site: Pick<PublishSiteInput, 'membersEnabled' | 'editorDefaultEmailRecipients'>,
+): EmailUnavailableReason | null {
+  if (post.isPage) {
+    return 'page';
+  }
+  if (post.email) {
+    return 'already-emailed';
+  }
+  if (site.editorDefaultEmailRecipients === 'disabled' || !site.membersEnabled) {
+    return 'disabled-in-settings';
+  }
+  return null;
+}
+
+export function getEmailDisabledReason(
+  site: Pick<PublishSiteInput, 'mailgunConfigured' | 'memberCount'>,
+  emailBlock: EmailBlock | null,
+): EmailDisabledReason | null {
+  if (!site.mailgunConfigured) {
+    return 'no-mailgun';
+  }
+  if (site.memberCount === 0) {
+    return 'no-members';
+  }
+  return emailBlock?.kind ?? null;
+}
+
+export function getInitialPublishType(
+  post: PublishPostInput,
+  site: Pick<
+    PublishSiteInput,
+    'editorDefaultEmailRecipients' | 'editorDefaultEmailRecipientsFilter'
+  >,
+  { emailUnavailable, emailDisabled }: { emailUnavailable: boolean; emailDisabled: boolean },
+): PublishType {
+  let publishType: PublishType = 'publish+send';
+
+  if (emailUnavailable || emailDisabled) {
+    publishType = 'publish';
+  }
+
+  // "Usually nobody" starts as publish-only but keeps recipients matching visibility,
+  // so turning email on is a single click.
+  if (
+    site.editorDefaultEmailRecipients === 'filter' &&
+    site.editorDefaultEmailRecipientsFilter === null
+  ) {
+    publishType = 'publish';
+  }
+
+  if (post.status === 'sent') {
+    publishType = 'send';
+  }
+
+  return publishType;
+}
+
+/** Splits the host's message so the upgrade phrase can be rendered as a link without HTML injection. */
+export function splitUpgradeMessage(message: string): LimitMessagePart[] {
+  const match = UPGRADE_PHRASE.exec(message);
+
+  if (!match) {
+    return [{ text: message, kind: 'text' }];
+  }
+
+  const parts: LimitMessagePart[] = [];
+  const before = message.slice(0, match.index);
+  const after = message.slice(match.index + match[0].length);
+
+  if (before) {
+    parts.push({ text: before, kind: 'text' });
+  }
+  parts.push({ text: match[0], kind: 'upgrade' });
+  if (after) {
+    parts.push({ text: after, kind: 'text' });
+  }
+
+  return parts;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createPublishOptions({
+  post,
+  site,
+  user,
+  limits = {},
+  now = () => new Date(),
+}: PublishOptionsInputs): PublishOptionsMachine {
+  const newsletters = selectableNewsletters(site.newsletters);
+  const defaultNewsletter = newsletters[0] ?? null;
+  const isDraft = post.status === 'draft';
+
+  const emailUnavailableReason = getEmailUnavailableReason(post, site);
+  const emailUnavailable = emailUnavailableReason !== null;
+
+  let emailBlock: EmailBlock | null = null;
+  let publishBlock: PublishBlock | null = null;
+
+  const emailDisabledReason = () => getEmailDisabledReason(site, emailBlock);
+  const emailDisabled = () => emailDisabledReason() !== null;
+
+  const minScheduledAt = () => zeroMilliseconds(now().getTime() + MIN_SCHEDULE_LEAD_MS);
+  const defaultScheduledAt = () => zeroMilliseconds(now().getTime() + DEFAULT_SCHEDULE_LEAD_MS);
+
+  let publishType = getInitialPublishType(post, site, {
+    emailUnavailable,
+    emailDisabled: emailDisabled(),
+  });
+  let publishTypeTouched = false;
+  let isScheduled = false;
+  let scheduledAt = minScheduledAt();
+  let newsletter: NewsletterInput | null = defaultNewsletter;
+  // `undefined` means "not chosen": the filter follows the post and the site default.
+  let selectedRecipientFilter: string | null | undefined;
+
+  const recipientFilter = (): string | null => {
+    if (selectedRecipientFilter === undefined) {
+      return (
+        (post.newsletter && post.emailSegment) || getDefaultRecipientFilter(post, site) || null
+      );
+    }
+    return selectedRecipientFilter;
+  };
+
+  let initial = {
+    publishType,
+    isScheduled,
+    scheduledAt,
+    newsletterSlug: newsletter?.slug ?? null,
+    recipientFilter: recipientFilter(),
+  };
+
+  const fullRecipientFilter = (): string | null => {
+    if (!newsletter) {
+      return null;
+    }
+    return getFullRecipientFilter(
+      getNewsletterRecipientFilter({ slug: newsletter.slug, visibility: newsletter.visibility }),
+      recipientFilter(),
+    );
+  };
+
+  const willEmail = (): boolean => {
+    const hasEmail = Boolean(post.email);
+    const emailFailed = post.email?.status === 'failed';
+
+    return (
+      (publishType !== 'publish' && Boolean(recipientFilter()) && isDraft && !hasEmail) ||
+      (isDraft && hasEmail && emailFailed)
+    );
+  };
+
+  const publishTypeOptions = (): PublishTypeOption[] => {
+    const disabled = emailDisabled();
+
+    return [
+      { value: 'publish+send', label: 'Publish and email', display: 'Publish and email', disabled },
+      { value: 'publish', label: 'Publish only', display: 'Publish', disabled: false },
+      { value: 'send', label: 'Email only', display: 'Email', disabled },
+    ];
+  };
+
+  const isDirty = (): boolean =>
+    publishType !== initial.publishType ||
+    isScheduled !== initial.isScheduled ||
+    scheduledAt !== initial.scheduledAt ||
+    (newsletter?.slug ?? null) !== initial.newsletterSlug ||
+    recipientFilter() !== initial.recipientFilter;
+
+  const getState = (): PublishOptionsState => {
+    const options = publishTypeOptions();
+    const emails = willEmail();
+
+    return {
+      publishType,
+      publishTypeOptions: options,
+      availablePublishTypes: options.filter((o) => !o.disabled).map((o) => o.value),
+      isScheduled,
+      scheduledAt,
+      minScheduledAt: minScheduledAt(),
+      newsletter,
+      newsletters,
+      onlyDefaultNewsletter: newsletters.length === 1,
+      recipientFilter: recipientFilter(),
+      fullRecipientFilter: fullRecipientFilter(),
+      willEmail: emails,
+      willEmailImmediately: emails && !isScheduled,
+      willPublish: publishType !== 'send',
+      willOnlyEmail: publishType === 'send',
+      emailUnavailable,
+      emailUnavailableReason,
+      emailDisabled: emailDisabled(),
+      emailDisabledReason: emailDisabledReason(),
+      emailBlock,
+      publishBlock,
+      canPublish: isDraft,
+      isDirty: isDirty(),
+    };
+  };
+
+  const setScheduledAt = (date: string | Date): void => {
+    const time = date instanceof Date ? date.getTime() : Date.parse(date);
+
+    if (Number.isNaN(time)) {
+      return;
+    }
+
+    const candidate = zeroMilliseconds(time);
+    const floor = minScheduledAt();
+
+    scheduledAt = isBefore(candidate, floor) ? floor : candidate;
+  };
+
+  const runSendingCheck = async (): Promise<void> => {
+    await limits.refreshSettings?.();
+
+    try {
+      if (!user.isAuthorOrContributor) {
+        await limits.checkSendingLimit?.();
+      }
+
+      // Checked after the limit so a site under its email limit still shows a verification hold.
+      const hold = limits.getEmailVerification?.();
+
+      if (hold?.required) {
+        emailBlock = {
+          kind: 'email-verification',
+          message: hold.message || EMAIL_VERIFICATION_HOLD_MESSAGE,
+        };
+      }
+    } catch (error) {
+      emailBlock = { kind: 'sending-limit', message: errorMessage(error) };
+    }
+  };
+
+  const runPublishingCheck = async (): Promise<void> => {
+    if (!user.isAdmin) {
+      return;
+    }
+
+    try {
+      await limits.checkPublishingLimit?.();
+    } catch (error) {
+      const message = errorMessage(error);
+      publishBlock = { kind: 'host-limit', message, parts: splitUpgradeMessage(message) };
+    }
+  };
+
+  return {
+    getState,
+
+    setPublishType(newValue) {
+      publishType = newValue;
+      publishTypeTouched = true;
+    },
+
+    setIsScheduled(shouldSchedule) {
+      isScheduled = shouldSchedule === undefined ? !isScheduled : shouldSchedule;
+
+      if (isScheduled && isBefore(scheduledAt, defaultScheduledAt())) {
+        scheduledAt = defaultScheduledAt();
+      }
+    },
+
+    setScheduledAt,
+
+    resetPastScheduledAt() {
+      if (isBefore(scheduledAt, minScheduledAt())) {
+        isScheduled = false;
+      }
+    },
+
+    setNewsletter(newValue) {
+      newsletter = newValue;
+    },
+
+    setRecipientFilter(filter) {
+      selectedRecipientFilter = filter;
+    },
+
+    reset() {
+      publishType = initial.publishType;
+      publishTypeTouched = false;
+      isScheduled = initial.isScheduled;
+      scheduledAt = initial.scheduledAt;
+      newsletter =
+        newsletters.find((option) => option.slug === initial.newsletterSlug) ?? defaultNewsletter;
+      selectedRecipientFilter = undefined;
+    },
+
+    async checkLimits() {
+      emailBlock = null;
+      publishBlock = null;
+
+      await Promise.all([runSendingCheck(), runPublishingCheck()]);
+
+      if (!publishTypeTouched) {
+        publishType = getInitialPublishType(post, site, {
+          emailUnavailable,
+          emailDisabled: emailDisabled(),
+        });
+        initial = { ...initial, publishType };
+      }
+
+      return { emailBlock, publishBlock };
+    },
+
+    toDispatch() {
+      if (!isDraft) {
+        return null;
+      }
+
+      const options: PublishCommandOptions = {};
+
+      if (willEmail()) {
+        options.emailOnly = publishType === 'send';
+
+        const filter = recipientFilter();
+
+        if (newsletter) {
+          options.newsletter = newsletter.slug;
+        }
+        if (filter) {
+          options.emailSegment = filter;
+        }
+      }
+
+      if (isScheduled) {
+        return { kind: 'schedule', options: { ...options, publishedAt: scheduledAt } };
+      }
+
+      return { kind: 'publish', options };
+    },
+
+    toRevertDispatch() {
+      return { kind: 'revert' };
+    },
+  };
+}

--- a/apps/admin/src/editor/publish/publish-options.ts
+++ b/apps/admin/src/editor/publish/publish-options.ts
@@ -146,7 +146,7 @@ export interface PublishOptionsState {
   readonly emailDisabledReason: EmailDisabledReason | null;
   readonly emailBlock: EmailBlock | null;
   readonly publishBlock: PublishBlock | null;
-  /** Publishing and scheduling are draft-only transitions. */
+  /** Draft-only, and false when email-only has no executable email. */
   readonly canPublish: boolean;
   readonly isDirty: boolean;
 }
@@ -166,7 +166,7 @@ export interface PublishOptionsMachine {
   setRecipientFilter(filter: string | null): void;
   reset(): void;
   checkLimits(): Promise<PublishLimits>;
-  /** Null when the post is not a draft: no status transition is on offer. */
+  /** Null when no safe status transition is on offer. */
   toDispatch(): PublishDispatch | null;
   toRevertDispatch(): PublishDispatch;
 }
@@ -200,6 +200,17 @@ export function tiersSegment(tiers: ReadonlyArray<{ slug: string }>): string | n
   return tiers.map((tier) => `tier:${tier.slug}`).join(',') || null;
 }
 
+/** Expands the API's legacy segment sentinels into the filters used by the editor. */
+export function normalizeRecipientFilter(filter: string | null | undefined): string | null {
+  if (filter === 'all') {
+    return EVERYONE_RECIPIENT_FILTER;
+  }
+  if (!filter || filter === 'none') {
+    return null;
+  }
+  return filter;
+}
+
 export function getDefaultRecipientFilter(
   post: PublishPostInput,
   site: Pick<
@@ -208,7 +219,7 @@ export function getDefaultRecipientFilter(
   >,
 ): string | null {
   const recipients = site.editorDefaultEmailRecipients;
-  const filter = site.editorDefaultEmailRecipientsFilter;
+  const filter = normalizeRecipientFilter(site.editorDefaultEmailRecipientsFilter);
   const usuallyNobody = recipients === 'filter' && filter === null;
 
   if (recipients === 'disabled') {
@@ -283,7 +294,7 @@ export function getInitialPublishType(
   // so turning email on is a single click.
   if (
     site.editorDefaultEmailRecipients === 'filter' &&
-    site.editorDefaultEmailRecipientsFilter === null
+    normalizeRecipientFilter(site.editorDefaultEmailRecipientsFilter) === null
   ) {
     publishType = 'publish';
   }
@@ -332,6 +343,15 @@ export function createPublishOptions({
   const newsletters = selectableNewsletters(site.newsletters);
   const defaultNewsletter = newsletters[0] ?? null;
   const isDraft = post.status === 'draft';
+  const retryingFailedEmail = isDraft && post.email?.status === 'failed';
+  const persistedNewsletter = post.newsletter
+    ? (site.newsletters.find((option) => option.slug === post.newsletter) ??
+      (retryingFailedEmail ? { slug: post.newsletter } : null))
+    : null;
+  const initialNewsletter =
+    persistedNewsletter && (persistedNewsletter.status === 'active' || retryingFailedEmail)
+      ? persistedNewsletter
+      : defaultNewsletter;
   // Only admins can browse members, so nobody else's count is trusted as a zero.
   const memberCount = user.isAdmin ? site.memberCount : null;
 
@@ -340,7 +360,7 @@ export function createPublishOptions({
 
   let emailBlock: EmailBlock | null = null;
   let publishBlock: PublishBlock | null = null;
-  let newsletter: NewsletterInput | null = defaultNewsletter;
+  let newsletter: NewsletterInput | null = initialNewsletter;
 
   const emailDisabledReason = () =>
     getEmailDisabledReason({ ...site, memberCount }, emailBlock, newsletter !== null);
@@ -364,7 +384,9 @@ export function createPublishOptions({
   const recipientFilter = (): string | null => {
     if (selectedRecipientFilter === undefined) {
       return (
-        (post.newsletter && post.emailSegment) || getDefaultRecipientFilter(post, site) || null
+        (post.newsletter && normalizeRecipientFilter(post.emailSegment)) ||
+        getDefaultRecipientFilter(post, site) ||
+        null
       );
     }
     return selectedRecipientFilter;
@@ -448,7 +470,7 @@ export function createPublishOptions({
       emailDisabledReason: emailDisabledReason(),
       emailBlock,
       publishBlock,
-      canPublish: isDraft,
+      canPublish: isDraft && (publishType !== 'send' || emails),
       isDirty: isDirty(),
     };
   };
@@ -531,7 +553,7 @@ export function createPublishOptions({
     },
 
     setRecipientFilter(filter) {
-      selectedRecipientFilter = filter;
+      selectedRecipientFilter = normalizeRecipientFilter(filter);
     },
 
     reset() {
@@ -541,8 +563,7 @@ export function createPublishOptions({
       // The construction-time floor may itself be in the past by now.
       scheduledAt = minScheduledAt();
       scheduledAtTouched = false;
-      newsletter =
-        newsletters.find((option) => option.slug === initial.newsletterSlug) ?? defaultNewsletter;
+      newsletter = initialNewsletter;
       selectedRecipientFilter = undefined;
     },
 
@@ -569,18 +590,29 @@ export function createPublishOptions({
         return null;
       }
 
+      const emails = willEmail();
+
+      // Never turn an invalid email-only choice into a public publish.
+      if (publishType === 'send' && !emails) {
+        return null;
+      }
+
       const options: PublishCommandOptions = {};
 
-      if (willEmail()) {
+      if (emails) {
         options.emailOnly = publishType === 'send';
 
-        const filter = recipientFilter();
+        // A retry must be validated against the newsletter and segment persisted with the
+        // failed email, not mutable picker state or the site's current default.
+        if (!retryingFailedEmail) {
+          const filter = recipientFilter();
 
-        if (newsletter) {
-          options.newsletter = newsletter.slug;
-        }
-        if (filter) {
-          options.emailSegment = filter;
+          if (newsletter) {
+            options.newsletter = newsletter.slug;
+          }
+          if (filter) {
+            options.emailSegment = filter;
+          }
         }
       }
 

--- a/apps/admin/src/editor/publish/publish-options.ts
+++ b/apps/admin/src/editor/publish/publish-options.ts
@@ -3,7 +3,7 @@ import {
   PAID_SEGMENT,
   getFullRecipientFilter,
   getNewsletterRecipientFilter,
-} from '@tryghost/admin-x-framework';
+} from '@tryghost/admin-x-framework/utils/recipient-filter';
 import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
 import type {
   PublishOptions as PublishCommandOptions,
@@ -60,7 +60,7 @@ export interface PublishSiteInput {
   mailgunConfigured: boolean;
   editorDefaultEmailRecipients: DefaultEmailRecipients;
   editorDefaultEmailRecipientsFilter: string | null;
-  /** Null when the count could not be read; treated as "has members". */
+  /** Read for admins only; null when the count could not be read, and treated as "has members". */
   memberCount: number | null;
   newsletters: ReadonlyArray<NewsletterInput>;
 }
@@ -116,6 +116,7 @@ export type EmailUnavailableReason = 'page' | 'already-emailed' | 'disabled-in-s
 export type EmailDisabledReason =
   | 'no-mailgun'
   | 'no-members'
+  | 'no-newsletter'
   | 'sending-limit'
   | 'email-verification';
 
@@ -248,14 +249,18 @@ export function getEmailUnavailableReason(
 }
 
 export function getEmailDisabledReason(
-  site: Pick<PublishSiteInput, 'mailgunConfigured' | 'memberCount'>,
+  { mailgunConfigured, memberCount }: Pick<PublishSiteInput, 'mailgunConfigured' | 'memberCount'>,
   emailBlock: EmailBlock | null,
+  hasNewsletter: boolean,
 ): EmailDisabledReason | null {
-  if (!site.mailgunConfigured) {
+  if (!mailgunConfigured) {
     return 'no-mailgun';
   }
-  if (site.memberCount === 0) {
+  if (memberCount === 0) {
     return 'no-members';
+  }
+  if (!hasNewsletter) {
+    return 'no-newsletter';
   }
   return emailBlock?.kind ?? null;
 }
@@ -327,14 +332,18 @@ export function createPublishOptions({
   const newsletters = selectableNewsletters(site.newsletters);
   const defaultNewsletter = newsletters[0] ?? null;
   const isDraft = post.status === 'draft';
+  // Only admins can browse members, so nobody else's count is trusted as a zero.
+  const memberCount = user.isAdmin ? site.memberCount : null;
 
   const emailUnavailableReason = getEmailUnavailableReason(post, site);
   const emailUnavailable = emailUnavailableReason !== null;
 
   let emailBlock: EmailBlock | null = null;
   let publishBlock: PublishBlock | null = null;
+  let newsletter: NewsletterInput | null = defaultNewsletter;
 
-  const emailDisabledReason = () => getEmailDisabledReason(site, emailBlock);
+  const emailDisabledReason = () =>
+    getEmailDisabledReason({ ...site, memberCount }, emailBlock, newsletter !== null);
   const emailDisabled = () => emailDisabledReason() !== null;
 
   const minScheduledAt = () => zeroMilliseconds(now().getTime() + MIN_SCHEDULE_LEAD_MS);
@@ -347,7 +356,8 @@ export function createPublishOptions({
   let publishTypeTouched = false;
   let isScheduled = false;
   let scheduledAt = minScheduledAt();
-  let newsletter: NewsletterInput | null = defaultNewsletter;
+  // A time only counts as a change once it is chosen, so unscheduling cannot leave the state dirty.
+  let scheduledAtTouched = false;
   // `undefined` means "not chosen": the filter follows the post and the site default.
   let selectedRecipientFilter: string | null | undefined;
 
@@ -379,6 +389,11 @@ export function createPublishOptions({
   };
 
   const willEmail = (): boolean => {
+    // No newsletter means no email can be built at all, whatever the type says.
+    if (!newsletter || emailDisabled()) {
+      return false;
+    }
+
     const hasEmail = Boolean(post.email);
     const emailFailed = post.email?.status === 'failed';
 
@@ -401,7 +416,7 @@ export function createPublishOptions({
   const isDirty = (): boolean =>
     publishType !== initial.publishType ||
     isScheduled !== initial.isScheduled ||
-    scheduledAt !== initial.scheduledAt ||
+    ((isScheduled || scheduledAtTouched) && scheduledAt !== initial.scheduledAt) ||
     (newsletter?.slug ?? null) !== initial.newsletterSlug ||
     recipientFilter() !== initial.recipientFilter;
 
@@ -412,7 +427,9 @@ export function createPublishOptions({
     return {
       publishType,
       publishTypeOptions: options,
-      availablePublishTypes: options.filter((o) => !o.disabled).map((o) => o.value),
+      availablePublishTypes: emailUnavailable
+        ? ['publish']
+        : options.filter((o) => !o.disabled).map((o) => o.value),
       isScheduled,
       scheduledAt,
       minScheduledAt: minScheduledAt(),
@@ -447,6 +464,7 @@ export function createPublishOptions({
     const floor = minScheduledAt();
 
     scheduledAt = isBefore(candidate, floor) ? floor : candidate;
+    scheduledAtTouched = true;
   };
 
   const runSendingCheck = async (): Promise<void> => {
@@ -520,7 +538,9 @@ export function createPublishOptions({
       publishType = initial.publishType;
       publishTypeTouched = false;
       isScheduled = initial.isScheduled;
-      scheduledAt = initial.scheduledAt;
+      // The construction-time floor may itself be in the past by now.
+      scheduledAt = minScheduledAt();
+      scheduledAtTouched = false;
       newsletter =
         newsletters.find((option) => option.slug === initial.newsletterSlug) ?? defaultNewsletter;
       selectedRecipientFilter = undefined;
@@ -532,7 +552,8 @@ export function createPublishOptions({
 
       await Promise.all([runSendingCheck(), runPublishingCheck()]);
 
-      if (!publishTypeTouched) {
+      // A block that lands after the user picked an email type still demotes that pick.
+      if (!publishTypeTouched || emailDisabled()) {
         publishType = getInitialPublishType(post, site, {
           emailUnavailable,
           emailDisabled: emailDisabled(),


### PR DESCRIPTION
The React editor's publish flow needs somewhere to hold what a user chooses before a post changes status: publish type, scheduling, newsletter and recipients. This adds that as `createPublishOptions()` under `apps/admin/src/editor/publish/` — a plain TypeScript state machine with no React, no network and no post mutation.

## What it does

- **Publish types** — `publish+send` / `publish` / `send`, with the initial selection narrowed by email availability, the "usually nobody" recipients default, and whether the post has already been sent. `availablePublishTypes` is what the UI offers, and email extras follow availability rather than the selection alone, so a type that cannot send never produces an email.
- **Email availability** — separates *unavailable* (page, already emailed, disabled in settings — the picker is not shown) from *disabled* (no bulk email provider, no members, no newsletter, a host limit or a verification hold — the picker is shown with the email types disabled), each with a typed reason.
- **Recipients** — the recipient filter follows the post's own segment, then the site default, then post visibility; the full filter is composed with the shared recipient-filter helpers rather than a fourth copy of the comma-split logic.
- **Scheduling** — ISO times with zeroed milliseconds, a five-second floor, a ten-minute default, and unscheduling of a time that fell into the past.
- **Limits** — the sending and publishing checks are injected async ports. Results come back typed: an email block (limit or verification hold) that disables the email types and demotes an email type already selected, and a publishing block whose "please upgrade" phrase is returned as message parts so the UI can render a link without injecting HTML.

## Producing a save command

`toDispatch()` returns exactly what the save engine's `dispatch()` accepts — `{kind: 'publish' | 'schedule', options}`, with `newsletter` and `emailSegment` only when the post will actually email — and `null` for a post that is not a draft, since publishing and scheduling are draft-only. `toRevertDispatch()` returns `{kind: 'revert'}` and lets the engine derive the rest.

Because the machine never mutates a post, it needs no snapshot-and-rollback around a failed save: the engine builds each request from its own snapshot and adopts the acknowledged status only on success.

## Behavior that intentionally differs from the Ember util it replaces

The rules are otherwise a faithful port, including quirks. These are the deliberate departures:

- **No newsletter to send with.** The Ember util threw when building the save options with no newsletter. Here a missing newsletter is its own `no-newsletter` disabled reason and nothing emails without one — otherwise the command would carry a segment with no newsletter, the request builder would drop both, and the post would publish silently while the flow reported an imminent email.
- **A block that lands after the user picked an email type** now demotes that selection. Ember re-applied the default unconditionally during setup, so it could not hit this case; skipping the demotion would leave a blocked send selected.
- **Unparseable scheduled dates are ignored.** Ember would store an invalid moment and surface "Invalid date".
- **Tiers visibility with no tier list resolves to no filter.** Ember fell through to the literal string `tiers` when the relation was not loaded, and to an empty string when it was loaded but empty.
- **`fullRecipientFilter` is `null` with no newsletter** instead of throwing a `TypeError`.
- **The publishing-limit message is returned as typed parts.** Ember marked the host's message as HTML-safe after a regex replace without escaping it, which made the host response an injection surface; nothing here produces markup.
- **The member count is only trusted from an admin.** Ember substituted `1` for everyone else; an unknown count reads as "has members" for the same reason.
- **Preserved on purpose:** the sending check reads the verification hold only when the email limit passes, so a site over its email limit still hides a hold. That ordering is pinned by a test rather than changed.

## Testing

137 table-driven unit tests cover publish-type availability across members/provider/newsletter/settings/status combinations, the will-email matrix, scheduling (floor, default, millisecond zeroing, past reset, reset floor), recipient filter composition, every `toDispatch()` shape, revert, limit ordering, role gating and demotion, and dirty tracking.

`apps/admin` lint, `tsc -b`, the full unit suite (2741 tests) and `nx run @tryghost/admin:build` pass.