### PR TITLE
Cleaned migration context from the editor

### DIFF
--- a/apps/admin/src/editor/card-config.test.ts
+++ b/apps/admin/src/editor/card-config.test.ts
@@ -90,7 +90,7 @@ describe('getCardVisibilitySettings', () => {
 });
 
 describe('buildPostCardConfig', () => {
-  it('assembles the Ember editor card config', () => {
+  it('assembles the post editor card config', () => {
     const cardConfig = buildPostCardConfig(sources(), ports);
 
     expect(cardConfig).toMatchObject({

--- a/apps/admin/src/editor/editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor.acceptance.test.tsx
@@ -13,15 +13,8 @@ const FLAG_ON = { labs: { editorReact: true } };
 const FLAG_OFF = { labs: { editorReact: false } };
 
 /**
- * Proves the `editorReact` flag swap end-to-end in the real admin app: the
- * React editor appears only when the flag is on, and the Ember side of the
- * URL is delegated to otherwise.
- *
- * There is no Ember app in this harness, so "Ember serves it" shows up as the
- * React editor being absent rather than as an Ember editor being present —
- * the Ember half of the handshake (the lexical-editor route aborting its
- * transition) is covered in
- * apps/ember-admin/tests/acceptance/editor-react-flag-test.js.
+ * The editor route mounts only when its feature flag is enabled. Disabled and
+ * missing flags leave it unmounted.
  */
 describe('Editor flag', () => {
   function fakeEditorWorld() {
@@ -54,13 +47,13 @@ describe('Editor flag', () => {
     await expect.element(editorScreen.backLink('page')).toHaveAttribute('href', '#/pages');
   });
 
-  it('defers to Ember when the flag is off', async () => {
+  it('does not mount the editor when the flag is off', async () => {
     await renderAdminApp('/editor/post/abc123', FLAG_OFF);
 
     await expect(editorScreen.root()).toHaveCount(0);
   });
 
-  it('defers to Ember when the flag is absent entirely', async () => {
+  it('does not mount the editor when the flag is absent', async () => {
     await renderAdminApp('/editor/post/abc123');
 
     await expect(editorScreen.root()).toHaveCount(0);

--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -1,10 +1,17 @@
 # Editor engine
 
-The pure-TypeScript core of the React post editor: the save engine (`save-engine.ts`, this PR), the change tracker and the slug machine (each lands with its own PR). None of them import React or the network; every side effect goes through an injected port, and the editor's wiring hook composes the three. This file states the intended behavior; the modules' tests pin it.
+The pure-TypeScript state-management core of the post editor consists of the
+save engine, change tracker, and slug machine. None of them import React or the
+network; every side effect goes through an injected port, and the editor's
+wiring hook composes the three. This file documents their behavior and shared
+contracts; the modules' tests enforce them.
 
 ## Save engine
 
-Replaces the Ember editor's three ember-concurrency modifiers (an `enqueue` group, a `drop` autosave, a `restartable` debounce) and the ad-hoc branches of the `lexical-editor` controller with one single-flight queue over typed save commands.
+Coordinates all persistence through one single-flight queue over typed save
+commands. The queue combines restartable and timed autosaves, field saves,
+explicit saves, leave saves, and status transitions without allowing requests
+to overlap.
 
 ### Intents
 
@@ -83,11 +90,13 @@ Reconcile-before-drain is a hard ordering contract because Core enforces optimis
 
 ## Change tracker
 
-Lands with the change tracker PR. Answers one question for the editor: does the live post differ from what is persisted, and why. Pure, React-free; the hidden second Koenig instance stays — the tracker consumes its serialization as the baseline.
+Answers one question for the editor: does the live post differ from what is
+persisted, and why? It is pure and React-free. The tracker consumes the hidden
+Koenig instance's post-load serialization as its normalization baseline.
 
 ### State model
 
-Three documents: **saved** (last persisted state, from load/refetch/ack), **baseline** (the hidden instance's post-load serialization — the document after Lexical's load-time transforms), **live** (the visible editor). Body verdict: dirty ⇔ live differs from saved **and** from baseline. Baseline readiness is separate from its value: `pending` (not reported yet), `ready` (a known document; `null`, `''`, and an empty root are all known-empty), `failed`. A live edit while pending is dirty (`BASELINE_PENDING`, fail closed); a failed baseline falls back to live-vs-saved (`BASELINE_FAILED`) and never disables body protection. Title, ordered tag names, and the editable attributes contribute their own dirty bits. Reason codes mirror Ember's (`POST_HAS_ERROR`, `POST_TAGS_DIVERGED`, `POST_TITLE_DIVERGED`, `SCRATCH_DIVERGED_FROM_SECONDARY`, `NEW_POST_HAS_CHANGED_ATTRIBUTES`, `POST_HAS_DIRTY_ATTRIBUTES`) plus `BASELINE_PENDING`, `BASELINE_FAILED`, `LEXICAL_PARSE_FAILED` (malformed or structurally invalid Lexical is dirty, never a thrown route blocker).
+Three documents: **saved** (last persisted state, from load/refetch/ack), **baseline** (the hidden instance's post-load serialization — the document after Lexical's load-time transforms), **live** (the visible editor). Body verdict: dirty ⇔ live differs from saved **and** from baseline. Baseline readiness is separate from its value: `pending` (not reported yet), `ready` (a known document; `null`, `''`, and an empty root are all known-empty), `failed`. A live edit while pending is dirty (`BASELINE_PENDING`, fail closed); a failed baseline falls back to live-vs-saved (`BASELINE_FAILED`) and never disables body protection. Title, ordered tag names, and the editable attributes contribute their own dirty bits. Stable reason codes identify each cause: `POST_HAS_ERROR`, `POST_TAGS_DIVERGED`, `POST_TITLE_DIVERGED`, `SCRATCH_DIVERGED_FROM_SECONDARY`, `NEW_POST_HAS_CHANGED_ATTRIBUTES`, `POST_HAS_DIRTY_ATTRIBUTES`, `BASELINE_PENDING`, `BASELINE_FAILED`, and `LEXICAL_PARSE_FAILED`. Malformed or structurally invalid Lexical is dirty rather than becoming a thrown route blocker.
 
 ### API (id-first; events for another post are dropped)
 
@@ -277,34 +286,34 @@ Ordering and staleness
 
 ## Invariants
 
-| Invariant                                                                                                                     | Pinned in                                                  |
-| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| A background command (`autosave`/`timed`/`field`) can never change status, publish, or send email                             | `save-engine.test.ts` "invariant 1"                        |
-| No two saves are in flight; payloads are built at execution; coalescing never loses the newest content                        | "invariant 2", "lifecycle"                                 |
-| Session expiry during a save loses nothing: re-auth completes, the save lands, content is present                             | "invariant 3", "re-auth outcomes"                          |
-| Save-on-leave fires at most once per attempt and only for dirty drafts                                                        | "invariant 4", "leave outcomes"                            |
-| Loading any post, including old-schema fixtures, is a clean verdict until the user edits                                      | the change tracker PR (fixture corpus)                     |
-| A failed save leaves the post dirty and recoverable; no error path discards the payload                                       | "invariant 6", "collisions"                                |
-| Explicit and leave saves set `save_revision`; background saves do not; publish does not force one (coalescing ORs)            | "invariant 7"                                              |
-| A published/scheduled/sent post's persisted state changes only via explicit Update, publish-flow commands, delete, or restore | "invariant 1", "commands"                                  |
-| Slug generation never overwrites a custom slug and never applies a stale proposal                                             | the slug machine PR; "prepare stage" for the port contract |
-| Scheduled saves serialize with zeroed milliseconds and preserve the publish time unless the user changed it                   | "invariant 10", `deriveTarget`                             |
+| Invariant                                                                                                                     | Pinned in                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| A background command (`autosave`/`timed`/`field`) can never change status, publish, or send email                             | `save-engine.test.ts` "background saves"                      |
+| No two saves are in flight; payloads are built at execution; coalescing never loses the newest content                        | "single flight", "lifecycle"                                  |
+| Session expiry during a save loses nothing: re-auth completes, the save lands, content is present                             | "session expiry", "re-auth outcomes"                          |
+| Save-on-leave fires at most once per attempt and only for dirty drafts                                                        | "save-on-leave", "leave outcomes"                             |
+| Loading any post, including old-schema fixtures, is a clean verdict until the user edits                                      | `change-tracker.test.ts` fixture corpus                       |
+| A failed save leaves the post dirty and recoverable; no error path discards the payload                                       | "failed save", "collisions"                                   |
+| Explicit and leave saves set `save_revision`; background saves do not; publish does not force one (coalescing ORs)            | "only explicit and leave saves set save_revision"             |
+| A published/scheduled/sent post's persisted state changes only via explicit Update, publish-flow commands, delete, or restore | "background saves", "commands"                                |
+| Slug generation never overwrites a custom slug and never applies a stale proposal                                             | `slug-machine.test.ts`; "prepare stage" for the port contract |
+| Scheduled saves serialize with zeroed milliseconds and preserve the publish time unless the user changed it                   | "scheduled saves", `deriveTarget`                             |
 
-## Deliberate Ember deltas
+## Design decisions
 
-- Pending-slot coalescing instead of `drop`-task starvation: autosaves during an in-flight create are carried, not lost.
-- Leaving a post that is still dirty after the leave save asks for confirmation instead of proceeding.
+- Pending-slot coalescing carries autosaves that arrive during an in-flight create.
+- Leaving a post that is still dirty after the leave save asks for confirmation.
 - Sidebar edits on published/scheduled/sent posts are staged until Update; nothing persists immediately.
-- An explicit save on a past-scheduled post preserves `scheduled` and lets the server own the transition (Ember guessed `published`/`draft`).
-- `UPDATE_COLLISION` is a typed `conflict` state with a retry affordance, not a generic error.
-- After re-auth, publish/schedule/revert resolve `needs-retry` and safe saves re-run; Ember's retry was a no-op.
+- An explicit save on a past-scheduled post preserves `scheduled` and lets the server own the transition.
+- `UPDATE_COLLISION` enters a typed `conflict` state with a retry affordance.
+- After re-auth, publish/schedule/revert resolve `needs-retry`; safe saves re-enter the queue.
 - A manually edited slug stays custom for the session; a server-deduplicated slug keeps following the title.
-- Recursive `direction` strip before compare (Ember: top level only).
+- `direction` is stripped recursively before Lexical documents are compared.
 - A query refetch never re-baselines; only an acknowledged save does.
-- Structural site-URL normalization on known URL-bearing node props (Ember: none on the dirty check).
-- Fail closed on malformed Lexical (Ember threw and the route blocker failed open).
+- Site URLs are normalized structurally only on known URL-bearing node properties.
+- Malformed Lexical fails closed and remains dirty.
 - Explicitly clearing a non-empty body is dirty.
-- The leave-modal diff humanizer actually runs (Ember's read a nonexistent field and threw).
+- `verdict({includeDiff: true})` produces the human-readable diff used by the leave modal.
 
 ## What the caller owns
 
@@ -312,7 +321,7 @@ Ordering and staleness
 
 - A no-redirect request mode: the framework transport redirects on 401 (`apps/admin-x-framework/src/utils/api/fetch-api.ts`); the editor adapter must instead throw `SessionExpiredError` so the engine can enter `reauth-pending`.
 - Mapping API failures to `SaveError` kinds in `execute` (401 → `session-invalid`, 404 → `not-found`, `UPDATE_COLLISION` → `conflict`, 422 → `validation`, host-limit errors → `host-limit`, unreachable → `transport`).
-- Past-scheduled detection for the UI (Ember's `pastScheduledTime`); the engine only preserves the status.
+- Detecting a past-scheduled post for the UI; the engine preserves the status but does not interpret its publish time.
 - Replacing the URL from new → edit as a state-driven effect after the create ack, with the editor screen keyed on the editing-session instance so the switch does not remount the editor.
 - The `SlugPort` adapter over the slug machine (`settled` = latest submission chain, `fromTitle` = `titleCommitted` → settled proposal), including pre-slugifying the raw title before the generator request.
 - `(Untitled)` substitution is the engine's prepare duty; the title input never shows it.

--- a/apps/admin/src/editor/engine/__fixtures__/after-load.test.tsx
+++ b/apps/admin/src/editor/engine/__fixtures__/after-load.test.tsx
@@ -28,7 +28,7 @@ const tick = () =>
     setTimeout(resolve, 0);
   });
 
-// Mirrors the hidden secondary instance in Ember's koenig-lexical-editor.js.
+// Render the same hidden Koenig instance that supplies the change tracker's normalization baseline.
 async function loadThroughKoenig(before: LexicalDocument): Promise<LexicalDocument> {
   let api: EditorApi | undefined;
 

--- a/apps/admin/src/editor/engine/change-tracker.test.ts
+++ b/apps/admin/src/editor/engine/change-tracker.test.ts
@@ -101,7 +101,7 @@ describe('createChangeTracker', () => {
     expect(tracker.verdict()).toEqual({ dirty: false, reasons: [] });
   });
 
-  describe('invariant 5: loading old-schema content is clean until the user edits', () => {
+  describe('loading old-schema content is clean until the user edits', () => {
     it.each(OLD_SCHEMA_CORPUS)('$name ($provenance)', ({ before, after }) => {
       const tracker = createChangeTracker();
       tracker.load(POST_ID, post({ lexical: serialize(before) }));

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -343,7 +343,7 @@ describe('zeroMilliseconds', () => {
 });
 
 describe('createSaveEngine', () => {
-  describe('invariant 1: background saves never change status', () => {
+  describe('background saves never change status', () => {
     it('persists a field change on a draft pinned to draft without a revision', async () => {
       const h = setup({ publishedAt: PAST });
 
@@ -388,7 +388,7 @@ describe('createSaveEngine', () => {
     });
   });
 
-  describe('invariant 2: single flight, payload built at execution time, coalescing loses nothing', () => {
+  describe('single flight: payloads are built at execution time and coalescing loses nothing', () => {
     it('runs one save at a time and builds each payload from the snapshot current at execution', async () => {
       const h = setup();
       const first = h.engine.dispatch('explicit');
@@ -440,7 +440,7 @@ describe('createSaveEngine', () => {
     });
   });
 
-  describe('invariant 3: session expiry loses nothing', () => {
+  describe('session expiry loses nothing', () => {
     it('freezes the queue on 401 and re-dispatches the failed save after re-authentication', async () => {
       const h = setup();
       const autosave = h.engine.dispatch('autosave');
@@ -506,7 +506,7 @@ describe('createSaveEngine', () => {
     });
   });
 
-  describe('invariant 4: save-on-leave fires at most once and only for dirty drafts', () => {
+  describe('save-on-leave fires at most once and only for dirty drafts', () => {
     it('saves a dirty draft with unrevisioned changes exactly once, with a revision, then proceeds', async () => {
       const h = setup();
       const decision = h.engine.leaveRequested();
@@ -563,7 +563,7 @@ describe('createSaveEngine', () => {
     });
   });
 
-  describe('invariant 6: a failed save keeps the post dirty and recoverable', () => {
+  describe('a failed save keeps the post dirty and recoverable', () => {
     it.each([validation, hostLimit, transport, unknown])(
       'surfaces a $kind error to the dispatcher and still runs the pending explicit save',
       async (error) => {
@@ -621,7 +621,7 @@ describe('createSaveEngine', () => {
     });
   });
 
-  describe('invariant 7: only explicit and leave saves set save_revision', () => {
+  describe('only explicit and leave saves set save_revision', () => {
     it.each<[DispatchIntent, boolean]>([
       ['explicit', true],
       ['leave', true],
@@ -657,7 +657,7 @@ describe('createSaveEngine', () => {
     });
   });
 
-  describe('invariant 10: scheduled saves zero milliseconds and preserve the publish time', () => {
+  describe('scheduled saves zero milliseconds and preserve the publish time', () => {
     it('serializes a future scheduled post with a zeroed publish time across saves', async () => {
       const h = setup({ status: 'scheduled', publishedAt: '2026-09-03T09:30:15.789Z' });
 

--- a/apps/admin/src/editor/engine/slug-machine.test.ts
+++ b/apps/admin/src/editor/engine/slug-machine.test.ts
@@ -466,7 +466,7 @@ describe('createSlugMachine', () => {
       });
     });
 
-    it('ignores a whitespace-only generator result like Ember does', async () => {
+    it('ignores a whitespace-only title result', async () => {
       const { machine } = createHarness(vi.fn().mockResolvedValueOnce('   '));
       machine.loaded({ slug: 'hello', title: 'Hello' });
 
@@ -649,7 +649,7 @@ describe('createSlugMachine', () => {
       expect(machine.getState().mode).toBe('derived');
     });
 
-    it('ignores a whitespace-only manual result like Ember does for generated slugs', async () => {
+    it('ignores a whitespace-only manual result', async () => {
       const { machine } = createHarness(vi.fn().mockResolvedValueOnce('   '));
       machine.loaded({ slug: 'hello', title: 'Hello' });
 

--- a/apps/admin/src/editor/engine/slug-machine.ts
+++ b/apps/admin/src/editor/engine/slug-machine.ts
@@ -3,14 +3,13 @@
  * ----------------------
  *
  * This machine owns slug intent and request ordering; callers own the input UI and persistence of
- * emitted proposals. Its behavior follows Ember Admin unless an intentional rule below says
- * otherwise.
+ * emitted proposals. The rules below define its complete behavior contract.
  *
  * Ownership
  * - A derived slug follows eligible title commits. A custom slug stops following the title.
  * - Loading infers ownership structurally because posts do not persist slug provenance: a slug
  *   matching `slugify(title)` is derived; a different slug is custom. `(Untitled)` and titles ending
- *   in `(Copy)` remain derived to preserve Ember's first-real-title and duplicated-post behavior.
+ *   in `(Copy)` remain derived so a first meaningful title or duplicated-post rename regenerates it.
  * - A successful manual edit makes the slug custom. Blank, unchanged, failed, or rejected manual
  *   edits leave ownership unchanged.
  *
@@ -96,8 +95,8 @@ export interface SlugMachine {
   subscribe(listener: SlugListener): () => void;
 }
 
-// Mirrors Ember generateSlugTask: a slug that differs from slugify(saved title) is treated as
-// custom unless the saved title is (Untitled) or ends with (Copy).
+// A slug that differs from slugify(saved title) is custom unless the saved title is
+// (Untitled) or ends with (Copy), whose next meaningful title should regenerate it.
 export function isCustomSlug(slug: string, title: string): boolean {
   if (!slug) {
     return false;
@@ -134,8 +133,8 @@ export function normalizeManualSlug(input: string, currentSlug: string): string 
   return candidate;
 }
 
-// Mirrors Ember updateSlugTask: keep the current slug when the server only appended an
-// incrementor to it and the user did not type that exact value.
+// Keep the current slug when the server only appended an incrementor to it and the user did not
+// type that exact value.
 export function resolveDedupedSlug(
   serverSlug: string,
   candidate: string,

--- a/apps/admin/src/editor/link-suggestions.test.ts
+++ b/apps/admin/src/editor/link-suggestions.test.ts
@@ -21,7 +21,7 @@ describe('buildAutocompleteLinks', () => {
     recommendationsEnabled: true,
   };
 
-  it('lists every portal link in the Ember order', () => {
+  it('lists every portal link in display order', () => {
     const offerLinks = buildOfferLinks(
       [{ name: 'Spring sale', code: 'spring' }],
       settings.homepageUrl,

--- a/apps/admin/src/editor/link-suggestions.ts
+++ b/apps/admin/src/editor/link-suggestions.ts
@@ -121,7 +121,7 @@ export function buildAutocompleteLinks(
   ];
 }
 
-// Ember renders `D MMM YYYY` in the site timezone
+// Published dates use `D MMM YYYY` in the site's timezone.
 export function formatPublishedDate(publishedAt: string, timezone: string): string {
   const parts = new Intl.DateTimeFormat('en-US', {
     day: 'numeric',

--- a/apps/admin/src/editor/post-editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/post-editor.acceptance.test.tsx
@@ -59,10 +59,9 @@ function pasteText(content: string) {
 }
 
 /**
- * The React post editor behind the `editorReact` flag: loads the post,
- * mounts Koenig with its hidden secondary instance and keeps edits in memory.
- * Nothing is saved yet — any write request other than the mobiledoc
- * conversion would 418 and fail the test.
+ * Covers post loading, Koenig mounting, and in-memory editing. Write requests
+ * remain unfaked unless a test expects a mobiledoc conversion, so any
+ * unexpected write returns 418 and fails the test.
  */
 describe('Post editor', () => {
   it('loads the post into the title and body', async () => {

--- a/apps/admin/src/editor/tk.ts
+++ b/apps/admin/src/editor/tk.ts
@@ -1,5 +1,4 @@
-// Ported from the Ember lexical-editor controller; matches Koenig's TK node
-// detection for plain-text fields (title, excerpt).
+// Matches Koenig's TK node detection for plain-text fields such as titles and excerpts.
 const TK_REGEX = /(^|.)([^\p{L}\p{N}\s]*(TK)+[^\p{L}\p{N}\s]*)(.)?/u;
 const WORD_CHAR_REGEX = /\p{L}|\p{N}/u;
 


### PR DESCRIPTION
## Summary

- rewrites the editor engine documentation around its current contracts and design decisions
- removes Ember, migration, and stacked-review context from editor comments and test descriptions
- replaces numbered invariant labels with standalone behavior descriptions

## Why

The save, change-tracking, and slug-generation engines have all landed. Their documentation and tests should explain the code as it exists now without requiring knowledge of the migration or review sequence.

## Testing

- full Admin unit suite: 185 files and 2,604 tests passed
- focused editor engine suite: 7 files and 422 tests passed
- focused editor acceptance suite: 2 files and 26 tests passed
- Admin lint passed with no errors
- formatting, dependency rules, Markdown lint, link validation, secret scanning, and changeset validation passed

## Notes

The full Admin typecheck still reaches an unrelated existing TS2339 error in `apps/admin/src/settings/membership/tiers/tier-checkout-collection.tsx:118`.

- [x] I have read and followed the Contributor Guide
- [x] I have explained the change
- [x] Existing automated coverage passes; this PR changes documentation, comments, and test labels only