### PR TITLE
🐛 Fixed navigation icons failing to save on local installs

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
@@ -43,11 +43,25 @@ function isValidNavigationUrl(value) {
   );
 }
 
+// Local installs serve uploaded icons from http://localhost:2368, which has no TLD
+function isLocalhostIconUrl(value) {
+  try {
+    return (
+      new URL(value).hostname === 'localhost' &&
+      validator.isURL(value, { ...iconUrlOptions, require_tld: false })
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isValidNavigationIcon(value) {
   return (
     _.isString(value) &&
     !value.match(/\s/) &&
-    (validator.isURL(value, iconUrlOptions) || value.match(iconUrlRegex))
+    (validator.isURL(value, iconUrlOptions) ||
+      value.match(iconUrlRegex) ||
+      isLocalhostIconUrl(value))
   );
 }
 

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -406,6 +406,70 @@ describe('Settings API', function () {
         .expect(422);
     });
 
+    it('Can edit navigation items with a localhost icon URL', async function () {
+      await checkCanEdit(
+        'navigation',
+        JSON.stringify([
+          {
+            label: 'Members',
+            url: '/members/',
+            icon: 'http://localhost:2368/content/images/nav-members.svg',
+            visibility: 'public',
+          },
+        ]),
+        [
+          {
+            label: 'Members',
+            url: '/members/',
+            icon: 'http://localhost:2368/content/images/nav-members.svg',
+            visibility: 'public',
+          },
+        ],
+      );
+    });
+
+    it('Cannot edit navigation items with an icon on another TLD-less host', async function () {
+      const settingsToChange = {
+        settings: [
+          {
+            key: 'navigation',
+            value: JSON.stringify([
+              { label: 'Invalid', url: '/invalid/', icon: 'http://intranet/icon.svg' },
+            ]),
+          },
+        ],
+      };
+
+      await request
+        .put(localUtils.API.getApiQuery('settings/'))
+        .set('Origin', config.get('url'))
+        .send(settingsToChange)
+        .expect('Content-Type', /json/)
+        .expect('Cache-Control', testUtils.cacheRules.private)
+        .expect(422);
+    });
+
+    it('Cannot edit navigation items with a non-http(s) localhost icon URL', async function () {
+      const settingsToChange = {
+        settings: [
+          {
+            key: 'navigation',
+            value: JSON.stringify([
+              { label: 'Invalid', url: '/invalid/', icon: 'ftp://localhost:2368/icon.svg' },
+            ]),
+          },
+        ],
+      };
+
+      await request
+        .put(localUtils.API.getApiQuery('settings/'))
+        .set('Origin', config.get('url'))
+        .send(settingsToChange)
+        .expect('Content-Type', /json/)
+        .expect('Cache-Control', testUtils.cacheRules.private)
+        .expect(422);
+    });
+
     it('Cannot edit navigation items with invalid icon', async function () {
       const settingsToChange = {
         settings: [


### PR DESCRIPTION
ref https://forum.ghost.org/t/working-locally-on-navigation-and-cant-save-icons/63703

### Why

Navigation items with icons could not be saved on a local install. Every save came back as a 422 `Please enter a valid navigation item`, with no indication of which field was at fault. The forum workaround was to run the site on `127.0.0.1:2368` instead of `localhost:2368`.

### What

Navigation icon URLs are validated in `core/server/api/endpoints/utils/validators/input/settings.js` with `validator.isURL`, whose `require_tld` option defaults to `true`. Admin uploads an icon and gets back the absolute site URL, so on a local install the value sent is `http://localhost:2368/content/images/...`:

- `localhost` has no TLD, so `isURL` returns false
- `iconUrlRegex` only covers `/...` and `__GHOST_URL__/...`, so it doesn't rescue it
- input validation runs *before* the input serializer's URL transform, so the validator always sees the raw absolute URL

The navigation `url` field was never affected because `navUrlRegex` (`^(\/|#|[a-zA-Z0-9-]+:)`) accepts anything with a scheme prefix. Icons had no equivalent escape hatch.

Dropping `require_tld` altogether would also start accepting arbitrary single-label hosts such as `http://intranet/icon.svg` on production sites, so instead the TLD requirement stays and a narrow fallback allows a parsed hostname of exactly `localhost`. The protocol allowlist still applies on that path, so `ftp://localhost:2368/icon.svg` remains invalid.

### Notes for reviewers

The existing coverage passed because it builds the icon URL from `config.get('url')`, which in the test environment is `http://127.0.0.1:2369` — an IP address, which `isURL` accepts. That is the same reason the forum workaround worked. The new tests hardcode a `localhost:2368` icon URL so it can't drift back, and bound the exception from both sides.

Verified behaviour against the real validator:

| icon | result |
| --- | --- |
| `http://localhost:2368/content/images/x.svg` | accepted |
| `https://example.com/x.svg`, `http://127.0.0.1:2368/x.svg` | accepted |
| `__GHOST_URL__/content/images/x.svg`, `/content/images/x.svg` | accepted |
| `http://intranet/icon.svg` | rejected |
| `ftp://localhost:2368/icon.svg` | rejected |
| `mailto:`, `http://local host/x.svg` | rejected |

The legacy suite needs MySQL on port 3306, which isn't available in this environment, so the new tests were not executed locally — CI will run them.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)