### PR TITLE
Added saving to the React post editor behind the editorReact flag

### DIFF
--- a/apps/admin-x-framework/src/api/pages.ts
+++ b/apps/admin-x-framework/src/api/pages.ts
@@ -102,11 +102,15 @@ export const useEditorPage = (
 export interface AddPagePayload {
   page: CreateContentData<PageEditableData>;
   options?: PostCreateOptions;
+  /** False when the caller handles an expired session itself instead of leaving the page. */
+  sessionExpiryRedirect?: boolean;
 }
 
 export interface EditPagePayload {
   page: EditContentData<PageEditableData>;
   options?: PageWriteOptions;
+  /** False when the caller handles an expired session itself instead of leaving the page. */
+  sessionExpiryRedirect?: boolean;
 }
 
 export const useAddPage = createMutation<PageResponseType, AddPagePayload>({
@@ -114,6 +118,7 @@ export const useAddPage = createMutation<PageResponseType, AddPagePayload>({
   path: () => '/pages/',
   searchParams: ({ options }) => buildPageWriteParams(options),
   body: ({ page }) => ({ pages: [serializePostPayload(page, 'page')] }),
+  requestOptions: ({ sessionExpiryRedirect }) => ({ sessionExpiryRedirect }),
   invalidateQueries: { dataType },
 });
 
@@ -122,6 +127,7 @@ export const useEditPage = createMutation<PageResponseType, EditPagePayload>({
   path: ({ page }) => `/pages/${page.id}/`,
   searchParams: ({ options }) => buildPageWriteParams(options),
   body: ({ page }) => ({ pages: [serializePostPayload(page, 'page')] }),
+  requestOptions: ({ sessionExpiryRedirect }) => ({ sessionExpiryRedirect }),
   invalidateQueries: { dataType },
 });
 

--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -120,11 +120,15 @@ export const useEditorPost = (
 export interface AddPostPayload {
   post: CreateContentData<PostEditableData>;
   options?: PostCreateOptions;
+  /** False when the caller handles an expired session itself instead of leaving the page. */
+  sessionExpiryRedirect?: boolean;
 }
 
 export interface EditPostPayload {
   post: EditContentData<PostEditableData>;
   options?: PostWriteOptions;
+  /** False when the caller handles an expired session itself instead of leaving the page. */
+  sessionExpiryRedirect?: boolean;
 }
 
 export const useAddPost = createMutation<PostResponseType, AddPostPayload>({
@@ -132,6 +136,7 @@ export const useAddPost = createMutation<PostResponseType, AddPostPayload>({
   path: () => '/posts/',
   searchParams: ({ options }) => buildPostWriteParams(options),
   body: ({ post }) => ({ posts: [serializePostPayload(post)] }),
+  requestOptions: ({ sessionExpiryRedirect }) => ({ sessionExpiryRedirect }),
   invalidateQueries: { dataType },
 });
 
@@ -140,6 +145,7 @@ export const useEditPost = createMutation<PostResponseType, EditPostPayload>({
   path: ({ post }) => `/posts/${post.id}/`,
   searchParams: ({ options }) => buildPostWriteParams(options),
   body: ({ post }) => ({ posts: [serializePostPayload(post)] }),
+  requestOptions: ({ sessionExpiryRedirect }) => ({ sessionExpiryRedirect }),
   invalidateQueries: { dataType },
 });
 

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -23,6 +23,8 @@ export interface RequestOptions {
   retry?: boolean;
   /** Resolve the raw response body instead of parsing it as JSON/text */
   responseType?: ResponseType;
+  /** False leaves the caller to handle `SessionExpiredError` instead of leaving the page. */
+  sessionExpiryRedirect?: boolean;
   onUploadProgress?: (progress: number) => void;
 }
 
@@ -172,6 +174,7 @@ export const useFetchApi = () => {
         timeout,
         retry = true,
         responseType,
+        sessionExpiryRedirect = true,
         onUploadProgress,
       }: RequestOptions = {},
     ): Promise<ResponseData> => {
@@ -265,7 +268,9 @@ export const useFetchApi = () => {
             }
 
             if (error instanceof UnauthorizedError && isSessionExpiry(endpoint)) {
-              redirectOnSessionExpiry();
+              if (sessionExpiryRedirect) {
+                redirectOnSessionExpiry();
+              }
               throw new SessionExpiredError(error.response!, error.data, { cause: error });
             }
 

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -172,6 +172,8 @@ interface MutationOptions<ResponseData, Payload>
   headers?: Record<string, string>;
   body?: (payload: Payload) => FormData | object;
   searchParams?: (payload: Payload) => { [key: string]: string };
+  /** Per-payload transport options, merged over the ones declared on the hook. */
+  requestOptions?: (payload: Payload) => Omit<RequestOptions, 'body'>;
   invalidateQueries?:
     | { dataType: string | string[] }
     | {
@@ -198,7 +200,7 @@ const mutate = <ResponseData, Payload>({
   searchParams?: Record<string, string>;
   options: Omit<MutationOptions<ResponseData, Payload>, 'path'>;
 }) => {
-  const { defaultSearchParams, body, ...requestOptions } = options;
+  const { defaultSearchParams, body, requestOptions, ...staticOptions } = options;
   const url = apiUrl(path, searchParams || defaultSearchParams);
   const generatedBody = payload && body?.(payload);
 
@@ -211,7 +213,8 @@ const mutate = <ResponseData, Payload>({
 
   return fetchApi<ResponseData>(url, {
     body: requestBody,
-    ...requestOptions,
+    ...staticOptions,
+    ...(payload === undefined ? {} : requestOptions?.(payload)),
   });
 };
 

--- a/apps/admin/src/editor/editor-save.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-save.acceptance.test.tsx
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentRoute,
+  fakeAdminEndpoint,
+  fakePosts,
+  fakeSnippets,
+  post,
+  renderAdminApp,
+  type EndpointCapture,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+import { OLD_SCHEMA_CORPUS } from '@/editor/engine/__fixtures__';
+
+const POST_ID = 'abc123';
+const NEW_POST_ID = 'new789';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+
+// The autosave debounce is 3s, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const SAVE_POLL = { timeout: 10_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] };
+  return body.posts[0];
+}
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+}
+
+/**
+ * A post that answers saves the way Ghost does: the response carries the
+ * submitted fields back with a fresh collision token, and the read endpoint
+ * serves whatever was saved last.
+ */
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), () => ({ posts: [current] }));
+
+  const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+
+  return saveApi;
+}
+
+async function typeIntoBody(text: string) {
+  await editorScreen.body().click();
+  await userEvent.keyboard(`{End}${text}`);
+}
+
+function bodyElement(): Element | null {
+  return document.querySelector('[data-testid="editor-body"]');
+}
+
+/**
+ * The React post editor's save engine wired to the API: body edits autosave,
+ * a new post is created on its first edit, and a rejected save surfaces in
+ * place instead of losing what was typed.
+ */
+describe('Post editor saving', () => {
+  it(
+    'autosaves the body and sends the write contract',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      await typeIntoBody(' and more');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      const url = saveApi.lastRequest?.url ?? '';
+      expect(url).toContain('formats=mobiledoc%2Clexical');
+      expect(url).toContain('include=tags%2Cauthors');
+      // A background save never asks the server for a revision.
+      expect(url).not.toContain('save_revision');
+
+      expect(submittedPost(saveApi)).toMatchObject({
+        id: POST_ID,
+        title: 'Hello from React',
+        slug: 'hello-from-react',
+        status: 'draft',
+        updated_at: LOADED_AT,
+      });
+      expect(String(submittedPost(saveApi).lexical)).toContain('Hello from React and more');
+    },
+    SLOW,
+  );
+
+  it(
+    'stays clean once the save has been acknowledged and refetched',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      await typeIntoBody(' and more');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      await editorScreen.titleInput().click();
+      await editorScreen.body().click();
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves an old-schema post alone until it is edited',
+    async () => {
+      const legacy = OLD_SCHEMA_CORPUS.find(({ name }) => name === 'legacy-text-nodes');
+      const saveApi = fakeSavablePost({ lexical: JSON.stringify(legacy?.before) });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toBeVisible();
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(0);
+
+      await typeIntoBody(' edited');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+    },
+    SLOW,
+  );
+
+  it(
+    'creates a new post on the first edit and swaps the URL without remounting',
+    async () => {
+      editorChrome();
+      fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
+      let created = post({
+        id: NEW_POST_ID,
+        title: '(Untitled)',
+        slug: 'untitled',
+        status: 'draft',
+        updated_at: LOADED_AT,
+        published_at: null,
+        tags: [],
+      });
+      const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+        const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+        created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: LOADED_AT };
+        return { posts: [created] };
+      });
+      fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
+      fakeAdminEndpoint('PUT', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
+
+      await renderAdminApp('/editor/post', FLAG_ON);
+      await expect.element(editorScreen.body()).toBeVisible();
+      const mountedBody = bodyElement();
+
+      await typeIntoBody('First words');
+
+      await expect.poll(() => createApi.requests.length, SAVE_POLL).toBe(1);
+      expect(submittedPost(createApi)).toMatchObject({ title: '(Untitled)', slug: 'untitled' });
+      expect(submittedPost(createApi).id).toBeUndefined();
+
+      await expect.poll(currentRoute).toBe(`/editor/post/${NEW_POST_ID}`);
+      expect(bodyElement()).toBe(mountedBody);
+      await expect.element(editorScreen.body()).toHaveTextContent('First words');
+    },
+    SLOW,
+  );
+
+  it(
+    'halts on a collision and keeps the content',
+    async () => {
+      editorChrome();
+      fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
+        posts: [
+          post({
+            id: POST_ID,
+            title: 'Hello from React',
+            slug: 'hello-from-react',
+            status: 'draft',
+            lexical: buildLexicalParagraph('Hello from React'),
+            updated_at: LOADED_AT,
+            tags: [],
+          }),
+        ],
+      });
+      const saveApi = fakeAdminEndpoint(
+        'PUT',
+        new RegExp(`^/posts/${POST_ID}/\\?`),
+        {
+          errors: [
+            {
+              code: 'UPDATE_COLLISION',
+              type: 'UpdateCollisionError',
+              message: 'Saving failed! Someone else is editing this post.',
+            },
+          ],
+        },
+        { status: 409 },
+      );
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      await typeIntoBody(' and more');
+
+      await expect
+        .element(editorScreen.conflictBanner())
+        .toHaveTextContent('Someone else is editing this post');
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React and more');
+
+      await typeIntoBody(' again');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      await expect.element(editorScreen.body()).toHaveTextContent('and more again');
+    },
+    SLOW,
+  );
+
+  it(
+    'offers a retry in place when the session expired',
+    async () => {
+      editorChrome();
+      fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
+        posts: [
+          post({
+            id: POST_ID,
+            title: 'Hello from React',
+            slug: 'hello-from-react',
+            status: 'draft',
+            lexical: buildLexicalParagraph('Hello from React'),
+            updated_at: LOADED_AT,
+            tags: [],
+          }),
+        ],
+      });
+      const saveApi = fakeAdminEndpoint(
+        'PUT',
+        new RegExp(`^/posts/${POST_ID}/\\?`),
+        { errors: [{ type: 'UnauthorizedError', message: 'Authorization failed' }] },
+        { status: 401 },
+      );
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      await typeIntoBody(' and more');
+
+      await expect.element(editorScreen.reauthBanner()).toHaveTextContent('Your session expired');
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React and more');
+      expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
+
+      await editorScreen.retryReauth().click();
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(2);
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -28,6 +28,8 @@ import {
 } from '@tryghost/admin-x-framework/api/users';
 import type { CardConfigPostSource, PostType } from './card-config';
 import { PostEditor } from './post-editor';
+import { SessionBanners } from './session/session-banners';
+import { useEditorSession, useEditorSessionKey } from './session/use-editor-session';
 import { usePostCardConfig } from './use-post-card-config';
 import { usePostSnippets } from './use-post-snippets';
 
@@ -70,10 +72,7 @@ function EditorHeader({ postType }: { postType: PostType }) {
 function EditorSurface({ postType, record }: { postType: PostType; record?: EditorRecord }) {
   const { data: currentUser } = useCurrentUser();
   const showExcerpt = useFeatureFlag('editorExcerpt');
-  const [title, setTitle] = useState(() =>
-    record?.title === '(Untitled)' ? '' : (record?.title ?? ''),
-  );
-  const [excerpt, setExcerpt] = useState(() => record?.custom_excerpt ?? '');
+  const session = useEditorSession({ postType, record });
 
   const canManageSnippets =
     !!currentUser &&
@@ -104,17 +103,18 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
   return (
     <Stack className="h-full" gap="none">
       <EditorHeader postType={postType} />
+      <SessionBanners
+        state={session.state}
+        onDismissReauth={session.reauthAbandoned}
+        onRetryReauth={session.reauthSucceeded}
+      />
       <div className="min-h-0 flex-1">
         <PostEditor
+          {...session.bind}
           autofocusTitle={!record}
           cardConfig={cardConfig}
-          excerpt={excerpt}
-          initialLexical={record?.lexical ?? null}
           postType={postType}
           showExcerpt={showExcerpt}
-          title={title}
-          onExcerptChange={setExcerpt}
-          onTitleChange={setTitle}
         />
       </div>
       {snippetDialog}
@@ -167,15 +167,17 @@ function useLexicalConversion(postType: PostType) {
   return { state, convert };
 }
 
-function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }) {
+function EditorLoader({ postType, id }: { postType: PostType; id?: string }) {
+  // A create replaces the URL with the id it acquired; the load must not restart.
+  const [openedId] = useState(id);
   const navigate = useNavigate();
   const { data: currentUser } = useCurrentUser();
-  const postQuery = useEditorPost(id, {
-    enabled: postType === 'post',
+  const postQuery = useEditorPost(openedId ?? '', {
+    enabled: postType === 'post' && !!openedId,
     defaultErrorHandler: false,
   });
-  const pageQuery = useEditorPage(id, {
-    enabled: postType === 'page',
+  const pageQuery = useEditorPage(openedId ?? '', {
+    enabled: postType === 'page' && !!openedId,
     defaultErrorHandler: false,
   });
   const query = postType === 'page' ? pageQuery : postQuery;
@@ -197,6 +199,10 @@ function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }
       void convert(loaded);
     }
   }, [needsConversion, loaded, conversion?.id, convert]);
+
+  if (!openedId) {
+    return <EditorSurface postType={postType} />;
+  }
 
   const notFound = query.error instanceof APIError && query.error.response?.status === 404;
   if (notFound) {
@@ -240,11 +246,12 @@ function ExistingPostEditor({ postType, id }: { postType: PostType; id: string }
     record = converted.record;
   }
 
-  return <EditorSurface key={record.id} postType={postType} record={record} />;
+  return <EditorSurface postType={postType} record={record} />;
 }
 
 export default function EditorScreen() {
   const editorPath = useParams()['*'] ?? '';
+  const sessionKey = useEditorSessionKey();
   const [typeSegment, id, ...rest] = editorPath.split('/').filter(Boolean);
 
   if (!typeSegment) {
@@ -255,9 +262,5 @@ export default function EditorScreen() {
     return <NotFound />;
   }
 
-  if (id) {
-    return <ExistingPostEditor id={id} postType={typeSegment} />;
-  }
-
-  return <EditorSurface key={typeSegment} postType={typeSegment} />;
+  return <EditorLoader key={sessionKey} id={id} postType={typeSegment} />;
 }

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -1,8 +1,10 @@
 import { page } from 'vitest/browser';
 import {
   editorBody,
+  editorConflictBanner,
   editorExcerptInput,
   editorLoadError,
+  editorReauthBanner,
   editorSecondaryInstance,
   editorTitleInput,
   editorWordCount,
@@ -22,6 +24,9 @@ export const editorScreen = {
   secondaryInstance: () => page.getByTestId(editorSecondaryInstance),
   wordCount: () => page.getByTestId(editorWordCount),
   loadError: () => page.getByTestId(editorLoadError),
+  reauthBanner: () => page.getByTestId(editorReauthBanner),
+  retryReauth: () => page.getByTestId(editorReauthBanner).getByRole('button', { name: 'Retry' }),
+  conflictBanner: () => page.getByTestId(editorConflictBanner),
   notFound: () => page.getByRole('heading', { name: 'Page not found' }),
   titleTkIndicator: () => page.getByTestId(tkIndicator),
   backLink: (postType: 'post' | 'page') =>

--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -317,6 +317,28 @@ Ordering and staleness
 
 ## What the caller owns
 
+### Editing session
+
+The wiring hook owns everything the three modules deliberately do not:
+
+- One session per opened post, built and disposed together. A new post always
+  gets its own; nothing is carried from one new post to the next.
+- A live projection held beside the tracker and patched on every title, excerpt
+  and body change, so a snapshot can be read synchronously at any moment. The
+  version counter moves with it.
+- The persisted identity (id and collision token), replaced from every
+  acknowledgement, so the next request carries the token the server just issued.
+- A blank title held in the live projection as the default title while the input
+  stays empty, so a post persisted under that title does not read as permanently
+  diverged from what the writer sees.
+- Routing query responses to `setSaved` and mutation responses to
+  `saveAcknowledged`, passing the projection the request submitted and the full
+  record the server acknowledged.
+- Replacing the URL once a create acquires an id, with the screen keyed on the
+  session so the swap does not remount the editor.
+- Deciding what a halted queue looks like: `reauth-pending` and `conflict` are
+  states, not UI. The writer gets a way back in and the content stays untouched.
+
 ### Save engine
 
 - A no-redirect request mode: the framework transport redirects on 401 (`apps/admin-x-framework/src/utils/api/fetch-api.ts`); the editor adapter must instead throw `SessionExpiredError` so the engine can enter `reauth-pending`.

--- a/apps/admin/src/editor/koenig-post-editor.tsx
+++ b/apps/admin/src/editor/koenig-post-editor.tsx
@@ -25,6 +25,8 @@ export interface KoenigPostEditorProps {
   cursorDidExitAtTop?: () => void;
   onChange?: (lexical: unknown) => void;
   onSecondaryChange?: (lexical: unknown) => void;
+  /** The hidden instance failed, so its serialization cannot be a change baseline. */
+  onSecondaryError?: (error: unknown) => void;
   registerAPI: (api: KoenigInstance | null) => void;
   registerSecondaryAPI: (api: KoenigInstance | null) => void;
   onWordCountChange: (count: number) => void;
@@ -87,8 +89,9 @@ function KoenigInstanceMount({
 
 export function KoenigPostEditor(props: KoenigPostEditorProps) {
   const editor = useMemo(() => loadKoenig(), []);
+  const { onSecondaryError } = props;
 
-  const onError = useCallback((error: unknown) => {
+  const reportError = useCallback((error: unknown) => {
     // eslint-disable-next-line no-console
     console.error(error);
 
@@ -103,6 +106,14 @@ export function KoenigPostEditor(props: KoenigPostEditorProps) {
     // not rethrown: Lexical attempts to recover without losing user data
   }, []);
 
+  const onSecondaryInstanceError = useCallback(
+    (error: unknown) => {
+      reportError(error);
+      onSecondaryError?.(error);
+    },
+    [reportError, onSecondaryError],
+  );
+
   return (
     <div className="koenig-react-editor koenig-lexical mx-auto w-full max-w-[740px]">
       <ErrorBoundary name="the editor">
@@ -113,8 +124,18 @@ export function KoenigPostEditor(props: KoenigPostEditorProps) {
             </div>
           }
         >
-          <KoenigInstanceMount {...props} editor={editor} isSecondary={false} onError={onError} />
-          <KoenigInstanceMount {...props} editor={editor} isSecondary={true} onError={onError} />
+          <KoenigInstanceMount
+            {...props}
+            editor={editor}
+            isSecondary={false}
+            onError={reportError}
+          />
+          <KoenigInstanceMount
+            {...props}
+            editor={editor}
+            isSecondary={true}
+            onError={onSecondaryInstanceError}
+          />
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/apps/admin/src/editor/post-editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/post-editor.acceptance.test.tsx
@@ -61,7 +61,8 @@ function pasteText(content: string) {
 /**
  * Covers post loading, Koenig mounting, and in-memory editing. Write requests
  * remain unfaked unless a test expects a mobiledoc conversion, so any
- * unexpected write returns 418 and fails the test.
+ * unexpected write returns 418 and fails the test. Saving is covered in
+ * editor-save.acceptance.test.tsx.
  */
 describe('Post editor', () => {
   it('loads the post into the title and body', async () => {

--- a/apps/admin/src/editor/post-editor.tsx
+++ b/apps/admin/src/editor/post-editor.tsx
@@ -18,9 +18,12 @@ export interface PostEditorProps {
   showExcerpt: boolean;
   autofocusTitle?: boolean;
   onTitleChange: (title: string) => void;
+  onTitleBlur?: () => void;
   onExcerptChange: (excerpt: string) => void;
+  onExcerptBlur?: () => void;
   onLexicalChange?: (lexical: unknown) => void;
   onSecondaryChange?: (lexical: unknown) => void;
+  onSecondaryError?: (error: unknown) => void;
   registerEditorApi?: (api: KoenigInstance | null) => void;
   registerSecondaryApi?: (api: KoenigInstance | null) => void;
   onTkCountChange?: (count: number) => void;
@@ -84,9 +87,12 @@ export function PostEditor({
   showExcerpt,
   autofocusTitle = false,
   onTitleChange,
+  onTitleBlur,
   onExcerptChange,
+  onExcerptBlur,
   onLexicalChange,
   onSecondaryChange,
+  onSecondaryError,
   registerEditorApi,
   registerSecondaryApi,
   onTkCountChange,
@@ -260,6 +266,7 @@ export function PostEditor({
               placeholder={`${capitalize(postType)} title`}
               rows={1}
               value={title}
+              onBlur={onTitleBlur}
               onChange={(event) => onTitleChange(event.target.value)}
               onKeyDown={onTitleKeyDown}
               onPaste={cleanPastedTitle}
@@ -280,6 +287,7 @@ export function PostEditor({
                   placeholder="Add an excerpt"
                   rows={1}
                   value={excerpt}
+                  onBlur={onExcerptBlur}
                   onChange={(event) => onExcerptChange(event.target.value)}
                   onKeyDown={onExcerptKeyDown}
                 />
@@ -297,6 +305,7 @@ export function PostEditor({
             registerSecondaryAPI={registerSecondary}
             onChange={onLexicalChange}
             onSecondaryChange={onSecondaryChange}
+            onSecondaryError={onSecondaryError}
             onTkCountChange={setBodyTkCount}
             onWordCountChange={setWordCount}
           />

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest';
+import { slugify } from '@tryghost/string';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+import {
+  createEditorSession,
+  type EditorSessionOptions,
+  type EditorWritePayload,
+} from './editor-session';
+import type { EditorRecord } from './projection';
+
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+
+function body(text: string): unknown {
+  return JSON.parse(buildLexicalParagraph(text));
+}
+
+function record(overrides: Partial<EditorRecord> = {}): EditorRecord {
+  return {
+    id: 'abc123',
+    uuid: 'uuid',
+    url: 'https://example.com/hello/',
+    title: 'Hello',
+    slug: 'hello',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    tags: [],
+    ...overrides,
+  };
+}
+
+interface Harness {
+  updates: Array<{ payload: EditorWritePayload; saveRevision?: boolean }>;
+  creates: EditorWritePayload[];
+  acquiredIds: string[];
+  /** The record every acknowledgement answers with; tests advance it. */
+  acknowledged: EditorRecord;
+}
+
+function harness(options: Partial<EditorSessionOptions> = {}) {
+  const state: Harness = {
+    updates: [],
+    creates: [],
+    acquiredIds: [],
+    acknowledged: record(),
+  };
+  let saveCount = 0;
+
+  const session = createEditorSession({
+    saveFailureMessage: 'Couldn’t save this post.',
+    onIdAcquired: (id) => state.acquiredIds.push(id),
+    onError: vi.fn(),
+    transport: {
+      create: (payload) => {
+        state.creates.push(payload);
+        saveCount += 1;
+        state.acknowledged = record({
+          ...state.acknowledged,
+          id: 'created-id',
+          title: payload.title as string,
+          slug: payload.slug as string,
+          lexical: payload.lexical as string,
+          updated_at: `2026-01-01T00:00:0${saveCount}.000Z`,
+        });
+        return Promise.resolve(state.acknowledged);
+      },
+      update: (payload, writeOptions) => {
+        state.updates.push({ payload, saveRevision: writeOptions.saveRevision });
+        saveCount += 1;
+        state.acknowledged = record({
+          ...state.acknowledged,
+          title: payload.title as string,
+          slug: payload.slug as string,
+          lexical: payload.lexical as string,
+          custom_excerpt: (payload.custom_excerpt ?? null) as string | null,
+          updated_at: `2026-01-01T00:00:0${saveCount}.000Z`,
+        });
+        return Promise.resolve(state.acknowledged);
+      },
+      generateSlug: (text) => Promise.resolve(slugify(text)),
+    },
+    ...options,
+  });
+
+  return { session, state };
+}
+
+describe('createEditorSession', () => {
+  it('loads a post clean and dirties it on the first edit', () => {
+    const { session } = harness({ record: record() });
+
+    expect(session.isDirty()).toBe(false);
+
+    session.patchLexical(body('Hello and more'));
+
+    expect(session.isDirty()).toBe(true);
+  });
+
+  it('submits the edited body and lands the post clean again', async () => {
+    const { session, state } = harness({ record: record() });
+    const edited = body('Hello and more');
+
+    session.setBaseline(record().lexical);
+    session.patchLexical(edited);
+    await session.dispatchExplicit();
+
+    expect(state.updates).toHaveLength(1);
+    expect(state.updates[0].payload).toMatchObject({
+      id: 'abc123',
+      title: 'Hello',
+      slug: 'hello',
+      lexical: JSON.stringify(edited),
+      updated_at: LOADED_AT,
+      status: 'draft',
+    });
+    expect(state.updates[0].saveRevision).toBe(true);
+    expect(session.isDirty()).toBe(false);
+  });
+
+  it('sends the acknowledged collision token on the next save', async () => {
+    const { session, state } = harness({ record: record() });
+
+    session.patchLexical(body('One'));
+    await session.dispatchExplicit();
+    session.patchLexical(body('Two'));
+    await session.dispatchExplicit();
+
+    expect(state.updates[0].payload.updated_at).toBe(LOADED_AT);
+    expect(state.updates[1].payload.updated_at).toBe('2026-01-01T00:00:01.000Z');
+  });
+
+  it('creates a new post, adopts its id and updates it afterwards', async () => {
+    const { session, state } = harness();
+
+    session.patchLexical(body('First words'));
+    await session.dispatchExplicit();
+
+    expect(state.creates).toHaveLength(1);
+    expect(state.creates[0]).not.toHaveProperty('id');
+    // A blank title persists as the default and its slug is generated from it.
+    expect(state.creates[0]).toMatchObject({ title: '(Untitled)', slug: 'untitled' });
+    expect(state.acquiredIds).toEqual(['created-id']);
+
+    session.patchLexical(body('More words'));
+    await session.dispatchExplicit();
+
+    expect(state.updates[0].payload).toMatchObject({ id: 'created-id' });
+    expect(state.acquiredIds).toEqual(['created-id']);
+  });
+
+  it('keeps the excerpt it was given and clears it back to null', async () => {
+    const { session, state } = harness({ record: record() });
+
+    session.patchExcerpt('A summary');
+    await session.dispatchExplicit();
+    session.patchExcerpt('');
+    await session.dispatchExplicit();
+
+    expect(state.updates[0].payload.custom_excerpt).toBe('A summary');
+    expect(state.updates[1].payload.custom_excerpt).toBeNull();
+  });
+
+  it('gives each new post its own state', () => {
+    const first = harness();
+    const second = harness();
+
+    first.session.patchLexical(body('Only mine'));
+
+    expect(first.session.isDirty()).toBe(true);
+    expect(second.session.isDirty()).toBe(false);
+  });
+
+  it('adopts a refetched record without re-baselining', () => {
+    const { session } = harness({ record: record() });
+    const edited = body('Unsaved edit');
+
+    session.setBaseline(record().lexical);
+    session.patchLexical(edited);
+    session.recordRefetched(record({ updated_at: '2026-01-02T00:00:00.000Z' }));
+
+    expect(session.isDirty()).toBe(true);
+  });
+
+  it('stops saving once disposed', async () => {
+    const { session, state } = harness({ record: record() });
+
+    session.patchLexical(body('Too late'));
+    session.dispose();
+    await session.dispatchExplicit();
+
+    expect(state.updates).toHaveLength(0);
+  });
+});

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -1,0 +1,278 @@
+import { createChangeTracker } from '@/editor/engine/change-tracker';
+import { createSlugMachine } from '@/editor/engine/slug-machine';
+import {
+  DEFAULT_TITLE,
+  createSaveEngine,
+  type PersistedIdentity,
+  type PostStatus,
+  type SaveCompletion,
+  type SaveEngineState,
+  type SaveOutcome,
+  type SaveRequest,
+  type SaveResult,
+} from '@/editor/engine/save-engine';
+import type { EditablePostProjection, RevisionProjection } from '@/editor/engine/change-tracker';
+import type { LexicalInput } from '@/editor/engine/lexical-compare';
+import type { PostWriteOptions } from '@tryghost/admin-x-framework/api/post-contract';
+import { toSaveError } from './error-mapping';
+import { createSlugPort } from './slug-port';
+import { buildSaveSnapshot, type EditorSaveSnapshot } from './snapshot';
+import { latestRevisionOf, newPostProjection, projectionOf, type EditorRecord } from './projection';
+
+export type EditorWritePayload = Record<string, unknown>;
+
+/** The full acknowledged record travels with the result so reconcile can rebase on it. */
+export interface EditorSaveResult extends SaveResult {
+  post: EditorRecord;
+}
+
+export interface PreparedSave extends SaveRequest<EditorSaveSnapshot> {
+  /** What the request submits, for the tracker's three-way rebase. */
+  projection: EditablePostProjection;
+  payload: EditorWritePayload;
+  options: PostWriteOptions;
+  isCreate: boolean;
+}
+
+export interface EditorSessionTransport {
+  create: (payload: EditorWritePayload) => Promise<EditorRecord | undefined>;
+  update: (
+    payload: EditorWritePayload,
+    options: PostWriteOptions,
+  ) => Promise<EditorRecord | undefined>;
+  generateSlug: (text: string, postId: string | null) => Promise<string>;
+}
+
+export interface EditorSessionOptions {
+  record?: EditorRecord;
+  siteUrl?: string;
+  saveFailureMessage: string;
+  transport: EditorSessionTransport;
+  /** Called once the create acknowledges; the caller replaces the URL. */
+  onIdAcquired: (id: string) => void;
+  onError: (error: unknown) => void;
+}
+
+export interface EditorSession {
+  getState: () => SaveEngineState;
+  subscribe: (listener: () => void) => () => void;
+  isDirty: () => boolean;
+  patchTitle: (title: string) => void;
+  patchExcerpt: (excerpt: string) => void;
+  patchLexical: (lexical: unknown) => void;
+  setBaseline: (lexical: LexicalInput) => void;
+  baselineFailed: (error: unknown) => void;
+  commitTitle: (title: string) => void;
+  dispatchField: () => void;
+  dispatchAutosave: () => void;
+  dispatchExplicit: () => Promise<SaveCompletion>;
+  recordRefetched: (record: EditorRecord) => void;
+  reauthSucceeded: () => void;
+  reauthAbandoned: () => void;
+  dispose: () => void;
+}
+
+function isOlder(candidate: string, held: string | null): boolean {
+  if (!held) {
+    return false;
+  }
+  const candidateTime = Date.parse(candidate);
+  const heldTime = Date.parse(held);
+  return !Number.isNaN(candidateTime) && !Number.isNaN(heldTime) && candidateTime < heldTime;
+}
+
+/**
+ * Composes the change tracker, slug machine and save engine into one editing
+ * session: one per opened post, never shared between two new posts.
+ */
+export function createEditorSession({
+  record,
+  siteUrl,
+  saveFailureMessage,
+  transport,
+  onIdAcquired,
+  onError,
+}: EditorSessionOptions): EditorSession {
+  let identity: PersistedIdentity = record
+    ? { id: record.id, updatedAt: record.updated_at ?? '' }
+    : { id: null, updatedAt: null };
+  let status: PostStatus = record?.status ?? 'draft';
+  let publishedAt: string | null = record?.published_at ?? null;
+  let live: EditablePostProjection = record ? projectionOf(record) : newPostProjection();
+  let latestRevision: RevisionProjection | null = latestRevisionOf(record);
+  let version = 0;
+
+  const tracker = createChangeTracker({ siteUrl });
+  tracker.load(identity.id, live);
+
+  const machine = createSlugMachine({
+    generateSlug: (text) => transport.generateSlug(text, identity.id),
+    onListenerError: onError,
+  });
+  machine.loaded({ slug: live.slug, title: live.title });
+
+  const slug = createSlugPort(machine);
+
+  function patchLive(patch: Partial<EditablePostProjection>): void {
+    live = { ...live, ...patch };
+    version += 1;
+    tracker.setLive(identity.id, patch);
+  }
+
+  function getSnapshot(): EditorSaveSnapshot {
+    return buildSaveSnapshot({
+      identity,
+      status,
+      publishedAt,
+      title: live.title,
+      slug: machine.getState().slug,
+      slugIsCustom: machine.getState().mode === 'custom',
+      verdict: tracker.verdict(),
+      changedSinceLastRevision: tracker.hasChangedSinceRevision(latestRevision),
+      version,
+    });
+  }
+
+  function prepare(request: SaveRequest<EditorSaveSnapshot>): Promise<PreparedSave> {
+    const isCreate = request.snapshot.id === null;
+    const projection: EditablePostProjection = {
+      ...live,
+      title: request.title,
+      slug: request.slug,
+      updated_at: request.snapshot.updatedAt,
+    };
+
+    const payload: EditorWritePayload = {
+      title: projection.title,
+      slug: projection.slug,
+      lexical: projection.lexical,
+      custom_excerpt: projection.custom_excerpt,
+      feature_image: projection.feature_image,
+      feature_image_alt: projection.feature_image_alt,
+      feature_image_caption: projection.feature_image_caption,
+      tags: projection.tags,
+      status: request.target.status,
+      published_at: request.target.publishedAt,
+    };
+    if (!isCreate) {
+      payload.id = request.snapshot.id;
+      payload.updated_at = projection.updated_at;
+    }
+    if (request.target.emailOnly !== undefined) {
+      payload.email_only = request.target.emailOnly;
+    }
+
+    return Promise.resolve({
+      ...request,
+      projection,
+      payload,
+      options: {
+        saveRevision: request.saveRevision,
+        newsletter: request.target.newsletter,
+        emailSegment: request.target.emailSegment,
+      },
+      isCreate,
+    });
+  }
+
+  async function execute(prepared: PreparedSave): Promise<SaveOutcome<EditorSaveResult>> {
+    try {
+      const saved = prepared.isCreate
+        ? await transport.create(prepared.payload)
+        : await transport.update(prepared.payload, prepared.options);
+
+      if (!saved) {
+        return { ok: false, error: { kind: 'unknown', message: saveFailureMessage } };
+      }
+
+      return {
+        ok: true,
+        result: {
+          id: saved.id,
+          status: saved.status ?? 'draft',
+          updatedAt: saved.updated_at ?? '',
+          post: saved,
+        },
+      };
+    } catch (error) {
+      return { ok: false, error: toSaveError(error, saveFailureMessage) };
+    }
+  }
+
+  function reconcile(prepared: PreparedSave, result: EditorSaveResult): void {
+    const acknowledged = projectionOf(result.post);
+    tracker.saveAcknowledged(result.id, prepared.projection, acknowledged);
+
+    const created = identity.id === null;
+    identity = { id: result.id, updatedAt: result.updatedAt };
+    status = result.status;
+    publishedAt = result.post.published_at ?? null;
+    latestRevision = latestRevisionOf(result.post);
+    live = { ...live, slug: acknowledged.slug, updated_at: result.updatedAt };
+
+    if (created) {
+      onIdAcquired(result.id);
+    }
+  }
+
+  const engine = createSaveEngine<EditorSaveSnapshot, PreparedSave, EditorSaveResult>({
+    getSnapshot,
+    slug: slug.port,
+    prepare,
+    execute,
+    reconcile,
+    onStateChange: (next) => {
+      if (next.kind === 'error' || next.kind === 'conflict') {
+        tracker.markSaveError(next.error.message);
+      }
+    },
+    onListenerError: onError,
+  });
+
+  return {
+    getState: () => engine.getState(),
+    subscribe: (listener) => engine.subscribe(listener),
+    isDirty: () => tracker.verdict().dirty,
+
+    // A blank title persists as the default, so the live projection carries it
+    // even while the input stays empty.
+    patchTitle: (title) => patchLive({ title: title.trim() ? title : DEFAULT_TITLE }),
+    patchExcerpt: (excerpt) => patchLive({ custom_excerpt: excerpt === '' ? null : excerpt }),
+    patchLexical: (lexical) => patchLive({ lexical: JSON.stringify(lexical) }),
+    setBaseline: (lexical) => tracker.setBaseline(identity.id, lexical),
+    baselineFailed: (error) => tracker.baselineFailed(identity.id, error),
+
+    // Only a draft's title drives the slug; a published URL must not move.
+    commitTitle: (title) => {
+      if (status === 'draft') {
+        slug.commitTitle(title);
+      }
+    },
+    dispatchField: () => void engine.dispatch('field'),
+    dispatchAutosave: () => void engine.dispatch('autosave'),
+    dispatchExplicit: () => engine.dispatch('explicit'),
+
+    recordRefetched: (next) => {
+      if (identity.id !== next.id) {
+        return;
+      }
+      tracker.setSaved(next.id, projectionOf(next));
+      const updatedAt = next.updated_at ?? '';
+      if (isOlder(updatedAt, identity.updatedAt)) {
+        return;
+      }
+      identity = { id: next.id, updatedAt };
+      status = next.status ?? status;
+      publishedAt = next.published_at ?? null;
+      latestRevision = latestRevisionOf(next);
+    },
+
+    reauthSucceeded: () => engine.reauthSucceeded(),
+    reauthAbandoned: () => engine.reauthAbandoned(),
+
+    dispose: () => {
+      engine.dispose();
+      tracker.dispose();
+    },
+  };
+}

--- a/apps/admin/src/editor/session/error-mapping.test.ts
+++ b/apps/admin/src/editor/session/error-mapping.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  APIError,
+  HostLimitError,
+  JSONError,
+  MaintenanceError,
+  ServerUnreachableError,
+  SessionExpiredError,
+  TimeoutError,
+  UnauthorizedError,
+  ValidationError,
+  type ErrorResponse,
+} from '@tryghost/admin-x-framework/errors';
+import { toSaveError } from './error-mapping';
+
+function errorBody(overrides: Partial<ErrorResponse['errors'][number]> = {}): ErrorResponse {
+  return {
+    errors: [
+      {
+        code: '',
+        context: null,
+        details: null,
+        ghostErrorCode: null,
+        help: '',
+        id: 'id',
+        message: 'Saving failed.',
+        property: null,
+        type: 'InternalServerError',
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function response(status: number): Response {
+  return new Response(null, { status });
+}
+
+describe('toSaveError', () => {
+  it.each<[string, unknown, string]>([
+    [
+      'a collision',
+      new JSONError(response(409), errorBody({ code: 'UPDATE_COLLISION' })),
+      'conflict',
+    ],
+    ['an expired session', new SessionExpiredError(response(401), errorBody()), 'session-invalid'],
+    [
+      'an unauthorized response',
+      new UnauthorizedError(response(401), errorBody()),
+      'session-invalid',
+    ],
+    ['a host limit', new HostLimitError(response(403), errorBody()), 'host-limit'],
+    ['an unreachable server', new ServerUnreachableError(), 'transport'],
+    ['maintenance', new MaintenanceError(response(503), ''), 'transport'],
+    ['a timeout', new TimeoutError(), 'transport'],
+    ['a validation failure', new ValidationError(response(422), errorBody()), 'validation'],
+    ['a missing post', new APIError(response(404)), 'not-found'],
+    ['an unprocessable body', new JSONError(response(422), errorBody()), 'validation'],
+    ['a server error', new JSONError(response(500), errorBody()), 'unknown'],
+    ['a thrown non-error', 'broken', 'unknown'],
+  ])('maps %s', (_label, error, kind) => {
+    expect(toSaveError(error, 'fallback').kind).toBe(kind);
+  });
+
+  it('keeps the fallback message when the failure carries none', () => {
+    expect(toSaveError({}, 'Could not save').message).toBe('Could not save');
+  });
+
+  it('carries the cause for reporting', () => {
+    const error = new ServerUnreachableError();
+    expect(toSaveError(error, 'fallback').cause).toBe(error);
+  });
+
+  it('reads a collision ahead of the status it arrives with', () => {
+    // Core answers 409 for UPDATE_COLLISION, which no framework error class claims.
+    const collision = new JSONError(response(409), errorBody({ code: 'UPDATE_COLLISION' }));
+    expect(toSaveError(collision, 'fallback').kind).toBe('conflict');
+  });
+});

--- a/apps/admin/src/editor/session/error-mapping.ts
+++ b/apps/admin/src/editor/session/error-mapping.ts
@@ -1,0 +1,65 @@
+import {
+  APIError,
+  HostLimitError,
+  JSONError,
+  MaintenanceError,
+  ServerUnreachableError,
+  SessionExpiredError,
+  TimeoutError,
+  UnauthorizedError,
+  ValidationError,
+} from '@tryghost/admin-x-framework/errors';
+import type { SaveError } from '@/editor/engine/save-engine';
+
+// @tryghost/bookshelf-collision rejects a stale updated_at with this code.
+const COLLISION_CODE = 'UPDATE_COLLISION';
+
+function apiErrorCode(error: unknown): string | undefined {
+  return error instanceof JSONError ? (error.data?.errors?.[0]?.code ?? undefined) : undefined;
+}
+
+function status(error: unknown): number | undefined {
+  return error instanceof APIError ? error.response?.status : undefined;
+}
+
+function messageOf(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+/** Maps a transport failure onto the save engine's error kinds. */
+export function toSaveError(error: unknown, fallback: string): SaveError {
+  const kind = ((): SaveError['kind'] => {
+    if (apiErrorCode(error) === COLLISION_CODE) {
+      return 'conflict';
+    }
+    if (error instanceof SessionExpiredError || error instanceof UnauthorizedError) {
+      return 'session-invalid';
+    }
+    if (error instanceof HostLimitError) {
+      return 'host-limit';
+    }
+    if (
+      error instanceof ServerUnreachableError ||
+      error instanceof MaintenanceError ||
+      error instanceof TimeoutError
+    ) {
+      return 'transport';
+    }
+    if (error instanceof ValidationError) {
+      return 'validation';
+    }
+    const code = status(error);
+    if (code === 401) {
+      return 'session-invalid';
+    }
+    if (code === 404) {
+      return 'not-found';
+    }
+    if (code === 422) {
+      return 'validation';
+    }
+    return 'unknown';
+  })();
+
+  return { kind, message: messageOf(error, fallback), cause: error };
+}

--- a/apps/admin/src/editor/session/projection.ts
+++ b/apps/admin/src/editor/session/projection.ts
@@ -1,0 +1,57 @@
+import type { PageEditorRecord } from '@tryghost/admin-x-framework/api/pages';
+import type { PostEditorRecord, PostRevision } from '@tryghost/admin-x-framework/api/posts';
+import type { EditablePostProjection, RevisionProjection } from '@/editor/engine/change-tracker';
+
+export type EditorRecord = PostEditorRecord | PageEditorRecord;
+
+export function newPostProjection(): EditablePostProjection {
+  return {
+    title: '',
+    slug: '',
+    lexical: null,
+    tags: [],
+    custom_excerpt: null,
+    feature_image: null,
+    feature_image_alt: null,
+    feature_image_caption: null,
+    updated_at: null,
+  };
+}
+
+export function projectionOf(record: EditorRecord): EditablePostProjection {
+  return {
+    title: record.title,
+    slug: record.slug,
+    lexical: record.lexical ?? null,
+    tags: record.tags ?? [],
+    custom_excerpt: record.custom_excerpt ?? null,
+    feature_image: record.feature_image ?? null,
+    feature_image_alt: record.feature_image_alt ?? null,
+    feature_image_caption: record.feature_image_caption ?? null,
+    updated_at: record.updated_at,
+  };
+}
+
+function revisionTime(revision: PostRevision): number {
+  const time = Date.parse(revision.created_at ?? '');
+  return Number.isNaN(time) ? 0 : time;
+}
+
+/** The newest revision the server sent, or null when the record carries none. */
+export function latestRevisionOf(record: EditorRecord | undefined): RevisionProjection | null {
+  const revisions = record?.post_revisions ?? [];
+  if (revisions.length === 0) {
+    return null;
+  }
+
+  const latest = revisions.reduce((newest, revision) =>
+    revisionTime(revision) >= revisionTime(newest) ? revision : newest,
+  );
+
+  return {
+    lexical: latest.lexical ?? null,
+    title: latest.title ?? '',
+    custom_excerpt: latest.custom_excerpt ?? null,
+    feature_image: latest.feature_image ?? null,
+  };
+}

--- a/apps/admin/src/editor/session/session-banners.tsx
+++ b/apps/admin/src/editor/session/session-banners.tsx
@@ -1,0 +1,60 @@
+import { Banner, Button } from '@tryghost/shade/components';
+import { Inline, Text } from '@tryghost/shade/primitives';
+import type { SaveEngineState } from '@/editor/engine/save-engine';
+
+export interface SessionBannersProps {
+  state: SaveEngineState;
+  onRetryReauth: () => void;
+  onDismissReauth: () => void;
+}
+
+export function SessionBanners({ state, onRetryReauth, onDismissReauth }: SessionBannersProps) {
+  if (state.kind === 'reauth-pending') {
+    return (
+      <Banner
+        className="mx-4 mb-2 shrink-0"
+        data-testid="editor-reauth-banner"
+        role="alert"
+        size="sm"
+        variant="warning"
+      >
+        <Inline align="center" gap="sm">
+          <Text>Your session expired. Sign in again in a new tab, then retry.</Text>
+          <Button size="sm" variant="outline" onClick={onRetryReauth}>
+            Retry
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onDismissReauth}>
+            Dismiss
+          </Button>
+        </Inline>
+      </Banner>
+    );
+  }
+
+  if (state.kind === 'conflict') {
+    return (
+      <Banner
+        className="mx-4 mb-2 shrink-0"
+        data-testid="editor-conflict-banner"
+        role="alert"
+        size="sm"
+        variant="destructive"
+      >
+        <Inline align="center" gap="sm">
+          <Text>Someone else is editing this post</Text>
+          <Button size="sm" variant="outline" onClick={reloadAfterConfirm}>
+            Reload
+          </Button>
+        </Inline>
+      </Banner>
+    );
+  }
+
+  return null;
+}
+
+function reloadAfterConfirm(): void {
+  if (window.confirm('Reload to get the latest version? Unsaved changes will be lost.')) {
+    window.location.reload();
+  }
+}

--- a/apps/admin/src/editor/session/slug-port.test.ts
+++ b/apps/admin/src/editor/session/slug-port.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import { slugify } from '@tryghost/string';
+import { deferred } from '@/utils/deferred';
+import { createSlugMachine } from '@/editor/engine/slug-machine';
+import { createSlugPort } from './slug-port';
+
+function harness(generateSlug = vi.fn((text: string) => Promise.resolve(slugify(text)))) {
+  const machine = createSlugMachine({ generateSlug, onListenerError: vi.fn() });
+  machine.loaded({ slug: 'original', title: 'Original' });
+  return { machine, generateSlug, ...createSlugPort(machine) };
+}
+
+const flush = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+// The engine's signal is only used to abandon work the session already dropped.
+const signal = () => new AbortController().signal;
+
+describe('createSlugPort', () => {
+  it('resolves a generated proposal from the title', async () => {
+    const { port } = harness();
+
+    await expect(port.fromTitle('A New Title', null, signal())).resolves.toEqual({
+      slug: 'a-new-title',
+      source: 'generated',
+    });
+  });
+
+  it('reports a refused commit as unchanged', async () => {
+    const { port } = harness();
+
+    await expect(port.fromTitle('Original', null, signal())).resolves.toEqual({
+      slug: 'original',
+      source: 'unchanged',
+    });
+  });
+
+  it('answers a superseded commit with the slug the machine holds', async () => {
+    const active = deferred<string>();
+    const generateSlug = vi
+      .fn<(text: string) => Promise<string>>()
+      .mockReturnValueOnce(active.promise)
+      .mockImplementation((text) => Promise.resolve(slugify(text)));
+    const { port, commitTitle, machine } = harness(generateSlug);
+
+    commitTitle('First');
+    const superseded = port.fromTitle('Second', null, signal());
+    commitTitle('Third');
+    active.resolve('first');
+
+    // The stale answer never proposes a slug of its own; the engine re-reads
+    // the snapshot instead.
+    await expect(superseded).resolves.toEqual({
+      slug: machine.getState().slug,
+      source: 'unchanged',
+    });
+    await port.settled();
+    expect(machine.getState().slug).toBe('third');
+  });
+
+  it('settles on the latest submission rather than the pending flag', async () => {
+    const active = deferred<string>();
+    const queued = deferred<string>();
+    const generateSlug = vi
+      .fn<(text: string) => Promise<string>>()
+      .mockReturnValueOnce(active.promise)
+      .mockReturnValueOnce(queued.promise);
+    const { port, commitTitle, machine } = harness(generateSlug);
+
+    commitTitle('First');
+    commitTitle('Second');
+
+    let settled = false;
+    void port.settled().then(() => {
+      settled = true;
+    });
+
+    active.resolve('first');
+    await flush();
+    expect(settled).toBe(false);
+    expect(machine.getState().pending).toBe(true);
+
+    queued.resolve('second');
+    await flush();
+    expect(settled).toBe(true);
+    expect(machine.getState().slug).toBe('second');
+  });
+
+  it('settles immediately when nothing was submitted', async () => {
+    const { port } = harness();
+
+    await expect(port.settled()).resolves.toBeUndefined();
+  });
+});

--- a/apps/admin/src/editor/session/slug-port.ts
+++ b/apps/admin/src/editor/session/slug-port.ts
@@ -1,0 +1,43 @@
+import type { SlugMachine } from '@/editor/engine/slug-machine';
+import type { SlugPort, SlugProposal } from '@/editor/engine/save-engine';
+
+export interface SlugPortAdapter {
+  port: SlugPort;
+  /** Commits a title without waiting for it; the save's `settled()` picks the work up. */
+  commitTitle: (title: string) => void;
+}
+
+/**
+ * Adapter over the slug machine. The machine's `pending` flag reads false
+ * between an active request and a queued one, so settling follows the
+ * submission promises instead.
+ */
+export function createSlugPort(machine: SlugMachine): SlugPortAdapter {
+  let latest: Promise<unknown> = Promise.resolve();
+
+  function track<T>(submission: Promise<T>): Promise<T> {
+    latest = submission.catch(() => undefined);
+    return submission;
+  }
+
+  async function settled(): Promise<void> {
+    let awaited;
+    do {
+      awaited = latest;
+      await awaited;
+    } while (awaited !== latest);
+  }
+
+  async function fromTitle(title: string): Promise<SlugProposal> {
+    const proposal = await track(machine.titleCommitted(title));
+
+    return proposal.source === 'generated'
+      ? { slug: proposal.slug, source: 'generated' }
+      : { slug: machine.getState().slug, source: 'unchanged' };
+  }
+
+  return {
+    port: { settled, fromTitle },
+    commitTitle: (title) => void track(machine.titleCommitted(title)),
+  };
+}

--- a/apps/admin/src/editor/session/snapshot.test.ts
+++ b/apps/admin/src/editor/session/snapshot.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { ChangeVerdict } from '@/editor/engine/change-tracker';
+import { buildSaveSnapshot, type SnapshotSources } from './snapshot';
+
+const clean: ChangeVerdict = { dirty: false, reasons: [] };
+
+const titleDiverged: ChangeVerdict = {
+  dirty: true,
+  reasons: [{ code: 'POST_TITLE_DIVERGED', reason: 'title is different', context: {} }],
+};
+
+function sources(overrides: Partial<SnapshotSources> = {}): SnapshotSources {
+  return {
+    identity: { id: 'abc', updatedAt: '2026-01-01T00:00:00.000Z' },
+    status: 'draft',
+    publishedAt: null,
+    title: 'Hello',
+    slug: 'hello',
+    slugIsCustom: false,
+    verdict: clean,
+    changedSinceLastRevision: false,
+    version: 3,
+    ...overrides,
+  };
+}
+
+describe('buildSaveSnapshot', () => {
+  it('carries the persisted identity of a saved post', () => {
+    expect(buildSaveSnapshot(sources())).toMatchObject({
+      id: 'abc',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      status: 'draft',
+      title: 'Hello',
+      slug: 'hello',
+      version: 3,
+    });
+  });
+
+  it('pairs a null id with a null collision token', () => {
+    const snapshot = buildSaveSnapshot(sources({ identity: { id: null, updatedAt: null } }));
+
+    expect(snapshot.id).toBeNull();
+    expect(snapshot.updatedAt).toBeNull();
+  });
+
+  it('takes dirtiness from the verdict', () => {
+    expect(buildSaveSnapshot(sources()).isDirty).toBe(false);
+    expect(buildSaveSnapshot(sources({ verdict: titleDiverged })).isDirty).toBe(true);
+  });
+
+  it('reads the title bit off the verdict reasons', () => {
+    expect(buildSaveSnapshot(sources()).titleDirty).toBe(false);
+    expect(buildSaveSnapshot(sources({ verdict: titleDiverged })).titleDirty).toBe(true);
+  });
+
+  it('reports the slug ownership and revision state it was given', () => {
+    const snapshot = buildSaveSnapshot(
+      sources({ slugIsCustom: true, changedSinceLastRevision: true, publishedAt: '2026-02-02' }),
+    );
+
+    expect(snapshot.slugIsCustom).toBe(true);
+    expect(snapshot.changedSinceLastRevision).toBe(true);
+    expect(snapshot.publishedAt).toBe('2026-02-02');
+  });
+});

--- a/apps/admin/src/editor/session/snapshot.ts
+++ b/apps/admin/src/editor/session/snapshot.ts
@@ -1,0 +1,47 @@
+import type { PersistedIdentity, PostStatus, SaveSnapshot } from '@/editor/engine/save-engine';
+import type { ChangeVerdict } from '@/editor/engine/change-tracker';
+
+export type EditorSaveSnapshot = SaveSnapshot & {
+  titleDirty: boolean;
+  slugIsCustom: boolean;
+};
+
+export interface SnapshotSources {
+  identity: PersistedIdentity;
+  status: PostStatus;
+  publishedAt: string | null;
+  title: string;
+  slug: string;
+  slugIsCustom: boolean;
+  verdict: ChangeVerdict;
+  changedSinceLastRevision: boolean;
+  version: number;
+}
+
+export function buildSaveSnapshot({
+  identity,
+  status,
+  publishedAt,
+  title,
+  slug,
+  slugIsCustom,
+  verdict,
+  changedSinceLastRevision,
+  version,
+}: SnapshotSources): EditorSaveSnapshot {
+  const editable = {
+    status,
+    publishedAt,
+    title,
+    slug,
+    slugIsCustom,
+    isDirty: verdict.dirty,
+    titleDirty: verdict.reasons.some((reason) => reason.code === 'POST_TITLE_DIVERGED'),
+    changedSinceLastRevision,
+    version,
+  };
+
+  return identity.id === null
+    ? { id: null, updatedAt: null, ...editable }
+    : { id: identity.id, updatedAt: identity.updatedAt, ...editable };
+}

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -1,0 +1,247 @@
+import * as Sentry from '@sentry/react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useLocation, useNavigate } from '@tryghost/admin-x-framework';
+import { useGenerateSlug } from '@tryghost/admin-x-framework/api/slugs';
+import { useBrowseSite } from '@tryghost/admin-x-framework/api/site';
+import {
+  useAddPage,
+  useEditPage,
+  useEditorPage,
+  type PageEditableData,
+} from '@tryghost/admin-x-framework/api/pages';
+import {
+  useAddPost,
+  useEditPost,
+  useEditorPost,
+  type PostEditableData,
+} from '@tryghost/admin-x-framework/api/posts';
+import type {
+  CreateContentData,
+  EditContentData,
+} from '@tryghost/admin-x-framework/api/content-types';
+import type { PostWriteOptions } from '@tryghost/admin-x-framework/api/post-contract';
+import { DEFAULT_TITLE, type SaveEngineState } from '@/editor/engine/save-engine';
+import type { LexicalInput } from '@/editor/engine/lexical-compare';
+import type { PostType } from '@/editor/card-config';
+import { createEditorSession, type EditorSession, type EditorWritePayload } from './editor-session';
+import type { EditorRecord } from './projection';
+
+interface EditorSessionLocationState {
+  editorSession?: string;
+}
+
+/**
+ * Identifies the editing session behind the current URL. A create replaces the
+ * URL and carries the key forward, so the same session survives the swap.
+ */
+export function useEditorSessionKey(): string {
+  const location = useLocation();
+  const state = location.state as EditorSessionLocationState | null;
+  return state?.editorSession ?? location.key;
+}
+
+export interface EditorSessionBinding {
+  title: string;
+  excerpt: string;
+  initialLexical: string | null;
+  onTitleChange: (title: string) => void;
+  onTitleBlur: () => void;
+  onExcerptChange: (excerpt: string) => void;
+  onExcerptBlur: () => void;
+  onLexicalChange: (lexical: unknown) => void;
+  onSecondaryChange: (lexical: unknown) => void;
+  onSecondaryError: (error: unknown) => void;
+}
+
+export interface EditorSessionHandle {
+  bind: EditorSessionBinding;
+  state: SaveEngineState;
+  isDirty: () => boolean;
+  dispatchExplicit: () => void;
+  reauthSucceeded: () => void;
+  reauthAbandoned: () => void;
+}
+
+export interface UseEditorSessionOptions {
+  postType: PostType;
+  record?: EditorRecord;
+}
+
+function reportError(error: unknown): void {
+  // eslint-disable-next-line no-console
+  console.error(error);
+  Sentry.captureException(error);
+}
+
+export function useEditorSession({
+  postType,
+  record,
+}: UseEditorSessionOptions): EditorSessionHandle {
+  const navigate = useNavigate();
+  const sessionKey = useEditorSessionKey();
+  const generateSlug = useGenerateSlug();
+  const { data: site } = useBrowseSite();
+  const { mutateAsync: addPost } = useAddPost();
+  const { mutateAsync: editPost } = useEditPost();
+  const { mutateAsync: addPage } = useAddPage();
+  const { mutateAsync: editPage } = useEditPage();
+
+  const [persistedId, setPersistedId] = useState<string | null>(record?.id ?? null);
+  const [title, setTitle] = useState(() =>
+    record?.title === DEFAULT_TITLE ? '' : (record?.title ?? ''),
+  );
+  const [excerpt, setExcerpt] = useState(() => record?.custom_excerpt ?? '');
+  const [initialLexical] = useState(() => record?.lexical ?? null);
+
+  const transport = useRef({ addPost, editPost, addPage, editPage, generateSlug, postType });
+  useEffect(() => {
+    transport.current = { addPost, editPost, addPage, editPage, generateSlug, postType };
+  });
+
+  const [session] = useState<EditorSession>(() =>
+    createEditorSession({
+      record,
+      siteUrl: site?.site.url,
+      saveFailureMessage: `Couldn’t save this ${postType}.`,
+      onIdAcquired: setPersistedId,
+      onError: reportError,
+      transport: {
+        create: async (payload: EditorWritePayload) => {
+          const current = transport.current;
+          if (current.postType === 'page') {
+            const { pages } = await current.addPage({
+              page: payload as CreateContentData<PageEditableData>,
+              sessionExpiryRedirect: false,
+            });
+            return pages[0];
+          }
+          const { posts } = await current.addPost({
+            post: payload as CreateContentData<PostEditableData>,
+            sessionExpiryRedirect: false,
+          });
+          return posts[0];
+        },
+        update: async (payload: EditorWritePayload, options: PostWriteOptions) => {
+          const current = transport.current;
+          if (current.postType === 'page') {
+            const { pages } = await current.editPage({
+              page: payload as EditContentData<PageEditableData>,
+              options,
+              sessionExpiryRedirect: false,
+            });
+            return pages[0];
+          }
+          const { posts } = await current.editPost({
+            post: payload as EditContentData<PostEditableData>,
+            options,
+            sessionExpiryRedirect: false,
+          });
+          return posts[0];
+        },
+        generateSlug: (text, postId) =>
+          transport.current.generateSlug({ type: 'post', text, id: postId ?? undefined }),
+      },
+    }),
+  );
+
+  // Disposal is deferred by a tick: StrictMode tears an effect down and sets it
+  // up again in the same commit, and that must not dispose a live session.
+  const pendingDispose = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => {
+    clearTimeout(pendingDispose.current);
+    return () => {
+      pendingDispose.current = setTimeout(() => session.dispose());
+    };
+  }, [session]);
+
+  const state = useSyncExternalStore(session.subscribe, session.getState);
+
+  // The saved record: the same query key the screen loaded with, so an existing
+  // post shares one cache entry and a created one starts observing its own.
+  const postQuery = useEditorPost(persistedId ?? '', {
+    enabled: postType === 'post' && !!persistedId,
+    defaultErrorHandler: false,
+  });
+  const pageQuery = useEditorPage(persistedId ?? '', {
+    enabled: postType === 'page' && !!persistedId,
+    defaultErrorHandler: false,
+  });
+  const saved = postType === 'page' ? pageQuery.data?.pages[0] : postQuery.data?.posts[0];
+
+  useEffect(() => {
+    if (saved) {
+      session.recordRefetched(saved);
+    }
+  }, [saved, session]);
+
+  const isNew = !record;
+  useEffect(() => {
+    if (isNew && persistedId) {
+      navigate(`/editor/${postType}/${persistedId}`, {
+        replace: true,
+        state: { editorSession: sessionKey },
+      });
+    }
+  }, [isNew, persistedId, postType, navigate, sessionKey]);
+
+  const onTitleChange = useCallback(
+    (next: string) => {
+      setTitle(next);
+      session.patchTitle(next);
+    },
+    [session],
+  );
+
+  const onExcerptChange = useCallback(
+    (next: string) => {
+      setExcerpt(next);
+      session.patchExcerpt(next);
+    },
+    [session],
+  );
+
+  const onTitleBlur = useCallback(() => {
+    session.commitTitle(title);
+    session.dispatchField();
+  }, [session, title]);
+
+  const onExcerptBlur = useCallback(() => session.dispatchField(), [session]);
+
+  const onLexicalChange = useCallback(
+    (lexical: unknown) => {
+      session.patchLexical(lexical);
+      session.dispatchAutosave();
+    },
+    [session],
+  );
+
+  const onSecondaryChange = useCallback(
+    (lexical: unknown) => session.setBaseline(lexical as LexicalInput),
+    [session],
+  );
+
+  const onSecondaryError = useCallback(
+    (error: unknown) => session.baselineFailed(error),
+    [session],
+  );
+
+  return {
+    bind: {
+      title,
+      excerpt,
+      initialLexical,
+      onTitleChange,
+      onTitleBlur,
+      onExcerptChange,
+      onExcerptBlur,
+      onLexicalChange,
+      onSecondaryChange,
+      onSecondaryError,
+    },
+    state,
+    isDirty: session.isDirty,
+    dispatchExplicit: () => void session.dispatchExplicit(),
+    reauthSucceeded: session.reauthSucceeded,
+    reauthAbandoned: session.reauthAbandoned,
+  };
+}

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -11,6 +11,8 @@ export const editorBody = 'editor-body';
 export const editorSecondaryInstance = 'editor-secondary-instance';
 export const editorWordCount = 'editor-word-count';
 export const editorLoadError = 'editor-load-error';
+export const editorReauthBanner = 'editor-reauth-banner';
+export const editorConflictBanner = 'editor-conflict-banner';
 export const tkIndicator = 'tk-indicator';
 
 // accessible names


### PR DESCRIPTION
The React post editor behind the `editorReact` flag mounted Koenig and kept every edit in memory — nothing it did reached the API. The save engine, change tracker and slug machine were already in the tree as pure modules with no consumer. This composes them into one editing session and hangs it off the editor's seams, so the flagged editor actually saves.

## What this does

`useEditorSession` builds one change tracker, one slug machine and one save engine per opened post, and owns everything those modules deliberately leave to a caller:

- the live projection a snapshot is read from, patched on every title, excerpt and body change, with the version counter that lifts save suppression
- the persisted id and collision token, replaced from every acknowledgement so the next request carries the token the server just issued
- the port adapters: a snapshot builder, an error mapper, a slug port over the machine's submission chain, and prepare/execute/reconcile against the posts and pages write hooks

The seams are wired as: body change → live patch + autosave (3s debounce, immediate for a new post); title or excerpt blur → field save, with the title commit also driving the slug for drafts; the hidden Koenig instance's serialization → the change baseline, and its failure → a failed baseline so the dirty check fails closed.

A new post is created on its first edit. The id it acquires replaces the URL, and the screen is keyed on the editing session rather than the post id, so the swap does not remount the editor and typed content survives it.

## Failure handling

A rejected save is surfaced where the writer is instead of being swallowed:

- **Expired session** — a banner offering a retry in place. That needs the transport to stop redirecting away on the editor's own 401, which would drop unsaved content: request options can now be derived per payload, and the post and page write hooks pass that opt-out through. Every other caller is unaffected.
- **Collision** — a banner naming what happened. The engine keeps the queue halted, so background saves stop until the writer resolves it.

In both cases the content is untouched and still dirty.

A blank title is persisted under the default title; the live projection carries that substitution while the input stays empty, so a post saved that way does not read as permanently unsaved.

## Not in this PR

Cmd-S and the publish flow (the session exposes an explicit dispatch, nothing calls it yet), the unsaved-changes guard, and the sidebar fields. Tag writes are not wired, so post writes still do not invalidate tag queries.

## Testing

- Unit: the error-mapping table, the snapshot builder, the slug port (settling on the submission chain, superseded commits), and the session itself (submitted projection, collision token carried forward, create-then-update, per-post isolation, disposal).
- Acceptance (real Chromium, fake admin API): autosave sends the write contract; the post stays clean after the save and its refetch; an old-schema fixture stays clean until edited; a new post is created on the first keystroke and the URL swaps without remounting; a collision halts saving with the content intact; an expired session shows the banner and Retry re-sends.
- `apps/admin` lint, `tsc -b`, unit and the full acceptance suite; `apps/admin-x-framework` lint and unit; `nx run @tryghost/admin:build`.
