### PR TITLE
Added the status chip, Cmd-S and feature image to the React post editor

### DIFF
--- a/apps/admin-x-framework/src/utils/recipient-filter.ts
+++ b/apps/admin-x-framework/src/utils/recipient-filter.ts
@@ -14,6 +14,17 @@ export const PAID_SEGMENT = 'status:-free';
  */
 export const EVERYONE_RECIPIENT_FILTER = `${FREE_SEGMENT},${PAID_SEGMENT}`;
 
+/** Expands the API's legacy segment sentinels into the filters used by Admin. */
+export function normalizeRecipientFilter(filter: string | null | undefined): string | null {
+  if (filter === 'all') {
+    return EVERYONE_RECIPIENT_FILTER;
+  }
+  if (!filter || filter === 'none') {
+    return null;
+  }
+  return filter;
+}
+
 const BASE_SEGMENTS: string[] = [FREE_SEGMENT, PAID_SEGMENT];
 
 export interface RecipientFilterSegments {

--- a/apps/admin-x-framework/test/unit/utils/recipient-filter.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/recipient-filter.test.ts
@@ -7,10 +7,24 @@ import {
   getFullRecipientFilter,
   getNewsletterRecipientFilter,
   getRecipientType,
+  normalizeRecipientFilter,
   parseRecipientFilter,
 } from '../../../src/utils/recipient-filter';
 
 describe('recipient-filter', () => {
+  describe('normalizeRecipientFilter', () => {
+    it('expands legacy all and none sentinels', () => {
+      expect(normalizeRecipientFilter('all')).toBe(EVERYONE_RECIPIENT_FILTER);
+      expect(normalizeRecipientFilter('none')).toBeNull();
+    });
+
+    it('preserves real filters and normalizes empty values', () => {
+      expect(normalizeRecipientFilter('label:vip')).toBe('label:vip');
+      expect(normalizeRecipientFilter(null)).toBeNull();
+      expect(normalizeRecipientFilter(undefined)).toBeNull();
+    });
+  });
+
   describe('parseRecipientFilter', () => {
     it('returns empty segments for null, undefined and empty filters', () => {
       for (const filter of [null, undefined, '']) {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -36,6 +36,7 @@
     "@tryghost/custom-field-types": "workspace:*",
     "@tryghost/custom-fonts": "catalog:",
     "@tryghost/i18n": "workspace:*",
+    "@tryghost/kg-clean-basic-html": "workspace:*",
     "@tryghost/kg-unsplash-selector": "workspace:*",
     "@tryghost/koenig-lexical": "workspace:*",
     "@tryghost/nql": "catalog:",

--- a/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
@@ -120,7 +120,9 @@ describe('Post editor feature image', () => {
       await editorScreen.featureImageCaption().click();
       await userEvent.keyboard('Photo by me');
 
-      expect(saveApi.requests.length).toBe(0);
+      // The caption has reached the editor, so a save would have been sent by now.
+      await expect.element(editorScreen.featureImageCaption()).toHaveTextContent('Photo by me');
+      await expect.poll(() => saveApi.requests.length).toBe(0);
 
       await editorScreen.titleInput().click();
 
@@ -129,6 +131,56 @@ describe('Post editor feature image', () => {
       // Lexical wraps typed text in a `white-space: pre-wrap` span; the
       // caption is stored as it serializes it.
       expect(String(submittedPost(saveApi).feature_image_caption)).toContain('Photo by me');
+    },
+    SLOW,
+  );
+
+  it(
+    'opens a post whose caption carries markup without making it unsaved',
+    async () => {
+      const saveApi = fakeSavablePost({
+        feature_image: UPLOADED,
+        feature_image_caption: 'Photo by <a href="https://example.com/j">Jane</a>',
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      // The caption editor has loaded and re-serialized what it was given.
+      await expect.element(editorScreen.featureImageCaption()).toHaveTextContent('Photo by Jane');
+      await editorScreen.titleInput().click();
+
+      await expect.poll(() => saveApi.requests.length).toBe(0);
+      await expect.element(editorScreen.status()).toHaveTextContent('Draft - Saved');
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a feature image edit on a published post until it is saved explicitly',
+    async () => {
+      const saveApi = fakeSavablePost({
+        feature_image: UPLOADED,
+        status: 'published',
+        published_at: '2026-01-01T00:00:00.000Z',
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await editorScreen.featureImageAltToggle().click();
+      await editorScreen.featureImageAltInput().fill('Rolling hills');
+
+      // A published post's background saves are dropped: the sidebar stages
+      // these edits until Update.
+      await expect.element(editorScreen.featureImageAltInput()).toHaveValue('Rolling hills');
+      await expect.poll(() => saveApi.requests.length).toBe(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        id: POST_ID,
+        status: 'published',
+        feature_image: UPLOADED,
+        feature_image_alt: 'Rolling hills',
+      });
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  fakeAdminEndpoint,
+  fakePosts,
+  fakeSnippets,
+  post,
+  renderAdminApp,
+  type EndpointCapture,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const UPLOADED = 'https://example.com/content/images/2026/09/hills.png';
+
+// The autosave debounce is 3s, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const SAVE_POLL = { timeout: 10_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] };
+  return body.posts[0];
+}
+
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  fakeSnippets([]);
+  fakePosts([]);
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    tags: [],
+    feature_image: null,
+    feature_image_alt: null,
+    feature_image_caption: null,
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+}
+
+/**
+ * The feature image above the post title: uploading one, describing it with
+ * alt text, and captioning it. Every change reaches the post through the same
+ * save engine the body uses.
+ */
+describe('Post editor feature image', () => {
+  it(
+    'saves an uploaded image as soon as it lands',
+    async () => {
+      const saveApi = fakeSavablePost();
+      const uploadApi = fakeAdminEndpoint('POST', '/images/upload/', {
+        images: [{ url: UPLOADED, ref: null }],
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.featureImage()).toBeVisible();
+      await userEvent.upload(
+        editorScreen.featureImageInput().element(),
+        new File(['image'], 'hills.png', { type: 'image/png' }),
+      );
+
+      await expect.poll(() => uploadApi.requests.length, SAVE_POLL).toBe(1);
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        id: POST_ID,
+        title: 'Hello from React',
+        status: 'draft',
+        updated_at: LOADED_AT,
+        feature_image: UPLOADED,
+      });
+      await expect.element(editorScreen.removeFeatureImage()).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'saves alt text for the image',
+    async () => {
+      const saveApi = fakeSavablePost({ feature_image: UPLOADED });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await editorScreen.featureImageAltToggle().click();
+      await editorScreen.featureImageAltInput().fill('Rolling hills');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBeGreaterThan(0);
+      await expect
+        .poll(() => submittedPost(saveApi).feature_image_alt, SAVE_POLL)
+        .toBe('Rolling hills');
+      expect(submittedPost(saveApi)).toMatchObject({ feature_image: UPLOADED });
+    },
+    SLOW,
+  );
+
+  it(
+    'saves the caption once it loses focus',
+    async () => {
+      const saveApi = fakeSavablePost({ feature_image: UPLOADED });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.featureImageCaption()).toBeVisible();
+      await editorScreen.featureImageCaption().click();
+      await userEvent.keyboard('Photo by me');
+
+      expect(saveApi.requests.length).toBe(0);
+
+      await editorScreen.titleInput().click();
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({ id: POST_ID, feature_image: UPLOADED });
+      // Lexical wraps typed text in a `white-space: pre-wrap` span; the
+      // caption is stored as it serializes it.
+      expect(String(submittedPost(saveApi).feature_image_caption)).toContain('Photo by me');
+    },
+    SLOW,
+  );
+
+  it(
+    'clears the alt text and caption along with the image',
+    async () => {
+      const saveApi = fakeSavablePost({
+        feature_image: UPLOADED,
+        feature_image_alt: 'Rolling hills',
+        feature_image_caption: 'Photo by me',
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await editorScreen.removeFeatureImage().click();
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        feature_image: null,
+        feature_image_alt: null,
+        feature_image_caption: null,
+      });
+      await expect.element(editorScreen.featureImageInput()).toBeInTheDocument();
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
@@ -93,6 +93,45 @@ describe('Post editor feature image', () => {
   );
 
   it(
+    'does not insert a dropped feature image into the post body',
+    async () => {
+      const saveApi = fakeSavablePost();
+      const uploadApi = fakeAdminEndpoint('POST', '/images/upload/', {
+        images: [{ url: UPLOADED, ref: null }],
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.featureImage()).toBeVisible();
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+
+      const dropzone = editorScreen
+        .featureImage()
+        .element()
+        .querySelector('[data-slot="image-upload-dropzone"]');
+      expect(dropzone).not.toBeNull();
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(new File(['image'], 'hills.png', { type: 'image/png' }));
+      dropzone!.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      );
+
+      await expect.poll(() => uploadApi.requests.length, SAVE_POLL).toBe(1);
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+
+      const saved = submittedPost(saveApi);
+      expect(saved.feature_image).toBe(UPLOADED);
+      expect(saved.lexical).toBeTypeOf('string');
+      expect(String(saved.lexical)).not.toContain('"type":"image"');
+    },
+    SLOW,
+  );
+
+  it(
     'saves alt text for the image',
     async () => {
       const saveApi = fakeSavablePost({ feature_image: UPLOADED });

--- a/apps/admin/src/editor/editor-save.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-save.acceptance.test.tsx
@@ -189,6 +189,45 @@ describe('Post editor saving', () => {
   );
 
   it(
+    'saves on Cmd-S and asks the server for a revision',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      await typeIntoBody(' and more');
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      expect(saveApi.lastRequest?.url ?? '').toContain('save_revision=true');
+      expect(submittedPost(saveApi)).toMatchObject({
+        id: POST_ID,
+        title: 'Hello from React',
+        slug: 'hello-from-react',
+        status: 'draft',
+        updated_at: LOADED_AT,
+      });
+      expect(String(submittedPost(saveApi).lexical)).toContain('Hello from React and more');
+    },
+    SLOW,
+  );
+
+  it(
+    'reports the save in the header and settles on saved',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.status()).toHaveTextContent('Draft');
+      await typeIntoBody(' and more');
+
+      await expect.element(editorScreen.status(), SAVE_POLL).toHaveTextContent('Saving');
+      await expect.element(editorScreen.status(), SAVE_POLL).toHaveTextContent('Saved');
+    },
+    SLOW,
+  );
+
+  it(
     'halts on a collision and keeps the content',
     async () => {
       editorChrome();

--- a/apps/admin/src/editor/editor-save.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-save.acceptance.test.tsx
@@ -218,11 +218,11 @@ describe('Post editor saving', () => {
       fakeSavablePost();
       await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
 
-      await expect.element(editorScreen.status()).toHaveTextContent('Draft');
+      await expect.element(editorScreen.status()).toHaveTextContent('Draft - Saved');
       await typeIntoBody(' and more');
 
       await expect.element(editorScreen.status(), SAVE_POLL).toHaveTextContent('Saving');
-      await expect.element(editorScreen.status(), SAVE_POLL).toHaveTextContent('Saved');
+      await expect.element(editorScreen.status(), SAVE_POLL).toHaveTextContent('Draft - Saved');
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
 import { AdminLink } from '@/shared/admin-link';
 import { NotFound } from '@/shared/not-found';
 import { Navigate, useNavigate, useParams } from '@tryghost/admin-x-framework';
@@ -27,11 +27,15 @@ import {
   isOwnerUser,
 } from '@tryghost/admin-x-framework/api/users';
 import type { CardConfigPostSource, PostType } from './card-config';
+import { EditorStatus } from './editor-status';
 import { PostEditor } from './post-editor';
+import type { EditorStatusRecord } from './post-status';
 import { SessionBanners } from './session/session-banners';
+import { useFeatureImageBinding } from './session/feature-image-binding';
 import { useEditorSession, useEditorSessionKey } from './session/use-editor-session';
 import { usePostCardConfig } from './use-post-card-config';
 import { usePostSnippets } from './use-post-snippets';
+import { useSaveShortcut } from './use-save-shortcut';
 
 type EditorRecord = PostEditorRecord | PageEditorRecord;
 
@@ -54,7 +58,7 @@ function EditorLoadError({ message, onRetry }: { message: string; onRetry: () =>
   );
 }
 
-function EditorHeader({ postType }: { postType: PostType }) {
+function EditorHeader({ postType, children }: { postType: PostType; children?: ReactNode }) {
   const listLabel = postType === 'page' ? 'Pages' : 'Posts';
 
   return (
@@ -65,14 +69,47 @@ function EditorHeader({ postType }: { postType: PostType }) {
           {listLabel}
         </AdminLink>
       </Button>
+      {children}
     </Inline>
   );
 }
 
-function EditorSurface({ postType, record }: { postType: PostType; record?: EditorRecord }) {
+// A created post has no loaded record yet, but it is no longer new.
+function statusRecordOf(
+  record: EditorRecord | undefined,
+  createdId?: string,
+): EditorStatusRecord | undefined {
+  if (!record) {
+    return createdId ? { status: 'draft' } : undefined;
+  }
+
+  const email = 'email' in record ? record.email : null;
+
+  return {
+    status: record.status,
+    publishedAt: record.published_at,
+    url: record.url,
+    emailOnly: 'email_only' in record ? record.email_only : false,
+    emailStatus: email?.status ?? null,
+    emailCount: email?.email_count ?? 0,
+  };
+}
+
+function EditorSurface({
+  postType,
+  record,
+  createdId,
+}: {
+  postType: PostType;
+  record?: EditorRecord;
+  createdId?: string;
+}) {
   const { data: currentUser } = useCurrentUser();
   const showExcerpt = useFeatureFlag('editorExcerpt');
   const session = useEditorSession({ postType, record });
+  const featureImage = useFeatureImageBinding(session, record);
+
+  useSaveShortcut(session.dispatchExplicit);
 
   const canManageSnippets =
     !!currentUser &&
@@ -102,7 +139,13 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
 
   return (
     <Stack className="h-full" gap="none">
-      <EditorHeader postType={postType} />
+      <EditorHeader postType={postType}>
+        <EditorStatus
+          isDirty={session.isDirty()}
+          record={statusRecordOf(record, createdId)}
+          state={session.state}
+        />
+      </EditorHeader>
       <SessionBanners
         state={session.state}
         onDismissReauth={session.reauthAbandoned}
@@ -113,6 +156,7 @@ function EditorSurface({ postType, record }: { postType: PostType; record?: Edit
           {...session.bind}
           autofocusTitle={!record}
           cardConfig={cardConfig}
+          featureImage={featureImage}
           postType={postType}
           showExcerpt={showExcerpt}
         />
@@ -201,7 +245,7 @@ function EditorLoader({ postType, id }: { postType: PostType; id?: string }) {
   }, [needsConversion, loaded, conversion?.id, convert]);
 
   if (!openedId) {
-    return <EditorSurface postType={postType} />;
+    return <EditorSurface createdId={id} postType={postType} />;
   }
 
   const notFound = query.error instanceof APIError && query.error.response?.status === 404;

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -29,7 +29,7 @@ import {
 import type { CardConfigPostSource, PostType } from './card-config';
 import { EditorStatus } from './editor-status';
 import { PostEditor } from './post-editor';
-import type { EditorStatusRecord } from './post-status';
+import type { EditorStatusNewsletter, EditorStatusRecord } from './post-status';
 import { SessionBanners } from './session/session-banners';
 import { useFeatureImageBinding } from './session/feature-image-binding';
 import { useEditorSession, useEditorSessionKey } from './session/use-editor-session';
@@ -84,12 +84,18 @@ function statusRecordOf(
   }
 
   const email = 'email' in record ? record.email : null;
+  // The API types the relation as a bare object; the editor read includes it.
+  const newsletter =
+    'newsletter' in record ? (record.newsletter as EditorStatusNewsletter | null) : null;
 
   return {
     status: record.status,
     publishedAt: record.published_at,
     url: record.url,
     emailOnly: 'email_only' in record ? record.email_only : false,
+    newsletter,
+    emailSegment: 'email_segment' in record ? record.email_segment : null,
+    hasEmail: !!email,
     emailStatus: email?.status ?? null,
     emailCount: email?.email_count ?? 0,
   };

--- a/apps/admin/src/editor/editor-status.test.tsx
+++ b/apps/admin/src/editor/editor-status.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RecipientCount } from './editor-status';
+
+const mocks = vi.hoisted(() => ({
+  useMembersCount: vi.fn(() => ({ count: null })),
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/members', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tryghost/admin-x-framework/api/members')>();
+  return {
+    ...actual,
+    useMembersCount: mocks.useMembersCount,
+  };
+});
+
+describe('RecipientCount', () => {
+  it('keeps descriptive copy when the member count is unavailable', () => {
+    const filter = 'newsletters.slug:weekly+email_disabled:0+(status:free,status:-free)';
+
+    render(<RecipientCount filter={filter} segment="status:free,status:-free" />);
+
+    expect(screen.getByText('all members')).toBeInTheDocument();
+    expect(mocks.useMembersCount).toHaveBeenCalledWith(filter);
+  });
+});

--- a/apps/admin/src/editor/editor-status.tsx
+++ b/apps/admin/src/editor/editor-status.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { Inline, Text } from '@tryghost/shade/primitives';
+import { formatNumber } from '@tryghost/shade/utils';
+import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
+import { formatPostTime } from '@/posts/list/post-time';
+import type { SaveEngineState } from './engine/save-engine';
+import {
+  type EditorStatusRecord,
+  type EditorStatusView,
+  deriveEditorStatus,
+  useSavingHold,
+} from './post-status';
+
+function members(count: number): string {
+  return `${formatNumber(count)} ${count === 1 ? 'member' : 'members'}`;
+}
+
+function ScheduleCountdown({
+  publishedAt,
+  emailOnly,
+  timezone,
+}: {
+  publishedAt: string | null;
+  emailOnly: boolean;
+  timezone: string;
+}) {
+  return (
+    <time
+      className="text-state-success"
+      data-testid="editor-schedule-countdown"
+      dateTime={publishedAt ?? undefined}
+    >
+      {emailOnly ? 'to be sent' : 'to be published'}{' '}
+      {formatPostTime(publishedAt, { timezone, scheduled: true })}
+    </time>
+  );
+}
+
+function StatusBody({
+  view,
+  timezone,
+  isHovered,
+}: {
+  view: EditorStatusView;
+  timezone: string;
+  isHovered: boolean;
+}) {
+  switch (view.kind) {
+    case 'problem':
+      return <Text tone="secondary">{view.message}</Text>;
+    case 'saving':
+      return <Text tone="secondary">Saving…</Text>;
+    case 'new':
+      return <Text tone="secondary">New</Text>;
+    case 'draft':
+      return <Text tone="secondary">{view.saved ? 'Draft - Saved' : 'Draft'}</Text>;
+    case 'sent':
+      return view.failed ? (
+        <Text tone="secondary">Failed to send newsletter.</Text>
+      ) : (
+        <Text tone="secondary">Sent to {members(view.count)}</Text>
+      );
+    case 'scheduled':
+      return (
+        <Text tone="secondary">
+          Scheduled
+          {isHovered && (
+            <>
+              {' '}
+              <ScheduleCountdown
+                emailOnly={view.emailOnly}
+                publishedAt={view.publishedAt}
+                timezone={timezone}
+              />
+            </>
+          )}
+        </Text>
+      );
+    default:
+      return (
+        <Text tone="secondary">
+          {view.url ? (
+            <a
+              className="hover:text-foreground"
+              href={view.url}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Published
+            </a>
+          ) : (
+            'Published'
+          )}
+          {view.email === 'sending' && ` and sending to ${members(view.count)}`}
+          {view.email === 'sent' && ` and sent to ${members(view.count)}`}
+          {view.email === 'failed' && ' but failed to send newsletter.'}
+        </Text>
+      );
+  }
+}
+
+export interface EditorStatusProps {
+  state: SaveEngineState;
+  record?: EditorStatusRecord;
+  isDirty: boolean;
+}
+
+/** Where the post stands: its status, the newsletter, and the last save. */
+export function EditorStatus({ state, record, isDirty }: EditorStatusProps) {
+  const { data: settingsData } = useBrowseSettings();
+  const timezone = getSettingValue<string>(settingsData?.settings ?? null, 'timezone') ?? 'Etc/UTC';
+  const isSaving = useSavingHold(state.kind === 'saving' || state.kind === 'pending-coalesced');
+  const [isHovered, setIsHovered] = useState(false);
+  const [, setTick] = useState(0);
+
+  // The countdown only reads while hovered, so it only has to tick then.
+  useEffect(() => {
+    if (!isHovered) {
+      return;
+    }
+    const interval = setInterval(() => setTick((tick) => tick + 1), 1000);
+    return () => clearInterval(interval);
+  }, [isHovered]);
+
+  return (
+    <Inline
+      align="center"
+      className="text-sm"
+      data-testid="editor-status"
+      gap="xs"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <StatusBody
+        isHovered={isHovered}
+        timezone={timezone}
+        view={deriveEditorStatus({ state, record, isDirty, isSaving })}
+      />
+    </Inline>
+  );
+}

--- a/apps/admin/src/editor/editor-status.tsx
+++ b/apps/admin/src/editor/editor-status.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Inline, Text } from '@tryghost/shade/primitives';
 import { formatNumber } from '@tryghost/shade/utils';
 import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
+import { useMembersCount } from '@tryghost/admin-x-framework/api/members';
 import { formatPostTime } from '@/posts/list/post-time';
 import type { SaveEngineState } from './engine/save-engine';
 import {
@@ -15,13 +16,21 @@ function members(count: number): string {
   return `${formatNumber(count)} ${count === 1 ? 'member' : 'members'}`;
 }
 
+/** The send's audience, counted the way the publish flow counts it. */
+function RecipientCount({ filter }: { filter: string }) {
+  const { count } = useMembersCount(filter);
+  return <>{members(count ?? 0)}</>;
+}
+
 function ScheduleCountdown({
   publishedAt,
   emailOnly,
+  recipientFilter,
   timezone,
 }: {
   publishedAt: string | null;
   emailOnly: boolean;
+  recipientFilter: string | null;
   timezone: string;
 }) {
   return (
@@ -30,7 +39,13 @@ function ScheduleCountdown({
       data-testid="editor-schedule-countdown"
       dateTime={publishedAt ?? undefined}
     >
-      {emailOnly ? 'to be sent' : 'to be published'}{' '}
+      {emailOnly ? 'to be sent' : 'to be published'}
+      {recipientFilter && (
+        <>
+          {emailOnly ? ' to ' : ' and sent to '}
+          <RecipientCount filter={recipientFilter} />
+        </>
+      )}{' '}
       {formatPostTime(publishedAt, { timezone, scheduled: true })}
     </time>
   );
@@ -47,7 +62,7 @@ function StatusBody({
 }) {
   switch (view.kind) {
     case 'problem':
-      return <Text tone="secondary">{view.message}</Text>;
+      return <Text className="text-state-danger">{view.message}</Text>;
     case 'saving':
       return <Text tone="secondary">Saving…</Text>;
     case 'new':
@@ -70,6 +85,7 @@ function StatusBody({
               <ScheduleCountdown
                 emailOnly={view.emailOnly}
                 publishedAt={view.publishedAt}
+                recipientFilter={view.recipientFilter}
                 timezone={timezone}
               />
             </>

--- a/apps/admin/src/editor/editor-status.tsx
+++ b/apps/admin/src/editor/editor-status.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'react';
 import { Inline, Text } from '@tryghost/shade/primitives';
 import { formatNumber } from '@tryghost/shade/utils';
 import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
-import { useMembersCount } from '@tryghost/admin-x-framework/api/members';
+import { membersCountString, useMembersCount } from '@tryghost/admin-x-framework/api/members';
 import { formatPostTime } from '@/posts/list/post-time';
 import type { SaveEngineState } from './engine/save-engine';
 import {
   type EditorStatusRecord,
   type EditorStatusView,
   deriveEditorStatus,
+  useScheduledBoundary,
   useSavingHold,
 } from './post-status';
 
@@ -17,20 +18,22 @@ function members(count: number): string {
 }
 
 /** The send's audience, counted the way the publish flow counts it. */
-function RecipientCount({ filter }: { filter: string }) {
+export function RecipientCount({ filter, segment }: { filter: string; segment: string }) {
   const { count } = useMembersCount(filter);
-  return <>{members(count ?? 0)}</>;
+  return <>{typeof count === 'number' ? members(count) : membersCountString(segment, { count })}</>;
 }
 
 function ScheduleCountdown({
   publishedAt,
   emailOnly,
   recipientFilter,
+  recipientSegment,
   timezone,
 }: {
   publishedAt: string | null;
   emailOnly: boolean;
   recipientFilter: string | null;
+  recipientSegment: string | null;
   timezone: string;
 }) {
   return (
@@ -40,10 +43,10 @@ function ScheduleCountdown({
       dateTime={publishedAt ?? undefined}
     >
       {emailOnly ? 'to be sent' : 'to be published'}
-      {recipientFilter && (
+      {recipientFilter && recipientSegment && (
         <>
           {emailOnly ? ' to ' : ' and sent to '}
-          <RecipientCount filter={recipientFilter} />
+          <RecipientCount filter={recipientFilter} segment={recipientSegment} />
         </>
       )}{' '}
       {formatPostTime(publishedAt, { timezone, scheduled: true })}
@@ -86,6 +89,7 @@ function StatusBody({
                 emailOnly={view.emailOnly}
                 publishedAt={view.publishedAt}
                 recipientFilter={view.recipientFilter}
+                recipientSegment={view.recipientSegment}
                 timezone={timezone}
               />
             </>
@@ -128,6 +132,11 @@ export function EditorStatus({ state, record, isDirty }: EditorStatusProps) {
   const isSaving = useSavingHold(state.kind === 'saving' || state.kind === 'pending-coalesced');
   const [isHovered, setIsHovered] = useState(false);
   const [, setTick] = useState(0);
+
+  useScheduledBoundary(
+    record?.publishedAt,
+    record?.status === 'scheduled' && record.emailOnly !== true,
+  );
 
   // The countdown only reads while hovered, so it only has to tick then.
   useEffect(() => {

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -1,17 +1,27 @@
 import { page } from 'vitest/browser';
 import {
+  addFeatureImageLabel,
   editorBody,
   editorConflictBanner,
   editorExcerptInput,
+  editorFeatureImage,
+  editorFeatureImageCaption,
   editorLoadError,
   editorReauthBanner,
+  editorScheduleCountdown,
   editorSecondaryInstance,
+  editorStatus,
   editorTitleInput,
   editorWordCount,
+  featureImageAltLabel,
+  featureImageTkIndicator,
+  featureImageUnsplashButton,
   pagesBackLink,
   postEditor,
   postsBackLink,
+  removeFeatureImageButton,
   tkIndicator,
+  toggleFeatureImageAltButton,
 } from '@tryghost/test-data/selectors/editor';
 
 /** Editor screen locators and gestures for acceptance specs; no assertions. */
@@ -27,8 +37,20 @@ export const editorScreen = {
   reauthBanner: () => page.getByTestId(editorReauthBanner),
   retryReauth: () => page.getByTestId(editorReauthBanner).getByRole('button', { name: 'Retry' }),
   conflictBanner: () => page.getByTestId(editorConflictBanner),
+  status: () => page.getByTestId(editorStatus),
+  scheduleCountdown: () => page.getByTestId(editorScheduleCountdown),
   notFound: () => page.getByRole('heading', { name: 'Page not found' }),
   titleTkIndicator: () => page.getByTestId(tkIndicator),
+
+  featureImage: () => page.getByTestId(editorFeatureImage),
+  featureImageInput: () => page.getByLabelText(addFeatureImageLabel),
+  featureImageUnsplashButton: () => page.getByRole('button', { name: featureImageUnsplashButton }),
+  removeFeatureImage: () => page.getByRole('button', { name: removeFeatureImageButton }),
+  featureImageAltToggle: () => page.getByRole('button', { name: toggleFeatureImageAltButton }),
+  featureImageAltInput: () => page.getByLabelText(featureImageAltLabel),
+  /** The caption's Koenig content editable. */
+  featureImageCaption: () => page.getByTestId(editorFeatureImageCaption).getByRole('textbox'),
+  featureImageTkIndicator: () => page.getByTestId(featureImageTkIndicator),
   backLink: (postType: 'post' | 'page') =>
     page.getByRole('link', {
       name: postType === 'page' ? pagesBackLink : postsBackLink,

--- a/apps/admin/src/editor/feature-image-caption.tsx
+++ b/apps/admin/src/editor/feature-image-caption.tsx
@@ -1,0 +1,94 @@
+import * as Sentry from '@sentry/react';
+import { Suspense, useCallback, useMemo } from 'react';
+import ErrorBoundary from '@/settings/components/error-boundary';
+import {
+  type EditorResource,
+  type KoenigInstance,
+  loadKoenig,
+} from '@/settings/components/koenig-loader';
+import type { PostCardConfig } from './card-config';
+
+export interface FeatureImageCaptionProps {
+  /** Paragraph-wrapped caption HTML; the editor parses it as a document. */
+  html: string | null;
+  placeholder: string;
+  darkMode: boolean;
+  searchLinks: PostCardConfig['searchLinks'];
+  onChangeHtml: (html: string) => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  onTkCountChange: (count: number) => void;
+  registerAPI: (api: KoenigInstance | null) => void;
+}
+
+function CaptionMount({
+  editor,
+  html,
+  placeholder,
+  darkMode,
+  searchLinks,
+  onChangeHtml,
+  onFocus,
+  onBlur,
+  onTkCountChange,
+  registerAPI,
+  onError,
+}: FeatureImageCaptionProps & { editor: EditorResource; onError: (error: unknown) => void }) {
+  const {
+    KoenigComposer,
+    KoenigComposableEditor,
+    HtmlOutputPlugin,
+    EmojiPickerPlugin,
+    TKCountPlugin,
+    MINIMAL_NODES,
+    MINIMAL_TRANSFORMERS,
+  } = editor.read();
+
+  return (
+    <KoenigComposer
+      cardConfig={{ searchLinks }}
+      isTKEnabled={true}
+      nodes={MINIMAL_NODES}
+      onError={onError}
+    >
+      <KoenigComposableEditor
+        className="koenig-lexical-editor-input"
+        darkMode={darkMode}
+        isSnippetsEnabled={false}
+        markdownTransformers={MINIMAL_TRANSFORMERS}
+        placeholderClassName="koenig-lexical-editor-input-placeholder"
+        placeholderText={placeholder}
+        registerAPI={registerAPI}
+        singleParagraph={true}
+        onBlur={onBlur}
+        onFocus={onFocus}
+      >
+        <HtmlOutputPlugin html={html ?? undefined} setHtml={onChangeHtml} />
+        <EmojiPickerPlugin />
+        <TKCountPlugin onChange={onTkCountChange} />
+      </KoenigComposableEditor>
+    </KoenigComposer>
+  );
+}
+
+/** The feature image caption: one paragraph of basic formatting, emitted as HTML. */
+export function FeatureImageCaption(props: FeatureImageCaptionProps) {
+  const editor = useMemo(() => loadKoenig(), []);
+
+  const onError = useCallback((error: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    Sentry.captureException(error, { tags: { lexical: true } });
+    // not rethrown: Lexical attempts to recover without losing user data
+  }, []);
+
+  return (
+    <div className="koenig-react-editor koenig-lexical flex-1">
+      <ErrorBoundary name="the feature image caption">
+        <Suspense fallback={null}>
+          <CaptionMount {...props} editor={editor} onError={onError} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/apps/admin/src/editor/feature-image-caption.tsx
+++ b/apps/admin/src/editor/feature-image-caption.tsx
@@ -1,5 +1,4 @@
-import * as Sentry from '@sentry/react';
-import { Suspense, useCallback, useMemo } from 'react';
+import { Suspense, useMemo } from 'react';
 import ErrorBoundary from '@/settings/components/error-boundary';
 import {
   type EditorResource,
@@ -7,6 +6,7 @@ import {
   loadKoenig,
 } from '@/settings/components/koenig-loader';
 import type { PostCardConfig } from './card-config';
+import { reportKoenigError } from './koenig-error';
 
 export interface FeatureImageCaptionProps {
   /** Paragraph-wrapped caption HTML; the editor parses it as a document. */
@@ -32,8 +32,7 @@ function CaptionMount({
   onBlur,
   onTkCountChange,
   registerAPI,
-  onError,
-}: FeatureImageCaptionProps & { editor: EditorResource; onError: (error: unknown) => void }) {
+}: FeatureImageCaptionProps & { editor: EditorResource }) {
   const {
     KoenigComposer,
     KoenigComposableEditor,
@@ -49,7 +48,7 @@ function CaptionMount({
       cardConfig={{ searchLinks }}
       isTKEnabled={true}
       nodes={MINIMAL_NODES}
-      onError={onError}
+      onError={reportKoenigError}
     >
       <KoenigComposableEditor
         className="koenig-lexical-editor-input"
@@ -75,18 +74,11 @@ function CaptionMount({
 export function FeatureImageCaption(props: FeatureImageCaptionProps) {
   const editor = useMemo(() => loadKoenig(), []);
 
-  const onError = useCallback((error: unknown) => {
-    // eslint-disable-next-line no-console
-    console.error(error);
-    Sentry.captureException(error, { tags: { lexical: true } });
-    // not rethrown: Lexical attempts to recover without losing user data
-  }, []);
-
   return (
     <div className="koenig-react-editor koenig-lexical flex-1">
       <ErrorBoundary name="the feature image caption">
         <Suspense fallback={null}>
-          <CaptionMount {...props} editor={editor} onError={onError} />
+          <CaptionMount {...props} editor={editor} />
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/apps/admin/src/editor/feature-image.tsx
+++ b/apps/admin/src/editor/feature-image.tsx
@@ -110,6 +110,22 @@ export function FeatureImage({
     [onTkCountChange],
   );
 
+  // A new identity re-registers the caption editor on every keystroke
+  const registerCaptionApi = useCallback((api: KoenigInstance | null) => {
+    captionApi.current = api;
+  }, []);
+
+  const focusCaption = useCallback(() => {
+    captionApi.current?.focusEditor({ position: 'bottom' });
+  }, []);
+
+  const onCaptionFocus = useCallback(() => setCaptionFocused(true), []);
+
+  const onCaptionBlurred = useCallback(() => {
+    setCaptionFocused(false);
+    onCaptionBlur();
+  }, [onCaptionBlur]);
+
   const clearImage = () => {
     setIsEditingAlt(false);
     relayTkCount(0);
@@ -209,16 +225,11 @@ export function FeatureImage({
               darkMode={darkMode}
               html={caption}
               placeholder={captionFocused ? '' : 'Add a caption to the feature image'}
-              registerAPI={(api) => {
-                captionApi.current = api;
-              }}
+              registerAPI={registerCaptionApi}
               searchLinks={cardConfig.searchLinks}
-              onBlur={() => {
-                setCaptionFocused(false);
-                onCaptionBlur();
-              }}
+              onBlur={onCaptionBlurred}
               onChangeHtml={onCaptionChange}
-              onFocus={() => setCaptionFocused(true)}
+              onFocus={onCaptionFocus}
               onTkCountChange={relayTkCount}
             />
           </div>
@@ -228,7 +239,7 @@ export function FeatureImage({
             className="rounded-sm bg-state-warning px-1.5 py-0.5 text-2xs font-bold text-foreground"
             data-testid="feature-image-tk-indicator"
             type="button"
-            onClick={() => captionApi.current?.focusEditor({ position: 'bottom' })}
+            onClick={focusCaption}
           >
             TK
           </button>

--- a/apps/admin/src/editor/feature-image.tsx
+++ b/apps/admin/src/editor/feature-image.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
+import { UnsplashSearchModal } from '@tryghost/kg-unsplash-selector';
+import { Button, LoadingIndicator } from '@tryghost/shade/components';
+import {
+  ImageUpload,
+  ImageUploadAction,
+  ImageUploadActions,
+  ImageUploadDropzone,
+  ImageUploadImage,
+  ImageUploadPreview,
+} from '@tryghost/shade/patterns';
+import { Inline, Stack } from '@tryghost/shade/primitives';
+import { LucideIcon, cn } from '@tryghost/shade/utils';
+import { getImageUrl, useUploadImage } from '@tryghost/admin-x-framework/api/images';
+import { useFramework } from '@tryghost/admin-x-framework';
+import {
+  JSONError,
+  RequestEntityTooLargeError,
+  UnsupportedMediaTypeError,
+} from '@tryghost/admin-x-framework/errors';
+import BrandIcon from '@/shared/brand-icon/brand-icon';
+import type { KoenigInstance } from '@/settings/components/koenig-loader';
+import type { PostCardConfig } from './card-config';
+import { FeatureImageCaption } from './feature-image-caption';
+
+const ACCEPTED_IMAGE_TYPES = {
+  'image/gif': ['.gif'],
+  'image/jpeg': ['.jpg', '.jpeg'],
+  'image/png': ['.png'],
+  'image/svg+xml': ['.svg', '.svgz'],
+  'image/webp': ['.webp'],
+};
+
+const UNSUPPORTED_IMAGE_MESSAGE =
+  'The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP';
+
+const ALT_MAX_LENGTH = 191;
+
+function uploadErrorMessage(error: unknown): string {
+  if (error instanceof UnsupportedMediaTypeError) {
+    return UNSUPPORTED_IMAGE_MESSAGE;
+  }
+  if (error instanceof RequestEntityTooLargeError) {
+    return 'The image you uploaded was larger than the maximum file size your server allows.';
+  }
+  if (error instanceof JSONError && error.data?.errors[0]?.message) {
+    return error.data.errors[0].message;
+  }
+  return 'Couldn’t upload the feature image.';
+}
+
+export interface FeatureImageProps {
+  image: string | null;
+  alt: string | null;
+  /** Paragraph-wrapped caption HTML. */
+  caption: string | null;
+  cardConfig: PostCardConfig;
+  darkMode: boolean;
+  onImageChange: (url: string) => void;
+  onImageClear: () => void;
+  onAltChange: (alt: string) => void;
+  onCaptionChange: (html: string) => void;
+  onCaptionBlur: () => void;
+  onTkCountChange: (count: number) => void;
+}
+
+/**
+ * The post's feature image: uploaded from the file picker or a drop, picked
+ * from Unsplash, and described by either alt text or a caption.
+ */
+export function FeatureImage({
+  image,
+  alt,
+  caption,
+  cardConfig,
+  darkMode,
+  onImageChange,
+  onImageClear,
+  onAltChange,
+  onCaptionChange,
+  onCaptionBlur,
+  onTkCountChange,
+}: FeatureImageProps) {
+  const { mutateAsync: uploadImage, isPending } = useUploadImage();
+  const { unsplashConfig } = useFramework();
+  const [showUnsplash, setShowUnsplash] = useState(false);
+  const [isEditingAlt, setIsEditingAlt] = useState(false);
+  const [captionFocused, setCaptionFocused] = useState(false);
+  const [captionTkCount, setCaptionTkCount] = useState(0);
+  const captionApi = useRef<KoenigInstance | null>(null);
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      try {
+        onImageChange(getImageUrl(await uploadImage({ file })));
+      } catch (error) {
+        toast.error(uploadErrorMessage(error));
+      }
+    },
+    [uploadImage, onImageChange],
+  );
+
+  const relayTkCount = useCallback(
+    (count: number) => {
+      setCaptionTkCount(count);
+      onTkCountChange(count);
+    },
+    [onTkCountChange],
+  );
+
+  const clearImage = () => {
+    setIsEditingAlt(false);
+    relayTkCount(0);
+    onImageClear();
+  };
+
+  if (!image) {
+    return (
+      <ImageUpload className="mb-4 h-14" data-testid="editor-feature-image">
+        <ImageUploadDropzone
+          accept={ACCEPTED_IMAGE_TYPES}
+          className="group/dropzone border-transparent bg-transparent transition-colors hover:bg-interactive-hover"
+          disabled={isPending}
+          inputAriaLabel="Add feature image"
+          onDropAccepted={(files) => files[0] && void handleUpload(files[0])}
+          onDropRejected={() => toast.error(UNSUPPORTED_IMAGE_MESSAGE)}
+        >
+          {isPending ? (
+            <LoadingIndicator size="sm" />
+          ) : (
+            <Inline gap="sm">
+              <LucideIcon.Plus
+                aria-hidden="true"
+                className="size-4 text-muted-foreground transition-colors group-hover/dropzone:text-foreground"
+              />
+              <span className="text-sm text-muted-foreground transition-colors group-hover/dropzone:text-foreground">
+                Add feature image
+              </span>
+            </Inline>
+          )}
+        </ImageUploadDropzone>
+        {cardConfig.unsplash && (
+          <ImageUploadActions className="top-1/2 right-2 -translate-y-1/2 opacity-100">
+            <Button
+              aria-label="Select feature image from Unsplash"
+              className="group/unsplash hover:bg-button-hover"
+              disabled={isPending}
+              size="icon"
+              type="button"
+              variant="ghost"
+              onClick={() => setShowUnsplash(true)}
+            >
+              <BrandIcon
+                className="size-4 text-muted-foreground transition-colors group-hover/unsplash:text-foreground"
+                name="unsplash"
+              />
+            </Button>
+          </ImageUploadActions>
+        )}
+        {showUnsplash &&
+          createPortal(
+            <UnsplashSearchModal
+              unsplashProviderConfig={unsplashConfig}
+              onClose={() => setShowUnsplash(false)}
+              onImageInsert={(inserted) => {
+                if (inserted.src) {
+                  onImageChange(inserted.src);
+                  onCaptionChange(inserted.caption ?? '');
+                }
+                setShowUnsplash(false);
+              }}
+            />,
+            document.body,
+          )}
+      </ImageUpload>
+    );
+  }
+
+  return (
+    <Stack className="mb-4" data-testid="editor-feature-image" gap="sm">
+      <ImageUpload className="max-h-[480px]">
+        <ImageUploadPreview>
+          <ImageUploadImage alt={alt ?? ''} role={alt ? 'img' : 'presentation'} src={image} />
+          <ImageUploadActions>
+            <ImageUploadAction aria-label="Remove feature image" onClick={clearImage}>
+              <LucideIcon.Trash2 />
+            </ImageUploadAction>
+          </ImageUploadActions>
+        </ImageUploadPreview>
+      </ImageUpload>
+      <Inline align="center" className="relative" gap="sm">
+        {isEditingAlt ? (
+          <input
+            aria-label="Alt text for feature image"
+            className="flex-1 border-0 bg-transparent p-0 text-sm text-text-secondary outline-none placeholder:text-muted-foreground"
+            maxLength={ALT_MAX_LENGTH}
+            name="alt"
+            placeholder="Add alt text to the feature image"
+            type="text"
+            value={alt ?? ''}
+            autoFocus
+            onChange={(event) => onAltChange(event.target.value)}
+          />
+        ) : (
+          <div className="flex-1 text-sm" data-testid="editor-feature-image-caption">
+            <FeatureImageCaption
+              darkMode={darkMode}
+              html={caption}
+              placeholder={captionFocused ? '' : 'Add a caption to the feature image'}
+              registerAPI={(api) => {
+                captionApi.current = api;
+              }}
+              searchLinks={cardConfig.searchLinks}
+              onBlur={() => {
+                setCaptionFocused(false);
+                onCaptionBlur();
+              }}
+              onChangeHtml={onCaptionChange}
+              onFocus={() => setCaptionFocused(true)}
+              onTkCountChange={relayTkCount}
+            />
+          </div>
+        )}
+        {captionTkCount > 0 && !isEditingAlt && (
+          <button
+            className="rounded-sm bg-state-warning px-1.5 py-0.5 text-2xs font-bold text-foreground"
+            data-testid="feature-image-tk-indicator"
+            type="button"
+            onClick={() => captionApi.current?.focusEditor({ position: 'bottom' })}
+          >
+            TK
+          </button>
+        )}
+        <button
+          aria-label="Toggle between editing alt text and caption"
+          className={cn(
+            'rounded-md border px-1.5 py-0.5 text-2xs font-medium tracking-wide',
+            isEditingAlt
+              ? 'border-state-success bg-state-success text-state-success-foreground'
+              : 'border-border-default bg-transparent text-text-tertiary',
+          )}
+          type="button"
+          onClick={() => setIsEditingAlt(!isEditingAlt)}
+        >
+          Alt
+        </button>
+      </Inline>
+    </Stack>
+  );
+}

--- a/apps/admin/src/editor/feature-image.tsx
+++ b/apps/admin/src/editor/feature-image.tsx
@@ -140,6 +140,7 @@ export function FeatureImage({
           className="group/dropzone border-transparent bg-transparent transition-colors hover:bg-interactive-hover"
           disabled={isPending}
           inputAriaLabel="Add feature image"
+          noDragEventsBubbling
           onDropAccepted={(files) => files[0] && void handleUpload(files[0])}
           onDropRejected={() => toast.error(UNSUPPORTED_IMAGE_MESSAGE)}
         >

--- a/apps/admin/src/editor/koenig-error.ts
+++ b/apps/admin/src/editor/koenig-error.ts
@@ -1,0 +1,15 @@
+import * as Sentry from '@sentry/react';
+
+/**
+ * Reports a Lexical failure from any of the editor's Koenig instances. Never
+ * rethrown: Lexical attempts to recover without losing what the writer typed.
+ */
+export function reportKoenigError(error: unknown): void {
+  // eslint-disable-next-line no-console
+  console.error(error);
+
+  Sentry.captureException(error, {
+    tags: { lexical: true },
+    contexts: { koenig: { version: window['@tryghost/koenig-lexical']?.version } },
+  });
+}

--- a/apps/admin/src/editor/koenig-post-editor.tsx
+++ b/apps/admin/src/editor/koenig-post-editor.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { Suspense, useCallback, useMemo } from 'react';
 import { LoadingIndicator } from '@tryghost/shade/components';
 import { koenigFileUploadTypes, useKoenigFileUpload } from '@tryghost/admin-x-framework/hooks';
@@ -9,6 +8,7 @@ import {
   loadKoenig,
 } from '@/settings/components/koenig-loader';
 import type { PostCardConfig } from './card-config';
+import { reportKoenigError } from './koenig-error';
 
 const fileUploader = {
   useFileUpload: useKoenigFileUpload,
@@ -91,27 +91,12 @@ export function KoenigPostEditor(props: KoenigPostEditorProps) {
   const editor = useMemo(() => loadKoenig(), []);
   const { onSecondaryError } = props;
 
-  const reportError = useCallback((error: unknown) => {
-    // eslint-disable-next-line no-console
-    console.error(error);
-
-    Sentry.captureException(error, {
-      tags: { lexical: true },
-      contexts: {
-        koenig: {
-          version: window['@tryghost/koenig-lexical']?.version,
-        },
-      },
-    });
-    // not rethrown: Lexical attempts to recover without losing user data
-  }, []);
-
   const onSecondaryInstanceError = useCallback(
     (error: unknown) => {
-      reportError(error);
+      reportKoenigError(error);
       onSecondaryError?.(error);
     },
-    [reportError, onSecondaryError],
+    [onSecondaryError],
   );
 
   return (
@@ -128,7 +113,7 @@ export function KoenigPostEditor(props: KoenigPostEditorProps) {
             {...props}
             editor={editor}
             isSecondary={false}
-            onError={reportError}
+            onError={reportKoenigError}
           />
           <KoenigInstanceMount
             {...props}

--- a/apps/admin/src/editor/post-editor.tsx
+++ b/apps/admin/src/editor/post-editor.tsx
@@ -5,13 +5,16 @@ import { useFocusContext } from '@tryghost/shade/app';
 import { focusKoenigEditorOnBottomClick } from '@tryghost/admin-x-framework';
 import type { KoenigInstance } from '@/settings/components/koenig-loader';
 import type { PostCardConfig, PostType } from './card-config';
+import { FeatureImage } from './feature-image';
 import { KoenigPostEditor } from './koenig-post-editor';
 import { textHasTk } from './tk';
+import type { FeatureImageBinding } from './session/feature-image-binding';
 
 export interface PostEditorProps {
   postType: PostType;
   title: string;
   excerpt: string;
+  featureImage: FeatureImageBinding;
   /** Initial body; the editor owns its own state after mount. */
   initialLexical: string | null;
   cardConfig: PostCardConfig;
@@ -82,6 +85,7 @@ export function PostEditor({
   postType,
   title,
   excerpt,
+  featureImage,
   initialLexical,
   cardConfig,
   showExcerpt,
@@ -104,6 +108,7 @@ export function PostEditor({
   const skipFocusEditorRef = useRef(false);
   const [wordCount, setWordCount] = useState(0);
   const [bodyTkCount, setBodyTkCount] = useState(0);
+  const [featureImageTkCount, setFeatureImageTkCount] = useState(0);
 
   useAutosize(titleRef, title);
   useAutosize(excerptRef, excerpt);
@@ -112,8 +117,10 @@ export function PostEditor({
   const excerptHasTk = showExcerpt && textHasTk(excerpt);
 
   useEffect(() => {
-    onTkCountChange?.((titleHasTk ? 1 : 0) + (excerptHasTk ? 1 : 0) + bodyTkCount);
-  }, [onTkCountChange, titleHasTk, excerptHasTk, bodyTkCount]);
+    onTkCountChange?.(
+      (titleHasTk ? 1 : 0) + (excerptHasTk ? 1 : 0) + bodyTkCount + featureImageTkCount,
+    );
+  }, [onTkCountChange, titleHasTk, excerptHasTk, bodyTkCount, featureImageTkCount]);
 
   const focusTitle = useCallback(() => {
     titleRef.current?.focus();
@@ -253,6 +260,19 @@ export function PostEditor({
           onMouseUp={focusEditorOnPaneClick}
         >
           <div className="relative mx-auto w-full max-w-[740px]">
+            <FeatureImage
+              alt={featureImage.featureImageAlt}
+              caption={featureImage.featureImageCaption}
+              cardConfig={cardConfig}
+              darkMode={darkMode}
+              image={featureImage.featureImage}
+              onAltChange={featureImage.onFeatureImageAltChange}
+              onCaptionBlur={featureImage.onFeatureImageCaptionBlur}
+              onCaptionChange={featureImage.onFeatureImageCaptionChange}
+              onImageChange={featureImage.onFeatureImageChange}
+              onImageClear={featureImage.onFeatureImageClear}
+              onTkCountChange={setFeatureImageTkCount}
+            />
             {titleHasTk && <TkIndicator testId="tk-indicator" onClick={focusTitle} />}
             <textarea
               ref={titleRef}

--- a/apps/admin/src/editor/post-status.test.ts
+++ b/apps/admin/src/editor/post-status.test.ts
@@ -46,9 +46,14 @@ describe('deriveEditorStatus', () => {
     expect(
       derive({ status: 'draft' }, { state: { kind: 'error', intent: 'field', error } }),
     ).toEqual({ kind: 'problem', message: 'Title is too long.' });
+  });
+
+  it('leaves a collision to its own banner', () => {
+    const error = { kind: 'conflict' as const, message: 'Someone else is editing this post.' };
+
     expect(
       derive({ status: 'draft' }, { state: { kind: 'conflict', intent: 'autosave', error } }),
-    ).toEqual({ kind: 'problem', message: 'Title is too long.' });
+    ).toEqual({ kind: 'draft', saved: true });
   });
 
   it('prefers the engine message over a save in progress', () => {
@@ -72,13 +77,51 @@ describe('deriveEditorStatus', () => {
       kind: 'scheduled',
       publishedAt: '2026-09-02T13:00:00.000Z',
       emailOnly: false,
+      recipientFilter: null,
     });
   });
 
   it('marks an email-only scheduled post as one that will be sent', () => {
     expect(
       derive({ status: 'scheduled', publishedAt: '2026-09-02T13:00:00.000Z', emailOnly: true }),
-    ).toEqual({ kind: 'scheduled', publishedAt: '2026-09-02T13:00:00.000Z', emailOnly: true });
+    ).toMatchObject({ kind: 'scheduled', emailOnly: true });
+  });
+
+  it('counts the audience of a scheduled send that has not been handed over', () => {
+    expect(
+      derive({
+        status: 'scheduled',
+        publishedAt: '2026-09-02T13:00:00.000Z',
+        newsletter: { slug: 'weekly' },
+        emailSegment: 'status:free',
+      }),
+    ).toMatchObject({
+      kind: 'scheduled',
+      recipientFilter: 'newsletters.slug:weekly+email_disabled:0+(status:free)',
+    });
+  });
+
+  it('scopes a paid-only newsletter to paid members', () => {
+    expect(
+      derive({
+        status: 'scheduled',
+        publishedAt: '2026-09-02T13:00:00.000Z',
+        newsletter: { slug: 'weekly', visibility: 'paid' },
+      }),
+    ).toMatchObject({
+      recipientFilter: 'newsletters.slug:weekly+email_disabled:0+status:-free',
+    });
+  });
+
+  it('stops counting once the send has an email record', () => {
+    expect(
+      derive({
+        status: 'scheduled',
+        publishedAt: '2026-09-02T13:00:00.000Z',
+        newsletter: { slug: 'weekly' },
+        hasEmail: true,
+      }),
+    ).toMatchObject({ recipientFilter: null });
   });
 
   it('reports the newsletter alongside a published post', () => {

--- a/apps/admin/src/editor/post-status.test.ts
+++ b/apps/admin/src/editor/post-status.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { SaveEngineState } from './engine/save-engine';
+import {
+  SAVING_MIN_DISPLAY_MS,
+  deriveEditorStatus,
+  useSavingHold,
+  type EditorStatusRecord,
+} from './post-status';
+
+const NOW = new Date('2026-09-02T12:00:00.000Z');
+
+const IDLE: SaveEngineState = { kind: 'idle' };
+
+function derive(
+  record: EditorStatusRecord | undefined,
+  overrides: { state?: SaveEngineState; isDirty?: boolean; isSaving?: boolean } = {},
+) {
+  return deriveEditorStatus({
+    state: overrides.state ?? IDLE,
+    record,
+    isDirty: overrides.isDirty ?? false,
+    isSaving: overrides.isSaving ?? false,
+    now: NOW,
+  });
+}
+
+describe('deriveEditorStatus', () => {
+  it('reads a post with no record as new', () => {
+    expect(derive(undefined)).toEqual({ kind: 'new' });
+  });
+
+  it('separates a dirty draft from a saved one', () => {
+    expect(derive({ status: 'draft' }, { isDirty: true })).toEqual({ kind: 'draft', saved: false });
+    expect(derive({ status: 'draft' })).toEqual({ kind: 'draft', saved: true });
+  });
+
+  it('shows a save in progress only while the post is a draft', () => {
+    expect(derive({ status: 'draft' }, { isSaving: true })).toEqual({ kind: 'saving' });
+    expect(derive({ status: 'published' }, { isSaving: true }).kind).toBe('published');
+  });
+
+  it('carries the engine message for a failed or colliding save', () => {
+    const error = { kind: 'validation' as const, message: 'Title is too long.' };
+
+    expect(
+      derive({ status: 'draft' }, { state: { kind: 'error', intent: 'field', error } }),
+    ).toEqual({ kind: 'problem', message: 'Title is too long.' });
+    expect(
+      derive({ status: 'draft' }, { state: { kind: 'conflict', intent: 'autosave', error } }),
+    ).toEqual({ kind: 'problem', message: 'Title is too long.' });
+  });
+
+  it('prefers the engine message over a save in progress', () => {
+    const state: SaveEngineState = {
+      kind: 'error',
+      intent: 'explicit',
+      error: { kind: 'transport', message: 'Couldn’t save this post.' },
+    };
+
+    expect(derive({ status: 'draft' }, { state, isSaving: true }).kind).toBe('problem');
+  });
+
+  it('reads a scheduled post whose time has passed as published', () => {
+    expect(
+      derive({ status: 'scheduled', publishedAt: '2026-09-02T11:00:00.000Z', url: 'https://x/y' }),
+    ).toEqual({ kind: 'published', url: 'https://x/y', email: 'none', count: 0 });
+  });
+
+  it('keeps a scheduled post scheduled until its time arrives', () => {
+    expect(derive({ status: 'scheduled', publishedAt: '2026-09-02T13:00:00.000Z' })).toEqual({
+      kind: 'scheduled',
+      publishedAt: '2026-09-02T13:00:00.000Z',
+      emailOnly: false,
+    });
+  });
+
+  it('marks an email-only scheduled post as one that will be sent', () => {
+    expect(
+      derive({ status: 'scheduled', publishedAt: '2026-09-02T13:00:00.000Z', emailOnly: true }),
+    ).toEqual({ kind: 'scheduled', publishedAt: '2026-09-02T13:00:00.000Z', emailOnly: true });
+  });
+
+  it('reports the newsletter alongside a published post', () => {
+    expect(
+      derive({ status: 'published', emailStatus: 'submitting', emailCount: 12 }),
+    ).toMatchObject({ kind: 'published', email: 'sending', count: 12 });
+    expect(derive({ status: 'published', emailStatus: 'submitted', emailCount: 12 })).toMatchObject(
+      {
+        email: 'sent',
+      },
+    );
+    expect(derive({ status: 'published', emailStatus: 'failed' })).toMatchObject({
+      email: 'failed',
+    });
+  });
+
+  it('separates a sent post from one whose newsletter failed', () => {
+    expect(derive({ status: 'sent', emailCount: 40 })).toEqual({
+      kind: 'sent',
+      failed: false,
+      count: 40,
+    });
+    expect(derive({ status: 'sent', emailStatus: 'failed', emailCount: 40 })).toEqual({
+      kind: 'sent',
+      failed: true,
+      count: 40,
+    });
+  });
+});
+
+describe('useSavingHold', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps a save visible for the minimum window after it finishes', () => {
+    const { result, rerender } = renderHook(({ saving }) => useSavingHold(saving), {
+      initialProps: { saving: true },
+    });
+
+    expect(result.current).toBe(true);
+
+    rerender({ saving: false });
+    expect(result.current).toBe(true);
+
+    act(() => void vi.advanceTimersByTime(SAVING_MIN_DISPLAY_MS));
+    expect(result.current).toBe(false);
+  });
+
+  it('does not extend the window for a save that starts inside it', () => {
+    const { result, rerender } = renderHook(({ saving }) => useSavingHold(saving), {
+      initialProps: { saving: true },
+    });
+
+    act(() => void vi.advanceTimersByTime(SAVING_MIN_DISPLAY_MS - 500));
+    rerender({ saving: false });
+    rerender({ saving: true });
+    rerender({ saving: false });
+
+    act(() => void vi.advanceTimersByTime(500));
+    expect(result.current).toBe(false);
+  });
+
+  it('opens a new window while the save is still running', () => {
+    const { result } = renderHook(() => useSavingHold(true));
+
+    act(() => void vi.advanceTimersByTime(SAVING_MIN_DISPLAY_MS));
+    expect(result.current).toBe(true);
+  });
+
+  it('stays quiet while nothing is saving', () => {
+    const { result } = renderHook(() => useSavingHold(false));
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/admin/src/editor/post-status.test.ts
+++ b/apps/admin/src/editor/post-status.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import type { SaveEngineState } from './engine/save-engine';
 import {
+  MAX_SCHEDULE_TIMEOUT_MS,
   SAVING_MIN_DISPLAY_MS,
   deriveEditorStatus,
+  useScheduledBoundary,
   useSavingHold,
   type EditorStatusRecord,
 } from './post-status';
@@ -78,6 +80,7 @@ describe('deriveEditorStatus', () => {
       publishedAt: '2026-09-02T13:00:00.000Z',
       emailOnly: false,
       recipientFilter: null,
+      recipientSegment: null,
     });
   });
 
@@ -98,7 +101,33 @@ describe('deriveEditorStatus', () => {
     ).toMatchObject({
       kind: 'scheduled',
       recipientFilter: 'newsletters.slug:weekly+email_disabled:0+(status:free)',
+      recipientSegment: 'status:free',
     });
+  });
+
+  it('normalizes the persisted all recipient sentinel', () => {
+    expect(
+      derive({
+        status: 'scheduled',
+        publishedAt: '2026-09-02T13:00:00.000Z',
+        newsletter: { slug: 'weekly' },
+        emailSegment: 'all',
+      }),
+    ).toMatchObject({
+      recipientFilter: 'newsletters.slug:weekly+email_disabled:0+(status:free,status:-free)',
+      recipientSegment: 'status:free,status:-free',
+    });
+  });
+
+  it('does not count a persisted none recipient sentinel', () => {
+    expect(
+      derive({
+        status: 'scheduled',
+        publishedAt: '2026-09-02T13:00:00.000Z',
+        newsletter: { slug: 'weekly' },
+        emailSegment: 'none',
+      }),
+    ).toMatchObject({ recipientFilter: null, recipientSegment: null });
   });
 
   it('scopes a paid-only newsletter to paid members', () => {
@@ -149,6 +178,48 @@ describe('deriveEditorStatus', () => {
       failed: true,
       count: 40,
     });
+  });
+});
+
+describe('useScheduledBoundary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  function renderScheduledBoundary(publishedAt: string) {
+    const record: EditorStatusRecord = { status: 'scheduled', publishedAt };
+
+    return renderHook(() => {
+      useScheduledBoundary(publishedAt, true);
+      return deriveEditorStatus({
+        state: IDLE,
+        record,
+        isDirty: false,
+        isSaving: false,
+      });
+    });
+  }
+
+  it('rerenders when the scheduled time arrives', () => {
+    const { result } = renderScheduledBoundary('2026-09-02T12:00:01.000Z');
+    expect(result.current.kind).toBe('scheduled');
+
+    act(() => void vi.advanceTimersByTime(1000));
+
+    expect(result.current.kind).toBe('published');
+  });
+
+  it('reschedules posts beyond the browser timeout limit', () => {
+    const publishedAt = new Date(NOW.getTime() + MAX_SCHEDULE_TIMEOUT_MS + 1000).toISOString();
+    const { result } = renderScheduledBoundary(publishedAt);
+
+    act(() => void vi.advanceTimersByTime(MAX_SCHEDULE_TIMEOUT_MS));
+    expect(result.current.kind).toBe('scheduled');
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(result.current.kind).toBe('published');
   });
 });
 

--- a/apps/admin/src/editor/post-status.ts
+++ b/apps/admin/src/editor/post-status.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  EVERYONE_RECIPIENT_FILTER,
+  PAID_SEGMENT,
   getFullRecipientFilter,
   getNewsletterRecipientFilter,
+  normalizeRecipientFilter,
 } from '@tryghost/admin-x-framework/utils/recipient-filter';
 import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
 import type { SaveEngineState } from './engine/save-engine';
@@ -41,6 +44,8 @@ export type EditorStatusView =
       emailOnly: boolean;
       /** Members the send will reach, or null when nothing will be sent. */
       recipientFilter: string | null;
+      /** The selected segment without its newsletter scope, for descriptive count copy. */
+      recipientSegment: string | null;
     }
   | {
       kind: 'published';
@@ -71,16 +76,25 @@ function publishedEmailState(
   return status === 'failed' ? 'failed' : 'none';
 }
 
+interface ScheduledRecipientAudience {
+  filter: string;
+  segment: string;
+}
+
 /** Who a scheduled send will reach, or null once an email exists or none is going out. */
-function scheduledRecipientFilter(record: EditorStatusRecord): string | null {
-  if (!record.newsletter || record.hasEmail) {
+function scheduledRecipientAudience(record: EditorStatusRecord): ScheduledRecipientAudience | null {
+  if (!record.newsletter || record.hasEmail || record.emailSegment === 'none') {
     return null;
   }
 
-  return getFullRecipientFilter(
-    getNewsletterRecipientFilter(record.newsletter),
-    record.emailSegment,
-  );
+  const segment = normalizeRecipientFilter(record.emailSegment);
+  const descriptiveSegment =
+    segment ?? (record.newsletter.visibility === 'paid' ? PAID_SEGMENT : EVERYONE_RECIPIENT_FILTER);
+
+  return {
+    filter: getFullRecipientFilter(getNewsletterRecipientFilter(record.newsletter), segment),
+    segment: descriptiveSegment,
+  };
 }
 
 /** A scheduled post whose time has passed reads as published; the server owns the transition. */
@@ -115,6 +129,7 @@ export function deriveEditorStatus({
   }
 
   const count = record.emailCount ?? 0;
+  const recipientAudience = status === 'scheduled' ? scheduledRecipientAudience(record) : null;
 
   if (status === 'sent') {
     return { kind: 'sent', failed: record.emailStatus === 'failed', count };
@@ -125,7 +140,8 @@ export function deriveEditorStatus({
       kind: 'scheduled',
       publishedAt: record.publishedAt ?? null,
       emailOnly: true,
-      recipientFilter: scheduledRecipientFilter(record),
+      recipientFilter: recipientAudience?.filter ?? null,
+      recipientSegment: recipientAudience?.segment ?? null,
     };
   }
 
@@ -143,11 +159,40 @@ export function deriveEditorStatus({
       kind: 'scheduled',
       publishedAt: record.publishedAt ?? null,
       emailOnly: false,
-      recipientFilter: scheduledRecipientFilter(record),
+      recipientFilter: recipientAudience?.filter ?? null,
+      recipientSegment: recipientAudience?.segment ?? null,
     };
   }
 
   return { kind: 'draft', saved: !isDirty };
+}
+
+/** Browsers clamp longer timeouts; reschedule in bounded steps for distant posts. */
+export const MAX_SCHEDULE_TIMEOUT_MS = 2_147_483_647;
+
+/** Rerenders the caller when a future scheduled time is reached. */
+export function useScheduledBoundary(
+  publishedAt: string | null | undefined,
+  enabled: boolean,
+): void {
+  const [generation, setGeneration] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || !publishedAt) {
+      return;
+    }
+
+    const remaining = Date.parse(publishedAt) - Date.now();
+    if (!Number.isFinite(remaining) || remaining <= 0) {
+      return;
+    }
+
+    const timer = setTimeout(
+      () => setGeneration((current) => current + 1),
+      Math.min(remaining, MAX_SCHEDULE_TIMEOUT_MS),
+    );
+    return () => clearTimeout(timer);
+  }, [enabled, generation, publishedAt]);
 }
 
 /**

--- a/apps/admin/src/editor/post-status.ts
+++ b/apps/admin/src/editor/post-status.ts
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from 'react';
+import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
+import type { SaveEngineState } from './engine/save-engine';
+
+/** How long "Saving…" stays on screen once a save starts, so it is noticeable. */
+export const SAVING_MIN_DISPLAY_MS = 3000;
+
+export type EmailDeliveryStatus = 'pending' | 'submitting' | 'submitted' | 'failed';
+
+export interface EditorStatusRecord {
+  status?: PostStatus;
+  publishedAt?: string | null;
+  url?: string;
+  emailOnly?: boolean;
+  emailStatus?: EmailDeliveryStatus | null;
+  emailCount?: number;
+}
+
+export type EditorStatusView =
+  /** A save engine state the writer has to act on; the message is the engine's. */
+  | { kind: 'problem'; message: string }
+  | { kind: 'saving' }
+  | { kind: 'new' }
+  | { kind: 'draft'; saved: boolean }
+  | { kind: 'scheduled'; publishedAt: string | null; emailOnly: boolean }
+  | {
+      kind: 'published';
+      url?: string;
+      email: 'none' | 'sending' | 'sent' | 'failed';
+      count: number;
+    }
+  | { kind: 'sent'; failed: boolean; count: number };
+
+export interface DeriveEditorStatusInput {
+  state: SaveEngineState;
+  record?: EditorStatusRecord;
+  isDirty: boolean;
+  /** Held true for a minimum window after a save starts. */
+  isSaving: boolean;
+  now?: Date;
+}
+
+function publishedEmailState(
+  status?: EmailDeliveryStatus | null,
+): 'none' | 'sending' | 'sent' | 'failed' {
+  if (status === 'submitting' || status === 'pending') {
+    return 'sending';
+  }
+  if (status === 'submitted') {
+    return 'sent';
+  }
+  return status === 'failed' ? 'failed' : 'none';
+}
+
+/** A scheduled post whose time has passed reads as published; the server owns the transition. */
+function isPastScheduled(record: EditorStatusRecord, now: Date): boolean {
+  if (record.status !== 'scheduled' || !record.publishedAt) {
+    return false;
+  }
+  const time = Date.parse(record.publishedAt);
+  return !Number.isNaN(time) && time <= now.getTime();
+}
+
+export function deriveEditorStatus({
+  state,
+  record,
+  isDirty,
+  isSaving,
+  now = new Date(),
+}: DeriveEditorStatusInput): EditorStatusView {
+  if (state.kind === 'error' || state.kind === 'conflict') {
+    return { kind: 'problem', message: state.error.message };
+  }
+
+  const status = record?.status ?? 'draft';
+
+  if (isSaving && status === 'draft') {
+    return { kind: 'saving' };
+  }
+
+  if (!record) {
+    return { kind: 'new' };
+  }
+
+  const count = record.emailCount ?? 0;
+
+  if (status === 'sent') {
+    return { kind: 'sent', failed: record.emailStatus === 'failed', count };
+  }
+
+  if (record.emailOnly && status === 'scheduled') {
+    return { kind: 'scheduled', publishedAt: record.publishedAt ?? null, emailOnly: true };
+  }
+
+  if (status === 'published' || isPastScheduled(record, now)) {
+    return {
+      kind: 'published',
+      url: record.url,
+      email: publishedEmailState(record.emailStatus),
+      count,
+    };
+  }
+
+  if (status === 'scheduled') {
+    return { kind: 'scheduled', publishedAt: record.publishedAt ?? null, emailOnly: false };
+  }
+
+  return { kind: 'draft', saved: !isDirty };
+}
+
+/**
+ * Holds `true` for `minMs` once a save starts. A save that begins inside the
+ * window does not extend it; one still running when it closes opens a new one.
+ */
+export function useSavingHold(isSaving: boolean, minMs: number = SAVING_MIN_DISPLAY_MS): boolean {
+  const [held, setHeld] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    if (!isSaving || timer.current) {
+      return;
+    }
+    setHeld(true);
+    timer.current = setTimeout(() => {
+      timer.current = undefined;
+      setHeld(false);
+    }, minMs);
+  }, [isSaving, held, minMs]);
+
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  return held;
+}

--- a/apps/admin/src/editor/post-status.ts
+++ b/apps/admin/src/editor/post-status.ts
@@ -1,4 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
+import {
+  getFullRecipientFilter,
+  getNewsletterRecipientFilter,
+} from '@tryghost/admin-x-framework/utils/recipient-filter';
 import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
 import type { SaveEngineState } from './engine/save-engine';
 
@@ -7,22 +11,37 @@ export const SAVING_MIN_DISPLAY_MS = 3000;
 
 export type EmailDeliveryStatus = 'pending' | 'submitting' | 'submitted' | 'failed';
 
+export interface EditorStatusNewsletter {
+  slug: string;
+  visibility?: string;
+}
+
 export interface EditorStatusRecord {
   status?: PostStatus;
   publishedAt?: string | null;
   url?: string;
   emailOnly?: boolean;
+  newsletter?: EditorStatusNewsletter | null;
+  emailSegment?: string | null;
+  /** An email record exists, so the send has already been handed over. */
+  hasEmail?: boolean;
   emailStatus?: EmailDeliveryStatus | null;
   emailCount?: number;
 }
 
 export type EditorStatusView =
-  /** A save engine state the writer has to act on; the message is the engine's. */
+  /** A save the writer has to act on; the message is the engine's. */
   | { kind: 'problem'; message: string }
   | { kind: 'saving' }
   | { kind: 'new' }
   | { kind: 'draft'; saved: boolean }
-  | { kind: 'scheduled'; publishedAt: string | null; emailOnly: boolean }
+  | {
+      kind: 'scheduled';
+      publishedAt: string | null;
+      emailOnly: boolean;
+      /** Members the send will reach, or null when nothing will be sent. */
+      recipientFilter: string | null;
+    }
   | {
       kind: 'published';
       url?: string;
@@ -52,6 +71,18 @@ function publishedEmailState(
   return status === 'failed' ? 'failed' : 'none';
 }
 
+/** Who a scheduled send will reach, or null once an email exists or none is going out. */
+function scheduledRecipientFilter(record: EditorStatusRecord): string | null {
+  if (!record.newsletter || record.hasEmail) {
+    return null;
+  }
+
+  return getFullRecipientFilter(
+    getNewsletterRecipientFilter(record.newsletter),
+    record.emailSegment,
+  );
+}
+
 /** A scheduled post whose time has passed reads as published; the server owns the transition. */
 function isPastScheduled(record: EditorStatusRecord, now: Date): boolean {
   if (record.status !== 'scheduled' || !record.publishedAt) {
@@ -68,7 +99,8 @@ export function deriveEditorStatus({
   isSaving,
   now = new Date(),
 }: DeriveEditorStatusInput): EditorStatusView {
-  if (state.kind === 'error' || state.kind === 'conflict') {
+  // A collision has its own banner; a failed save has nowhere else to surface.
+  if (state.kind === 'error') {
     return { kind: 'problem', message: state.error.message };
   }
 
@@ -89,7 +121,12 @@ export function deriveEditorStatus({
   }
 
   if (record.emailOnly && status === 'scheduled') {
-    return { kind: 'scheduled', publishedAt: record.publishedAt ?? null, emailOnly: true };
+    return {
+      kind: 'scheduled',
+      publishedAt: record.publishedAt ?? null,
+      emailOnly: true,
+      recipientFilter: scheduledRecipientFilter(record),
+    };
   }
 
   if (status === 'published' || isPastScheduled(record, now)) {
@@ -102,7 +139,12 @@ export function deriveEditorStatus({
   }
 
   if (status === 'scheduled') {
-    return { kind: 'scheduled', publishedAt: record.publishedAt ?? null, emailOnly: false };
+    return {
+      kind: 'scheduled',
+      publishedAt: record.publishedAt ?? null,
+      emailOnly: false,
+      recipientFilter: scheduledRecipientFilter(record),
+    };
   }
 
   return { kind: 'draft', saved: !isDirty };

--- a/apps/admin/src/editor/publish/publish-options.test.ts
+++ b/apps/admin/src/editor/publish/publish-options.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { normalizeRecipientFilter } from '@tryghost/admin-x-framework/utils/recipient-filter';
 import {
   DEFAULT_SCHEDULE_LEAD_MS,
   EMAIL_VERIFICATION_HOLD_MESSAGE,
@@ -8,7 +9,6 @@ import {
   getEmailDisabledReason,
   getEmailUnavailableReason,
   getInitialPublishType,
-  normalizeRecipientFilter,
   selectableNewsletters,
   splitUpgradeMessage,
   tiersSegment,

--- a/apps/admin/src/editor/publish/publish-options.ts
+++ b/apps/admin/src/editor/publish/publish-options.ts
@@ -3,6 +3,7 @@ import {
   PAID_SEGMENT,
   getFullRecipientFilter,
   getNewsletterRecipientFilter,
+  normalizeRecipientFilter,
 } from '@tryghost/admin-x-framework/utils/recipient-filter';
 import type { PostStatus } from '@tryghost/admin-x-framework/api/posts';
 import type {
@@ -198,17 +199,6 @@ export function selectableNewsletters(
 /** The tier list spelled as a recipient filter; null when the post has no tiers. */
 export function tiersSegment(tiers: ReadonlyArray<{ slug: string }>): string | null {
   return tiers.map((tier) => `tier:${tier.slug}`).join(',') || null;
-}
-
-/** Expands the API's legacy segment sentinels into the filters used by the editor. */
-export function normalizeRecipientFilter(filter: string | null | undefined): string | null {
-  if (filter === 'all') {
-    return EVERYONE_RECIPIENT_FILTER;
-  }
-  if (!filter || filter === 'none') {
-    return null;
-  }
-  return filter;
 }
 
 export function getDefaultRecipientFilter(

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -59,6 +59,11 @@ export interface EditorSession {
   isDirty: () => boolean;
   patchTitle: (title: string) => void;
   patchExcerpt: (excerpt: string) => void;
+  patchFeatureImage: (
+    patch: Partial<
+      Pick<EditablePostProjection, 'feature_image' | 'feature_image_alt' | 'feature_image_caption'>
+    >,
+  ) => void;
   patchLexical: (lexical: unknown) => void;
   setBaseline: (lexical: LexicalInput) => void;
   baselineFailed: (error: unknown) => void;
@@ -238,6 +243,7 @@ export function createEditorSession({
     // even while the input stays empty.
     patchTitle: (title) => patchLive({ title: title.trim() ? title : DEFAULT_TITLE }),
     patchExcerpt: (excerpt) => patchLive({ custom_excerpt: excerpt === '' ? null : excerpt }),
+    patchFeatureImage: (patch) => patchLive(patch),
     patchLexical: (lexical) => patchLive({ lexical: JSON.stringify(lexical) }),
     setBaseline: (lexical) => tracker.setBaseline(identity.id, lexical),
     baselineFailed: (error) => tracker.baselineFailed(identity.id, error),

--- a/apps/admin/src/editor/session/feature-image-binding.test.ts
+++ b/apps/admin/src/editor/session/feature-image-binding.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { EditorRecord } from './projection';
+import {
+  cleanCaptionHtml,
+  normalizeCaptionHtml,
+  useFeatureImageBinding,
+  withCaptionParagraph,
+} from './feature-image-binding';
+
+function port() {
+  return { patchFeatureImage: vi.fn(), dispatchField: vi.fn() };
+}
+
+function record(overrides: Partial<EditorRecord> = {}): EditorRecord {
+  return {
+    id: 'post-1',
+    url: 'https://example.com/post-1/',
+    slug: 'post-1',
+    title: 'Post',
+    updated_at: '2026-09-02T12:00:00.000Z',
+    ...overrides,
+  } as EditorRecord;
+}
+
+describe('caption html', () => {
+  it('stores the paragraph content, not the paragraph', () => {
+    expect(cleanCaptionHtml('<p>A <strong>caption</strong></p>')).toBe(
+      'A <strong>caption</strong>',
+    );
+  });
+
+  it('gives a stored caption its paragraph back for the editor', () => {
+    expect(withCaptionParagraph('A caption')).toBe('<p>A caption</p>');
+    expect(withCaptionParagraph('<p>A caption</p>')).toBe('<p>A caption</p>');
+    expect(withCaptionParagraph(null)).toBeNull();
+  });
+
+  it('ignores the wrapper spans Lexical adds on load', () => {
+    const loaded = '<p><span style="white-space: pre-wrap;">A caption</span></p>';
+
+    expect(normalizeCaptionHtml(loaded)).toBe(normalizeCaptionHtml('<p>A caption</p>'));
+  });
+});
+
+describe('useFeatureImageBinding', () => {
+  it('starts from the loaded post', () => {
+    const { result } = renderHook(() =>
+      useFeatureImageBinding(
+        port(),
+        record({
+          feature_image: 'https://example.com/a.png',
+          feature_image_alt: 'A',
+          feature_image_caption: 'A caption',
+        }),
+      ),
+    );
+
+    expect(result.current.featureImage).toBe('https://example.com/a.png');
+    expect(result.current.featureImageAlt).toBe('A');
+    expect(result.current.featureImageCaption).toBe('<p>A caption</p>');
+  });
+
+  it('saves a new image straight away', () => {
+    const session = port();
+    const { result } = renderHook(() => useFeatureImageBinding(session, record()));
+
+    act(() => result.current.onFeatureImageChange('https://example.com/a.png'));
+
+    expect(session.patchFeatureImage).toHaveBeenCalledWith({
+      feature_image: 'https://example.com/a.png',
+    });
+    expect(session.dispatchField).toHaveBeenCalledTimes(1);
+    expect(result.current.featureImage).toBe('https://example.com/a.png');
+  });
+
+  it('clears the alt text and caption along with the image', () => {
+    const session = port();
+    const { result } = renderHook(() =>
+      useFeatureImageBinding(
+        session,
+        record({
+          feature_image: 'https://example.com/a.png',
+          feature_image_alt: 'A',
+          feature_image_caption: 'A caption',
+        }),
+      ),
+    );
+
+    act(() => result.current.onFeatureImageClear());
+
+    expect(session.patchFeatureImage).toHaveBeenCalledWith({
+      feature_image: null,
+      feature_image_alt: null,
+      feature_image_caption: null,
+    });
+    expect(session.dispatchField).toHaveBeenCalledTimes(1);
+    expect(result.current.featureImageCaption).toBeNull();
+  });
+
+  it('saves alt text as it is typed', () => {
+    const session = port();
+    const { result } = renderHook(() => useFeatureImageBinding(session, record()));
+
+    act(() => result.current.onFeatureImageAltChange('A field of grass'));
+
+    expect(session.patchFeatureImage).toHaveBeenCalledWith({
+      feature_image_alt: 'A field of grass',
+    });
+    expect(session.dispatchField).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds the caption until it loses focus', () => {
+    const session = port();
+    const { result } = renderHook(() => useFeatureImageBinding(session, record()));
+
+    act(() => result.current.onFeatureImageCaptionChange('<p>A caption</p>'));
+
+    expect(session.patchFeatureImage).toHaveBeenCalledWith({ feature_image_caption: 'A caption' });
+    expect(session.dispatchField).not.toHaveBeenCalled();
+
+    act(() => result.current.onFeatureImageCaptionBlur());
+
+    expect(session.dispatchField).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a caption the editor only re-serialized', () => {
+    const session = port();
+    const { result } = renderHook(() =>
+      useFeatureImageBinding(session, record({ feature_image_caption: 'A caption' })),
+    );
+
+    act(() =>
+      result.current.onFeatureImageCaptionChange(
+        '<p><span style="white-space: pre-wrap;">A caption</span></p>',
+      ),
+    );
+
+    expect(session.patchFeatureImage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/editor/session/feature-image-binding.test.ts
+++ b/apps/admin/src/editor/session/feature-image-binding.test.ts
@@ -37,9 +37,37 @@ describe('caption html', () => {
   });
 
   it('ignores the wrapper spans Lexical adds on load', () => {
-    const loaded = '<p><span style="white-space: pre-wrap;">A caption</span></p>';
+    // The shape the editor actually emits for a stored plain-text caption.
+    const loaded = '<p dir="ltr"><span style="white-space: pre-wrap;">A caption</span></p>';
 
-    expect(normalizeCaptionHtml(loaded)).toBe(normalizeCaptionHtml('<p>A caption</p>'));
+    expect(normalizeCaptionHtml(loaded)).toBe('A caption');
+    expect(normalizeCaptionHtml(loaded)).toBe(normalizeCaptionHtml('A caption'));
+  });
+
+  it('keeps a span that carries anything of its own', () => {
+    expect(normalizeCaptionHtml('<p><span class="x">A caption</span></p>')).toBe(
+      '<span class="x">A caption</span>',
+    );
+    expect(
+      normalizeCaptionHtml(
+        '<p><span style="white-space: pre-wrap; color: red">A caption</span></p>',
+      ),
+    ).toContain('span');
+  });
+
+  it('keeps a caption with markup whole on both sides of the compare', () => {
+    expect(normalizeCaptionHtml('<p>Photo by <a href="/j">Jane</a></p>')).toBe(
+      'Photo by <a href="/j">Jane</a>',
+    );
+    expect(normalizeCaptionHtml('Photo by <a href="/j">Jane</a>')).toBe(
+      'Photo by <a href="/j">Jane</a>',
+    );
+  });
+
+  it('separates markup captions that differ only outside their first element', () => {
+    expect(normalizeCaptionHtml('<a href="/j">Jane</a> took this')).not.toBe(
+      normalizeCaptionHtml('<a href="/j">Jane</a> shot this'),
+    );
   });
 });
 
@@ -137,5 +165,33 @@ describe('useFeatureImageBinding', () => {
     );
 
     expect(session.patchFeatureImage).not.toHaveBeenCalled();
+  });
+
+  it('loads a caption with markup clean', () => {
+    const session = port();
+    const stored = 'Photo by <a href="/j">Jane</a>';
+    const { result } = renderHook(() =>
+      useFeatureImageBinding(session, record({ feature_image_caption: stored })),
+    );
+
+    act(() => result.current.onFeatureImageCaptionChange(`<p>${stored}</p>`));
+
+    expect(session.patchFeatureImage).not.toHaveBeenCalled();
+  });
+
+  it('still sees an edit that changes only the text after a link', () => {
+    const session = port();
+    const { result } = renderHook(() =>
+      useFeatureImageBinding(
+        session,
+        record({ feature_image_caption: '<a href="/j">Jane</a> took this' }),
+      ),
+    );
+
+    act(() => result.current.onFeatureImageCaptionChange('<p><a href="/j">Jane</a> shot this</p>'));
+
+    expect(session.patchFeatureImage).toHaveBeenCalledWith({
+      feature_image_caption: '<a href="/j">Jane</a> shot this',
+    });
   });
 });

--- a/apps/admin/src/editor/session/feature-image-binding.ts
+++ b/apps/admin/src/editor/session/feature-image-binding.ts
@@ -31,21 +31,39 @@ export function cleanCaptionHtml(html: string | null | undefined): string {
   return cleanBasicHtml(html ?? '', { firstChildInnerContent: true });
 }
 
+// The style attribute is read as written, not through the CSSOM: browsers
+// expand `white-space` into longhands, so a property count cannot identify it.
 function isLexicalPlainTextSpan(element: Element): boolean {
-  return (
-    element.tagName === 'SPAN' &&
-    element instanceof HTMLElement &&
-    element.style.length === 1 &&
-    element.style.whiteSpace === 'pre-wrap'
-  );
+  if (element.tagName !== 'SPAN' || element.attributes.length !== 1) {
+    return false;
+  }
+
+  const declarations = (element.getAttribute('style') ?? '')
+    .split(';')
+    .map((declaration) => declaration.trim())
+    .filter(Boolean);
+
+  return declarations.length === 1 && /^white-space\s*:\s*pre-wrap$/i.test(declarations[0]);
+}
+
+/** The caption editor parses a document, so a bare fragment needs its paragraph back. */
+export function withCaptionParagraph(html: string | null | undefined): string | null {
+  if (!html) {
+    return null;
+  }
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return doc.body.firstElementChild?.tagName === 'P' ? html : `<p>${html}</p>`;
 }
 
 /**
- * Lexical wraps plain text in `white-space: pre-wrap` spans on load. Ignoring
- * those wrappers keeps an API-loaded caption from reading as an edit.
+ * One comparable form for a caption in either shape. Both sides are wrapped
+ * back into a paragraph first, so `firstChildInnerContent` unwraps that
+ * paragraph rather than a caption's own leading element, and Lexical's
+ * load-time `white-space: pre-wrap` spans are ignored.
  */
 export function normalizeCaptionHtml(html: string | null | undefined): string {
-  const cleaned = cleanCaptionHtml(html);
+  const cleaned = cleanCaptionHtml(withCaptionParagraph(html));
   const doc = new DOMParser().parseFromString(cleaned, 'text/html');
 
   doc.body.querySelectorAll('span').forEach((element) => {
@@ -55,16 +73,6 @@ export function normalizeCaptionHtml(html: string | null | undefined): string {
   });
 
   return doc.body.innerHTML.trim();
-}
-
-/** The caption editor parses a document, so a bare fragment needs its paragraph back. */
-export function withCaptionParagraph(html: string | null): string | null {
-  if (!html) {
-    return null;
-  }
-
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  return doc.body.firstElementChild?.tagName === 'P' ? html : `<p>${html}</p>`;
 }
 
 /**

--- a/apps/admin/src/editor/session/feature-image-binding.ts
+++ b/apps/admin/src/editor/session/feature-image-binding.ts
@@ -1,0 +1,132 @@
+import { useCallback, useRef, useState } from 'react';
+import { cleanBasicHtml } from '@tryghost/kg-clean-basic-html';
+import type { EditorRecord } from './projection';
+
+export interface FeatureImagePatch {
+  feature_image?: string | null;
+  feature_image_alt?: string | null;
+  feature_image_caption?: string | null;
+}
+
+/** The session calls the feature image needs; the rest of the handle is irrelevant to it. */
+export interface FeatureImagePort {
+  patchFeatureImage: (patch: FeatureImagePatch) => void;
+  dispatchField: () => void;
+}
+
+export interface FeatureImageBinding {
+  featureImage: string | null;
+  featureImageAlt: string | null;
+  /** Wrapped in a paragraph, the shape the caption editor loads. */
+  featureImageCaption: string | null;
+  onFeatureImageChange: (url: string) => void;
+  onFeatureImageClear: () => void;
+  onFeatureImageAltChange: (alt: string) => void;
+  onFeatureImageCaptionChange: (html: string) => void;
+  onFeatureImageCaptionBlur: () => void;
+}
+
+/** The stored caption is the paragraph's inner content, not the paragraph. */
+export function cleanCaptionHtml(html: string | null | undefined): string {
+  return cleanBasicHtml(html ?? '', { firstChildInnerContent: true });
+}
+
+function isLexicalPlainTextSpan(element: Element): boolean {
+  return (
+    element.tagName === 'SPAN' &&
+    element instanceof HTMLElement &&
+    element.style.length === 1 &&
+    element.style.whiteSpace === 'pre-wrap'
+  );
+}
+
+/**
+ * Lexical wraps plain text in `white-space: pre-wrap` spans on load. Ignoring
+ * those wrappers keeps an API-loaded caption from reading as an edit.
+ */
+export function normalizeCaptionHtml(html: string | null | undefined): string {
+  const cleaned = cleanCaptionHtml(html);
+  const doc = new DOMParser().parseFromString(cleaned, 'text/html');
+
+  doc.body.querySelectorAll('span').forEach((element) => {
+    if (isLexicalPlainTextSpan(element)) {
+      element.replaceWith(...element.childNodes);
+    }
+  });
+
+  return doc.body.innerHTML.trim();
+}
+
+/** The caption editor parses a document, so a bare fragment needs its paragraph back. */
+export function withCaptionParagraph(html: string | null): string | null {
+  if (!html) {
+    return null;
+  }
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return doc.body.firstElementChild?.tagName === 'P' ? html : `<p>${html}</p>`;
+}
+
+/**
+ * Feature image, alt text and caption as the editor holds them. Setting,
+ * clearing and alt edits save immediately; the caption saves on blur.
+ */
+export function useFeatureImageBinding(
+  port: FeatureImagePort,
+  record?: EditorRecord,
+): FeatureImageBinding {
+  const session = useRef(port);
+  session.current = port;
+
+  const [featureImage, setFeatureImage] = useState(record?.feature_image ?? null);
+  const [featureImageAlt, setFeatureImageAlt] = useState(record?.feature_image_alt ?? null);
+  const [caption, setCaption] = useState(record?.feature_image_caption ?? null);
+  const captionRef = useRef(caption);
+  captionRef.current = caption;
+
+  const onFeatureImageChange = useCallback((url: string) => {
+    setFeatureImage(url);
+    session.current.patchFeatureImage({ feature_image: url });
+    session.current.dispatchField();
+  }, []);
+
+  const onFeatureImageClear = useCallback(() => {
+    setFeatureImage(null);
+    setFeatureImageAlt(null);
+    setCaption(null);
+    session.current.patchFeatureImage({
+      feature_image: null,
+      feature_image_alt: null,
+      feature_image_caption: null,
+    });
+    session.current.dispatchField();
+  }, []);
+
+  const onFeatureImageAltChange = useCallback((alt: string) => {
+    setFeatureImageAlt(alt);
+    session.current.patchFeatureImage({ feature_image_alt: alt });
+    session.current.dispatchField();
+  }, []);
+
+  const onFeatureImageCaptionChange = useCallback((html: string) => {
+    const cleaned = cleanCaptionHtml(html);
+    if (normalizeCaptionHtml(cleaned) === normalizeCaptionHtml(captionRef.current)) {
+      return;
+    }
+    setCaption(cleaned);
+    session.current.patchFeatureImage({ feature_image_caption: cleaned });
+  }, []);
+
+  const onFeatureImageCaptionBlur = useCallback(() => session.current.dispatchField(), []);
+
+  return {
+    featureImage,
+    featureImageAlt,
+    featureImageCaption: withCaptionParagraph(caption),
+    onFeatureImageChange,
+    onFeatureImageClear,
+    onFeatureImageAltChange,
+    onFeatureImageCaptionChange,
+    onFeatureImageCaptionBlur,
+  };
+}

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -57,6 +57,8 @@ export interface EditorSessionHandle {
   bind: EditorSessionBinding;
   state: SaveEngineState;
   isDirty: () => boolean;
+  patchFeatureImage: EditorSession['patchFeatureImage'];
+  dispatchField: () => void;
   dispatchExplicit: () => void;
   reauthSucceeded: () => void;
   reauthAbandoned: () => void;
@@ -240,6 +242,8 @@ export function useEditorSession({
     },
     state,
     isDirty: session.isDirty,
+    patchFeatureImage: session.patchFeatureImage,
+    dispatchField: session.dispatchField,
     dispatchExplicit: () => void session.dispatchExplicit(),
     reauthSucceeded: session.reauthSucceeded,
     reauthAbandoned: session.reauthAbandoned,

--- a/apps/admin/src/editor/use-save-shortcut.test.ts
+++ b/apps/admin/src/editor/use-save-shortcut.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useSaveShortcut } from './use-save-shortcut';
+
+function pressSave(key = 's', modifiers: Partial<KeyboardEventInit> = { metaKey: true }) {
+  const event = new KeyboardEvent('keydown', { key, cancelable: true, ...modifiers });
+  document.dispatchEvent(event);
+  return event;
+}
+
+function focusedTextInput(onBlur: () => void): HTMLInputElement {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.addEventListener('blur', onBlur);
+  document.body.append(input);
+  input.focus();
+  return input;
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
+  });
+}
+
+describe('useSaveShortcut', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('saves on Cmd-S and on Ctrl-S, replacing the browser save dialog', async () => {
+    const onSave = vi.fn();
+    renderHook(() => useSaveShortcut(onSave));
+
+    expect(pressSave().defaultPrevented).toBe(true);
+    expect(pressSave('S', { ctrlKey: true }).defaultPrevented).toBe(true);
+    await flush();
+
+    expect(onSave).toHaveBeenCalledTimes(2);
+  });
+
+  it('commits the focused text input before the save reads the post', async () => {
+    const order: string[] = [];
+    renderHook(() => useSaveShortcut(() => order.push('save')));
+    focusedTextInput(() => order.push('blur'));
+
+    pressSave();
+    await flush();
+
+    expect(order).toEqual(['blur', 'save']);
+  });
+
+  it('leaves other keys and unmodified presses to the page', async () => {
+    const onSave = vi.fn();
+    renderHook(() => useSaveShortcut(onSave));
+
+    expect(pressSave('s', {}).defaultPrevented).toBe(false);
+    expect(pressSave('a').defaultPrevented).toBe(false);
+    expect(pressSave('s', { metaKey: true, altKey: true }).defaultPrevented).toBe(false);
+    await flush();
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once the editor unmounts', async () => {
+    const onSave = vi.fn();
+    const { unmount } = renderHook(() => useSaveShortcut(onSave));
+
+    unmount();
+    pressSave();
+    await flush();
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/editor/use-save-shortcut.test.ts
+++ b/apps/admin/src/editor/use-save-shortcut.test.ts
@@ -64,6 +64,29 @@ describe('useSaveShortcut', () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
+  it('saves once for a held key, not once per repeat', async () => {
+    const onSave = vi.fn();
+    renderHook(() => useSaveShortcut(onSave));
+
+    pressSave();
+    expect(pressSave('s', { metaKey: true, repeat: true }).defaultPrevented).toBe(true);
+    pressSave('s', { metaKey: true, repeat: true });
+    await flush();
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a save the editor unmounted before', async () => {
+    const onSave = vi.fn();
+    const { unmount } = renderHook(() => useSaveShortcut(onSave));
+
+    pressSave();
+    unmount();
+    await flush();
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
   it('stops listening once the editor unmounts', async () => {
     const onSave = vi.fn();
     const { unmount } = renderHook(() => useSaveShortcut(onSave));

--- a/apps/admin/src/editor/use-save-shortcut.ts
+++ b/apps/admin/src/editor/use-save-shortcut.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+
+/** Text inputs commit on blur, so the focused one has to lose focus before the save reads the post. */
+function blurFocusedTextInput(): void {
+  const focused = document.activeElement;
+  if (focused instanceof HTMLInputElement && focused.type === 'text') {
+    focused.blur();
+  }
+}
+
+/**
+ * Cmd/Ctrl+S saves whatever is open, replacing the browser's save dialog.
+ * Scoped to the mounted editor: nothing listens once the screen unmounts.
+ */
+export function useSaveShortcut(onSave: () => void): void {
+  const save = useRef(onSave);
+  save.current = onSave;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const withModifier = event.metaKey || event.ctrlKey;
+      if (event.key.toLowerCase() !== 's' || !withModifier || event.altKey) {
+        return;
+      }
+
+      event.preventDefault();
+      blurFocusedTextInput();
+      // the blur's handlers have to land in the session before the save reads it
+      setTimeout(() => save.current());
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+}

--- a/apps/admin/src/editor/use-save-shortcut.ts
+++ b/apps/admin/src/editor/use-save-shortcut.ts
@@ -17,19 +17,33 @@ export function useSaveShortcut(onSave: () => void): void {
   save.current = onSave;
 
   useEffect(() => {
+    const pending = new Set<ReturnType<typeof setTimeout>>();
+
     const onKeyDown = (event: KeyboardEvent) => {
       const withModifier = event.metaKey || event.ctrlKey;
       if (event.key.toLowerCase() !== 's' || !withModifier || event.altKey) {
         return;
       }
 
+      // A held key repeats; one press is one save.
       event.preventDefault();
+      if (event.repeat) {
+        return;
+      }
+
       blurFocusedTextInput();
       // the blur's handlers have to land in the session before the save reads it
-      setTimeout(() => save.current());
+      const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+        pending.delete(timer);
+        save.current();
+      });
+      pending.add(timer);
     };
 
     document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      pending.forEach(clearTimeout);
+    };
   }, []);
 }

--- a/apps/shade/src/components/ui/dropzone.tsx
+++ b/apps/shade/src/components/ui/dropzone.tsx
@@ -45,6 +45,7 @@ export interface DropzoneProps
   multiple?: boolean;
   maxFiles?: number;
   disabled?: boolean;
+  noDragEventsBubbling?: boolean;
   inputId?: string;
   inputAriaLabel?: string;
   inputTestId?: string;
@@ -60,6 +61,7 @@ export const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
       multiple = false,
       maxFiles = multiple ? 0 : 1,
       disabled = false,
+      noDragEventsBubbling = false,
       inputId,
       inputAriaLabel,
       inputTestId,
@@ -87,6 +89,7 @@ export const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
       multiple,
       maxFiles,
       disabled,
+      noDragEventsBubbling,
       onDropAccepted,
       onDropRejected,
     });

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -13,8 +13,18 @@ export const editorWordCount = 'editor-word-count';
 export const editorLoadError = 'editor-load-error';
 export const editorReauthBanner = 'editor-reauth-banner';
 export const editorConflictBanner = 'editor-conflict-banner';
+export const editorStatus = 'editor-status';
+export const editorScheduleCountdown = 'editor-schedule-countdown';
+export const editorFeatureImage = 'editor-feature-image';
+export const editorFeatureImageCaption = 'editor-feature-image-caption';
 export const tkIndicator = 'tk-indicator';
+export const featureImageTkIndicator = 'feature-image-tk-indicator';
 
 // accessible names
 export const postsBackLink = 'Posts';
 export const pagesBackLink = 'Pages';
+export const addFeatureImageLabel = 'Add feature image';
+export const featureImageAltLabel = 'Alt text for feature image';
+export const featureImageUnsplashButton = 'Select feature image from Unsplash';
+export const removeFeatureImageButton = 'Remove feature image';
+export const toggleFeatureImageAltButton = 'Toggle between editing alt text and caption';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -906,6 +906,9 @@ importers:
       '@tryghost/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n
+      '@tryghost/kg-clean-basic-html':
+        specifier: workspace:*
+        version: link:../../koenig/kg-clean-basic-html
       '@tryghost/kg-unsplash-selector':
         specifier: workspace:*
         version: link:../../koenig/kg-unsplash-selector


### PR DESCRIPTION
The React post editor behind the `editorReact` flag could save, but it gave no sign that it had, offered no way to ask for one, and had no feature image — so opening a post that had one and editing it silently risked it.

This adds the three pieces that close that gap.

### Status chip

A header chip derived from the save engine state and the post record:

| Post | Reads |
| --- | --- |
| Never saved | `New` |
| Draft | `Draft`, or `Draft - Saved` once it is clean |
| Saving a draft | `Saving…`, held long enough to be noticed |
| Published | `Published`, linked to the post, plus the newsletter outcome (`and sending to…`, `and sent to…`, `but failed to send newsletter.`) |
| Scheduled | `Scheduled`, with the countdown revealed on hover and ticking every second while it is |
| Scheduled, time passed | `Published` — the server owns that transition |
| Sent | `Sent to N members`, or `Failed to send newsletter.` |
| Failed or colliding save | the engine's own message |

The derivation is a pure function over `(engine state, record, dirty, saving)`; the minimum display window for `Saving…` is a hook beside it. Both are unit tested, including the past-scheduled boundary and the window's timing.

### Cmd/Ctrl+S

A keybinding scoped to the mounted editor. It takes over from the browser's save dialog, blurs the focused text input so a field that commits on blur reaches the post first, and only then dispatches an explicit save — which is the save that asks the server for a revision.

### Feature image

The block above the title:

- upload from the file picker or by dropping a file on it, with typed messages for an unsupported type, an oversized file, and a rejected upload
- Unsplash, using the same provider configuration the editor's cards already use
- alt text, behind the `Alt` toggle
- a caption in a single-paragraph editor with basic formatting, emoji and link search, whose TK count joins the editor's total

Setting an image, clearing it, and alt edits reach the post immediately. The caption is held while it is being typed and saved when it loses focus. Clearing the image clears its alt text and caption with it. A caption the editor only re-serialized on load is not treated as an edit, so opening a post with one does not mark it unsaved.

### Session

The editing session gained one method, `patchFeatureImage`, so these three fields reach the live projection the save payload is built from; the hook exposes it and `dispatchField` alongside the existing handle. Everything else about the block lives in `session/feature-image-binding.ts`.

### Testing

- `apps/admin` lint and `tsc -b` clean; 2851 unit tests pass
- new unit tests: status derivation across the state × record matrix, the minimum display window under fake timers, the blur-before-dispatch ordering of the keybinding, and the feature image binding's save points
- new acceptance tests (real Chromium, fake Admin API): Cmd-S sends a `save_revision=true` write with the pinned payload; typing shows `Saving…` and settles on `Saved`; an uploaded image, an alt edit, a caption blur and a clear each send the pinned write

### Not included

Pintura editing of the feature image, the hidden-on-page indicator, the recipient counts inside the scheduled countdown, and the retry buttons on a failed newsletter — the last two need the publish flow, which is not in the React editor yet.
