### PR TITLE
Fixed a race in the members checkout webhook test

### DIFF
--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -1310,11 +1310,6 @@ describe('Members API', function () {
       assert.equal(member.status, 'paid', 'The member should be "paid"');
       assert.equal(member.subscriptions.length, 1, 'The member should have a single subscription');
 
-      mockManager.assert.sentEmail({
-        subject: '🙌 Thank you for signing up to Ghost!',
-        to: 'checkout-webhook-test@email.com',
-      });
-
       // Check whether MRR and status has been set
       await assertSubscription(member.subscriptions[0].id, {
         subscription_id: subscription.id,
@@ -1357,10 +1352,20 @@ describe('Members API', function () {
         ],
       });
 
-      // Wait for the dispatched events (because this happens async)
+      // Neither of these emails is sent by the webhook request itself. The staff
+      // notification comes from a subscriber to a domain event that is only dispatched
+      // once the member transaction has committed, and the member's own signup email is
+      // started by the webhook handler without being awaited. Both can therefore still
+      // be in flight when the request returns, and nothing decides which of the two is
+      // sent first, so wait for each on its own rather than reading them in send order.
       await DomainEvents.allSettled();
 
-      mockManager.assert.sentEmail({
+      await mockManager.assert.sentEmailEventually({
+        subject: '🙌 Thank you for signing up to Ghost!',
+        to: 'checkout-webhook-test@email.com',
+      });
+
+      await mockManager.assert.sentEmailEventually({
         subject: '💸 Paid subscription started: checkout-webhook-test@email.com',
         to: 'jbloggs@example.com',
       });

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -322,6 +322,65 @@ const sentEmail = (matchers) => {
   return spyCall.args[0];
 };
 
+/**
+ * Asserts that an email matching every matcher was sent, waiting for it to arrive if
+ * it has not been sent yet.
+ *
+ * sentEmail() reads the emails in send order, one per call. That only works when the
+ * request under test has finished sending them by the time it returns. Where an email
+ * is sent by work that outlives the request — a subscriber to a domain event, or a
+ * promise the request never awaited — it may not have been sent yet, and nothing fixes
+ * its position relative to the other emails. This searches every email sent so far,
+ * and keeps looking until the timeout, so neither timing nor order matters.
+ */
+const sentEmailEventually = async (matchers, { timeout = 5000, interval = 50 } = {}) => {
+  if (!mocks.mail) {
+    throw new errors.IncorrectUsageError({
+      message: 'Cannot assert on mail when mail has not been mocked',
+    });
+  }
+
+  const isMatch = (email) =>
+    Object.keys(matchers).every((key) => {
+      const value = matchers[key];
+      const actual = email[key];
+
+      if (value instanceof RegExp) {
+        // A fresh copy per test: a global or sticky expression carries lastIndex
+        // between calls, so reusing one would skip matches on later emails.
+        return typeof actual === 'string' && new RegExp(value.source, value.flags).test(actual);
+      }
+
+      return actual === value;
+    });
+
+  const deadline = Date.now() + timeout;
+  let sent = [];
+
+  for (;;) {
+    sent = mocks.mail.getCalls().map((spyCall) => spyCall.args[0]);
+
+    const match = sent.find(isMatch);
+    if (match) {
+      return match;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      break;
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.min(interval, remaining));
+    });
+  }
+
+  assert.fail(
+    `Expected an email matching ${JSON.stringify(matchers)} to be sent within ${timeout}ms, ` +
+      `got ${JSON.stringify(sent.map((email) => ({ subject: email.subject, to: email.to })))}`,
+  );
+};
+
 const sentEmailCount = (expectedCount) => {
   if (!mocks.mail) {
     throw new errors.IncorrectUsageError({
@@ -544,6 +603,7 @@ module.exports = {
   stripeMocker,
   assert: {
     sentEmail,
+    sentEmailEventually,
     sentEmailCount,
     emittedEvent,
   },


### PR DESCRIPTION
## Problem

The members webhook test `Will create a member if one does not exist` fails intermittently on unmodified `main`. When it fails, the message is:

```
Expected Email 1 to have subject of 🙌 Thank you for signing up to Ghost!
+ actual   '💸 Paid subscription started: checkout-webhook-test@email.com'
- expected '🙌 Thank you for signing up to Ghost!'
```

The test posts a Stripe `checkout.session.completed` webhook, which creates a paid member, and then checks that two emails went out: a signup email to the new member, and a notification to staff that a paid subscription started. It checked them with `mockManager.assert.sentEmail`, which walks the emails in the order they were sent, one per call. So the first call was really asserting "the first email sent was the signup email".

Neither email is sent by the webhook request. The staff notification is sent by a subscriber to a domain event, and Ghost deliberately holds those events back until the database transaction that created the member has committed, so that nothing is told about a change before the change is real. The member's signup email is started by the webhook handler and never awaited, because failing to send it must not fail the webhook and make Stripe retry the payment work.

Both pieces of work therefore outlive the HTTP response the test waits on. When the test starts asserting, either email may still be in flight, and nothing decides which of the two lands first: they are two independent chains of database queries and template rendering, and whichever finishes first is recorded first.

Instrumenting the failing test recorded both of the ways that breaks the assertion. On one run, at the moment the assertion ran, exactly one email had been sent and it was the staff notification, with the signup email not sent at all yet. On another run, after all outstanding work had settled, both emails were present but in the order staff-then-signup. A positional assertion cannot accept either.

## Solution

Wait for each of the two emails on its own terms, and stop caring which arrived first.

This adds `mockManager.assert.sentEmailEventually` alongside the existing `sentEmail`. It searches every email sent so far for one matching the given fields rather than taking the next one in send order, and if none matches yet it keeps looking until a timeout. That covers both of the observed failures: an email that has not been sent yet, and an email sent in the other order. `sentEmail` is untouched and still right for the many tests whose emails are sent by the request itself.

The test now waits for domain events to settle, as it already did, and then asserts each of the two emails through the new helper. Everything else it checks is unchanged. There is no production change: the asynchrony is intentional, so the test has to accommodate it rather than the other way round.

## Follow-ups, not addressed here

The `Member attribution` tests in the same file are separately flaky, failing on some runs with `Cannot read properties of undefined (reading 'member_id')`. They read `SubscriptionCreatedEvent` rows straight after the webhook response with no wait for the async subscriber that writes them, which is the same class of race in different tests. They fail the same way before this change.

## What was measured

Measured locally against a dedicated MySQL, on a machine that had other work running, so treat the numbers as indicative rather than clean.

Running the whole `test/e2e-api/members` directory at the default worker count, which is what CI and a normal local run use, the test failed on 4 of 4 runs before the change and 0 of 6 runs after it. One further post-change run is excluded because it collapsed on a stale migration lock left by an earlier interrupted run, which failed all twenty files before any test executed.

Running the same directory pinned to a single worker with no file parallelism, the test passed 4 of 4 runs before the change, so it did not reproduce at all. That is expected rather than reassuring: the failure is a race between two chains of asynchronous work, and with one worker on an otherwise quiet machine the timing simply does not get disturbed enough to lose it. The instrumentation described above is the real evidence, because it captures the two failing interleavings directly and does not depend on how often a rate happens to expose them.

https://claude.ai/code/session_01XFCbqgYHYhd9rZ5WXtqZyT
