### PR TITLE
Fixed a race in the member attribution webhook tests

### DIFF
--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -58,6 +58,13 @@ async function getOfferByStripeCoupon(stripeCouponId) {
 }
 
 async function assertMemberEvents({ eventType, memberId, asserts }) {
+  // These rows are not written by the request under test. Ghost dispatches the member
+  // and subscription events once the transaction that created them has committed, and a
+  // subscriber then writes a row for each one. That write is still running when the
+  // response reaches us, so read the rows only once every dispatched event has been
+  // handled.
+  await DomainEvents.allSettled();
+
   const events = (await models[eventType].where('member_id', memberId).fetchAll()).toJSON();
   for (let i = 0; i < asserts.length; i++) {
     assertObjectMatches(events[i], asserts[i]);


### PR DESCRIPTION
## Problem

The Member attribution tests in the members webhook suite fail intermittently, a different handful on each run, always the same way: the test reads a database row that is not there yet.

Each of those tests sends Ghost a Stripe webhook that creates a paying member, waits for the response, and then reads the rows Ghost keeps to record that a member was created and that a subscription was started. The webhook request does not write those rows. Ghost describes what happened as an event, holds that event back until the database transaction that created the member has committed, and then hands it to a subscriber whose job is to write the row. The subscriber runs on its own and nothing about the request waits for it, so the response can come back while the row is still being written and the test gets there first.

The window is only tens of milliseconds, which is why the failure comes and goes. It does not need a busy machine. Running the group on its own, on an idle machine with a single test worker, three of six runs failed.

## Solution

The test helper that reads these rows now waits for every event Ghost has dispatched to have been handled before it reads. Ghost's event dispatcher counts events out and back in when running under test for exactly this purpose, and other tests in this file already wait on it where the delay was anticipated. The helper is the right place for the wait because every row it reads is written by a subscriber, so it is correct for all of its callers and not just the tests that happened to be failing.

The delay was measured rather than assumed. At the moment the test reads, Ghost has always already handed the event to the subscriber, and the only thing still outstanding is the subscriber's own write, so waiting on the dispatcher is sufficient and no polling or extra timeout is needed.

Twelve single-worker runs and six runs at the normal worker count are now clean, against three failures in six and one in six respectively before the change. The full members end-to-end suite passes.

https://claude.ai/code/session_01XFCbqgYHYhd9rZ5WXtqZyT
