### PR TITLE
Changed Admin 7 font features for headings

### DIFF
--- a/apps/admin/src/analytics/analytics.acceptance.test.tsx
+++ b/apps/admin/src/analytics/analytics.acceptance.test.tsx
@@ -176,6 +176,29 @@ describe('Analytics overview', () => {
       .toContain('Inter Admin 7');
   });
 
+  it('uses display font features only on Admin 7 headings', async () => {
+    seedAnalyticsWorld();
+    seedTopPostsViews();
+    await renderAdminApp('/analytics', {
+      labs: { admin7PageChrome: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(analyticsScreen.membersValue()).toHaveTextContent('175');
+    const heading = page.getByRole('heading', { name: 'Analytics' });
+    await expect.element(heading).toBeVisible();
+    const headingFeatures = getComputedStyle(heading.element()).fontFeatureSettings;
+    const smallTextFeatures = getComputedStyle(
+      analyticsScreen.activeVisitors().element(),
+    ).fontFeatureSettings;
+    expect(headingFeatures).toContain('dlig');
+    expect(headingFeatures).toContain('cv05');
+    expect(smallTextFeatures).toContain('zero');
+    expect(smallTextFeatures).toContain('ss01');
+    expect(smallTextFeatures).not.toContain('dlig');
+    expect(smallTextFeatures).not.toContain('cv05');
+  });
+
   it('re-queries Tinybird when the date range changes', async () => {
     const { kpisApi } = seedAnalyticsWorld();
     seedTopPostsViews();

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -25,11 +25,30 @@
     'Inter Admin 7', Inter, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue,
     helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif;
   --font-family: var(--font-sans);
-  --font-feature-settings: 'dlig' 1, 'zero' 1, 'ss01' 1, 'cv05' 1;
+  --font-feature-settings: 'zero' 1, 'ss01' 1;
+  --heading-font-feature-settings: 'dlig' 1, 'zero' 1, 'ss01' 1, 'cv05' 1;
   font-family: var(--font-sans);
   font-optical-sizing: none;
   font-variation-settings: 'opsz' 14;
   font-feature-settings: var(--font-feature-settings);
+}
+
+/* Display alternates feel crowded at small sizes, so reserve them for
+   semantic headings across both Admin screens and Settings overlays. */
+:where(
+    .admin7,
+    body.react-admin:has(> #root .admin7)
+      > :is(
+        .shade.shade-admin,
+        #ember-basic-dropdown-wormhole,
+        #ember-modal-wormhole,
+        #ember-liquid-wormhole,
+        #ember-alerts-wormhole,
+        #ember-notifications-wormhole
+      )
+  )
+  :where(h1, h2, h3, h4, h5, h6) {
+  font-feature-settings: var(--heading-font-feature-settings);
 }
 
 /* Browser form-control defaults can reset these inherited font properties.

--- a/apps/admin/src/settings/layout.acceptance.test.tsx
+++ b/apps/admin/src/settings/layout.acceptance.test.tsx
@@ -21,6 +21,7 @@ describe('Settings layout', () => {
       await renderAdminApp('/settings', { labs: { admin7PageChrome: enabled } });
 
       await expect.element(settingsScreen.search()).toBeVisible();
+      const heading = page.getByRole('heading', { name: 'General settings', exact: true }).first();
       const titleAndDescriptionEdit = settingsScreen
         .titleAndDescription()
         .getByRole('button', { name: 'Edit' });
@@ -34,6 +35,16 @@ describe('Settings layout', () => {
         await expect
           .poll(() => getComputedStyle(element).fontFamily.includes('Inter Admin 7'))
           .toBe(enabled);
+      }
+      if (enabled) {
+        const headingFeatures = getComputedStyle(heading.element()).fontFeatureSettings;
+        const searchFeatures = getComputedStyle(
+          settingsScreen.search().element(),
+        ).fontFeatureSettings;
+        expect(headingFeatures).toContain('dlig');
+        expect(headingFeatures).toContain('cv05');
+        expect(searchFeatures).not.toContain('dlig');
+        expect(searchFeatures).not.toContain('cv05');
       }
       expect(document.querySelector('.admin7') !== null).toBe(enabled);
       expect(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1509

## Why

The display-oriented `dlig` and `cv05` Inter features introduced with Admin 7 page chrome look noisy in compact labels and controls. They should remain part of the editorial heading treatment without changing the rest of the Milestone 1 typography rollout.

## What changed

- keep `zero` and `ss01` across eligible Admin 7 typography
- apply `dlig` and `cv05` only to semantic `h1`–`h6` headings
- preserve the existing Admin 7 flag and portal boundaries for Admin and Settings
- add computed-style acceptance coverage for both Admin and Settings

## Verification

- [x] Settings layout acceptance suite (8 tests)
- [x] Analytics acceptance suite (15 tests)
- [x] Targeted ESLint and formatting checks
- [x] Admin production Vite build
- [ ] Package-wide lint/typecheck currently have unrelated baseline failures in `tier-checkout-collection.tsx` and `feature-image.tsx`; changed files lint clean