### PR TITLE
🐛 Fixed LinkedIn company and school URLs with underscores being rejected as invalid

### DIFF
--- a/apps/admin/src/settings/utils/social-urls/linkedin.ts
+++ b/apps/admin/src/settings/utils/social-urls/linkedin.ts
@@ -4,11 +4,17 @@ import type { UsernameRule } from './platform-validator';
 // validation info: https://www.linkedin.com/help/linkedin/answer/a542685/manage-your-public-profile-url?lang=en
 // Letters and numbers in any language (company/school slugs and vanity URLs
 // can contain accented characters — see ONC-1856), hyphens, 3–100 characters.
+// Personal /in/ and /pub/ profiles: alphanumeric (any script) and hyphen only.
+// Company and school pages also allow underscores (e.g. /company/some_company).
 const LINKEDIN_USERNAME_RULE: UsernameRule = {
   unicode: true,
   extra: '-',
   min: 3,
   max: 100,
+};
+const LINKEDIN_COMPANY_USERNAME_RULE: UsernameRule = {
+  ...LINKEDIN_USERNAME_RULE,
+  extra: '-_',
 };
 
 // /in/ profiles are stored as a bare handle; the other path types keep their
@@ -25,8 +31,8 @@ const linkedin = createPlatformValidator({
       storagePrefix: 'pub/',
       rule: { ...LINKEDIN_USERNAME_RULE, nestedSegments: true },
     },
-    { urlPrefix: 'company/', storagePrefix: 'company/', rule: LINKEDIN_USERNAME_RULE },
-    { urlPrefix: 'school/', storagePrefix: 'school/', rule: LINKEDIN_USERNAME_RULE },
+    { urlPrefix: 'company/', storagePrefix: 'company/', rule: LINKEDIN_COMPANY_USERNAME_RULE },
+    { urlPrefix: 'school/', storagePrefix: 'school/', rule: LINKEDIN_COMPANY_USERNAME_RULE },
   ],
   errors: {
     invalidUrl: 'The URL must be in a format like https://www.linkedin.com/in/yourUsername',

--- a/apps/admin/src/settings/utils/social-urls/social-urls.test.ts
+++ b/apps/admin/src/settings/utils/social-urls/social-urls.test.ts
@@ -472,6 +472,10 @@ const FIXTURES: PlatformFixture[] = [
       ['linkedin.com/in/山田太郎', 'https://www.linkedin.com/in/山田太郎'],
       // decomposed accents (e + combining acute) normalise to composed form
       ['linkedin.com/in/josé-garcia', 'https://www.linkedin.com/in/josé-garcia'],
+      // company/school pages allow underscores; personal /in/ does not
+      ['https://www.linkedin.com/company/eyeshot_2/', 'https://www.linkedin.com/company/eyeshot_2'],
+      ['linkedin.com/company/some_company', 'https://www.linkedin.com/company/some_company'],
+      ['linkedin.com/school/some_school', 'https://www.linkedin.com/school/some_school'],
     ],
     invalid: [
       ['https://twitter.com/johnsmith', LINKEDIN_URL_ERROR],
@@ -484,6 +488,7 @@ const FIXTURES: PlatformFixture[] = [
       ['linkedin.com/in/john%20smith', LINKEDIN_USERNAME_ERROR], // percent-encoded space
       ['linkedin.com/in/john%3Fsmith', LINKEDIN_USERNAME_ERROR], // percent-encoded ?
       ['linkedin.com/in/john%2smith', LINKEDIN_USERNAME_ERROR], // malformed percent-encoding
+      ['linkedin.com/in/john_smith', LINKEDIN_USERNAME_ERROR], // underscores not allowed on /in/
       // a leftover '@' after the 'company/' prefix mixes two
       // incompatible URL conventions and is rejected, not silently stripped
       ['linkedin.com/company/@acme', LINKEDIN_USERNAME_ERROR],
@@ -496,6 +501,8 @@ const FIXTURES: PlatformFixture[] = [
       ['in/johnsmith', 'https://www.linkedin.com/in/johnsmith'],
       ['company/ghost-foundation', 'https://www.linkedin.com/company/ghost-foundation'],
       ['company/ghost-foundation/', 'https://www.linkedin.com/company/ghost-foundation'],
+      ['company/eyeshot_2', 'https://www.linkedin.com/company/eyeshot_2'],
+      ['school/some_school', 'https://www.linkedin.com/school/some_school'],
       ['pub/johnsmith/12/34/567', 'https://www.linkedin.com/pub/johnsmith/12/34/567'],
       [
         'company/la-revue-européenne-des-médias-et-du-numérique',
@@ -506,6 +513,7 @@ const FIXTURES: PlatformFixture[] = [
       ['john@smith', LINKEDIN_USERNAME_ERROR],
       ['john#smith', LINKEDIN_USERNAME_ERROR],
       ['john.smith', LINKEDIN_USERNAME_ERROR], // dots are not allowed on linkedin
+      ['john_smith', LINKEDIN_USERNAME_ERROR], // underscores not allowed on personal handles
       ['jo', LINKEDIN_USERNAME_ERROR], // too short
       ['a'.repeat(101), LINKEDIN_USERNAME_ERROR], // too long
       ['company/@acme', LINKEDIN_USERNAME_ERROR],
@@ -524,6 +532,7 @@ const FIXTURES: PlatformFixture[] = [
       ['linkedin.com/pub/johnsmith/12/34/567', 'pub/johnsmith/12/34/567'],
       ['https://www.linkedin.com/company/ghost-foundation', 'company/ghost-foundation'],
       ['https://www.linkedin.com/company/ghost-foundation/', 'company/ghost-foundation'],
+      ['https://www.linkedin.com/company/eyeshot_2/', 'company/eyeshot_2'],
       ['linkedin.com/school/mit', 'school/mit'],
       [
         'https://www.linkedin.com/company/la-revue-europ%C3%A9enne-des-m%C3%A9dias-et-du-num%C3%A9rique/',


### PR DESCRIPTION
## Summary
- LinkedIn company/school profile URLs that contain underscores (e.g. `https://www.linkedin.com/company/eyeshot_2/`) were rejected with "Your Username is not a valid LinkedIn Username"
- Company and school path types now use a username rule that allows `_` in addition to hyphens; personal `/in/` and `/pub/` profiles stay hyphen-only
- Adds coverage for `eyeshot_2` / underscore company+school URLs, and for rejecting underscores on personal handles

## History
This is not a new limitation — an earlier fix never landed after the social-validator refactor.

| PR | Intent | Outcome |
|---|---|---|
| [#28893](https://github.com/TryGhost/Ghost/pull/28893) | Allow `_` in company/school URLs — used exactly `eyeshot_2` as the example | Closed as “fixed in #29051” |
| [#29022](https://github.com/TryGhost/Ghost/pull/29022) | Unicode / accented company slugs | Closed in favour of #29051 |
| [#29051](https://github.com/TryGhost/Ghost/pull/29051) | Wholesale social-validator refactor | Merged — fixed **unicode**, not underscores |

`#29051` only covered the unicode issue (`ONC-1856` / `#29022`). Closing `#28893` as fixed was a miss: the refactor set `extra: '-'` (hyphen only) and never added `_`. `#28893` itself cannot be revived — it patches the pre-refactor `admin-x-settings` validator/tests that no longer exist.

## Test plan
- [x] `pnpm test:unit src/settings/utils/social-urls/social-urls.test.ts` (100 passed)
- [x] Confirm Settings → Social accounts accepts `https://www.linkedin.com/company/eyeshot_2/`
- [x] Confirm personal `/in/john_smith` is still rejected