### PR TITLE
Fixed the admin acceptance specs racing the unsaved-changes guard

### DIFF
--- a/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
@@ -7,6 +7,7 @@ import {
   member,
   renderAdminApp,
   type Member,
+  unsavedChangesGuarded,
 } from '@test-utils/acceptance';
 import { membersScreen } from '@/members/members.screen';
 import { memberDetailScreen } from './member-detail.screen';
@@ -39,6 +40,7 @@ describe('Member detail leave guard', () => {
     await renderAdminApp(`/members/${m.id}`);
 
     await memberDetailScreen.nameInput().fill('Ada B');
+    await expect.poll(unsavedChangesGuarded).toBe(true);
     await memberDetailScreen.backLink().click();
 
     await expect.element(memberDetailScreen.leaveConfirmationText()).toBeVisible();
@@ -50,6 +52,7 @@ describe('Member detail leave guard', () => {
     await renderAdminApp(`/members/${m.id}`);
 
     await memberDetailScreen.nameInput().fill('Ada B');
+    await expect.poll(unsavedChangesGuarded).toBe(true);
     await sidebarScreen.shellNav().getByRole('link', { name: 'Members' }).click();
 
     await expect.element(memberDetailScreen.leaveConfirmationText()).toBeVisible();
@@ -61,9 +64,13 @@ describe('Member detail leave guard', () => {
     await renderAdminApp(`/members/${m.id}`);
 
     await memberDetailScreen.nameInput().fill('Ada B');
+    await expect.poll(unsavedChangesGuarded).toBe(true);
     await sidebarScreen.shellNav().getByRole('link', { name: 'Members' }).click();
 
     await memberDetailScreen.stayButton().click();
+    // The dismissed dialog outlives the click, so re-triggering the guard
+    // without waiting it out clicks Leave on the instance already going away.
+    await expect(memberDetailScreen.leaveConfirmationText()).toHaveCount(0);
     await expect.element(memberDetailScreen.nameInput()).toHaveValue('Ada B');
 
     await sidebarScreen.shellNav().getByRole('link', { name: 'Members' }).click();
@@ -81,14 +88,13 @@ describe('Member detail leave guard', () => {
     await membersScreen.link('Ada Lovelace').click();
     await expect.poll(currentRoute).toMatch(new RegExp(`^/members/${m.id}`));
     await memberDetailScreen.nameInput().fill('Ada B');
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
-    });
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.back();
 
     await expect.element(memberDetailScreen.leaveConfirmationText()).toBeVisible();
     await memberDetailScreen.stayButton().click();
+    await expect(memberDetailScreen.leaveConfirmationText()).toHaveCount(0);
     await expect.poll(currentRoute).toMatch(new RegExp(`^/members/${m.id}`));
     await expect.element(memberDetailScreen.nameInput()).toHaveValue('Ada B');
 
@@ -108,6 +114,7 @@ describe('Member detail leave guard', () => {
     await membersScreen.link('Ada Lovelace').click();
     await expect.poll(currentRoute).toMatch(new RegExp(`^/members/${m.id}`));
     await memberDetailScreen.nameInput().fill('Ada B');
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.back();
 

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -6,14 +6,10 @@ import {
   fakeAnalyticsOverview,
   fakeSettingsScreens,
   renderAdminApp,
+  unsavedChangesGuarded,
 } from '@test-utils/acceptance';
 import { settingsScreen } from './settings.screen';
 import { fakeStaffWorld } from './general/staff.test-helpers';
-
-const flushEffects = () =>
-  new Promise<void>((resolve) => {
-    requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
-  });
 
 // Settings navigations are real router pushes; these specs pin the history
 // semantics the router swap introduced.
@@ -41,9 +37,7 @@ describe('Settings navigation history', () => {
     await expect.element(modal).toBeVisible();
     await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
     await modal.getByLabelText('Location').fill('Somewhere new');
-    // The dirty flag reaches the history blocker through passive effects
-    // (dialog → global dirty state → guard re-render); let them flush.
-    await flushEffects();
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.back();
 
@@ -67,16 +61,22 @@ describe('Settings navigation history', () => {
     const modal = settingsScreen.userDetailModal();
     await modal.getByRole('button', { name: 'Close' }).click();
     await expect.poll(currentRoute).toBe('/settings/staff');
+    // The URL leads the router, so the dialog this spec reopens is still on
+    // screen here. Without waiting it out, the fill below can land on the
+    // instance that is about to unmount and the edit goes nowhere.
+    await expect(modal).toHaveCount(0);
 
     window.history.back();
     await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
+    await expect.element(modal).toBeVisible();
     await modal.getByLabelText('Location').fill('Somewhere new');
-    await flushEffects();
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.forward();
 
     await expect.element(settingsScreen.confirmationModal()).toHaveTextContent(/leave/i);
     await settingsScreen.confirmationAction('Stay').click();
+    await expect(settingsScreen.confirmationModal()).toHaveCount(0);
     await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}`);
     await expect.element(modal).toBeVisible();
 
@@ -96,7 +96,7 @@ describe('Settings navigation history', () => {
     const modal = settingsScreen.userDetailModal();
     await expect.element(modal).toBeVisible();
     await modal.getByLabelText('Location').fill('Somewhere new');
-    await flushEffects();
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.back();
 
@@ -114,7 +114,7 @@ describe('Settings navigation history', () => {
     await modal.getByLabelText('Location').fill('Somewhere new');
     await modal.getByRole('tab', { name: 'Social Links' }).click();
     await expect.poll(currentRoute).toBe(`/settings/staff/${currentUser.slug}/social-links`);
-    await flushEffects();
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.back();
 

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -11,6 +11,7 @@ import {
   renderAdminApp,
   tag,
   type Tag,
+  unsavedChangesGuarded,
 } from '@test-utils/acceptance';
 import { sidebarScreen } from '@/layout/sidebar.screen';
 import { tagsScreen } from '@/tags/tags.screen';
@@ -311,6 +312,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
     await expect.element(tagDetailScreen.savedButton()).toBeVisible();
 
     await tagDetailScreen.descriptionInput().fill('A later edit');
+    await expect.poll(unsavedChangesGuarded).toBe(true);
     await tagDetailScreen.backLink().click();
 
     await expect.element(tagDetailScreen.leaveConfirmationText()).toBeVisible();
@@ -658,11 +660,15 @@ describe('Tag detail (tagDetailsReact on)', () => {
     await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
     await tagDetailScreen.nameInput().fill('Renamed');
+    await expect.poll(unsavedChangesGuarded).toBe(true);
     await tagDetailScreen.backLink().click();
 
     // The dialog carries Ember's ConfirmUnsavedChangesModal copy.
     await expect.element(tagDetailScreen.leaveConfirmationText()).toBeVisible();
     await tagDetailScreen.stayButton().click();
+    // The dismissed dialog outlives the click, so re-triggering the guard
+    // without waiting it out clicks Leave on the instance already going away.
+    await expect(tagDetailScreen.leaveConfirmationText()).toHaveCount(0);
     await expect.element(tagDetailScreen.nameInput()).toHaveValue('Renamed');
 
     await tagDetailScreen.backLink().click();
@@ -683,14 +689,13 @@ describe('Tag detail history guard', () => {
     await tagsScreen.tagRows().getByRole('link', { name: 'News' }).click();
     await expect.poll(currentRoute).toBe('/tags/news');
     await tagDetailScreen.nameInput().fill('Renamed');
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve)));
-    });
+    await expect.poll(unsavedChangesGuarded).toBe(true);
 
     window.history.back();
 
     await expect.element(tagDetailScreen.leaveConfirmationText()).toBeVisible();
     await tagDetailScreen.stayButton().click();
+    await expect(tagDetailScreen.leaveConfirmationText()).toHaveCount(0);
     await expect.poll(currentRoute).toBe('/tags/news');
     await expect.element(tagDetailScreen.nameInput()).toHaveValue('Renamed');
 

--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -25,6 +25,10 @@ await expect.poll(currentRoute).toBe("/members");   // URL assertions
 await expect.poll(() => document.documentElement.classList.contains("dark")).toBe(true);   // DOM state no locator reaches
 ```
 
+**The URL leads the app.** `currentRoute` reads the address bar, which the browser updates before the router has re-rendered — so a route assertion says where the app is going, not what is on screen. That is fine for asserting the URL, and wrong as a cue to act: after `window.history.back()` or a dialog close, wait for the screen itself (`await expect(dialog).toHaveCount(0)`, `await expect.element(dialog).toBeVisible()`). A spec that reopens the same dialog, or dismisses a confirmation and triggers it again, will otherwise act on the instance that is on its way out — the click lands, the departing copy takes it, and nothing happens.
+
+**Unsaved-changes guards.** Typing into a dirty screen arms its navigation guard through a chain of passive effects, so a spec that navigates straight after a `fill` races the guard and an unguarded navigation just goes through. Wait for the guard itself, never for a frame count: `await expect.poll(unsavedChangesGuarded).toBe(true)` before the click or `window.history.back()`.
+
 **One render per test.** Each `renderAdminApp` gets a fresh QueryClient and the fake API resets between tests — there is no reload. State that would be persisted on a real server (user preferences, settings) is _represented_ by boot overrides; a journey that genuinely needs persistence across reloads belongs in `e2e/`.
 
 **Host page.** `renderAdminApp` mounts into a stand-in of the production host page (the `react-admin` body class + `#root` from index.html), so the shell's viewport-bounded grid applies and scroll-driven behaviors — virtualized lists, infinite paging — work like production.

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -54,6 +54,7 @@ export {
 } from './tinybird';
 export type { TinybirdPipeCapture, TinybirdPipeQuery } from './tinybird';
 export { fakeAdminStats } from './stats';
+export { unsavedChangesGuarded } from './unsaved-changes-guard';
 
 // Test-data re-exports, so a spec needs a single import surface.
 export {

--- a/apps/admin/test-utils/acceptance/unsaved-changes-guard.ts
+++ b/apps/admin/test-utils/acceptance/unsaved-changes-guard.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether the app would currently stop you leaving with unsaved changes.
+ *
+ * Typing into a dirty screen arms its navigation guard through a chain of
+ * passive effects — input, dirty state, guard re-render, blocker registration
+ * — and none of it has landed by the time a `fill` resolves. A spec that
+ * navigates straight afterwards races the guard, and an unguarded navigation
+ * simply goes through: no dialog, and the assertion times out on a screen that
+ * has already left.
+ *
+ * Both guards (`useUnsavedChangesGuard` and settings' `DirtyNavigationGuard`)
+ * register the `beforeunload` prompt alongside the router blocker, from the
+ * same commit, so a cancelable probe event asks the app the question directly
+ * rather than guessing how many frames the chain needs:
+ *
+ * ```ts
+ * await nameInput().fill('Renamed');
+ * await expect.poll(unsavedChangesGuarded).toBe(true);
+ * window.history.back();
+ * ```
+ *
+ * The fake API drops MSW's own `beforeunload` teardown so the probe can't stop
+ * it (see startFakeApi).
+ */
+export function unsavedChangesGuarded(): boolean {
+  const probe = new Event('beforeunload', { cancelable: true });
+  window.dispatchEvent(probe);
+  return probe.defaultPrevented;
+}

--- a/apps/admin/test-utils/acceptance/worker.ts
+++ b/apps/admin/test-utils/acceptance/worker.ts
@@ -468,11 +468,35 @@ export async function startFakeApi({
 
   trackInFlightRequests(worker);
 
-  await worker.start({
-    serviceWorker: { url: '/mockServiceWorker.js' },
-    onUnhandledRequest: 'bypass',
-    quiet: true,
-  });
+  // MSW stops its service worker on `beforeunload`. Nothing here ever unloads
+  // the page — vitest disposes it — so that listener buys this tier nothing,
+  // and it actively hurts: a spec reads the app's unsaved-changes guard by
+  // dispatching a synthetic `beforeunload` (see unsavedChangesGuarded), which
+  // would take the fake API down with it. Drop it as the worker registers it,
+  // then put back exactly what was there — the browser runner installs its own
+  // addEventListener, and discarding it silently breaks error reporting.
+  const installed = Object.getOwnPropertyDescriptor(window, 'addEventListener');
+  const addListener = window.addEventListener.bind(window);
+  window.addEventListener = function (type: string, ...rest: unknown[]) {
+    if (type === 'beforeunload') {
+      return;
+    }
+    (addListener as (...args: unknown[]) => void)(type, ...rest);
+  } as typeof window.addEventListener;
+
+  try {
+    await worker.start({
+      serviceWorker: { url: '/mockServiceWorker.js' },
+      onUnhandledRequest: 'bypass',
+      quiet: true,
+    });
+  } finally {
+    if (installed) {
+      Object.defineProperty(window, 'addEventListener', installed);
+    } else {
+      Reflect.deleteProperty(window, 'addEventListener');
+    }
+  }
 
   return worker;
 }


### PR DESCRIPTION
On main, an admin acceptance spec failed in CI: it hit the browser's forward button on a screen with unsaved edits, expecting the "you have unsaved changes" dialog, and no dialog appeared. Two separate races were behind it, and the specs papered over both by waiting a fixed number of animation frames and hoping — which holds on a quiet machine and does not on a loaded CI runner.

The first is that admin does not arm that guard the instant you type. The keystroke has to reach the screen's record of being edited, which re-renders the guard, which then registers itself with the router. Measured, the guard is still not armed when the typing step finishes, so a spec that navigates immediately afterwards can slip past it. The fix is to wait for a fact instead of a duration: a screen that guards navigation also asks the browser to confirm before the tab closes, and it sets both of those up together, so the specs now dispatch a synthetic close-the-tab event and check whether the app objects. That says precisely when the guard is live.

The second only showed up once the first was fixed and the failure became loud instead of silent. The specs used a route assertion as their cue to act, but that reads the address bar, which the browser updates before the app has re-rendered — so it says where the app is going, not what is on screen. A spec that closes a dialog and reopens it could therefore type into the copy that was already on its way out; the edit went nowhere and the screen never became dirty at all. The same shape appears wherever a spec dismisses a confirmation and immediately triggers it again, clicking a button on the instance already going away. Every one of those now waits for the departing dialog to actually be gone, and the rule is written into the harness guide, since the trap is in what a route assertion means rather than in any one spec.

One knock-on: the fake API the suite runs against also shuts itself down when the page is closing, so it now ignores the probe.

To verify, delaying the guard's arming by a fraction of a second makes the old specs fail exactly the way CI did while the new ones stay green; the dialog outliving its route assertion reproduces directly, with no load needed; and the whole admin acceptance suite passes, repeatedly and under CPU contention.

https://claude.ai/code/session_01HjrKZqSXQ54LgAsX1VMzQp
