### PR TITLE
Removed the permission to read member custom field definitions

### DIFF
--- a/ghost/core/core/server/api/endpoints/member-metafields.ts
+++ b/ghost/core/core/server/api/endpoints/member-metafields.ts
@@ -1,4 +1,5 @@
 import { actingContext, definitions } from '../../services/members-metafields';
+import { assertDefinable } from '../../services/members-metafields/namespaces';
 
 const permissionsService = require('../../services/permissions');
 
@@ -10,11 +11,28 @@ interface Frame {
   options: { namespace: string; key: string; context: unknown; [key: string]: unknown };
 }
 
-// With `permissions: true` the framework checks against the Bookshelf model named after
-// the resource. These fields have no Bookshelf model, so each handler asks the permissions
-// service directly.
+// Reading a definition needs no permission. A definition says only that the site collects
+// a shoe size, and every signed-in member is already shown the whole list, so there is
+// nothing here to keep from staff. Defining one is the publisher's own, and with
+// `permissions: true` the framework would check against the Bookshelf model named after
+// the resource — these fields have no Bookshelf model, so each writing handler asks the
+// permissions service directly.
 function canThis(frame: Frame) {
   return permissionsService.canThis(frame.options.context);
+}
+
+/**
+ * Settle the namespace before the caller.
+ *
+ * Which namespace is being written to decides whose authority applies, so it is resolved
+ * first; only once the publisher turns out to own it does a staff role become the
+ * question. The other order answers a request to define a field somewhere nobody owns
+ * with "you lack a permission", which sends the caller after a permission that would not
+ * have helped.
+ */
+async function canDefine(frame: Frame, action: (frame: Frame) => Promise<unknown>) {
+  assertDefinable(frame.options.namespace);
+  return action(frame);
 }
 
 const noCacheInvalidation = { cacheInvalidate: false };
@@ -26,9 +44,7 @@ const controller = {
     headers: noCacheInvalidation,
     options: ['namespace', 'filter'],
     validation: { options: { namespace: { required: true } } },
-    permissions(frame: Frame) {
-      return canThis(frame).browse.member_custom_field();
-    },
+    permissions: false,
     query(frame: Frame) {
       return definitions!.browse({
         namespace: frame.options.namespace,
@@ -41,9 +57,7 @@ const controller = {
     headers: noCacheInvalidation,
     options: ['namespace', 'key'],
     validation: { options: { namespace: { required: true }, key: { required: true } } },
-    permissions(frame: Frame) {
-      return canThis(frame).read.member_custom_field(frame.options.key);
-    },
+    permissions: false,
     query(frame: Frame) {
       return definitions!.read(frame.options.namespace, frame.options.key);
     },
@@ -55,7 +69,7 @@ const controller = {
     options: ['namespace'],
     validation: { options: { namespace: { required: true } } },
     permissions(frame: Frame) {
-      return canThis(frame).add.member_custom_field();
+      return canDefine(frame, (f) => canThis(f).add.member_custom_field());
     },
     query(frame: Frame) {
       return definitions!.add(
@@ -71,7 +85,7 @@ const controller = {
     options: ['namespace'],
     validation: { options: { namespace: { required: true } } },
     permissions(frame: Frame) {
-      return canThis(frame).edit.member_custom_field();
+      return canDefine(frame, (f) => canThis(f).edit.member_custom_field());
     },
     query(frame: Frame) {
       return definitions!.reorder(
@@ -87,7 +101,7 @@ const controller = {
     options: ['namespace', 'key'],
     validation: { options: { namespace: { required: true }, key: { required: true } } },
     permissions(frame: Frame) {
-      return canThis(frame).edit.member_custom_field(frame.options.key);
+      return canDefine(frame, (f) => canThis(f).edit.member_custom_field(f.options.key));
     },
     query(frame: Frame) {
       return definitions!.edit(
@@ -105,7 +119,7 @@ const controller = {
     options: ['namespace', 'key'],
     validation: { options: { namespace: { required: true }, key: { required: true } } },
     permissions(frame: Frame) {
-      return canThis(frame).destroy.member_custom_field(frame.options.key);
+      return canDefine(frame, (f) => canThis(f).destroy.member_custom_field(f.options.key));
     },
     async query(frame: Frame) {
       await definitions!.destroy(

--- a/ghost/core/core/server/data/migrations/versions/6.63/2026-09-03-11-03-31-remove-member-custom-field-read-permissions.js
+++ b/ghost/core/core/server/data/migrations/versions/6.63/2026-09-03-11-03-31-remove-member-custom-field-read-permissions.js
@@ -1,0 +1,30 @@
+const { combineTransactionalMigrations, createRemovePermissionMigration } = require('../../utils');
+
+const RESOURCE = 'member_custom_field';
+
+// Reading a field definition is no longer a permission. A definition says a site collects
+// a shoe size; every signed-in member already sees the whole list through Portal, so
+// gating staff behind a role protected nothing and inverted the two halves: an integration
+// holding `member: browse` received members' field values on the member payload, which
+// never consults this permission, while a request for the definitions describing those
+// values was refused.
+//
+// What remains on this resource is defining fields, which stays with the publisher.
+module.exports = combineTransactionalMigrations(
+  createRemovePermissionMigration(
+    {
+      name: 'Browse member custom fields',
+      action: 'browse',
+      object: RESOURCE,
+    },
+    ['Administrator', 'Admin Integration', 'Super Editor'],
+  ),
+  createRemovePermissionMigration(
+    {
+      name: 'Read member custom fields',
+      action: 'read',
+      object: RESOURCE,
+    },
+    ['Administrator', 'Admin Integration', 'Super Editor'],
+  ),
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -516,16 +516,6 @@
           "object_type": "label"
         },
         {
-          "name": "Browse member custom fields",
-          "action_type": "browse",
-          "object_type": "member_custom_field"
-        },
-        {
-          "name": "Read member custom fields",
-          "action_type": "read",
-          "object_type": "member_custom_field"
-        },
-        {
           "name": "Edit member custom fields",
           "action_type": "edit",
           "object_type": "member_custom_field"
@@ -1069,7 +1059,6 @@
           "collection": "all",
           "recommendation": ["browse", "read"],
           "member": ["browse", "read", "add", "edit", "destroy"],
-          "member_custom_field": ["browse", "read"],
           "member_signin_url": "read",
           "offer": ["browse", "read"],
           "comment": "all",

--- a/ghost/core/core/server/services/members-metafields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-metafields/definitions-service.ts
@@ -6,6 +6,7 @@ import { Metafield } from './models';
 import { FieldTypeSchema, type FieldType } from '@tryghost/metafield-types';
 import { CUSTOM_NAMESPACE } from '@tryghost/metafield-types/identity';
 import { metafieldCodec } from './codec';
+import { assertDefinable } from './namespaces';
 import { FIELD_STATUS, FieldStatusSchema } from './schema';
 import { ADMIN, readableFields, type Audience } from './access';
 import { activeFields, fieldByKey, inFieldOrder, type DefinitionQuery } from './queries';
@@ -133,15 +134,6 @@ export class MetafieldDefinitionsService {
     return namespace === CUSTOM_NAMESPACE;
   }
 
-  private assertDefinable(namespace: string): void {
-    if (!this.isStored(namespace)) {
-      throw new errors.ValidationError({
-        message: `Fields cannot be defined in the "${namespace}" namespace.`,
-        property: 'namespace',
-      });
-    }
-  }
-
   async browse(
     options: { namespace?: string; filter?: string } = {},
     audience: Audience = ADMIN,
@@ -192,7 +184,7 @@ export class MetafieldDefinitionsService {
    * key get distinct ones, exactly as if they had arrived as separate requests.
    */
   async add(context: RequestContext, namespace: string, input: unknown): Promise<Metafield[]> {
-    this.assertDefinable(namespace);
+    assertDefinable(namespace);
     const requestedCount = Array.isArray(input) ? input.length : 0;
 
     const parsed = AddFieldsInput.safeParse(input);
@@ -399,7 +391,7 @@ export class MetafieldDefinitionsService {
    * Returns every definition, archived included, matching what the request named.
    */
   async reorder(context: RequestContext, namespace: string, input: unknown): Promise<Metafield[]> {
-    this.assertDefinable(namespace);
+    assertDefinable(namespace);
     const parsed = ReorderInput.safeParse(input);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];

--- a/ghost/core/core/server/services/members-metafields/namespaces.ts
+++ b/ghost/core/core/server/services/members-metafields/namespaces.ts
@@ -1,0 +1,29 @@
+import errors from '@tryghost/errors';
+import { CUSTOM_NAMESPACE } from '@tryghost/metafield-types/identity';
+
+/**
+ * Who may define fields in a namespace.
+ *
+ * This is a property of the namespace, not of whoever is asking, so it is settled before
+ * any question about the caller. Asking the caller first gets the order wrong in a way
+ * that shows: a request to define a field in a namespace nobody owns would be refused for
+ * want of a permission, telling the caller to go and get one, when no permission would
+ * have helped.
+ *
+ * The publisher owns `custom` and nothing owns anything else yet. An app owning its own
+ * namespace resolves here too, and will not resolve to a permission at all: the caller
+ * has to *be* that app rather than hold a role, which is why the staff permission stays
+ * named after the publisher's fields rather than after metafields at large.
+ */
+export function definableByPublisher(namespace: string): boolean {
+  return namespace === CUSTOM_NAMESPACE;
+}
+
+export function assertDefinable(namespace: string): void {
+  if (!definableByPublisher(namespace)) {
+    throw new errors.ValidationError({
+      message: `Fields cannot be defined in the "${namespace}" namespace.`,
+      property: 'namespace',
+    });
+  }
+}

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -2230,7 +2230,7 @@ describe('Member Custom Fields Admin API', function () {
 
   describe('Authorization', function () {
     // The full role matrix is pinned in migration.test.js; here we only prove
-    // the endpoint enforces the permission — a role without it is rejected.
+    // the endpoint enforces the permission — a role without it may look but not touch.
     beforeAll(async function () {
       await agent.loginAsEditor();
     });
@@ -2239,8 +2239,9 @@ describe('Member Custom Fields Admin API', function () {
       await agent.loginAsOwner();
     });
 
-    it('forbids a role without permission from browsing', async function () {
-      await agent.get('members/metafields/custom/').expectStatus(403);
+    it('lets a role without permission read what the site collects', async function () {
+      await agent.get('members/metafields/custom/').expectStatus(200);
+      await agent.get('members/metafields/custom/company/').expectStatus(404);
     });
 
     it('forbids a role without permission from creating', async function () {
@@ -2255,6 +2256,17 @@ describe('Member Custom Fields Admin API', function () {
         .put('members/metafields/custom/')
         .body({ members_metafields: [{ key: 'topic' }] })
         .expectStatus(403);
+    });
+
+    it('answers for the namespace before it answers for the caller', async function () {
+      // Nobody can define a field here, so the namespace is the reason and the role is
+      // beside the point. Answering 403 would send this caller after a permission that
+      // would not have helped them.
+      const { body } = await agent
+        .post('members/metafields/shopify/')
+        .body({ members_metafields: [{ name: 'Topic', type: 'short_text' }] })
+        .expectStatus(422);
+      assert.match(body.errors[0].context, /shopify/);
     });
   });
 

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -87,7 +87,7 @@ describe('Migrations', function () {
     // Custom assertion to wrap all permissions
     function assertCompletePermissions(permissions) {
       // If you have to change this number, please add the relevant `assertHavePermission` checks below
-      assert.equal(permissions.length, 143);
+      assert.equal(permissions.length, 141);
 
       assertHavePermission(permissions, 'Export database', [
         'Administrator',
@@ -477,16 +477,6 @@ describe('Migrations', function () {
         'Super Editor',
       ]);
 
-      assertHavePermission(permissions, 'Browse member custom fields', [
-        'Administrator',
-        'Admin Integration',
-        'Super Editor',
-      ]);
-      assertHavePermission(permissions, 'Read member custom fields', [
-        'Administrator',
-        'Admin Integration',
-        'Super Editor',
-      ]);
       assertHavePermission(permissions, 'Add member custom fields', [
         'Administrator',
         'Admin Integration',

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -398,7 +398,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 150;
+            const FIXTURE_COUNT = 149;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -38,7 +38,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
 describe('DB version integrity', function () {
   // Only these variables should need updating
   const currentSchemaHash = '29d413d3d965639382e8506d5db877d2';
-  const currentFixturesHash = '1727a789194847da33d68dd95301b416';
+  const currentFixturesHash = '5718e0d4eb037f159c312369e949829a';
   const currentSettingsHash = '6ea42a00cca61a1ba87f66eb6e25a78a';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -547,16 +547,6 @@
                     "object_type": "label"
                 },
                 {
-                    "name": "Browse member custom fields",
-                    "action_type": "browse",
-                    "object_type": "member_custom_field"
-                },
-                {
-                    "name": "Read member custom fields",
-                    "action_type": "read",
-                    "object_type": "member_custom_field"
-                },
-                {
                     "name": "Edit member custom fields",
                     "action_type": "edit",
                     "object_type": "member_custom_field"
@@ -1261,7 +1251,6 @@
                     "recommendation": ["browse", "read"],
                     "member": ["browse", "read", "add", "edit", "destroy"],
                     "member_signin_url": "read",
-                    "member_custom_field": ["browse", "read"],
                     "offer": ["browse", "read"],
                     "comment": "all",
                     "gift_link": "manage"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3922/rename-the-code-behind-the-metafields-api-to-match-the-domain-language

## Background

Ghost lets a publisher define extra fields on their member records — a shoe size, a company name. A **definition** records that the site collects a shoe size; a **value** is what one member entered for it. Definitions are grouped under a **namespace** naming whoever owns them. The publisher's namespace is `custom`, the only one today; others are intended for installed apps.

Ghost guards these with a permission called `member_custom_field`, carrying five actions: browse, read, add, edit and destroy. Administrators and Admin Integrations hold all five. The Super Editor role holds browse and read, and nothing else.

## Problem 1: the read permission protects nothing, and is inverted

A definition records only that the site collects a shoe size. Every signed-in member is already shown the complete list of them through Portal, Ghost's member-facing interface. So withholding that list from staff keeps back nothing that is not already on offer elsewhere.

It is also the wrong way round. An integration holding permission to browse members receives those members' field *values* on the member payload — that code path never consults this permission. The same integration asking for the definitions that describe those values is refused. It can read the data but not the schema.

The HTTP routes already draw the correct line, and do so deliberately: reads are not behind the feature flag, so Admin can ask any site for the list and get an empty one back, while everything that changes something is behind it. Only the permission layer had not caught up.

## Problem 2: two checks run in the wrong order

Defining a field requires two things to be true: fields must be definable in the namespace named in the URL, and the caller must be allowed to define them. Ghost asked the second question first.

So a request naming a namespace that nobody can define fields in was refused for want of a permission. That answer sends the caller off to acquire a permission that nobody holds and that would not have helped them, when the real answer is that the namespace was never writable by anyone.

## Solution

**Reads need no permission.** The browse and read handlers stop checking one. The two permission records are removed from Ghost's fixtures, along with the Super Editor grant, which consisted of nothing else. A migration removes both from sites that already have them. What remains on the permission is defining a field, which stays with the publisher.

**The namespace settles before the caller.** That check moves out of the definitions service into a module of its own, and the endpoint runs it first. A namespace nobody can define in is now refused on that ground, naming the namespace, whatever role the caller holds.

## Consequence worth noting

Staff reads widen from Super Editor and above to any authenticated staff member. This is intended: a Contributor can now see a list that any signed-in member could already see.

## Why the permission keeps its name

It governs who may define fields in the publisher's namespace, and it will only ever govern that. Other namespaces are to be owned by installed apps, and an app managing its own fields does not hold a staff role — it has to *be* that app, which is an ownership check rather than a permission check. Naming this permission after metafields generally would claim an authority it is never going to have.

The new namespace module is where that ownership check will live.

## Verification

The migration replay test passes against both MySQL and SQLite, along with the metafields suites and the fixture and schema integrity checks. Three existing tests changed to match the new behaviour, and one was added pinning the new ordering: a role without the define permission, naming a namespace nobody owns, is now told about the namespace rather than about a permission.

## Where this sits

| | |
|---|---|
| #30492 | shared field-type package |
| #30494 | database tables and columns |
| #30495 | server-side service and its types |
| **this PR** | permission to read and define fields |

Last of four. Stacked on #30495, on #30494, on #30492 — review those first. Merging this one brings the whole stack in.

https://claude.ai/code/session_01XFCbqgYHYhd9rZ5WXtqZyT
