### PR TITLE
✨ Released Admin 7 page chrome

### DIFF
--- a/apps/admin/src/analytics/analytics.acceptance.test.tsx
+++ b/apps/admin/src/analytics/analytics.acceptance.test.tsx
@@ -161,10 +161,7 @@ describe('Analytics overview', () => {
   it('uses Admin 7 typography in the portalled trend tooltip', async () => {
     seedAnalyticsWorld();
     seedTopPostsViews();
-    await renderAdminApp('/analytics', {
-      labs: { admin7PageChrome: true },
-      boot: webAnalyticsBootOverrides(),
-    });
+    await renderAdminApp('/analytics', { boot: webAnalyticsBootOverrides() });
     await expect.element(analyticsScreen.membersValue()).toHaveTextContent('175');
     await expect.poll(() => document.querySelector('#root .admin7')).not.toBeNull();
     await analyticsScreen.membersCard().getByTestId('kpi-card-header-diff').hover();
@@ -179,10 +176,7 @@ describe('Analytics overview', () => {
   it('uses display font features only on Admin 7 headings', async () => {
     seedAnalyticsWorld();
     seedTopPostsViews();
-    await renderAdminApp('/analytics', {
-      labs: { admin7PageChrome: true },
-      boot: webAnalyticsBootOverrides(),
-    });
+    await renderAdminApp('/analytics', { boot: webAnalyticsBootOverrides() });
 
     await expect.element(analyticsScreen.membersValue()).toHaveTextContent('175');
     const heading = page.getByRole('heading', { name: 'Analytics' });

--- a/apps/admin/src/layout/admin-layout.tsx
+++ b/apps/admin/src/layout/admin-layout.tsx
@@ -15,7 +15,7 @@ const networkPageChrome = {
   contentGutter: 'var(--page-gutter)',
 };
 
-const admin7PageChromeClassName = [
+const pageChromeClassName = [
   'admin7:[&_.max-w-page]:max-w-(--content-width)',
   'admin7:[&_[data-list-page=list-page]]:px-(--page-gutter)',
   'admin7:[&_[data-detail-page=detail-page]]:px-(--page-gutter)',
@@ -94,7 +94,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
       <SidebarInset
         className={`overflow-y-auto bg-background sidebar:max-h-full ${sidebarVisible ? 'max-h-[calc(100%-var(--mobile-navbar-height))]' : 'max-h-full'}`}
       >
-        <main className={cn('flex-1', pageChromeEnabled && admin7PageChromeClassName)}>
+        <main className={cn('flex-1', pageChromeEnabled && pageChromeClassName)}>
           <ActivityPubHostLayoutProvider value={pageChromeEnabled ? networkPageChrome : undefined}>
             {children}
           </ActivityPubHostLayoutProvider>

--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 describe('Sidebar navigation', () => {
-  it('keeps the shell hidden until Admin 7 eligibility is known', async () => {
+  it('applies the Admin 7 shell without waiting for Labs config', async () => {
     fakeTags([]);
     let resolveConfig!: (value: ReturnType<typeof configResponse>) => void;
     const pendingConfig = new Promise<ReturnType<typeof configResponse>>((resolve) => {
@@ -71,14 +71,13 @@ describe('Sidebar navigation', () => {
       document.querySelector('[data-sidebar="sidebar"]')?.closest('.group\\/sidebar-wrapper');
     await expect.poll(getShell).toBeTruthy();
     const shell = getShell()!;
-    expect(shell).toHaveClass('invisible');
-
-    resolveConfig(configResponse({ labs: { admin7PageChrome: true } }));
-    await expect.poll(() => shell?.classList.contains('invisible')).toBe(false);
+    expect(shell).not.toHaveClass('invisible');
     expect(shell).toHaveClass('admin7');
+
+    resolveConfig(configResponse());
   });
 
-  it('shows the existing shell when Admin 7 config cannot be loaded', async () => {
+  it('applies the Admin 7 shell when config cannot be loaded', async () => {
     fakeTags([]);
     await renderAdminApp('/tags', {
       boot: {
@@ -95,7 +94,7 @@ describe('Sidebar navigation', () => {
         ?.closest('[class~="group/sidebar-wrapper"]');
     await expect.poll(getShell).toBeTruthy();
     await expect.poll(() => getShell()?.classList.contains('invisible')).toBe(false);
-    expect(getShell()).not.toHaveClass('admin7');
+    expect(getShell()).toHaveClass('admin7');
   });
 
   it('uses default preferences when accessibility JSON is malformed', async () => {
@@ -103,10 +102,7 @@ describe('Sidebar navigation', () => {
     const me = currentUserResponse();
     me.users[0].accessibility = '{invalid json';
 
-    await renderAdminApp('/tags', {
-      labs: { admin7PageChrome: true },
-      boot: { browseMe: { response: me } },
-    });
+    await renderAdminApp('/tags', { boot: { browseMe: { response: me } } });
 
     const getShell = () =>
       document
@@ -125,10 +121,7 @@ describe('Sidebar navigation', () => {
       nightShift: 'light',
     });
 
-    await renderAdminApp('/tags', {
-      labs: { admin7PageChrome: true },
-      boot: { browseMe: { response: me } },
-    });
+    await renderAdminApp('/tags', { boot: { browseMe: { response: me } } });
 
     await expect.element(sidebarScreen.shellNav()).toBeVisible();
     await expect.poll(() => document.querySelector('.admin7')).not.toBeNull();
@@ -141,10 +134,7 @@ describe('Sidebar navigation', () => {
     const me = currentUserResponse();
     me.users[0].accessibility = JSON.stringify({ nightShift: 'dark' });
 
-    await renderAdminApp('/tags', {
-      labs: { admin7PageChrome: true },
-      boot: { browseMe: { response: me } },
-    });
+    await renderAdminApp('/tags', { boot: { browseMe: { response: me } } });
 
     await expect.poll(() => document.documentElement.classList.contains('dark')).toBe(true);
     await expect.poll(() => document.querySelector('.admin7')).not.toBeNull();
@@ -153,7 +143,7 @@ describe('Sidebar navigation', () => {
 
   it('applies Admin 7 typography to legacy alert and notification portals', async () => {
     fakeTags([]);
-    await renderAdminApp('/tags', { labs: { admin7PageChrome: true } });
+    await renderAdminApp('/tags');
     await expect.poll(() => document.querySelector('.admin7')).not.toBeNull();
 
     const shell = document.querySelector<HTMLElement>('.admin7')!;
@@ -195,14 +185,6 @@ describe('Sidebar navigation', () => {
       marker.setAttribute('data-react-admin-mounted', '');
       bridgeHost.appendChild(emberApp);
     }
-  });
-
-  it('keeps the existing sidebar treatment when Admin 7 page chrome is disabled', async () => {
-    fakeTags([]);
-    await renderAdminApp('/tags', { labs: { admin7PageChrome: false } });
-
-    await expect.element(sidebarScreen.shellNav()).toBeVisible();
-    expect(document.querySelector('.admin7')).toBeNull();
   });
 
   it('renders the navigation for the current user', async () => {

--- a/apps/admin/src/layout/use-admin7.ts
+++ b/apps/admin/src/layout/use-admin7.ts
@@ -1,5 +1,4 @@
 import { useLocation } from '@tryghost/admin-x-framework';
-import { useBrowseConfig } from '@tryghost/admin-x-framework/api/config';
 import { useIsMobile } from '@tryghost/shade/utils';
 import { useThemeContext } from '@/providers/theme-context';
 
@@ -9,16 +8,11 @@ interface Admin7Eligibility {
 }
 
 export function useAdmin7({ hasNavigation, isEligibleUser }: Admin7Eligibility) {
-  const { data: config, isPending: isConfigPending } = useBrowseConfig({
-    refetchOnMount: false,
-  });
-  const flagEnabled = config?.config.labs?.admin7PageChrome === true;
   const isMobile = useIsMobile();
   const { isThemeReady } = useThemeContext();
   const { pathname } = useLocation();
-  const isReady =
-    !isEligibleUser || isMobile || (!isConfigPending && (!flagEnabled || isThemeReady));
-  const enabled = flagEnabled && isEligibleUser && !isMobile && isThemeReady;
+  const isReady = !isEligibleUser || isMobile || isThemeReady;
+  const enabled = isEligibleUser && !isMobile && isThemeReady;
   const isSettings = /^\/settings(?:\/|$)/.test(pathname);
 
   return {

--- a/apps/admin/src/members/import-members-gate.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-gate.acceptance.test.tsx
@@ -39,7 +39,7 @@ describe('Import members gate', () => {
   it.each([false, true])(
     'inherits portal typography in the import flow (redesigned: %s)',
     async (membersImportRedesign) => {
-      await openMappingStep({ admin7PageChrome: true, membersImportRedesign });
+      await openMappingStep({ membersImportRedesign });
       const modal = membersScreen.dialog();
       await expect.element(modal).toBeVisible();
       expect(modal.element().closest('#root')).toBeNull();

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -131,7 +131,6 @@ describe('Post analytics overview', () => {
   it('applies the Admin 7 chrome on post analytics', async () => {
     seedPostAnalyticsWorld();
     await renderAdminApp(`/posts/analytics/${POST_ID}`, {
-      labs: { admin7PageChrome: true },
       boot: webAnalyticsBootOverrides(),
     });
     await expect.element(postAnalyticsScreen.postTitle('Attack of the Clones')).toBeVisible();

--- a/apps/admin/src/settings/advanced/advanced.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/advanced.acceptance.test.tsx
@@ -38,58 +38,6 @@ function advancedSettings(overrides: Record<string, string | boolean | null>) {
 }
 
 describe('Advanced settings', () => {
-  it('offers the page chrome toggle only in developer experiments', async () => {
-    fakeSettingsScreens();
-    const response = configResponse();
-    response.config.enableDeveloperExperiments = false;
-    await renderAdminApp('/settings/labs', { boot: { browseConfig: { response } } });
-
-    const section = settingsScreen.section('labs');
-    await section.getByRole('button', { name: 'Open' }).click();
-    await expect
-      .element(section.getByRole('tab', { name: 'Private features' }))
-      .not.toBeInTheDocument();
-    await expect
-      .element(section.getByRole('switch', { name: 'Admin 7 page chrome' }))
-      .not.toBeInTheDocument();
-  });
-
-  it('saves the private page chrome flag without changing other Labs settings', async () => {
-    fakeSettingsScreens();
-    const settingsApi = fakeEditSettings();
-    const labs = { admin7PageChrome: false, tagsX: true };
-    const response = configResponse();
-    response.config.enableDeveloperExperiments = true;
-    await renderAdminApp('/settings/labs', { labs, boot: { browseConfig: { response } } });
-
-    const section = settingsScreen.section('labs');
-    await section.getByRole('button', { name: 'Open' }).click();
-    await section.getByRole('tab', { name: 'Private features' }).click();
-    const toggle = section.getByRole('switch', { name: 'Admin 7 page chrome' });
-    await expect.element(toggle).not.toBeChecked();
-    await toggle.click();
-    await expect(settingsApi).toHaveEditedSettings([
-      {
-        key: 'labs',
-        value: String(
-          settingsResponse({ labs: { ...labs, admin7PageChrome: true } }).settings.find(
-            (setting) => setting.key === 'labs',
-          )!.value,
-        ),
-      },
-    ]);
-    await expect.element(toggle).toBeChecked();
-    await toggle.click();
-    await expect(settingsApi).toHaveEditedSettings([
-      {
-        key: 'labs',
-        value: String(
-          settingsResponse({ labs }).settings.find((setting) => setting.key === 'labs')!.value,
-        ),
-      },
-    ]);
-  });
-
   it('treats an absent React editor flag as off and allows enabling it', async () => {
     fakeSettingsScreens();
     const settingsApi = fakeEditSettings();

--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -45,11 +45,6 @@ const features: Feature[] = [
     flag: 'adminUIRefresh',
   },
   {
-    title: 'Admin 7 page chrome',
-    description: 'Enable the new Admin page chrome on desktop in light mode.',
-    flag: 'admin7PageChrome',
-  },
-  {
     title: 'Tags X',
     description: 'Enables the new Tags UI',
     flag: 'tagsX',

--- a/apps/admin/src/settings/layout.acceptance.test.tsx
+++ b/apps/admin/src/settings/layout.acceptance.test.tsx
@@ -14,58 +14,46 @@ import {
 import { settingsScreen } from './settings.screen';
 
 describe('Settings layout', () => {
-  it.each([true, false])(
-    'uses Admin 7 typography in Settings only when enabled (%s)',
-    async (enabled) => {
-      fakeSettingsScreens();
-      await renderAdminApp('/settings', { labs: { admin7PageChrome: enabled } });
+  it('uses Admin 7 typography in Settings without page chrome', async () => {
+    fakeSettingsScreens();
+    await renderAdminApp('/settings');
 
-      await expect.element(settingsScreen.search()).toBeVisible();
-      const heading = page.getByRole('heading', { name: 'General settings', exact: true }).first();
-      const titleAndDescriptionEdit = settingsScreen
-        .titleAndDescription()
-        .getByRole('button', { name: 'Edit' });
-      await expect.element(titleAndDescriptionEdit).toBeVisible();
-      const elements = [
-        ...page.getByRole('heading', { name: 'General settings', exact: true }).elements(),
-        settingsScreen.search().element(),
-        titleAndDescriptionEdit.element(),
-      ];
-      for (const element of elements) {
-        await expect
-          .poll(() => getComputedStyle(element).fontFamily.includes('Inter Admin 7'))
-          .toBe(enabled);
-      }
-      if (enabled) {
-        const headingFeatures = getComputedStyle(heading.element()).fontFeatureSettings;
-        const searchFeatures = getComputedStyle(
-          settingsScreen.search().element(),
-        ).fontFeatureSettings;
-        expect(headingFeatures).toContain('dlig');
-        expect(headingFeatures).toContain('cv05');
-        expect(searchFeatures).not.toContain('dlig');
-        expect(searchFeatures).not.toContain('cv05');
-      }
-      expect(document.querySelector('.admin7') !== null).toBe(enabled);
-      expect(
-        getComputedStyle(document.querySelector('#root > div')!).getPropertyValue(
-          '--content-width',
-        ),
-      ).toBe('');
-      expect(getComputedStyle(document.body).fontFamily).not.toContain('Inter Admin 7');
-      await expect.element(settingsScreen.sidebar()).toBeVisible();
-      await expect.element(settingsScreen.exitButton()).toBeVisible();
-    },
-  );
+    await expect.element(settingsScreen.search()).toBeVisible();
+    const heading = page.getByRole('heading', { name: 'General settings', exact: true }).first();
+    const titleAndDescriptionEdit = settingsScreen
+      .titleAndDescription()
+      .getByRole('button', { name: 'Edit' });
+    await expect.element(titleAndDescriptionEdit).toBeVisible();
+    const elements = [
+      ...page.getByRole('heading', { name: 'General settings', exact: true }).elements(),
+      settingsScreen.search().element(),
+      titleAndDescriptionEdit.element(),
+    ];
+    for (const element of elements) {
+      await expect
+        .poll(() => getComputedStyle(element).fontFamily.includes('Inter Admin 7'))
+        .toBe(true);
+    }
+    const headingFeatures = getComputedStyle(heading.element()).fontFeatureSettings;
+    const searchFeatures = getComputedStyle(settingsScreen.search().element()).fontFeatureSettings;
+    expect(headingFeatures).toContain('dlig');
+    expect(headingFeatures).toContain('cv05');
+    expect(searchFeatures).not.toContain('dlig');
+    expect(searchFeatures).not.toContain('cv05');
+    expect(document.querySelector('.admin7')).not.toBeNull();
+    expect(
+      getComputedStyle(document.querySelector('#root > div')!).getPropertyValue('--content-width'),
+    ).toBe('');
+    expect(getComputedStyle(document.body).fontFamily).not.toContain('Inter Admin 7');
+    await expect.element(settingsScreen.sidebar()).toBeVisible();
+    await expect.element(settingsScreen.exitButton()).toBeVisible();
+  });
 
   it('uses Admin 7 typography without page chrome in dark mode', async () => {
     fakeSettingsScreens();
     const me = currentUserResponse();
     me.users[0].accessibility = JSON.stringify({ nightShift: 'dark' });
-    await renderAdminApp('/settings', {
-      labs: { admin7PageChrome: true },
-      boot: { browseMe: { response: me } },
-    });
+    await renderAdminApp('/settings', { boot: { browseMe: { response: me } } });
     await expect.element(settingsScreen.search()).toBeVisible();
     await expect.poll(() => document.documentElement.classList.contains('dark')).toBe(true);
     expect(getComputedStyle(settingsScreen.search().element()).fontFamily).toContain(
@@ -79,7 +67,7 @@ describe('Settings layout', () => {
 
   it('limits Settings typography to desktop without opting into page chrome', async () => {
     fakeSettingsScreens();
-    await renderAdminApp('/settings', { labs: { admin7PageChrome: true } });
+    await renderAdminApp('/settings');
     await expect.element(settingsScreen.search()).toBeVisible();
     const hasNewFont = () =>
       getComputedStyle(settingsScreen.search().element()).fontFamily.includes('Inter Admin 7');
@@ -148,7 +136,6 @@ describe('Settings layout', () => {
     fakeSettingsScreens();
     fakeTiers([tier({ name: 'Supporter' })]);
     await renderAdminApp('/settings/portal/edit', {
-      labs: { admin7PageChrome: true },
       boot: {
         browseSettings: {
           response: settingsResponse({

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -46,7 +46,6 @@ const PRIVATE_FEATURES = [
   'importMemberTier',
   'csvContentImporter',
   'adminUIRefresh',
-  'admin7PageChrome',
   'tagsX',
   'emailUniqueid',
   'improveSendingUI',

--- a/ghost/core/test/e2e-api/admin/config.test.js
+++ b/ghost/core/test/e2e-api/admin/config.test.js
@@ -61,9 +61,6 @@ describe('Config API', function () {
             labsValues.every((value) => typeof value === 'boolean'),
             'expected all labs flags to be booleans',
           );
-          // Fixture setup enables every registered writable flag. Keep an
-          // explicit assertion while this private rollout uses dynamic snapshots.
-          assert.equal(labs.admin7PageChrome, true);
         })
         .matchHeaderSnapshot({
           'content-version': anyContentVersion,

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -32,18 +32,6 @@ describe('Labs Service', function () {
     await configUtils.restore();
   });
 
-  it('keeps page chrome opt-in and respects an explicit rollback override', function () {
-    const getStub = sinon.stub(settingsCache, 'get');
-    getStub.withArgs('labs').returns({});
-    assert.equal(labs.isSet('admin7PageChrome'), false);
-
-    getStub.withArgs('labs').returns({ admin7PageChrome: true });
-    assert.equal(labs.isSet('admin7PageChrome'), true);
-
-    configUtils.set('labs', { admin7PageChrome: false });
-    assert.equal(labs.isSet('admin7PageChrome'), false);
-  });
-
   it('can getAll, even if empty with enabled members', function () {
     assert.deepEqual(
       labs.getAll(),


### PR DESCRIPTION
## What changed

Milestone 1 of the [Admin 7.0 project](https://linear.app/ghost/project/admin-70-3ca7c71a645b/overview) has completed private dogfooding. This makes the new desktop Admin shell and typography the default for eligible users.

- Removes `admin7PageChrome` from the Core Labs allowlist and Admin private-features UI.
- Removes the Labs config dependency from the Admin 7 rollout boundary.
- Deletes the obsolete flag-off assertions and updates coverage to prove the shell works while Labs config is pending or unavailable.
- Preserves the existing mobile, contributor, and Settings page-chrome boundaries.

## Testing

- [x] Admin acceptance: sidebar navigation (29 tests)
- [x] Admin acceptance: Settings layout (7 tests)
- [x] Admin acceptance: advanced settings (21 tests)
- [x] Admin acceptance: analytics, post analytics, and members import (33 tests)
- [x] Core Labs unit tests (19 tests)
- [x] Core Admin config and settings API tests (36 tests)
- [x] Targeted Admin/Core ESLint and dependency checks
- [x] Formatting check

Package-wide Admin lint/typecheck remains blocked by existing errors in unchanged `src/settings/membership/tiers/tier-checkout-collection.tsx`.

- [x] I have read and followed the Contributor Guide
- [x] I have explained my change
- [x] I have written automated tests to prove my change works