### PR TITLE
Added URL overrides for Admin Labs flags

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-feature-flag.ts
+++ b/apps/admin-x-framework/src/hooks/use-feature-flag.ts
@@ -1,11 +1,14 @@
 import { useBrowseConfig } from '../api/config';
+import { useFeatureFlagOverrides } from '../providers/feature-flag-overrides-context';
 
 /**
- * Returns whether a Labs flag is explicitly enabled. Only boolean `true`
- * counts — `false` while config is loading, missing, or failed.
- * Avoids refetching stale config when a feature-gated component mounts.
+ * Returns whether a Labs flag is explicitly enabled by config or the current
+ * session's URL overrides. Only boolean `true` config values count. Avoids
+ * refetching stale config when a feature-gated component mounts.
  */
 export const useFeatureFlag = (flag: string): boolean => {
   const { data: config } = useBrowseConfig({ refetchOnMount: false });
-  return config?.config.labs?.[flag] === true;
+  const { enabledFlags } = useFeatureFlagOverrides();
+
+  return config?.config.labs?.[flag] === true || enabledFlags.includes(flag);
 };

--- a/apps/admin-x-framework/src/providers/feature-flag-overrides-context.ts
+++ b/apps/admin-x-framework/src/providers/feature-flag-overrides-context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+interface FeatureFlagOverridesContextValue {
+  enabledFlags: string[];
+}
+
+export const FeatureFlagOverridesContext = createContext<FeatureFlagOverridesContextValue>({
+  enabledFlags: [],
+});
+
+export const useFeatureFlagOverrides = () => useContext(FeatureFlagOverridesContext);

--- a/apps/admin-x-framework/src/providers/framework-provider.tsx
+++ b/apps/admin-x-framework/src/providers/framework-provider.tsx
@@ -44,6 +44,8 @@ export interface FrameworkProviderProps {
   onUpdate: (dataType: string, response: unknown) => void;
   onInvalidate: (dataType: string) => void;
   onDelete: (dataType: string, id: string) => void;
+  // Called after URL overrides are synced to sessionStorage. May return cleanup work.
+  onFeatureFlagOverridesChange?: () => void | (() => void);
 
   // Optional QueryClient override. Defaults to the shared window-level
   // singleton; test harnesses pass a fresh client per render for isolation.

--- a/apps/admin-x-framework/src/providers/router-provider.tsx
+++ b/apps/admin-x-framework/src/providers/router-provider.tsx
@@ -37,8 +37,13 @@ export interface RouterProviderProps {
 
 function FeatureFlagOverridesRouteProvider({ children }: { children: React.ReactNode }) {
   const { search } = useLocation();
+  const { onFeatureFlagOverridesChange } = useFramework();
   const enabledFlags = useMemo(() => syncFeatureFlagOverrides(search), [search]);
   const value = useMemo(() => ({ enabledFlags }), [enabledFlags]);
+
+  useEffect(() => {
+    return onFeatureFlagOverridesChange?.();
+  }, [enabledFlags, onFeatureFlagOverridesChange]);
 
   return (
     <FeatureFlagOverridesContext.Provider value={value}>

--- a/apps/admin-x-framework/src/providers/router-provider.tsx
+++ b/apps/admin-x-framework/src/providers/router-provider.tsx
@@ -12,6 +12,8 @@ import {
 import { useFramework } from './framework-provider';
 import { NavigationStackProvider } from './navigation-stack-provider';
 import { ErrorPage } from '@tryghost/shade/primitives';
+import { syncFeatureFlagOverrides } from '../utils/feature-flag-overrides';
+import { FeatureFlagOverridesContext } from './feature-flag-overrides-context';
 
 /**
  * This provider uses React Router to provide a router context to React apps
@@ -31,6 +33,18 @@ export interface RouterProviderProps {
   // Custom routing props
   errorElement?: React.ReactNode;
   children?: React.ReactNode;
+}
+
+function FeatureFlagOverridesRouteProvider({ children }: { children: React.ReactNode }) {
+  const { search } = useLocation();
+  const enabledFlags = useMemo(() => syncFeatureFlagOverrides(search), [search]);
+  const value = useMemo(() => ({ enabledFlags }), [enabledFlags]);
+
+  return (
+    <FeatureFlagOverridesContext.Provider value={value}>
+      {children}
+    </FeatureFlagOverridesContext.Provider>
+  );
 }
 
 // Store scroll positions globally
@@ -100,7 +114,11 @@ export function RouterProvider({ routes, prefix, errorElement, children }: Route
     // Create a root route that wraps all routes with NavigationStackProvider
     // and any additional children (providers) so they have access to routing
     const rootRoute: RouteObject = {
-      element: <NavigationStackProvider>{children}</NavigationStackProvider>,
+      element: (
+        <FeatureFlagOverridesRouteProvider>
+          <NavigationStackProvider>{children}</NavigationStackProvider>
+        </FeatureFlagOverridesRouteProvider>
+      ),
       hydrateFallbackElement: <></>,
       children: routes.map((route) => ({
         ...route,

--- a/apps/admin-x-framework/src/utils/feature-flag-overrides.ts
+++ b/apps/admin-x-framework/src/utils/feature-flag-overrides.ts
@@ -1,0 +1,46 @@
+const LABS_QUERY_PARAM = 'labs';
+const LABS_STORAGE_KEY = 'ghost-admin:labs-overrides';
+
+const getUrlFeatureFlags = (searchParams: URLSearchParams): string[] => {
+  return searchParams
+    .getAll(LABS_QUERY_PARAM)
+    .flatMap((value) => value.split(','))
+    .filter(Boolean);
+};
+
+export const getStoredFeatureFlagOverrides = (): string[] => {
+  try {
+    const storedFlags: unknown = JSON.parse(sessionStorage.getItem(LABS_STORAGE_KEY) ?? '[]');
+
+    if (!Array.isArray(storedFlags)) {
+      return [];
+    }
+
+    return storedFlags.filter((flag): flag is string => typeof flag === 'string');
+  } catch {
+    return [];
+  }
+};
+
+export const syncFeatureFlagOverrides = (search: string): string[] => {
+  const searchParams = new URLSearchParams(search);
+
+  if (!searchParams.has(LABS_QUERY_PARAM)) {
+    return getStoredFeatureFlagOverrides();
+  }
+
+  const flags = getUrlFeatureFlags(searchParams);
+
+  try {
+    if (flags.length > 0) {
+      sessionStorage.setItem(LABS_STORAGE_KEY, JSON.stringify(flags));
+    } else {
+      sessionStorage.removeItem(LABS_STORAGE_KEY);
+    }
+  } catch {
+    // Storage can be unavailable in restricted browser environments. The URL
+    // override still applies to the current React render in that case.
+  }
+
+  return flags;
+};

--- a/apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts
@@ -4,10 +4,15 @@ import { useFeatureFlag } from '../../../src/hooks/use-feature-flag';
 vi.mock('../../../src/api/config', () => ({
   useBrowseConfig: vi.fn(),
 }));
+vi.mock('../../../src/providers/feature-flag-overrides-context', () => ({
+  useFeatureFlagOverrides: vi.fn(),
+}));
 
 import { useBrowseConfig } from '../../../src/api/config';
+import { useFeatureFlagOverrides } from '../../../src/providers/feature-flag-overrides-context';
 
 const mockUseBrowseConfig = useBrowseConfig as any;
+const mockUseFeatureFlagOverrides = vi.mocked(useFeatureFlagOverrides);
 
 const withLabs = (labs: Record<string, unknown>) => ({
   data: { config: { labs } },
@@ -16,6 +21,7 @@ const withLabs = (labs: Record<string, unknown>) => ({
 describe('useFeatureFlag', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseFeatureFlagOverrides.mockReturnValue({ enabledFlags: [] });
   });
 
   it('returns true when the flag is explicitly true', () => {
@@ -60,6 +66,24 @@ describe('useFeatureFlag', () => {
 
   it('returns false when the flag value is truthy but not boolean true', () => {
     mockUseBrowseConfig.mockReturnValue(withLabs({ myFlag: 'true' }));
+
+    const { result } = renderHook(() => useFeatureFlag('myFlag'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('enables a flag when the session override enables it', () => {
+    mockUseBrowseConfig.mockReturnValue(withLabs({ myFlag: false }));
+    mockUseFeatureFlagOverrides.mockReturnValue({ enabledFlags: ['myFlag'] });
+
+    const { result } = renderHook(() => useFeatureFlag('myFlag'));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the session override does not enable the flag', () => {
+    mockUseBrowseConfig.mockReturnValue(withLabs({ myFlag: false }));
+    mockUseFeatureFlagOverrides.mockReturnValue({ enabledFlags: ['otherFlag'] });
 
     const { result } = renderHook(() => useFeatureFlag('myFlag'));
 

--- a/apps/admin-x-framework/test/unit/providers/router-provider.test.tsx
+++ b/apps/admin-x-framework/test/unit/providers/router-provider.test.tsx
@@ -1,7 +1,34 @@
 import { StrictMode } from 'react';
 import { render, waitFor } from '@testing-library/react';
-import { Navigate } from '../../../src/providers/router-provider';
+import { Navigate, RouterProvider } from '../../../src/providers/router-provider';
 import { TestWrapper } from '../../../src/test/test-utils';
+
+describe('feature flag overrides', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    window.location.hash = '';
+  });
+
+  it('notifies the host after storing URL overrides', async () => {
+    window.location.hash = '#/?labs=testFlag';
+    const onFeatureFlagOverridesChange = vi.fn(() => {
+      expect(sessionStorage.getItem('ghost-admin:labs-overrides')).toBe('["testFlag"]');
+    });
+
+    render(
+      <TestWrapper frameworkProps={{ onFeatureFlagOverridesChange }}>
+        <RouterProvider prefix="/" routes={[{ path: '/', element: <div>Home</div> }]} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => expect(onFeatureFlagOverridesChange).toHaveBeenCalled());
+  });
+});
 
 describe('Navigate', () => {
   it('performs cross-app navigation once after mounting in Strict Mode', async () => {

--- a/apps/admin-x-framework/test/unit/utils/feature-flag-overrides.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/feature-flag-overrides.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getStoredFeatureFlagOverrides,
+  syncFeatureFlagOverrides,
+} from '../../../src/utils/feature-flag-overrides';
+
+describe('feature flag overrides', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('stores flags listed in the labs query parameter', () => {
+    expect(syncFeatureFlagOverrides('?labs=testFlag,secondFlag')).toEqual([
+      'testFlag',
+      'secondFlag',
+    ]);
+    expect(getStoredFeatureFlagOverrides()).toEqual(['testFlag', 'secondFlag']);
+  });
+
+  it('supports repeated labs query parameters', () => {
+    expect(syncFeatureFlagOverrides('?labs=testFlag&labs=secondFlag')).toEqual([
+      'testFlag',
+      'secondFlag',
+    ]);
+  });
+
+  it('uses stored overrides when the URL has no labs parameter', () => {
+    syncFeatureFlagOverrides('?labs=testFlag');
+
+    expect(syncFeatureFlagOverrides('?page=2')).toEqual(['testFlag']);
+  });
+
+  it('replaces stored overrides when the URL specifies new flags', () => {
+    syncFeatureFlagOverrides('?labs=testFlag');
+
+    expect(syncFeatureFlagOverrides('?labs=secondFlag')).toEqual(['secondFlag']);
+    expect(getStoredFeatureFlagOverrides()).toEqual(['secondFlag']);
+  });
+
+  it('clears stored overrides for an empty labs parameter', () => {
+    syncFeatureFlagOverrides('?labs=testFlag');
+
+    expect(syncFeatureFlagOverrides('?labs=')).toEqual([]);
+    expect(getStoredFeatureFlagOverrides()).toEqual([]);
+  });
+
+  it('ignores malformed stored overrides', () => {
+    sessionStorage.setItem('ghost-admin:labs-overrides', '{invalid');
+
+    expect(getStoredFeatureFlagOverrides()).toEqual([]);
+  });
+});

--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -44,6 +44,7 @@ function createMockStateBridge(sidebarVisible = true) {
     onUpdate: vi.fn(),
     onInvalidate: vi.fn(),
     onDelete: vi.fn(),
+    refreshFeatureFlagOverrides: vi.fn(),
     isFeatureEnabled: vi.fn().mockReturnValue(false),
     on,
     off,
@@ -638,6 +639,22 @@ describe('theme bridge helpers', () => {
 });
 
 describe('emberMutationHandlers', () => {
+  test('waits for Ember to load before refreshing feature flag overrides', async () => {
+    vi.useFakeTimers();
+    const { emberMutationHandlers } = await import('./ember-bridge');
+
+    const stopWaiting = emberMutationHandlers.onFeatureFlagOverridesChange();
+    const mock = createMockStateBridge();
+    window.EmberBridge = { state: mock.stateBridge };
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(mock.stateBridge.refreshFeatureFlagOverrides).toHaveBeenCalledTimes(1);
+    stopWaiting();
+  });
+
   test('resolves the bridge at call time, not import time', async () => {
     // Import first, install the bridge after: forwarding must still work.
     const { emberMutationHandlers } = await import('./ember-bridge');

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -23,6 +23,7 @@ export interface StateBridge {
   onUpdate: (dataType: string, response: unknown) => void;
   onInvalidate: (dataType: string) => void;
   onDelete: (dataType: string, id: string) => void;
+  refreshFeatureFlagOverrides?: () => void;
   isFeatureEnabled?: (name: string) => boolean | undefined;
   preloadAdminThemeStylesheet?: () => Promise<void>;
   applyAdminThemePreference?: (mode: AdminThemeMode) => Promise<void> | void;
@@ -315,11 +316,15 @@ export function applyEmberAdminThemePreference(mode: AdminThemeMode): boolean {
 }
 
 /**
- * React -> Ember mutation sync handlers for the FrameworkProvider. Each
- * forwards a successful React mutation to Ember's store sync and no-ops when
- * the bridge is absent (standalone React).
+ * React -> Ember handlers for the FrameworkProvider. Feature flag overrides
+ * wait for Ember to load; mutation handlers no-op when the bridge is absent.
  */
 export const emberMutationHandlers = {
+  onFeatureFlagOverridesChange: (): (() => void) => {
+    return waitForStateBridge((stateBridge) => {
+      stateBridge.refreshFeatureFlagOverrides?.();
+    });
+  },
   onUpdate: (dataType: string, response: unknown): void => {
     window.EmberBridge?.state.onUpdate(dataType, response);
   },

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -35,6 +35,7 @@ afterEach(async () => {
   } finally {
     resetFakeApi();
     resetDeclaredResources();
+    sessionStorage.clear();
     window.location.hash = '';
     verifyNoUnhandledRequests();
   }

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -20,7 +20,9 @@ function getStoredFeatureFlagOverrides() {
 
 export function feature(name, options = {}) {
     let {user, onChange} = options;
-    let watchedProps = user ? [`accessibility.${name}`] : [`config.${name}`, `labs.${name}`, 'router.currentURL'];
+    let watchedProps = user
+        ? [`accessibility.${name}`]
+        : [`config.${name}`, `labs.${name}`, '_featureFlagOverridesRevision'];
 
     return computed.apply(Ember, watchedProps.concat({
         get() {
@@ -57,7 +59,6 @@ export default class FeatureService extends Service {
     @service ghostPaths;
     @service lazyLoader;
     @service notifications;
-    @service router;
     @service session;
     @service settings;
     @service store;
@@ -102,6 +103,11 @@ export default class FeatureService extends Service {
     @feature('postsListReact') postsListReact;
     @feature('editorReact') editorReact;
     _user = null;
+    _featureFlagOverridesRevision = 0;
+
+    refreshFeatureFlagOverrides() {
+        this.incrementProperty('_featureFlagOverridesRevision');
+    }
 
     @computed('settings.labs')
     get labs() {

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -6,9 +6,21 @@ import classic from 'ember-classic-decorator';
 import {computed, set} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
 
+const LABS_STORAGE_KEY = 'ghost-admin:labs-overrides';
+
+function getStoredFeatureFlagOverrides() {
+    try {
+        const storedFlags = JSON.parse(sessionStorage.getItem(LABS_STORAGE_KEY) || '[]');
+
+        return Array.isArray(storedFlags) ? storedFlags.filter(flag => typeof flag === 'string') : [];
+    } catch (e) {
+        return [];
+    }
+}
+
 export function feature(name, options = {}) {
     let {user, onChange} = options;
-    let watchedProps = user ? [`accessibility.${name}`] : [`config.${name}`, `labs.${name}`];
+    let watchedProps = user ? [`accessibility.${name}`] : [`config.${name}`, `labs.${name}`, 'router.currentURL'];
 
     return computed.apply(Ember, watchedProps.concat({
         get() {
@@ -16,6 +28,8 @@ export function feature(name, options = {}) {
 
             if (user) {
                 enabled = this.get(`accessibility.${name}`);
+            } else if (getStoredFeatureFlagOverrides().includes(name)) {
+                enabled = true;
             } else if (typeof this.get(`config.${name}`) === 'boolean') {
                 enabled = this.get(`config.${name}`);
             } else {
@@ -43,6 +57,7 @@ export default class FeatureService extends Service {
     @service ghostPaths;
     @service lazyLoader;
     @service notifications;
+    @service router;
     @service session;
     @service settings;
     @service store;

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -61,6 +61,14 @@ export default class StateBridgeService extends Service.extend(Evented) {
         this.trigger('featureFlagsChange');
     }
 
+    @action
+    refreshFeatureFlagOverrides() {
+        this.feature.refreshFeatureFlagOverrides();
+        // React route ownership subscribes to this event so it can re-read
+        // Ember's invalidated value. It does not write overrides back.
+        this.triggerFeatureFlagsChange();
+    }
+
     constructor() {
         super(...arguments);
         this.router.on('routeDidChange', this, this.handleRouteDidChange);

--- a/apps/ember-admin/tests/integration/services/feature-test.js
+++ b/apps/ember-admin/tests/integration/services/feature-test.js
@@ -108,7 +108,7 @@ describe('Integration: Service: feature', function () {
         });
     }
 
-    it('re-reads session overrides when the current route changes', async function () {
+    it('re-reads session overrides when requested by the state bridge', async function () {
         stubSettings(server, {testFlag: false});
         stubUser(server, {});
 
@@ -118,14 +118,12 @@ describe('Integration: Service: feature', function () {
         await session.populateUser();
 
         let service = this.owner.lookup('service:feature');
-        sinon.stub(service.router, 'currentURL').get(() => '/editor/post/1');
-
         await service.fetch();
         expect(service.get('labs.testFlag')).to.be.false;
         expect(service.get('testFlag')).to.be.false;
 
         sessionStorage.setItem('ghost-admin:labs-overrides', JSON.stringify(['testFlag']));
-        service.router.notifyPropertyChange('currentURL');
+        service.refreshFeatureFlagOverrides();
 
         expect(service.get('testFlag')).to.be.true;
     });

--- a/apps/ember-admin/tests/integration/services/feature-test.js
+++ b/apps/ember-admin/tests/integration/services/feature-test.js
@@ -87,6 +87,7 @@ describe('Integration: Service: feature', function () {
     beforeEach(function () {
         server = new Pretender();
         originalMatchMedia = window.matchMedia;
+        sessionStorage.clear();
     });
 
     afterEach(function () {
@@ -96,6 +97,7 @@ describe('Integration: Service: feature', function () {
             configurable: true,
             value: originalMatchMedia
         });
+        sessionStorage.clear();
         server.shutdown();
     });
 
@@ -105,6 +107,28 @@ describe('Integration: Service: feature', function () {
             value: sinon.stub().returns(mediaQuery)
         });
     }
+
+    it('re-reads session overrides when the current route changes', async function () {
+        stubSettings(server, {testFlag: false});
+        stubUser(server, {});
+
+        addTestFlag();
+
+        let session = this.owner.lookup('service:session');
+        await session.populateUser();
+
+        let service = this.owner.lookup('service:feature');
+        sinon.stub(service.router, 'currentURL').get(() => '/editor/post/1');
+
+        await service.fetch();
+        expect(service.get('labs.testFlag')).to.be.false;
+        expect(service.get('testFlag')).to.be.false;
+
+        sessionStorage.setItem('ghost-admin:labs-overrides', JSON.stringify(['testFlag']));
+        service.router.notifyPropertyChange('currentURL');
+
+        expect(service.get('testFlag')).to.be.true;
+    });
 
     it('loads labs and user settings correctly', async function () {
         stubSettings(server, {testFlag: true});

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -73,6 +73,19 @@ describe('Unit: Service: state-bridge', function () {
         });
     });
 
+    describe('#refreshFeatureFlagOverrides', function () {
+        it('refreshes Ember flags and notifies React subscribers', function () {
+            const refreshFeatureFlagOverrides = sinon.spy(feature, 'refreshFeatureFlagOverrides');
+            const featureFlagsChange = sinon.spy();
+            service.on('featureFlagsChange', featureFlagsChange);
+
+            service.refreshFeatureFlagOverrides();
+
+            expect(refreshFeatureFlagOverrides.calledOnce).to.be.true;
+            expect(featureFlagsChange.calledOnce).to.be.true;
+        });
+    });
+
     describe('#onUpdate', function () {
         it('ignores unknown data types', function () {
             run(() => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3920/

Adds URL overrides of labs flags, for example, `#/posts/analytics/:postId?labs=improveSendingUI` enables the client-side flag for that Admin session without changing site-wide settings. Multiple flags can be supplied as `labs=flagA,flagB`.

- enable comma-separated Labs flags with a labs query parameter in React and Ember Admin
- preserve the labs parameter across Admin X internal navigation
- update Ember computed flags when its current route changes
- cover both implementations with application-independent test flags

This is the first PR in a stack on top of #30465.