### PR TITLE
Added email sending status to post analytics

### DIFF
--- a/apps/admin-x-framework/src/api/emails.ts
+++ b/apps/admin-x-framework/src/api/emails.ts
@@ -1,10 +1,43 @@
-import { createMutation } from '../utils/api/hooks';
+import { createMutation, createQueryWithId } from '../utils/api/hooks';
 import { postsDataType } from './posts';
 import type { Email } from './content-types';
 
 export interface EmailsResponseType {
   emails: Email[];
 }
+
+export type EmailSendingPhase = 'preparing' | 'submitting';
+
+export interface EmailSendingProgress {
+  completed: number;
+  total: number;
+  estimated_seconds_remaining: number | null;
+}
+
+export type EmailSendingState =
+  | {
+      status: EmailSendingPhase | 'submitted';
+      progress: EmailSendingProgress;
+    }
+  | {
+      status: 'failed';
+      progress: EmailSendingProgress;
+      failed_during: EmailSendingPhase;
+    };
+
+export interface EmailSendingStatus {
+  id: string;
+  sending: EmailSendingState;
+}
+
+export interface EmailStatusesResponseType {
+  email_statuses: EmailSendingStatus[];
+}
+
+export const useEmailSendingStatus = createQueryWithId<EmailStatusesResponseType>({
+  dataType: 'EmailStatusesResponseType',
+  path: (id) => `/emails/${id}/status/`,
+});
 
 /**
  * Retry a failed email send.

--- a/apps/admin-x-framework/src/api/emails.ts
+++ b/apps/admin-x-framework/src/api/emails.ts
@@ -1,42 +1,57 @@
 import { createMutation, createQueryWithId } from '../utils/api/hooks';
 import { postsDataType } from './posts';
 import type { Email } from './content-types';
+import { z } from 'zod';
 
 export interface EmailsResponseType {
   emails: Email[];
 }
 
-export type EmailSendingPhase = 'preparing' | 'submitting';
+export const EmailSendingPhaseSchema = z.enum(['preparing', 'submitting']);
 
-export interface EmailSendingProgress {
-  completed: number;
-  total: number;
-  estimated_seconds_remaining: number | null;
-}
+export const EmailSendingProgressSchema = z.object({
+  completed: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+  estimated_seconds_remaining: z.number().int().nonnegative().nullable(),
+});
 
-export type EmailSendingState =
-  | {
-      status: EmailSendingPhase | 'submitted';
-      progress: EmailSendingProgress;
-    }
-  | {
-      status: 'failed';
-      progress: EmailSendingProgress;
-      failed_during: EmailSendingPhase;
-    };
+export const EmailSendingStateSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: EmailSendingPhaseSchema,
+    progress: EmailSendingProgressSchema,
+  }),
+  z.object({
+    status: z.literal('submitted'),
+    progress: EmailSendingProgressSchema,
+  }),
+  z.object({
+    status: z.literal('failed'),
+    progress: EmailSendingProgressSchema,
+    failed_during: EmailSendingPhaseSchema,
+  }),
+]);
 
-export interface EmailSendingStatus {
-  id: string;
-  sending: EmailSendingState;
-}
+export const EmailSendingStatusSchema = z.object({
+  id: z.string(),
+  sending: EmailSendingStateSchema,
+});
 
-export interface EmailStatusesResponseType {
-  email_statuses: EmailSendingStatus[];
-}
+export const EmailStatusesResponseSchema = z.object({
+  email_statuses: z.array(EmailSendingStatusSchema),
+});
+
+export type EmailSendingPhase = z.infer<typeof EmailSendingPhaseSchema>;
+export type EmailSendingProgress = z.infer<typeof EmailSendingProgressSchema>;
+export type EmailSendingState = z.infer<typeof EmailSendingStateSchema>;
+export type EmailSendingStatus = z.infer<typeof EmailSendingStatusSchema>;
+export type EmailStatusesResponseType = z.infer<typeof EmailStatusesResponseSchema>;
+
+const emailStatusesDataType = 'EmailStatusesResponseType';
 
 export const useEmailSendingStatus = createQueryWithId<EmailStatusesResponseType>({
-  dataType: 'EmailStatusesResponseType',
+  dataType: emailStatusesDataType,
   path: (id) => `/emails/${id}/status/`,
+  parseResponse: (data) => EmailStatusesResponseSchema.parse(data),
 });
 
 /**

--- a/apps/admin-x-framework/src/api/emails.ts
+++ b/apps/admin-x-framework/src/api/emails.ts
@@ -7,6 +7,17 @@ export interface EmailsResponseType {
   emails: Email[];
 }
 
+export const EmailBatchStatusSchema = z.enum(['pending', 'submitting', 'submitted', 'failed']);
+
+export const EmailBatchSchema = z.object({
+  id: z.string(),
+  status: EmailBatchStatusSchema,
+});
+
+export const EmailBatchesResponseSchema = z.object({
+  batches: z.array(EmailBatchSchema),
+});
+
 export const EmailSendingPhaseSchema = z.enum(['preparing', 'submitting']);
 
 export const EmailSendingProgressSchema = z.object({
@@ -45,8 +56,17 @@ export type EmailSendingProgress = z.infer<typeof EmailSendingProgressSchema>;
 export type EmailSendingState = z.infer<typeof EmailSendingStateSchema>;
 export type EmailSendingStatus = z.infer<typeof EmailSendingStatusSchema>;
 export type EmailStatusesResponseType = z.infer<typeof EmailStatusesResponseSchema>;
+export type EmailBatch = z.infer<typeof EmailBatchSchema>;
+export type EmailBatchesResponseType = z.infer<typeof EmailBatchesResponseSchema>;
 
 const emailStatusesDataType = 'EmailStatusesResponseType';
+const emailBatchesDataType = 'EmailBatchesResponseType';
+
+export const useBrowseEmailBatches = createQueryWithId<EmailBatchesResponseType>({
+  dataType: emailBatchesDataType,
+  path: (id) => `/emails/${id}/batches/`,
+  parseResponse: (data) => EmailBatchesResponseSchema.parse(data),
+});
 
 export const useEmailSendingStatus = createQueryWithId<EmailStatusesResponseType>({
   dataType: emailStatusesDataType,

--- a/apps/admin-x-framework/src/api/feedback.ts
+++ b/apps/admin-x-framework/src/api/feedback.ts
@@ -20,9 +20,9 @@ export interface FeedbackResponseType {
   feedback: FeedbackItem[];
 }
 
-const dataType = 'FeedbackResponseType';
+export const feedbackDataType = 'FeedbackResponseType';
 
 export const usePostFeedbackQuery = createQueryWithId<FeedbackResponseType>({
-  dataType,
+  dataType: feedbackDataType,
   path: (id) => `/feedback/${id}/`,
 });

--- a/apps/admin-x-framework/src/api/links.ts
+++ b/apps/admin-x-framework/src/api/links.ts
@@ -39,8 +39,10 @@ export type useBulkEditLinksParameters = {
   editedUrl: string;
 };
 
+export const linksDataType = 'LinkResponseType';
+
 export const useTopLinks = createQuery<LinkResponseType>({
-  dataType: 'LinkResponseType',
+  dataType: linksDataType,
   path: '/links/',
 });
 

--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -229,8 +229,8 @@ const memberCountHistoryDataType = 'MemberCountHistoryResponseType';
 const topPostsStatsDataType = 'TopPostsStatsResponseType';
 const postReferrersDataType = 'PostReferrersResponseType';
 const newsletterStatsDataType = 'NewsletterStatsResponseType';
-const newsletterBasicStatsDataType = 'NewsletterBasicStatsResponseType';
-const newsletterClickStatsDataType = 'NewsletterClickStatsResponseType';
+export const newsletterBasicStatsDataType = 'NewsletterBasicStatsResponseType';
+export const newsletterClickStatsDataType = 'NewsletterClickStatsResponseType';
 const newsletterSubscriberStatsDataType = 'NewsletterSubscriberStatsResponseType';
 
 const postGrowthStatsDataType = 'PostGrowthStatsResponseType';

--- a/apps/admin-x-framework/test/unit/api/emails.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/emails.test.tsx
@@ -32,13 +32,13 @@ describe('emails api', () => {
 
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-        const statusRequest = mock.calls.find(([url]) =>
-          String(url).includes('/emails/email-1/status/'),
+        const statusRequest = (mock.calls as Array<Parameters<typeof globalThis.fetch>>).find(
+          ([url]) => String(url).includes('/emails/email-1/status/'),
         );
         expect(statusRequest).toBeDefined();
         const [url, options] = statusRequest!;
         expect(new URL(url as string).pathname).toBe('/ghost/api/admin/emails/email-1/status/');
-        expect(options.method).toBe('GET');
+        expect(options?.method).toBe('GET');
         expect(result.current.data?.email_statuses[0]?.sending).toEqual({
           status: 'submitting',
           progress: {
@@ -47,6 +47,24 @@ describe('emails api', () => {
             estimated_seconds_remaining: 30,
           },
         });
+      },
+    );
+  });
+
+  it('rejects malformed email sending status responses', async () => {
+    await withMockFetch(
+      {
+        json: {},
+        headers: { 'content-type': 'application/json' },
+      },
+      async () => {
+        const { result } = renderHookWithProviders(() =>
+          useEmailSendingStatus('email-1', { defaultErrorHandler: false }),
+        );
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.data).toBeUndefined();
       },
     );
   });

--- a/apps/admin-x-framework/test/unit/api/emails.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/emails.test.tsx
@@ -1,11 +1,56 @@
-import { act } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { createTestQueryClient, renderHookWithProviders } from '../../../src/test/test-utils';
-import { useRetryEmail } from '../../../src/api/emails';
+import { useEmailSendingStatus, useRetryEmail } from '../../../src/api/emails';
 import { postsDataType } from '../../../src/api/posts';
 import { withMockFetch } from '../../utils/mock-fetch';
 
 describe('emails api', () => {
+  it('reads an email sending status via the status endpoint', async () => {
+    await withMockFetch(
+      {
+        json: {
+          users: [{ id: 'user-1', roles: [] }],
+          email_statuses: [
+            {
+              id: 'email-1',
+              sending: {
+                status: 'submitting',
+                progress: {
+                  completed: 500,
+                  total: 1000,
+                  estimated_seconds_remaining: 30,
+                },
+              },
+            },
+          ],
+        },
+        headers: { 'content-type': 'application/json' },
+      },
+      async (mock) => {
+        const { result } = renderHookWithProviders(() => useEmailSendingStatus('email-1'));
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const statusRequest = mock.calls.find(([url]) =>
+          String(url).includes('/emails/email-1/status/'),
+        );
+        expect(statusRequest).toBeDefined();
+        const [url, options] = statusRequest!;
+        expect(new URL(url as string).pathname).toBe('/ghost/api/admin/emails/email-1/status/');
+        expect(options.method).toBe('GET');
+        expect(result.current.data?.email_statuses[0]?.sending).toEqual({
+          status: 'submitting',
+          progress: {
+            completed: 500,
+            total: 1000,
+            estimated_seconds_remaining: 30,
+          },
+        });
+      },
+    );
+  });
+
   it('retries a failed email via the retry endpoint', async () => {
     await withMockFetch(
       {

--- a/apps/admin-x-framework/test/unit/api/emails.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/emails.test.tsx
@@ -1,11 +1,64 @@
 import { act, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { createTestQueryClient, renderHookWithProviders } from '../../../src/test/test-utils';
-import { useEmailSendingStatus, useRetryEmail } from '../../../src/api/emails';
+import {
+  useBrowseEmailBatches,
+  useEmailSendingStatus,
+  useRetryEmail,
+} from '../../../src/api/emails';
 import { postsDataType } from '../../../src/api/posts';
 import { withMockFetch } from '../../utils/mock-fetch';
 
 describe('emails api', () => {
+  it('reads filtered email batches via the batches endpoint', async () => {
+    await withMockFetch(
+      {
+        json: { batches: [{ id: 'batch-1', status: 'submitting' }] },
+        headers: { 'content-type': 'application/json' },
+      },
+      async (mock) => {
+        const { result } = renderHookWithProviders(() =>
+          useBrowseEmailBatches('email-1', {
+            searchParams: { filter: 'status:submitting', fields: 'id,status', limit: '1' },
+          }),
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const batchRequest = (mock.calls as Array<Parameters<typeof globalThis.fetch>>).find(
+          ([url]) => String(url).includes('/emails/email-1/batches/'),
+        );
+        expect(batchRequest).toBeDefined();
+        const [url, options] = batchRequest!;
+        const requestUrl = new URL(url as string);
+        expect(requestUrl.pathname).toBe('/ghost/api/admin/emails/email-1/batches/');
+        expect(requestUrl.searchParams.get('filter')).toBe('status:submitting');
+        expect(requestUrl.searchParams.get('fields')).toBe('id,status');
+        expect(requestUrl.searchParams.get('limit')).toBe('1');
+        expect(options?.method).toBe('GET');
+        expect(result.current.data?.batches).toEqual([{ id: 'batch-1', status: 'submitting' }]);
+      },
+    );
+  });
+
+  it('rejects malformed email batch responses', async () => {
+    await withMockFetch(
+      {
+        json: { batches: [{ id: 'batch-1', status: 'unknown' }] },
+        headers: { 'content-type': 'application/json' },
+      },
+      async () => {
+        const { result } = renderHookWithProviders(() =>
+          useBrowseEmailBatches('email-1', { defaultErrorHandler: false }),
+        );
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.data).toBeUndefined();
+      },
+    );
+  });
+
   it('reads an email sending status via the status endpoint', async () => {
     await withMockFetch(
       {

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -18,16 +18,6 @@
   }
 }
 
-.email-sending-arrow-rise {
-  animation: email-sending-arrow-rise 1200ms linear infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .email-sending-arrow-rise {
-    animation: none;
-  }
-}
-
 /* The shell owns rollout eligibility. Admin overlays mount beside #root, so
    mirror typography into Shade portals and the three legacy overlay hosts.
    Do not set body fonts or change component weights, sizes, or line heights. */
@@ -113,6 +103,7 @@
    must be generated in this Tailwind lane; the font files themselves load with
    settings/custom-fonts.css in the settings chunk. */
 @theme {
+  --animate-email-sending-arrow-rise: email-sending-arrow-rise 1200ms linear infinite;
   --font-cardo: Cardo;
   --font-manrope: Manrope;
   --font-merriweather: Merriweather;

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -8,6 +8,26 @@
 
 @custom-variant admin7 (&:where(.admin7, .admin7 *));
 
+@keyframes email-sending-arrow-rise {
+  from {
+    transform: translateY(115%);
+  }
+
+  to {
+    transform: translateY(-115%);
+  }
+}
+
+.email-sending-arrow-rise {
+  animation: email-sending-arrow-rise 1200ms linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .email-sending-arrow-rise {
+    animation: none;
+  }
+}
+
 /* The shell owns rollout eligibility. Admin overlays mount beside #root, so
    mirror typography into Shade portals and the three legacy overlay hosts.
    Do not set body fonts or change component weights, sizes, or line heights. */

--- a/apps/admin/src/posts/analytics/components/post-analytics-header.tsx
+++ b/apps/admin/src/posts/analytics/components/post-analytics-header.tsx
@@ -42,7 +42,6 @@ import { getSiteTimezone } from '@tryghost/admin-x-framework/utils/get-site-time
 import { giftAccessLabel } from '@/posts/analytics/utils/gift-link';
 import {
   isEmailOnly,
-  isPublishedAndEmailed,
   isPublishedOnly,
   trackEvent,
   useActiveVisitors,
@@ -73,13 +72,17 @@ const PostAnalyticsHeader: React.FC<PostAnalyticsHeaderProps> = ({ currentTab, c
   const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
   const { settings, site, statsConfig } = useAnalyticsData();
   const { post, isPostLoading, postId } = usePostAnalytics();
-  const { hasNewsletterAnalytics } = useEmailSendingStatusContext();
+  const { hasNewsletterAnalytics, status: emailSendingStatus } = useEmailSendingStatusContext();
   const canManageGiftLink = useCanManageGiftLink(post);
   const editorPath = `/editor/post/${postId}`;
   // Whether the editor needs a hash navigation depends on the `editorReact` flag.
   const editorIsEmberOwned = useIsEmberOwnedRoute(editorPath);
 
   const siteTimezone = getSiteTimezone(settings);
+  const isPublishedPost = post?.status === 'published';
+  const hasFailedEmail = emailSendingStatus?.sending.status === 'failed';
+  const showPublishedOnSite = isPublishedPost && (!hasNewsletterAnalytics || hasFailedEmail);
+  const showPublishedAndSent = isPublishedPost && hasNewsletterAnalytics && !hasFailedEmail;
 
   // Track once per open — canManageGiftLink can flip while the modal is open
   // (current-user query resolving), which must not re-fire the event.
@@ -289,9 +292,9 @@ const PostAnalyticsHeader: React.FC<PostAnalyticsHeaderProps> = ({ currentTab, c
                     <div className="mt-0.5 flex items-center justify-start leading-[1.65em] text-muted-foreground">
                       {isEmailOnly(post) &&
                         `Sent on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
-                      {isPublishedOnly(post) &&
+                      {showPublishedOnSite &&
                         `Published on your site on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
-                      {isPublishedAndEmailed(post) &&
+                      {showPublishedAndSent &&
                         `Published and sent on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
                     </div>
                   )}

--- a/apps/admin/src/posts/analytics/components/post-analytics-header.tsx
+++ b/apps/admin/src/posts/analytics/components/post-analytics-header.tsx
@@ -1,5 +1,6 @@
 import GiftLinkModal from '@/posts/analytics/modals/gift-link-modal';
 import PostShareModal from '@/shared/analytics/post-share-modal';
+import EmailSendingStatusBanner from '@/posts/analytics/email-sending-status/email-sending-status-banner';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertDialog,
@@ -40,7 +41,6 @@ import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-con
 import { getSiteTimezone } from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import { giftAccessLabel } from '@/posts/analytics/utils/gift-link';
 import {
-  hasBeenEmailed,
   isEmailOnly,
   isPublishedAndEmailed,
   isPublishedOnly,
@@ -55,6 +55,7 @@ import {
 import { useCanManageGiftLink } from '@/posts/analytics/hooks/use-can-manage-gift-link';
 import { useDeletePost } from '@tryghost/admin-x-framework/api/posts';
 import { useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { useEmailSendingStatusContext } from '@/posts/analytics/email-sending-status/email-sending-status-context';
 
 interface PostAnalyticsHeaderProps {
   currentTab?: string;
@@ -72,6 +73,7 @@ const PostAnalyticsHeader: React.FC<PostAnalyticsHeaderProps> = ({ currentTab, c
   const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
   const { settings, site, statsConfig } = useAnalyticsData();
   const { post, isPostLoading, postId } = usePostAnalytics();
+  const { hasNewsletterAnalytics } = useEmailSendingStatusContext();
   const canManageGiftLink = useCanManageGiftLink(post);
   const editorPath = `/editor/post/${postId}`;
   // Whether the editor needs a hash navigation depends on the `editorReact` flag.
@@ -119,7 +121,7 @@ const PostAnalyticsHeader: React.FC<PostAnalyticsHeaderProps> = ({ currentTab, c
         tabs.push('Web');
       }
     }
-    if (hasBeenEmailed(post)) {
+    if (hasNewsletterAnalytics) {
       tabs.push('Newsletter');
     }
     // Only show Growth tab if member source tracking is enabled
@@ -128,7 +130,7 @@ const PostAnalyticsHeader: React.FC<PostAnalyticsHeaderProps> = ({ currentTab, c
     }
 
     return tabs;
-  }, [post, webAnalyticsEnabled, membersTrackSources]);
+  }, [post, webAnalyticsEnabled, membersTrackSources, hasNewsletterAnalytics]);
 
   const handleDeletePost = () => {
     if (!post) {
@@ -296,6 +298,7 @@ const PostAnalyticsHeader: React.FC<PostAnalyticsHeaderProps> = ({ currentTab, c
                 </div>
               </div>
             )}
+            <EmailSendingStatusBanner />
           </div>
         </div>
       </header>

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -83,7 +83,8 @@ const failureDetail = (
 
 const EmailSendingStatusBanner = () => {
   const { post } = usePostAnalytics();
-  const { status, isRetrying, retrySending } = useEmailSendingStatusContext();
+  const { status, hasUnknownDeliveryOutcome, isRetrying, retrySending } =
+    useEmailSendingStatusContext();
   const sending = status?.sending;
 
   if (!sending || sending.status === 'submitted') {
@@ -92,7 +93,9 @@ const EmailSendingStatusBanner = () => {
 
   const isFailed = sending.status === 'failed';
   const hasSentEmails = isFailed
-    ? sending.failed_during === 'submitting' && sending.progress.completed > 0
+    ? !hasUnknownDeliveryOutcome &&
+      sending.failed_during === 'submitting' &&
+      sending.progress.completed > 0
     : false;
   const title = isFailed
     ? hasSentEmails
@@ -101,7 +104,11 @@ const EmailSendingStatusBanner = () => {
     : sending.status === 'preparing'
       ? 'Preparing emails'
       : 'Sending emails';
-  const detail = isFailed ? failureDetail(sending, post?.email?.error) : activeDetail(sending);
+  const detail = isFailed
+    ? hasUnknownDeliveryOutcome
+      ? 'Something went wrong while sending this email.'
+      : failureDetail(sending, post?.email?.error)
+    : activeDetail(sending);
   const retryLabel = hasSentEmails ? 'Send remaining emails' : 'Retry sending email';
 
   return (
@@ -126,7 +133,7 @@ const EmailSendingStatusBanner = () => {
             )}
           </Text>
         </Inline>
-        {isFailed && (
+        {isFailed && !hasUnknownDeliveryOutcome && (
           <Button
             className="shrink-0"
             disabled={isRetrying}

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -1,0 +1,142 @@
+import { Button } from '@tryghost/shade/components';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { LucideIcon, formatNumber } from '@tryghost/shade/utils';
+import { useEmailSendingStatusContext } from './email-sending-status-context';
+import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
+import type { EmailSendingState } from '@tryghost/admin-x-framework/api/emails';
+import type { ReactNode } from 'react';
+
+const formatEta = (seconds: number): string => {
+  if (seconds > 80) {
+    return `About ${formatNumber(Math.ceil(seconds / 60))} minutes left`;
+  }
+  if (seconds > 40) {
+    return 'About 1 minute left';
+  }
+  return 'Less than 1 minute left';
+};
+
+const HalfFullGlyph = () => (
+  <svg aria-hidden="true" fill="none" height="12" viewBox="0 0 12 12" width="12">
+    <path d="M1.2 6 A4.8 4.8 0 0 1 10.8 6 Z" fill="currentColor" />
+  </svg>
+);
+
+const StatusGlyph = ({ sending }: { sending: EmailSendingState }) => {
+  if (sending.status === 'preparing') {
+    return (
+      <span className="relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted-foreground text-white ring-1 ring-muted-foreground ring-offset-1 ring-offset-background">
+        <HalfFullGlyph />
+      </span>
+    );
+  }
+
+  if (sending.status === 'failed') {
+    return (
+      <span className="relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-state-danger text-white ring-1 ring-state-danger ring-offset-1 ring-offset-background">
+        <LucideIcon.X aria-hidden="true" size={12} strokeWidth={2.5} />
+      </span>
+    );
+  }
+
+  return (
+    <span className="relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-state-info text-white ring-1 ring-state-info ring-offset-1 ring-offset-background">
+      <span className="email-sending-arrow-rise">
+        <LucideIcon.ArrowUp aria-hidden="true" size={12} strokeWidth={2.5} />
+      </span>
+    </span>
+  );
+};
+
+const activeDetail = (sending: Exclude<EmailSendingState, { status: 'failed' }>): ReactNode => {
+  const { completed, total, estimated_seconds_remaining: eta } = sending.progress;
+  const estimate = eta === null ? null : formatEta(eta);
+
+  if (total === 0) {
+    return estimate;
+  }
+
+  return (
+    <>
+      <span className="inline-block min-w-[7ch] text-right">{formatNumber(completed)}</span>
+      {` of ${formatNumber(total)}`}
+      {estimate && ` · ${estimate}`}
+    </>
+  );
+};
+
+const failureDetail = (
+  sending: Extract<EmailSendingState, { status: 'failed' }>,
+  error?: string | null,
+) => {
+  const { completed, total } = sending.progress;
+  const progress =
+    completed > 0
+      ? `${formatNumber(completed)} of ${formatNumber(total)} emails were sent.`
+      : total > 0
+        ? `None of the ${formatNumber(total)} emails were sent.`
+        : 'No emails were sent.';
+
+  return error ? `${progress} ${error}` : progress;
+};
+
+const EmailSendingStatusBanner = () => {
+  const { post } = usePostAnalytics();
+  const { status, isRetrying, retrySending } = useEmailSendingStatusContext();
+  const sending = status?.sending;
+
+  if (!sending || sending.status === 'submitted') {
+    return null;
+  }
+
+  const isFailed = sending.status === 'failed';
+  const title = isFailed
+    ? sending.progress.completed > 0
+      ? 'Some emails failed to send'
+      : 'Emails failed to send'
+    : sending.status === 'preparing'
+      ? 'Preparing emails'
+      : 'Sending emails';
+  const detail = isFailed ? failureDetail(sending, post?.email?.error) : activeDetail(sending);
+  const retryLabel =
+    sending.progress.completed > 0 ? 'Send remaining emails' : 'Retry sending email';
+
+  return (
+    <Stack
+      className="rounded-lg border border-border-default bg-surface-elevated p-4"
+      data-testid="email-sending-status-banner"
+      gap="none"
+      role={isFailed ? 'alert' : 'status'}
+    >
+      <Inline align="center" gap="md" justify="between" wrap>
+        <Inline align="center" className="min-w-0" gap="sm">
+          <StatusGlyph sending={sending} />
+          <Text className="min-w-0 tabular-nums" size="sm">
+            <Text as="strong" size="sm" weight="semibold">
+              {title}
+            </Text>
+            {detail && (
+              <Text as="span" size="sm" tone="secondary">
+                {' · '}
+                {detail}
+              </Text>
+            )}
+          </Text>
+        </Inline>
+        {isFailed && (
+          <Button
+            className="shrink-0"
+            disabled={isRetrying}
+            size="sm"
+            variant="outline"
+            onClick={() => void retrySending()}
+          >
+            {isRetrying ? 'Sending…' : retryLabel}
+          </Button>
+        )}
+      </Inline>
+    </Stack>
+  );
+};
+
+export default EmailSendingStatusBanner;

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@tryghost/shade/components';
-import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { Banner, Button } from '@tryghost/shade/components';
+import { Inline, Text } from '@tryghost/shade/primitives';
 import { LucideIcon, formatNumber } from '@tryghost/shade/utils';
 import { useEmailSendingStatusContext } from './email-sending-status-context';
 import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
@@ -8,7 +8,8 @@ import type { ReactNode } from 'react';
 
 const formatEta = (seconds: number): string => {
   if (seconds > 80) {
-    return `About ${formatNumber(Math.ceil(seconds / 60))} minutes left`;
+    const minutes = Math.round(seconds / 60);
+    return `About ${formatNumber(minutes)} ${minutes === 1 ? 'minute' : 'minutes'} left`;
   }
   if (seconds > 40) {
     return 'About 1 minute left';
@@ -41,7 +42,7 @@ const StatusGlyph = ({ sending }: { sending: EmailSendingState }) => {
 
   return (
     <span className="relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-state-info text-white ring-1 ring-state-info ring-offset-1 ring-offset-background">
-      <span className="email-sending-arrow-rise">
+      <span className="animate-email-sending-arrow-rise motion-reduce:animate-none">
         <LucideIcon.ArrowUp aria-hidden="true" size={12} strokeWidth={2.5} />
       </span>
     </span>
@@ -106,17 +107,17 @@ const EmailSendingStatusBanner = () => {
       : 'Sending emails';
   const detail = isFailed
     ? hasUnknownDeliveryOutcome
-      ? 'Something went wrong while sending this email.'
+      ? post?.email?.error || 'Something went wrong while sending this email.'
       : failureDetail(sending, post?.email?.error)
     : activeDetail(sending);
   const retryLabel = hasSentEmails ? 'Send remaining emails' : 'Retry sending email';
 
   return (
-    <Stack
-      className="rounded-lg border border-border-default bg-surface-elevated p-4"
+    <Banner
+      className="bg-surface-elevated shadow-none hover:shadow-none"
       data-testid="email-sending-status-banner"
-      gap="none"
       role={isFailed ? 'alert' : 'status'}
+      size="lg"
     >
       <Inline align="center" gap="md" justify="between" wrap>
         <Inline align="center" className="min-w-0" gap="sm">
@@ -145,7 +146,7 @@ const EmailSendingStatusBanner = () => {
           </Button>
         )}
       </Inline>
-    </Stack>
+    </Banner>
   );
 };
 

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -70,9 +70,10 @@ const failureDetail = (
   error?: string | null,
 ) => {
   const { completed, total } = sending.progress;
+  const sent = sending.failed_during === 'submitting' ? completed : 0;
   const progress =
-    completed > 0
-      ? `${formatNumber(completed)} of ${formatNumber(total)} emails were sent.`
+    sent > 0
+      ? `${formatNumber(sent)} of ${formatNumber(total)} emails were sent.`
       : total > 0
         ? `None of the ${formatNumber(total)} emails were sent.`
         : 'No emails were sent.';
@@ -90,16 +91,18 @@ const EmailSendingStatusBanner = () => {
   }
 
   const isFailed = sending.status === 'failed';
+  const hasSentEmails = isFailed
+    ? sending.failed_during === 'submitting' && sending.progress.completed > 0
+    : false;
   const title = isFailed
-    ? sending.progress.completed > 0
+    ? hasSentEmails
       ? 'Some emails failed to send'
       : 'Emails failed to send'
     : sending.status === 'preparing'
       ? 'Preparing emails'
       : 'Sending emails';
   const detail = isFailed ? failureDetail(sending, post?.email?.error) : activeDetail(sending);
-  const retryLabel =
-    sending.progress.completed > 0 ? 'Send remaining emails' : 'Retry sending email';
+  const retryLabel = hasSentEmails ? 'Send remaining emails' : 'Retry sending email';
 
   return (
     <Stack

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-context.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-context.ts
@@ -8,6 +8,7 @@ export interface EmailSendingStatusContextValue {
   isNewsletterDataHidden: boolean;
   newsletterDataHiddenReason: 'sending' | 'failed' | null;
   hasNewsletterAnalytics: boolean;
+  hasUnknownDeliveryOutcome: boolean;
   isRetrying: boolean;
   retrySending: () => Promise<void>;
 }

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-context.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-context.ts
@@ -2,7 +2,6 @@ import { createContext, useContext } from 'react';
 import type { EmailSendingStatus } from '@tryghost/admin-x-framework/api/emails';
 
 export interface EmailSendingStatusContextValue {
-  enabled: boolean;
   status: EmailSendingStatus | undefined;
   isStatusLoading: boolean;
   isNewsletterDataHidden: boolean;

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-context.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-context.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext } from 'react';
+import type { EmailSendingStatus } from '@tryghost/admin-x-framework/api/emails';
+
+export interface EmailSendingStatusContextValue {
+  enabled: boolean;
+  status: EmailSendingStatus | undefined;
+  isStatusLoading: boolean;
+  isNewsletterDataHidden: boolean;
+  newsletterDataHiddenReason: 'sending' | 'failed' | null;
+  hasNewsletterAnalytics: boolean;
+  isRetrying: boolean;
+  retrySending: () => Promise<void>;
+}
+
+export const EmailSendingStatusContext = createContext<EmailSendingStatusContextValue | undefined>(
+  undefined,
+);
+
+export const useEmailSendingStatusContext = (): EmailSendingStatusContextValue => {
+  const context = useContext(EmailSendingStatusContext);
+  if (!context) {
+    throw new Error(
+      'useEmailSendingStatusContext must be used within an EmailSendingStatusProvider',
+    );
+  }
+  return context;
+};

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
@@ -1,13 +1,28 @@
 import { EmailSendingStatusContext } from './email-sending-status-context';
 import { hasBeenEmailed } from '@tryghost/admin-x-framework';
+import { linksDataType } from '@tryghost/admin-x-framework/api/links';
+import { postsDataType } from '@tryghost/admin-x-framework/api/posts';
+import {
+  newsletterBasicStatsDataType,
+  newsletterClickStatsDataType,
+} from '@tryghost/admin-x-framework/api/stats';
 import { useEmailSendingStatus, useRetryEmail } from '@tryghost/admin-x-framework/api/emails';
-import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
+import { useQueryClient } from '@tanstack/react-query';
+
 const STATUS_POLL_INTERVAL = 2000;
+const NEWSLETTER_DATA_TYPES = new Set([
+  postsDataType,
+  linksDataType,
+  newsletterBasicStatsDataType,
+  newsletterClickStatsDataType,
+]);
 
 const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
   const { post, refetchPost } = usePostAnalytics();
+  const queryClient = useQueryClient();
   const enabled = useFeatureFlag('improveSendingUI');
   const emailId = post?.email?.id;
   const emailStatus = post?.email?.status;
@@ -34,25 +49,55 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
   const handleError = useHandleError();
 
   const status = statusQuery.data?.email_statuses[0];
-  const refreshedSubmittedEmailId = useRef<string | null>(null);
+  const sendingStatus = status?.sending.status;
+  const lastHandledSendingState = useRef<string | null>(null);
+  const [refreshedSubmittedEmailId, setRefreshedSubmittedEmailId] = useState<string | null>(null);
 
   useEffect(() => {
-    if (
-      !emailId ||
-      status?.sending.status !== 'submitted' ||
-      refreshedSubmittedEmailId.current === emailId
-    ) {
+    if (!emailId || !sendingStatus) {
       return;
     }
 
-    refreshedSubmittedEmailId.current = emailId;
-    void refetchPost();
-  }, [emailId, refetchPost, status?.sending.status]);
+    const sendingStateKey = `${emailId}:${sendingStatus}`;
+    if (lastHandledSendingState.current === sendingStateKey) {
+      return;
+    }
+    lastHandledSendingState.current = sendingStateKey;
+
+    if (sendingStatus !== 'submitted') {
+      setRefreshedSubmittedEmailId((currentEmailId) =>
+        currentEmailId === emailId ? null : currentEmailId,
+      );
+    }
+
+    if (sendingStatus === 'failed') {
+      void refetchPost();
+      return;
+    }
+
+    if (sendingStatus === 'submitted') {
+      void queryClient
+        .refetchQueries({
+          type: 'active',
+          predicate: (query) => {
+            const dataType = query.queryKey[0];
+            return typeof dataType === 'string' && NEWSLETTER_DATA_TYPES.has(dataType);
+          },
+        })
+        .then(() => setRefreshedSubmittedEmailId(emailId));
+    }
+  }, [emailId, queryClient, refetchPost, sendingStatus]);
 
   const hasInitialError = statusQuery.isError && !statusQuery.data;
   const isStatusLoading = shouldQuery && statusQuery.isLoading && !status;
+  const isRefreshingSubmittedData = Boolean(
+    emailId && sendingStatus === 'submitted' && refreshedSubmittedEmailId !== emailId,
+  );
   const isNewsletterDataHidden = Boolean(
-    enabled && !hasInitialError && status && status.sending.status !== 'submitted',
+    enabled &&
+    !hasInitialError &&
+    status &&
+    (status.sending.status !== 'submitted' || isRefreshingSubmittedData),
   );
   const newsletterDataHiddenReason: 'sending' | 'failed' | null = isNewsletterDataHidden
     ? status?.sending.status === 'failed'

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
@@ -1,4 +1,6 @@
 import { EmailSendingStatusContext } from './email-sending-status-context';
+import { APIError } from '@tryghost/admin-x-framework/errors';
+import { feedbackDataType } from '@tryghost/admin-x-framework/api/feedback';
 import { hasBeenEmailed } from '@tryghost/admin-x-framework';
 import { linksDataType } from '@tryghost/admin-x-framework/api/links';
 import { postsDataType } from '@tryghost/admin-x-framework/api/posts';
@@ -16,12 +18,13 @@ import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hook
 import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
 import { useQueryClient } from '@tanstack/react-query';
 
-const STATUS_POLL_INTERVAL = 2000;
+const STATUS_POLL_INTERVAL = import.meta.env.MODE === 'test' ? 50 : 2000;
 const NEWSLETTER_DATA_TYPES = new Set([
   postsDataType,
   linksDataType,
   newsletterBasicStatsDataType,
   newsletterClickStatsDataType,
+  feedbackDataType,
 ]);
 
 const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
@@ -30,14 +33,24 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
   const enabled = useFeatureFlag('improveSendingUI');
   const emailId = post?.email?.id;
   const emailStatus = post?.email?.status;
-  const shouldQuery =
-    enabled && Boolean(emailId) && Boolean(emailStatus) && emailStatus !== 'submitted';
+  const hasPublishedEmail =
+    Boolean(emailId) && (post?.status === 'published' || post?.status === 'sent');
+  const shouldQuery = enabled && hasPublishedEmail && Boolean(emailStatus);
 
   const statusQuery = useEmailSendingStatus(emailId ?? '', {
     enabled: (query) => {
       const queriedStatus = query.state.data?.email_statuses[0]?.sending.status;
-      const hasInitialError = query.state.status === 'error' && !query.state.data;
-      return shouldQuery && !hasInitialError && queriedStatus !== 'submitted';
+      const missingBackend =
+        !query.state.data &&
+        query.state.error instanceof APIError &&
+        query.state.error.response?.status === 404;
+      const submittedBeforeStatusLoaded = !query.state.data && emailStatus === 'submitted';
+      return (
+        shouldQuery &&
+        !missingBackend &&
+        !submittedBeforeStatusLoaded &&
+        queriedStatus !== 'submitted'
+      );
     },
     defaultErrorHandler: false,
     refetchInterval: (query) => {
@@ -48,9 +61,10 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
     refetchOnWindowFocus: true,
     retry: false,
   });
-  const { mutateAsync: retryEmail, isPending: isRetrying } = useRetryEmail();
+  const { mutateAsync: retryEmail, isPending: isRetryMutationPending } = useRetryEmail();
   const { refetch: refetchStatus } = statusQuery;
   const handleError = useHandleError();
+  const [isRetryRefreshPending, setIsRetryRefreshPending] = useState(false);
 
   const status = statusQuery.data?.email_statuses[0];
   const sendingStatus = status?.sending.status;
@@ -59,7 +73,9 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
     enabled: shouldQueryBatches,
     searchParams: { filter: 'status:submitting', fields: 'id,status', limit: '1' },
     defaultErrorHandler: false,
+    refetchOnWindowFocus: true,
     retry: false,
+    staleTime: 0,
   });
   const hasUnknownDeliveryOutcome = Boolean(
     shouldQueryBatches &&
@@ -69,6 +85,7 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
       batchesQuery.data.batches.some((batch) => batch.status === 'submitting')),
   );
   const lastHandledSendingState = useRef<string | null>(null);
+  const retryInFlight = useRef(false);
   const [refreshedSubmittedEmailId, setRefreshedSubmittedEmailId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -94,28 +111,20 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
     }
 
     if (sendingStatus === 'submitted') {
-      void queryClient
-        .refetchQueries({
-          type: 'active',
-          predicate: (query) => {
-            const dataType = query.queryKey[0];
-            return typeof dataType === 'string' && NEWSLETTER_DATA_TYPES.has(dataType);
-          },
-        })
-        .then(() => setRefreshedSubmittedEmailId(emailId));
+      void Promise.all(
+        [...NEWSLETTER_DATA_TYPES].map((dataType) =>
+          queryClient.invalidateQueries({ queryKey: [dataType] }),
+        ),
+      ).then(() => setRefreshedSubmittedEmailId(emailId));
     }
   }, [emailId, queryClient, refetchPost, sendingStatus]);
 
-  const hasInitialError = statusQuery.isError && !statusQuery.data;
   const isStatusLoading = shouldQuery && statusQuery.isLoading && !status;
   const isRefreshingSubmittedData = Boolean(
     emailId && sendingStatus === 'submitted' && refreshedSubmittedEmailId !== emailId,
   );
   const isNewsletterDataHidden = Boolean(
-    enabled &&
-    !hasInitialError &&
-    status &&
-    (status.sending.status !== 'submitted' || isRefreshingSubmittedData),
+    enabled && status && (status.sending.status !== 'submitted' || isRefreshingSubmittedData),
   );
   const newsletterDataHiddenReason: 'sending' | 'failed' | null = isNewsletterDataHidden
     ? status?.sending.status === 'failed'
@@ -123,25 +132,33 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
       : 'sending'
     : null;
   const hasNewsletterAnalytics = Boolean(
-    post && (hasBeenEmailed(post) || (enabled && !hasInitialError && status && post.email)),
+    post &&
+    (post.status === 'published' || post.status === 'sent') &&
+    (hasBeenEmailed(post) || (enabled && status && post.email)),
   );
 
   const retrySending = useCallback(async () => {
-    if (!emailId) {
+    if (!emailId || retryInFlight.current) {
       return;
     }
 
+    retryInFlight.current = true;
+    setIsRetryRefreshPending(true);
     try {
       await retryEmail(emailId);
-      await refetchStatus();
+      await refetchStatus({ throwOnError: true });
     } catch (error) {
       handleError(error);
+    } finally {
+      retryInFlight.current = false;
+      setIsRetryRefreshPending(false);
     }
   }, [emailId, handleError, refetchStatus, retryEmail]);
 
+  const isRetrying = isRetryMutationPending || isRetryRefreshPending;
+
   const value = useMemo(
     () => ({
-      enabled,
       status,
       isStatusLoading,
       isNewsletterDataHidden,
@@ -152,7 +169,6 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
       retrySending,
     }),
     [
-      enabled,
       status,
       isStatusLoading,
       isNewsletterDataHidden,

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
@@ -6,7 +6,11 @@ import {
   newsletterBasicStatsDataType,
   newsletterClickStatsDataType,
 } from '@tryghost/admin-x-framework/api/stats';
-import { useEmailSendingStatus, useRetryEmail } from '@tryghost/admin-x-framework/api/emails';
+import {
+  useBrowseEmailBatches,
+  useEmailSendingStatus,
+  useRetryEmail,
+} from '@tryghost/admin-x-framework/api/emails';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
@@ -50,6 +54,20 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
 
   const status = statusQuery.data?.email_statuses[0];
   const sendingStatus = status?.sending.status;
+  const shouldQueryBatches = Boolean(enabled && emailId && sendingStatus === 'failed');
+  const batchesQuery = useBrowseEmailBatches(emailId ?? '', {
+    enabled: shouldQueryBatches,
+    searchParams: { filter: 'status:submitting', fields: 'id,status', limit: '1' },
+    defaultErrorHandler: false,
+    retry: false,
+  });
+  const hasUnknownDeliveryOutcome = Boolean(
+    shouldQueryBatches &&
+    (batchesQuery.isFetching ||
+      batchesQuery.isError ||
+      !batchesQuery.data ||
+      batchesQuery.data.batches.some((batch) => batch.status === 'submitting')),
+  );
   const lastHandledSendingState = useRef<string | null>(null);
   const [refreshedSubmittedEmailId, setRefreshedSubmittedEmailId] = useState<string | null>(null);
 
@@ -129,6 +147,7 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
       isNewsletterDataHidden,
       newsletterDataHiddenReason,
       hasNewsletterAnalytics,
+      hasUnknownDeliveryOutcome,
       isRetrying,
       retrySending,
     }),
@@ -139,6 +158,7 @@ const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
       isNewsletterDataHidden,
       newsletterDataHiddenReason,
       hasNewsletterAnalytics,
+      hasUnknownDeliveryOutcome,
       isRetrying,
       retrySending,
     ],

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-provider.tsx
@@ -1,0 +1,109 @@
+import { EmailSendingStatusContext } from './email-sending-status-context';
+import { hasBeenEmailed } from '@tryghost/admin-x-framework';
+import { useEmailSendingStatus, useRetryEmail } from '@tryghost/admin-x-framework/api/emails';
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
+const STATUS_POLL_INTERVAL = 2000;
+
+const EmailSendingStatusProvider = ({ children }: { children: ReactNode }) => {
+  const { post, refetchPost } = usePostAnalytics();
+  const enabled = useFeatureFlag('improveSendingUI');
+  const emailId = post?.email?.id;
+  const emailStatus = post?.email?.status;
+  const shouldQuery =
+    enabled && Boolean(emailId) && Boolean(emailStatus) && emailStatus !== 'submitted';
+
+  const statusQuery = useEmailSendingStatus(emailId ?? '', {
+    enabled: (query) => {
+      const queriedStatus = query.state.data?.email_statuses[0]?.sending.status;
+      const hasInitialError = query.state.status === 'error' && !query.state.data;
+      return shouldQuery && !hasInitialError && queriedStatus !== 'submitted';
+    },
+    defaultErrorHandler: false,
+    refetchInterval: (query) => {
+      const status = query.state.data?.email_statuses[0]?.sending.status;
+      return status === 'preparing' || status === 'submitting' ? STATUS_POLL_INTERVAL : false;
+    },
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+  const { mutateAsync: retryEmail, isPending: isRetrying } = useRetryEmail();
+  const { refetch: refetchStatus } = statusQuery;
+  const handleError = useHandleError();
+
+  const status = statusQuery.data?.email_statuses[0];
+  const refreshedSubmittedEmailId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (
+      !emailId ||
+      status?.sending.status !== 'submitted' ||
+      refreshedSubmittedEmailId.current === emailId
+    ) {
+      return;
+    }
+
+    refreshedSubmittedEmailId.current = emailId;
+    void refetchPost();
+  }, [emailId, refetchPost, status?.sending.status]);
+
+  const hasInitialError = statusQuery.isError && !statusQuery.data;
+  const isStatusLoading = shouldQuery && statusQuery.isLoading && !status;
+  const isNewsletterDataHidden = Boolean(
+    enabled && !hasInitialError && status && status.sending.status !== 'submitted',
+  );
+  const newsletterDataHiddenReason: 'sending' | 'failed' | null = isNewsletterDataHidden
+    ? status?.sending.status === 'failed'
+      ? 'failed'
+      : 'sending'
+    : null;
+  const hasNewsletterAnalytics = Boolean(
+    post && (hasBeenEmailed(post) || (enabled && !hasInitialError && status && post.email)),
+  );
+
+  const retrySending = useCallback(async () => {
+    if (!emailId) {
+      return;
+    }
+
+    try {
+      await retryEmail(emailId);
+      await refetchStatus();
+    } catch (error) {
+      handleError(error);
+    }
+  }, [emailId, handleError, refetchStatus, retryEmail]);
+
+  const value = useMemo(
+    () => ({
+      enabled,
+      status,
+      isStatusLoading,
+      isNewsletterDataHidden,
+      newsletterDataHiddenReason,
+      hasNewsletterAnalytics,
+      isRetrying,
+      retrySending,
+    }),
+    [
+      enabled,
+      status,
+      isStatusLoading,
+      isNewsletterDataHidden,
+      newsletterDataHiddenReason,
+      hasNewsletterAnalytics,
+      isRetrying,
+      retrySending,
+    ],
+  );
+
+  return (
+    <EmailSendingStatusContext.Provider value={value}>
+      {children}
+    </EmailSendingStatusContext.Provider>
+  );
+};
+
+export default EmailSendingStatusProvider;

--- a/apps/admin/src/posts/analytics/email-sending-status/pending-send-empty.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/pending-send-empty.tsx
@@ -27,15 +27,13 @@ const PendingSendEmpty = ({
   }
 
   return (
-    <div className="py-20 text-center">
-      <EmptyIndicator
-        className="h-full"
-        description={newsletterDataHiddenReason === 'failed' ? failedDescription : description}
-        title={newsletterDataHiddenReason === 'failed' ? failedTitle : title}
-      >
-        <LucideIcon.Mail strokeWidth={1.5} />
-      </EmptyIndicator>
-    </div>
+    <EmptyIndicator
+      className="py-20"
+      description={newsletterDataHiddenReason === 'failed' ? failedDescription : description}
+      title={newsletterDataHiddenReason === 'failed' ? failedTitle : title}
+    >
+      <LucideIcon.Mail strokeWidth={1.5} />
+    </EmptyIndicator>
   );
 };
 

--- a/apps/admin/src/posts/analytics/email-sending-status/pending-send-empty.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/pending-send-empty.tsx
@@ -1,0 +1,42 @@
+import { EmptyIndicator } from '@tryghost/shade/components';
+import { LucideIcon } from '@tryghost/shade/utils';
+import { useEmailSendingStatusContext } from './email-sending-status-context';
+import type { ReactNode } from 'react';
+
+interface PendingSendEmptyProps {
+  children?: ReactNode;
+  className?: string;
+  description: string;
+  failedDescription?: string;
+  failedTitle?: string;
+  title: string;
+}
+
+const PendingSendEmpty = ({
+  children,
+  className,
+  description,
+  failedDescription = 'There is no newsletter performance data for this post',
+  failedTitle = 'No newsletter data available',
+  title,
+}: PendingSendEmptyProps) => {
+  const { isNewsletterDataHidden, newsletterDataHiddenReason } = useEmailSendingStatusContext();
+
+  if (!isNewsletterDataHidden) {
+    return children ? <div className={className}>{children}</div> : null;
+  }
+
+  return (
+    <div className="py-20 text-center">
+      <EmptyIndicator
+        className="h-full"
+        description={newsletterDataHiddenReason === 'failed' ? failedDescription : description}
+        title={newsletterDataHiddenReason === 'failed' ? failedTitle : title}
+      >
+        <LucideIcon.Mail strokeWidth={1.5} />
+      </EmptyIndicator>
+    </div>
+  );
+};
+
+export default PendingSendEmpty;

--- a/apps/admin/src/posts/analytics/hooks/use-post-success-modal.test.tsx
+++ b/apps/admin/src/posts/analytics/hooks/use-post-success-modal.test.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { test as baseTest, beforeEach, describe, expect, vi } from 'vitest';
 import { post, type Post } from '@tryghost/test-data';
 import type { QueryClient } from '@tanstack/react-query';
@@ -7,6 +7,20 @@ import type { SetupServer } from 'msw/node';
 import { serverFixture } from '@test-utils/fixtures/msw';
 import { queryClientFixtures, type TestWrapperComponent } from '@test-utils/fixtures/query-client';
 import { usePostSuccessModal } from '@/posts/analytics/hooks/use-post-success-modal';
+
+const { mockUseFeatureFlag } = vi.hoisted(() => ({
+  mockUseFeatureFlag: vi.fn(),
+}));
+
+vi.mock('@tryghost/admin-x-framework/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/hooks')>(
+    '@tryghost/admin-x-framework/hooks',
+  );
+  return {
+    ...actual,
+    useFeatureFlag: (flag: string) => mockUseFeatureFlag(flag) as boolean,
+  };
+});
 
 // Mock the shared analytics data hook (not HTTP)
 vi.mock('@/shared/analytics/use-analytics-data', () => ({
@@ -47,6 +61,7 @@ const test = baseTest.extend<{
 describe('usePostSuccessModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseFeatureFlag.mockReturnValue(false);
 
     // Default mocks
     mockUseAnalyticsData.mockReturnValue({
@@ -422,6 +437,48 @@ describe('usePostSuccessModal', () => {
       expect(publishedOnlyResult.current.modalProps?.emailOnly).toBeFalsy();
       expect(publishedOnlyResult.current.modalProps?.description).toBeTruthy();
     });
+  });
+
+  test('uses in-progress copy for a post and email when improved sending UI is enabled', async ({
+    server,
+    wrapper,
+  }) => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    mockPosts(server, [
+      buildPost({
+        email: { email_count: 100, opened_count: 0 },
+        newsletter: { id: 'newsletter-123', name: 'Weekly Newsletter' },
+      }),
+    ]);
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify({ id: 'post-123', type: 'post' }));
+
+    const { result } = renderHook(() => usePostSuccessModal(), { wrapper });
+
+    await waitFor(() => expect(result.current.modalProps).toBeTruthy());
+    render(result.current.modalProps?.description);
+    expect(
+      screen.getByText(/Your post was published on your site and is being sent to/),
+    ).toBeTruthy();
+  });
+
+  test('uses in-progress copy for an email-only send when improved sending UI is enabled', async ({
+    server,
+    wrapper,
+  }) => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    mockPosts(server, [
+      buildPost({
+        email_only: true,
+        email: { email_count: 50, opened_count: 0 },
+      }),
+    ]);
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify({ id: 'post-123', type: 'post' }));
+
+    const { result } = renderHook(() => usePostSuccessModal(), { wrapper });
+
+    await waitFor(() => expect(result.current.modalProps).toBeTruthy());
+    render(result.current.modalProps?.description);
+    expect(screen.getByText(/Your email is being sent to/)).toBeTruthy();
   });
 
   test('handles loading state', ({ server, wrapper }) => {

--- a/apps/admin/src/posts/analytics/hooks/use-post-success-modal.test.tsx
+++ b/apps/admin/src/posts/analytics/hooks/use-post-success-modal.test.tsx
@@ -461,6 +461,26 @@ describe('usePostSuccessModal', () => {
     ).toBeTruthy();
   });
 
+  test('uses completed copy when the legacy flow has already observed submission', async ({
+    server,
+    wrapper,
+  }) => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    mockPosts(server, [
+      buildPost({
+        email: { email_count: 100, opened_count: 0, status: 'submitted' },
+        newsletter: { id: 'newsletter-123', name: 'Weekly Newsletter' },
+      }),
+    ]);
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify({ id: 'post-123', type: 'post' }));
+
+    const { result } = renderHook(() => usePostSuccessModal(), { wrapper });
+
+    await waitFor(() => expect(result.current.modalProps).toBeTruthy());
+    render(result.current.modalProps?.description);
+    expect(screen.getByText(/Your post was published on your site and sent to/)).toBeTruthy();
+  });
+
   test('uses in-progress copy for an email-only send when improved sending UI is enabled', async ({
     server,
     wrapper,

--- a/apps/admin/src/posts/analytics/hooks/use-post-success-modal.ts
+++ b/apps/admin/src/posts/analytics/hooks/use-post-success-modal.ts
@@ -74,16 +74,17 @@ export const usePostSuccessModal = () => {
     }
 
     const showPostCount = !!postCount;
+    const isEmailStillSending = improveSendingUI && post.email?.status !== 'submitted';
 
     // Build description with React elements to match Ember modal format with bold text
     const getDescription = () => {
       const parts = [];
 
       if (post.email_only) {
-        parts.push(improveSendingUI ? 'Your email is being sent to' : 'Your email was sent to');
+        parts.push(isEmailStillSending ? 'Your email is being sent to' : 'Your email was sent to');
       } else if (post.email?.email_count) {
         parts.push(
-          improveSendingUI
+          isEmailStillSending
             ? 'Your post was published on your site and is being sent to'
             : 'Your post was published on your site and sent to',
         );

--- a/apps/admin/src/posts/analytics/hooks/use-post-success-modal.ts
+++ b/apps/admin/src/posts/analytics/hooks/use-post-success-modal.ts
@@ -3,6 +3,7 @@ import { type Post, useBrowsePosts } from '@tryghost/admin-x-framework/api/posts
 import { formatNumber } from '@tryghost/shade/utils';
 import { useEffect, useMemo, useState } from 'react';
 import { useAnalyticsData } from '@/shared/analytics/use-analytics-data';
+import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 
 interface PublishedPostData {
   id: string;
@@ -24,6 +25,7 @@ export const usePostSuccessModal = () => {
   const [publishedPostData, setPublishedPostData] = useState<PublishedPostData | null>(null);
   const [postCount, setPostCount] = useState<number | null>(null);
   const { site } = useAnalyticsData();
+  const improveSendingUI = useFeatureFlag('improveSendingUI');
 
   // Fetch the published post data if we have it
   const { data: postResponse } = useBrowsePosts({
@@ -78,9 +80,13 @@ export const usePostSuccessModal = () => {
       const parts = [];
 
       if (post.email_only) {
-        parts.push('Your email was sent to');
+        parts.push(improveSendingUI ? 'Your email is being sent to' : 'Your email was sent to');
       } else if (post.email?.email_count) {
-        parts.push('Your post was published on your site and sent to');
+        parts.push(
+          improveSendingUI
+            ? 'Your post was published on your site and is being sent to'
+            : 'Your post was published on your site and sent to',
+        );
       } else {
         parts.push('Your post was published on your site');
       }
@@ -156,7 +162,7 @@ export const usePostSuccessModal = () => {
       author: getAuthorsText(post.authors),
       onClose: handleClose,
     };
-  }, [post, isModalOpen, postCount, site?.title]);
+  }, [post, isModalOpen, postCount, site?.title, improveSendingUI]);
 
   useEffect(() => {
     const checkForPublishedPost = () => {

--- a/apps/admin/src/posts/analytics/newsletter/components/feedback.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/components/feedback.tsx
@@ -30,6 +30,8 @@ import { formatMemberName, getMemberInitials } from '@/members/api';
 import { useNavigate, useParams } from '@tryghost/admin-x-framework';
 import { usePostFeedback } from '@/posts/analytics/hooks/use-post-feedback';
 import { useState } from 'react';
+import PendingSendEmpty from '@/posts/analytics/email-sending-status/pending-send-empty';
+import { useEmailSendingStatusContext } from '@/posts/analytics/email-sending-status/email-sending-status-context';
 
 interface FeedbackProps {
   feedbackStats: {
@@ -42,6 +44,7 @@ interface FeedbackProps {
 const Feedback: React.FC<FeedbackProps> = ({ feedbackStats }) => {
   const { postId } = useParams();
   const navigate = useNavigate();
+  const { isNewsletterDataHidden } = useEmailSendingStatusContext();
   const [activeFeedbackTab, setActiveFeedbackTab] = useState<'positive' | 'negative'>('positive');
   const ITEMS_PER_PAGE = 9;
 
@@ -70,92 +73,104 @@ const Feedback: React.FC<FeedbackProps> = ({ feedbackStats }) => {
         <CardTitle>Feedback</CardTitle>
         <CardDescription>What did your readers think?</CardDescription>
       </CardHeader>
-      {feedbackStats.totalFeedback > 0 ? (
+      {isNewsletterDataHidden ? (
         <CardContent className="pb-3">
-          <div className="flex items-center justify-between gap-3">
-            <Tabs
-              className="pb-3"
-              defaultValue="positive"
-              value={activeFeedbackTab}
-              variant="button"
-              onValueChange={(value) => setActiveFeedbackTab(value as 'positive' | 'negative')}
-            >
-              <TabsList className="gap-1">
-                <TabsTrigger className="h-7" value="positive">
-                  <div className="flex items-center gap-1 text-xs">
-                    <LucideIcon.ThumbsUp size={14} strokeWidth={1.25} />
-                    <span className="hidden font-medium sm:visible! sm:inline!">
-                      More like this
-                    </span>
-                    <span className="font-semibold tracking-tight">
-                      {formatPercentage(
-                        feedbackStats.positiveFeedback / feedbackStats.totalFeedback,
-                      )}
-                    </span>
-                  </div>
-                </TabsTrigger>
-                <TabsTrigger className="h-7" value="negative">
-                  <div className="flex items-center gap-1 text-xs">
-                    <LucideIcon.ThumbsDown size={14} strokeWidth={1.25} />
-                    <span className="hidden font-medium sm:visible! sm:inline!">
-                      Less like this
-                    </span>
-                    <span className="font-semibold tracking-tight">
-                      {formatPercentage(
-                        feedbackStats.negativeFeedback / feedbackStats.totalFeedback,
-                      )}
-                    </span>
-                  </div>
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-            <HTable className="mr-2 mb-3 lg:hidden xl:visible! xl:block!">Date</HTable>
-          </div>
-          <Separator />
-          {isLoading ? (
-            <SkeletonTable className="mt-3" lines={3} />
-          ) : paginatedFeedback && paginatedFeedback.length > 0 ? (
-            <div className="flex w-full flex-col py-3">
-              {paginatedFeedback.map((item) => (
-                <div
-                  key={item.id}
-                  className="flex h-10 w-full items-center justify-between gap-3 rounded-sm border-none px-2 text-sm hover:cursor-pointer hover:bg-accent"
-                  onClick={() => {
-                    navigate(`/members/${item.member.id}`);
-                  }}
-                >
-                  <div className="flex items-center gap-2 font-medium">
-                    <Avatar className="size-7">
-                      {item.member?.avatar_image && (
-                        <img
-                          className="absolute aspect-square size-full"
-                          src={item.member?.avatar_image}
-                        />
-                      )}
-                      <AvatarFallback
-                        className="text-white"
-                        style={{
-                          backgroundColor: `${stringToHslColor(formatMemberName(item.member), '45', '55')}`,
-                        }}
-                      >
-                        {getMemberInitials(item.member)}
-                      </AvatarFallback>
-                    </Avatar>
-                    {formatMemberName(item.member)}
-                  </div>
-                  <div className="whitespace-nowrap text-muted-foreground">
-                    {formatTimestamp(item.created_at)}
-                  </div>
-                </div>
-              ))}
+          <PendingSendEmpty
+            description="Once the first responses are recorded, they'll show here"
+            title="No feedback data available"
+          />
+        </CardContent>
+      ) : feedbackStats.totalFeedback > 0 ? (
+        <CardContent className="pb-3">
+          <PendingSendEmpty
+            description="Once the first responses are recorded, they'll show here"
+            title="No feedback data available"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <Tabs
+                className="pb-3"
+                defaultValue="positive"
+                value={activeFeedbackTab}
+                variant="button"
+                onValueChange={(value) => setActiveFeedbackTab(value as 'positive' | 'negative')}
+              >
+                <TabsList className="gap-1">
+                  <TabsTrigger className="h-7" value="positive">
+                    <div className="flex items-center gap-1 text-xs">
+                      <LucideIcon.ThumbsUp size={14} strokeWidth={1.25} />
+                      <span className="hidden font-medium sm:visible! sm:inline!">
+                        More like this
+                      </span>
+                      <span className="font-semibold tracking-tight">
+                        {formatPercentage(
+                          feedbackStats.positiveFeedback / feedbackStats.totalFeedback,
+                        )}
+                      </span>
+                    </div>
+                  </TabsTrigger>
+                  <TabsTrigger className="h-7" value="negative">
+                    <div className="flex items-center gap-1 text-xs">
+                      <LucideIcon.ThumbsDown size={14} strokeWidth={1.25} />
+                      <span className="hidden font-medium sm:visible! sm:inline!">
+                        Less like this
+                      </span>
+                      <span className="font-semibold tracking-tight">
+                        {formatPercentage(
+                          feedbackStats.negativeFeedback / feedbackStats.totalFeedback,
+                        )}
+                      </span>
+                    </div>
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <HTable className="mr-2 mb-3 lg:hidden xl:visible! xl:block!">Date</HTable>
             </div>
-          ) : (
-            <div className="flex h-full items-center justify-center py-8 text-center text-sm text-muted-foreground">
-              <div>
-                No {activeFeedbackTab === 'positive' ? 'positive' : 'negative'} feedback yet
+            <Separator />
+            {isLoading ? (
+              <SkeletonTable className="mt-3" lines={3} />
+            ) : paginatedFeedback && paginatedFeedback.length > 0 ? (
+              <div className="flex w-full flex-col py-3">
+                {paginatedFeedback.map((item) => (
+                  <div
+                    key={item.id}
+                    className="flex h-10 w-full items-center justify-between gap-3 rounded-sm border-none px-2 text-sm hover:cursor-pointer hover:bg-accent"
+                    onClick={() => {
+                      navigate(`/members/${item.member.id}`);
+                    }}
+                  >
+                    <div className="flex items-center gap-2 font-medium">
+                      <Avatar className="size-7">
+                        {item.member?.avatar_image && (
+                          <img
+                            className="absolute aspect-square size-full"
+                            src={item.member?.avatar_image}
+                          />
+                        )}
+                        <AvatarFallback
+                          className="text-white"
+                          style={{
+                            backgroundColor: `${stringToHslColor(formatMemberName(item.member), '45', '55')}`,
+                          }}
+                        >
+                          {getMemberInitials(item.member)}
+                        </AvatarFallback>
+                      </Avatar>
+                      {formatMemberName(item.member)}
+                    </div>
+                    <div className="whitespace-nowrap text-muted-foreground">
+                      {formatTimestamp(item.created_at)}
+                    </div>
+                  </div>
+                ))}
               </div>
-            </div>
-          )}
+            ) : (
+              <div className="flex h-full items-center justify-center py-8 text-center text-sm text-muted-foreground">
+                <div>
+                  No {activeFeedbackTab === 'positive' ? 'positive' : 'negative'} feedback yet
+                </div>
+              </div>
+            )}
+          </PendingSendEmpty>
         </CardContent>
       ) : (
         <CardContent className="flex grow flex-col items-center justify-center text-center text-sm text-muted-foreground">
@@ -163,7 +178,7 @@ const Feedback: React.FC<FeedbackProps> = ({ feedbackStats }) => {
           <div>When someone does, you&apos;ll see their response here.</div>
         </CardContent>
       )}
-      {feedbackStats.totalFeedback > 0 && (
+      {feedbackStats.totalFeedback > 0 && !isNewsletterDataHidden && (
         <CardFooter className="grow-0">
           <div className="flex w-full items-center justify-between gap-3">
             <Button

--- a/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
@@ -360,6 +360,7 @@ const Newsletter: React.FC = () => {
                 >
                   <KpiCard className="group relative isolate grow p-3 md:px-6 md:py-5">
                     <KpiCardMoreButton
+                      disabled={isNewsletterDataHidden}
                       onClick={() => {
                         navigateToMembers(`emails.post_id:${postId}`);
                       }}
@@ -384,6 +385,7 @@ const Newsletter: React.FC = () => {
                   {emailTrackOpensEnabled && (
                     <KpiCard className="p-3 md:px-6 md:py-5">
                       <KpiCardMoreButton
+                        disabled={isNewsletterDataHidden}
                         onClick={() => {
                           navigateToMembers(`opened_emails.post_id:${postId}`);
                         }}
@@ -409,6 +411,7 @@ const Newsletter: React.FC = () => {
                   {emailTrackClicksEnabled && (
                     <KpiCard className="group relative isolate grow p-3 md:px-6 md:py-5">
                       <KpiCardMoreButton
+                        disabled={isNewsletterDataHidden}
                         onClick={() => {
                           navigateToMembers(`clicked_links.post_id:${postId}`);
                         }}

--- a/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
@@ -1,4 +1,5 @@
 import Feedback from './components/feedback';
+import PendingSendEmpty from '@/posts/analytics/email-sending-status/pending-send-empty';
 import KpiCard, {
   KpiCardContent,
   KpiCardLabel,
@@ -47,13 +48,14 @@ import {
 import { type Post, usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
 import { buildMembersUrl } from '@/members/api';
 import { getLinkById } from '@/posts/analytics/utils/link-helpers';
-import { hasBeenEmailed, useNavigate } from '@tryghost/admin-x-framework';
+import { useNavigate } from '@tryghost/admin-x-framework';
 import { toast } from 'sonner';
 import { useBulkEditLinks } from '@tryghost/admin-x-framework/api/links';
 import { useEmailTrackClicks, useEmailTrackOpens } from '@tryghost/admin-x-framework/api/settings';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { usePostNewsletterStats } from '@/posts/analytics/hooks/use-post-newsletter-stats';
 import { useResponsiveChartSize } from '@/posts/analytics/hooks/use-responsive-chart-size';
+import { useEmailSendingStatusContext } from '@/posts/analytics/email-sending-status/email-sending-status-context';
 
 const FunnelArrow: React.FC = () => {
   return (
@@ -105,20 +107,22 @@ const Newsletter: React.FC = () => {
   const { chartSize } = useResponsiveChartSize();
   const emailTrackClicksEnabled = useEmailTrackClicks();
   const emailTrackOpensEnabled = useEmailTrackOpens();
+  const { hasNewsletterAnalytics, isNewsletterDataHidden, isStatusLoading } =
+    useEmailSendingStatusContext();
 
   // Use shared post data from context
   const { post, isPostLoading, postId } = usePostAnalytics();
   const navigateToMembers = (filter: string) => navigate(buildMembersUrl({ filter }));
   const typedPost = post as Post;
   // Use the utility function from admin-x-framework
-  const showNewsletterSection = hasBeenEmailed(typedPost);
+  const showNewsletterSection = hasNewsletterAnalytics;
 
   useEffect(() => {
     // Redirect to overview if the post wasn't sent as a newsletter
-    if (!isPostLoading && !showNewsletterSection) {
+    if (!isPostLoading && !isStatusLoading && !showNewsletterSection) {
       navigate(`/posts/analytics/${postId}`);
     }
-  }, [navigate, postId, isPostLoading, showNewsletterSection]);
+  }, [navigate, postId, isPostLoading, isStatusLoading, showNewsletterSection]);
 
   const {
     stats,
@@ -241,7 +245,9 @@ const Newsletter: React.FC = () => {
     }
   }, [editingLinkId, editedUrl, topLinks]);
 
-  const isLoading = isNewsletterStatsLoading || isPostLoading;
+  const isLoading = isNewsletterStatsLoading || isPostLoading || isStatusLoading;
+  const showClicksCard = emailTrackClicksEnabled && !isNewsletterDataHidden;
+  const noValue = <span className="font-normal text-muted-foreground">&ndash;</span>;
 
   // "Sent" Chart
   const sentChartData: NewsletterRadialChartData[] = [
@@ -336,9 +342,9 @@ const Newsletter: React.FC = () => {
       <PostAnalyticsHeader currentTab="Newsletter" />
       <PostAnalyticsContent>
         <div
-          className={`grid grid-cols-1 gap-6 ${shouldShowFeedback && emailTrackClicksEnabled && 'lg:grid-cols-2'}`}
+          className={`grid grid-cols-1 gap-6 ${shouldShowFeedback && showClicksCard && 'lg:grid-cols-2'}`}
         >
-          <Card className={shouldShowFeedback && emailTrackClicksEnabled ? 'lg:col-span-2' : ''}>
+          <Card className={shouldShowFeedback && showClicksCard ? 'lg:col-span-2' : ''}>
             <CardHeader className="hidden">
               <CardTitle>Newsletters</CardTitle>
               <CardDescription>How did this post perform</CardDescription>
@@ -349,7 +355,9 @@ const Newsletter: React.FC = () => {
               </CardContent>
             ) : (
               <CardContent className="p-0">
-                <div className={`grid ${chartHeaderClass} items-stretch border-b`}>
+                <div
+                  className={`grid ${chartHeaderClass} items-stretch border-b ${isNewsletterDataHidden ? 'pointer-events-none opacity-40' : ''}`}
+                >
                   <KpiCard className="group relative isolate grow p-3 md:px-6 md:py-5">
                     <KpiCardMoreButton
                       onClick={() => {
@@ -368,7 +376,7 @@ const Newsletter: React.FC = () => {
                     </KpiCardLabel>
                     <KpiCardContent>
                       <KpiCardValue className="text-xl leading-none sm:text-2xl md:text-[2.6rem]">
-                        {formatNumber(stats.sent)}
+                        {isNewsletterDataHidden ? noValue : formatNumber(stats.sent)}
                       </KpiCardValue>
                     </KpiCardContent>
                   </KpiCard>
@@ -392,7 +400,7 @@ const Newsletter: React.FC = () => {
                       </KpiCardLabel>
                       <KpiCardContent>
                         <KpiCardValue className="text-xl leading-none sm:text-2xl md:text-[2.6rem]">
-                          {formatNumber(stats.opened)}
+                          {isNewsletterDataHidden ? noValue : formatNumber(stats.opened)}
                         </KpiCardValue>
                       </KpiCardContent>
                     </KpiCard>
@@ -417,78 +425,83 @@ const Newsletter: React.FC = () => {
                       </KpiCardLabel>
                       <KpiCardContent>
                         <KpiCardValue className="text-xl leading-none sm:text-2xl md:text-[2.6rem]">
-                          {formatNumber(stats.clicked)}
+                          {isNewsletterDataHidden ? noValue : formatNumber(stats.clicked)}
                         </KpiCardValue>
                       </KpiCardContent>
                     </KpiCard>
                   )}
                 </div>
-                <div
-                  className={`$ mx-auto grid grid-cols-1 items-center justify-center gap-4 transition-all md:gap-0 ${chartHeaderClass === 'grid-cols-2' && 'md:grid-cols-2'} ${chartHeaderClass === 'grid-cols-3' && 'md:grid-cols-3'}`}
+                <PendingSendEmpty
+                  description="Sends, opens and clicks will appear once every email has been sent"
+                  title="This newsletter is still sending"
                 >
                   <div
-                    className={`relative border-r-0 px-6 ${(emailTrackOpensEnabled || emailTrackClicksEnabled) && 'md:border-r'}`}
+                    className={`$ mx-auto grid grid-cols-1 items-center justify-center gap-4 transition-all md:gap-0 ${chartHeaderClass === 'grid-cols-2' && 'md:grid-cols-2'} ${chartHeaderClass === 'grid-cols-3' && 'md:grid-cols-3'}`}
                   >
-                    <NewsletterRadialChart
-                      className={chartClass}
-                      config={sentChartConfig}
-                      data={sentChartData}
-                      percentageLabel="Sent"
-                      percentageValue={formatPercentage(1)}
-                      size={chartSize}
-                      tooltip={false}
-                    />
-                    {(emailTrackOpensEnabled || emailTrackClicksEnabled) && <FunnelArrow />}
-                  </div>
-
-                  {emailTrackOpensEnabled && (
                     <div
-                      className={`group/block relative border-r-0 px-6 transition-all hover:bg-muted/25 ${emailTrackClicksEnabled && 'md:border-r'}`}
+                      className={`relative border-r-0 px-6 ${(emailTrackOpensEnabled || emailTrackClicksEnabled) && 'md:border-r'}`}
                     >
-                      <BlockTooltip
-                        avgValue={formatPercentage(averageStats.openedRate)}
-                        dataColor="var(--chart-blue)"
-                        value={formatPercentage(stats.openedRate)}
-                      />
                       <NewsletterRadialChart
                         className={chartClass}
-                        config={openedChartConfig}
-                        data={openedChartData}
-                        percentageLabel="Open rate"
-                        percentageValue={formatPercentage(stats.openedRate)}
+                        config={sentChartConfig}
+                        data={sentChartData}
+                        percentageLabel="Sent"
+                        percentageValue={formatPercentage(1)}
                         size={chartSize}
                         tooltip={false}
                       />
-                      {emailTrackClicksEnabled && <FunnelArrow />}
+                      {(emailTrackOpensEnabled || emailTrackClicksEnabled) && <FunnelArrow />}
                     </div>
-                  )}
 
-                  {emailTrackClicksEnabled && (
-                    <div className="group/block relative px-6 transition-all hover:bg-muted/25">
-                      <BlockTooltip
-                        avgValue={formatPercentage(averageStats.clickedRate)}
-                        dataColor="var(--chart-teal)"
-                        value={formatPercentage(stats.clickedRate)}
-                      />
-                      <NewsletterRadialChart
-                        className={chartClass}
-                        config={clickedChartConfig}
-                        data={clickedChartData}
-                        percentageLabel="Click rate"
-                        percentageValue={formatPercentage(stats.clickedRate)}
-                        size={chartSize}
-                        tooltip={false}
-                      />
-                    </div>
-                  )}
-                </div>
+                    {emailTrackOpensEnabled && (
+                      <div
+                        className={`group/block relative border-r-0 px-6 transition-all hover:bg-muted/25 ${emailTrackClicksEnabled && 'md:border-r'}`}
+                      >
+                        <BlockTooltip
+                          avgValue={formatPercentage(averageStats.openedRate)}
+                          dataColor="var(--chart-blue)"
+                          value={formatPercentage(stats.openedRate)}
+                        />
+                        <NewsletterRadialChart
+                          className={chartClass}
+                          config={openedChartConfig}
+                          data={openedChartData}
+                          percentageLabel="Open rate"
+                          percentageValue={formatPercentage(stats.openedRate)}
+                          size={chartSize}
+                          tooltip={false}
+                        />
+                        {emailTrackClicksEnabled && <FunnelArrow />}
+                      </div>
+                    )}
+
+                    {emailTrackClicksEnabled && (
+                      <div className="group/block relative px-6 transition-all hover:bg-muted/25">
+                        <BlockTooltip
+                          avgValue={formatPercentage(averageStats.clickedRate)}
+                          dataColor="var(--chart-teal)"
+                          value={formatPercentage(stats.clickedRate)}
+                        />
+                        <NewsletterRadialChart
+                          className={chartClass}
+                          config={clickedChartConfig}
+                          data={clickedChartData}
+                          percentageLabel="Click rate"
+                          percentageValue={formatPercentage(stats.clickedRate)}
+                          size={chartSize}
+                          tooltip={false}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </PendingSendEmpty>
               </CardContent>
             )}
           </Card>
 
           {shouldShowFeedback && <Feedback feedbackStats={feedbackStats} />}
 
-          {emailTrackClicksEnabled && (
+          {showClicksCard && (
             <Card className="group/datalist overflow-hidden">
               <div className="flex items-center justify-between p-6">
                 <CardHeader className="p-0">

--- a/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
@@ -114,7 +114,6 @@ const Newsletter: React.FC = () => {
   const { post, isPostLoading, postId } = usePostAnalytics();
   const navigateToMembers = (filter: string) => navigate(buildMembersUrl({ filter }));
   const typedPost = post as Post;
-  // Use the utility function from admin-x-framework
   const showNewsletterSection = hasNewsletterAnalytics;
 
   useEffect(() => {
@@ -439,7 +438,7 @@ const Newsletter: React.FC = () => {
                   title="This newsletter is still sending"
                 >
                   <div
-                    className={`$ mx-auto grid grid-cols-1 items-center justify-center gap-4 transition-all md:gap-0 ${chartHeaderClass === 'grid-cols-2' && 'md:grid-cols-2'} ${chartHeaderClass === 'grid-cols-3' && 'md:grid-cols-3'}`}
+                    className={`mx-auto grid grid-cols-1 items-center justify-center gap-4 transition-all md:gap-0 ${chartHeaderClass === 'grid-cols-2' && 'md:grid-cols-2'} ${chartHeaderClass === 'grid-cols-3' && 'md:grid-cols-3'}`}
                   >
                     <div
                       className={`relative border-r-0 px-6 ${(emailTrackOpensEnabled || emailTrackClicksEnabled) && 'md:border-r'}`}

--- a/apps/admin/src/posts/analytics/overview/components/newsletter-overview.tsx
+++ b/apps/admin/src/posts/analytics/overview/components/newsletter-overview.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import PendingSendEmpty from '@/posts/analytics/email-sending-status/pending-send-empty';
 import {
   BarChartLoadingIndicator,
   Button,
@@ -28,6 +29,7 @@ import { type Post } from '@tryghost/admin-x-framework/api/posts';
 import { cleanTrackedUrl, processAndGroupTopLinks } from '@/posts/analytics/utils/link-helpers';
 import { useNavigate, useParams } from '@tryghost/admin-x-framework';
 import { useTopLinks } from '@tryghost/admin-x-framework/api/links';
+import { useEmailSendingStatusContext } from '@/posts/analytics/email-sending-status/email-sending-status-context';
 
 interface NewsletterOverviewProps {
   post: Post;
@@ -42,6 +44,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({
 }) => {
   const { postId } = useParams();
   const navigate = useNavigate();
+  const { isNewsletterDataHidden } = useEmailSendingStatusContext();
 
   // Calculate stats from post data
   const stats = useMemo(() => {
@@ -108,16 +111,18 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({
             Newsletter performance
           </CardTitle>
         </CardHeader>
-        <Button
-          className="absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100"
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            navigate(`/posts/analytics/${postId}/newsletter`);
-          }}
-        >
-          View more
-        </Button>
+        {!isNewsletterDataHidden && (
+          <Button
+            className="absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100"
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              navigate(`/posts/analytics/${postId}/newsletter`);
+            }}
+          >
+            View more
+          </Button>
+        )}
       </div>
       {isNewsletterStatsLoading ? (
         <CardContent>
@@ -126,111 +131,117 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({
           </div>
         </CardContent>
       ) : (
-        <CardContent className={`${fullWidth && 'grid grid-cols-2'}`}>
-          <div className={`${fullWidth && 'border-r pr-6'}`}>
-            <div className="grid grid-cols-2 gap-6">
-              <KpiCardHeader className="group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0">
-                <div className="flex grow flex-col gap-1.5 border-none pb-0">
-                  <KpiCardHeaderLabel color="var(--chart-blue)">Open rate</KpiCardHeaderLabel>
-                  <KpiCardHeaderValue
-                    // diffDirection={'up'}
-                    // diffTooltip={'Better than the average'}
-                    // diffValue={1.45}
-                    value={formatPercentage(stats.openedRate)}
-                  />
-                </div>
-              </KpiCardHeader>
-              <KpiCardHeader className="group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0">
-                <div className="flex grow flex-col gap-1.5 border-none pb-0">
-                  <KpiCardHeaderLabel color="var(--chart-teal)">Click rate</KpiCardHeaderLabel>
-                  <KpiCardHeaderValue
-                    // diffDirection={'up'}
-                    // diffTooltip={'Better than the average'}
-                    // diffValue={1.45}
-                    value={formatPercentage(stats.clickedRate)}
-                  />
-                </div>
-              </KpiCardHeader>
-            </div>
-            {!fullWidth && <Separator />}
-            <div className="mx-auto my-6 h-[240px]">
-              <NewsletterRadialChart
-                className="pointer-events-none aspect-square h-[240px]"
-                config={commonChartConfig}
-                data={commonChartData}
-                tooltip={false}
-              />
-            </div>
-          </div>
-
-          <div className={`${fullWidth && 'pl-6'}`}>
-            {!fullWidth && <Separator />}
-            <div className={fullWidth ? '' : 'pt-3'}>
-              <div
-                className={`flex items-center justify-between gap-3 ${fullWidth ? 'pb-3' : 'py-3'}`}
-              >
-                <span className="font-medium text-muted-foreground">
-                  Top clicked links in this email
-                </span>
-                <HTable>Members</HTable>
+        <CardContent>
+          <PendingSendEmpty
+            className={`${fullWidth && 'grid grid-cols-2'}`}
+            description="Opens and clicks will appear once every email has been sent"
+            title="This newsletter is still sending"
+          >
+            <div className={`${fullWidth && 'border-r pr-6'}`}>
+              <div className="grid grid-cols-2 gap-6">
+                <KpiCardHeader className="group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0">
+                  <div className="flex grow flex-col gap-1.5 border-none pb-0">
+                    <KpiCardHeaderLabel color="var(--chart-blue)">Open rate</KpiCardHeaderLabel>
+                    <KpiCardHeaderValue
+                      // diffDirection={'up'}
+                      // diffTooltip={'Better than the average'}
+                      // diffValue={1.45}
+                      value={formatPercentage(stats.openedRate)}
+                    />
+                  </div>
+                </KpiCardHeader>
+                <KpiCardHeader className="group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0">
+                  <div className="flex grow flex-col gap-1.5 border-none pb-0">
+                    <KpiCardHeaderLabel color="var(--chart-teal)">Click rate</KpiCardHeaderLabel>
+                    <KpiCardHeaderValue
+                      // diffDirection={'up'}
+                      // diffTooltip={'Better than the average'}
+                      // diffValue={1.45}
+                      value={formatPercentage(stats.clickedRate)}
+                    />
+                  </div>
+                </KpiCardHeader>
               </div>
-
-              {topLinks.length > 0 ? (
-                <DataList className="">
-                  <DataListBody>
-                    {topLinks.slice(0, fullWidth ? 10 : 5).map((link) => {
-                      const percentage = stats.clicked > 0 ? link.count / stats.clicked : 0;
-                      return (
-                        <DataListRow key={link.link.link_id}>
-                          <DataListBar
-                            style={{
-                              width: `${percentage ? Math.round(percentage * 100) : 0}%`,
-                            }}
-                          />
-                          <DataListItemContent>
-                            <div className="flex items-center space-x-2 overflow-hidden">
-                              <LucideIcon.Link
-                                className="shrink-0 text-muted-foreground"
-                                size={16}
-                                strokeWidth={1.5}
-                              />
-                              <a
-                                className="block truncate font-medium hover:underline"
-                                href={link.link.to}
-                                rel="noreferrer"
-                                target="_blank"
-                                title={link.link.to}
-                              >
-                                {cleanTrackedUrl(link.link.to, true)}
-                              </a>
-                            </div>
-                          </DataListItemContent>
-                          <DataListItemValue>
-                            <DataListItemValueAbs>
-                              {formatNumber(link.count || 0)}
-                            </DataListItemValueAbs>
-                            <DataListItemValuePerc>
-                              {formatPercentage(percentage)}
-                            </DataListItemValuePerc>
-                          </DataListItemValue>
-                        </DataListRow>
-                      );
-                    })}
-                  </DataListBody>
-                </DataList>
-              ) : (
-                <div className="py-20 text-center text-sm text-gray-700">
-                  You have no links in your post.
-                </div>
-              )}
+              {!fullWidth && <Separator />}
+              <div className="mx-auto my-6 h-[240px]">
+                <NewsletterRadialChart
+                  className="pointer-events-none aspect-square h-[240px]"
+                  config={commonChartConfig}
+                  data={commonChartData}
+                  tooltip={false}
+                />
+              </div>
             </div>
-          </div>
-          {/* <Button variant='outline' onClick={() => {
+
+            <div className={`${fullWidth && 'pl-6'}`}>
+              {!fullWidth && <Separator />}
+              <div className={fullWidth ? '' : 'pt-3'}>
+                <div
+                  className={`flex items-center justify-between gap-3 ${fullWidth ? 'pb-3' : 'py-3'}`}
+                >
+                  <span className="font-medium text-muted-foreground">
+                    Top clicked links in this email
+                  </span>
+                  <HTable>Members</HTable>
+                </div>
+
+                {topLinks.length > 0 ? (
+                  <DataList className="">
+                    <DataListBody>
+                      {topLinks.slice(0, fullWidth ? 10 : 5).map((link) => {
+                        const percentage = stats.clicked > 0 ? link.count / stats.clicked : 0;
+                        return (
+                          <DataListRow key={link.link.link_id}>
+                            <DataListBar
+                              style={{
+                                width: `${percentage ? Math.round(percentage * 100) : 0}%`,
+                              }}
+                            />
+                            <DataListItemContent>
+                              <div className="flex items-center space-x-2 overflow-hidden">
+                                <LucideIcon.Link
+                                  className="shrink-0 text-muted-foreground"
+                                  size={16}
+                                  strokeWidth={1.5}
+                                />
+                                <a
+                                  className="block truncate font-medium hover:underline"
+                                  href={link.link.to}
+                                  rel="noreferrer"
+                                  target="_blank"
+                                  title={link.link.to}
+                                >
+                                  {cleanTrackedUrl(link.link.to, true)}
+                                </a>
+                              </div>
+                            </DataListItemContent>
+                            <DataListItemValue>
+                              <DataListItemValueAbs>
+                                {formatNumber(link.count || 0)}
+                              </DataListItemValueAbs>
+                              <DataListItemValuePerc>
+                                {formatPercentage(percentage)}
+                              </DataListItemValuePerc>
+                            </DataListItemValue>
+                          </DataListRow>
+                        );
+                      })}
+                    </DataListBody>
+                  </DataList>
+                ) : (
+                  <div className="py-20 text-center text-sm text-gray-700">
+                    You have no links in your post.
+                  </div>
+                )}
+              </div>
+            </div>
+            {/* <Button variant='outline' onClick={() => {
                         navigate(`/posts/analytics/${postId}/newsletter`);
                     }}>
                         View all
                         <LucideIcon.ArrowRight />
                     </Button> */}
+          </PendingSendEmpty>
         </CardContent>
       )}
     </Card>

--- a/apps/admin/src/posts/analytics/overview/overview.tsx
+++ b/apps/admin/src/posts/analytics/overview/overview.tsx
@@ -162,7 +162,6 @@ const Overview: React.FC = () => {
   const kpiIsLoading = isConfigLoading || isTotalsLoading || isPostLoading || chartLoading;
   const chartIsLoading = isPostLoading || isConfigLoading || chartLoading;
 
-  // Use the utility function from admin-x-framework
   const showNewsletterSection =
     hasNewsletterAnalytics && emailTrackOpensEnabled && emailTrackClicksEnabled;
   const showWebSection = !post?.email_only && webAnalyticsEnabled;

--- a/apps/admin/src/posts/analytics/overview/overview.tsx
+++ b/apps/admin/src/posts/analytics/overview/overview.tsx
@@ -31,12 +31,7 @@ import {
   getRangeForStartDate,
   sanitizeChartData,
 } from '@/shared/analytics/chart-helpers';
-import {
-  hasBeenEmailed,
-  isPublishedOnly,
-  useNavigate,
-  useTinybirdQuery,
-} from '@tryghost/admin-x-framework';
+import { isPublishedOnly, useNavigate, useTinybirdQuery } from '@tryghost/admin-x-framework';
 import { useActiveGiftLink } from '@tryghost/admin-x-framework/api/gift-links';
 import { useAnalyticsData } from '@/shared/analytics/use-analytics-data';
 import {
@@ -50,6 +45,7 @@ import { useCanManageGiftLink } from '@/posts/analytics/hooks/use-can-manage-gif
 import { useEffect, useMemo, useState } from 'react';
 import { useGiftLinkUsage } from '@/posts/analytics/hooks/use-gift-link-usage';
 import { usePostReferrers } from '@/posts/analytics/hooks/use-post-referrers';
+import { useEmailSendingStatusContext } from '@/posts/analytics/email-sending-status/email-sending-status-context';
 
 const Overview: React.FC = () => {
   const navigate = useNavigate();
@@ -61,6 +57,7 @@ const Overview: React.FC = () => {
   const membersTrackSources = useMembersTrackSources();
   const paidMembersEnabled = usePaidMembersEnabled();
   const webAnalyticsEnabled = useWebAnalyticsEnabled();
+  const { hasNewsletterAnalytics, isStatusLoading } = useEmailSendingStatusContext();
 
   // Gift link card: only for eligible posts. Read the active link (without
   // minting) to scope the usage count to the current token, matching the modal.
@@ -167,7 +164,7 @@ const Overview: React.FC = () => {
 
   // Use the utility function from admin-x-framework
   const showNewsletterSection =
-    hasBeenEmailed(post as Post) && emailTrackOpensEnabled && emailTrackClicksEnabled;
+    hasNewsletterAnalytics && emailTrackOpensEnabled && emailTrackClicksEnabled;
   const showWebSection = !post?.email_only && webAnalyticsEnabled;
   const showGrowthSection = membersTrackSources;
   const showGiftLinkCard = Boolean(canManageGiftLink && post && webAnalyticsEnabled);
@@ -208,7 +205,7 @@ const Overview: React.FC = () => {
           )}
           {showNewsletterSection && (
             <NewsletterOverview
-              isNewsletterStatsLoading={isPostLoading}
+              isNewsletterStatsLoading={isPostLoading || isStatusLoading}
               isWebShown={showWebSection}
               post={post as Post}
             />

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
+import { focusManager } from '@tanstack/react-query';
 
 import {
   currentRoute,
@@ -260,7 +261,7 @@ describe('Post analytics overview', () => {
     await expect
       .poll(() => statusRequestCount, { timeout: 3500 })
       .toBeGreaterThan(pendingStatusRequestCount);
-    await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+    await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
     await expect.poll(() => postsApi.requests.length).toBeGreaterThan(1);
     await expect.poll(() => detailedPostsApi.requests.length).toBeGreaterThan(1);
     await expect.poll(() => basicStatsApi.requests.length).toBeGreaterThan(1);
@@ -320,6 +321,8 @@ describe('Post analytics overview', () => {
     });
 
     await expect.element(page.getByText('Some emails failed to send')).toBeVisible();
+    await expect.element(page.getByText(/^Published on your site on/)).toBeVisible();
+    await expect.element(page.getByText(/^Published and sent on/)).not.toBeInTheDocument();
     await expect.element(page.getByText(/Mailgun rejected the batch/)).toBeVisible();
     await expect.element(page.getByText('No newsletter data available')).toBeVisible();
 
@@ -327,7 +330,7 @@ describe('Post analytics overview', () => {
     await expect.poll(() => retryApi.requests.length).toBe(1);
     await expect.element(page.getByText('Sending emails')).toBeVisible();
     await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(2);
-    await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+    await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
   });
 
   it('shows a generic failure without retry when a batch has an unknown delivery outcome', async () => {
@@ -353,22 +356,16 @@ describe('Post analytics overview', () => {
       ],
     });
     const batchesApi = fakeSubmittingBatches([{ id: 'batch-1', status: 'submitting' }]);
-
     await renderAdminApp(`/posts/analytics/${POST_ID}`, {
       labs: { improveSendingUI: true },
       boot: webAnalyticsBootOverrides(),
     });
 
     await expect.element(page.getByText('Emails failed to send')).toBeVisible();
-    await expect
-      .element(page.getByText('Something went wrong while sending this email.'))
-      .toBeVisible();
-    await expect.element(page.getByText(/only partially sent/)).not.toBeInTheDocument();
+    await expect.element(page.getByText(/only partially sent/)).toBeVisible();
     await expect
       .element(
-        page
-          .getByTestId('email-sending-status-banner')
-          .getByRole('button', { name: /send|retry/i }),
+        postAnalyticsScreen.emailSendingStatusBanner().getByRole('button', { name: /send|retry/i }),
       )
       .not.toBeInTheDocument();
     await expect
@@ -467,9 +464,74 @@ describe('Post analytics overview', () => {
     await expect
       .element(page.getByText('This newsletter is still sending'))
       .not.toBeInTheDocument();
-    await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+    await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
     await expect.poll(() => statusApi.requests.length).toBe(1);
     await app.unmount();
+  });
+
+  it('recovers from a transient status error on focus', async () => {
+    seedPostAnalyticsWorld({
+      email: { id: EMAIL_ID, email_count: 1000, opened_count: 400, status: 'submitting' },
+    });
+    const failedStatusApi = fakeAdminEndpoint(
+      'GET',
+      `/emails/${EMAIL_ID}/status/`,
+      { errors: [{ message: 'Bad gateway' }] },
+      { status: 502 },
+    );
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.poll(() => failedStatusApi.requests.length).toBe(1);
+
+    const recoveredStatusApi = fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, {
+      email_statuses: [
+        {
+          id: EMAIL_ID,
+          sending: {
+            status: 'submitting',
+            progress: { completed: 500, total: 1000, estimated_seconds_remaining: 30 },
+          },
+        },
+      ],
+    });
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+
+    await expect.poll(() => recoveredStatusApi.requests.length).toBeGreaterThan(0);
+    await expect.element(page.getByText('Sending emails')).toBeVisible();
+    focusManager.setFocused(undefined);
+  });
+
+  it('does not show sending UI or retry a failed email after the post is unpublished', async () => {
+    seedPostAnalyticsWorld({
+      status: 'draft',
+      email: { id: EMAIL_ID, email_count: 0, opened_count: 0, status: 'failed' },
+    });
+    const statusApi = fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, {
+      email_statuses: [
+        {
+          id: EMAIL_ID,
+          sending: {
+            status: 'failed',
+            failed_during: 'preparing',
+            progress: { completed: 0, total: 1000, estimated_seconds_remaining: null },
+          },
+        },
+      ],
+    });
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
+    await expect.element(postAnalyticsScreen.newsletterTab()).not.toBeInTheDocument();
+    expect(statusApi.requests).toHaveLength(0);
   });
 
   it('applies the Admin 7 chrome on post analytics', async () => {

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -71,7 +71,7 @@ function seedPostAnalyticsWorld(
     stats: [{ date: daysAgo(1), mrr: 50000 }],
     totals: [{ currency: 'usd', mrr: 50000 }],
   });
-  fakeAdminEndpoint('GET', /^\/links\//, {
+  const linksApi = fakeAdminEndpoint('GET', /^\/links\//, {
     links: [
       {
         post_id: POST_ID,
@@ -94,6 +94,7 @@ function seedPostAnalyticsWorld(
   const topLocationsApi = fakeTinybirdPipe('api_top_locations', [{ location: 'US', visits: 200 }]);
   return {
     postsApi,
+    linksApi,
     topSourcesApi,
     topLocationsApi,
     kpisApi: fakeTinybirdPipe('api_kpis', [
@@ -138,7 +139,7 @@ describe('Post analytics overview', () => {
       email: { id: EMAIL_ID, email_count: 0, opened_count: 0, status: 'submitting' },
     } as const;
     let postRequestCount = 0;
-    const { postsApi } = seedPostAnalyticsWorld(postOverrides, () => {
+    const { linksApi, postsApi } = seedPostAnalyticsWorld(postOverrides, () => {
       postRequestCount += 1;
       return [
         seededPost(
@@ -155,11 +156,60 @@ describe('Post analytics overview', () => {
         ),
       ];
     });
-    fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/`), {
-      posts: [seededPost(postOverrides)],
+    let detailedPostRequestCount = 0;
+    const detailedPostsApi = fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/`), () => {
+      detailedPostRequestCount += 1;
+      return {
+        posts: [
+          seededPost(
+            detailedPostRequestCount === 1
+              ? postOverrides
+              : {
+                  email: {
+                    id: EMAIL_ID,
+                    email_count: 1000,
+                    opened_count: 400,
+                    status: 'submitted',
+                  },
+                  count: { clicks: 60, positive_feedback: 0, negative_feedback: 0 },
+                },
+          ),
+        ],
+      };
     });
-    fakeAdminStats.newsletterBasic([]);
-    fakeAdminStats.newsletterClicks([]);
+    let basicStatsRequestCount = 0;
+    const basicStatsApi = fakeAdminEndpoint('GET', /^\/stats\/newsletter-basic-stats\//, () => {
+      basicStatsRequestCount += 1;
+      return {
+        stats:
+          basicStatsRequestCount === 1
+            ? []
+            : [
+                {
+                  post_id: POST_ID,
+                  post_title: 'Attack of the Clones',
+                  send_date: `${daysAgo(10)}T10:00:00.000Z`,
+                  sent_to: 1000,
+                  total_opens: 400,
+                  open_rate: 0.4,
+                },
+              ],
+        meta: {},
+      };
+    });
+    const clickStatsApi = fakeAdminEndpoint('GET', /^\/stats\/newsletter-click-stats\//, () => {
+      return {
+        stats: [
+          {
+            post_id: POST_ID,
+            total_clicks: 60,
+            click_rate: 0.06,
+            email_count: 1000,
+          },
+        ],
+        meta: {},
+      };
+    });
     let statusRequestCount = 0;
     fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
       statusRequestCount += 1;
@@ -197,10 +247,18 @@ describe('Post analytics overview', () => {
     await expect
       .element(page.getByText('Sends, opens and clicks will appear once every email has been sent'))
       .toBeVisible();
+    await expect.element(page.getByRole('button', { name: /View members/ }).first()).toBeDisabled();
 
     await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(1);
     await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
     await expect.poll(() => postsApi.requests.length).toBeGreaterThan(1);
+    await expect.poll(() => detailedPostsApi.requests.length).toBeGreaterThan(1);
+    await expect.poll(() => basicStatsApi.requests.length).toBeGreaterThan(1);
+    await expect.poll(() => clickStatsApi.requests.length).toBeGreaterThan(0);
+    await expect.poll(() => linksApi.requests.length).toBeGreaterThan(1);
+    await expect.element(page.getByText('1,000').first()).toBeVisible();
+    await expect.element(page.getByText('400').first()).toBeVisible();
+    await expect.element(page.getByRole('button', { name: /View members/ }).first()).toBeEnabled();
   });
 
   it('moves a failed send and its retry action into the banner', async () => {
@@ -213,33 +271,7 @@ describe('Post analytics overview', () => {
         error: 'Mailgun rejected the batch.',
       },
     } as const;
-    let postRequestCount = 0;
-    seedPostAnalyticsWorld(postOverrides, () => {
-      postRequestCount += 1;
-      return [
-        seededPost(
-          postRequestCount === 1
-            ? postOverrides
-            : postRequestCount === 2
-              ? {
-                  email: {
-                    id: EMAIL_ID,
-                    email_count: 250,
-                    opened_count: 0,
-                    status: 'submitting',
-                  },
-                }
-              : {
-                  email: {
-                    id: EMAIL_ID,
-                    email_count: 1000,
-                    opened_count: 400,
-                    status: 'submitted',
-                  },
-                },
-        ),
-      ];
-    });
+    seedPostAnalyticsWorld(postOverrides);
     let statusRequestCount = 0;
     fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
       statusRequestCount += 1;
@@ -287,6 +319,71 @@ describe('Post analytics overview', () => {
     await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
   });
 
+  it('refreshes the failure reason and does not count prepared recipients as sent', async () => {
+    const postOverrides = {
+      email: { id: EMAIL_ID, email_count: 0, opened_count: 0, status: 'submitting' },
+    } as const;
+    let postRequestCount = 0;
+    const { postsApi } = seedPostAnalyticsWorld(postOverrides, () => {
+      postRequestCount += 1;
+      return [
+        seededPost(
+          postRequestCount === 1
+            ? postOverrides
+            : {
+                email: {
+                  id: EMAIL_ID,
+                  email_count: 0,
+                  opened_count: 0,
+                  status: 'failed',
+                  error: 'Preparation failed.',
+                },
+              },
+        ),
+      ];
+    });
+    let statusRequestCount = 0;
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
+      statusRequestCount += 1;
+      return {
+        email_statuses: [
+          {
+            id: EMAIL_ID,
+            sending:
+              statusRequestCount === 1
+                ? {
+                    status: 'preparing',
+                    progress: { completed: 100, total: 1000, estimated_seconds_remaining: 30 },
+                  }
+                : {
+                    status: 'failed',
+                    failed_during: 'preparing',
+                    progress: {
+                      completed: 250,
+                      total: 1000,
+                      estimated_seconds_remaining: null,
+                    },
+                  },
+          },
+        ],
+      };
+    });
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(page.getByText('Preparing emails')).toBeVisible();
+    await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(1);
+    await expect.poll(() => postsApi.requests.length).toBeGreaterThan(1);
+    await expect.element(page.getByText('Emails failed to send')).toBeVisible();
+    await expect
+      .element(page.getByText(/None of the 1,000 emails were sent\. Preparation failed\./))
+      .toBeVisible();
+    await expect.element(page.getByRole('button', { name: 'Retry sending email' })).toBeVisible();
+  });
+
   it('falls back to the production analytics UI when the status endpoint is unavailable', async () => {
     seedPostAnalyticsWorld({
       email: { id: EMAIL_ID, email_count: 1000, opened_count: 400, status: 'submitting' },
@@ -309,7 +406,7 @@ describe('Post analytics overview', () => {
   it('applies the Admin 7 chrome on post analytics', async () => {
     seedPostAnalyticsWorld();
     await renderAdminApp(`/posts/analytics/${POST_ID}`, {
-      labs: { admin7PageChrome: true },
+      labs: { admin7PageChrome: true, improveSendingUI: false },
       boot: webAnalyticsBootOverrides(),
     });
     await expect.element(postAnalyticsScreen.postTitle('Attack of the Clones')).toBeVisible();

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -21,6 +21,7 @@ import { postAnalyticsScreen } from './post-analytics.screen';
 const POST_ID = '64d623b64676110001e897d9';
 const POST_UUID = '0d5cea22-f4d5-4b23-a0f7-1d9c46ae5f2a';
 const NEWSLETTER_ID = '64d623b64676110001e897aa';
+const EMAIL_ID = '64d623b64676110001e897ab';
 
 function daysAgo(days: number): string {
   const date = new Date();
@@ -28,7 +29,7 @@ function daysAgo(days: number): string {
   return date.toISOString().slice(0, 10);
 }
 
-function seededPost() {
+function seededPost(overrides: Partial<ReturnType<typeof post>> = {}) {
   return post({
     id: POST_ID,
     uuid: POST_UUID,
@@ -38,9 +39,10 @@ function seededPost() {
     visibility: 'public',
     published_at: `${daysAgo(10)}T10:00:00.000Z`,
     url: 'https://example.com/attack-of-the-clones/',
-    email: { email_count: 1000, opened_count: 400, status: 'submitted' },
+    email: { id: EMAIL_ID, email_count: 1000, opened_count: 400, status: 'submitted' },
     count: { clicks: 60, positive_feedback: 0, negative_feedback: 0 },
     newsletter: { id: NEWSLETTER_ID },
+    ...overrides,
   });
 }
 
@@ -50,8 +52,11 @@ function seededPost() {
  * and the Tinybird KPI + active-visitors pipes. Tab-specific endpoints are
  * declared per test.
  */
-function seedPostAnalyticsWorld() {
-  const postsApi = fakePosts([seededPost()]);
+function seedPostAnalyticsWorld(
+  postOverrides: Partial<ReturnType<typeof post>> = {},
+  postResponse: Parameters<typeof fakePosts>[0] = [seededPost(postOverrides)],
+) {
+  const postsApi = fakePosts(postResponse);
   fakeAdminStats.postReferrers(POST_ID, [
     {
       source: 'Google',
@@ -128,6 +133,179 @@ function seedEmptyPostAnalyticsWorld() {
 }
 
 describe('Post analytics overview', () => {
+  it('shows sending progress and withholds newsletter figures with the URL override', async () => {
+    const postOverrides = {
+      email: { id: EMAIL_ID, email_count: 0, opened_count: 0, status: 'submitting' },
+    } as const;
+    let postRequestCount = 0;
+    const { postsApi } = seedPostAnalyticsWorld(postOverrides, () => {
+      postRequestCount += 1;
+      return [
+        seededPost(
+          postRequestCount === 1
+            ? postOverrides
+            : {
+                email: {
+                  id: EMAIL_ID,
+                  email_count: 1000,
+                  opened_count: 400,
+                  status: 'submitted',
+                },
+              },
+        ),
+      ];
+    });
+    fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/`), {
+      posts: [seededPost(postOverrides)],
+    });
+    fakeAdminStats.newsletterBasic([]);
+    fakeAdminStats.newsletterClicks([]);
+    let statusRequestCount = 0;
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
+      statusRequestCount += 1;
+      return {
+        email_statuses: [
+          {
+            id: EMAIL_ID,
+            sending:
+              statusRequestCount === 1
+                ? {
+                    status: 'submitting',
+                    progress: { completed: 500, total: 1000, estimated_seconds_remaining: 30 },
+                  }
+                : {
+                    status: 'submitted',
+                    progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
+                  },
+          },
+        ],
+      };
+    });
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}?labs=improveSendingUI`, {
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(page.getByText('Sending emails')).toBeVisible();
+    await expect.element(page.getByText(/500 of 1,000/)).toBeVisible();
+    await expect.element(page.getByText('This newsletter is still sending')).toBeVisible();
+    await expect.element(postAnalyticsScreen.uniqueVisitors()).toHaveTextContent('250');
+
+    await postAnalyticsScreen.newsletterTab().click();
+    await expect.poll(currentRoute).toBe(`/posts/analytics/${POST_ID}/newsletter`);
+    await expect.element(page.getByText('Newsletter clicks')).not.toBeInTheDocument();
+    await expect
+      .element(page.getByText('Sends, opens and clicks will appear once every email has been sent'))
+      .toBeVisible();
+
+    await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(1);
+    await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+    await expect.poll(() => postsApi.requests.length).toBeGreaterThan(1);
+  });
+
+  it('moves a failed send and its retry action into the banner', async () => {
+    const postOverrides = {
+      email: {
+        id: EMAIL_ID,
+        email_count: 250,
+        opened_count: 0,
+        status: 'failed',
+        error: 'Mailgun rejected the batch.',
+      },
+    } as const;
+    let postRequestCount = 0;
+    seedPostAnalyticsWorld(postOverrides, () => {
+      postRequestCount += 1;
+      return [
+        seededPost(
+          postRequestCount === 1
+            ? postOverrides
+            : postRequestCount === 2
+              ? {
+                  email: {
+                    id: EMAIL_ID,
+                    email_count: 250,
+                    opened_count: 0,
+                    status: 'submitting',
+                  },
+                }
+              : {
+                  email: {
+                    id: EMAIL_ID,
+                    email_count: 1000,
+                    opened_count: 400,
+                    status: 'submitted',
+                  },
+                },
+        ),
+      ];
+    });
+    let statusRequestCount = 0;
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
+      statusRequestCount += 1;
+      return {
+        email_statuses: [
+          {
+            id: EMAIL_ID,
+            sending:
+              statusRequestCount === 1
+                ? {
+                    status: 'failed',
+                    failed_during: 'submitting',
+                    progress: { completed: 250, total: 1000, estimated_seconds_remaining: null },
+                  }
+                : statusRequestCount === 2
+                  ? {
+                      status: 'submitting',
+                      progress: { completed: 250, total: 1000, estimated_seconds_remaining: 30 },
+                    }
+                  : {
+                      status: 'submitted',
+                      progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
+                    },
+          },
+        ],
+      };
+    });
+    const retryApi = fakeAdminEndpoint('PUT', `/emails/${EMAIL_ID}/retry/`, {
+      emails: [{ id: EMAIL_ID, email_count: 250, opened_count: 0, status: 'submitting' }],
+    });
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(page.getByText('Some emails failed to send')).toBeVisible();
+    await expect.element(page.getByText(/Mailgun rejected the batch/)).toBeVisible();
+    await expect.element(page.getByText('No newsletter data available')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Send remaining emails' }).click();
+    await expect.poll(() => retryApi.requests.length).toBe(1);
+    await expect.element(page.getByText('Sending emails')).toBeVisible();
+    await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(2);
+    await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the production analytics UI when the status endpoint is unavailable', async () => {
+    seedPostAnalyticsWorld({
+      email: { id: EMAIL_ID, email_count: 1000, opened_count: 400, status: 'submitting' },
+    });
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, null, { status: 404 });
+
+    const app = await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(page.getByText('Newsletter performance')).toBeVisible();
+    await expect
+      .element(page.getByText('This newsletter is still sending'))
+      .not.toBeInTheDocument();
+    await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+    await app.unmount();
+  });
+
   it('applies the Admin 7 chrome on post analytics', async () => {
     seedPostAnalyticsWorld();
     await renderAdminApp(`/posts/analytics/${POST_ID}`, {
@@ -160,7 +338,23 @@ describe('Post analytics overview', () => {
 
   it('keeps the post context when switching to the web tab', async () => {
     const { kpisApi } = seedPostAnalyticsWorld();
-    await renderAdminApp(`/posts/analytics/${POST_ID}`, { boot: webAnalyticsBootOverrides() });
+    // The browser runner can deliver a queued focus refetch from the preceding
+    // status-query scenarios after rotating their per-test handlers.
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, {
+      email_statuses: [
+        {
+          id: EMAIL_ID,
+          sending: {
+            status: 'submitted',
+            progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
+          },
+        },
+      ],
+    });
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: false },
+      boot: webAnalyticsBootOverrides(),
+    });
 
     await expect.element(postAnalyticsScreen.postTitle('Attack of the Clones')).toBeVisible();
     await expect.element(postAnalyticsScreen.uniqueVisitors()).toHaveTextContent('250');

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -211,22 +211,22 @@ describe('Post analytics overview', () => {
       };
     });
     let statusRequestCount = 0;
+    let completeSending = false;
     fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
       statusRequestCount += 1;
       return {
         email_statuses: [
           {
             id: EMAIL_ID,
-            sending:
-              statusRequestCount === 1
-                ? {
-                    status: 'submitting',
-                    progress: { completed: 500, total: 1000, estimated_seconds_remaining: 30 },
-                  }
-                : {
-                    status: 'submitted',
-                    progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
-                  },
+            sending: !completeSending
+              ? {
+                  status: 'submitting',
+                  progress: { completed: 500, total: 1000, estimated_seconds_remaining: 30 },
+                }
+              : {
+                  status: 'submitted',
+                  progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
+                },
           },
         ],
       };
@@ -249,7 +249,11 @@ describe('Post analytics overview', () => {
       .toBeVisible();
     await expect.element(page.getByRole('button', { name: /View members/ }).first()).toBeDisabled();
 
-    await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(1);
+    completeSending = true;
+    const pendingStatusRequestCount = statusRequestCount;
+    await expect
+      .poll(() => statusRequestCount, { timeout: 3500 })
+      .toBeGreaterThan(pendingStatusRequestCount);
     await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
     await expect.poll(() => postsApi.requests.length).toBeGreaterThan(1);
     await expect.poll(() => detailedPostsApi.requests.length).toBeGreaterThan(1);
@@ -388,7 +392,12 @@ describe('Post analytics overview', () => {
     seedPostAnalyticsWorld({
       email: { id: EMAIL_ID, email_count: 1000, opened_count: 400, status: 'submitting' },
     });
-    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, null, { status: 404 });
+    const statusApi = fakeAdminEndpoint(
+      'GET',
+      `/emails/${EMAIL_ID}/status/`,
+      { errors: [{ message: 'Resource not found' }] },
+      { status: 404 },
+    );
 
     const app = await renderAdminApp(`/posts/analytics/${POST_ID}`, {
       labs: { improveSendingUI: true },
@@ -400,6 +409,7 @@ describe('Post analytics overview', () => {
       .element(page.getByText('This newsletter is still sending'))
       .not.toBeInTheDocument();
     await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
+    await expect.poll(() => statusApi.requests.length).toBe(1);
     await app.unmount();
   });
 
@@ -435,19 +445,6 @@ describe('Post analytics overview', () => {
 
   it('keeps the post context when switching to the web tab', async () => {
     const { kpisApi } = seedPostAnalyticsWorld();
-    // The browser runner can deliver a queued focus refetch from the preceding
-    // status-query scenarios after rotating their per-test handlers.
-    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, {
-      email_statuses: [
-        {
-          id: EMAIL_ID,
-          sending: {
-            status: 'submitted',
-            progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
-          },
-        },
-      ],
-    });
     await renderAdminApp(`/posts/analytics/${POST_ID}`, {
       labs: { improveSendingUI: false },
       boot: webAnalyticsBootOverrides(),

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -46,6 +46,12 @@ function seededPost(overrides: Partial<ReturnType<typeof post>> = {}) {
   });
 }
 
+function fakeSubmittingBatches(batches: Array<{ id: string; status: string }> = []) {
+  return fakeAdminEndpoint('GET', new RegExp(`^/emails/${EMAIL_ID}/batches/(?:\\?|$)`), {
+    batches,
+  });
+}
+
 /**
  * The world every post-analytics tab reads: the routed post, its growth
  * stats (referrers/growth/mrr feed both the overview and the growth tab),
@@ -276,6 +282,7 @@ describe('Post analytics overview', () => {
       },
     } as const;
     seedPostAnalyticsWorld(postOverrides);
+    fakeSubmittingBatches();
     let statusRequestCount = 0;
     fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
       statusRequestCount += 1;
@@ -323,6 +330,57 @@ describe('Post analytics overview', () => {
     await expect.element(page.getByTestId('email-sending-status-banner')).not.toBeInTheDocument();
   });
 
+  it('shows a generic failure without retry when a batch has an unknown delivery outcome', async () => {
+    seedPostAnalyticsWorld({
+      email: {
+        id: EMAIL_ID,
+        email_count: 250,
+        opened_count: 0,
+        status: 'failed',
+        error: 'An error occurred, and your newsletter was only partially sent.',
+      },
+    });
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, {
+      email_statuses: [
+        {
+          id: EMAIL_ID,
+          sending: {
+            status: 'failed',
+            failed_during: 'submitting',
+            progress: { completed: 250, total: 1000, estimated_seconds_remaining: null },
+          },
+        },
+      ],
+    });
+    const batchesApi = fakeSubmittingBatches([{ id: 'batch-1', status: 'submitting' }]);
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect.element(page.getByText('Emails failed to send')).toBeVisible();
+    await expect
+      .element(page.getByText('Something went wrong while sending this email.'))
+      .toBeVisible();
+    await expect.element(page.getByText(/only partially sent/)).not.toBeInTheDocument();
+    await expect
+      .element(
+        page
+          .getByTestId('email-sending-status-banner')
+          .getByRole('button', { name: /send|retry/i }),
+      )
+      .not.toBeInTheDocument();
+    await expect
+      .poll(() =>
+        new URL(batchesApi.lastRequest?.url ?? 'http://localhost').searchParams.get('filter'),
+      )
+      .toBe('status:submitting');
+    const batchRequestUrl = new URL(batchesApi.lastRequest!.url);
+    expect(batchRequestUrl.searchParams.get('fields')).toBe('id,status');
+    expect(batchRequestUrl.searchParams.get('limit')).toBe('1');
+  });
+
   it('refreshes the failure reason and does not count prepared recipients as sent', async () => {
     const postOverrides = {
       email: { id: EMAIL_ID, email_count: 0, opened_count: 0, status: 'submitting' },
@@ -346,6 +404,7 @@ describe('Post analytics overview', () => {
         ),
       ];
     });
+    fakeSubmittingBatches();
     let statusRequestCount = 0;
     fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
       statusRequestCount += 1;

--- a/apps/admin/src/posts/analytics/post-analytics.screen.ts
+++ b/apps/admin/src/posts/analytics/post-analytics.screen.ts
@@ -17,6 +17,7 @@ export const postAnalyticsScreen = {
     page.getByTestId(sel.webPerformance).getByRole('button', { name: 'View more' }),
   uniqueVisitors: () => page.getByTestId(sel.uniqueVisitors),
   growthCard: () => page.getByTestId(sel.growth),
+  emailSendingStatusBanner: () => page.getByTestId(sel.emailSendingStatusBanner),
   growthViewMoreButton: () =>
     page.getByTestId(sel.growth).getByRole('button', { name: 'View more' }),
 

--- a/apps/admin/src/posts/analytics/providers/post-analytics-context.ts
+++ b/apps/admin/src/posts/analytics/providers/post-analytics-context.ts
@@ -32,6 +32,7 @@ export type PostAnalyticsContextType = {
   postId: string;
   post: Post | undefined;
   isPostLoading: boolean;
+  refetchPost: () => Promise<void>;
   range: number;
   setRange: (value: number) => void;
 };

--- a/apps/admin/src/posts/analytics/providers/post-analytics-provider.tsx
+++ b/apps/admin/src/posts/analytics/providers/post-analytics-provider.tsx
@@ -1,6 +1,6 @@
 import { POST_ANALYTICS_INCLUDE, STATS_RANGES } from '@/shared/analytics/constants';
 import { PostAnalyticsContext } from '@/posts/analytics/providers/post-analytics-context';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 import { useBrowsePosts } from '@tryghost/admin-x-framework/api/posts';
 import { useParams } from '@tryghost/admin-x-framework';
 
@@ -18,12 +18,19 @@ const PostAnalyticsProvider = ({ children }: { children: ReactNode }) => {
 
   // Fetch post data with all required includes. The gift-link modal reuses
   // POST_ANALYTICS_INCLUDE for the same query key, so both read one cached post.
-  const { data: { posts: [post] } = { posts: [] }, isLoading: isPostLoading } = useBrowsePosts({
+  const {
+    data: { posts: [post] } = { posts: [] },
+    isLoading: isPostLoading,
+    refetch,
+  } = useBrowsePosts({
     searchParams: {
       filter: `id:${postId}`,
       include: POST_ANALYTICS_INCLUDE,
     },
   });
+  const refetchPost = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   return (
     <PostAnalyticsContext.Provider
@@ -31,6 +38,7 @@ const PostAnalyticsProvider = ({ children }: { children: ReactNode }) => {
         postId: postId,
         post: post,
         isPostLoading,
+        refetchPost,
         range,
         setRange,
       }}

--- a/apps/admin/src/posts/analytics/routes.tsx
+++ b/apps/admin/src/posts/analytics/routes.tsx
@@ -5,14 +5,21 @@ import { type RouteObject, lazyComponent } from '@tryghost/admin-x-framework';
 // lazy composes the provider around the screen so neither chunk loads before
 // the route is visited. `lazy:` is preserved for per-view code-splitting.
 export const lazyPostAnalyticsRoot = async () => {
-  const [{ default: PostAnalyticsProvider }, { default: PostAnalytics }] = await Promise.all([
+  const [
+    { default: PostAnalyticsProvider },
+    { default: EmailSendingStatusProvider },
+    { default: PostAnalytics },
+  ] = await Promise.all([
     import('./providers/post-analytics-provider'),
+    import('./email-sending-status/email-sending-status-provider'),
     import('./post-analytics'),
   ]);
   return {
     element: (
       <PostAnalyticsProvider>
-        <PostAnalytics />
+        <EmailSendingStatusProvider>
+          <PostAnalytics />
+        </EmailSendingStatusProvider>
       </PostAnalyticsProvider>
     ),
   };

--- a/apps/ember-admin/app/components/editor/publish-management.js
+++ b/apps/ember-admin/app/components/editor/publish-management.js
@@ -23,7 +23,9 @@ export const CONFIRM_EMAIL_MAX_POLL_LENGTH = 15 * 1000;
 // modal display, and provide an editor-specific save behaviour wrapper around
 // PublishOptions saving.
 export default class PublishManagement extends Component {
+    @service ajax;
     @service feature;
+    @service ghostPaths;
     @service modals;
     @service notifications;
     @service settings;
@@ -256,9 +258,13 @@ export default class PublishManagement extends Component {
         // perform any post-save cleanup for the editor
         yield this.args.afterPublish(result);
 
-        // if emailed, wait until it has been submitted so we can show a failure message if needed
-        if (willEmailImmediately && this.publishOptions.post.email && !this.feature.improveSendingUI) {
-            yield this.confirmEmailTask.perform();
+        if (willEmailImmediately && this.publishOptions.post.email) {
+            const supportsSendingStatus = this.feature.improveSendingUI && (yield this._supportsSendingStatus());
+
+            // Older Core versions need the legacy poll so failures remain visible in the publish flow.
+            if (!supportsSendingStatus) {
+                yield this.confirmEmailTask.perform();
+            }
         }
 
         return result;
@@ -306,6 +312,21 @@ export default class PublishManagement extends Component {
         }
 
         return true;
+    }
+
+    async _supportsSendingStatus() {
+        const emailId = this.publishOptions.post.email?.id;
+        if (!emailId) {
+            return false;
+        }
+
+        try {
+            const url = this.ghostPaths.url.api(`/emails/${emailId}/status`);
+            await this.ajax.request(url);
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     @task

--- a/apps/ember-admin/app/components/editor/publish-management.js
+++ b/apps/ember-admin/app/components/editor/publish-management.js
@@ -23,9 +23,7 @@ export const CONFIRM_EMAIL_MAX_POLL_LENGTH = 15 * 1000;
 // modal display, and provide an editor-specific save behaviour wrapper around
 // PublishOptions saving.
 export default class PublishManagement extends Component {
-    @service ajax;
     @service feature;
-    @service ghostPaths;
     @service modals;
     @service notifications;
     @service settings;
@@ -259,10 +257,7 @@ export default class PublishManagement extends Component {
         yield this.args.afterPublish(result);
 
         if (willEmailImmediately && this.publishOptions.post.email) {
-            const supportsSendingStatus = this.feature.improveSendingUI && (yield this._supportsSendingStatus());
-
-            // Older Core versions need the legacy poll so failures remain visible in the publish flow.
-            if (!supportsSendingStatus) {
+            if (!this.feature.improveSendingUI) {
                 yield this.confirmEmailTask.perform();
             }
         }
@@ -312,21 +307,6 @@ export default class PublishManagement extends Component {
         }
 
         return true;
-    }
-
-    async _supportsSendingStatus() {
-        const emailId = this.publishOptions.post.email?.id;
-        if (!emailId) {
-            return false;
-        }
-
-        try {
-            const url = this.ghostPaths.url.api(`/emails/${emailId}/status`);
-            await this.ajax.request(url);
-            return true;
-        } catch {
-            return false;
-        }
     }
 
     @task

--- a/apps/ember-admin/app/components/editor/publish-management.js
+++ b/apps/ember-admin/app/components/editor/publish-management.js
@@ -257,7 +257,7 @@ export default class PublishManagement extends Component {
         yield this.args.afterPublish(result);
 
         // if emailed, wait until it has been submitted so we can show a failure message if needed
-        if (willEmailImmediately && this.publishOptions.post.email) {
+        if (willEmailImmediately && this.publishOptions.post.email && !this.feature.improveSendingUI) {
             yield this.confirmEmailTask.perform();
         }
 

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -102,6 +102,7 @@ export default class FeatureService extends Service {
     @feature('csvContentImporter') csvContentImporter;
     @feature('postsListReact') postsListReact;
     @feature('editorReact') editorReact;
+    @feature('improveSendingUI') improveSendingUI;
     _user = null;
     _featureFlagOverridesRevision = 0;
 

--- a/apps/ember-admin/tests/acceptance/editor/publish-flow-test.js
+++ b/apps/ember-admin/tests/acceptance/editor/publish-flow-test.js
@@ -1,6 +1,5 @@
 import loginAsRole from '../../helpers/login-as-role';
 import moment from 'moment-timezone';
-import {Response} from 'miragejs';
 import {blur, click, currentURL, fillIn, find, findAll, triggerEvent, waitFor, waitUntil} from '@ember/test-helpers';
 import {clickTrigger, removeMultipleOption, selectChoose} from 'ember-power-select/test-support/helpers';
 import {disableMailgun, enableMailgun} from '../../helpers/mailgun';
@@ -786,13 +785,12 @@ describe('Acceptance: Publish flow', function () {
 
         it('handles server error when confirming');
 
-        it('uses the analytics sending flow when the status endpoint is available', async function () {
+        it('uses the analytics sending flow when improved sending UI is enabled', async function () {
             enableLabsFlag(this.server, 'improveSendingUI');
 
             await loginAsRole('Administrator', this.server);
             const post = this.server.create('post', {status: 'draft'});
             const email = this.server.create('email', {status: 'pending'});
-            let statusRequestCount = 0;
 
             this.server.put('/posts/:id/', function ({posts}, {params}) {
                 return posts.find(params.id).update({
@@ -800,37 +798,17 @@ describe('Acceptance: Publish flow', function () {
                     email
                 });
             });
-            this.server.get('/emails/:id/status/', () => {
-                statusRequestCount += 1;
-                return {
-                    email_statuses: [{
-                        id: email.id,
-                        sending: {
-                            status: 'preparing',
-                            progress: {
-                                completed: 0,
-                                total: 7,
-                                estimated_seconds_remaining: null
-                            }
-                        }
-                    }]
-                };
-            });
-
             await visit(`/editor/post/${post.id}`);
             await click('[data-test-button="publish-flow"]');
             await click('[data-test-button="continue"]');
             await click('[data-test-button="confirm-publish"]');
 
-            expect(statusRequestCount, 'status support request').to.equal(1);
             await waitUntil(() => currentURL() === `/posts/analytics/${post.id}`);
             expect(find('[data-test-modal="publish-flow"]'), 'publish flow closed after save').not.to.exist;
             expect(email.status, 'legacy poll did not reload the failed email').to.equal('pending');
         });
 
-        it('preserves the email failure flow when the sending status endpoint is unavailable', async function () {
-            enableLabsFlag(this.server, 'improveSendingUI');
-
+        it('preserves the legacy email failure flow when improved sending UI is disabled', async function () {
             await loginAsRole('Administrator', this.server);
             const post = this.server.create('post', {status: 'draft'});
             const email = this.server.create('email', {status: 'pending'});
@@ -841,9 +819,6 @@ describe('Acceptance: Publish flow', function () {
                     email
                 });
             });
-            this.server.get('/emails/:id/status/', () => new Response(404, {}, {
-                errors: [{message: 'Resource not found.', type: 'NotFoundError'}]
-            }));
             this.server.get('/posts/:id/', function ({posts}, {params}) {
                 const savedPost = posts.find(params.id);
                 if (savedPost.status === 'published') {

--- a/apps/ember-admin/tests/acceptance/editor/publish-flow-test.js
+++ b/apps/ember-admin/tests/acceptance/editor/publish-flow-test.js
@@ -1,6 +1,7 @@
 import loginAsRole from '../../helpers/login-as-role';
 import moment from 'moment-timezone';
-import {blur, click, fillIn, find, findAll, triggerEvent, waitFor} from '@ember/test-helpers';
+import {Response} from 'miragejs';
+import {blur, click, currentURL, fillIn, find, findAll, triggerEvent, waitFor, waitUntil} from '@ember/test-helpers';
 import {clickTrigger, removeMultipleOption, selectChoose} from 'ember-power-select/test-support/helpers';
 import {disableMailgun, enableMailgun} from '../../helpers/mailgun';
 import {disableMembers, enableMembers} from '../../helpers/members';
@@ -784,7 +785,85 @@ describe('Acceptance: Publish flow', function () {
         });
 
         it('handles server error when confirming');
-        it('handles email sending error');
+
+        it('uses the analytics sending flow when the status endpoint is available', async function () {
+            enableLabsFlag(this.server, 'improveSendingUI');
+
+            await loginAsRole('Administrator', this.server);
+            const post = this.server.create('post', {status: 'draft'});
+            const email = this.server.create('email', {status: 'pending'});
+            let statusRequestCount = 0;
+
+            this.server.put('/posts/:id/', function ({posts}, {params}) {
+                return posts.find(params.id).update({
+                    status: 'published',
+                    email
+                });
+            });
+            this.server.get('/emails/:id/status/', () => {
+                statusRequestCount += 1;
+                return {
+                    email_statuses: [{
+                        id: email.id,
+                        sending: {
+                            status: 'preparing',
+                            progress: {
+                                completed: 0,
+                                total: 7,
+                                estimated_seconds_remaining: null
+                            }
+                        }
+                    }]
+                };
+            });
+
+            await visit(`/editor/post/${post.id}`);
+            await click('[data-test-button="publish-flow"]');
+            await click('[data-test-button="continue"]');
+            await click('[data-test-button="confirm-publish"]');
+
+            expect(statusRequestCount, 'status support request').to.equal(1);
+            await waitUntil(() => currentURL() === `/posts/analytics/${post.id}`);
+            expect(find('[data-test-modal="publish-flow"]'), 'publish flow closed after save').not.to.exist;
+            expect(email.status, 'legacy poll did not reload the failed email').to.equal('pending');
+        });
+
+        it('preserves the email failure flow when the sending status endpoint is unavailable', async function () {
+            enableLabsFlag(this.server, 'improveSendingUI');
+
+            await loginAsRole('Administrator', this.server);
+            const post = this.server.create('post', {status: 'draft'});
+            const email = this.server.create('email', {status: 'pending'});
+
+            this.server.put('/posts/:id/', function ({posts}, {params}) {
+                return posts.find(params.id).update({
+                    status: 'published',
+                    email
+                });
+            });
+            this.server.get('/emails/:id/status/', () => new Response(404, {}, {
+                errors: [{message: 'Resource not found.', type: 'NotFoundError'}]
+            }));
+            this.server.get('/posts/:id/', function ({posts}, {params}) {
+                const savedPost = posts.find(params.id);
+                if (savedPost.status === 'published') {
+                    email.update({
+                        status: 'failed',
+                        error: 'Mailgun rejected the batch.'
+                    });
+                }
+                return savedPost;
+            });
+
+            await visit(`/editor/post/${post.id}`);
+            await click('[data-test-button="publish-flow"]');
+            await click('[data-test-button="continue"]');
+            await click('[data-test-button="confirm-publish"]');
+
+            await waitFor('.gh-publish-title .red');
+            expect(find('.gh-publish-confirmation'), 'email error')
+                .to.contain.trimmed.text('Mailgun rejected the batch.');
+        });
 
         it('defaults to publish-only when default recipients is "Usually nobody"', async function () {
             // Set default recipients to "Usually nobody" (filter with null filter)

--- a/packages/testing/test-data/src/builders/post.ts
+++ b/packages/testing/test-data/src/builders/post.ts
@@ -58,7 +58,9 @@ export interface Post {
   // before the setting changed keeps the flags it went out with, and that is
   // what decides whether the Opens/Clicks columns show.
   email?: {
+    id?: string;
     email_count: number;
+    error?: string | null;
     opened_count: number;
     status?: string;
     track_opens?: boolean;

--- a/packages/testing/test-data/src/selectors/post-analytics.ts
+++ b/packages/testing/test-data/src/selectors/post-analytics.ts
@@ -17,6 +17,7 @@ export const giftLinkViews = 'gift-link-views';
 export const giftLinkCardVisitors = 'gift-link-card-visitors';
 export const statsFilterContainer = 'stats-filter-container';
 export const statsFilterClearButton = 'stats-filter-clear-button';
+export const emailSendingStatusBanner = 'email-sending-status-banner';
 /** Per-row testid prefixes; append the source domain / country code. */
 export const sourceRowPrefix = 'source-row-';
 export const locationRowPrefix = 'location-row-';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3920/

Adds a status banner showing progress during the sending phase of an email to provide visibility for large sends that can take a while to complete.

- add email sending status banner that shows during preparing and sending phases, polling the new email send status API for progress and ETA data
- hide newsletter figures while a send is preparing or submitting while preserving the production card shells
- replace analytics failure treatments with the banner failure state and retry action
- refresh the post and email at submitted so terminal data is authoritative and polling stops
- skip the legacy publish confirmation wait and update share-modal copy under improveSendingUI