### PR TITLE
Changed selected Admin 7 titles to use heading features

### DIFF
--- a/apps/admin/src/editor/post-editor.tsx
+++ b/apps/admin/src/editor/post-editor.tsx
@@ -280,7 +280,7 @@ export function PostEditor({
               autoFocus={autofocusTitle}
               className={cn(
                 fieldClassName,
-                'mb-4 text-4xl leading-tight font-bold tracking-tight text-foreground placeholder:font-bold placeholder:text-muted-foreground',
+                'admin7-heading-features mb-4 text-4xl leading-tight font-bold tracking-tight text-foreground placeholder:font-bold placeholder:text-muted-foreground',
               )}
               data-testid="editor-title-input"
               placeholder={`${capitalize(postType)} title`}

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -71,6 +71,24 @@
   font-variation-settings: inherit;
 }
 
+/* These components are visually headings but do not all use heading elements.
+   Keep the display alternates scoped to their title text in Admin 7. */
+:where(
+    .admin7,
+    body.react-admin:has(> #root .admin7)
+      > :is(
+        .shade.shade-admin,
+        #ember-basic-dropdown-wormhole,
+        #ember-modal-wormhole,
+        #ember-liquid-wormhole,
+        #ember-alerts-wormhole,
+        #ember-notifications-wormhole
+      )
+  )
+  :where(.admin7-heading-features, .gh-publish-title) {
+  font-feature-settings: var(--heading-font-feature-settings);
+}
+
 /* Site custom-font families for the settings font pickers. The font-* utilities
    must be generated in this Tailwind lane; the font files themselves load with
    settings/custom-fonts.css in the settings chunk. */

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -85,7 +85,7 @@
         #ember-notifications-wormhole
       )
   )
-  :where(.admin7-heading-features, .gh-publish-title) {
+  :is(.admin7-heading-features, .gh-publish-title) {
   font-feature-settings: var(--heading-font-feature-settings);
 }
 

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
@@ -39,7 +39,9 @@ function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeade
               <img alt="Site icon" className="size-full rounded-md object-cover" src={siteIcon} />
             </div>
             <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
-              <div className="min-w-0 truncate text-lg font-semibold text-foreground">{title}</div>
+              <div className="admin7-heading-features min-w-0 truncate text-lg font-semibold text-foreground">
+                {title}
+              </div>
               {isPrivate && (
                 <a aria-label="Open access settings" className="shrink-0" href="#/settings/members">
                   <Badge

--- a/apps/ember-admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/apps/ember-admin/app/components/gh-koenig-editor-lexical.hbs
@@ -39,7 +39,7 @@
             {{/if}}
 
             <GhTextarea
-                @class="gh-editor-title {{if (and (not @cardOptions.post.showTitleAndFeatureImage) (not this.titleIsFocused)) "faded"}}"
+                @class="gh-editor-title admin7-heading-features {{if (and (not @cardOptions.post.showTitleAndFeatureImage) (not this.titleIsFocused)) "faded"}}"
                 @placeholder={{@titlePlaceholder}}
                 @shouldFocus={{or @titleAutofocus false}}
                 @tabindex="1"


### PR DESCRIPTION
## Why

The Admin 7 display-oriented Inter features are intentionally limited to headings, but three prominent title treatments are not all represented by semantic heading elements. They should use the same title typography while the surrounding UI keeps the quieter base feature set.

## What changed

- Applied the existing heading Inter features to the sidebar site title.
- Applied them to the post title field in the editor.
- Applied them to publish-flow titles, including “Ready, set, publish. Share it with the world.”
- Kept the change inside the existing `admin7PageChrome` shell and portal scope, so flag-off presentation is unchanged.
- Added no automated tests because this is a CSS-only font-feature adjustment with no behavioral contract; visual acceptance will be done manually before merge.

## Validation

- `pnpm exec oxfmt --check apps/admin/src/index.css apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx`
- `pnpm --filter @tryghost/admin exec eslint src/layout/app-sidebar/app-sidebar-header.tsx`
- `pnpm --filter ghost-admin exec ember-template-lint app/components/gh-koenig-editor-lexical.hbs`
- `pnpm --filter ghost-admin build`
- `pnpm --filter @tryghost/admin exec vite build`
- `git diff --check`

The combined `pnpm --filter @tryghost/admin build` remains blocked during its TypeScript phase by the existing error at `src/settings/membership/tiers/tier-checkout-collection.tsx:118` (`key` is not present on every custom-field fixture union member). The standalone production Vite bundle passes, and none of the changed files are involved in that error.

ref https://linear.app/ghost/issue/DES-1519