### PR TITLE
Spike: run Ghost on Postgres

### DIFF
--- a/compose.dev.postgres.yaml
+++ b/compose.dev.postgres.yaml
@@ -1,0 +1,43 @@
+# Spike: run the development stack against Postgres instead of MySQL.
+#
+#   pnpm dev:postgres
+#
+# Ghost connects with database__client=pg. The MySQL container is disabled by
+# putting it behind a profile so it never starts.
+services:
+  mysql:
+    profiles:
+      - mysql
+
+  postgres:
+    image: postgres:16
+    container_name: ghost-dev-postgres
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-root}
+      POSTGRES_DB: ${POSTGRES_DATABASE:-ghost_dev}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U root -d ${POSTGRES_DATABASE:-ghost_dev}']
+      interval: 1s
+      retries: 120
+
+  ghost-dev:
+    environment:
+      database__client: pg
+      database__connection__host: postgres
+      database__connection__port: 5432
+      database__connection__user: root
+      database__connection__password: ${POSTGRES_PASSWORD:-root}
+      database__connection__database: ${POSTGRES_DATABASE:-ghost_dev}
+    depends_on:
+      mysql:
+        required: false
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres-data:

--- a/ghost/core/core/server/api/endpoints/labels.js
+++ b/ghost/core/core/server/api/endpoints/labels.js
@@ -1,6 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
+const { isDuplicateEntryError } = require('../../data/db/sql-helpers');
 
 const messages = {
   labelNotFound: 'Label not found.',
@@ -12,9 +13,7 @@ const ALLOWED_INCLUDES = ['count.members'];
 // SQLITE_CONSTRAINT covers more than unique violations, but schema validation
 // rejects null/oversize names before the database, so only the unique
 // constraint on name/slug can reach this catch
-const isUniqueConstraintViolation = (error) => {
-  return error.code === 'ER_DUP_ENTRY' || error.code === 'SQLITE_CONSTRAINT';
-};
+const isUniqueConstraintViolation = isDuplicateEntryError;
 
 const handleDuplicateNameError = (error) => {
   if (isUniqueConstraintViolation(error)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/slug-filter-order.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/slug-filter-order.js
@@ -7,7 +7,7 @@ const slugFilterOrder = (table, filter) => {
     let bindings = [];
 
     orderSlugs.forEach((slug, index) => {
-      caseParts.push(`WHEN \`${table}\`.\`slug\` = ? THEN ?`);
+      caseParts.push(`WHEN ${table}.slug = ? THEN ?`);
       bindings.push(slug.trim(), index);
     });
 

--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -79,6 +79,26 @@ function configure(dbConfig) {
     }
   }
 
+  if (client === 'pg') {
+    const pgTypes = require('pg').types;
+    // Match mysql2 behaviour: numbers come back as numbers, not strings
+    pgTypes.setTypeParser(pgTypes.builtins.INT8, (val) => (val === null ? null : Number(val)));
+    pgTypes.setTypeParser(pgTypes.builtins.NUMERIC, (val) => (val === null ? null : Number(val)));
+    // Ghost stores naive UTC timestamps; parse `timestamp without time zone` as UTC
+    // (mirrors mysql2's `timezone: 'Z'`) instead of the server's local zone.
+    pgTypes.setTypeParser(pgTypes.builtins.TIMESTAMP, (val) =>
+      val === null ? null : new Date(val.replace(' ', 'T') + 'Z'),
+    );
+    // DATE() style columns as plain strings, not local Date objects
+    pgTypes.setTypeParser(pgTypes.builtins.DATE, (val) => val);
+
+    dbConfig.pool = Object.assign({}, dbConfig.pool, {
+      afterCreate(conn, cb) {
+        conn.query("SET TIME ZONE 'UTC'", (err) => cb(err, conn));
+      },
+    });
+  }
+
   return dbConfig;
 }
 

--- a/ghost/core/core/server/data/db/database-info.js
+++ b/ghost/core/core/server/data/db/database-info.js
@@ -1,0 +1,33 @@
+const BaseDatabaseInfo = require('@tryghost/database-info');
+
+/**
+ * Local extension of @tryghost/database-info that understands Postgres.
+ * @TODO: upstream to @tryghost/database-info
+ */
+class DatabaseInfo extends BaseDatabaseInfo {
+  /** @param {import('knex').Knex} knex */
+  static isPostgres(knex) {
+    return knex?.client?.config?.client === 'pg';
+  }
+
+  static isPostgresConfig(config) {
+    return config.client === 'pg';
+  }
+
+  async init() {
+    if (this._driver !== 'pg') {
+      return super.init();
+    }
+    this._databaseDetails.database = 'PostgreSQL';
+    this._databaseDetails.engine = 'postgres';
+    try {
+      const result = await this._knex.raw('SHOW server_version');
+      this._databaseDetails.version = result.rows[0].server_version;
+    } catch {
+      // ignore
+    }
+    return this._databaseDetails;
+  }
+}
+
+module.exports = DatabaseInfo;

--- a/ghost/core/core/server/data/db/info.js
+++ b/ghost/core/core/server/data/db/info.js
@@ -1,4 +1,4 @@
 const connection = require('./connection');
-const DatabaseInfo = require('@tryghost/database-info');
+const DatabaseInfo = require('./database-info');
 
 module.exports = new DatabaseInfo(connection);

--- a/ghost/core/core/server/data/db/sql-helpers.js
+++ b/ghost/core/core/server/data/db/sql-helpers.js
@@ -1,0 +1,107 @@
+/**
+ * Small dialect-portability helpers for the places Ghost talks to knex directly.
+ * MySQL (mysql2), SQLite (better-sqlite3) and Postgres (pg) all surface errors,
+ * raw results and a few SQL functions differently.
+ */
+
+const UNIQUE_VIOLATION_CODES = new Set(['ER_DUP_ENTRY', '23505']);
+const FOREIGN_KEY_CODES = new Set([
+  'ER_NO_REFERENCED_ROW',
+  'ER_NO_REFERENCED_ROW_2',
+  'ER_ROW_IS_REFERENCED',
+  'ER_ROW_IS_REFERENCED_2',
+  '23503',
+  'SQLITE_CONSTRAINT_FOREIGNKEY',
+]);
+const UNKNOWN_COLUMN_CODES = new Set(['ER_BAD_FIELD_ERROR', '42703']);
+
+/**
+ * @param {unknown} err
+ * @returns {boolean} true when the error is a unique constraint violation
+ */
+function isDuplicateEntryError(err) {
+  const code = err && typeof err === 'object' ? /** @type {any} */ (err).code : undefined;
+  if (typeof code !== 'string') {
+    return false;
+  }
+  return UNIQUE_VIOLATION_CODES.has(code) || code.startsWith('SQLITE_CONSTRAINT');
+}
+
+/**
+ * @param {unknown} err
+ * @returns {boolean} true when the error is a foreign key constraint violation
+ */
+function isForeignKeyError(err) {
+  const e = /** @type {any} */ (err) || {};
+  if (e.errno === 1452 || e.errno === 1451) {
+    return true;
+  }
+  if (typeof e.code !== 'string') {
+    return false;
+  }
+  if (FOREIGN_KEY_CODES.has(e.code)) {
+    return true;
+  }
+  return e.code === 'SQLITE_CONSTRAINT' && /FOREIGN KEY constraint failed/.test(e.message || '');
+}
+
+/**
+ * @param {unknown} err
+ * @returns {boolean} true when the error is an unknown column / bad field error
+ */
+function isUnknownColumnError(err) {
+  const e = /** @type {any} */ (err) || {};
+  return e.errno === 1054 || e.errno === 1 || UNKNOWN_COLUMN_CODES.has(e.code);
+}
+
+/**
+ * Normalises the result of `knex.raw()` to an array of rows.
+ * mysql2 returns `[rows, fields]`, pg returns `{rows}`, sqlite returns `rows`.
+ *
+ * @param {any} result
+ * @returns {any[]}
+ */
+function rawRows(result) {
+  if (result && Array.isArray(result.rows)) {
+    return result.rows;
+  }
+  if (Array.isArray(result) && Array.isArray(result[0])) {
+    return result[0];
+  }
+  return Array.isArray(result) ? result : [];
+}
+
+/**
+ * Quotes an identifier for the connected dialect (backticks on MySQL, double quotes on Postgres).
+ *
+ * @param {import('knex').Knex} knex
+ * @param {string} identifier
+ * @returns {string}
+ */
+function quoteIdentifier(knex, identifier) {
+  return knex.client.wrapIdentifier(identifier);
+}
+
+/**
+ * Comma-joined aggregate of a column, as `GROUP_CONCAT` on MySQL/SQLite and `string_agg` on Postgres.
+ *
+ * @param {import('knex').Knex} knex
+ * @param {string} column
+ * @param {string} alias
+ * @returns {import('knex').Knex.Raw}
+ */
+function groupConcat(knex, column, alias) {
+  if (knex.client.config.client === 'pg') {
+    return knex.raw("string_agg(??::text, ',') as ??", [column, alias]);
+  }
+  return knex.raw('GROUP_CONCAT(??) as ??', [column, alias]);
+}
+
+module.exports = {
+  isDuplicateEntryError,
+  isForeignKeyError,
+  isUnknownColumnError,
+  rawRows,
+  quoteIdentifier,
+  groupConcat,
+};

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -44,6 +44,9 @@ function addTableColumn(
     } else {
       column = tableBuilder[columnSpec.type](columnName, 191);
     }
+  } else if (columnSpec.type === 'dateTime' && tableBuilder.client.config.client === 'pg') {
+    // Ghost stores naive UTC datetimes; avoid knex's default `timestamptz` on Postgres
+    column = tableBuilder.dateTime(columnName, { useTz: false });
   } else {
     column = tableBuilder[columnSpec.type](columnName);
   }
@@ -295,7 +298,7 @@ async function addIndex(tableName, columns, transaction = db.knex, options = {})
       logging.warn(`Index for '${columns}' already exists for table '${tableName}'`);
       return;
     }
-    if (err.code === 'ER_DUP_KEYNAME') {
+    if (err.code === 'ER_DUP_KEYNAME' || err.code === '42P07' || err.code === '42710') {
       logging.warn(`Index for '${columns}' already exists for table '${tableName}'`);
       return;
     }
@@ -322,7 +325,7 @@ async function dropIndex(tableName, columns, transaction = db.knex) {
       logging.warn(`Constraint for '${columns}' does not exist for table '${tableName}'`);
       return;
     }
-    if (err.code === 'ER_CANT_DROP_FIELD_OR_KEY') {
+    if (err.code === 'ER_CANT_DROP_FIELD_OR_KEY' || err.code === '42704') {
       logging.warn(`Constraint for '${columns}' does not exist for table '${tableName}'`);
       return;
     }
@@ -354,7 +357,7 @@ async function addUnique(tableName, columns, transaction = db.knex, indexName) {
       logging.warn(`Constraint for '${columns}' already exists for table '${tableName}'`);
       return;
     }
-    if (err.code === 'ER_DUP_KEYNAME') {
+    if (err.code === 'ER_DUP_KEYNAME' || err.code === '42P07' || err.code === '42710') {
       logging.warn(`Constraint for '${columns}' already exists for table '${tableName}'`);
       return;
     }
@@ -383,7 +386,7 @@ async function dropUnique(tableName, columns, transaction = db.knex, indexName) 
       logging.warn(`Constraint for '${columns}' does not exist for table '${tableName}'`);
       return;
     }
-    if (err.code === 'ER_CANT_DROP_FIELD_OR_KEY') {
+    if (err.code === 'ER_CANT_DROP_FIELD_OR_KEY' || err.code === '42704') {
       logging.warn(`Constraint for '${columns}' does not exist for table '${tableName}'`);
       return;
     }
@@ -572,7 +575,7 @@ async function dropForeign({
       }
     }
   } catch (err) {
-    if (err.code === 'ER_CANT_DROP_FIELD_OR_KEY') {
+    if (err.code === 'ER_CANT_DROP_FIELD_OR_KEY' || err.code === '42704') {
       logging.warn(
         `Skipped dropping foreign key from ${fromTable}.${fromColumn} to ${toTable}.${toColumn} - does not exist`,
       );
@@ -737,6 +740,11 @@ async function getTables(transaction = db.knex) {
   } else if (client === 'mysql2') {
     const response = await transaction.raw("show full tables where Table_type = 'BASE TABLE'");
     return _.map(response[0], (entry) => _.values(entry)[0]);
+  } else if (client === 'pg') {
+    const response = await transaction.raw(
+      "select table_name from information_schema.tables where table_schema = current_schema() and table_type = 'BASE TABLE'",
+    );
+    return _.map(response.rows, 'table_name');
   }
 
   return Promise.reject(tpl(messages.noSupportForDatabase, { client: client }));
@@ -755,6 +763,12 @@ async function getIndexes(table, transaction = db.knex) {
   } else if (client === 'mysql2') {
     const response = await transaction.raw(`SHOW INDEXES from ${table}`);
     return _.flatten(_.map(response[0], 'Key_name'));
+  } else if (client === 'pg') {
+    const response = await transaction.raw(
+      'select indexname from pg_indexes where schemaname = current_schema() and tablename = ?',
+      [table],
+    );
+    return _.map(response.rows, 'indexname');
   }
 
   return Promise.reject(tpl(messages.noSupportForDatabase, { client: client }));
@@ -771,6 +785,12 @@ async function getColumns(table, transaction = db.knex) {
   } else if (DatabaseInfo.isMySQL(transaction)) {
     const response = await transaction.raw(`SHOW COLUMNS from ${table}`);
     return _.flatten(_.map(response[0], 'Field'));
+  } else if (transaction.client.config.client === 'pg') {
+    const response = await transaction.raw(
+      'select column_name from information_schema.columns where table_schema = current_schema() and table_name = ?',
+      [table],
+    );
+    return _.map(response.rows, 'column_name');
   }
 
   return Promise.reject(

--- a/ghost/core/core/server/models/automation.js
+++ b/ghost/core/core/server/models/automation.js
@@ -56,7 +56,7 @@ const Automation = ghostBookshelf.Model.extend(
   },
   {
     orderDefaultRaw() {
-      return '`created_at` ASC';
+      return 'created_at ASC';
     },
   },
 );

--- a/ghost/core/core/server/models/base/plugins/bulk-operations.js
+++ b/ghost/core/core/server/models/base/plugins/bulk-operations.js
@@ -1,6 +1,21 @@
 const _ = require('lodash');
 const { byColumnValues, CHUNK_SIZE } = require('./bulk-filters');
 
+/**
+ * Runs `fn` inside a savepoint when a transaction is active. A failed statement aborts
+ * the whole transaction on Postgres, so the try-chunk-then-retry-rows pattern below
+ * needs each attempt isolated for the transaction to stay usable.
+ *
+ * @param {object} options
+ * @param {(options: object) => Promise<any>} fn
+ */
+async function attempt(options, fn) {
+  if (!options.transacting) {
+    return fn(options);
+  }
+  return options.transacting.transaction((savepoint) => fn({ ...options, transacting: savepoint }));
+}
+
 function createBulkOperation(singular, multiple) {
   return async function (knex, table, data, options) {
     const result = {
@@ -12,7 +27,7 @@ function createBulkOperation(singular, multiple) {
 
     for (const chunkedData of _.chunk(data, CHUNK_SIZE)) {
       try {
-        await multiple(knex, table, chunkedData, options);
+        await attempt(options, (opts) => multiple(knex, table, chunkedData, opts));
         result.successful += chunkedData.length;
       } catch (errToIgnore) {
         if (options.throwErrors) {
@@ -20,7 +35,7 @@ function createBulkOperation(singular, multiple) {
         }
         for (const singularData of chunkedData) {
           try {
-            await singular(knex, table, singularData, options);
+            await attempt(options, (opts) => singular(knex, table, singularData, opts));
             result.successful += 1;
           } catch (err) {
             err.errorDetails = singularData;

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -2,10 +2,29 @@ const _ = require('lodash');
 const errors = require('@tryghost/errors');
 
 const tpl = require('@tryghost/tpl');
+const DatabaseInfo = require('../../../data/db/database-info');
+const { isUnknownColumnError } = require('../../../data/db/sql-helpers');
 
 const messages = {
   couldNotUnderstandRequest: 'Could not understand request.',
 };
+
+/**
+ * Bookshelf applies `options.lock` to eager-loaded relations as well as to the main
+ * query. Postgres rejects `FOR UPDATE` on the `SELECT DISTINCT` bookshelf emits for
+ * belongsToMany relations, so on Postgres we lock the target row explicitly instead.
+ *
+ * @param {import('bookshelf').Model} model - forged model carrying the lookup attributes
+ * @param {Object} options - must contain `transacting`
+ */
+async function applyRowLock(model, options) {
+  const attrs = model.attributes;
+  if (DatabaseInfo.isPostgres(options.transacting) && !_.isEmpty(attrs)) {
+    await options.transacting(model.tableName).where(attrs).forUpdate();
+    return;
+  }
+  options.lock = 'forUpdate';
+}
 
 // If user requested an excerpt we need to ensure plaintext and custom_excerpt is also included so we can include it when we query the database.
 const requiredForExcerpt = (requestedColumns) => {
@@ -217,7 +236,7 @@ module.exports = function (Bookshelf) {
        * @param {Object} [unfilteredOptions]
        * @return {Promise<Bookshelf['Model']>} Single Model
        */
-      findOne: function findOne(data, unfilteredOptions) {
+      findOne: async function findOne(data, unfilteredOptions) {
         const options = this.filterOptions(unfilteredOptions, 'findOne');
         data = this.filterData(data);
         const model = this.forge(data);
@@ -236,12 +255,12 @@ module.exports = function (Bookshelf) {
         }
 
         if (options.transacting && options.forUpdate) {
-          options.lock = 'forUpdate';
+          await applyRowLock(model, options);
         }
 
         return model.fetch(options).catch((err) => {
           // CASE: SQL syntax is incorrect
-          if (err.errno === 1054 || err.errno === 1) {
+          if (isUnknownColumnError(err)) {
             throw new errors.BadRequestError({
               message: tpl(messages.couldNotUnderstandRequest),
               err,
@@ -281,7 +300,7 @@ module.exports = function (Bookshelf) {
         }
 
         if (options.transacting) {
-          options.lock = 'forUpdate';
+          await applyRowLock(model, options);
         }
 
         const object = await model.fetch(options);

--- a/ghost/core/core/server/models/base/plugins/events.js
+++ b/ghost/core/core/server/models/base/plugins/events.js
@@ -6,10 +6,60 @@ const schema = require('../../../data/schema');
 
 // This wires up our model event system
 const events = require('../../../lib/common/events');
+const DatabaseInfo = require('../../../data/db/database-info');
 
 // Run tests or development with NUMERIC_IDS=1 to enable numeric object IDs
 let forceNumericObjectIds = process.env.NODE_ENV !== 'production' && !!process.env.NUMERIC_IDS;
 let numberGenerator = 0;
+
+/**
+ * Lock the rows of the current query for update when the caller asked for it.
+ *
+ * Bookshelf fires `fetching` for eager-loaded relations with the same options as the
+ * parent fetch, and emits `SELECT DISTINCT` for those relation queries. Postgres rejects
+ * `FOR UPDATE` combined with `DISTINCT`, so skip the lock there: the target row was
+ * already locked explicitly by the crud plugin.
+ *
+ * @param {Object} options
+ */
+function lockQueryForUpdate(options) {
+  if (!options.forUpdate || !options.transacting || !options.query) {
+    return;
+  }
+
+  if (DatabaseInfo.isPostgres(options.transacting)) {
+    const isDistinct = (options.query._statements || []).some(
+      (statement) => statement.grouping === 'columns' && statement.distinct,
+    );
+    if (isDistinct) {
+      return;
+    }
+  }
+
+  options.query.forUpdate();
+}
+
+/**
+ * MySQL and SQLite treat NULL as the lowest value when sorting (first on ASC, last on
+ * DESC); Postgres treats it as the highest. Pin Postgres to the MySQL behaviour so, for
+ * example, drafts (NULL published_at) keep sorting last under `published_at desc`.
+ * Raw order clauses are left alone.
+ *
+ * @param {Object} options
+ */
+function applyMySQLNullOrdering(options) {
+  if (!options.query || !DatabaseInfo.isPostgres(options.query)) {
+    return;
+  }
+
+  for (const statement of options.query._statements || []) {
+    if (statement.grouping !== 'order' || statement.nulls || typeof statement.value !== 'string') {
+      continue;
+    }
+    statement.nulls =
+      String(statement.direction || 'asc').toLowerCase() === 'desc' ? 'last' : 'first';
+  }
+}
 
 module.exports = function (Bookshelf) {
   Bookshelf.Model = Bookshelf.Model.extend(
@@ -120,17 +170,15 @@ module.exports = function (Bookshelf) {
        * This avoids collisions and possible content override cases.
        */
       onFetching: function onFetching(model, columns, options) {
-        if (options.forUpdate && options.transacting) {
-          options.query.forUpdate();
-        }
+        lockQueryForUpdate(options);
+        applyMySQLNullOrdering(options);
       },
 
       onFetchedCollection() {},
 
       onFetchingCollection: function onFetchingCollection(model, columns, options) {
-        if (options.forUpdate && options.transacting) {
-          options.query.forUpdate();
-        }
+        lockQueryForUpdate(options);
+        applyMySQLNullOrdering(options);
       },
 
       onCreated(model, options) {

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -131,12 +131,15 @@ const Comment = ghostBookshelf.Model.extend(
         }
 
         if (options.pinnedFirst) {
+          // NULLs sort first on DESC in Postgres but last in MySQL/SQLite, so order
+          // explicitly on "has a pinned_at" before the timestamp itself.
           if (options.isAdmin) {
-            qb.orderBy('comments.pinned_at', 'DESC');
+            qb.orderByRaw('comments.pinned_at IS NULL, comments.pinned_at DESC');
           } else {
-            qb.orderByRaw('CASE WHEN comments.status = ? THEN comments.pinned_at END DESC', [
-              'published',
-            ]);
+            qb.orderByRaw(
+              'CASE WHEN comments.status = ? AND comments.pinned_at IS NOT NULL THEN 0 ELSE 1 END, CASE WHEN comments.status = ? THEN comments.pinned_at END DESC',
+              ['published', 'published'],
+            );
           }
         }
       });

--- a/ghost/core/core/server/models/member-click-event.js
+++ b/ghost/core/core/server/models/member-click-event.js
@@ -53,7 +53,15 @@ const MemberClickEvent = ghostBookshelf.Model.extend(
     permittedOptions(methodName) {
       let options = ghostBookshelf.Model.permittedOptions.call(this, methodName);
       const validOptions = {
-        findPage: ['selectRaw', 'whereRaw', 'cte', 'from', 'useCTE', 'filterRelations'],
+        findPage: [
+          'selectRaw',
+          'whereRaw',
+          'cte',
+          'from',
+          'useCTE',
+          'filterRelations',
+          'autoOrder',
+        ],
       };
 
       if (validOptions[methodName]) {

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const { chainTransformers } = require('@tryghost/mongo-utils');
 const config = require('../../shared/config');
 const { MemberCommentingCodec } = require('../services/members/commenting');
+const DatabaseInfo = require('../data/db/database-info');
 const {
   CUSTOM_FIELDS_RELATION,
   createCustomFieldsFilterTransformer,
@@ -612,12 +613,10 @@ const Member = ghostBookshelf.Model.extend(
     },
 
     searchQuery: function searchQuery(queryBuilder, query) {
+      // MySQL's default collation makes LIKE case-insensitive; Postgres needs ILIKE for that
+      const like = DatabaseInfo.isPostgres(queryBuilder) ? 'ilike' : 'like';
       queryBuilder.where(function () {
-        this.where('members.name', 'like', `%${query}%`).orWhere(
-          'members.email',
-          'like',
-          `%${query}%`,
-        );
+        this.where('members.name', like, `%${query}%`).orWhere('members.email', like, `%${query}%`);
       });
     },
 

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -284,7 +284,7 @@ Post = ghostBookshelf.Model.extend(
           };
         }
         return {
-          orderByRaw: `(select AVG(score) from \`members_feedback\` where posts.id = members_feedback.post_id) ${direction}`,
+          orderByRaw: `(select AVG(score) from members_feedback where posts.id = members_feedback.post_id) ${direction}`,
         };
       }
       if (field === 'email.open_rate' && withRelated && withRelated.indexOf('email') > -1) {

--- a/ghost/core/core/server/models/redirect.js
+++ b/ghost/core/core/server/models/redirect.js
@@ -1,4 +1,5 @@
 const ghostBookshelf = require('./base');
+const { quoteIdentifier } = require('../data/db/sql-helpers');
 const urlUtils = require('../../shared/url-utils').default;
 
 const Redirect = ghostBookshelf.Model.extend(
@@ -29,10 +30,11 @@ const Redirect = ghostBookshelf.Model.extend(
   },
   {
     orderDefaultRaw(options) {
+      const to = quoteIdentifier(ghostBookshelf.knex, 'to');
       if (options.withRelated && options.withRelated.includes('count.clicks')) {
-        return '`count__clicks` DESC, `to` DESC';
+        return `count__clicks DESC, ${to} DESC`;
       }
-      return '`to` DESC';
+      return `${to} DESC`;
     },
 
     permittedOptions(methodName) {

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -1001,9 +1001,9 @@ async function isRunAutomationActive(
 
 async function selectExists(trx: Knex.Transaction, query: Knex.QueryBuilder): Promise<boolean> {
   const row = await trx
-    .select<{ exists: boolean | number | string }>(trx.raw('exists ? as `exists`', [query]))
+    .select<{ row_exists: boolean | number | string }>(trx.raw('exists ? as row_exists', [query]))
     .first();
-  return Boolean(Number(row?.exists));
+  return Boolean(Number(row?.row_exists));
 }
 
 /**

--- a/ghost/core/core/server/services/content-import/import/relations.ts
+++ b/ghost/core/core/server/services/content-import/import/relations.ts
@@ -2,6 +2,7 @@ import type { PostData } from './post-data';
 
 const { slugify } = require('@tryghost/string');
 const validator = require('@tryghost/validator');
+const { isDuplicateEntryError } = require('../../../data/db/sql-helpers');
 
 interface RelationModel {
   id: string;
@@ -214,11 +215,5 @@ function splitList(value?: string): Array<string | undefined> {
 }
 
 function isUniqueConstraintError(error: unknown): boolean {
-  const code =
-    typeof error === 'object' && error !== null && 'code' in error
-      ? (error as { code?: unknown }).code
-      : undefined;
-  return (
-    code === 'ER_DUP_ENTRY' || (typeof code === 'string' && code.startsWith('SQLITE_CONSTRAINT'))
-  );
+  return isDuplicateEntryError(error);
 }

--- a/ghost/core/core/server/services/email-analytics/lib/queries.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.ts
@@ -108,7 +108,7 @@ export class Queries {
           continue;
         }
         const row = await knex(cursorSeed.tableName)
-          .select(knex.raw('MAX(??) as maxTimestamp', [columnName]))
+          .select(knex.raw('MAX(??) as ??', [columnName, 'maxTimestamp']))
           .first();
         timestamps.push(row.maxTimestamp);
       }
@@ -307,7 +307,7 @@ export class Queries {
   async aggregateMemberStats(memberId: string): Promise<void> {
     const { trackedEmailCount } =
       (await this.#knex('email_recipients')
-        .select(this.#knex.raw('COUNT(email_recipients.id) as trackedEmailCount'))
+        .select(this.#knex.raw('COUNT(email_recipients.id) as ??', ['trackedEmailCount']))
         .leftJoin('emails', 'email_recipients.email_id', 'emails.id')
         .where('email_recipients.member_id', memberId)
         .where('emails.track_opens', true)
@@ -349,7 +349,9 @@ export class Queries {
         this.#knex.raw(
           'SUM(CASE WHEN email_recipients.opened_at IS NOT NULL THEN 1 ELSE 0 END) as email_opened_count',
         ),
-        this.#knex.raw('SUM(CASE WHEN emails.track_opens = 1 THEN 1 ELSE 0 END) as tracked_count'),
+        this.#knex.raw(
+          'SUM(CASE WHEN emails.track_opens = TRUE THEN 1 ELSE 0 END) as tracked_count',
+        ),
       )
       .whereIn('email_recipients.member_id', memberIds)
       .groupBy('email_recipients.member_id');
@@ -414,14 +416,16 @@ export class Queries {
       ...memberIds,
     ];
 
-    // Execute batched update with CASE statements
+    // Execute batched update with CASE statements. The ELSE branches never match a row
+    // (the WHERE IN restricts to the listed ids) but give the CASE the column's type, which
+    // Postgres needs to coerce the untyped bound values.
     await this.#knex.raw(
       `
             UPDATE members
             SET
-                email_count = CASE id ${emailCountCases.join(' ')} END,
-                email_opened_count = CASE id ${emailOpenedCountCases.join(' ')} END,
-                email_open_rate = CASE id ${emailOpenRateCases.join(' ')} END
+                email_count = CASE id ${emailCountCases.join(' ')} ELSE email_count END,
+                email_opened_count = CASE id ${emailOpenedCountCases.join(' ')} ELSE email_opened_count END,
+                email_open_rate = CASE id ${emailOpenRateCases.join(' ')} ELSE email_open_rate END
             WHERE id IN (${memberIds.map(() => '?').join(',')})
         `,
       bindings,

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -1,6 +1,7 @@
 const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const { isDuplicateEntryError } = require('../../data/db/sql-helpers');
 
 class NewsletterEmailEventStorage {
   #config;
@@ -227,7 +228,7 @@ class NewsletterEmailEventStorage {
       // Remove from Mailgun's suppression list so it doesn't affect other sites on the same domain
       await this.#emailSuppressionList.removeComplaint(event.email);
     } catch (err) {
-      if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+      if (!isDuplicateEntryError(err)) {
         logging.error(err);
       }
     }
@@ -346,7 +347,7 @@ class NewsletterEmailEventStorage {
 
     const sql = `
             UPDATE email_recipients
-            SET delivered_at = CASE id ${caseClauses} END
+            SET delivered_at = CASE id ${caseClauses} ELSE delivered_at END
             WHERE id IN (${recipientIds.map(() => '?').join(',')})
             AND delivered_at IS NULL
         `;
@@ -375,7 +376,7 @@ class NewsletterEmailEventStorage {
 
     const sql = `
             UPDATE email_recipients
-            SET opened_at = CASE id ${caseClauses} END
+            SET opened_at = CASE id ${caseClauses} ELSE opened_at END
             WHERE id IN (${recipientIds.map(() => '?').join(',')})
             AND opened_at IS NULL
         `;
@@ -404,7 +405,7 @@ class NewsletterEmailEventStorage {
 
     const sql = `
             UPDATE email_recipients
-            SET failed_at = CASE id ${caseClauses} END
+            SET failed_at = CASE id ${caseClauses} ELSE failed_at END
             WHERE id IN (${recipientIds.map(() => '?').join(',')})
             AND failed_at IS NULL
         `;

--- a/ghost/core/core/server/services/email-suppression-list/mailgun-email-suppression-list.js
+++ b/ghost/core/core/server/services/email-suppression-list/mailgun-email-suppression-list.js
@@ -8,6 +8,7 @@ const { EmailBouncedEvent } = require('../email-service/events/email-bounced-eve
 const DomainEvents = require('@tryghost/domain-events');
 const logging = require('@tryghost/logging');
 const models = require('../../models');
+const { isDuplicateEntryError } = require('../../data/db/sql-helpers');
 
 /**
  * @typedef {object} IMailgunAPIClient
@@ -137,7 +138,7 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
           created_at: event.timestamp,
         });
       } catch (err) {
-        if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+        if (!isDuplicateEntryError(err)) {
           logging.error(err);
           return;
         }

--- a/ghost/core/core/server/services/link-redirection/link-redirects-service.js
+++ b/ghost/core/core/server/services/link-redirection/link-redirects-service.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const DomainEvents = require('@tryghost/domain-events');
 const RedirectEvent = require('./redirect-event');
 const { LinkRedirect } = require('./link-redirect');
+const { isDuplicateEntryError } = require('../../data/db/sql-helpers');
 
 /**
  * @typedef {object} ILinkRedirectRepository
@@ -20,8 +21,7 @@ const MEMBER_UUID_PLACEHOLDER = '%%{uuid}%%';
 //   Ghost uses UUID v4; this regex is not that strict
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const isUniqueConstraintError = (err) =>
-  err?.code === 'ER_DUP_ENTRY' || err?.code?.startsWith?.('SQLITE_CONSTRAINT');
+const isUniqueConstraintError = isDuplicateEntryError;
 
 class LinkRedirectsService {
   /** @type ILinkRedirectRepository */

--- a/ghost/core/core/server/services/link-tracking/post-link-repository.js
+++ b/ghost/core/core/server/services/link-tracking/post-link-repository.js
@@ -38,7 +38,7 @@ module.exports = class PostLinkRepository {
 
     // Apply ordering
     itemCollection.query((qb) => {
-      qb.orderByRaw('`count__clicks` DESC, `to` DESC');
+      qb.orderByRaw('count__clicks DESC, ?? DESC', ['to']);
     });
 
     // Fetch the collection with the applied query modifications

--- a/ghost/core/core/server/services/machine-payments/events/machine-payment-event-repository.ts
+++ b/ghost/core/core/server/services/machine-payments/events/machine-payment-event-repository.ts
@@ -11,14 +11,9 @@ type BookshelfModel = {
   findOne: (data: Record<string, unknown>) => Promise<BookshelfModelInstance | null | undefined>;
 };
 
-type UniqueConstraintError = {
-  code?: string;
-};
+const { isDuplicateEntryError } = require('../../../data/db/sql-helpers');
 
-const isUniqueConstraintError = (err: unknown): boolean => {
-  const code = (err as UniqueConstraintError)?.code;
-  return code === 'ER_DUP_ENTRY' || Boolean(code?.startsWith?.('SQLITE_CONSTRAINT'));
-};
+const isUniqueConstraintError = (err: unknown): boolean => isDuplicateEntryError(err);
 
 export class MachinePaymentEventRepository {
   #Model: BookshelfModel;

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -11,6 +11,8 @@ import { activeFields, fieldByKey, inFieldOrder, type DefinitionQuery } from './
 import { KEY_CHARACTERS, mintableKey } from './key';
 import { type RecordCustomFieldAction, type RequestContext } from './actions';
 
+const { isDuplicateEntryError } = require('../../data/db/sql-helpers');
+
 // The same NQL -> knex bridge Bookshelf's filter plugin uses, applied directly to
 // our raw-knex query: nql parses the `filter` string to a Mongo query, mongo-knex
 // turns that into parametrised WHERE clauses. Neither needs a Bookshelf model.
@@ -690,8 +692,7 @@ function batchContext(index: PropertyKey | undefined, requestedCount: number): s
 }
 
 function isUniqueConstraintViolation(error: unknown): boolean {
-  const code = (error as { code?: string })?.code;
-  return code === 'ER_DUP_ENTRY' || code === 'SQLITE_CONSTRAINT';
+  return isDuplicateEntryError(error);
 }
 
 // Apply a caller-supplied NQL filter to the definition query. A malformed filter

--- a/ghost/core/core/server/services/members/import-export/export/exporter.ts
+++ b/ghost/core/core/server/services/members/import-export/export/exporter.ts
@@ -5,6 +5,7 @@ import type { Knex } from 'knex';
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const { csvCellsForFields } = require('@tryghost/custom-field-types/csv');
+const { groupConcat } = require('../../../../data/db/sql-helpers');
 
 // Options accepted by the export, forwarded to the members query for filtering.
 export interface ExportOptions {
@@ -290,12 +291,12 @@ export default class MembersCSVExporter {
     const [tiers, labels, stripeCustomers, subscriptions, gifts, customFieldValuesMap] =
       await Promise.all([
         knex('members_products')
-          .select('member_id', knex.raw('GROUP_CONCAT(product_id) as tiers'))
+          .select('member_id', groupConcat(knex, 'product_id', 'tiers'))
           .whereIn('member_id', memberIds)
           .groupBy('member_id'),
 
         knex('members_labels')
-          .select('member_id', knex.raw('GROUP_CONCAT(label_id) as labels'))
+          .select('member_id', groupConcat(knex, 'label_id', 'labels'))
           .whereIn('member_id', memberIds)
           .groupBy('member_id'),
 

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -680,15 +680,15 @@ module.exports = class EventRepository {
                 created_at,
                 ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY created_at, id) AS rn
             FROM
-                PostClicks
+                post_clicks
         `;
 
     const mainQuery = `SELECT COUNT(DISTINCT redirect_id)
-                    FROM PostClicks AS inner_mce
-                    WHERE inner_mce.member_id = FirstClicks.member_id
+                    FROM post_clicks AS inner_mce
+                    WHERE inner_mce.member_id = first_clicks.member_id
                     AND inner_mce.redirect_id IN (
                         SELECT redirect_id
-                        FROM PostClicks
+                        FROM post_clicks
                     )`;
     options = {
       ...options,
@@ -712,18 +712,21 @@ module.exports = class EventRepository {
       // Note: we cannot do `count(distinct redirect_id) as count__clicks`, because we don't want the created_at filter to affect that count
       // For pagination to work correctly, we also need to return the id of the first event (or the minimum id if multiple events happend at the same time, but should be the first). Just MIN(id) won't work because that value changes if filter created_at < x is applied.
       selectRaw: `id, member_id, created_at, (${mainQuery}) as count__clicks`,
-      whereRaw: `rn = 1 ORDER BY created_at DESC, id DESC`,
+      whereRaw: `rn = 1`,
+      // Ordering must not live inside `whereRaw`: the pagination count query reuses the
+      // where clause and Postgres rejects ORDER BY on a non-aggregated column there.
+      autoOrder: 'created_at DESC, id DESC',
       cte: [
         {
-          name: `PostClicks`,
+          name: `post_clicks`,
           query: postClicksQuery,
         },
         {
-          name: `FirstClicks`,
+          name: `first_clicks`,
           query: firstClicksQuery,
         },
       ],
-      from: 'FirstClicks',
+      from: 'first_clicks',
       order: '',
     };
 

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -22,6 +22,7 @@ const {
 const { MEMBER_WELCOME_EMAIL_SLUGS } = require('../../../member-welcome-emails/constants');
 const db = require('../../../../data/db');
 const labs = require('../../../../../shared/labs');
+const { isDuplicateEntryError } = require('../../../../data/db/sql-helpers');
 /** @import {Knex} from 'knex' */
 /** @import * as automationsApi from '../../../automations/automations-api' */
 
@@ -628,7 +629,7 @@ module.exports = class MemberRepository {
             { batch_id: options.batch_id },
           );
         } catch (err) {
-          if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+          if (!isDuplicateEntryError(err)) {
             throw err;
           }
           throw new errors.ConflictError({

--- a/ghost/core/core/server/services/members/stats/members-stats.js
+++ b/ghost/core/core/server/services/members/stats/members-stats.js
@@ -1,4 +1,6 @@
 const moment = require('moment-timezone');
+const { rawRows } = require('../../../data/db/sql-helpers');
+const DatabaseInfo = require('../../../data/db/database-info');
 
 const dateFormat = 'YYYY-MM-DD HH:mm:ss';
 class MembersStats {
@@ -19,7 +21,7 @@ class MembersStats {
    */
   async getTotalMembers() {
     const result = await this._db.knex.raw('SELECT COUNT(id) AS total FROM members');
-    return this._isSQLite ? result[0].total : result[0][0].total;
+    return rawRows(result)[0].total;
   }
 
   /**
@@ -43,7 +45,7 @@ class MembersStats {
       'SELECT COUNT(id) AS total FROM members WHERE created_at >= ?',
       [startOfRange],
     );
-    return this._isSQLite ? result[0].total : result[0][0].total;
+    return rawRows(result)[0].total;
   }
 
   /**
@@ -57,7 +59,7 @@ class MembersStats {
       'SELECT count(id) AS total FROM members WHERE created_at >= ?',
       [startOfToday],
     );
-    return this._isSQLite ? result[0].total : result[0][0].total;
+    return rawRows(result)[0].total;
   }
 
   /**
@@ -94,6 +96,22 @@ class MembersStats {
           }
         })
         .groupByRaw('DATE(created_at, ?)', [dateModifier]);
+    } else if (DatabaseInfo.isPostgres(this._db.knex)) {
+      // created_at is stored as naive UTC; shift it into the site timezone before truncating to a date
+      result = await this._db
+        .knex('members')
+        .select(
+          this._db.knex.raw(
+            "DATE(created_at + (? * interval '1 minute')) AS created_at, COUNT(*) AS count",
+            [tzOffsetMins],
+          ),
+        )
+        .where((builder) => {
+          if (days !== 'all-time') {
+            builder.whereRaw('created_at >= ?', [startOfRange]);
+          }
+        })
+        .groupByRaw("DATE(created_at + (? * interval '1 minute'))", [tzOffsetMins]);
     } else {
       const mins = Math.abs(tzOffsetMins) % 60;
       const hours = (Math.abs(tzOffsetMins) - mins) / 60;

--- a/ghost/core/core/server/services/milestones/milestone-queries.js
+++ b/ghost/core/core/server/services/milestones/milestone-queries.js
@@ -26,7 +26,7 @@ module.exports = class MilestoneQueries {
       .knex('members_paid_subscription_events as stripe')
       .select(
         this.#db.knex.raw(
-          'ROUND(SUM(stripe.mrr_delta) * 12) / 100 AS arr, stripe.currency as currency',
+          'ROUND(SUM(stripe.mrr_delta) * 12) / 100.0 AS arr, stripe.currency as currency',
         ),
       )
       .groupBy('stripe.currency');

--- a/ghost/core/core/server/services/offers/application/offers-api.js
+++ b/ghost/core/core/server/services/offers/application/offers-api.js
@@ -10,6 +10,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const debug = require('@tryghost/debug')('offers:api');
+const { isDuplicateEntryError } = require('../../../data/db/sql-helpers');
 /** @import {PublicOfferDTO, OfferDTO} from './offer-mapper' */
 
 const messages = {
@@ -314,7 +315,7 @@ class OffersAPI {
       } catch (err) {
         // Handle race condition: another request may have created the offer
         // between the check and save. If so, return the existing offer.
-        if (err.code === 'ER_DUP_ENTRY' || err.code === 'SQLITE_CONSTRAINT') {
+        if (isDuplicateEntryError(err)) {
           const createdOffer = await this.repository.getByStripeCouponId(coupon.id, txOptions);
           if (createdOffer) {
             return OfferMapper.toDTO(createdOffer);

--- a/ghost/core/core/server/services/stats/mrr-stats-service.js
+++ b/ghost/core/core/server/services/stats/mrr-stats-service.js
@@ -45,11 +45,11 @@ class MrrStatsService {
     const rows = await knex('members_paid_subscription_events')
       .select('currency')
       // In SQLite, DATE(created_at) would map to a string value, while DATE(created_at) would map to a JSDate object in MySQL
-      // That is why we need the cast here (to have some consistency)
-      .select(knex.raw('CAST(DATE(created_at) as CHAR) as date'))
+      // That is why we need the cast here (to have some consistency). CHAR(10) rather than CHAR: a bare CHAR is char(1) on Postgres.
+      .select(knex.raw('CAST(DATE(created_at) AS CHAR(10)) as date'))
       .select(knex.raw(`SUM(mrr_delta) as delta`))
       .where('created_at', '>=', startDate)
-      .groupByRaw('CAST(DATE(created_at) as CHAR), currency');
+      .groupByRaw('CAST(DATE(created_at) AS CHAR(10)), currency');
     return rows;
   }
 

--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -787,11 +787,11 @@ class PostsStatsService {
           this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
           this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
           this.knex.raw(
-            'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate',
+            'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) * 1.0 / COALESCE(e.email_count, 0) ELSE 0 END as open_rate',
           ),
           this.knex.raw('COALESCE(clicks.click_count, 0) as total_clicks'),
           this.knex.raw(
-            'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate',
+            'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) * 1.0 / COALESCE(e.email_count, 0) ELSE 0 END as click_rate',
           ),
         )
         .from('posts as p')
@@ -881,11 +881,11 @@ class PostsStatsService {
             this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
             this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
             this.knex.raw(
-              'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate',
+              'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) * 1.0 / COALESCE(e.email_count, 0) ELSE 0 END as open_rate',
             ),
             this.knex.raw('COALESCE(clicks.click_count, 0) as total_clicks'),
             this.knex.raw(
-              'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate',
+              'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) * 1.0 / COALESCE(e.email_count, 0) ELSE 0 END as click_rate',
             ),
           )
           .from('posts as p')
@@ -908,7 +908,7 @@ class PostsStatsService {
             this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
             this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
             this.knex.raw(
-              'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate',
+              'CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) * 1.0 / COALESCE(e.email_count, 0) ELSE 0 END as open_rate',
             ),
           )
           .from('posts as p')
@@ -972,7 +972,7 @@ class PostsStatsService {
         .groupBy('r.post_id')
         .select(
           this.knex.raw(
-            'CASE WHEN MAX(COALESCE(e.email_count, 0)) > 0 THEN COALESCE(COUNT(DISTINCT mce.member_id), 0) / MAX(COALESCE(e.email_count, 0)) ELSE 0 END as click_rate',
+            'CASE WHEN MAX(COALESCE(e.email_count, 0)) > 0 THEN COALESCE(COUNT(DISTINCT mce.member_id), 0) * 1.0 / MAX(COALESCE(e.email_count, 0)) ELSE 0 END as click_rate',
           ),
         );
 
@@ -1010,7 +1010,7 @@ class PostsStatsService {
             this.select('*')
               .from('members as m')
               .whereRaw('m.id = mn.member_id')
-              .where('m.email_disabled', 1);
+              .whereRaw('m.email_disabled = TRUE');
           }),
 
         // Get daily deltas (optimized query)
@@ -1098,14 +1098,14 @@ class PostsStatsService {
     let deltasQuery = this.knex('members_subscribe_events as mse')
       .select(
         this.knex.raw(`DATE(mse.created_at) as date`),
-        this.knex.raw(`SUM(CASE WHEN mse.subscribed = 1 THEN 1 ELSE -1 END) as value`),
+        this.knex.raw(`SUM(CASE WHEN mse.subscribed = TRUE THEN 1 ELSE -1 END) as value`),
       )
       .where('mse.newsletter_id', newsletterId)
       .whereNotExists(function () {
         this.select('*')
           .from('members as m')
           .whereRaw('m.id = mse.member_id')
-          .where('m.email_disabled', 1);
+          .whereRaw('m.email_disabled = TRUE');
       })
       .groupByRaw('DATE(mse.created_at)')
       .orderBy('date', 'asc');

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -6,6 +6,7 @@ const {
   canWelcomeEmailReplaceSignupPaidEmail,
 } = require('../../../lib/member-signup-contexts');
 const { collectedByPort } = require('../checkout/completed-session');
+const { isDuplicateEntryError } = require('../../../../data/db/sql-helpers');
 /** @typedef {import('../../../lib/member-signup-contexts').SignupContext} SignupContext */
 
 function isStripeMetadataTrue(value) {
@@ -285,7 +286,7 @@ module.exports = class CheckoutSessionEventService {
           subscription: updatedSubscription,
         });
       } catch (err) {
-        if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+        if (!isDuplicateEntryError(err)) {
           throw err;
         }
         throw new errors.ConflictError({
@@ -312,7 +313,7 @@ module.exports = class CheckoutSessionEventService {
             subscription: updatedSubscription,
           });
         } catch (err) {
-          if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+          if (!isDuplicateEntryError(err)) {
             throw err;
           }
           throw new errors.ConflictError({
@@ -411,7 +412,7 @@ module.exports = class CheckoutSessionEventService {
             attribution,
           });
         } catch (err) {
-          if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+          if (!isDuplicateEntryError(err)) {
             throw err;
           }
           throw new errors.ConflictError({

--- a/ghost/core/core/server/services/stripe/services/webhook/subscription-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/subscription-event-service.js
@@ -1,5 +1,6 @@
 const errors = require('@tryghost/errors');
 const _ = require('lodash');
+const { isDuplicateEntryError } = require('../../../../data/db/sql-helpers');
 
 /**
  * Handles `customer.subscription.*` webhook events
@@ -44,7 +45,7 @@ module.exports = class SubscriptionEventService {
           subscription,
         });
       } catch (err) {
-        if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
+        if (!isDuplicateEntryError(err)) {
           throw err;
         }
         throw new errors.ConflictError({ err });

--- a/ghost/core/core/server/services/webhooks/webhooks-service.js
+++ b/ghost/core/core/server/services/webhooks/webhooks-service.js
@@ -1,5 +1,6 @@
 const { ValidationError } = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
+const { isForeignKeyError } = require('../../data/db/sql-helpers');
 
 const messages = {
   webhookAlreadyExists: 'Target URL has already been used for this event.',
@@ -33,12 +34,7 @@ class WebhooksService {
       return newWebhook;
     } catch (error) {
       // Handle foreign key constraint errors for non-existing integration_id in MySQL and SQLite engines
-      if (
-        error.errno === 1452 ||
-        (error.code === 'SQLITE_CONSTRAINT' &&
-          /FOREIGN KEY constraint failed/.test(error.message)) ||
-        error.code === 'SQLITE_CONSTRAINT_FOREIGNKEY'
-      ) {
+      if (isForeignKeyError(error)) {
         throw new ValidationError({
           message: tpl(messages.nonExistingIntegrationIdProvided.message, {
             key: 'integration_id',

--- a/ghost/core/core/shared/config/utils.ts
+++ b/ghost/core/core/shared/config/utils.ts
@@ -67,10 +67,14 @@ function sanitizeDatabaseProperties(nconf: Provider): void {
     nconf.set('database:client', 'better-sqlite3');
   }
 
+  if (['postgres', 'postgresql'].includes(nconf.get('database:client'))) {
+    nconf.set('database:client', 'pg');
+  }
+
   const database = nconf.get('database');
   const client = nconf.get('database:client');
 
-  if (client === 'mysql2') {
+  if (client === 'mysql2' || client === 'pg') {
     delete database.connection.filename;
   } else {
     delete database.connection.host;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -230,6 +230,8 @@
     "otplib": "12.0.1",
     "papaparse": "5.5.4",
     "path-match": "1.2.4",
+    "pg": "8.23.0",
+    "pg-query-stream": "4.10.0",
     "probability-distributions": "0.9.1",
     "probe-image-size": "7.3.0",
     "rss": "1.2.2",

--- a/ghost/core/test/unit/api/endpoints/utils/serializers/input/utils/slug-filter-order.test.js
+++ b/ghost/core/test/unit/api/endpoints/utils/serializers/input/utils/slug-filter-order.test.js
@@ -7,7 +7,7 @@ describe('Unit: endpoints/utils/serializers/input/utils/slug-filter-order', func
 
     assert.equal(
       result.sql,
-      'CASE WHEN `tags`.`slug` = ? THEN ? WHEN `tags`.`slug` = ? THEN ? WHEN `tags`.`slug` = ? THEN ? END ASC',
+      'CASE WHEN tags.slug = ? THEN ? WHEN tags.slug = ? THEN ? WHEN tags.slug = ? THEN ? END ASC',
     );
     assert.deepEqual(result.bindings, ['kitchen-sink', 0, 'bacon', 1, 'chorizo', 2]);
   });
@@ -27,7 +27,7 @@ describe('Unit: endpoints/utils/serializers/input/utils/slug-filter-order', func
   it('handles single slug', function () {
     const result = slugFilterOrder('posts', 'slug:[only-one]');
 
-    assert.equal(result.sql, 'CASE WHEN `posts`.`slug` = ? THEN ? END ASC');
+    assert.equal(result.sql, 'CASE WHEN posts.slug = ? THEN ? END ASC');
     assert.deepEqual(result.bindings, ['only-one', 0]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean:hard": "node ./scripts/clean.js",
     "dev": "pnpm nx run ghost-monorepo:docker:dev",
     "dev:sqlite": "DEV_COMPOSE_FILES='-f compose.dev.sqlite.yaml' pnpm nx run ghost-monorepo:docker:dev",
+    "dev:postgres": "DEV_COMPOSE_FILES='-f compose.dev.postgres.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:mailgun": "DEV_COMPOSE_FILES='-f compose.dev.mailgun.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:lexical": "EDITOR_URL=http://localhost:2368/ghost/assets/koenig-lexical/ pnpm nx run ghost-monorepo:docker:dev:lexical",
     "dev:public": "pnpm nx run ghost-monorepo:docker:dev:public",

--- a/patches/@tryghost__bookshelf-pagination@2.4.1.patch
+++ b/patches/@tryghost__bookshelf-pagination@2.4.1.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/bookshelf-pagination.js b/lib/bookshelf-pagination.js
+index bee7b4d1edd1fc2034b96b7a1546a855a52db1d8..edc460bcf6d290c3b08f7625048ce1fc38e423cf 100644
+--- a/lib/bookshelf-pagination.js
++++ b/lib/bookshelf-pagination.js
+@@ -225,6 +225,8 @@ const pagination = function pagination(bookshelf) {
+                 }
+ 
+                 countQuery.clear('select');
++                // ORDER BY has no effect on a count and Postgres rejects it under count(*)
++                countQuery.clear('order');
+                 // Skipping distinct for simple queries where we know result rows are unique.
+                 // useBasicCount forces count(*) even for multi-table queries, for callers
+                 // that know their result set is unique.

--- a/patches/knex-migrator@5.4.1.patch
+++ b/patches/knex-migrator@5.4.1.patch
@@ -1,0 +1,127 @@
+diff --git a/lib/database.js b/lib/database.js
+index 61e4fe2e5ea6a3ff9392d8a4f4e8488842664db9..65961c44a280ff6c82d2f4a79fef271ccf2bdb2d 100644
+--- a/lib/database.js
++++ b/lib/database.js
+@@ -33,6 +33,10 @@ exports.connect = function connect(options) {
+         delete options.connection.filename;
+     }
+ 
++    if (client === 'pg') {
++        delete options.connection.filename;
++    }
++
+     return knex(options);
+ };
+ 
+@@ -108,6 +112,33 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
+     // @NOTE: Skip, because sqlite3 is a file based database.
+     if (DatabaseInfo.isSQLiteConfig(dbConfig)) {
+         return Promise.resolve();
++    } else if (dbConfig.client === 'pg') {
++        const pgConnection = exports.connect({
++            client: 'pg',
++            connection: Object.assign({}, dbConfig.connection, {database: 'postgres'})
++        });
++
++        debug('Create database', name);
++
++        return exports.ensureConnectionWorks(pgConnection)
++            .then(function () {
++                return pgConnection.raw('CREATE DATABASE "' + name + '";');
++            })
++            .catch(function (err) {
++                // CASE: DB exists (duplicate_database)
++                if (err.code === '42P04') {
++                    return Promise.resolve();
++                }
++
++                throw new errors.DatabaseError({
++                    message: err.message,
++                    err: err,
++                    code: 'DATABASE_CREATION_FAILED'
++                });
++            })
++            .finally(function () {
++                return pgConnection.destroy();
++            });
+     } else if (!DatabaseInfo.isMySQLConfig(dbConfig)) {
+         return Promise.reject(new errors.KnexMigrateError({
+             message: 'Database is not supported.'
+@@ -216,6 +247,16 @@ exports.drop = function drop(options) {
+                     return connection.raw('PRAGMA foreign_keys = ON;');
+                 }
+             });
++    } else if (connection.client.config.client === 'pg') {
++        // @NOTE: We are connected to the database itself, so drop and recreate the schema instead.
++        debug('Drop schema public: ' + dbConfig.connection.database);
++
++        return connection.raw('DROP SCHEMA public CASCADE; CREATE SCHEMA public;')
++            .catch(function (err) {
++                return Promise.reject(new errors.KnexMigrateError({
++                    err: err
++                }));
++            });
+     } else {
+         return Promise.reject(new errors.KnexMigrateError({
+             message: 'Database client not supported: ' + dbConfig.client
+diff --git a/lib/index.js b/lib/index.js
+index 293ee7a3815a0db59728a7f4b8fe17ccba87ed07..19915b075eaaf314b81e060ef0ea37ae7d47fc2b 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -481,7 +481,7 @@ KnexMigrator.prototype.reset = function reset(options) {
+             dbConfig: self.dbConfig
+         }).catch(function onRestError(err) {
+             // Database does not exist. MySql.
+-            if (err.errno === 1049) {
++            if (err.errno === 1049 || err.code === '3D000') {
+                 return Promise.resolve();
+             }
+ 
+@@ -521,7 +521,7 @@ KnexMigrator.prototype.reset = function reset(options) {
+             debug('Reset error: ' + err.message);
+ 
+             // CASE: Database does not exist. For MySql.
+-            if (err.errno === 1049) {
++            if (err.errno === 1049 || err.code === '3D000') {
+                 return Promise.resolve();
+             }
+ 
+@@ -604,7 +604,7 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
+         })
+         .catch(function (err) {
+             // CASE: database does not exist
+-            if (err.errno === 1049) {
++            if (err.errno === 1049 || err.code === '3D000') {
+                 throw new errors.DatabaseIsNotOkError({
+                     message: 'Please run `yarn knex-migrator init`',
+                     code: 'DB_NOT_INITIALISED'
+@@ -1199,7 +1199,7 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
+         }
+ 
+         // CASE: database does not exist
+-        if (err.errno === 1049) {
++        if (err.errno === 1049 || err.code === '3D000') {
+             throw new errors.DatabaseIsNotOkError({
+                 message: 'Please run `yarn knex-migrator init`',
+                 code: 'DB_NOT_INITIALISED'
+@@ -1210,6 +1210,7 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
+         if (
+             err.errno === 1
+             || err.errno === 1146
++            || err.code === '42P01'
+             || (err.code === 'SQLITE_ERROR' && /no such table: migrations/.test(err.message))
+         ) {
+             throw new errors.DatabaseIsNotOkError({
+diff --git a/migrations/add-primary-key-to-lock-table.js b/migrations/add-primary-key-to-lock-table.js
+index c0a73e84dac7537e4df6bbda64f46e2e0a8efbe1..9d8240e19061d22846f42f9fc293def9a883570b 100644
+--- a/migrations/add-primary-key-to-lock-table.js
++++ b/migrations/add-primary-key-to-lock-table.js
+@@ -37,7 +37,7 @@ function addPrimaryKey(tableName, columns, knex) {
+     return knex.schema.table(tableName, function (table) {
+         table.primary(columns);
+     }).catch((err) => {
+-        if (err.code === 'ER_MULTIPLE_PRI_KEY') {
++        if (err.code === 'ER_MULTIPLE_PRI_KEY' || err.code === '42P16') {
+             debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
+             return;
+         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,10 @@ packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
 
 pnpmfileChecksum: sha256-qqNuypA2kX16OHjG3pLjbOVjA/Gsi92LRvE/r6+Nehs=
 
+patchedDependencies:
+  '@tryghost/bookshelf-pagination@2.4.1': 6912f5259724396eef2133ffae35924546fae8f088ac60b90ad671307d8d42d1
+  knex-migrator@5.4.1: 542ae918312a314e6120647535543e63217c730238120ead1ed36bca8f7eb959
+
 importers:
 
   .:
@@ -2375,7 +2379,7 @@ importers:
         version: 2.3.8(supports-color@10.2.2)
       '@tryghost/brute-knex':
         specifier: 'catalog:'
-        version: 3.2.2(better-sqlite3@12.11.1)(express@4.22.2(supports-color@10.2.2))(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+        version: 3.2.2(better-sqlite3@12.11.1)(express@4.22.2(supports-color@10.2.2))(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
       '@tryghost/checkout':
         specifier: workspace:*
         version: link:../../packages/checkout
@@ -2537,10 +2541,10 @@ importers:
         version: 1.20.6(supports-color@10.2.2)
       bookshelf:
         specifier: 1.2.0
-        version: 1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2))
+        version: 1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2))
       bookshelf-relations:
         specifier: 2.8.0
-        version: 2.8.0(bookshelf@1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)))(supports-color@10.2.2)
+        version: 2.8.0(bookshelf@1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)))(supports-color@10.2.2)
       bson-objectid:
         specifier: 'catalog:'
         version: 2.0.4
@@ -2693,10 +2697,10 @@ importers:
         version: 9.1.0(encoding@0.1.13)
       knex:
         specifier: 2.4.2
-        version: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+        version: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
       knex-migrator:
         specifier: 'catalog:'
-        version: 5.4.1(@types/node@22.20.1)(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 5.4.1(patch_hash=542ae918312a314e6120647535543e63217c730238120ead1ed36bca8f7eb959)(@types/node@22.20.1)(bluebird@3.7.2)(pg@8.23.0)(supports-color@10.2.2)
       leaky-bucket:
         specifier: 2.2.0
         version: 2.2.0
@@ -2784,6 +2788,12 @@ importers:
       path-match:
         specifier: 1.2.4
         version: 1.2.4
+      pg:
+        specifier: 8.23.0
+        version: 8.23.0
+      pg-query-stream:
+        specifier: 4.10.0
+        version: 4.10.0(pg@8.23.0)
       probability-distributions:
         specifier: 0.9.1
         version: 0.9.1
@@ -2853,7 +2863,7 @@ importers:
         version: 2.1.0
       '@types/bookshelf':
         specifier: 1.2.9
-        version: 1.2.9(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+        version: 1.2.9(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
       '@types/common-tags':
         specifier: 1.8.4
         version: 1.8.4
@@ -19080,6 +19090,12 @@ packages:
     resolution: {integrity: sha512-vtjFuJI+oYKGb9p/x/LUsu9h36DTUzNfrveGzzwilKIupshpjyDUBM6V+isHl9MBlH9cnVe5Iu0MzpgscwCxyA==}
     engines: {node: '>= 0.10.0'}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
   pg-connection-string@2.4.0:
     resolution: {integrity: sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==}
 
@@ -19088,6 +19104,44 @@ packages:
 
   pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
+
+  pg-cursor@2.22.0:
+    resolution: {integrity: sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw==}
+    peerDependencies:
+      pg: ^8
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-query-stream@4.10.0:
+    resolution: {integrity: sha512-w4h/zgnjI5mIEkK9Bufeo+V4EsHp4lTt9HD8f4Zqt3kYMb30bn/2iLq/UyZb4MMxhZO78Lr6kBLyfGsqq4H7Fw==}
+    peerDependencies:
+      pg: ^8
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
@@ -19788,6 +19842,22 @@ packages:
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   preact@10.29.8:
     resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
@@ -29077,7 +29147,7 @@ snapshots:
     dependencies:
       lodash: 4.18.1
 
-  '@tryghost/bookshelf-pagination@2.4.1':
+  '@tryghost/bookshelf-pagination@2.4.1(patch_hash=6912f5259724396eef2133ffae35924546fae8f088ac60b90ad671307d8d42d1)':
     dependencies:
       '@tryghost/errors': 3.3.9
       '@tryghost/tpl': 2.3.7
@@ -29092,7 +29162,7 @@ snapshots:
       '@tryghost/bookshelf-has-posts': 2.4.7(supports-color@10.2.2)
       '@tryghost/bookshelf-include-count': 2.3.7(supports-color@10.2.2)
       '@tryghost/bookshelf-order': 2.3.7
-      '@tryghost/bookshelf-pagination': 2.4.1
+      '@tryghost/bookshelf-pagination': 2.4.1(patch_hash=6912f5259724396eef2133ffae35924546fae8f088ac60b90ad671307d8d42d1)
       '@tryghost/bookshelf-search': 2.3.7
       '@tryghost/bookshelf-transaction-events': 2.3.7
     transitivePeerDependencies:
@@ -29102,10 +29172,10 @@ snapshots:
 
   '@tryghost/bookshelf-transaction-events@2.3.7': {}
 
-  '@tryghost/brute-knex@3.2.2(better-sqlite3@12.11.1)(express@4.22.2(supports-color@10.2.2))(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)':
+  '@tryghost/brute-knex@3.2.2(better-sqlite3@12.11.1)(express@4.22.2(supports-color@10.2.2))(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)':
     dependencies:
       express-brute: 1.0.1(express@4.22.2(supports-color@10.2.2))
-      knex: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+      knex: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
     transitivePeerDependencies:
       - better-sqlite3
       - express
@@ -29626,12 +29696,12 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 26.0.0
 
-  '@types/bookshelf@1.2.9(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)':
+  '@types/bookshelf@1.2.9(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)':
     dependencies:
       '@types/bluebird': 3.5.42
       '@types/create-error': 0.3.33
       '@types/lodash': 4.17.25
-      knex: 0.21.21(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+      knex: 0.21.21(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
     transitivePeerDependencies:
       - mssql
       - mysql
@@ -32348,22 +32418,22 @@ snapshots:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
 
-  bookshelf-relations@2.8.0(bookshelf@1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)))(supports-color@10.2.2):
+  bookshelf-relations@2.8.0(bookshelf@1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)))(supports-color@10.2.2):
     dependencies:
       '@tryghost/debug': 0.1.40(supports-color@10.2.2)
       '@tryghost/errors': 3.3.9
       bluebird: 3.7.2
-      bookshelf: 1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2))
+      bookshelf: 1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2))
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  bookshelf@1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)):
+  bookshelf@1.2.0(knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)):
     dependencies:
       bluebird: 3.7.2
       create-error: 0.3.1
       inflection: 1.13.4
-      knex: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+      knex: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
       lodash: 4.18.1
 
   boolbase@1.0.0: {}
@@ -40187,7 +40257,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex-migrator@5.4.1(@types/node@22.20.1)(bluebird@3.7.2)(supports-color@10.2.2):
+  knex-migrator@5.4.1(patch_hash=542ae918312a314e6120647535543e63217c730238120ead1ed36bca8f7eb959)(@types/node@22.20.1)(bluebird@3.7.2)(pg@8.23.0)(supports-color@10.2.2):
     dependencies:
       '@tryghost/database-info': 0.3.35
       '@tryghost/errors': 3.3.9
@@ -40196,7 +40266,7 @@ snapshots:
       commander: 5.1.0
       compare-ver: 2.0.2
       debug: 4.4.3(supports-color@10.2.2)
-      knex: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2)
+      knex: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2)
       lodash: 4.18.1
       moment: 2.30.1
       mysql2: 3.22.5(@types/node@22.20.1)
@@ -40215,7 +40285,7 @@ snapshots:
       - supports-color
       - tedious
 
-  knex@0.21.21(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2):
+  knex@0.21.21(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2):
     dependencies:
       colorette: 1.2.1
       commander: 6.2.1
@@ -40231,10 +40301,11 @@ snapshots:
       v8flags: 3.2.0
     optionalDependencies:
       mysql2: 3.22.5(@types/node@22.20.1)
+      pg: 8.23.0
     transitivePeerDependencies:
       - supports-color
 
-  knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(supports-color@10.2.2):
+  knex@2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.1))(pg@8.23.0)(supports-color@10.2.2):
     dependencies:
       colorette: 2.0.19
       commander: 9.5.0
@@ -40253,6 +40324,7 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.11.1
       mysql2: 3.22.5(@types/node@22.20.1)
+      pg: 8.23.0
     transitivePeerDependencies:
       - supports-color
 
@@ -43049,11 +43121,55 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
   pg-connection-string@2.4.0: {}
 
   pg-connection-string@2.5.0: {}
 
   pg-connection-string@2.6.2: {}
+
+  pg-cursor@2.22.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-query-stream@4.10.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+      pg-cursor: 2.22.0(pg@8.23.0)
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@0.2.1: {}
 
@@ -43806,6 +43922,16 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   preact@10.29.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -341,3 +341,6 @@ versioning:
     - '@tryghost/portal'
     - '@tryghost/signup-form'
     - '@tryghost/sodo-search'
+patchedDependencies:
+  '@tryghost/bookshelf-pagination@2.4.1': patches/@tryghost__bookshelf-pagination@2.4.1.patch
+  knex-migrator@5.4.1: patches/knex-migrator@5.4.1.patch


### PR DESCRIPTION
Spike exploring what a Postgres-only Ghost would take, prompted by Ghost-CLI being deprecated in favour of a Docker-based setup (which removes the "self-hosters need the zero-dependency SQLite install" constraint).

**Not for merging.** This branch keeps MySQL and SQLite working and adds `pg` as a third client so the two can be compared. The point is to enumerate what actually breaks and how much of it is structural.

## Running it

```bash
pnpm dev:postgres
```

That swaps the MySQL container for Postgres 16 via `compose.dev.postgres.yaml`. Or, against any Postgres, from `ghost/core`:

```bash
NODE_ENV=development \
database__client=pg \
database__connection__host=127.0.0.1 \
database__connection__port=5432 \
database__connection__user=root \
database__connection__password=root \
database__connection__database=ghost_dev \
node --conditions=source --import=tsx index.js
```

`knex-migrator init` runs on first boot: 94 tables, the view, and fixtures, in a few seconds.

## What's in here

**Driver and plumbing (commit 1)**

- `pg` and `pg-query-stream` (needed for knex `.stream()`) added to Ghost core
- Config sanitizer accepts `pg`/`postgres`/`postgresql` and no longer strips connection keys for non-MySQL clients
- `connection.js` gets a `pg` branch: `SET TIME ZONE 'UTC'` per connection, and type parsers so `bigint`/`numeric` come back as numbers and naive timestamps parse as UTC (mirrors mysql2's `timezone: 'Z'` + `decimalNumbers`)
- `schema/commands.js` gains Postgres introspection for tables/indexes/columns, creates datetime columns as `timestamp` (not knex's default `timestamptz`), and accepts Postgres duplicate/undefined-object codes in the index guards
- A local `DatabaseInfo` subclass with `isPostgres` (needs to go upstream to `@tryghost/database-info`)
- pnpm patch on `knex-migrator`: create/drop database for pg, pg error codes for "database/relation does not exist", and the internal lock-table migration only swallowed MySQL's multiple-primary-key error
- pnpm patch on `@tryghost/bookshelf-pagination`: `clear('order')` on the count query, which Postgres rejects under `count(*)`

**Dialect fixes (commit 2)**

A new `data/db/sql-helpers.js` with `isDuplicateEntryError`, `isForeignKeyError`, `isUnknownColumnError`, `rawRows`, `quoteIdentifier`, and `groupConcat`, used at the 14 sites that previously checked `ER_DUP_ENTRY`/`SQLITE_CONSTRAINT` by hand. Then the behavioural differences, each handled only on Postgres unless the portable form is identical:

| Postgres behaviour | Where it bit | Fix |
|---|---|---|
| `FOR UPDATE` rejected with `DISTINCT` (bookshelf emits DISTINCT for eager-loaded relations, and passes `options.lock` down to them) | Post publish | `crud.js` locks the target row explicitly; the `fetching` hook skips `forUpdate()` on distinct queries |
| NULLs sort first on DESC | Drafts sorted first under `published_at desc`; pinned comments | `events.js` sets knex `nulls: first/last` on non-raw `orderBy`; comment ordering made NULL-aware |
| `int / int` truncates | Open/click rates in stats, ARR | `* 1.0`, `/ 100.0` |
| `CAST(x AS CHAR)` is `char(1)` | MRR date | `CHAR(10)` |
| Real booleans | `subscribed = 1`, `track_opens = 1`, `email_disabled = 1` | `= TRUE` |
| Untyped bound values in `CASE id WHEN ? THEN ? END` resolve to `text` | Batched email analytics / event storage updates | `ELSE <column>` branch gives the CASE the column type |
| Failed statement aborts the transaction | Bulk insert chunk-then-retry-rows pattern | Each attempt runs in a savepoint |
| Unquoted identifiers fold to lowercase | `PostClicks` CTE, `maxTimestamp` alias | Lowercased / bound with `??` |
| `ORDER BY` inside a `WHERE` fragment reused by the count query | Member click events | Moved to `autoOrder` |
| `LIKE` is case-sensitive | Member search | `ILIKE` on pg (NQL `~` was already case-insensitive via `lower()`) |
| Backticks are not identifier quotes | Links, automations, slug ordering, post sentiment ordering | Portable quoting via `??` / `wrapIdentifier` |
| No `GROUP_CONCAT` | Members CSV export | `string_agg` on pg |
| No `CONVERT_TZ` / two-arg `DATE()` | Members-by-date stats | Interval arithmetic branch |

Note `DATE(col)` itself works on Postgres, so the 15 bare `DATE()` sites are fine.

## Verified against Postgres

Seeded members, a paid subscription with MRR events, an email with recipients, link clicks, comments, and a draft post, then checked by hand:

- Newsletter stats: open rate 0.25, click rate 0.5 (both would have been 0 with integer division)
- MRR history 1500 → 1234; ARR 148.08
- Link click counts, member click events, member counts over time
- Member search `PAID` matches `Paid.Member@Example.com`
- Drafts last under `published_at desc`, first under `asc`; pinned comment first
- Bulk insert with a duplicate inside a transaction: 2 committed, 1 rejected with 23505, transaction still usable
- Post create → publish with authors/tags → edit → frontend render; members CSV export; JSON db export; ~50 admin endpoints return 200

## Test status

- Unit suite: green except 7 pre-existing failures (cron day-of-week, gift-preview PNG, email-renderer) that fail identically on clean `main`
- MySQL integration and legacy suites: fully green
- MySQL e2e-api: `admin/members.test.js` and `members/webhooks.test.js` are flaky locally on clean `main` too (36 failures clean vs 19 on this branch, overlapping sets), so not regressions
- No Postgres-backed test harness yet; `test/utils/db-utils.js` and `db-template.js` are MySQL-specific (`SET FOREIGN_KEY_CHECKS`, `SHOW CREATE TABLE`, `GET_LOCK`)

## Not done / open questions

- The three external packages (`knex-migrator`, `@tryghost/database-info`, `@tryghost/bookshelf-pagination`) need upstream PRs; the pnpm patches and local subclass are stand-ins
- `@tryghost/mongo-knex` should get a Postgres test suite; it appears to work but is only exercised via the API here
- Migration path for existing installs: fresh installs only run `init/` from `schema.js`, so the 340 versioned migrations don't need to be dual-dialect if MySQL → Postgres is a data-level export/import
- Test infra, CI, `Dockerfile.production`, e2e `mysql-manager.ts`, the Admin "unsupported database" warning, and the dev seeder (`LOAD DATA INFILE`, `SET FOREIGN_KEY_CHECKS`) are untouched
- `newsletter-email-event-storage.js` still string-interpolates ids/timestamps into its CASE statement (pre-existing)
