### PR TITLE
Added a host limit that can switch custom member fields off per site

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -74,6 +74,10 @@ export type Config = {
         disabled: boolean;
         error?: string;
       };
+      limitCustomFields?: {
+        disabled: boolean;
+        error?: string;
+      };
       publicSiteAccess?: {
         disabled: boolean;
         // Copy shown in the pre-launch banner when public site access is disabled.

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -54,6 +54,7 @@ import { memberCustomFieldCsvColumns } from '@tryghost/admin-x-framework/api/mem
 import { useCustomFieldDefinitions } from '@/shared/member-custom-fields/use-definitions';
 import { parseCSV } from '@/members/components/bulk-action-modals/import-members/csv';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useLabelPicker } from '@/members/hooks/use-label-picker';
 
@@ -75,7 +76,7 @@ export function ImportMembersModal({
   const { mutateAsync: importMembers } = useImportMembers();
   const importMemberTier = useFeatureFlag('importMemberTier');
 
-  const canCreateCustomFields = useFeatureFlag('membersCustomFields');
+  const canCreateCustomFields = useCustomFieldsAvailable();
   const { data: customFieldsData, isError: customFieldsFailed } = useCustomFieldDefinitions();
   // A field created from the mapping step is in here the moment it is created: the create
   // mutation puts it into the cached list, so there is no window where a row points at a

--- a/apps/admin/src/settings/layout/sidebar.tsx
+++ b/apps/admin/src/settings/layout/sidebar.tsx
@@ -31,6 +31,7 @@ import { searchKeywords as growthSearchKeywords } from '@/settings/growth/search
 import { searchKeywords as membershipSearchKeywords } from '@/settings/membership/search-keywords';
 import { searchKeywords as siteSearchKeywords } from '@/settings/site/search-keywords';
 
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useGlobalData } from '@/settings/providers/global-data-context';
 import { useSettingsNavigation } from '@/settings/hooks/use-settings-navigation';
@@ -124,7 +125,7 @@ const Sidebar: React.FC = () => {
   const paidMembersEnabled = usePaidMembersEnabled();
   const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
   const hasAutomations = useFeatureFlag('automations');
-  const hasCustomFields = useFeatureFlag('membersCustomFields');
+  const hasCustomFields = useCustomFieldsAvailable();
   const hasNewslettersEnabled = useNewslettersEnabled() === true;
   const mailgunIsConfigured = Boolean(config.mailgunIsConfigured);
   const hasMailgun = hasNewslettersEnabled && !mailgunIsConfigured;

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
+  configResponse,
   fakeAdminEndpoint,
   fakeMemberCustomFields,
   fakeSettingsScreens,
@@ -63,6 +64,42 @@ describe('Custom fields', () => {
 
     await expect(settingsScreen.customFields()).toHaveCount(0);
     expect(customFieldsApi.requests).toHaveLength(0);
+  });
+
+  // A host can switch custom fields off for a site separately from the flag, so the
+  // feature can be sold with a plan. Settings is where a publisher would go to set fields
+  // up, so a limited site is offered nothing to set up. Reading definitions stays open on
+  // the server, so this is the check that stops a limited site being shown a section whose
+  // every save would come back refused.
+  it('stays hidden when the host limit disables the feature', async () => {
+    fakeSettingsScreens();
+    const customFieldsApi = fakeCustomFields();
+    const config = configResponse({ labs: { membersCustomFields: true } });
+    config.config.hostSettings = {
+      limits: { limitCustomFields: { disabled: true } },
+    };
+    await renderAdminApp('/settings', {
+      ...flagOn,
+      boot: { browseConfig: { response: config } },
+    });
+
+    await expect(settingsScreen.customFields()).toHaveCount(0);
+    expect(customFieldsApi.requests).toHaveLength(0);
+  });
+
+  it('stays visible when the host sets the limit but leaves it enabled', async () => {
+    fakeSettingsScreens();
+    fakeCustomFields();
+    const config = configResponse({ labs: { membersCustomFields: true } });
+    config.config.hostSettings = {
+      limits: { limitCustomFields: { disabled: false } },
+    };
+    await renderAdminApp('/settings', {
+      ...flagOn,
+      boot: { browseConfig: { response: config } },
+    });
+
+    await expect.element(settingsScreen.customFields()).toBeVisible();
   });
 
   it('lists each field with its user-facing type, opting into archived fields', async () => {

--- a/apps/admin/src/settings/membership/custom-fields.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.tsx
@@ -28,7 +28,8 @@ import {
   useReorderMemberCustomFields,
   userTypeForField,
 } from '@tryghost/admin-x-framework/api/member-custom-fields';
-import { useFeatureFlag, useHandleError } from '@tryghost/admin-x-framework/hooks';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
+import { useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { useQueryClient } from '@tryghost/admin-x-framework';
 import { withErrorBoundary } from '@/settings/components/with-error-boundary';
 import type { MemberCustomField } from '@tryghost/admin-x-framework/api/member-custom-fields';
@@ -182,11 +183,11 @@ const FieldList: React.FC<{
 };
 
 const CustomFields: React.FC<{ keywords: string[] }> = ({ keywords }) => {
-  // The endpoint is closed (404s) while the flag is off, so keep the query in
-  // step with the flag rather than firing it into a wall. Settings is the one
-  // place that manages archived fields too, so it uses the include-archived
+  // Nothing to fetch when the site cannot use custom fields at all, so keep the
+  // query in step with availability rather than firing it into a wall. Settings is
+  // the one place that manages archived fields too, so it uses the include-archived
   // variant rather than the default active-only browse.
-  const hasCustomFields = useFeatureFlag('membersCustomFields');
+  const hasCustomFields = useCustomFieldsAvailable();
   const { data } = useBrowseMemberCustomFieldsIncludingArchived({
     enabled: hasCustomFields,
   });

--- a/apps/admin/src/settings/membership/membership-settings.tsx
+++ b/apps/admin/src/settings/membership/membership-settings.tsx
@@ -14,6 +14,7 @@ import {
   usePaidMembersEnabled,
 } from '@tryghost/admin-x-framework/api/settings';
 import { searchKeywords } from './search-keywords';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
 import { useFeatureFlag } from '@tryghost/admin-x-framework/hooks';
 import { useGlobalData } from '@/settings/providers/global-data-context';
 
@@ -23,7 +24,7 @@ const MembershipSettings: React.FC = () => {
   const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
   const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
   const hasAutomations = useFeatureFlag('automations');
-  const hasCustomFields = useFeatureFlag('membersCustomFields');
+  const hasCustomFields = useCustomFieldsAvailable();
   const visibleSearchKeywords = [
     searchKeywords.access,
     searchKeywords.tiers,

--- a/apps/admin/src/settings/membership/tiers/tier-checkout-collection.tsx
+++ b/apps/admin/src/settings/membership/tiers/tier-checkout-collection.tsx
@@ -30,11 +30,8 @@ import {
   type StripePort,
 } from '@tryghost/checkout';
 import { JSONError, getErrorMessage } from '@tryghost/admin-x-framework/errors';
-import {
-  type ErrorMessages,
-  useFeatureFlag,
-  useHandleError,
-} from '@tryghost/admin-x-framework/hooks';
+import { useCustomFieldsAvailable } from '@/shared/member-custom-fields/use-availability';
+import { type ErrorMessages, useHandleError } from '@tryghost/admin-x-framework/hooks';
 import { Text } from '@tryghost/shade/primitives';
 import {
   type MemberCustomField,
@@ -297,7 +294,7 @@ const TierCheckoutCollection = forwardRef<
   const { mutateAsync: editCheckoutConfig } = useEditTierCheckoutConfig();
   const handleError = useHandleError();
 
-  const canManageFields = useFeatureFlag('membersCustomFields');
+  const canManageFields = useCustomFieldsAvailable();
   const { data: fieldsData } = useBrowseMemberCustomFields({ enabled: canManageFields });
   const allFields = fieldsData ?? [];
   // What each collected value may be kept in is the server's rule, so it is read from the

--- a/apps/admin/src/shared/member-custom-fields/use-availability.ts
+++ b/apps/admin/src/shared/member-custom-fields/use-availability.ts
@@ -1,0 +1,24 @@
+import { useFeatureFlag, useHostLimits } from '@tryghost/admin-x-framework/hooks';
+
+/**
+ * Whether this site may use custom member fields.
+ *
+ * Two separate things can withhold them, and one place answers for both, so a screen
+ * cannot be left checking one and forgetting the other. The labs flag says whether this
+ * build of Ghost offers the feature at all; the host limit says whether this site's plan
+ * includes it. When the flag goes at GA only this function changes.
+ *
+ * The limit is unset on every self-hosted site and on any plan that includes the feature,
+ * which is every site today.
+ *
+ * A boolean because that is all any screen needs so far. The server does distinguish the
+ * two refusals, answering "not found" for the flag and "forbidden" for the limit, so a
+ * screen that offers an upgrade will want to know which applies. Nothing offers one yet,
+ * so the reason is not reported until something reads it.
+ */
+export const useCustomFieldsAvailable = (): boolean => {
+  const hasFlag = useFeatureFlag('membersCustomFields');
+  const limit = useHostLimits()?.limitCustomFields;
+
+  return hasFlag && limit?.disabled !== true;
+};

--- a/ghost/core/core/server/services/limits.js
+++ b/ghost/core/core/server/services/limits.js
@@ -47,6 +47,22 @@ const init = () => {
   }
 };
 
+/**
+ * Route guard for a feature a host can switch off, for the routes that exist only to
+ * change it. Answers 403 with the host's own wording, which is a different thing to tell a
+ * caller than the 404 a labs flag gives: the feature exists, this plan does not include it.
+ */
+const requireFeature = (limitName) =>
+  async function requireFeatureMw(req, res, next) {
+    try {
+      await limitService.errorIfWouldGoOverLimit(limitName);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+
 module.exports = limitService;
 
 module.exports.init = init;
+module.exports.requireFeature = requireFeature;

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -5,6 +5,7 @@ const auth = require('../../../../services/auth');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
 const labs = require('../../../../../shared/labs');
+const limits = require('../../../../services/limits');
 
 const shared = require('../../../shared');
 
@@ -195,40 +196,38 @@ module.exports = function apiRoutes() {
 
   router.get('/members/stripe_connect', mw.authAdminApi, http(api.membersStripeConnect.auth));
 
-  // Reading definitions is deliberately not behind the feature flag: Admin asks every site
-  // for them, and a site without the flag simply has none, so the answer is an empty list
-  // rather than a 404. Creating and changing them is flagged. Registered before /members/:id
-  // so the literal path is not captured as an id.
-  router.get('/members/metafields/:namespace', mw.authAdminApi, http(api.membersMetafields.browse));
-  router.post(
-    '/members/metafields/:namespace',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersMetafields.add),
-  );
-  router.put(
-    '/members/metafields/:namespace',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersMetafields.reorder),
-  );
-  router.get(
-    '/members/metafields/:namespace/:key',
-    mw.authAdminApi,
-    http(api.membersMetafields.read),
-  );
-  router.put(
-    '/members/metafields/:namespace/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersMetafields.edit),
-  );
-  router.delete(
-    '/members/metafields/:namespace/:key',
-    mw.authAdminApi,
-    labs.enabledMiddleware('membersCustomFields'),
-    http(api.membersMetafields.destroy),
-  );
+  // Custom field definitions. Mounted rather than listed so every route under it is
+  // reached the same way, and so the guards are stated once each instead of on every
+  // route that needs them.
+  //
+  // Order carries the rule here, the way Express reads it: a request walks this stack
+  // from the top, so the reads below are answered before the guards are reached, and
+  // everything registered after them passes through both. A route added at the end is
+  // guarded by being there, which is the safer way round to forget.
+  //
+  // Mounted before /members/:id so the literal path is not captured as an id.
+  const metafieldsRouter = express.Router('admin api members metafields');
+  router.use('/members/metafields', metafieldsRouter);
+
+  metafieldsRouter.use(mw.authAdminApi);
+
+  // Reading is deliberately open: Admin asks every site for its definitions to draw
+  // screens it renders either way, and a site that has none simply answers with an empty
+  // list rather than a 404.
+  metafieldsRouter.get('/:namespace', http(api.membersMetafields.browse));
+  metafieldsRouter.get('/:namespace/:key', http(api.membersMetafields.read));
+
+  // Changing one needs the feature to exist in this build and the site's plan to include
+  // it. Two separate questions, asked once each: a 404 says the feature is not here, a 403
+  // says the plan does not cover it, and only the second is something a publisher can act
+  // on.
+  metafieldsRouter.use(labs.enabledMiddleware('membersCustomFields'));
+  metafieldsRouter.use(limits.requireFeature('limitCustomFields'));
+
+  metafieldsRouter.post('/:namespace', http(api.membersMetafields.add));
+  metafieldsRouter.put('/:namespace', http(api.membersMetafields.reorder));
+  metafieldsRouter.put('/:namespace/:key', http(api.membersMetafields.edit));
+  metafieldsRouter.delete('/:namespace/:key', http(api.membersMetafields.destroy));
 
   router.get('/members/:id', mw.authAdminApi, http(api.members.read));
   router.put('/members/:id', mw.authAdminApi, http(api.members.edit));

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -5,6 +5,7 @@ const {
   fixtureManager,
   mockManager,
   configUtils,
+  hostLimits,
 } = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const events = require('../../../core/server/lib/common/events');
@@ -2312,6 +2313,171 @@ describe('Member Custom Fields Admin API', function () {
 
     it('404s the delete endpoint', async function () {
       await agent.delete('members/metafields/custom/company/').expectStatus(404);
+    });
+  });
+  // Custom fields can be switched off for a site by its host, separately from the flag,
+  // so the feature can be sold with a plan. The limit is unset everywhere today, which is
+  // what the first test pins: nothing changes for a site nobody has limited. When it is
+  // set, changing definitions answers 403 with the host's copy, distinct from the 404 the
+  // flag gives, because "your plan does not include this" is a different thing to tell a
+  // caller than "this does not exist here". Reading stays open either way, so a site whose
+  // plan drops can still see and export the fields it already has.
+  describe('Host limit', function () {
+    afterEach(async function () {
+      await hostLimits.restoreHostLimits();
+    });
+
+    it('leaves every route alone when the limit is unset', async function () {
+      const field = await createField({ name: 'Unlimited' });
+
+      await agent.get('members/metafields/custom/').expectStatus(200);
+      await agent
+        .put(`members/metafields/custom/${field.key}/`)
+        .body({ members_metafields: [{ name: 'Still unlimited' }] })
+        .expectStatus(200);
+      // Deleting is only offered on an archived field, so archiving is the step
+      // that proves the edit route is open, and the delete that follows it too.
+      await setStatus(field.key, 'archived');
+      await agent.delete(`members/metafields/custom/${field.key}/`).expectStatus(204);
+    });
+
+    it('leaves every route alone when the limit is present but not disabled', async function () {
+      await hostLimits.setHostLimits({ limitCustomFields: { disabled: false } });
+
+      const field = await createField({ name: 'Permitted' });
+      await setStatus(field.key, 'archived');
+      await agent.delete(`members/metafields/custom/${field.key}/`).expectStatus(204);
+    });
+
+    describe('when the host disables the feature', function () {
+      let existingKey: string;
+
+      beforeEach(async function () {
+        // Created before the limit goes on, standing in for a site that had the feature
+        // and then dropped below the plan that includes it.
+        existingKey = (await createField({ name: 'Bought earlier' })).key;
+        await hostLimits.setHostLimits({
+          limitCustomFields: {
+            disabled: true,
+            error: 'Custom fields are available on the Publisher plan and above.',
+          },
+        });
+      });
+
+      it('still lists the fields the site already has', async function () {
+        const { body } = await agent.get('members/metafields/custom/').expectStatus(200);
+        assert.equal(
+          body.members_metafields.some((field: { key: string }) => field.key === existingKey),
+          true,
+        );
+      });
+
+      it('still reads a single field', async function () {
+        await agent.get(`members/metafields/custom/${existingKey}/`).expectStatus(200);
+      });
+
+      it('403s the create endpoint, with the host copy', async function () {
+        const { body } = await agent
+          .post('members/metafields/custom/')
+          .body({ members_metafields: [{ name: 'Company', type: 'short_text' }] })
+          .expectStatus(403);
+
+        // The guard is middleware, so the refusal reaches the caller as the limit service
+        // raised it. Endpoints that catch a host limit and re-word it put their own sentence
+        // in `message` and move the host's to `context`; this route has nowhere doing that,
+        // so the publisher reads what their host wrote and `context` stays empty.
+        assert.equal(
+          body.errors[0].message,
+          'Custom fields are available on the Publisher plan and above.',
+        );
+        assert.equal(body.errors[0].context, null);
+        assert.equal(body.errors[0].details.name, 'limitCustomFields');
+      });
+
+      it('403s the reorder endpoint', async function () {
+        await agent
+          .put('members/metafields/custom/')
+          .body({ members_metafields: [{ key: existingKey }] })
+          .expectStatus(403);
+      });
+
+      it('403s the edit endpoint', async function () {
+        await agent
+          .put(`members/metafields/custom/${existingKey}/`)
+          .body({ members_metafields: [{ name: 'Employer' }] })
+          .expectStatus(403);
+      });
+
+      it('403s the delete endpoint', async function () {
+        await agent.delete(`members/metafields/custom/${existingKey}/`).expectStatus(403);
+      });
+
+      // Turning checkout collection on makes the field the collected value lands in, so
+      // this route creates definitions without going near the routes above. That is
+      // deliberate and stays allowed: the publisher is not managing custom fields here,
+      // they are turning on shipping, and the field is the machinery that serves it.
+      //
+      // What makes it safe is the packaging, not anything enforced along the way. Only one
+      // plan limit is involved at all: limitStripeConnect, which withholds Stripe, without
+      // which there is nothing to charge for and so no reason to have a paid tier. Admin
+      // then offers a checkout configuration only on a paid tier. The plan that includes
+      // Stripe is the plan that will include custom fields, so a site that reaches here is
+      // entitled to what it provisions.
+      //
+      // That chain holds by coincidence of pricing, and only its first link is enforced.
+      // The last one is a convention of the interface: this route accepts a free tier, and
+      // checks neither the tier's type nor whether Stripe is connected. Nor does the
+      // stripeCheckoutCollection flag stand in for any of it, being a rollout switch with
+      // no view on what a site pays for.
+      //
+      // So this pins a decision, not a mechanism. If checkout collection is ever sold
+      // apart from custom fields, this route needs a limit of its own rather than
+      // borrowing this one, because what it governs is what a checkout may collect.
+      it('still provisions the field a checkout collection needs', async function () {
+        const { body: tiers } = await agent
+          .get('tiers/?limit=1&filter=type:paid')
+          .expectStatus(200);
+
+        await agent
+          .put(`tiers/${tiers.tiers[0].id}/checkout_config/`)
+          .body({
+            tiers_checkout_config: [
+              {
+                shipping: {
+                  collect: true,
+                  allowed_countries: ['GB'],
+                  name: { custom_field_key: 'shipping_name' },
+                  address: { custom_field_key: 'shipping_address' },
+                },
+              },
+            ],
+          })
+          .expectStatus(200);
+
+        const { body } = await agent.get('members/metafields/custom/').expectStatus(200);
+        assert.equal(
+          body.members_metafields.some(
+            (field: { key: string }) => field.key === 'shipping_address',
+          ),
+          true,
+        );
+      });
+
+      it('falls back to generic copy when the host sets no message', async function () {
+        await hostLimits.setHostLimits({ limitCustomFields: { disabled: true } });
+
+        const { body } = await agent
+          .post('members/metafields/custom/')
+          .body({ members_metafields: [{ name: 'Company', type: 'short_text' }] })
+          .expectStatus(403);
+
+        // The wording the limit service builds when a host supplies none, from the limit's
+        // own name.
+        assert.equal(
+          body.errors[0].message,
+          'Your plan does not support custom fields. Please upgrade to enable custom fields.',
+        );
+      });
     });
   });
 });

--- a/packages/limit-service/lib/config.js
+++ b/packages/limit-service/lib/config.js
@@ -59,5 +59,6 @@ module.exports = {
     limitStripeConnect: {},
     limitAnalytics: {},
     limitSocialWeb: {},
+    limitCustomFields: {},
     publicSiteAccess: {}
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3797/gate-custom-member-fields-to-the-publisher-tier-and-above

## Problem

Custom member fields let a publisher add their own questions to a member's record. They are meant to be included in the more expensive plans and withheld from the cheaper ones.

Ghost could not express that. The only switch that hides the feature is the flag used while it was being built, and that flag answers a different question: whether this version of Ghost has the feature at all. Its answer is the same for every site running that version, so it cannot allow the feature on one site and withhold it on another.

## Solution

A second switch the hosted service sets for one site at a time, held separately from the build-time flag.

No site has it set, so nothing changes for anyone today. Once the pricing decision is made, applying it is a change to the hosted service's own settings, and revising it later is the same. Ghost does not have to change again. The machinery that applies these switches already lives in this repository, so adding this one took a name in the list it recognises and no release of anything.

Where the switch is on, a publisher cannot add a custom field or change one, and the admin interface stops offering to. Fields the site already has stay fully usable: still visible on member records, still available to search and export by. A publisher who moves to a cheaper plan keeps everything they have already collected. That works because a field definition is the only root of the feature, so a site that cannot define fields has nothing further to reach.

A request refused for this reason says the plan does not cover the feature, rather than that the feature does not exist. Only the first is something a publisher can act on. It repeats whatever wording the hosted service supplies, and where it supplies none, wording that names the feature.

## Not included

A publisher on a plan without custom fields is shown nothing in place of them. What they should see instead, and whether to invite them to upgrade, is a design question rather than a technical one. The equivalent decision was made once already for traffic analytics and that work is the natural precedent.

