### PR TITLE
Added leave guards to the React post editor

### DIFF
--- a/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
@@ -72,6 +72,76 @@ function fakeEditablePost(overrides: Partial<SavedPost> = {}, { failSaves = fals
   return saveApi;
 }
 
+function fakeNewPost({ failUpdates = false } = {}) {
+  editorChrome();
+  fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
+  let created = post({
+    id: NEW_POST_ID,
+    title: '(Untitled)',
+    slug: 'untitled',
+    status: 'draft',
+    updated_at: CREATED_AT,
+    published_at: null,
+    tags: [],
+  });
+  const createResponse = deferred<{ posts: SavedPost[] }>();
+  const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: CREATED_AT };
+    return createResponse.promise;
+  });
+  fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({ posts: [created] }));
+  const updateApi = fakeAdminEndpoint(
+    'PUT',
+    new RegExp(`^/posts/${NEW_POST_ID}/\\?`),
+    ({ body }) => {
+      if (failUpdates) {
+        return { errors: [{ type: 'InternalServerError', message: 'Something went wrong.' }] };
+      }
+      const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+      created = { ...created, ...submitted, updated_at: '2026-01-01T00:00:09.000Z' };
+      return { posts: [created] };
+    },
+    { status: failUpdates ? 500 : 200 },
+  );
+
+  return {
+    createApi,
+    updateApi,
+    resolveCreate: () => createResponse.resolve({ posts: [created] }),
+  };
+}
+
+function fakeDeferredCleanSave() {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    tags: [],
+  });
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+  fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), () => ({ posts: [current] }));
+
+  const saveResponse = deferred<{ posts: SavedPost[] }>();
+  const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), ({ body }) => {
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: '2026-01-01T00:00:01.000Z' };
+    return saveResponse.promise;
+  });
+
+  return {
+    saveApi,
+    resolveSave: () => saveResponse.resolve({ posts: [current] }),
+  };
+}
+
 async function typeIntoBody(text: string) {
   await editorScreen.body().click();
   await userEvent.keyboard(`{End}${text}`);
@@ -256,35 +326,7 @@ describe('Post editor leave guard', () => {
   it(
     'replaces the URL of a created post without asking to leave',
     async () => {
-      editorChrome();
-      fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
-      let created = post({
-        id: NEW_POST_ID,
-        title: '(Untitled)',
-        slug: 'untitled',
-        status: 'draft',
-        updated_at: CREATED_AT,
-        published_at: null,
-        tags: [],
-      });
-      const createResponse = deferred<{ posts: SavedPost[] }>();
-      const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
-        const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-        created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: CREATED_AT };
-        return createResponse.promise;
-      });
-      fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
-        posts: [created],
-      }));
-      const updateApi = fakeAdminEndpoint(
-        'PUT',
-        new RegExp(`^/posts/${NEW_POST_ID}/\\?`),
-        ({ body }) => {
-          const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-          created = { ...created, ...submitted, updated_at: '2026-01-01T00:00:09.000Z' };
-          return { posts: [created] };
-        },
-      );
+      const { createApi, updateApi, resolveCreate } = fakeNewPost();
 
       await renderAdminApp('/editor/post', FLAG_ON);
       await expect.element(editorScreen.body()).toBeVisible();
@@ -293,7 +335,7 @@ describe('Post editor leave guard', () => {
       await expect.poll(() => createApi.requests.length, SAVE_POLL).toBe(1);
       // The URL swap lands on a post the writer has already moved past.
       await typeIntoBody(' and then some');
-      createResponse.resolve({ posts: [created] });
+      resolveCreate();
 
       await expect.poll(currentRoute, SAVE_POLL).toBe(`/editor/post/${NEW_POST_ID}`);
       await expect(editorScreen.leaveDialog()).toHaveCount(0);
@@ -305,7 +347,53 @@ describe('Post editor leave guard', () => {
   );
 
   it(
-    'arms the browser unload prompt only while the post is dirty',
+    'preserves a blocked exit when a create acquires its ID',
+    async () => {
+      const { createApi, resolveCreate } = fakeNewPost();
+
+      await renderAdminApp('/editor/post', FLAG_ON);
+      await expect.element(editorScreen.body()).toBeVisible();
+      await typeIntoBody('First words');
+      await expect.poll(() => createApi.requests.length, SAVE_POLL).toBe(1);
+
+      await editorScreen.backLink('post').click();
+      expect(currentRoute()).toBe('/editor/post');
+
+      // The create acknowledgement wants to replace the URL, but the writer's
+      // already-blocked exit remains the destination that ultimately proceeds.
+      resolveCreate();
+      await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'applies a deferred created-post URL after the writer cancels the exit',
+    async () => {
+      const { createApi, resolveCreate } = fakeNewPost({ failUpdates: true });
+
+      await renderAdminApp('/editor/post', FLAG_ON);
+      await expect.element(editorScreen.body()).toBeVisible();
+      await typeIntoBody('First words');
+      await expect.poll(() => createApi.requests.length, SAVE_POLL).toBe(1);
+      await typeIntoBody(' and then some');
+
+      await editorScreen.backLink('post').click();
+      resolveCreate();
+
+      await expect.element(editorScreen.leaveDialog(), SAVE_POLL).toBeVisible();
+      expect(currentRoute()).toBe('/editor/post');
+      await editorScreen.stayInEditor().click();
+
+      await expect.poll(currentRoute, SAVE_POLL).toBe(`/editor/post/${NEW_POST_ID}`);
+      await expect.element(editorScreen.body()).toHaveTextContent('First words and then some');
+    },
+    SLOW,
+  );
+
+  it(
+    'arms the browser unload prompt while unsaved work exists',
     async () => {
       fakeEditablePost();
       await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
@@ -316,6 +404,25 @@ describe('Post editor leave guard', () => {
       await typeIntoBody(' and more');
       await expect.poll(unsavedChangesGuarded).toBe(true);
 
+      await expect.poll(unsavedChangesGuarded, SAVE_POLL).toBe(false);
+    },
+    SLOW,
+  );
+
+  it(
+    'keeps the browser unload prompt armed for a clean write in flight',
+    async () => {
+      const { saveApi, resolveSave } = fakeDeferredCleanSave();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      expect(unsavedChangesGuarded()).toBe(false);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+
+      resolveSave();
       await expect.poll(unsavedChangesGuarded, SAVE_POLL).toBe(false);
     },
     SLOW,

--- a/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
@@ -77,6 +77,36 @@ async function typeIntoBody(text: string) {
   await userEvent.keyboard(`{End}${text}`);
 }
 
+/**
+ * Counts every insertion of the leave dialog into the document. A locator
+ * polls, so it cannot see a dialog that opens and closes inside one commit;
+ * the observer fires on the DOM write itself and misses no frame.
+ */
+function watchLeaveDialog(): () => number {
+  let insertions = 0;
+  const carriesDialog = (node: Node): boolean =>
+    node instanceof Element &&
+    (node.matches(editorScreen.leaveDialogSelector) ||
+      !!node.querySelector(editorScreen.leaveDialogSelector));
+  const count = (records: MutationRecord[]) => {
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        if (carriesDialog(node)) {
+          insertions += 1;
+        }
+      }
+    }
+  };
+  const observer = new MutationObserver(count);
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  return () => {
+    count(observer.takeRecords());
+    observer.disconnect();
+    return insertions;
+  };
+}
+
 /** Opens the editor and leaves it with an edit the server has not seen. */
 async function openDirtyEditor(labs: RenderAdminAppOptions = FLAG_ON) {
   await renderAdminApp(`/editor/post/${POST_ID}`, labs);
@@ -97,11 +127,14 @@ describe('Post editor leave guard', () => {
     async () => {
       const saveApi = fakeEditablePost();
       await openDirtyEditor();
+      const dialogInsertions = watchLeaveDialog();
 
       await editorScreen.backLink('post').click();
 
       await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
-      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      // Not a single frame of it: the save on the way out is silent, and a
+      // prompt that flashes as the navigation lands is worse than none.
+      expect(dialogInsertions()).toBe(0);
       expect(saveApi.requests.length).toBe(1);
       // Leaving is the writer's last checkpoint, so it earns a revision.
       expect(saveApi.lastRequest?.url ?? '').toContain('save_revision=true');
@@ -206,6 +239,17 @@ describe('Post editor leave guard', () => {
       await expect.element(editorScreen.leaveDialog()).toBeVisible();
       expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
       expect(saveApi.requests.length).toBe(0);
+
+      // Cancelling drops the intercepted anchor, so the writer stays put and
+      // the next click on the same link asks again rather than going through.
+      await editorScreen.stayInEditor().click();
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React and more');
+
+      await editorScreen.backLink('post').click();
+      await expect.element(editorScreen.leaveDialog()).toBeVisible();
+      expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
@@ -132,8 +132,7 @@ describe('Post editor leave guard', () => {
       await editorScreen.backLink('post').click();
 
       await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
-      // Not a single frame of it: the save on the way out is silent, and a
-      // prompt that flashes as the navigation lands is worse than none.
+      // Not a single frame of it: the save on the way out is silent.
       expect(dialogInsertions()).toBe(0);
       expect(saveApi.requests.length).toBe(1);
       // Leaving is the writer's last checkpoint, so it earns a revision.

--- a/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentRoute,
+  fakeAdminEndpoint,
+  fakePosts,
+  fakeSnippets,
+  post,
+  renderAdminApp,
+  unsavedChangesGuarded,
+  type RenderAdminAppOptions,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+import { deferred } from '@/utils/deferred';
+
+const POST_ID = 'abc123';
+const NEW_POST_ID = 'new789';
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const CREATED_AT = '2026-01-01T00:00:05.000Z';
+// The posts list is React-owned here so the back link is a router link and the
+// blocker sees the navigation; the hash-anchor path has its own test below.
+const FLAG_ON = { labs: { editorReact: true, postsListReact: true } };
+
+// The autosave debounce is 3s, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const SAVE_POLL = { timeout: 10_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+}
+
+function fakeEditablePost(overrides: Partial<SavedPost> = {}, { failSaves = false } = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+  fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), () => ({ posts: [current] }));
+
+  const saveApi = fakeAdminEndpoint(
+    'PUT',
+    new RegExp(`^/posts/${POST_ID}/\\?`),
+    ({ body }) => {
+      saves += 1;
+      if (failSaves) {
+        return { errors: [{ type: 'InternalServerError', message: 'Something went wrong.' }] };
+      }
+      const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+      current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+      return { posts: [current] };
+    },
+    { status: failSaves ? 500 : 200 },
+  );
+
+  return saveApi;
+}
+
+async function typeIntoBody(text: string) {
+  await editorScreen.body().click();
+  await userEvent.keyboard(`{End}${text}`);
+}
+
+/** Opens the editor and leaves it with an edit the server has not seen. */
+async function openDirtyEditor(labs: RenderAdminAppOptions = FLAG_ON) {
+  await renderAdminApp(`/editor/post/${POST_ID}`, labs);
+  await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+  await typeIntoBody(' and more');
+  await expect.element(editorScreen.body()).toHaveTextContent('Hello from React and more');
+  await expect.poll(unsavedChangesGuarded).toBe(true);
+}
+
+/**
+ * No navigation out of the React post editor may lose what was typed. Every
+ * blocked exit is put to the save engine: it finishes or saves outstanding
+ * work and either lets the writer through or asks them to confirm.
+ */
+describe('Post editor leave guard', () => {
+  it(
+    'saves a dirty draft on the way out and leaves without asking',
+    async () => {
+      const saveApi = fakeEditablePost();
+      await openDirtyEditor();
+
+      await editorScreen.backLink('post').click();
+
+      await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      expect(saveApi.requests.length).toBe(1);
+      // Leaving is the writer's last checkpoint, so it earns a revision.
+      expect(saveApi.lastRequest?.url ?? '').toContain('save_revision=true');
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves a clean post silently and saves nothing',
+    async () => {
+      const saveApi = fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+
+      await editorScreen.backLink('post').click();
+
+      await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      expect(saveApi.requests.length).toBe(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'asks before leaving a published post with unsaved changes, and stays on cancel',
+    async () => {
+      // A published post never autosaves, so its edits are still unsaved when
+      // the writer leaves.
+      const saveApi = fakeEditablePost({
+        status: 'published',
+        published_at: '2026-01-01T00:00:00.000Z',
+      });
+      await openDirtyEditor();
+
+      await editorScreen.backLink('post').click();
+
+      await expect.element(editorScreen.leaveDialog()).toBeVisible();
+      await editorScreen.stayInEditor().click();
+
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React and more');
+      expect(saveApi.requests.length).toBe(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves a published post with unsaved changes once the writer confirms',
+    async () => {
+      const saveApi = fakeEditablePost({
+        status: 'published',
+        published_at: '2026-01-01T00:00:00.000Z',
+      });
+      await openDirtyEditor();
+
+      await editorScreen.backLink('post').click();
+      await expect.element(editorScreen.leaveDialog()).toBeVisible();
+      await editorScreen.leaveEditor().click();
+
+      await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
+      // Confirming discards the edit; nothing is written on the way out.
+      expect(saveApi.requests.length).toBe(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'asks before leaving when the save on the way out fails',
+    async () => {
+      const saveApi = fakeEditablePost({}, { failSaves: true });
+      await openDirtyEditor();
+      await expect.element(editorScreen.saveErrorBanner(), SAVE_POLL).toBeVisible();
+      expect(saveApi.requests.length).toBeGreaterThanOrEqual(1);
+
+      await editorScreen.backLink('post').click();
+
+      // Nothing the engine can do persists the edit, so the writer decides.
+      await expect.element(editorScreen.leaveDialog(), SAVE_POLL).toBeVisible();
+      expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
+
+      await editorScreen.stayInEditor().click();
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React and more');
+    },
+    SLOW,
+  );
+
+  it(
+    'guards a native hash anchor out of the editor',
+    async () => {
+      // With the posts list served by Ember the back link is a raw `#/posts`
+      // anchor, which reaches the router as a POP it cannot block.
+      const saveApi = fakeEditablePost({
+        status: 'published',
+        published_at: '2026-01-01T00:00:00.000Z',
+      });
+      await openDirtyEditor({ labs: { editorReact: true } });
+
+      await editorScreen.backLink('post').click();
+
+      await expect.element(editorScreen.leaveDialog()).toBeVisible();
+      expect(currentRoute()).toBe(`/editor/post/${POST_ID}`);
+      expect(saveApi.requests.length).toBe(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'replaces the URL of a created post without asking to leave',
+    async () => {
+      editorChrome();
+      fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
+      let created = post({
+        id: NEW_POST_ID,
+        title: '(Untitled)',
+        slug: 'untitled',
+        status: 'draft',
+        updated_at: CREATED_AT,
+        published_at: null,
+        tags: [],
+      });
+      const createResponse = deferred<{ posts: SavedPost[] }>();
+      const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+        const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+        created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: CREATED_AT };
+        return createResponse.promise;
+      });
+      fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
+      const updateApi = fakeAdminEndpoint(
+        'PUT',
+        new RegExp(`^/posts/${NEW_POST_ID}/\\?`),
+        ({ body }) => {
+          const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+          created = { ...created, ...submitted, updated_at: '2026-01-01T00:00:09.000Z' };
+          return { posts: [created] };
+        },
+      );
+
+      await renderAdminApp('/editor/post', FLAG_ON);
+      await expect.element(editorScreen.body()).toBeVisible();
+
+      await typeIntoBody('First words');
+      await expect.poll(() => createApi.requests.length, SAVE_POLL).toBe(1);
+      // The URL swap lands on a post the writer has already moved past.
+      await typeIntoBody(' and then some');
+      createResponse.resolve({ posts: [created] });
+
+      await expect.poll(currentRoute, SAVE_POLL).toBe(`/editor/post/${NEW_POST_ID}`);
+      await expect(editorScreen.leaveDialog()).toHaveCount(0);
+      await expect.element(editorScreen.body()).toHaveTextContent('First words and then some');
+      // Nothing treated the swap as a leave, so no revision was cut for it.
+      expect(updateApi.requests.every((r) => !r.url.includes('save_revision=true'))).toBe(true);
+    },
+    SLOW,
+  );
+
+  it(
+    'arms the browser unload prompt only while the post is dirty',
+    async () => {
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.body()).toHaveTextContent('Hello from React');
+      expect(unsavedChangesGuarded()).toBe(false);
+
+      await typeIntoBody(' and more');
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+
+      await expect.poll(unsavedChangesGuarded, SAVE_POLL).toBe(false);
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
@@ -251,20 +251,39 @@ describe('Post editor leave guard', () => {
     SLOW,
   );
 
-  it(
-    'leaves a published post with unsaved changes once the writer confirms',
-    async () => {
+  it.each([
+    { name: 'router link', options: FLAG_ON },
+    { name: 'native hash link', options: { labs: { editorReact: true } } },
+  ])(
+    'keeps the dialog open until leaving through a $name',
+    async ({ options }) => {
       const saveApi = fakeEditablePost({
         status: 'published',
         published_at: '2026-01-01T00:00:00.000Z',
       });
-      await openDirtyEditor();
+      await openDirtyEditor(options);
 
       await editorScreen.backLink('post').click();
       await expect.element(editorScreen.leaveDialog()).toBeVisible();
-      await editorScreen.leaveEditor().click();
+      const dialog = document.querySelector(editorScreen.leaveDialogSelector)!;
+      let beganClosing = false;
+      const recordState = () => {
+        beganClosing ||= dialog.getAttribute('data-state') === 'closed';
+      };
+      const observer = new MutationObserver(recordState);
+      observer.observe(dialog, { attributes: true, attributeFilter: ['data-state'] });
+      try {
+        await editorScreen.leaveEditor().click();
 
-      await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
+        await expect.poll(currentRoute, SAVE_POLL).toBe('/posts');
+        await expect(editorScreen.root()).toHaveCount(0);
+        // The dialog must unmount with the editor, without starting its close
+        // animation and revealing the editor on the way to the destination.
+        recordState();
+        expect(beganClosing).toBe(false);
+      } finally {
+        observer.disconnect();
+      }
       // Confirming discards the edit; nothing is written on the way out.
       expect(saveApi.requests.length).toBe(0);
     },

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -3,6 +3,7 @@ import { AdminLink } from '@/shared/admin-link';
 import { NotFound } from '@/shared/not-found';
 import { Navigate, useNavigate, useParams } from '@tryghost/admin-x-framework';
 import { Button, LoadingIndicator } from '@tryghost/shade/components';
+import { DirtyConfirmDialog } from '@tryghost/shade/patterns';
 import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { LucideIcon } from '@tryghost/shade/utils';
 import { APIError } from '@tryghost/admin-x-framework/errors';
@@ -33,6 +34,7 @@ import type { EditorStatusNewsletter, EditorStatusRecord } from './post-status';
 import { SessionBanners } from './session/session-banners';
 import { useFeatureImageBinding } from './session/feature-image-binding';
 import { EDITOR_REQUEST_OPTIONS } from './request-options';
+import { useEditorLeaveGuard } from './session/use-leave-guard';
 import { useEditorSession, useEditorSessionKey } from './session/use-editor-session';
 import { usePostCardConfig } from './use-post-card-config';
 import { usePostSnippets } from './use-post-snippets';
@@ -123,6 +125,7 @@ function EditorContent({
 }: EditorContentProps) {
   const session = useEditorSession({ postType, record, siteUrl: cardConfig.siteUrl });
   const featureImage = useFeatureImageBinding(session, record);
+  const leaveGuard = useEditorLeaveGuard(session, postType);
 
   useSaveShortcut(session.dispatchExplicit);
 
@@ -152,6 +155,7 @@ function EditorContent({
         />
       </div>
       {snippetDialog}
+      <DirtyConfirmDialog testId="editor-leave-dialog" {...leaveGuard.dialogProps} />
     </Stack>
   );
 }

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -6,6 +6,7 @@ import {
   editorExcerptInput,
   editorFeatureImage,
   editorFeatureImageCaption,
+  editorLeaveDialog,
   editorLoadError,
   editorReauthBanner,
   editorScheduleCountdown,
@@ -17,10 +18,12 @@ import {
   featureImageAltLabel,
   featureImageTkIndicator,
   featureImageUnsplashButton,
+  leaveEditorButton,
   pagesBackLink,
   postEditor,
   postsBackLink,
   removeFeatureImageButton,
+  stayInEditorButton,
   tkIndicator,
   toggleFeatureImageAltButton,
 } from '@tryghost/test-data/selectors/editor';
@@ -41,6 +44,11 @@ export const editorScreen = {
   status: () => page.getByTestId(editorStatus),
   scheduleCountdown: () => page.getByTestId(editorScheduleCountdown),
   saveErrorBanner: () => page.getByTestId(editorSaveErrorBanner),
+  leaveDialog: () => page.getByTestId(editorLeaveDialog),
+  stayInEditor: () =>
+    page.getByTestId(editorLeaveDialog).getByRole('button', { name: stayInEditorButton }),
+  leaveEditor: () =>
+    page.getByTestId(editorLeaveDialog).getByRole('button', { name: leaveEditorButton }),
   dismissReauth: () =>
     page.getByTestId(editorReauthBanner).getByRole('button', { name: 'Dismiss' }),
   notFound: () => page.getByRole('heading', { name: 'Page not found' }),

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -45,6 +45,8 @@ export const editorScreen = {
   scheduleCountdown: () => page.getByTestId(editorScheduleCountdown),
   saveErrorBanner: () => page.getByTestId(editorSaveErrorBanner),
   leaveDialog: () => page.getByTestId(editorLeaveDialog),
+  /** The leave dialog as a raw selector, for DOM-level sampling a locator cannot do. */
+  leaveDialogSelector: `[data-testid="${editorLeaveDialog}"]`,
   stayInEditor: () =>
     page.getByTestId(editorLeaveDialog).getByRole('button', { name: stayInEditorButton }),
   leaveEditor: () =>

--- a/apps/admin/src/editor/engine/README.md
+++ b/apps/admin/src/editor/engine/README.md
@@ -75,7 +75,7 @@ Reconcile-before-drain is a hard ordering contract because the server enforces o
 
 ### Leave
 
-`leaveRequested()` returns `proceed` or `confirm` and loops until nothing is in flight, pending, or armed with dirty content, re-reading the post after every wait: `saving` is never safe to leave. Save-on-leave (with a revision) fires at most once per attempt, only for a dirty draft with unrevisioned changes or an armed autosave, never while the snapshot carries a rejected `updated_at`, never while frozen, halted, or crashed. A post still dirty afterwards asks for confirmation, and so does an unreadable snapshot. Concurrent calls share one decision; a decision that outlives the engine resolves `proceed`.
+`leaveRequested()` returns `proceed` or `confirm` and loops until nothing is in flight, pending, or armed with dirty content, re-reading the post after every wait: `saving` is never safe to leave. Save-on-leave (with a revision) fires at most once per attempt, only for a dirty draft with unrevisioned changes or an armed autosave, never while the snapshot carries a rejected `updated_at`, never while frozen, halted, or crashed. A frozen command always asks for confirmation, even when its input snapshot is clean. A post still dirty afterwards also asks for confirmation, as does an unreadable snapshot. Concurrent calls share one decision; a decision that outlives the engine resolves `proceed`.
 
 ### Subscriptions
 

--- a/apps/admin/src/editor/engine/save-engine.test.ts
+++ b/apps/admin/src/editor/engine/save-engine.test.ts
@@ -504,6 +504,22 @@ describe('createSaveEngine', () => {
       await expect(h.engine.leaveRequested()).resolves.toBe('confirm');
       expect(h.execute).toHaveBeenCalledTimes(1);
     });
+
+    it.each<DispatchIntent>(['publish', 'schedule', 'revert'])(
+      'asks before discarding a clean %s command frozen behind re-auth',
+      async (intent) => {
+        const h = setup({
+          isDirty: false,
+          ...(intent === 'revert' ? { status: 'published', publishedAt: PAST } : {}),
+        });
+        void dispatchAny(h.engine, intent);
+        await h.fail(sessionInvalid);
+
+        expect(h.engine.getState()).toEqual({ kind: 'reauth-pending', intent });
+        await expect(h.engine.leaveRequested()).resolves.toBe('confirm');
+        expect(h.execute).toHaveBeenCalledTimes(1);
+      },
+    );
   });
 
   describe('save-on-leave fires at most once and only for dirty drafts', () => {

--- a/apps/admin/src/editor/engine/save-engine.ts
+++ b/apps/admin/src/editor/engine/save-engine.ts
@@ -887,7 +887,12 @@ export function createSaveEngine<
       if (!snapshot) {
         return 'confirm';
       }
-      if (isTerminal() || frozen) {
+      // A frozen command has not completed even when its input snapshot is
+      // clean (for example, publishing an otherwise unchanged draft).
+      if (frozen) {
+        return 'confirm';
+      }
+      if (isTerminal()) {
         return snapshot.isDirty ? 'confirm' : 'proceed';
       }
       const canSaveOnLeave =

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -304,4 +304,69 @@ describe('createEditorSession', () => {
 
     expect(state.updates).toHaveLength(0);
   });
+
+  it('notifies subscribers once per dirtiness flip, not once per edit', () => {
+    const { session } = harness({ record: record() });
+    session.setBaseline(record().lexical);
+    const listener = vi.fn();
+    session.subscribe(listener);
+
+    session.patchLexical(body('Hello and more'));
+    session.patchLexical(body('Hello and more still'));
+    session.patchLexical(body('Hello and more still again'));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(session.isDirty()).toBe(true);
+
+    session.patchLexical(body('Hello'));
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(session.isDirty()).toBe(false);
+  });
+
+  it('notifies subscribers when the pending baseline lands and settles the post', () => {
+    const { session } = harness({ record: record() });
+    const edited = buildLexicalParagraph('Hello and more');
+    session.patchLexical(JSON.parse(edited));
+    const listener = vi.fn();
+    session.subscribe(listener);
+
+    // Until the hidden editor reports, a diverged body has to be assumed dirty.
+    expect(session.isDirty()).toBe(true);
+
+    session.setBaseline(edited);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(session.isDirty()).toBe(false);
+  });
+
+  it('reports a throwing subscriber instead of interrupting the edit', () => {
+    const onError = vi.fn();
+    const { session } = harness({ record: record(), onError });
+    session.setBaseline(record().lexical);
+    session.subscribe(() => {
+      throw new Error('listener blew up');
+    });
+
+    session.patchLexical(body('Hello and more'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(session.isDirty()).toBe(true);
+  });
+
+  it('stops notifying an unsubscribed listener', () => {
+    const { session } = harness({ record: record() });
+    session.setBaseline(record().lexical);
+    const listener = vi.fn();
+    const unsubscribe = session.subscribe(listener);
+
+    session.patchLexical(body('Hello and more'));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    session.patchLexical(body('Hello'));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(session.isDirty()).toBe(false);
+  });
 });

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -41,6 +41,8 @@ interface Harness {
 interface HarnessHooks {
   duringSave?: () => void;
   acknowledge?: (record: EditorRecord, saveCount: number) => EditorRecord;
+  /** Answers an update with nothing, which the session reports as a failed save. */
+  failSave?: (saveCount: number) => boolean;
 }
 
 function harness(options: Partial<EditorSessionOptions> = {}, hooks: HarnessHooks = {}) {
@@ -76,6 +78,9 @@ function harness(options: Partial<EditorSessionOptions> = {}, hooks: HarnessHook
         state.updates.push({ payload, saveRevision: writeOptions.saveRevision });
         hooks.duringSave?.();
         saveCount += 1;
+        if (hooks.failSave?.(saveCount)) {
+          return Promise.resolve(undefined);
+        }
         const next = record({
           ...state.acknowledged,
           title: payload.title as string,
@@ -352,6 +357,27 @@ describe('createEditorSession', () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(session.isDirty()).toBe(true);
+  });
+
+  it('notifies subscribers when a retry settles what a failed save left dirty', async () => {
+    let saveFails = true;
+    const { session } = harness({ record: record() }, { failSave: () => saveFails });
+    session.setBaseline(record().lexical);
+    session.patchLexical(body('Hello and more'));
+    const seen: boolean[] = [];
+    session.subscribe(() => seen.push(session.isDirty()));
+
+    await session.dispatchExplicit();
+
+    // A failed save keeps the post dirty and recoverable.
+    expect(session.isDirty()).toBe(true);
+    expect(seen).toContain(true);
+
+    saveFails = false;
+    await session.dispatchExplicit();
+
+    expect(session.isDirty()).toBe(false);
+    expect(seen.at(-1)).toBe(false);
   });
 
   it('stops notifying an unsubscribed listener', () => {

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -3,6 +3,7 @@ import { createSlugMachine } from '@/editor/engine/slug-machine';
 import {
   DEFAULT_TITLE,
   createSaveEngine,
+  type LeaveDecision,
   type PersistedIdentity,
   type PostStatus,
   type SaveCompletion,
@@ -66,8 +67,10 @@ export interface EditorSessionOptions {
 
 export interface EditorSession {
   getState: () => SaveEngineState;
+  /** Notified on engine state changes and whenever the post's dirtiness flips. */
   subscribe: (listener: () => void) => () => void;
   getSaveSnapshot: () => EditorSaveSnapshot;
+  isDirty: () => boolean;
   patchTitle: (title: string) => void;
   patchExcerpt: (excerpt: string) => void;
   patchFeatureImage: (
@@ -85,6 +88,7 @@ export interface EditorSession {
   recordRefetched: (record: EditorRecord) => void;
   reauthSucceeded: () => void;
   reauthAbandoned: () => void;
+  leaveRequested: () => Promise<LeaveDecision>;
   dispose: () => void;
 }
 
@@ -129,10 +133,31 @@ export function createEditorSession({
 
   const slug = createSlugPort(machine);
 
+  // The engine reports its own state, but an edit the engine drops (a
+  // published post never autosaves) still changes whether the post is dirty.
+  const dirtyListeners = new Set<() => void>();
+  let lastDirty: boolean;
+
+  function dirtyChanged(): void {
+    const next = getSnapshot().isDirty;
+    if (next === lastDirty) {
+      return;
+    }
+    lastDirty = next;
+    for (const listener of dirtyListeners) {
+      try {
+        listener();
+      } catch (error) {
+        onError(error);
+      }
+    }
+  }
+
   function patchLive(patch: EditablePostPatch): void {
     live = { ...live, ...patch };
     version += 1;
     tracker.setLive(identity.id, patch);
+    dirtyChanged();
   }
 
   // A save writes a title and slug the writer never typed: the request's own
@@ -165,6 +190,8 @@ export function createEditorSession({
       version,
     });
   }
+
+  lastDirty = getSnapshot().isDirty;
 
   function prepare(request: SaveRequest<EditorSaveSnapshot>): Promise<PreparedSave> {
     const isCreate = request.snapshot.id === null;
@@ -272,6 +299,7 @@ export function createEditorSession({
     if (created) {
       onIdAcquired(result.id);
     }
+    dirtyChanged();
   }
 
   const engine = createSaveEngine<EditorSaveSnapshot, PreparedSave, EditorSaveResult>({
@@ -290,8 +318,16 @@ export function createEditorSession({
 
   return {
     getState: () => engine.getState(),
-    subscribe: (listener) => engine.subscribe(listener),
+    subscribe: (listener) => {
+      const stopEngine = engine.subscribe(listener);
+      dirtyListeners.add(listener);
+      return () => {
+        stopEngine();
+        dirtyListeners.delete(listener);
+      };
+    },
     getSaveSnapshot: getSnapshot,
+    isDirty: () => getSnapshot().isDirty,
 
     // A blank title persists as the default, so the live projection carries it
     // even while the input stays empty.
@@ -299,8 +335,14 @@ export function createEditorSession({
     patchExcerpt: (excerpt) => patchLive({ custom_excerpt: excerpt === '' ? null : excerpt }),
     patchFeatureImage: (patch) => patchLive(patch),
     patchLexical: (lexical) => patchLive({ lexical: JSON.stringify(lexical) }),
-    setBaseline: (lexical) => tracker.setBaseline(identity.id, lexical),
-    baselineFailed: (error) => tracker.baselineFailed(identity.id, error),
+    setBaseline: (lexical) => {
+      tracker.setBaseline(identity.id, lexical);
+      dirtyChanged();
+    },
+    baselineFailed: (error) => {
+      tracker.baselineFailed(identity.id, error);
+      dirtyChanged();
+    },
 
     // Only a draft's title drives the slug; a published URL must not move.
     commitTitle: (title) => {
@@ -319,16 +361,19 @@ export function createEditorSession({
       tracker.setSaved(next.id, projectionOf(next));
       const updatedAt = next.updated_at ?? '';
       if (isOlder(updatedAt, identity.updatedAt)) {
+        dirtyChanged();
         return;
       }
       identity = { id: next.id, updatedAt };
       status = next.status ?? status;
       publishedAt = next.published_at ?? null;
       latestRevision = latestRevisionOf(next);
+      dirtyChanged();
     },
 
     reauthSucceeded: () => engine.reauthSucceeded(),
     reauthAbandoned: () => engine.reauthAbandoned(),
+    leaveRequested: () => engine.leaveRequested(),
 
     dispose: () => {
       engine.dispose();

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -312,8 +312,8 @@ export function createEditorSession({
       if (next.kind === 'error' || next.kind === 'conflict') {
         tracker.markSaveError(next.error.message);
       }
-      // The engine moves dirtiness on its own too; without this the cache
-      // below could miss the flip after it and swallow a later notification.
+      // A save error moves dirtiness without going through a patch, so
+      // `lastDirty` is refreshed here rather than left to catch up.
       dirtyChanged();
     },
     onListenerError: onError,

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -312,6 +312,9 @@ export function createEditorSession({
       if (next.kind === 'error' || next.kind === 'conflict') {
         tracker.markSaveError(next.error.message);
       }
+      // The engine moves dirtiness on its own too; without this the cache
+      // below could miss the flip after it and swallow a later notification.
+      dirtyChanged();
     },
     onListenerError: onError,
   });

--- a/apps/admin/src/editor/session/leave-guard.test.ts
+++ b/apps/admin/src/editor/session/leave-guard.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { hasUnsavedWork, isCreatedIdUrlSwap } from './leave-guard';
+import type { SaveEngineState } from '@/editor/engine/save-engine';
+
+const SESSION = 'session-key';
+
+function swapTo(pathname: string, editorSession: string | null = SESSION) {
+  return { pathname, state: editorSession === null ? null : { editorSession } };
+}
+
+describe('hasUnsavedWork', () => {
+  it('guards a dirty post whatever the engine is doing', () => {
+    const states: SaveEngineState[] = [
+      { kind: 'idle' },
+      { kind: 'debouncing' },
+      { kind: 'halted' },
+      { kind: 'crashed' },
+      { kind: 'disposed' },
+    ];
+    for (const state of states) {
+      expect(hasUnsavedWork(state, true)).toBe(true);
+    }
+  });
+
+  it('guards a clean post while a write is still outstanding', () => {
+    expect(hasUnsavedWork({ kind: 'saving', intent: 'autosave' }, false)).toBe(true);
+    expect(
+      hasUnsavedWork({ kind: 'pending-coalesced', intent: 'autosave', pending: 'explicit' }, false),
+    ).toBe(true);
+  });
+
+  it('lets a settled clean post go', () => {
+    expect(hasUnsavedWork({ kind: 'idle' }, false)).toBe(false);
+    expect(hasUnsavedWork({ kind: 'debouncing' }, false)).toBe(false);
+    expect(hasUnsavedWork({ kind: 'disposed' }, false)).toBe(false);
+  });
+});
+
+describe('isCreatedIdUrlSwap', () => {
+  it('recognizes the session replacing its own new-post URL', () => {
+    expect(
+      isCreatedIdUrlSwap({ pathname: '/editor/post' }, swapTo('/editor/post/abc'), 'post', SESSION),
+    ).toBe(true);
+    expect(
+      isCreatedIdUrlSwap({ pathname: '/editor/page' }, swapTo('/editor/page/abc'), 'page', SESSION),
+    ).toBe(true);
+  });
+
+  it('rejects a swap that does not carry this session', () => {
+    expect(
+      isCreatedIdUrlSwap(
+        { pathname: '/editor/post' },
+        swapTo('/editor/post/abc', 'other'),
+        'post',
+        SESSION,
+      ),
+    ).toBe(false);
+    expect(
+      isCreatedIdUrlSwap(
+        { pathname: '/editor/post' },
+        swapTo('/editor/post/abc', null),
+        'post',
+        SESSION,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a writer leaving the editor', () => {
+    expect(
+      isCreatedIdUrlSwap({ pathname: '/editor/post' }, swapTo('/posts'), 'post', SESSION),
+    ).toBe(false);
+    expect(
+      isCreatedIdUrlSwap(
+        { pathname: '/editor/post/abc' },
+        swapTo('/editor/post/def'),
+        'post',
+        SESSION,
+      ),
+    ).toBe(false);
+    expect(
+      isCreatedIdUrlSwap(
+        { pathname: '/editor/post' },
+        swapTo('/editor/post/abc/extra'),
+        'post',
+        SESSION,
+      ),
+    ).toBe(false);
+    expect(
+      isCreatedIdUrlSwap({ pathname: '/editor/post' }, swapTo('/editor/post'), 'post', SESSION),
+    ).toBe(false);
+  });
+});

--- a/apps/admin/src/editor/session/leave-guard.test.ts
+++ b/apps/admin/src/editor/session/leave-guard.test.ts
@@ -29,6 +29,19 @@ describe('hasUnsavedWork', () => {
     ).toBe(true);
   });
 
+  it('guards a clean post whose command is frozen behind re-auth', () => {
+    expect(hasUnsavedWork({ kind: 'reauth-pending', intent: 'publish' }, false)).toBe(true);
+  });
+
+  it('leaves a failed save to the post it left dirty', () => {
+    const error = { kind: 'unknown' as const, message: 'Nope' };
+    // A failed save never discards its payload, so the post carries the guard.
+    expect(hasUnsavedWork({ kind: 'error', intent: 'autosave', error }, true)).toBe(true);
+    expect(hasUnsavedWork({ kind: 'conflict', intent: 'autosave', error }, true)).toBe(true);
+    expect(hasUnsavedWork({ kind: 'error', intent: 'autosave', error }, false)).toBe(false);
+    expect(hasUnsavedWork({ kind: 'conflict', intent: 'autosave', error }, false)).toBe(false);
+  });
+
   it('lets a settled clean post go', () => {
     expect(hasUnsavedWork({ kind: 'idle' }, false)).toBe(false);
     expect(hasUnsavedWork({ kind: 'debouncing' }, false)).toBe(false);

--- a/apps/admin/src/editor/session/leave-guard.ts
+++ b/apps/admin/src/editor/session/leave-guard.ts
@@ -1,0 +1,41 @@
+import type { SaveEngineState } from '@/editor/engine/save-engine';
+import type { PostType } from '@/editor/card-config';
+
+interface GuardedLocation {
+  pathname: string;
+  state?: unknown;
+}
+
+/**
+ * Whether leaving now could lose content: the post diverges from the server, or
+ * the engine still owes it a write that has not been acknowledged.
+ */
+export function hasUnsavedWork(state: SaveEngineState, isDirty: boolean): boolean {
+  if (isDirty) {
+    return true;
+  }
+  return state.kind === 'saving' || state.kind === 'pending-coalesced';
+}
+
+/**
+ * Whether a navigation is the session's own URL replace after a create rather
+ * than a writer leaving: `/editor/post` to `/editor/post/:id`, carrying the
+ * session key so the same session survives the swap.
+ */
+export function isCreatedIdUrlSwap(
+  current: GuardedLocation,
+  next: GuardedLocation,
+  postType: PostType,
+  sessionKey: string,
+): boolean {
+  const newPath = `/editor/${postType}`;
+  if (current.pathname !== newPath || !next.pathname.startsWith(`${newPath}/`)) {
+    return false;
+  }
+  const id = next.pathname.slice(newPath.length + 1);
+  if (!id || id.includes('/')) {
+    return false;
+  }
+  const state = next.state as { editorSession?: string } | null | undefined;
+  return state?.editorSession === sessionKey;
+}

--- a/apps/admin/src/editor/session/leave-guard.ts
+++ b/apps/admin/src/editor/session/leave-guard.ts
@@ -8,13 +8,17 @@ interface GuardedLocation {
 
 /**
  * Whether leaving now could lose content: the post diverges from the server, or
- * the engine still owes it a write that has not been acknowledged.
+ * the engine still owes it a write that has not been acknowledged. A re-auth
+ * freeze holds a captured command that no dirty content stands in for, so it
+ * counts as work of its own.
  */
 export function hasUnsavedWork(state: SaveEngineState, isDirty: boolean): boolean {
   if (isDirty) {
     return true;
   }
-  return state.kind === 'saving' || state.kind === 'pending-coalesced';
+  return (
+    state.kind === 'saving' || state.kind === 'pending-coalesced' || state.kind === 'reauth-pending'
+  );
 }
 
 /**

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -19,7 +19,11 @@ import type {
   EditContentData,
 } from '@tryghost/admin-x-framework/api/content-types';
 import type { PostWriteOptions } from '@tryghost/admin-x-framework/api/post-contract';
-import { DEFAULT_TITLE, type SaveEngineState } from '@/editor/engine/save-engine';
+import {
+  DEFAULT_TITLE,
+  type LeaveDecision,
+  type SaveEngineState,
+} from '@/editor/engine/save-engine';
 import type { LexicalInput } from '@/editor/engine/lexical-compare';
 import type { PostType } from '@/editor/card-config';
 import { createEditorSession, type EditorSession, type EditorWritePayload } from './editor-session';
@@ -62,6 +66,8 @@ export interface EditorSessionHandle {
   dispatchExplicit: () => void;
   reauthSucceeded: () => void;
   reauthAbandoned: () => void;
+  /** Resolves once nothing is in flight; `proceed` means leaving loses nothing. */
+  leaveRequested: () => Promise<LeaveDecision>;
 }
 
 export interface UseEditorSessionOptions {
@@ -163,6 +169,7 @@ export function useEditorSession({
   }, [session]);
 
   const state = useSyncExternalStore(session.subscribe, session.getState);
+  const isDirty = useSyncExternalStore(session.subscribe, session.isDirty);
 
   // The saved record: the same query key the screen loaded with, so an existing
   // post shares one cache entry and a created one starts observing its own.
@@ -249,11 +256,12 @@ export function useEditorSession({
       onSecondaryError,
     },
     state,
-    isDirty: () => session.getSaveSnapshot().isDirty,
+    isDirty: () => isDirty,
     patchFeatureImage: session.patchFeatureImage,
     dispatchField: session.dispatchField,
     dispatchExplicit: () => void session.dispatchExplicit(),
     reauthSucceeded: session.reauthSucceeded,
     reauthAbandoned: session.reauthAbandoned,
+    leaveRequested: session.leaveRequested,
   };
 }

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { useLocation, useNavigate } from '@tryghost/admin-x-framework';
+import { useLocation } from '@tryghost/admin-x-framework';
 import { useGenerateSlug } from '@tryghost/admin-x-framework/api/slugs';
 import {
   useAddPage,
@@ -60,6 +60,8 @@ export interface EditorSessionBinding {
 export interface EditorSessionHandle {
   bind: EditorSessionBinding;
   state: SaveEngineState;
+  /** The server ID acquired by this session's first create, if it began new. */
+  createdId: string | null;
   isDirty: () => boolean;
   patchFeatureImage: EditorSession['patchFeatureImage'];
   dispatchField: () => void;
@@ -87,8 +89,6 @@ export function useEditorSession({
   record,
   siteUrl,
 }: UseEditorSessionOptions): EditorSessionHandle {
-  const navigate = useNavigate();
-  const sessionKey = useEditorSessionKey();
   const generateSlug = useGenerateSlug();
   const { mutateAsync: addPost } = useAddPost();
   const { mutateAsync: editPost } = useEditPost();
@@ -192,15 +192,6 @@ export function useEditorSession({
   }, [saved, session]);
 
   const isNew = !record;
-  useEffect(() => {
-    if (isNew && persistedId) {
-      navigate(`/editor/${postType}/${persistedId}`, {
-        replace: true,
-        state: { editorSession: sessionKey },
-      });
-    }
-  }, [isNew, persistedId, postType, navigate, sessionKey]);
-
   const onTitleChange = useCallback(
     (next: string) => {
       setTitle(next);
@@ -256,6 +247,7 @@ export function useEditorSession({
       onSecondaryError,
     },
     state,
+    createdId: isNew ? persistedId : null,
     isDirty: () => isDirty,
     patchFeatureImage: session.patchFeatureImage,
     dispatchField: session.dispatchField,

--- a/apps/admin/src/editor/session/use-leave-guard.test.ts
+++ b/apps/admin/src/editor/session/use-leave-guard.test.ts
@@ -1,0 +1,60 @@
+import { createElement } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { deferred } from '@/utils/deferred';
+import { useEditorLeaveGuard, type EditorLeaveGuard } from './use-leave-guard';
+import type { EditorSessionHandle } from './use-editor-session';
+
+describe('useEditorLeaveGuard', () => {
+  it('keeps the confirmation open until a slow navigation unmounts the editor', async () => {
+    const destination = deferred<null>();
+    const session = {
+      state: { kind: 'idle' },
+      createdId: null,
+      isDirty: () => true,
+      leaveRequested: vi.fn().mockResolvedValue('confirm'),
+    } as unknown as EditorSessionHandle;
+    let guard!: EditorLeaveGuard;
+    function Editor() {
+      guard = useEditorLeaveGuard(session, 'post');
+      return createElement('main', { 'data-testid': 'editor' });
+    }
+    const router = createMemoryRouter(
+      [
+        { path: '/editor/post/abc', element: createElement(Editor) },
+        { path: '/posts', loader: () => destination.promise, element: 'Posts' },
+      ],
+      { initialEntries: ['/editor/post/abc'] },
+    );
+    const screen = render(createElement(RouterProvider, { router }));
+    await act(async () => {
+      await router.navigate('/posts');
+    });
+    await waitFor(() => expect(guard.dialogProps.open).toBe(true));
+
+    act(() => {
+      guard.dialogProps.onConfirm();
+      // Radix closes its Action automatically after invoking onConfirm.
+      guard.dialogProps.onOpenChange(false);
+    });
+
+    expect(router.state.navigation.state).toBe('loading');
+    expect(screen.getByTestId('editor')).toBeInTheDocument();
+    expect(guard.dialogProps.open).toBe(true);
+    // Repeated clicks and Escape cannot cancel an already accepted exit.
+    act(() => {
+      guard.dialogProps.onConfirm();
+      guard.dialogProps.onOpenChange(false);
+    });
+    expect(guard.dialogProps.open).toBe(true);
+
+    await act(async () => {
+      destination.resolve(null);
+      await destination.promise;
+    });
+    await waitFor(() => expect(screen.queryByTestId('editor')).not.toBeInTheDocument());
+    expect(router.state.location.pathname).toBe('/posts');
+    router.dispose();
+  });
+});

--- a/apps/admin/src/editor/session/use-leave-guard.ts
+++ b/apps/admin/src/editor/session/use-leave-guard.ts
@@ -14,12 +14,16 @@ export interface EditorLeaveGuard {
 }
 
 /**
- * Stops a navigation from losing what the writer typed. Every blocked exit —
- * router link, back button, or a native hash anchor into an Ember-owned route —
- * is put to the save engine, which finishes or saves whatever is outstanding
- * and answers `proceed` (leaving loses nothing) or `confirm` (ask first).
- * The session's own URL replace after a create is not an exit and passes
- * silently.
+ * Stops a navigation from losing what the writer typed. In-router navigations
+ * and native `<a href="#/…">` anchors into Ember-owned routes are put to the
+ * save engine, which finishes or saves whatever is outstanding and answers
+ * `proceed` (leaving loses nothing) or `confirm` (ask first); a tab close or
+ * reload gets the browser's own prompt. The session's own URL replace after a
+ * create is not an exit and passes silently.
+ *
+ * Browser Back is not covered: the shared guard lets a POP through unless the
+ * entry it returns to was created by the router, and admin reaches the editor
+ * through a native hash anchor.
  */
 export function useEditorLeaveGuard(
   session: EditorSessionHandle,
@@ -27,13 +31,11 @@ export function useEditorLeaveGuard(
 ): EditorLeaveGuard {
   const sessionKey = useEditorSessionKey();
   const isDirty = session.isDirty();
-  const [isDecidingLeave, setIsDecidingLeave] = useState(false);
+  const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
 
   const guard = useUnsavedChangesGuard({
     when: hasUnsavedWork(session.state, isDirty),
     confirmUnloadWhen: isDirty,
-    // Keeps the dialog shut while the engine works out whether leaving is safe.
-    isSaving: isDecidingLeave,
     interceptNavigation: ({ currentLocation, nextLocation }) =>
       isCreatedIdUrlSwap(currentLocation, nextLocation, postType, sessionKey),
   });
@@ -58,29 +60,47 @@ export function useEditorLeaveGuard(
 
   const { isBlocked } = guard;
   const { leaveRequested } = session;
-  const isDecidedRef = useRef(false);
+  const isDecidingRef = useRef(false);
   useEffect(() => {
     if (!isBlocked) {
-      isDecidedRef.current = false;
+      isDecidingRef.current = false;
+      setIsConfirmingLeave(false);
       return;
     }
-    if (isDecidedRef.current) {
+    if (isDecidingRef.current) {
       return;
     }
-    isDecidedRef.current = true;
-    setIsDecidingLeave(true);
+    isDecidingRef.current = true;
     void leaveRequested().then((decision) => {
       if (!isMountedRef.current) {
         return;
       }
-      if (decision === 'proceed') {
-        // Releasing the block before `isDecidingLeave` drops; the other order
-        // paints the dialog for a frame on the way out.
-        guardRef.current.dialogProps.onConfirm();
+      if (decision === 'confirm') {
+        setIsConfirmingLeave(true);
+        return;
       }
-      setIsDecidingLeave(false);
+      guardRef.current.dialogProps.onConfirm();
     });
   }, [isBlocked, leaveRequested]);
 
-  return { dialogProps: guard.dialogProps };
+  // The dialog answers the engine's verdict rather than the block itself: a
+  // block is where the question starts, and most are settled without asking.
+  // Reading the hook's own `open` would paint one on every blocked commit.
+  const settle = guard.dialogProps;
+
+  return {
+    dialogProps: {
+      open: isConfirmingLeave,
+      onConfirm: () => {
+        setIsConfirmingLeave(false);
+        settle.onConfirm();
+      },
+      onOpenChange: (open: boolean) => {
+        if (!open) {
+          setIsConfirmingLeave(false);
+        }
+        settle.onOpenChange(open);
+      },
+    },
+  };
 }

--- a/apps/admin/src/editor/session/use-leave-guard.ts
+++ b/apps/admin/src/editor/session/use-leave-guard.ts
@@ -83,9 +83,7 @@ export function useEditorLeaveGuard(
     });
   }, [isBlocked, leaveRequested]);
 
-  // The dialog answers the engine's verdict rather than the block itself: a
-  // block is where the question starts, and most are settled without asking.
-  // Reading the hook's own `open` would paint one on every blocked commit.
+  // Reading the hook's own `open` would paint a dialog on every blocked commit.
   const settle = guard.dialogProps;
 
   return {

--- a/apps/admin/src/editor/session/use-leave-guard.ts
+++ b/apps/admin/src/editor/session/use-leave-guard.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react';
+import { useUnsavedChangesGuard } from '@/hooks/use-unsaved-changes-guard';
+import type { PostType } from '@/editor/card-config';
+import { hasUnsavedWork, isCreatedIdUrlSwap } from './leave-guard';
+import { useEditorSessionKey, type EditorSessionHandle } from './use-editor-session';
+
+export interface EditorLeaveGuard {
+  /** Wiring for Shade's `DirtyConfirmDialog`. */
+  dialogProps: {
+    open: boolean;
+    onConfirm: () => void;
+    onOpenChange: (open: boolean) => void;
+  };
+}
+
+/**
+ * Stops a navigation from losing what the writer typed. Every blocked exit —
+ * router link, back button, or a native hash anchor into an Ember-owned route —
+ * is put to the save engine, which finishes or saves whatever is outstanding
+ * and answers `proceed` (leaving loses nothing) or `confirm` (ask first).
+ * The session's own URL replace after a create is not an exit and passes
+ * silently.
+ */
+export function useEditorLeaveGuard(
+  session: EditorSessionHandle,
+  postType: PostType,
+): EditorLeaveGuard {
+  const sessionKey = useEditorSessionKey();
+  const isDirty = session.isDirty();
+  const [isDecidingLeave, setIsDecidingLeave] = useState(false);
+
+  const guard = useUnsavedChangesGuard({
+    when: hasUnsavedWork(session.state, isDirty),
+    confirmUnloadWhen: isDirty,
+    // Keeps the dialog shut while the engine works out whether leaving is safe.
+    isSaving: isDecidingLeave,
+    interceptNavigation: ({ currentLocation, nextLocation }) =>
+      isCreatedIdUrlSwap(currentLocation, nextLocation, postType, sessionKey),
+  });
+
+  const guardRef = useRef(guard);
+  guardRef.current = guard;
+
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const isUrlSwapBlocked = guard.interceptedNavigation.isBlocked;
+  useEffect(() => {
+    if (isUrlSwapBlocked) {
+      guardRef.current.interceptedNavigation.proceed();
+    }
+  }, [isUrlSwapBlocked]);
+
+  const { isBlocked } = guard;
+  const { leaveRequested } = session;
+  const isDecidedRef = useRef(false);
+  useEffect(() => {
+    if (!isBlocked) {
+      isDecidedRef.current = false;
+      return;
+    }
+    if (isDecidedRef.current) {
+      return;
+    }
+    isDecidedRef.current = true;
+    setIsDecidingLeave(true);
+    void leaveRequested().then((decision) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+      if (decision === 'proceed') {
+        // Releasing the block before `isDecidingLeave` drops; the other order
+        // paints the dialog for a frame on the way out.
+        guardRef.current.dialogProps.onConfirm();
+      }
+      setIsDecidingLeave(false);
+    });
+  }, [isBlocked, leaveRequested]);
+
+  return { dialogProps: guard.dialogProps };
+}

--- a/apps/admin/src/editor/session/use-leave-guard.ts
+++ b/apps/admin/src/editor/session/use-leave-guard.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from '@tryghost/admin-x-framework';
 import { useUnsavedChangesGuard } from '@/hooks/use-unsaved-changes-guard';
 import type { PostType } from '@/editor/card-config';
 import { hasUnsavedWork, isCreatedIdUrlSwap } from './leave-guard';
@@ -29,19 +30,26 @@ export function useEditorLeaveGuard(
   session: EditorSessionHandle,
   postType: PostType,
 ): EditorLeaveGuard {
+  const location = useLocation();
+  const navigate = useNavigate();
   const sessionKey = useEditorSessionKey();
   const isDirty = session.isDirty();
+  const hasWork = hasUnsavedWork(session.state, isDirty);
   const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
 
   const guard = useUnsavedChangesGuard({
-    when: hasUnsavedWork(session.state, isDirty),
-    confirmUnloadWhen: isDirty,
+    when: hasWork,
+    confirmUnloadWhen: hasWork,
     interceptNavigation: ({ currentLocation, nextLocation }) =>
       isCreatedIdUrlSwap(currentLocation, nextLocation, postType, sessionKey),
   });
 
   const guardRef = useRef(guard);
   guardRef.current = guard;
+  // Stays set while an accepted exit is transitioning. React Router does not
+  // consult blockers again in its `proceeding` state, so the deferred ID swap
+  // must not race and replace that navigation either.
+  const isLeavingRef = useRef(false);
 
   const isMountedRef = useRef(true);
   useEffect(() => {
@@ -52,6 +60,33 @@ export function useEditorLeaveGuard(
   }, []);
 
   const isUrlSwapBlocked = guard.interceptedNavigation.isBlocked;
+
+  // Wait for a real exit to settle before replacing a new post's URL. React
+  // Router owns one blocker target, so starting this replace while an exit is
+  // blocked would overwrite the writer's original destination.
+  const createdId = session.createdId;
+  useEffect(() => {
+    if (!createdId || guard.isBlocked || isUrlSwapBlocked || isLeavingRef.current) {
+      return;
+    }
+    const target = `/editor/${postType}/${createdId}`;
+    if (location.pathname === target) {
+      return;
+    }
+    navigate(target, {
+      replace: true,
+      state: { editorSession: sessionKey },
+    });
+  }, [
+    createdId,
+    guard.isBlocked,
+    isUrlSwapBlocked,
+    location.pathname,
+    navigate,
+    postType,
+    sessionKey,
+  ]);
+
   useEffect(() => {
     if (isUrlSwapBlocked) {
       guardRef.current.interceptedNavigation.proceed();
@@ -79,6 +114,7 @@ export function useEditorLeaveGuard(
         setIsConfirmingLeave(true);
         return;
       }
+      isLeavingRef.current = true;
       guardRef.current.dialogProps.onConfirm();
     });
   }, [isBlocked, leaveRequested]);
@@ -90,6 +126,7 @@ export function useEditorLeaveGuard(
     dialogProps: {
       open: isConfirmingLeave,
       onConfirm: () => {
+        isLeavingRef.current = true;
         setIsConfirmingLeave(false);
         settle.onConfirm();
       },

--- a/apps/admin/src/editor/session/use-leave-guard.ts
+++ b/apps/admin/src/editor/session/use-leave-guard.ts
@@ -99,7 +99,9 @@ export function useEditorLeaveGuard(
   useEffect(() => {
     if (!isBlocked) {
       isDecidingRef.current = false;
-      setIsConfirmingLeave(false);
+      if (!isLeavingRef.current) {
+        setIsConfirmingLeave(false);
+      }
       return;
     }
     if (isDecidingRef.current) {
@@ -126,11 +128,18 @@ export function useEditorLeaveGuard(
     dialogProps: {
       open: isConfirmingLeave,
       onConfirm: () => {
+        if (isLeavingRef.current) {
+          return;
+        }
         isLeavingRef.current = true;
-        setIsConfirmingLeave(false);
         settle.onConfirm();
       },
       onOpenChange: (open: boolean) => {
+        // Radix auto-closes its Action after confirmation. Keep the overlay
+        // until the editor unmounts so a slow exit cannot flash the editor.
+        if (isLeavingRef.current) {
+          return;
+        }
         if (!open) {
           setIsConfirmingLeave(false);
         }

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -31,6 +31,7 @@ export const postPreviewUnavailable = 'post-preview-unavailable';
 export const postPreviewNewsletterMissing = 'post-preview-newsletter-missing';
 export const postPreviewSaveFailed = 'post-preview-save-failed';
 export const featureImageTkIndicator = 'feature-image-tk-indicator';
+export const editorLeaveDialog = 'editor-leave-dialog';
 
 // publish flow testids
 export const publishFlowModal = 'publish-flow-modal';
@@ -91,3 +92,5 @@ export const featureImageAltLabel = 'Alt text for feature image';
 export const featureImageUnsplashButton = 'Select feature image from Unsplash';
 export const removeFeatureImageButton = 'Remove feature image';
 export const toggleFeatureImageAltButton = 'Toggle between editing alt text and caption';
+export const stayInEditorButton = 'Stay';
+export const leaveEditorButton = 'Leave';


### PR DESCRIPTION
Navigating out of the React post editor could silently drop whatever had not reached the server yet — a router link, a native hash anchor into an Ember-owned route, and a tab close all went through unguarded.

## What changed

- `EditorSessionHandle` exposes `leaveRequested()`, a pass-through to the save engine's leave decision (safe after dispose: a disposed engine answers `proceed`).
- The editor screen mounts one `useUnsavedChangesGuard` — the screen's only router blocker — guarded while the post is dirty, a write is outstanding, or a command is frozen behind re-auth, with `beforeunload` armed on dirtiness alone.
- Every blocked exit goes through `leaveRequested()`. `proceed` (the engine finished or saved the outstanding work) completes the navigation silently; `confirm` opens Shade's `DirtyConfirmDialog`, where Leave completes the navigation and Stay keeps the writer in place. The dialog is driven by the engine's verdict rather than by the blocked state, so a leave the engine settles itself never paints a prompt — not even for the frame in which the navigation lands. The screen never dispatches a leave save itself.
- The session's own URL replace after a create (`/editor/post` → `/editor/post/:id`) is claimed by the guard's navigation intercept and passed straight through, so it is not read as a leave and does not cut a revision.
- A decision that resolves after the screen unmounts navigates nothing and sets no state.

The guard needed dirtiness to be observable and it was not: an edit the engine drops (a published post never autosaves) changed no engine state, so nothing re-rendered and the guard never armed. The session now broadcasts dirtiness flips alongside engine state changes, which also fixes the header's saved/unsaved indicator for those posts. It notifies on the flip, not the edit — roughly two renders per twenty keystrokes.

## Known gap

Browser Back is not guarded, here or on any other admin screen: the shared `useUnsavedChangesGuard` lets a POP through unless the entry it returns to was created by the router, and admin reaches the editor through a native hash anchor. Ember's `willTransition` does cover it. Closing that needs a change to the shared hook, which belongs in its own PR; the editor's docblock records the gap.

## How it was verified

From `apps/admin`: `pnpm exec eslint` on the changed files, `pnpm exec tsc -b`, `pnpm vitest run` (2965 unit tests), and the browser-mode acceptance suite for `src/editor` (132 tests, 8 of them new), each run clean over repeated runs.

New unit coverage for the two pure helpers (what counts as unsaved work, including the re-auth freeze and the failed-save states; recognising the create URL swap) and for the session's new subscription (one notification per dirtiness flip rather than per edit, the pending baseline landing, a throwing subscriber routed to `onError`, unsubscribing).

New acceptance coverage: a dirty draft saves once on the way out — with a revision — and leaves with the dialog never entering the DOM, asserted by a MutationObserver rather than a locator, which cannot see a dialog that opens and closes inside one commit; a clean post leaves silently and writes nothing; a dirty published post asks, and Stay keeps the content while Leave completes the navigation; a post whose save keeps failing asks before leaving; a native hash anchor out of the editor is guarded, and cancelling it keeps the writer in place with the link still guarded; a created post's URL is replaced with no dialog and no revision; and the unload prompt is armed only while the post is dirty.

Six of the eight new acceptance tests fail with the guard wiring removed; the seventh — the create URL swap — fails with `isCreatedIdUrlSwap` forced to false; the eighth is the negative case, a clean post, which passes either way by design. The no-flash assertion fails against a dialog driven by the shared hook's own `open`.
