### PR TITLE
🐛 Fixed tag results in admin search not opening the tag

### DIFF
--- a/apps/ember-admin/app/routes/tag.js
+++ b/apps/ember-admin/app/routes/tag.js
@@ -25,9 +25,86 @@ export default class TagRoute extends AuthenticatedRoute {
 
         // React owns this URL when the flag is on. Keep the Ember route from
         // loading and rendering a second tag editor behind the React screen.
-        if (this.feature.tagDetailsReact === true) {
-            transition.abort();
+        if (this.feature.tagDetailsReact !== true) {
+            return;
         }
+
+        transition.abort();
+
+        const reactRouteUrl = this._reactRouteUrl(transition);
+
+        // Ember and React share window.location.hash, and an aborted
+        // transition never reaches updateURL. A URL intent (cold load, hash
+        // change, React-driven navigation) already has the browser URL
+        // pointing here, so React renders and there is nothing to do. A named
+        // intent (the Cmd-K search modal's tag results) has no URL yet -
+        // without writing one the click is a silent no-op.
+        if (!transition.intent?.url) {
+            this._navigateToReactRoute(reactRouteUrl);
+        }
+
+        this._parkOnReactFallback(reactRouteUrl);
+    }
+
+    // Built by hand rather than with `router.urlFor`, whose output depends on
+    // the configured location. `transition.to.params` is only populated for a
+    // transition passing string params - one passing a tag model serializes
+    // too late to read here, so fall back to the list rather than a bad URL.
+    _reactRouteUrl(transition) {
+        const {name, params} = transition.to ?? {};
+
+        if (name === 'tag.new') {
+            return '/tags/new';
+        }
+        if (name === 'tag' && typeof params?.tag_slug === 'string') {
+            return `/tags/${encodeURIComponent(params.tag_slug)}`;
+        }
+
+        return '/tags';
+    }
+
+    // Aborting stops Ember rendering this screen, but it also leaves the
+    // router believing it is still on the route we came from. That desync is
+    // only invisible until you navigate back to the very same URL: Ember
+    // compares it against the route it thinks it is on, finds no difference,
+    // and runs no transition at all. Park on `react-fallback` - the empty
+    // catch-all Ember already uses for URLs React owns - to keep the router's
+    // state honest. The fallback must use the real tag path: parking on
+    // `tag` briefly sends React to an unknown URL, and restoring the hash
+    // with replaceState does not notify React Router. That leaves the browser
+    // showing React's 404 until the next reload.
+    // See PostsRoute#_parkOnReactFallback for the full rationale (replace
+    // semantics, the parked-path guard, and URL restoration).
+    _parkOnReactFallback(reactRouteUrl) {
+        const fallbackPath = reactRouteUrl.replace(/^\//, '');
+        const parkedPath = this.router.currentRouteName === 'react-fallback'
+            ? this.router.currentRoute?.params?.path
+            : null;
+
+        if (parkedPath === fallbackPath) {
+            return;
+        }
+
+        const url = window.location.hash;
+        const state = window.history.state;
+
+        this.router.replaceWith('react-fallback', fallbackPath)
+            .finally(() => this._restoreUrl(url, state));
+    }
+
+    // Parking writes the fallback route's own path, so the captured URL goes
+    // back afterwards. `replaceState`: no history entry, and no `hashchange`
+    // to re-enter routing. The captured history state goes back with it -
+    // react-router keeps `{usr, key, idx}` there, and parking would otherwise
+    // drop it on the URL-intent path where React created the entry.
+    _restoreUrl(url, state) {
+        window.history.replaceState(state, '', url);
+    }
+
+    // Seam so tests can assert the navigation without a real hash location -
+    // Ember acceptance tests run with `location: 'none'`.
+    _navigateToReactRoute(url) {
+        window.location.hash = url;
     }
 
     model(params) {

--- a/apps/ember-admin/tests/acceptance/tag-react-flag-test.js
+++ b/apps/ember-admin/tests/acceptance/tag-react-flag-test.js
@@ -1,0 +1,119 @@
+import sinon from 'sinon';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession} from 'ember-simple-auth/test-support';
+import {enableLabsFlag} from '../helpers/labs-flag';
+import {expect} from 'chai';
+import {find, settled, visit} from '@ember/test-helpers';
+import {setupApplicationTest} from 'ember-mocha';
+import {setupMirage} from 'ember-cli-mirage/test-support';
+
+// The `tagDetailsReact` flag hands /tags/:slug to the React app. Ember's side
+// of that handshake is the tag route's beforeModel: it aborts so the Ember tag
+// editor stays unrendered, and drives window.location.hash so navigations
+// Ember itself starts (the Cmd-K search modal) still land somewhere — an
+// aborted transition never reaches updateURL, and the two apps share the hash.
+
+// `visit()` rejects with TransitionAborted whenever the route aborts, which is
+// the whole point of the flag being on. Swallow only that rejection so the
+// assertions below can run; anything else still fails the test.
+async function visitExpectingAbort(url) {
+    try {
+        await visit(url);
+    } catch (error) {
+        if (error?.message !== 'TransitionAborted' && error?.name !== 'TransitionAborted') {
+            throw error;
+        }
+    }
+    await settled();
+}
+
+describe('Acceptance: tag React flag', function () {
+    let hooks = setupApplicationTest();
+    setupMirage(hooks);
+
+    beforeEach(async function () {
+        this.server.loadFixtures('configs');
+        this.server.loadFixtures('settings');
+
+        let role = this.server.create('role', {name: 'Administrator'});
+        this.server.create('user', {roles: [role]});
+        this.server.create('tag', {name: 'My tag', slug: 'my-tag'});
+
+        return await authenticateSession();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('when the flag is off', function () {
+        it('renders the Ember tag editor', async function () {
+            await visit('/tags/my-tag');
+
+            expect(find('[data-test-screen-title]'), 'Ember tag editor title').to.exist;
+        });
+    });
+
+    describe('when the flag is on', function () {
+        beforeEach(function () {
+            enableLabsFlag(this.server, 'tagDetailsReact');
+        });
+
+        it('does not render the Ember tag editor', async function () {
+            await visitExpectingAbort('/tags/my-tag');
+
+            expect(find('[data-test-screen-title]'), 'Ember tag editor title').to.not.exist;
+        });
+
+        // The regression this guards: the Cmd-K search modal transitions by
+        // route name. Without supplying a URL the click is a silent no-op and
+        // the user is stranded on the previous screen.
+        it('navigates React when Ember initiates a tag transition', async function () {
+            const route = this.owner.lookup('route:tag');
+            const navigate = sinon.stub(route, '_navigateToReactRoute');
+
+            await visitExpectingAbort('/posts');
+            this.owner.lookup('service:router').transitionTo('tag', 'my-tag');
+            await settled();
+
+            expect(navigate.calledOnce, '_navigateToReactRoute called once').to.be.true;
+            expect(navigate.firstCall.args[0], 'target url').to.equal('/tags/my-tag');
+        });
+
+        it('navigates React when Ember initiates a new-tag transition', async function () {
+            const route = this.owner.lookup('route:tag.new');
+            const navigate = sinon.stub(route, '_navigateToReactRoute');
+
+            await visitExpectingAbort('/posts');
+            this.owner.lookup('service:router').transitionTo('tag.new');
+            await settled();
+
+            expect(navigate.calledOnce, '_navigateToReactRoute called once').to.be.true;
+            expect(navigate.firstCall.args[0], 'target url').to.equal('/tags/new');
+        });
+
+        // A URL that already points at the tag must be left exactly as it is —
+        // React is already rendering it.
+        it('does not rewrite a URL-initiated navigation', async function () {
+            const route = this.owner.lookup('route:tag');
+            const navigate = sinon.stub(route, '_navigateToReactRoute');
+
+            await visitExpectingAbort('/tags/my-tag');
+
+            expect(navigate.called, '_navigateToReactRoute called').to.be.false;
+        });
+
+        // Aborting alone leaves the router still reporting the route it came
+        // from, so returning to that same URL later would be a no-op
+        // transition that renders nothing. Parking on the catch-all at the
+        // actual tag path keeps both routers truthful.
+        it('parks the router on the React fallback at the tag path', async function () {
+            const router = this.owner.lookup('service:router');
+
+            await visitExpectingAbort('/tags/my-tag');
+
+            expect(router.currentRouteName, 'currentRouteName after aborting').to.equal('react-fallback');
+            expect(router.currentRoute?.params?.path, 'fallback path after aborting').to.equal('tags/my-tag');
+        });
+    });
+});

--- a/apps/ember-admin/tests/unit/routes/tag-test.js
+++ b/apps/ember-admin/tests/unit/routes/tag-test.js
@@ -11,7 +11,10 @@ describe('Unit: Route: tag', function () {
         sinon.restore();
     });
 
-    it('aborts the Ember transition when React owns the tag detail route', function () {
+    // The router is stubbed per-method on the real instance: wholesale service
+    // stubs miss the surface other injected services touch during the route's
+    // own instantiation.
+    function setupRoute(owner, {flagValue, routeName = 'route:tag'}) {
         const requireAuthentication = sinon.spy();
         class SessionStub extends Service {
             isAuthenticated = true;
@@ -19,37 +22,112 @@ describe('Unit: Route: tag', function () {
             requireAuthentication = requireAuthentication;
         }
         class FeatureStub extends Service {
-            tagDetailsReact = true;
+            tagDetailsReact = flagValue;
         }
-        this.owner.register('service:session', SessionStub);
-        this.owner.register('service:feature', FeatureStub);
+        owner.register('service:session', SessionStub);
+        owner.register('service:feature', FeatureStub);
 
-        const route = this.owner.lookup('route:tag');
-        const transition = {abort: sinon.spy()};
+        const router = owner.lookup('service:router');
+        // `finally` runs its callback synchronously so the URL restoration the
+        // real transition promise triggers is exercised, not just stubbed away.
+        const settled = {finally(callback) {
+            callback();
+            return settled;
+        }};
+        sinon.stub(router, 'replaceWith').returns(settled);
+
+        const route = owner.lookup(routeName);
+        const navigate = sinon.stub(route, '_navigateToReactRoute');
+        const replaceState = sinon.stub(window.history, 'replaceState');
+
+        return {route, router, navigate, replaceState, requireAuthentication};
+    }
+
+    it('aborts the Ember transition when React owns the tag detail route', function () {
+        const {route, router, navigate, requireAuthentication} = setupRoute(this.owner, {flagValue: true});
+        // A URL intent, so beforeModel does not rewrite the hash itself.
+        const transition = {
+            abort: sinon.spy(),
+            intent: {url: '/tags/my-tag'},
+            to: {name: 'tag', params: {tag_slug: 'my-tag'}}
+        };
 
         route.beforeModel(transition);
 
         expect(requireAuthentication.calledOnce).to.be.true;
-        expect(transition.abort.calledOnce).to.be.true;
+        expect(transition.abort.calledOnce, 'transition aborted').to.be.true;
+        expect(navigate.called, 'no hash rewrite for a URL intent').to.be.false;
+        expect(router.replaceWith.calledWith('react-fallback', 'tags/my-tag'), 'parked on react-fallback').to.be.true;
     });
 
-    it('keeps Ember ownership when the feature flag is not a boolean', function () {
-        class SessionStub extends Service {
-            isAuthenticated = true;
-            user = {isAuthorOrContributor: false};
-            requireAuthentication = sinon.spy();
-        }
-        class FeatureStub extends Service {
-            tagDetailsReact = 'true';
-        }
-        this.owner.register('service:session', SessionStub);
-        this.owner.register('service:feature', FeatureStub);
-
-        const route = this.owner.lookup('route:tag');
-        const transition = {abort: sinon.spy()};
+    // The Cmd-K search modal navigates by route name, so the abort leaves no
+    // URL behind for React to render - the click was a silent no-op.
+    it('writes the React URL for a named transition', function () {
+        const {route, router, navigate} = setupRoute(this.owner, {flagValue: true});
+        const transition = {
+            abort: sinon.spy(),
+            intent: {},
+            to: {name: 'tag', params: {tag_slug: 'my-tag'}}
+        };
 
         route.beforeModel(transition);
 
-        expect(transition.abort.called).to.be.false;
+        expect(navigate.calledOnceWith('/tags/my-tag'), 'hash written').to.be.true;
+        expect(router.replaceWith.calledWith('react-fallback', 'tags/my-tag'), 'parked on react-fallback').to.be.true;
+    });
+
+    it('writes the create URL for a named transition into tag.new', function () {
+        const {route, router, navigate} = setupRoute(this.owner, {flagValue: true, routeName: 'route:tag.new'});
+        const transition = {abort: sinon.spy(), intent: {}, to: {name: 'tag.new', params: {}}};
+
+        route.beforeModel(transition);
+
+        expect(navigate.calledOnceWith('/tags/new'), 'hash written').to.be.true;
+        expect(router.replaceWith.calledWith('react-fallback', 'tags/new'), 'parked on react-fallback').to.be.true;
+    });
+
+    it('restores the URL together with the history state react-router keeps', function () {
+        const {route, replaceState} = setupRoute(this.owner, {flagValue: true});
+        const state = {usr: null, key: 'abc123', idx: 4};
+
+        route._restoreUrl('#/tags/my-tag', state);
+
+        expect(replaceState.calledOnceWith(state, '', '#/tags/my-tag'), 'state restored with URL').to.be.true;
+    });
+
+    it('restores the captured URL after parking', function () {
+        const {route, replaceState} = setupRoute(this.owner, {flagValue: true});
+        const state = {usr: null, key: 'abc123', idx: 4};
+        sinon.stub(window.history, 'state').value(state);
+        const transition = {
+            abort: sinon.spy(),
+            intent: {url: '/tags/my-tag'},
+            to: {name: 'tag', params: {tag_slug: 'my-tag'}}
+        };
+
+        route.beforeModel(transition);
+
+        expect(replaceState.calledOnceWith(state, '', window.location.hash), 'URL and state restored').to.be.true;
+    });
+
+    it('does not park twice on the same fallback path', function () {
+        const {route, router} = setupRoute(this.owner, {flagValue: true});
+        sinon.stub(router, 'currentRouteName').value('react-fallback');
+        sinon.stub(router, 'currentRoute').value({params: {path: 'tags/my-tag'}});
+
+        route._parkOnReactFallback('/tags/my-tag');
+
+        expect(router.replaceWith.called, 'no re-parking').to.be.false;
+    });
+
+    it('keeps Ember ownership when the feature flag is not a boolean', function () {
+        const {route, router, navigate} = setupRoute(this.owner, {flagValue: 'true'});
+        const transition = {abort: sinon.spy(), intent: {}, to: {name: 'tag', params: {tag_slug: 'my-tag'}}};
+
+        route.beforeModel(transition);
+
+        expect(transition.abort.called, 'transition not aborted').to.be.false;
+        expect(navigate.called, 'no hash rewrite').to.be.false;
+        expect(router.replaceWith.called, 'no parking').to.be.false;
     });
 });


### PR DESCRIPTION
Clicking a tag in the Cmd-K search modal did nothing — the result was found and highlighted, but selecting it left you on the current screen.

## Cause

`gh-search-input.js` navigates tag results by Ember route name:

```js
if (selected.groupName === 'Tags') {
    let id = selected.id.replace('tag.', '');
    this.router.transitionTo('tag', id);
}
```

The Ember `tag` route aborts its transition when `tagDetailsReact` is on, so React can own `/tags/:tagSlug`. But an aborted transition never reaches `updateURL`, and the two apps share `window.location.hash` — so a transition Ember itself started leaves the hash untouched and React never navigates. A *named* intent is exactly the case with no URL of its own; a URL intent (cold load, React-driven navigation) already has the browser pointing at the right place.

`tagDetailsReact` is in `GA_FEATURES`, so this affects everyone.

## Fix

Write the React URL for named intents, then park on the `react-fallback` catch-all — the same handling `posts.js` and `lexical-editor.js` already have behind their own flags. The tag route was the first flag-gated route and predates that handling; it was never backfilled.

Parking also keeps `currentRouteName` honest. Without it Ember still believes it is on the route it came from, so returning to the same tag URL later is compared against that stale route, found identical, and runs no transition at all.

`/tags/new` gets the same treatment via `tag.new`, which extends this route.

## Tests

The existing search acceptance tests run with mirage labs `{}`, so `tagDetailsReact` is false there — they only covered the Ember-owned branch that no production user reaches, and would keep passing if this fix were reverted. Added `tag-react-flag-test.js`, which drives the real router with the flag on, mirroring the editor and posts equivalents. Reverting the fix fails 3 of its 6 tests.

Unit tests in `tag-test.js` cover the URL-intent vs named-intent split, `tag.new`, the parked-path guard, and URL/history-state restoration.

## Verification

- `ember test --filter "tag"` — 75 passing
- `ember test --filter "search"` — 77 passing
- `ember test --filter "Unit: Route"` — 13 passing
- `eslint app tests` clean

## Out of scope

Navigating away from a *dirty* React screen via any Ember-initiated hash write skips React's unsaved-changes blocker: the write creates a history entry with `history.state === null`, and `isOnRouterHistoryEntry()` returns false, so `useBlocker` declines. This is not introduced here — Ember's own `HashLocation.setURL` is `this.location.hash = path`, so Cmd-K results for Staff and the delete-tag-modal's `/tags` transition already behave this way. Worth a separate fix.