### PR TITLE
Improved testing and test data documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,7 @@ Practice and contributor guides explain how to make and verify changes:
 - [Internationalization](practices/internationalization.md)
 - [Performance testing](contributing/performance-testing.md)
 - [Stripe testing](contributing/testing-stripe.md)
+- [Test data](contributing/test-data.md)
 - [Testing development URLs and devices](contributing/testing-development-urls.md)
 
 Reference guides provide tables and other information to look up while working

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -136,7 +136,8 @@ pnpm reset:data
 This clears the development database while preserving the owner, then creates
 1,000 members and 100 posts. Use `pnpm reset:data:empty` for an empty site. Both
 commands are destructive and require the Docker development environment to be
-running.
+running. See [Working with test data](test-data.md) for larger and custom
+datasets.
 
 When developing a database migration, apply pending migrations to the running
 development database with:

--- a/docs/contributing/test-data.md
+++ b/docs/contributing/test-data.md
@@ -1,0 +1,64 @@
+# Working with Test Data
+
+Ghost includes a data generator for building repeatable local datasets. Use it
+instead of copying data from a real publication.
+
+## Reset the Development Site
+
+From the repository root, run:
+
+```bash
+pnpm reset:data
+```
+
+This clears generated data from the Docker development database, preserves the
+owner account, and creates 1,000 members and 100 posts using a fixed seed.
+
+Other prepared datasets are available:
+
+```bash
+pnpm reset:data:empty
+pnpm reset:data:xxl
+```
+
+`reset:data:empty` keeps the owner but generates no members or posts.
+`reset:data:xxl` creates two million members for testing behaviour at scale.
+
+These commands are destructive and require the Docker development environment
+to be running. Do not point the generator at a database containing data you
+need to keep. Restart `pnpm dev` after resetting data so running processes do
+not retain state from the old dataset.
+
+## Generate a Custom Dataset
+
+Run the generator inside the development container when the prepared datasets
+do not cover the scenario:
+
+```bash
+docker exec ghost-dev bash -c \
+  'cd /home/ghost/ghost/core && node index.js generate-data \
+  --clear-database --quantities members:10000,posts:500 --seed 123'
+```
+
+The generator supports:
+
+- `--clear-database` to clear the tables being generated while preserving the
+  owner account;
+- `--tables=members:10000,posts:500` to generate only named tables and their
+  dependencies, with optional quantities;
+- `--with-default` to add the other default tables when using `--tables`;
+- `--quantities=members:10000,posts:500` to override quantities without
+  changing which default tables are generated;
+- `--base-data-pack=/path/to/data.json` to import compatible newsletters,
+  posts, tags, products, settings, and custom theme settings before generating
+  the remaining tables. Importing a base pack replaces the existing settings;
+- `--seed=123` to make generated values repeatable. Timestamps can still move
+  so that generated content remains current;
+- `--print-dependencies` to show the table dependency order without importing.
+
+Use `--tables` for a narrow dataset and `--quantities` when the relationships
+from the full default dataset matter. The generator adds required table
+dependencies automatically and rejects unknown table names.
+
+For the implementation and instructions for adding an importer, see the
+[data generator README](../../ghost/core/core/server/data/seeders/README.md).

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -71,10 +71,10 @@ obvious to a reader.
 
 Coverage helps find code that a test never exercises; it does not replace
 meaningful assertions. Ghost Core uses Vitest's V8 coverage provider. CI applies
-separate thresholds to the integration and server E2E lanes and uploads their
-reports, together with Admin coverage, to Codecov. The current thresholds and
-excluded files live in the relevant Vitest configuration rather than in this
-guide.
+separate Vitest thresholds to the integration and server E2E lanes, then uploads
+both under Codecov's single `e2e-tests` project alongside Admin coverage. The
+Vitest configuration contains the lane thresholds, provider, and excluded files;
+`.github/codecov.yml` contains Codecov's project threshold.
 
 Do not work towards an assumed repository-wide percentage. Add the tests needed
 to protect the changed behaviour and treat an unexpected coverage reduction as

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -45,6 +45,50 @@ When a regression crosses several layers, prefer a focused test at the lowest
 layer that proves the fix. Add a broader acceptance or browser E2E test when the
 integration between layers is itself the behavior being protected.
 
+## Write Useful Tests
+
+- Test observable behaviour rather than private implementation details. A
+  refactor that preserves behaviour should not require unrelated test changes.
+- Use the smallest test boundary that provides confidence. Unit tests should
+  not boot Ghost or use a database; use an integration or server E2E test when
+  the database, HTTP boundary, or interaction between modules is the behaviour.
+- Set up only the data relevant to the scenario. Prefer existing fixtures and
+  factories over large shared datasets or dependencies on another test.
+- Never call a real external service from an automated test. Use the suite's
+  existing fake service, mock, or request interceptor and make its expectations
+  specific enough to catch the wrong method, path, payload, or request count.
+- Keep time, randomness, environment, and ordering deterministic. Restore
+  modified globals, timers, mocks, configuration, and singleton state.
+- Assert the result a user or caller depends on, including important side
+  effects. Avoid assertions that merely repeat how the implementation works.
+
+Snapshot tests are useful for stable, structured output, but a generated
+snapshot is not proof that the output is correct. Review every changed snapshot
+before committing it and add focused assertions for behaviour that should be
+obvious to a reader.
+
+## Coverage
+
+Coverage helps find code that a test never exercises; it does not replace
+meaningful assertions. Ghost Core uses Vitest's V8 coverage provider. CI applies
+separate thresholds to the integration and server E2E lanes and uploads their
+reports, together with Admin coverage, to Codecov. The current thresholds and
+excluded files live in the relevant Vitest configuration rather than in this
+guide.
+
+Do not work towards an assumed repository-wide percentage. Add the tests needed
+to protect the changed behaviour and treat an unexpected coverage reduction as
+a prompt to inspect what is missing.
+
+To inspect Ghost Core unit coverage locally, run:
+
+```bash
+cd ghost/core
+pnpm test:unit --coverage
+```
+
+The HTML report is written to `ghost/core/coverage/index.html`.
+
 For physical-device testing and URL configurations such as HTTPS,
 subdirectories, or a separate Admin origin, see
 [Testing development URLs and devices](testing-development-urls.md).
@@ -139,6 +183,44 @@ Use `pnpm test:e2e:debug` for Ghost E2E debug logs. See the
 isolation, fixtures, and debugging, and
 [Writing Browser E2E Tests](e2e-testing.md) for test conventions, selectors,
 and Page Objects.
+
+## Diagnose Flaky Tests
+
+A test is flaky when the same code and inputs can produce different results.
+Do not assume a passing retry means the test is harmless: the nondeterminism can
+come from application code as well as the test.
+
+Common causes include:
+
+- state shared between tests through a database, file, port, global, mock, or
+  singleton;
+- tests that depend on execution order or data created by another test;
+- fixed delays and assertions that run before an asynchronous operation has
+  reached an observable state;
+- uncontrolled time, randomness, timezone, network access, or external
+  services;
+- parallel tests competing for the same resource; and
+- a race or other nondeterminism in the application code itself.
+
+1. Re-run the smallest affected file or test, then run its containing group to
+   check for leaked state or order dependence.
+2. Read the first failure rather than relying on a later retry. Browser E2E
+   tests have retries disabled and retain a Playwright trace on failure.
+3. Reproduce with the same concurrency, timezone, service availability, and
+   isolation mode as the failing environment where those factors are relevant.
+4. Replace fixed delays with an observable state change. Use fake clocks for
+   time-dependent code and explicit fixtures for random or environment-derived
+   values.
+5. Check that each test owns its data and restores mocks, timers, globals, and
+   configuration. Cleanup belongs in suite hooks that still run when an
+   assertion fails.
+6. Fix the underlying race or isolation failure. Do not add a retry or increase
+   a timeout unless the operation is genuinely allowed to take longer.
+
+For browser failures, use `pnpm test:e2e --debug`, the retained Playwright trace,
+or the preserved-environment workflow in the E2E documentation. Ember Admin
+tests can temporarily use `await this.pauseTest()` as described in its README.
+Remove debugging changes before committing.
 
 ## Run Ember Admin Tests
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -95,6 +95,7 @@ subdirectories, or a separate Admin origin, see
 
 For provider-backed development and the test doubles used by browser tests, see
 [Email testing](testing-email.md) and [Stripe testing](testing-stripe.md).
+For repeatable local datasets, see [Working with test data](test-data.md).
 
 ## Run Focused Tests
 

--- a/ghost/core/core/server/data/seeders/README.md
+++ b/ghost/core/core/server/data/seeders/README.md
@@ -2,7 +2,7 @@
 
 The development data generator populates related Ghost tables in dependency
 order. Its CLI entry point is `node index.js generate-data`; contributors
-normally use the root `pnpm reset:data*` commands described in the
+normally use the root `reset:data` scripts described in the
 [test-data guide](../../../../../../docs/contributing/test-data.md).
 
 ## How It Works
@@ -12,10 +12,10 @@ default quantity and any dependencies that are not represented by schema
 foreign keys. The generator adds schema and declared dependencies, sorts the
 tables, generates their records, and calls each importer's `finalise()` method.
 
-A numeric seed resets Faker for every table. This keeps a table's generated
-values stable when another table is added or omitted. Use the provided Faker
-instances and random-data helpers rather than `Math.random()` so seeded runs
-remain repeatable.
+A numeric seed resets Faker for every table. This keeps Faker-generated values
+stable when another table is added or omitted. Time-dependent fields may still
+vary between runs. Use the provided Faker instances and random-data helpers
+rather than `Math.random()` so seeded values remain repeatable.
 
 ## Add or Change an Importer
 

--- a/ghost/core/core/server/data/seeders/README.md
+++ b/ghost/core/core/server/data/seeders/README.md
@@ -1,0 +1,48 @@
+# Data Generator
+
+The development data generator populates related Ghost tables in dependency
+order. Its CLI entry point is `node index.js generate-data`; contributors
+normally use the root `pnpm reset:data*` commands described in the
+[test-data guide](../../../../../../docs/contributing/test-data.md).
+
+## How It Works
+
+Importers live in `importers/` and each own one table. An importer declares its
+default quantity and any dependencies that are not represented by schema
+foreign keys. The generator adds schema and declared dependencies, sorts the
+tables, generates their records, and calls each importer's `finalise()` method.
+
+A numeric seed resets Faker for every table. This keeps a table's generated
+values stable when another table is added or omitted. Use the provided Faker
+instances and random-data helpers rather than `Math.random()` so seeded runs
+remain repeatable.
+
+## Add or Change an Importer
+
+- Extend `TableImporter` and register the importer in `importers/index.js`.
+- Set a modest `defaultQuantity`; callers can request larger datasets through
+  `--tables` or `--quantities`.
+- Declare dependencies that the database schema cannot supply. The generator
+  derives normal foreign-key dependencies itself.
+- Use `setReferencedModel()` and maps or indexes when records depend on another
+  generated table. Avoid repeatedly scanning large arrays during generation.
+- Generate IDs with `fastFakeObjectId()` rather than Faker's MongoDB ID helper.
+  The generated IDs are fast and safely earlier than the current time.
+- Put derived-table or summary work in `finalise()` so it runs after every
+  importer has completed.
+
+## Bulk Inserts
+
+`TableImporter.batchInsert()` uses Knex for small datasets. Above 5,000 records
+it writes CSV chunks and uses MySQL's `LOAD DATA LOCAL INFILE`, unless
+`DISABLE_FAST_IMPORT` is set.
+
+The CLI requires infile streaming. It is enabled automatically in development;
+other environments must explicitly set `ALLOW_INFILE_STREAM=1`. Do not broaden
+that permission in application configuration: it allows the database client to
+read a requested local file.
+
+The generator temporarily changes MySQL foreign-key, uniqueness, local-infile,
+and redo-log settings for fast imports. It re-enables redo logging at the end of
+a successful import. When changing this lifecycle, ensure failure paths also
+restore any persistent database setting they changed.

--- a/ghost/core/test/README.md
+++ b/ghost/core/test/README.md
@@ -49,6 +49,15 @@ The webhook mock receiver follows the same pattern for outgoing webhooks.
 Real network access is disabled when the framework boots. Use a focused mock or
 an existing `mockManager` helper for external services.
 
+When a test uses Nock directly, match the expected method and path and inspect
+the request body when it is part of the contract. When a path contains a dynamic
+value, constrain the matcher to the expected path and value format rather than
+using a catch-all expression. Use `.times()` when the number of requests matters.
+Avoid `.persist()` unless the behaviour genuinely makes an open-ended number of
+calls; persistent interceptors can hide unexpected requests. Restore
+interceptors after the test, and use Nock's pending mocks to diagnose an
+expectation that was never met.
+
 ## Snapshots
 
 Request agents provide `matchBodySnapshot()` and `matchHeaderSnapshot()`. Use

--- a/ghost/core/test/README.md
+++ b/ghost/core/test/README.md
@@ -54,9 +54,12 @@ the request body when it is part of the contract. When a path contains a dynamic
 value, constrain the matcher to the expected path and value format rather than
 using a catch-all expression. Use `.times()` when the number of requests matters.
 Avoid `.persist()` unless the behaviour genuinely makes an open-ended number of
-calls; persistent interceptors can hide unexpected requests. Restore
-interceptors after the test, and use Nock's pending mocks to diagnose an
-expectation that was never met.
+calls; persistent interceptors can hide unexpected requests. Use
+`nock.cleanAll()` to remove direct Nock interceptors after the test, or
+`mockManager.restore()` when resetting framework-managed state. Do not use
+`nock.restore()` for cleanup: it disables interception and requires
+`nock.activate()` before Nock can intercept another request. Use Nock's pending
+mocks to diagnose an expectation that was never met.
 
 ## Snapshots
 


### PR DESCRIPTION
## Summary

- Update the testing guide for Ghost's current Vitest, Playwright, Ember, and CI setup.
- Add guidance for writing useful tests, reviewing coverage, and diagnosing flaky tests.
- Document the development data generator, prepared datasets, custom options, and its implementation structure.

This replaces outdated testing guidance that still referred to Mocha, an abandoned Jest migration, and obsolete data-generation commands.

## Testing

- [x] `pnpm exec markdownlint-cli2 docs/README.md docs/contributing/testing.md docs/contributing/test-data.md ghost/core/test/README.md ghost/core/core/server/data/seeders/README.md`
- [x] `pnpm exec remark --frail --use remark-validate-links docs/README.md docs/contributing/testing.md docs/contributing/test-data.md ghost/core/test/README.md ghost/core/core/server/data/seeders/README.md`
- [x] Verified documented commands and behavior against package scripts, Nx targets, Vitest and Playwright configuration, CI workflows, and the data-generator implementation.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] Automated tests are not required for documentation-only changes
