### PR TITLE
Renamed repository setup command to bootstrap

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -14,7 +14,7 @@ fi
 
 export PATH="$node_dir/bin:$PATH"
 corepack enable --install-directory "$node_dir/bin"
-pnpm setup
+pnpm bootstrap
 
 profile_marker="# Ghost orb Node.js"
 profile_export="export PATH=\"$node_dir/bin:\$PATH\""

--- a/.changeset/new-ravens-film.md
+++ b/.changeset/new-ravens-film.md
@@ -1,0 +1,15 @@
+---
+"@tryghost/kg-utils": none
+"@tryghost/kg-unsplash-selector": none
+"@tryghost/kg-markdown-html-renderer": none
+"@tryghost/kg-lexical-html-renderer": none
+"@tryghost/kg-html-to-lexical": none
+"@tryghost/kg-default-transforms": none
+"@tryghost/kg-default-nodes": none
+"@tryghost/kg-default-cards": none
+"@tryghost/kg-converters": none
+"@tryghost/kg-clean-basic-html": none
+"@tryghost/kg-card-factory": none
+---
+
+Updated Ghost monorepo bootstrap instructions.

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -4,5 +4,5 @@ name = "Ghost"
 
 [setup]
 script = '''
-pnpm run setup
+pnpm bootstrap
 '''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Start with:
 - Always use `pnpm`, never npm or Yarn. External dependency versions belong in
   the catalogs in `pnpm-workspace.yaml`; workspace dependencies use
   `workspace:` versions.
-- Run `pnpm setup` before other commands in a fresh checkout or worktree.
+- Run `pnpm bootstrap` before other commands in a fresh checkout or worktree.
 - Use `pnpm check` as the default full validation command. Browser E2E and Ember
   Admin tests run separately; follow the testing guide.
 - Read the nearest `AGENTS.md`, `CLAUDE.md`, and README before changing a package

--- a/apps/admin-x-framework/README.md
+++ b/apps/admin-x-framework/README.md
@@ -4,7 +4,7 @@ Shared runtime for Ghost's React admin surfaces: the admin shell (`apps/admin`),
 
 ## Pre-requisites
 
-- Run `pnpm setup` in the Ghost monorepo root
+- Run `pnpm bootstrap` in the Ghost monorepo root
 
 ## Develop
 
@@ -13,7 +13,7 @@ This is a monorepo package.
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm setup` to install the workspace and initialize submodules.
+2. Run `pnpm bootstrap` to install the workspace and initialize submodules.
 
 ## Test
 

--- a/apps/announcement-bar/README.md
+++ b/apps/announcement-bar/README.md
@@ -6,7 +6,7 @@ Announcement banner injected into Ghost sites.
 
 ### Pre-requisites
 
-- Run `pnpm setup` in the Ghost monorepo root
+- Run `pnpm bootstrap` in the Ghost monorepo root
 
 ### Running via Ghost from the monorepo root
 

--- a/apps/comments-ui/README.md
+++ b/apps/comments-ui/README.md
@@ -6,7 +6,7 @@ Comments widget that is embedded at the bottom of posts in Ghost.
 
 ### Pre-requisites
 
-- Run `pnpm setup` in the Ghost monorepo root
+- Run `pnpm bootstrap` in the Ghost monorepo root
 
 ### Running via Ghost from the monorepo root
 

--- a/apps/shade/README.md
+++ b/apps/shade/README.md
@@ -58,7 +58,7 @@ root:
 
 ```bash
 corepack enable pnpm
-pnpm setup
+pnpm bootstrap
 ```
 
 After setup, run the package commands below from `apps/shade` or with

--- a/apps/signup-form/README.md
+++ b/apps/signup-form/README.md
@@ -6,7 +6,7 @@ Embed a Ghost signup form on any site.
 
 ### Pre-requisites
 
-- Run `pnpm setup` in the Ghost monorepo root
+- Run `pnpm bootstrap` in the Ghost monorepo root
 
 ### Running via Ghost from the monorepo root
 

--- a/apps/sodo-search/README.md
+++ b/apps/sodo-search/README.md
@@ -6,7 +6,7 @@ Search interface injected into Ghost sites.
 
 ### Pre-requisites
 
-- Run `pnpm setup` in the Ghost monorepo root
+- Run `pnpm bootstrap` in the Ghost monorepo root
 
 ### Running via Ghost from the monorepo root
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ installed:
 git clone --recurse-submodules git@github.com:TryGhost/Ghost.git
 cd Ghost
 
-pnpm setup
+pnpm bootstrap
 pnpm dev
 ```
 

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -47,12 +47,19 @@ to run Ghost locally.
 From the repository root:
 
 ```bash
-pnpm setup
+pnpm bootstrap
 ```
 
-`pnpm setup` installs the workspace and initializes all Git submodules. Run it
-after a fresh clone and whenever a branch changes workspace dependencies or
+`pnpm bootstrap` installs the workspace, initializes all Git submodules and
+configures Git to ignore formatting-only revisions in blame output. Run it after
+a fresh clone and whenever a branch changes workspace dependencies or
 submodules.
+
+Ghost calls this command `bootstrap` because [`pnpm setup`](https://pnpm.io/cli/setup)
+is a pnpm CLI command for configuring pnpm's global home and updating shell
+startup files. It does not run Ghost's repository initialization. Using a
+distinct script name avoids silently changing a contributor's shell when the
+intention is to prepare the Ghost checkout.
 
 ## Start Ghost
 
@@ -158,7 +165,7 @@ Before starting new work, update your local `main` from the canonical repository
 git fetch origin
 git switch main
 git pull --ff-only origin main
-pnpm setup
+pnpm bootstrap
 ```
 
 If dependencies or Nx state become inconsistent after switching branches, run:

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -24,7 +24,7 @@ Update the canonical checkout, then create a descriptive branch:
 git fetch origin
 git switch main
 git pull --ff-only origin main
-pnpm setup
+pnpm bootstrap
 
 git switch -c concise-change-name
 ```
@@ -67,8 +67,8 @@ pnpm format path/to/file.ts
 configuration; the root config is the only one.
 
 The one-time repository reformat is listed in `.git-blame-ignore-revs`. GitHub's
-blame view skips it automatically, and `pnpm setup` configures local Git to use
-the file. For an existing checkout, rerun `pnpm setup` or run once:
+blame view skips it automatically, and `pnpm bootstrap` configures local Git to use
+the file. For an existing checkout, rerun `pnpm bootstrap` or run once:
 
 ```bash
 git config --local blame.ignoreRevsFile .git-blame-ignore-revs

--- a/koenig/README.md
+++ b/koenig/README.md
@@ -53,7 +53,7 @@ from Mobiledoc. Avoid new work here.
 
 ## Development
 
-There is no linking or per-package install step — run `pnpm setup` once from
+There is no linking or per-package install step — run `pnpm bootstrap` once from
 the monorepo root and everything resolves through the workspace.
 
 ### Working on the editor (koenig-lexical)

--- a/koenig/kg-card-factory/README.md
+++ b/koenig/kg-card-factory/README.md
@@ -25,7 +25,7 @@ it creates, with per-render options taking precedence.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-card-factory`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-clean-basic-html/README.md
+++ b/koenig/kg-clean-basic-html/README.md
@@ -30,7 +30,7 @@ cleanBasicHtml(html, {
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-clean-basic-html`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-converters/README.md
+++ b/koenig/kg-converters/README.md
@@ -23,7 +23,7 @@ both formats know about.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-converters`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-default-cards/README.md
+++ b/koenig/kg-default-cards/README.md
@@ -27,7 +27,7 @@ Ghost applies when storing and serving content.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-default-cards`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-default-nodes/README.md
+++ b/koenig/kg-default-nodes/README.md
@@ -32,7 +32,7 @@ the server.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-default-nodes`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-default-transforms/README.md
+++ b/koenig/kg-default-transforms/README.md
@@ -24,7 +24,7 @@ it is only wanted when rendering.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-default-transforms`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-html-to-lexical/README.md
+++ b/koenig/kg-html-to-lexical/README.md
@@ -22,7 +22,7 @@ before storing. Runs headlessly via JSDOM, so it works server-side.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-html-to-lexical`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-lexical-html-renderer/README.md
+++ b/koenig/kg-lexical-html-renderer/README.md
@@ -44,7 +44,7 @@ others — for URL resolution and image handling.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-lexical-html-renderer`.
 
 `ghost/core` resolves this package via a `source` export condition pointing at

--- a/koenig/kg-markdown-html-renderer/README.md
+++ b/koenig/kg-markdown-html-renderer/README.md
@@ -30,7 +30,7 @@ render('## Hello, World!', {ghostVersion: '3.0'});
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-markdown-html-renderer`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/koenig/kg-unsplash-selector/README.md
+++ b/koenig/kg-unsplash-selector/README.md
@@ -26,7 +26,7 @@ standalone dev server uses.
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-unsplash-selector`.
 
 Run `pnpm dev` to start a standalone development server, which renders the

--- a/koenig/kg-utils/README.md
+++ b/koenig/kg-utils/README.md
@@ -32,7 +32,7 @@ slugify('Ünïcödé Tïtlé', {ghostVersion: '3.0'});
 
 This package is part of the [Ghost monorepo](https://github.com/TryGhost/Ghost)
 and resolves through the pnpm workspace — there is no linking or per-package
-install step. Run `pnpm setup` in the monorepo root, then work in
+install step. Run `pnpm bootstrap` in the monorepo root, then work in
 `koenig/kg-utils`.
 
 See the [Koenig README](../README.md) for the shared build, test and release

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fix": "pnpm store prune && rimraf -g '**/node_modules' && pnpm install && pnpm nx reset",
     "create-package": "node ./scripts/create-package.js",
     "knex-migrator": "pnpm --filter ghost run knex-migrator",
-    "setup": "pnpm install && git submodule update --init --recursive && git config --local blame.ignoreRevsFile .git-blame-ignore-revs",
+    "bootstrap": "pnpm install && git submodule update --init --recursive && git config --local blame.ignoreRevsFile .git-blame-ignore-revs",
     "migrate:db": "docker exec --workdir /home/ghost/ghost/core ghost-dev pnpm knex-migrator migrate",
     "rollback:db": "docker exec --workdir /home/ghost/ghost/core ghost-dev pnpm knex-migrator rollback",
     "reset:db": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && pnpm knex-migrator reset && pnpm knex-migrator init'",

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -11,7 +11,7 @@ root:
 
 ```bash
 corepack enable pnpm
-pnpm setup
+pnpm bootstrap
 ```
 
 After setup, run package commands from `packages/i18n` or with

--- a/scripts/enforce-package-manager.js
+++ b/scripts/enforce-package-manager.js
@@ -25,7 +25,7 @@ Use one of these instead:
   pnpm install
 
 Common command replacements:
-  yarn setup   -> pnpm run setup
+  yarn setup   -> pnpm bootstrap
   yarn dev     -> pnpm dev
   yarn test    -> pnpm test
   yarn lint    -> pnpm lint


### PR DESCRIPTION
## Context

[`pnpm setup`](https://pnpm.io/cli/setup) is now a pnpm CLI command that configures pnpm's global home, copies its executable and updates shell startup files. Ghost used the same command name for repository initialization, so `pnpm setup` could silently modify a contributor's shell instead of preparing the checkout.

## Summary

- Renames Ghost's repository initialization command from `setup` to the unambiguous `bootstrap`.
- Updates contributor docs, package READMEs, agent setup, Codex environment setup and package-manager guidance to use `pnpm bootstrap`.
- Records an explicit no-release intent for the affected Koenig packages because the README edits describe Ghost repository setup rather than npm package behavior.

## Testing

- [x] `pnpm bootstrap` — installed the workspace, initialized submodules and configured `blame.ignoreRevsFile`.
- [x] `pnpm help setup` — confirmed `setup` resolves to pnpm's own CLI command.
- [x] Repository-wide search confirmed there are no stale Ghost `pnpm setup`, `pnpm run setup` or root `"setup"` script references; remaining mentions explain pnpm's command or are unrelated snapshots/comments.
- [x] `pnpm format:check`
- [x] Focused Markdown lint and link validation for all changed documentation.
- [x] `node scripts/change-check.js origin/main HEAD`
- [ ] `pnpm check` — formatting, code lint, dependency boundaries, package policy, agent guidance and Markdown lint passed; the existing link from `e2e/README.md` to the missing `development-setup.md#stripe-webhooks` heading still fails full documentation link validation on `origin/main`.

## Compatibility

This intentionally removes the ambiguous root `setup` alias rather than retaining two names. Calls to `pnpm setup` cannot safely be supported as a compatibility alias because pnpm handles that command before package-script resolution.
