### PR TITLE
🎨 Added user-editable alt text for the Product card.

### DIFF
--- a/.changeset/product-card-image-alt-tests.md
+++ b/.changeset/product-card-image-alt-tests.md
@@ -1,0 +1,6 @@
+---
+"@tryghost/kg-html-to-lexical": none
+"@tryghost/kg-converters": none
+---
+
+Added test coverage for product card image alt text; no runtime change

--- a/.changeset/product-card-image-alt.md
+++ b/.changeset/product-card-image-alt.md
@@ -1,0 +1,6 @@
+---
+"@tryghost/kg-default-nodes": minor
+"@tryghost/koenig-lexical": minor
+---
+
+Added alt text support for the product card image: a productImageAlt property on the product node, rendered as the image's alt attribute on web and email, parsed from HTML on import, and editable from an Alt toggle on the card in the editor

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -8444,7 +8444,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                         
                             <tbody><tr>
                                 <td class=\\"kg-product-image\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; margin-bottom: 0; padding-top: 0; padding-bottom: 16px;\\" valign=\\"top\\">
-                                    <img src=\\"https://main.ghost.org/content/images/2023/12/ghost-logo.png\\" width=\\"560\\" height=\\"180\\" border=\\"0\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; width: 100%; height: auto; padding: 0; border: none;\\">
+                                    <img src=\\"https://main.ghost.org/content/images/2023/12/ghost-logo.png\\" width=\\"560\\" height=\\"180\\" alt=\\"Ghost logo\\" border=\\"0\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; width: 100%; height: auto; padding: 0; border: none;\\">
                                 </td>
                             </tr>
                         
@@ -10030,7 +10030,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                         
                             <tbody><tr>
                                 <td class=\\"kg-product-image\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; margin-bottom: 0; padding-top: 0; padding-bottom: 16px;\\" valign=\\"top\\">
-                                    <img src=\\"https://main.ghost.org/content/images/2023/12/ghost-logo.png\\" width=\\"560\\" height=\\"180\\" border=\\"0\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; width: 100%; height: auto; padding: 0; border: none;\\">
+                                    <img src=\\"https://main.ghost.org/content/images/2023/12/ghost-logo.png\\" width=\\"560\\" height=\\"180\\" alt=\\"Ghost logo\\" border=\\"0\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; width: 100%; height: auto; padding: 0; border: none;\\">
                                 </td>
                             </tr>
                         

--- a/ghost/core/test/unit/server/services/content-import/import/media.test.ts
+++ b/ghost/core/test/unit/server/services/content-import/import/media.test.ts
@@ -83,6 +83,7 @@ describe('PostMediaInliner', function () {
           {
             type: 'product',
             productImageSrc: 'https://assets.test/product.jpg',
+            productImageAlt: 'Product photo',
             productUrl: 'https://example.com/product',
           },
           {
@@ -156,6 +157,7 @@ describe('PostMediaInliner', function () {
     assert.equal(children[4].src, '__GHOST_URL__/content/files/guide.pdf');
     assert.equal(children[5].productImageSrc, '__GHOST_URL__/content/files/product.jpg');
     assert.equal(children[5].productUrl, 'https://example.com/product');
+    assert.equal(children[5].productImageAlt, 'Product photo');
     assert.equal(children[6].backgroundImageSrc, '__GHOST_URL__/content/files/header.jpg');
     assert.equal(children[6].buttonUrl, 'https://example.com/header-button');
     assert.equal(children[7].backgroundImageSrc, '__GHOST_URL__/content/files/signup.jpg');

--- a/ghost/core/test/utils/fixtures/email-service/golden-post.json
+++ b/ghost/core/test/utils/fixtures/email-service/golden-post.json
@@ -239,6 +239,7 @@
                 "productImageSrc": "https://main.ghost.org/content/images/2023/12/ghost-logo.png",
                 "productImageWidth": 800,
                 "productImageHeight": 257,
+                "productImageAlt": "Ghost logo",
                 "productTitle": "<span style=\"white-space: pre-wrap;\">Make a blog!</span>",
                 "productDescription": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">with Ghost</span></p>",
                 "productRatingEnabled": true,

--- a/koenig/kg-converters/test/lexical-to-mobiledoc.test.ts
+++ b/koenig/kg-converters/test/lexical-to-mobiledoc.test.ts
@@ -3066,6 +3066,67 @@ describe('lexicalToMobiledoc', function () {
       );
     });
 
+    it('keeps product card image alt text', function () {
+      const result = lexicalToMobiledoc(
+        JSON.stringify({
+          root: {
+            children: [
+              {
+                type: 'product',
+                version: 1,
+                productImageSrc: 'https://example.com/images/camera.jpg',
+                productImageWidth: 724,
+                productImageHeight: 76,
+                productImageAlt: 'A camera on a wooden table',
+                productTitle: 'Camera',
+                productDescription: 'A nice camera',
+                productRatingEnabled: false,
+                productStarRating: 5,
+                productButtonEnabled: false,
+                productButton: '',
+                productUrl: '',
+              },
+            ],
+            direction: null,
+            format: '',
+            indent: 0,
+            type: 'root',
+            version: 1,
+          },
+        }),
+      );
+
+      assert.equal(
+        result,
+        JSON.stringify({
+          version: MOBILEDOC_VERSION,
+          ghostVersion: GHOST_VERSION,
+          atoms: [],
+          cards: [
+            [
+              'product',
+              {
+                version: 1,
+                productImageSrc: 'https://example.com/images/camera.jpg',
+                productImageWidth: 724,
+                productImageHeight: 76,
+                productImageAlt: 'A camera on a wooden table',
+                productTitle: 'Camera',
+                productDescription: 'A nice camera',
+                productRatingEnabled: false,
+                productStarRating: 5,
+                productButtonEnabled: false,
+                productButton: '',
+                productUrl: '',
+              },
+            ],
+          ],
+          markups: [],
+          sections: [[10, 0]],
+        }),
+      );
+    });
+
     it('renames cards', function () {
       const result = lexicalToMobiledoc(
         JSON.stringify({

--- a/koenig/kg-converters/test/mobiledoc-to-lexical.test.ts
+++ b/koenig/kg-converters/test/mobiledoc-to-lexical.test.ts
@@ -2438,6 +2438,67 @@ describe('mobiledocToLexical', function () {
       );
     });
 
+    it('keeps product card image alt text', function () {
+      const result = mobiledocToLexical(
+        JSON.stringify({
+          version: MOBILEDOC_VERSION,
+          ghostVersion: GHOST_VERSION,
+          atoms: [],
+          cards: [
+            [
+              'product',
+              {
+                version: 1,
+                productImageSrc: 'https://example.com/images/camera.jpg',
+                productImageWidth: 724,
+                productImageHeight: 76,
+                productImageAlt: 'A camera on a wooden table',
+                productTitle: 'Camera',
+                productDescription: 'A nice camera',
+                productRatingEnabled: false,
+                productStarRating: 5,
+                productButtonEnabled: false,
+                productButton: '',
+                productUrl: '',
+              },
+            ],
+          ],
+          markups: [],
+          sections: [[10, 0]],
+        }),
+      );
+
+      assert.equal(
+        result,
+        JSON.stringify({
+          root: {
+            children: [
+              {
+                type: 'product',
+                version: 1,
+                productImageSrc: 'https://example.com/images/camera.jpg',
+                productImageWidth: 724,
+                productImageHeight: 76,
+                productImageAlt: 'A camera on a wooden table',
+                productTitle: 'Camera',
+                productDescription: 'A nice camera',
+                productRatingEnabled: false,
+                productStarRating: 5,
+                productButtonEnabled: false,
+                productButton: '',
+                productUrl: '',
+              },
+            ],
+            direction: null,
+            format: '',
+            indent: 0,
+            type: 'root',
+            version: 1,
+          },
+        }),
+      );
+    });
+
     it('renames cards', function () {
       const result = mobiledocToLexical(
         JSON.stringify({

--- a/koenig/kg-default-nodes/src/nodes/product/ProductNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/product/ProductNode.ts
@@ -6,6 +6,7 @@ const productProperties = {
     productImageSrc: {default: '', urlType: 'url'},
     productImageWidth: {default: null as number | null},
     productImageHeight: {default: null as number | null},
+    productImageAlt: {default: ''},
     productTitle: {default: '', urlType: 'html', wordCount: true},
     productDescription: {default: '', urlType: 'html', wordCount: true},
     productRatingEnabled: {default: false},
@@ -25,7 +26,7 @@ export class ProductNode extends generateDecoratorNode({
     /* override */
     exportJSON() {
         // checks if src is a data string
-        const {productImageSrc, productImageWidth, productImageHeight, productTitle, productDescription, productRatingEnabled, productStarRating, productButtonEnabled, productButton, productUrl} = this;
+        const {productImageSrc, productImageWidth, productImageHeight, productImageAlt, productTitle, productDescription, productRatingEnabled, productStarRating, productButtonEnabled, productButton, productUrl} = this;
         const isBlob = productImageSrc && productImageSrc.startsWith('data:');
 
         const dataset = {
@@ -34,6 +35,7 @@ export class ProductNode extends generateDecoratorNode({
             productImageSrc: isBlob ? '<base64String>' : productImageSrc,
             productImageWidth,
             productImageHeight,
+            productImageAlt,
             productTitle,
             productDescription,
             productRatingEnabled,

--- a/koenig/kg-default-nodes/src/nodes/product/product-parser.ts
+++ b/koenig/kg-default-nodes/src/nodes/product/product-parser.ts
@@ -22,6 +22,10 @@ export function parseProductNode(ProductNode: new (data: Record<string, unknown>
                         if (img && img.getAttribute('src')) {
                             payload.productImageSrc = img.getAttribute('src');
 
+                            if (img.getAttribute('alt')) {
+                                payload.productImageAlt = img.getAttribute('alt');
+                            }
+
                             if (img.getAttribute('width')) {
                                 const productImageWidth = Number(img.getAttribute('width'));
 

--- a/koenig/kg-default-nodes/src/nodes/product/product-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/product/product-renderer.ts
@@ -4,6 +4,7 @@ import {renderEmptyContainer} from '../../utils/render-empty-container.js';
 import {getFirstHtmlElement} from '../../utils/get-first-html-element.js';
 import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions.js';
 import {renderEmailButton} from '../../utils/render-helpers/email-button.js';
+import {escapeHtml} from '../../utils/escape-html.js';
 
 interface ProductNodeData {
     productStarRating: number;
@@ -19,6 +20,7 @@ interface ProductTemplateBaseData {
     productImageSrc: string;
     productImageWidth: number | null;
     productImageHeight: number | null;
+    productImageAlt: string;
     productTitle: string;
     productDescription: string;
     productRatingEnabled: boolean;
@@ -86,7 +88,7 @@ export function cardTemplate({data}: {data: ProductTemplateData; feature?: Expor
         `
         <div class="kg-card kg-product-card">
             <div class="kg-product-card-container">
-                ${data.productImageSrc ? `<img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} class="kg-product-card-image" loading="lazy" />` : ''}
+                ${data.productImageSrc ? `<img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} alt="${escapeHtml(data.productImageAlt)}" class="kg-product-card-image" loading="lazy" />` : ''}
                 <div class="kg-product-card-title-container">
                     <h4 class="kg-product-card-title">${data.productTitle}</h4>
                 </div>
@@ -139,7 +141,7 @@ export function emailCardTemplate({data}: {data: ProductTemplateData; feature?: 
                         ${data.productImageSrc ? `
                             <tr>
                                 <td class="kg-product-image" align="center">
-                                    <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} border="0"/>
+                                    <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} alt="${escapeHtml(data.productImageAlt)}" border="0"/>
                                 </td>
                             </tr>
                         ` : ''}

--- a/koenig/kg-default-nodes/src/nodes/product/product-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/product/product-renderer.ts
@@ -4,7 +4,7 @@ import {renderEmptyContainer} from '../../utils/render-empty-container.js';
 import {getFirstHtmlElement} from '../../utils/get-first-html-element.js';
 import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions.js';
 import {renderEmailButton} from '../../utils/render-helpers/email-button.js';
-import {escapeHtml} from '../../utils/escape-html.js';
+import {escapeAttribute} from 'entities';
 
 interface ProductNodeData {
     productStarRating: number;
@@ -88,7 +88,7 @@ export function cardTemplate({data}: {data: ProductTemplateData; feature?: Expor
         `
         <div class="kg-card kg-product-card">
             <div class="kg-product-card-container">
-                ${data.productImageSrc ? `<img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} alt="${escapeHtml(data.productImageAlt)}" class="kg-product-card-image" loading="lazy" />` : ''}
+                ${data.productImageSrc ? `<img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} alt="${escapeAttribute(data.productImageAlt ?? '')}" class="kg-product-card-image" loading="lazy" />` : ''}
                 <div class="kg-product-card-title-container">
                     <h4 class="kg-product-card-title">${data.productTitle}</h4>
                 </div>
@@ -141,7 +141,7 @@ export function emailCardTemplate({data}: {data: ProductTemplateData; feature?: 
                         ${data.productImageSrc ? `
                             <tr>
                                 <td class="kg-product-image" align="center">
-                                    <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} alt="${escapeHtml(data.productImageAlt)}" border="0"/>
+                                    <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} alt="${escapeAttribute(data.productImageAlt ?? '')}" border="0"/>
                                 </td>
                             </tr>
                         ` : ''}

--- a/koenig/kg-default-nodes/test/nodes/product.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/product.test.ts
@@ -255,7 +255,7 @@ describe('ProductNode', function () {
             const element = result.element as HTMLElement;
 
             assertPrettifiesTo(element.outerHTML, `
-                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><img src="https://example.com/images/ok.jpg" class="kg-product-card-image" loading="lazy" /><div class="kg-product-card-title-container"><h4 class="kg-product-card-title">Product title!</h4></div><div class="kg-product-card-rating"><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span></div><div class="kg-product-card-description">This product is ok</div><a href="https://example.com/product/ok" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>Click me</span></a></div></div>
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><img src="https://example.com/images/ok.jpg" alt="" class="kg-product-card-image" loading="lazy" /><div class="kg-product-card-title-container"><h4 class="kg-product-card-title">Product title!</h4></div><div class="kg-product-card-rating"><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span></div><div class="kg-product-card-description">This product is ok</div><a href="https://example.com/product/ok" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>Click me</span></a></div></div>
             `);
         }));
 
@@ -280,8 +280,50 @@ describe('ProductNode', function () {
             const element = result.element as HTMLElement;
 
             assertPrettifiesTo(element.outerHTML, `
-                <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0"><tbody><tr><td class="kg-product-card-container"><table cellspacing="0" cellpadding="0" border="0"><tbody><tr><td class="kg-product-image" align="center"><img src="https://example.com/images/ok.jpg" border="0"></td></tr><tr><td valign="top"><h4 class="kg-product-title">Product title!</h4></td></tr><tr class="kg-product-rating"><td valign="top"><img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" border="0"></td></tr><tr><td class="kg-product-description-wrapper">This product is ok</td></tr><tr><td class="kg-product-button-wrapper"><table class="btn" border="0" cellspacing="0" cellpadding="0"><tbody><tr><td align="center" width="100%"><a href="https://example.com/product/ok">Click me</a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table>
+                <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0"><tbody><tr><td class="kg-product-card-container"><table cellspacing="0" cellpadding="0" border="0"><tbody><tr><td class="kg-product-image" align="center"><img src="https://example.com/images/ok.jpg" alt="" border="0"></td></tr><tr><td valign="top"><h4 class="kg-product-title">Product title!</h4></td></tr><tr class="kg-product-rating"><td valign="top"><img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" border="0"></td></tr><tr><td class="kg-product-description-wrapper">This product is ok</td></tr><tr><td class="kg-product-button-wrapper"><table class="btn" border="0" cellspacing="0" cellpadding="0"><tbody><tr><td align="center" width="100%"><a href="https://example.com/product/ok">Click me</a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table>
             `);
+        }));
+
+        it('renders image alt text', editorTest(function () {
+            const productNode = $createProductNode({
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageAlt: 'A camera on a wooden table',
+                productTitle: 'Product title!'
+            });
+            const result = productNode.exportDOM(editor, exportOptions);
+            const element = result.element as HTMLElement;
+            const img = element.querySelector('img.kg-product-card-image')!;
+
+            expect(img.getAttribute('alt')).toBe('A camera on a wooden table');
+        }));
+
+        it('escapes image alt text', editorTest(function () {
+            const productNode = $createProductNode({
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageAlt: 'Fits "most" cameras & lenses',
+                productTitle: 'Product title!'
+            });
+            const result = productNode.exportDOM(editor, exportOptions);
+            const element = result.element as HTMLElement;
+            const img = element.querySelector('img.kg-product-card-image')!;
+
+            // unescaped quotes would truncate the attribute when the HTML is parsed
+            expect(img.getAttribute('alt')).toBe('Fits "most" cameras & lenses');
+            expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; lenses"');
+        }));
+
+        it('renders escaped image alt text in email', editorTest(function () {
+            const productNode = $createProductNode({
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageAlt: 'Fits "most" cameras & lenses',
+                productTitle: 'Product title!'
+            });
+            const result = productNode.exportDOM(editor, {...exportOptions, target: 'email'});
+            const element = result.element as HTMLElement;
+            const img = element.querySelector('td.kg-product-image img')!;
+
+            expect(img.getAttribute('alt')).toBe('Fits "most" cameras & lenses');
+            expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; lenses"');
         }));
     });
 

--- a/koenig/kg-default-nodes/test/nodes/product.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/product.test.ts
@@ -300,7 +300,7 @@ describe('ProductNode', function () {
         it('escapes image alt text', editorTest(function () {
             const productNode = $createProductNode({
                 productImageSrc: 'https://example.com/images/ok.jpg',
-                productImageAlt: 'Fits "most" cameras & lenses',
+                productImageAlt: 'Fits "most" cameras & <lenses>',
                 productTitle: 'Product title!'
             });
             const result = productNode.exportDOM(editor, exportOptions);
@@ -308,22 +308,22 @@ describe('ProductNode', function () {
             const img = element.querySelector('img.kg-product-card-image')!;
 
             // unescaped quotes would truncate the attribute when the HTML is parsed
-            expect(img.getAttribute('alt')).toBe('Fits "most" cameras & lenses');
-            expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; lenses"');
+            expect(img.getAttribute('alt')).toBe('Fits "most" cameras & <lenses>');
+            expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; ');
         }));
 
         it('renders escaped image alt text in email', editorTest(function () {
             const productNode = $createProductNode({
                 productImageSrc: 'https://example.com/images/ok.jpg',
-                productImageAlt: 'Fits "most" cameras & lenses',
+                productImageAlt: 'Fits "most" cameras & <lenses>',
                 productTitle: 'Product title!'
             });
             const result = productNode.exportDOM(editor, {...exportOptions, target: 'email'});
             const element = result.element as HTMLElement;
             const img = element.querySelector('td.kg-product-image img')!;
 
-            expect(img.getAttribute('alt')).toBe('Fits "most" cameras & lenses');
-            expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; lenses"');
+            expect(img.getAttribute('alt')).toBe('Fits "most" cameras & <lenses>');
+            expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; ');
         }));
     });
 
@@ -339,6 +339,7 @@ describe('ProductNode', function () {
             expect($isProductNode(productNode)).toBe(true);
 
             expect(productNode.productImageSrc).toBe('https://example.com/images/ok.jpg');
+            expect(productNode.productImageAlt).toBe('');
             expect(productNode.productTitle).toBe('Product title!');
             expect(productNode.productDescription).toBe('This product is ok');
             expect(productNode.productRatingEnabled).toBe(true);
@@ -416,6 +417,22 @@ describe('ProductNode', function () {
             expect(productNode.productImageSrc).toBe('https://example.com/images/ok.jpg');
             expect(productNode.productImageWidth).toBe(null);
             expect(productNode.productImageHeight).toBe(null);
+        }));
+
+        it('parses product card image alt text', editorTest(function () {
+            const document = createDocument(html`
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><img src="https://example.com/images/ok.jpg" width="200" height="100" alt="Fits &quot;most&quot; cameras &amp; &lt;lenses&gt;" class="kg-product-card-image" loading="lazy" /><div class="kg-product-card-title-container"><h4 class="kg-product-card-title">Product title!</h4></div><div class="kg-product-card-description">This product is ok</div></div></div>
+            `);
+            const nodes = $generateNodesFromDOM(editor, document);
+            expect(nodes.length).toBe(1);
+
+            const productNode = nodes[0] as ProductNode;
+            expect($isProductNode(productNode)).toBe(true);
+
+            expect(productNode.productImageSrc).toBe('https://example.com/images/ok.jpg');
+            expect(productNode.productImageAlt).toBe('Fits "most" cameras & <lenses>');
+            expect(productNode.productImageWidth!).toBe(200);
+            expect(productNode.productImageHeight!).toBe(100);
         }));
 
         it('handles arbitrary whitespace in button content', editorTest(function () {

--- a/koenig/kg-default-nodes/test/nodes/product.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/product.test.ts
@@ -30,6 +30,7 @@ describe('ProductNode', function () {
         expect(productNode.productImageSrc).toBe(data.productImageSrc);
         expect(productNode.productImageWidth!).toBe(data.productImageWidth);
         expect(productNode.productImageHeight!).toBe(data.productImageHeight);
+        expect(productNode.productImageAlt).toBe(data.productImageAlt);
         expect(productNode.productTitle).toBe(data.productTitle);
         expect(productNode.productDescription).toBe(data.productDescription);
         expect(productNode.productRatingEnabled).toBe(true);
@@ -46,6 +47,7 @@ describe('ProductNode', function () {
             productImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
             productImageWidth: 200,
             productImageHeight: 100,
+            productImageAlt: 'A camera on a wooden table',
             productTitle: 'This is a <b>title</b>',
             productDescription: 'This is a <b>description</b>',
             productRatingEnabled: true,
@@ -85,6 +87,10 @@ describe('ProductNode', function () {
             expect(productNode.productImageHeight).toBe(null);
             productNode.productImageHeight = 700;
             expect(productNode.productImageHeight).toBe(700);
+
+            expect(productNode.productImageAlt).toBe('');
+            productNode.productImageAlt = 'A camera on a wooden table';
+            expect(productNode.productImageAlt).toBe('A camera on a wooden table');
 
             expect(productNode.productTitle).toBe('');
             productNode.productTitle = 'Title';
@@ -184,6 +190,7 @@ describe('ProductNode', function () {
                 productImageSrc: dataset.productImageSrc,
                 productImageWidth: dataset.productImageWidth,
                 productImageHeight: dataset.productImageHeight,
+                productImageAlt: dataset.productImageAlt,
                 productTitle: dataset.productTitle,
                 productDescription: dataset.productDescription,
                 productRatingEnabled: dataset.productRatingEnabled,

--- a/koenig/kg-default-nodes/test/nodes/product.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/product.test.ts
@@ -312,6 +312,33 @@ describe('ProductNode', function () {
             expect(element.outerHTML).toContain('alt="Fits &quot;most&quot; cameras &amp; ');
         }));
 
+        it('preserves literal HTML entities in web and email alt text', editorTest(function () {
+            const alt = 'A label showing &amp;, &copy;, &#169;, &#x1f4f7; and "<lenses>"';
+            const productNode = $createProductNode({
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageAlt: alt
+            });
+
+            for (const target of ['web', 'email']) {
+                const result = productNode.exportDOM(editor, {...exportOptions, target});
+                const element = result.element as HTMLElement;
+                expect(element.querySelector('img')!.getAttribute('alt')).toBe(alt);
+            }
+        }));
+
+        it('preserves literal HTML entities through an HTML round trip', editorTest(function () {
+            const alt = 'A label showing &amp; and &copy;';
+            const productNode = $createProductNode({
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageAlt: alt
+            });
+            const result = productNode.exportDOM(editor, exportOptions);
+            const document = createDocument((result.element as HTMLElement).outerHTML);
+            const [importedNode] = $generateNodesFromDOM(editor, document);
+
+            expect(importedNode.exportJSON()).toMatchObject({productImageAlt: alt});
+        }));
+
         it('renders escaped image alt text in email', editorTest(function () {
             const productNode = $createProductNode({
                 productImageSrc: 'https://example.com/images/ok.jpg',

--- a/koenig/kg-default-nodes/test/renderers/product-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/product-renderer.test.ts
@@ -35,7 +35,7 @@ describe('renderers/product-renderer', function () {
             assertPrettifiesTo(result.html, html`
                 <div class="kg-card kg-product-card">
                     <div class="kg-product-card-container">
-                        <img src="/content/images/2022/11/koenig-lexical.jpg" width="200" height="100" class="kg-product-card-image" loading="lazy">
+                        <img src="/content/images/2022/11/koenig-lexical.jpg" width="200" height="100" alt="" class="kg-product-card-image" loading="lazy">
                         <div class="kg-product-card-title-container">
                             <h4 class="kg-product-card-title">This is a <b>title</b></h4>
                         </div>
@@ -71,6 +71,14 @@ describe('renderers/product-renderer', function () {
                             rel="noopener noreferrer"><span>Button text</span></a>
                     </div>
                 </div>
+            `);
+        });
+
+        it('renders escaped image alt text', function () {
+            const result = renderForWeb(getTestData({productImageAlt: 'Fits "most" cameras & lenses'}));
+
+            assertPrettifiedIncludes(result.html, html`
+                <img src="/content/images/2022/11/koenig-lexical.jpg" width="200" height="100" alt="Fits &quot;most&quot; cameras &amp; lenses" class="kg-product-card-image" loading="lazy">
             `);
         });
 
@@ -176,6 +184,7 @@ describe('renderers/product-renderer', function () {
                                                     src="/content/images/2022/11/koenig-lexical.jpg"
                                                     width="200"
                                                     height="100"
+                                                    alt=""
                                                     border="0" />
                                             </td>
                                         </tr>
@@ -219,6 +228,14 @@ describe('renderers/product-renderer', function () {
                         </tr>
                     </tbody>
                 </table>
+            `);
+        });
+
+        it('renders escaped image alt text', function () {
+            const result = renderForEmail(getTestData({productImageAlt: 'Fits "most" cameras & lenses'}), {feature: {}});
+
+            assertPrettifiedIncludes(result.html, html`
+                <img src="/content/images/2022/11/koenig-lexical.jpg" width="200" height="100" alt="Fits &quot;most&quot; cameras &amp; lenses" border="0" />
             `);
         });
 
@@ -266,7 +283,7 @@ describe('renderers/product-renderer', function () {
                                     <tbody>
                                         <tr>
                                             <td class="kg-product-image" align="center">
-                                                <img src="https://example.com/images/ok.jpg" border="0" />
+                                                <img src="https://example.com/images/ok.jpg" alt="" border="0" />
                                             </td>
                                         </tr>
                                         <tr>
@@ -322,7 +339,7 @@ describe('renderers/product-renderer', function () {
                                     <tbody>
                                         <tr>
                                             <td class="kg-product-image" align="center">
-                                                <img src="https://example.com/images/ok.jpg" border="0" />
+                                                <img src="https://example.com/images/ok.jpg" alt="" border="0" />
                                             </td>
                                         </tr>
                                         <tr>

--- a/koenig/kg-html-to-lexical/test/html-to-lexical.test.ts
+++ b/koenig/kg-html-to-lexical/test/html-to-lexical.test.ts
@@ -1022,6 +1022,7 @@ describe('HTMLtoLexical', function () {
                         src="__GHOST_URL__/content/images/2023/10/CleanShot-2023-07-19-at-12.57.37@2x.png"
                         width="724"
                         height="76"
+                        alt="product image"
                         class="kg-product-card-image"
                         loading="lazy"
                     />
@@ -1215,6 +1216,34 @@ describe('HTMLtoLexical', function () {
         'header',
         'signup',
       ]);
+    });
+
+    it('keeps product card image alt text', function () {
+      const html = `
+            <div class="kg-card kg-product-card">
+                <div class="kg-product-card-container">
+                    <img
+                        src="https://example.com/images/camera.jpg"
+                        width="724"
+                        height="76"
+                        alt="A camera on a wooden table"
+                        class="kg-product-card-image"
+                        loading="lazy"
+                    />
+                    <div class="kg-product-card-title-container">
+                        <h4 class="kg-product-card-title">Product title</h4>
+                    </div>
+                    <div class="kg-product-card-description">Product description</div>
+                </div>
+            </div>
+            `;
+
+      const lexical = htmlToLexical(html, options);
+      const [product] = lexical.root.children;
+
+      assert.equal(product.type, 'product');
+      assert.equal(product.productImageSrc, 'https://example.com/images/camera.jpg');
+      assert.equal(product.productImageAlt, 'A camera on a wooden table');
     });
   });
 

--- a/koenig/koenig-lexical/src/components/ui/cards/ProductCard.stories.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/ProductCard.stories.tsx
@@ -143,5 +143,6 @@ Populated.args = {
     buttonUrl: 'https://ghost.org/',
     rating: 4,
     imgMimeTypes: ['image/*'],
-    imgSrc: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+    imgSrc: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg',
+    imgAlt: 'Fujifilm X100V camera on a wooden table'
 };

--- a/koenig/koenig-lexical/src/components/ui/cards/ProductCard.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/ProductCard.tsx
@@ -9,6 +9,7 @@ import {isEditorEmpty} from '../../../utils/isEditorEmpty';
 
 export function ProductCard({
     isEditing,
+    imgAlt,
     imgSrc,
     isButtonEnabled,
     buttonText,
@@ -20,6 +21,7 @@ export function ProductCard({
     onButtonUrlChange,
     onRatingToggle,
     imgDragHandler,
+    onImgAltChange,
     onImgChange,
     imgMimeTypes,
     imgUploader,
@@ -38,6 +40,7 @@ export function ProductCard({
         <>
             <div className="mx-auto my-4 flex w-full max-w-[550px] flex-col rounded-md border border-grey/40 p-5 font-sans dark:border-grey/20">
                 <ProductCardImage
+                    imgAlt={imgAlt}
                     imgDragHandler={imgDragHandler}
                     imgMimeTypes={imgMimeTypes}
                     imgSrc={imgSrc}
@@ -45,6 +48,7 @@ export function ProductCard({
                     isEditing={isEditing}
                     isPinturaEnabled={isPinturaEnabled}
                     openImageEditor={openImageEditor}
+                    onImgAltChange={onImgAltChange}
                     onImgChange={onImgChange}
                     onRemoveImage={onRemoveImage}
                 />
@@ -137,6 +141,7 @@ export function ProductCard({
 
 ProductCard.propTypes = {
     isEditing: PropTypes.bool,
+    imgAlt: PropTypes.string,
     imgSrc: PropTypes.string,
     isButtonEnabled: PropTypes.bool,
     buttonText: PropTypes.string,
@@ -147,6 +152,7 @@ ProductCard.propTypes = {
     onButtonTextChange: PropTypes.func,
     onButtonUrlChange: PropTypes.func,
     onRatingToggle: PropTypes.func,
+    onImgAltChange: PropTypes.func,
     onImgChange: PropTypes.func,
     onRemoveImage: PropTypes.func,
     imgDragHandler: PropTypes.object,

--- a/koenig/koenig-lexical/src/components/ui/cards/ProductCard/ProductCardImage.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/ProductCard/ProductCardImage.tsx
@@ -4,13 +4,16 @@ import WandIcon from '../../../../assets/icons/kg-wand.svg?react';
 import {IconButton} from '../../IconButton.jsx';
 import {MediaPlaceholder} from '../../MediaPlaceholder.jsx';
 import {ProgressBar} from '../../ProgressBar.jsx';
+import {TextInput} from '../../TextInput';
 import {openFileSelection} from '../../../../utils/openFileSelection.js';
 
 export function ProductCardImage({
     imgSrc,
+    imgAlt = '',
     imgUploader = {},
     imgDragHandler = {},
     onImgChange,
+    onImgAltChange,
     imgMimeTypes,
     onRemoveImage,
     isPinturaEnabled,
@@ -18,95 +21,148 @@ export function ProductCardImage({
     isEditing
 }) {
     const fileInputRef = React.useRef(null);
+    const [isEditingAlt, setIsEditingAlt] = React.useState(false);
+
+    // always close the alt input when leaving edit mode or when the image goes away
+    React.useEffect(() => {
+        if (!isEditing || !imgSrc) {
+            setIsEditingAlt(false);
+        }
+    }, [isEditing, imgSrc]);
 
     const onRemove = (e) => {
         e.stopPropagation(); // prevents card from losing selected state
         onRemoveImage();
     };
 
+    const toggleIsEditingAlt = (e) => {
+        e.stopPropagation(); // prevents card from losing editing state
+        setIsEditingAlt(!isEditingAlt);
+    };
+
+    const handleAltChange = (e) => {
+        onImgAltChange?.(e.target.value);
+    };
+
     const showPlaceholder = imgDragHandler.isDraggedOver || !imgSrc;
+    const showAltToggle = isEditing && !showPlaceholder;
+    const showAltInput = showAltToggle && isEditingAlt;
     const progressStyle = {
         width: `${imgUploader.progress?.toFixed(0)}%`
     };
 
     return (
-        <div className="not-kg-prose group/image relative mb-4 w-full rounded-md">
-            {
-                showPlaceholder
-                    ? (
-                        <>
-                            <MediaPlaceholder
-                                desc={isEditing ? 'Click to select a product image' : ''}
-                                errors={imgUploader.errors}
-                                filePicker={() => openFileSelection({fileInputRef})}
-                                icon='product'
-                                isDraggedOver={imgDragHandler.isDraggedOver}
-                                placeholderRef={imgDragHandler.setRef}
-                                size='small'
-                            />
-
-                            <form onChange={onImgChange}>
-                                <input
-                                    ref={fileInputRef}
-                                    accept={imgMimeTypes.join(',')}
-                                    hidden={true}
-                                    name="image-input"
-                                    type='file'
+        <>
+            <div className="not-kg-prose group/image relative mb-4 w-full rounded-md">
+                {
+                    showPlaceholder
+                        ? (
+                            <>
+                                <MediaPlaceholder
+                                    desc={isEditing ? 'Click to select a product image' : ''}
+                                    errors={imgUploader.errors}
+                                    filePicker={() => openFileSelection({fileInputRef})}
+                                    icon='product'
+                                    isDraggedOver={imgDragHandler.isDraggedOver}
+                                    placeholderRef={imgDragHandler.setRef}
+                                    size='small'
                                 />
-                            </form>
-                        </>
-                    )
-                    : (
-                        <>
-                            <img alt="Product thumbnail" className="mx-auto max-h-[100%] rounded-md object-cover" data-testid="product-card-image" src={imgSrc} />
 
-                            {
-                                isEditing && (
-                                    <>
-                                        <div className="absolute inset-0 rounded-md bg-gradient-to-t from-black/0 via-black/5 to-black/30 opacity-0 transition-all group-hover/image:opacity-100"></div>
-                                    </>
-                                )
-                            }
+                                <form onChange={onImgChange}>
+                                    <input
+                                        ref={fileInputRef}
+                                        accept={imgMimeTypes.join(',')}
+                                        hidden={true}
+                                        name="image-input"
+                                        type='file'
+                                    />
+                                </form>
+                            </>
+                        )
+                        : (
+                            <>
+                                <img alt={imgAlt} className="mx-auto max-h-[100%] rounded-md object-cover" data-testid="product-card-image" src={imgSrc} />
 
-                            {
-                                isEditing && (
-                                    <>
-                                        <div className="absolute right-5 top-5 flex opacity-0 transition-all group-hover/image:opacity-100">
-                                            <IconButton dataTestId="replace-product-image" Icon={DeleteIcon} label="Delete" onClick={onRemove} />
+                                {
+                                    isEditing && (
+                                        <>
+                                            <div className="absolute inset-0 rounded-md bg-gradient-to-t from-black/0 via-black/5 to-black/30 opacity-0 transition-all group-hover/image:opacity-100"></div>
+                                        </>
+                                    )
+                                }
+
+                                {
+                                    isEditing && (
+                                        <>
+                                            <div className="absolute right-5 top-5 flex opacity-0 transition-all group-hover/image:opacity-100">
+                                                <IconButton dataTestId="replace-product-image" Icon={DeleteIcon} label="Delete" onClick={onRemove} />
+                                            </div>
+                                        </>
+                                    )
+                                }
+
+                                {
+                                    isEditing && isPinturaEnabled && (
+                                        <>
+                                            <div className="absolute right-16 top-5 flex opacity-0 transition-all group-hover/image:opacity-100">
+                                                <IconButton dataTestId="replace-product-image" Icon={WandIcon} label="Edit" onClick={() => openImageEditor({
+                                                    image: imgSrc,
+                                                    handleSave: (editedImage) => {
+                                                        onImgChange({
+                                                            target: {
+                                                                files: [editedImage]
+                                                            }
+                                                        });
+                                                    }
+                                                })} />
+                                            </div>
+                                        </>
+                                    )
+                                }
+
+                                {
+                                    showAltToggle && (
+                                        <button
+                                            aria-pressed={isEditingAlt}
+                                            className={`absolute bottom-0 right-0 m-2 cursor-pointer rounded-md border px-1 font-sans text-[1.3rem] font-normal leading-7 tracking-wide transition-all duration-100 ${isEditingAlt ? 'border-green bg-green text-white' : 'border-grey bg-white/90 text-grey-900 hover:bg-white'}`}
+                                            data-testid="product-image-alt-toggle"
+                                            name="alt-toggle-button"
+                                            type="button"
+                                            onClick={toggleIsEditingAlt}
+                                        >
+                                            Alt
+                                        </button>
+                                    )
+                                }
+
+                                {
+                                    imgUploader.isLoading && (
+                                        <div className="absolute inset-0 flex min-w-full items-center justify-center overflow-hidden bg-white/50">
+                                            <ProgressBar bgStyle='transparent' style={progressStyle} />
                                         </div>
-                                    </>
-                                )
-                            }
+                                    )
+                                }
+                            </>
+                        )
+                }
+            </div>
 
-                            {
-                                isEditing && isPinturaEnabled && (
-                                    <>
-                                        <div className="absolute right-16 top-5 flex opacity-0 transition-all group-hover/image:opacity-100">
-                                            <IconButton dataTestId="replace-product-image" Icon={WandIcon} label="Edit" onClick={() => openImageEditor({
-                                                image: imgSrc,
-                                                handleSave: (editedImage) => {
-                                                    onImgChange({
-                                                        target: {
-                                                            files: [editedImage]
-                                                        }
-                                                    });
-                                                }
-                                            })} />
-                                        </div>
-                                    </>
-                                )
-                            }
-
-                            {
-                                imgUploader.isLoading && (
-                                    <div className="absolute inset-0 flex min-w-full items-center justify-center overflow-hidden bg-white/50">
-                                        <ProgressBar bgStyle='transparent' style={progressStyle} />
-                                    </div>
-                                )
-                            }
-                        </>
-                    )
+            {
+                showAltInput && (
+                    <div className="not-kg-prose -mt-2 mb-4 w-full">
+                        <TextInput
+                            aria-label="Alt text"
+                            className="w-full bg-transparent font-sans text-sm font-normal leading-[1.625] tracking-wide text-grey-800 placeholder:text-grey-500 focus-visible:outline-none dark:text-grey-500 dark:placeholder:text-grey-800"
+                            data-testid="product-image-alt-input"
+                            placeholder="Type alt text for product image (optional)"
+                            value={imgAlt}
+                            autoFocus
+                            data-koenig-dnd-disabled
+                            onChange={handleAltChange}
+                        />
+                    </div>
+                )
             }
-        </div>
+        </>
     );
 }

--- a/koenig/koenig-lexical/src/components/ui/cards/ProductCard/ProductCardImage.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/ProductCard/ProductCardImage.tsx
@@ -124,7 +124,7 @@ export function ProductCardImage({
                                     showAltToggle && (
                                         <button
                                             aria-pressed={isEditingAlt}
-                                            className={`absolute bottom-0 right-0 m-2 cursor-pointer rounded-md border px-1 font-sans text-[1.3rem] font-normal leading-7 tracking-wide transition-all duration-100 ${isEditingAlt ? 'border-green bg-green text-white' : 'border-grey bg-white/90 text-grey-900 hover:bg-white'}`}
+                                            className={`absolute bottom-0 left-0 m-2 cursor-pointer rounded-md border px-1 font-sans text-[1.3rem] font-normal leading-7 tracking-wide transition-all duration-100 ${isEditingAlt ? 'border-green bg-green text-white' : 'border-grey bg-white/90 text-grey-900 hover:bg-white'}`}
                                             data-testid="product-image-alt-toggle"
                                             name="alt-toggle-button"
                                             type="button"

--- a/koenig/koenig-lexical/src/nodes/ProductNode.tsx
+++ b/koenig/koenig-lexical/src/nodes/ProductNode.tsx
@@ -91,6 +91,7 @@ export class ProductNode extends BaseProductNode {
                     description={this.productDescription}
                     descriptionEditor={this.__productDescriptionEditor}
                     descriptionEditorInitialState={this.__productDescriptionEditorInitialState}
+                    imgAlt={this.productImageAlt}
                     imgHeight={this.productImageHeight}
                     imgSrc={this.productImageSrc}
                     imgWidth={this.productImageWidth}

--- a/koenig/koenig-lexical/src/nodes/ProductNodeComponent.tsx
+++ b/koenig/koenig-lexical/src/nodes/ProductNodeComponent.tsx
@@ -15,6 +15,7 @@ export function ProductNodeComponent({
     nodeKey,
     buttonText,
     buttonUrl,
+    imgAlt,
     imgHeight,
     imgSrc,
     imgWidth,
@@ -76,6 +77,14 @@ export function ProductNodeComponent({
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.productImageSrc = '';
+            node.productImageAlt = '';
+        });
+    };
+
+    const handleImgAltChange = (value) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.productImageAlt = value;
         });
     };
 
@@ -132,6 +141,7 @@ export function ProductNodeComponent({
                 description={description}
                 descriptionEditor={descriptionEditor}
                 descriptionEditorInitialState={descriptionEditorInitialState}
+                imgAlt={imgAlt}
                 imgDragHandler={imgDragHandler}
                 imgHeight={imgHeight}
                 imgMimeTypes={imgMimeTypes}
@@ -150,6 +160,7 @@ export function ProductNodeComponent({
                 onButtonTextChange={handleButtonTextChange}
                 onButtonToggle={handleButtonToggle}
                 onButtonUrlChange={handleButtonUrlChange}
+                onImgAltChange={handleImgAltChange}
                 onImgChange={handleImgChange}
                 onRatingChange={handleRatingChange}
                 onRatingToggle={handleRatingToggle}

--- a/koenig/koenig-lexical/test/e2e/cards/product-card.test.ts
+++ b/koenig/koenig-lexical/test/e2e/cards/product-card.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import {assertHTML, createDataTransfer, createSnippet, focusEditor, html, initialize, insertCard, isMac} from '../../utils/e2e';
+import {assertHTML, createDataTransfer, createSnippet, focusEditor, getEditorStateJSON, html, initialize, insertCard, isMac} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -54,7 +54,7 @@ test.describe('Product card', async () => {
                     <div>
                         <div>
                             <img
-                                alt="Product thumbnail"
+                                alt=""
                                 src="/content/images/2022/11/koenig-lexical.jpg" />
                         </div>
                         <div>
@@ -190,6 +190,98 @@ test.describe('Product card', async () => {
 
         // Errors should be visible
         await expect(await page.getByTestId('media-placeholder-errors')).toBeVisible();
+    });
+
+    test('can set image alt text', async function () {
+        await withWideViewport(page, async () => {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'product'});
+            await uploadImg(page);
+            await expect(page.getByTestId('product-card-image')).toBeVisible();
+
+            // toggle is visible while editing with an image, input stays hidden until toggled
+            const altToggle = page.getByTestId('product-image-alt-toggle');
+            const altInput = page.getByTestId('product-image-alt-input');
+            await expect(altToggle).toBeVisible();
+            await expect(altInput).toBeHidden();
+
+            await altToggle.click();
+            await expect(altInput).toBeVisible();
+            await altInput.fill('A camera on a wooden table');
+
+            // preview image and serialized node both carry the alt text
+            await expect(page.getByTestId('product-card-image')).toHaveAttribute('alt', 'A camera on a wooden table');
+            const editorState = JSON.parse(await getEditorStateJSON(page));
+            expect(editorState.root.children[0].productImageAlt).toEqual('A camera on a wooden table');
+
+            // toggling again hides the input but keeps the value
+            await altToggle.click();
+            await expect(altInput).toBeHidden();
+            await expect(page.getByTestId('product-card-image')).toHaveAttribute('alt', 'A camera on a wooden table');
+        });
+    });
+
+    test('hides alt input when leaving edit mode', async function () {
+        await withWideViewport(page, async () => {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'product'});
+            await uploadImg(page);
+            await expect(page.getByTestId('product-card-image')).toBeVisible();
+
+            await page.getByTestId('product-image-alt-toggle').click();
+            await page.getByTestId('product-image-alt-input').fill('A camera on a wooden table');
+
+            await page.keyboard.press('Escape');
+            await expect(page.locator('[data-kg-card="product"]')).toHaveAttribute('data-kg-card-editing', 'false');
+            await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
+            await expect(page.getByTestId('product-image-alt-toggle')).toBeHidden();
+
+            // re-entering edit mode shows the toggle but not the input
+            await page.getByTestId('edit-product-card').click();
+            await expect(page.getByTestId('product-image-alt-toggle')).toBeVisible();
+            await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
+        });
+    });
+
+    test('clears alt text when image is removed', async function () {
+        await withWideViewport(page, async () => {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'product'});
+            await uploadImg(page);
+            await expect(page.getByTestId('product-card-image')).toBeVisible();
+
+            await page.getByTestId('product-image-alt-toggle').click();
+            await page.getByTestId('product-image-alt-input').fill('A camera on a wooden table');
+
+            await page.getByTestId('replace-product-image').click();
+            await expect(page.getByTestId('media-placeholder')).toBeVisible();
+            await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
+
+            const editorState = JSON.parse(await getEditorStateJSON(page));
+            expect(editorState.root.children[0].productImageSrc).toEqual('');
+            expect(editorState.root.children[0].productImageAlt).toEqual('');
+        });
+    });
+
+    test('keeps the caret position while editing alt text', async function () {
+        await withWideViewport(page, async () => {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'product'});
+            await uploadImg(page);
+            await expect(page.getByTestId('product-card-image')).toBeVisible();
+
+            await page.getByTestId('product-image-alt-toggle').click();
+            const altInput = page.getByTestId('product-image-alt-input');
+            await altInput.fill('camera on a table');
+
+            // move the caret to the start and type: each character must land at the caret
+            await page.keyboard.press('Home');
+            await page.keyboard.type('A ');
+
+            await expect(altInput).toHaveValue('A camera on a table');
+            const editorState = JSON.parse(await getEditorStateJSON(page));
+            expect(editorState.root.children[0].productImageAlt).toEqual('A camera on a table');
+        });
     });
 
     test('can show/hide rating starts if rating enabled/disabled', async function () {
@@ -445,7 +537,7 @@ test.describe('Product card', async () => {
                     <div>
                         <div>
                             <img
-                                alt="Product thumbnail"
+                                alt=""
                                 src="/content/images/2022/11/koenig-lexical.jpg" />
                         </div>
                         <div>
@@ -538,7 +630,7 @@ test.describe('Product card', async () => {
                     <div>
                         <div>
                             <img
-                                alt="Product thumbnail"
+                                alt=""
                                 src="/content/images/2022/11/koenig-lexical.jpg" />
                         </div>
                         <div>
@@ -712,4 +804,16 @@ async function uploadImg(page, src = 'large-image.png') {
     await mediaPlaceholder.click();
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles([imagePath]);
+}
+
+// the settings panel overlaps the image's bottom-right corner at the default
+// test viewport; the alt tests need it to sit beside the card instead
+async function withWideViewport(page, fn) {
+    const originalViewport = page.viewportSize();
+    await page.setViewportSize({width: 1400, height: 1000});
+    try {
+        await fn();
+    } finally {
+        await page.setViewportSize(originalViewport);
+    }
 }

--- a/koenig/koenig-lexical/test/e2e/cards/product-card.test.ts
+++ b/koenig/koenig-lexical/test/e2e/cards/product-card.test.ts
@@ -193,95 +193,88 @@ test.describe('Product card', async () => {
     });
 
     test('can set image alt text', async function () {
-        await withWideViewport(page, async () => {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'product'});
-            await uploadImg(page);
-            await expect(page.getByTestId('product-card-image')).toBeVisible();
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'product'});
+        await uploadImg(page);
+        await expect(page.getByTestId('product-card-image')).toBeVisible();
 
-            // toggle is visible while editing with an image, input stays hidden until toggled
-            const altToggle = page.getByTestId('product-image-alt-toggle');
-            const altInput = page.getByTestId('product-image-alt-input');
-            await expect(altToggle).toBeVisible();
-            await expect(altInput).toBeHidden();
+        // Keep the default viewport: the settings panel must not block the Alt toggle.
+        // The input stays hidden until toggled.
+        const altToggle = page.getByTestId('product-image-alt-toggle');
+        const altInput = page.getByTestId('product-image-alt-input');
+        await expect(altToggle).toBeVisible();
+        await expect(altInput).toBeHidden();
 
-            await altToggle.click();
-            await expect(altInput).toBeVisible();
-            await altInput.fill('A camera on a wooden table');
+        await altToggle.click();
+        await expect(altInput).toBeVisible();
+        await altInput.fill('A camera on a wooden table');
 
-            // preview image and serialized node both carry the alt text
-            await expect(page.getByTestId('product-card-image')).toHaveAttribute('alt', 'A camera on a wooden table');
-            const editorState = JSON.parse(await getEditorStateJSON(page));
-            expect(editorState.root.children[0].productImageAlt).toEqual('A camera on a wooden table');
+        // preview image and serialized node both carry the alt text
+        await expect(page.getByTestId('product-card-image')).toHaveAttribute('alt', 'A camera on a wooden table');
+        const editorState = JSON.parse(await getEditorStateJSON(page));
+        expect(editorState.root.children[0].productImageAlt).toEqual('A camera on a wooden table');
 
-            // toggling again hides the input but keeps the value
-            await altToggle.click();
-            await expect(altInput).toBeHidden();
-            await expect(page.getByTestId('product-card-image')).toHaveAttribute('alt', 'A camera on a wooden table');
-        });
+        // toggling again hides the input but keeps the value
+        await altToggle.click();
+        await expect(altInput).toBeHidden();
+        await expect(page.getByTestId('product-card-image')).toHaveAttribute('alt', 'A camera on a wooden table');
     });
 
     test('hides alt input when leaving edit mode', async function () {
-        await withWideViewport(page, async () => {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'product'});
-            await uploadImg(page);
-            await expect(page.getByTestId('product-card-image')).toBeVisible();
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'product'});
+        await uploadImg(page);
+        await expect(page.getByTestId('product-card-image')).toBeVisible();
 
-            await page.getByTestId('product-image-alt-toggle').click();
-            await page.getByTestId('product-image-alt-input').fill('A camera on a wooden table');
+        await page.getByTestId('product-image-alt-toggle').click();
+        await page.getByTestId('product-image-alt-input').fill('A camera on a wooden table');
 
-            await page.keyboard.press('Escape');
-            await expect(page.locator('[data-kg-card="product"]')).toHaveAttribute('data-kg-card-editing', 'false');
-            await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
-            await expect(page.getByTestId('product-image-alt-toggle')).toBeHidden();
+        await page.keyboard.press('Escape');
+        await expect(page.locator('[data-kg-card="product"]')).toHaveAttribute('data-kg-card-editing', 'false');
+        await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
+        await expect(page.getByTestId('product-image-alt-toggle')).toBeHidden();
 
-            // re-entering edit mode shows the toggle but not the input
-            await page.getByTestId('edit-product-card').click();
-            await expect(page.getByTestId('product-image-alt-toggle')).toBeVisible();
-            await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
-        });
+        // re-entering edit mode shows the toggle but not the input
+        await page.getByTestId('edit-product-card').click();
+        await expect(page.getByTestId('product-image-alt-toggle')).toBeVisible();
+        await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
     });
 
     test('clears alt text when image is removed', async function () {
-        await withWideViewport(page, async () => {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'product'});
-            await uploadImg(page);
-            await expect(page.getByTestId('product-card-image')).toBeVisible();
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'product'});
+        await uploadImg(page);
+        await expect(page.getByTestId('product-card-image')).toBeVisible();
 
-            await page.getByTestId('product-image-alt-toggle').click();
-            await page.getByTestId('product-image-alt-input').fill('A camera on a wooden table');
+        await page.getByTestId('product-image-alt-toggle').click();
+        await page.getByTestId('product-image-alt-input').fill('A camera on a wooden table');
 
-            await page.getByTestId('replace-product-image').click();
-            await expect(page.getByTestId('media-placeholder')).toBeVisible();
-            await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
+        await page.getByTestId('replace-product-image').click();
+        await expect(page.getByTestId('media-placeholder')).toBeVisible();
+        await expect(page.getByTestId('product-image-alt-input')).toBeHidden();
 
-            const editorState = JSON.parse(await getEditorStateJSON(page));
-            expect(editorState.root.children[0].productImageSrc).toEqual('');
-            expect(editorState.root.children[0].productImageAlt).toEqual('');
-        });
+        const editorState = JSON.parse(await getEditorStateJSON(page));
+        expect(editorState.root.children[0].productImageSrc).toEqual('');
+        expect(editorState.root.children[0].productImageAlt).toEqual('');
     });
 
     test('keeps the caret position while editing alt text', async function () {
-        await withWideViewport(page, async () => {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'product'});
-            await uploadImg(page);
-            await expect(page.getByTestId('product-card-image')).toBeVisible();
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'product'});
+        await uploadImg(page);
+        await expect(page.getByTestId('product-card-image')).toBeVisible();
 
-            await page.getByTestId('product-image-alt-toggle').click();
-            const altInput = page.getByTestId('product-image-alt-input');
-            await altInput.fill('camera on a table');
+        await page.getByTestId('product-image-alt-toggle').click();
+        const altInput = page.getByTestId('product-image-alt-input');
+        await altInput.fill('camera on a table');
 
-            // move the caret to the start and type: each character must land at the caret
-            await page.keyboard.press('Home');
-            await page.keyboard.type('A ');
+        // move the caret to the start and type: each character must land at the caret
+        await page.keyboard.press('Home');
+        await page.keyboard.type('A ');
 
-            await expect(altInput).toHaveValue('A camera on a table');
-            const editorState = JSON.parse(await getEditorStateJSON(page));
-            expect(editorState.root.children[0].productImageAlt).toEqual('A camera on a table');
-        });
+        await expect(altInput).toHaveValue('A camera on a table');
+        const editorState = JSON.parse(await getEditorStateJSON(page));
+        expect(editorState.root.children[0].productImageAlt).toEqual('A camera on a table');
     });
 
     test('can show/hide rating starts if rating enabled/disabled', async function () {
@@ -804,16 +797,4 @@ async function uploadImg(page, src = 'large-image.png') {
     await mediaPlaceholder.click();
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles([imagePath]);
-}
-
-// the settings panel overlaps the image's bottom-right corner at the default
-// test viewport; the alt tests need it to sit beside the card instead
-async function withWideViewport(page, fn) {
-    const originalViewport = page.viewportSize();
-    await page.setViewportSize({width: 1400, height: 1000});
-    try {
-        await fn();
-    } finally {
-        await page.setViewportSize(originalViewport);
-    }
 }

--- a/koenig/koenig-lexical/test/unit/productCard.test.ts
+++ b/koenig/koenig-lexical/test/unit/productCard.test.ts
@@ -72,4 +72,19 @@ describe('ProductNode', function () {
             expect(title).toEqual('<span style="white-space: pre-wrap;">Hello title</span><i><em style="white-space: pre-wrap;"> land </em></i><span style="white-space: pre-wrap;">baaaabeee.</span>');
         }));
     });
+
+    describe('image alt text', function () {
+        it('exports productImageAlt', editorTest(function () {
+            dataset.productImageAlt = 'A camera on a wooden table';
+            const productNode = $createProductNode(dataset);
+            const json = productNode.exportJSON();
+            expect(json.productImageAlt).toEqual('A camera on a wooden table');
+        }));
+
+        it('defaults productImageAlt to an empty string', editorTest(function () {
+            const productNode = $createProductNode(dataset);
+            const json = productNode.exportJSON();
+            expect(json.productImageAlt).toEqual('');
+        }));
+    });
 });


### PR DESCRIPTION
- [X] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [X] I've explained my change
- [X] I've written an automated test to prove my change works

The PR adds alt text support to the Koenig product card image. 

### What changed

- Product card node (kg-default-nodes): a new productImageAlt string property, default empty, included in the serialized JSON. Existing posts without the key load with an empty alt (""), so there is no migration.
- Rendering: the web and email templates always emit an alt attribute on the product image, escaped, and alt="" when unset so screen readers treat the image as decorative. Previously the image had no alt at all.  Lack of alt causes screen readers to read the filename.  "" is better for images that are display only.  (The screen reader says nothing if the image is decorative.)  And for important images (more common for the product card uses I've seen), we'll have actual alt text if the post author sets it.  Writing out "" for unset alt increases the number of snapshot and test changes slightly, but is the right thing to do.
- Parsing: HTML import and pasted product card markup now read the image's alt attribute back into the node.
- Editor (koenig-lexical): an "Alt" pill at the bottom-right of the image while the card is in edit mode. Clicking it reveals a single-line input beneath the image.  Removing the image clears the alt.
- Import and export: the mobiledoc/lexical converters and Core's content-import media inliner already pass unknown card properties through. 
- Email rendering includes alt text.
- Tests cover the node, renderer, parser, HTML import, both converter directions, the media inliner, the editor's serialization, and four Playwright scenarios: setting alt text, hiding the input on leaving edit mode, clearing on image removal, and caret position while editing.

Release intent: kg-default-nodes and koenig-lexical need a minor bump; kg-html-to-lexical and kg-converters don't need a release since they're tests only.

No changes to rating star rendering.  Separate PR needed.

Aside:  I considered refactoring to share the "alt" pill with the image card, but it meant touching the Image card, and the intended behavior is not quite identical, since this is an alt field that appears, rather than replacing the caption field.

While open in editor:
<img width="836" height="346" alt="image" src="https://github.com/user-attachments/assets/1acfec8a-5413-4176-a3c3-bef3b77b6989" />
<img width="573" height="375" alt="image" src="https://github.com/user-attachments/assets/480cfb1e-7811-4469-ac2b-d261050c9df4" />

Invisible while not editing the card:
<img width="429" height="320" alt="image" src="https://github.com/user-attachments/assets/12c43011-87c1-4960-8fc2-2fdc60c01508" />

HTML in public site:
<img width="472" height="91" alt="image" src="https://github.com/user-attachments/assets/4830fb6a-6771-4d3f-8984-0fbea58af258" />

Rendered card:
<img width="447" height="345" alt="image" src="https://github.com/user-attachments/assets/61fca2eb-9a69-4db2-9b7e-8b9b04e6f8d1" />


AI usage:  Cathy wrote the spec, approved all steps, did a full human run-through of the editor experience, reviewed all code generated, and wrote most of this PR text.  Claude handled the code generation.