### PR TITLE
Improved email sending time estimates

### DIFF
--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -1,21 +1,11 @@
 import { Banner, Button } from '@tryghost/shade/components';
 import { Inline, Text } from '@tryghost/shade/primitives';
 import { LucideIcon, formatNumber } from '@tryghost/shade/utils';
+import { useSendingEta } from './use-sending-eta';
 import { useEmailSendingStatusContext } from './email-sending-status-context';
 import { usePostAnalytics } from '@/posts/analytics/providers/post-analytics-context';
 import type { EmailSendingState } from '@tryghost/admin-x-framework/api/emails';
 import type { ReactNode } from 'react';
-
-const formatEta = (seconds: number): string => {
-  if (seconds > 80) {
-    const minutes = Math.round(seconds / 60);
-    return `About ${formatNumber(minutes)} ${minutes === 1 ? 'minute' : 'minutes'} left`;
-  }
-  if (seconds > 40) {
-    return 'About 1 minute left';
-  }
-  return 'Less than 1 minute left';
-};
 
 const FILL_CLIP_ID = 'email-sending-fill-clip';
 
@@ -68,9 +58,11 @@ const StatusGlyph = ({ sending }: { sending: EmailSendingState }) => {
   );
 };
 
-const activeDetail = (sending: Exclude<EmailSendingState, { status: 'failed' }>): ReactNode => {
-  const { completed, total, estimated_seconds_remaining: eta } = sending.progress;
-  const estimate = eta === null ? null : formatEta(eta);
+const activeDetail = (
+  sending: Exclude<EmailSendingState, { status: 'failed' }>,
+  estimate: string | null,
+): ReactNode => {
+  const { completed, total } = sending.progress;
 
   if (total === 0) {
     return estimate;
@@ -105,6 +97,7 @@ const EmailSendingStatusBanner = () => {
   const { status, hasUnknownDeliveryOutcome, isRetrying, retrySending } =
     useEmailSendingStatusContext();
   const sending = status?.sending;
+  const estimate = useSendingEta(status);
 
   if (!sending || sending.status === 'submitted') {
     return null;
@@ -127,7 +120,7 @@ const EmailSendingStatusBanner = () => {
     ? hasUnknownDeliveryOutcome
       ? post?.email?.error || 'Something went wrong while sending this email.'
       : failureDetail(sending, post?.email?.error)
-    : activeDetail(sending);
+    : activeDetail(sending, estimate);
   const retryLabel = hasSentEmails ? 'Send remaining emails' : 'Retry sending email';
 
   return (

--- a/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.test.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.test.ts
@@ -18,6 +18,19 @@ function status(
 }
 
 describe('useSendingEta', () => {
+  it('shows a calculating label until an active phase has an estimate', () => {
+    const { result, rerender } = renderHook(useSendingEta, {
+      initialProps: undefined as EmailSendingStatus | undefined,
+    });
+    expect(result.current).toBeNull();
+    rerender(status(null, 'preparing'));
+    expect(result.current).toBe('Calculating time remaining...');
+    rerender(status(null, 'submitting'));
+    expect(result.current).toBe('Calculating time remaining...');
+    rerender(status(30));
+    expect(result.current).toBe('Less than 1 minute left');
+  });
+
   it('keeps the less-than-a-minute label through jitter, but allows a real slowdown', () => {
     const { result, rerender } = renderHook(useSendingEta, { initialProps: status(39) });
     for (const seconds of [41, 39, 49, 50]) {
@@ -57,7 +70,7 @@ describe('useSendingEta', () => {
     rerender(status(35, 'submitting', 'email-2'));
     expect(result.current).toBe('Less than 1 minute left');
     rerender(status(null, 'submitting', 'email-2'));
-    expect(result.current).toBeNull();
+    expect(result.current).toBe('Calculating time remaining...');
     rerender(status(45, 'submitting', 'email-2'));
     expect(result.current).toBe('About 1 minute left');
     rerender(status(0, 'submitted', 'email-2'));

--- a/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.test.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useSendingEta } from './use-sending-eta';
+import type { EmailSendingStatus } from '@tryghost/admin-x-framework/api/emails';
+
+function status(
+  seconds: number | null,
+  phase: 'preparing' | 'submitting' | 'submitted' = 'submitting',
+  id = 'email-1',
+): EmailSendingStatus {
+  return {
+    id,
+    sending: {
+      status: phase,
+      progress: { completed: 10, total: 100, estimated_seconds_remaining: seconds },
+    },
+  };
+}
+
+describe('useSendingEta', () => {
+  it('keeps the less-than-a-minute label through jitter, but allows a real slowdown', () => {
+    const { result, rerender } = renderHook(useSendingEta, { initialProps: status(39) });
+    for (const seconds of [41, 39, 49, 50]) {
+      rerender(status(seconds));
+      expect(result.current).toBe('Less than 1 minute left');
+    }
+    rerender(status(51));
+    expect(result.current).toBe('About 1 minute left');
+    for (const seconds of [41, 39, 31]) {
+      rerender(status(seconds));
+      expect(result.current).toBe('About 1 minute left');
+    }
+    rerender(status(29));
+    expect(result.current).toBe('Less than 1 minute left');
+  });
+
+  it('buffers rounding boundaries for multi-minute labels in both directions', () => {
+    const { result, rerender } = renderHook(useSendingEta, { initialProps: status(120) });
+    for (const seconds of [89, 81, 151, 159]) {
+      rerender(status(seconds));
+      expect(result.current).toBe('About 2 minutes left');
+    }
+    rerender(status(161));
+    expect(result.current).toBe('About 3 minutes left');
+    rerender(status(79));
+    expect(result.current).toBe('About 1 minute left');
+    rerender(status(101));
+    expect(result.current).toBe('About 2 minutes left');
+  });
+
+  it('resets history for another email, phase, unknown ETA, and terminal status', () => {
+    const { result, rerender } = renderHook(useSendingEta, {
+      initialProps: status(20, 'preparing'),
+    });
+    rerender(status(45));
+    expect(result.current).toBe('About 1 minute left');
+    rerender(status(35, 'submitting', 'email-2'));
+    expect(result.current).toBe('Less than 1 minute left');
+    rerender(status(null, 'submitting', 'email-2'));
+    expect(result.current).toBeNull();
+    rerender(status(45, 'submitting', 'email-2'));
+    expect(result.current).toBe('About 1 minute left');
+    rerender(status(0, 'submitted', 'email-2'));
+    expect(result.current).toBeNull();
+    rerender(status(35, 'submitting', 'email-2'));
+    expect(result.current).toBe('Less than 1 minute left');
+  });
+
+  it('hides the estimate after failure and starts fresh for a retry', () => {
+    const { result, rerender } = renderHook(useSendingEta, { initialProps: status(20) });
+    rerender({
+      id: 'email-1',
+      sending: {
+        status: 'failed',
+        failed_during: 'submitting',
+        progress: status(null).sending.progress,
+      },
+    });
+    expect(result.current).toBeNull();
+    rerender(status(45));
+    expect(result.current).toBe('About 1 minute left');
+  });
+});

--- a/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.test.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.test.ts
@@ -18,15 +18,15 @@ function status(
 }
 
 describe('useSendingEta', () => {
-  it('shows a calculating label until an active phase has an estimate', () => {
+  it('hides the time label until an active phase has an estimate', () => {
     const { result, rerender } = renderHook(useSendingEta, {
       initialProps: undefined as EmailSendingStatus | undefined,
     });
     expect(result.current).toBeNull();
     rerender(status(null, 'preparing'));
-    expect(result.current).toBe('Calculating time remaining...');
+    expect(result.current).toBeNull();
     rerender(status(null, 'submitting'));
-    expect(result.current).toBe('Calculating time remaining...');
+    expect(result.current).toBeNull();
     rerender(status(30));
     expect(result.current).toBe('Less than 1 minute left');
   });
@@ -70,7 +70,7 @@ describe('useSendingEta', () => {
     rerender(status(35, 'submitting', 'email-2'));
     expect(result.current).toBe('Less than 1 minute left');
     rerender(status(null, 'submitting', 'email-2'));
-    expect(result.current).toBe('Calculating time remaining...');
+    expect(result.current).toBeNull();
     rerender(status(45, 'submitting', 'email-2'));
     expect(result.current).toBe('About 1 minute left');
     rerender(status(0, 'submitted', 'email-2'));

--- a/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { formatNumber } from '@tryghost/shade/utils';
+import type { EmailSendingStatus } from '@tryghost/admin-x-framework/api/emails';
+
+// Keep the current label within ten seconds of its usual boundaries.
+const THRESHOLD_BUFFER_SECONDS = 10;
+
+const label = (seconds: number): number => (seconds <= 40 ? 0 : Math.round(seconds / 60));
+
+function etaMinutes(seconds: number, previous: number | null): number {
+  const keep =
+    previous !== null &&
+    label(seconds - THRESHOLD_BUFFER_SECONDS) <= previous &&
+    previous <= label(seconds + THRESHOLD_BUFFER_SECONDS);
+  return keep ? previous : label(seconds);
+}
+
+export function useSendingEta(status: EmailSendingStatus | undefined): string | null {
+  const sending = status?.sending;
+  const key = status ? `${status.id}:${status.sending.status}` : null;
+  const seconds =
+    sending?.status === 'preparing' || sending?.status === 'submitting'
+      ? sending.progress.estimated_seconds_remaining
+      : null;
+  const [previous, setPrevious] = useState<{ key: string | null; minutes: number | null }>({
+    key: null,
+    minutes: null,
+  });
+  const minutes =
+    seconds === null ? null : etaMinutes(seconds, previous.key === key ? previous.minutes : null);
+
+  // Adjust during render so a changed email/phase never flashes the old label.
+  if (previous.key !== key || previous.minutes !== minutes) {
+    setPrevious({ key, minutes });
+  }
+
+  if (minutes === null) {
+    return null;
+  }
+  return minutes === 0
+    ? 'Less than 1 minute left'
+    : `About ${formatNumber(minutes)} ${minutes === 1 ? 'minute' : 'minutes'} left`;
+}

--- a/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.ts
@@ -33,7 +33,7 @@ export function useSendingEta(status: EmailSendingStatus | undefined): string | 
   }
 
   if (minutes === null) {
-    return isActive ? 'Calculating time remaining...' : null;
+    return null;
   }
   return minutes === 0
     ? 'Less than 1 minute left'

--- a/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.ts
+++ b/apps/admin/src/posts/analytics/email-sending-status/use-sending-eta.ts
@@ -18,10 +18,8 @@ function etaMinutes(seconds: number, previous: number | null): number {
 export function useSendingEta(status: EmailSendingStatus | undefined): string | null {
   const sending = status?.sending;
   const key = status ? `${status.id}:${status.sending.status}` : null;
-  const seconds =
-    sending?.status === 'preparing' || sending?.status === 'submitting'
-      ? sending.progress.estimated_seconds_remaining
-      : null;
+  const isActive = sending?.status === 'preparing' || sending?.status === 'submitting';
+  const seconds = isActive ? sending.progress.estimated_seconds_remaining : null;
   const [previous, setPrevious] = useState<{ key: string | null; minutes: number | null }>({
     key: null,
     minutes: null,
@@ -35,7 +33,7 @@ export function useSendingEta(status: EmailSendingStatus | undefined): string | 
   }
 
   if (minutes === null) {
-    return null;
+    return isActive ? 'Calculating time remaining...' : null;
   }
   return minutes === 0
     ? 'Less than 1 minute left'

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -274,6 +274,38 @@ describe('Post analytics overview', () => {
     await expect.element(page.getByRole('button', { name: /View members/ }).first()).toBeEnabled();
   });
 
+  it('shows a calculating label until a sending estimate is available', async () => {
+    seedPostAnalyticsWorld({
+      email: { id: EMAIL_ID, email_count: 1000, opened_count: 0, status: 'submitting' },
+    });
+    let estimate: number | null = null;
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => ({
+      email_statuses: [
+        {
+          id: EMAIL_ID,
+          sending: {
+            status: 'submitting',
+            progress: { completed: 250, total: 1000, estimated_seconds_remaining: estimate },
+          },
+        },
+      ],
+    }));
+
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    await expect
+      .element(postAnalyticsScreen.emailSendingStatusBanner())
+      .toHaveTextContent('Sending emails · 250 of 1,000 · Calculating time remaining...');
+    estimate = 30;
+    await expect
+      .element(postAnalyticsScreen.emailSendingStatusBanner())
+      .toHaveTextContent('Sending emails · 250 of 1,000 · Less than 1 minute left');
+    await expect.element(page.getByText(/Calculating time remaining/)).not.toBeInTheDocument();
+  });
+
   it('moves a failed send and its retry action into the banner', async () => {
     const postOverrides = {
       email: {

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -274,7 +274,7 @@ describe('Post analytics overview', () => {
     await expect.element(page.getByRole('button', { name: /View members/ }).first()).toBeEnabled();
   });
 
-  it('shows a calculating label until a sending estimate is available', async () => {
+  it('shows only recipient counts until a sending estimate is available', async () => {
     seedPostAnalyticsWorld({
       email: { id: EMAIL_ID, email_count: 1000, opened_count: 0, status: 'submitting' },
     });
@@ -298,12 +298,11 @@ describe('Post analytics overview', () => {
 
     await expect
       .element(postAnalyticsScreen.emailSendingStatusBanner())
-      .toHaveTextContent('Sending emails · 250 of 1,000 · Calculating time remaining...');
+      .toHaveTextContent('Sending emails · 250 of 1,000');
     estimate = 30;
     await expect
       .element(postAnalyticsScreen.emailSendingStatusBanner())
       .toHaveTextContent('Sending emails · 250 of 1,000 · Less than 1 minute left');
-    await expect.element(page.getByText(/Calculating time remaining/)).not.toBeInTheDocument();
   });
 
   it('moves a failed send and its retry action into the banner', async () => {

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -22,8 +22,9 @@ attempts, so a retried email reports submitting with frozen progress while it
 waits for its job, and `failed_during` is the same derivation applied to a
 failed email.
 
-The rough ETA uses recent batch timings, accounts for recipient counts, and
-filters timing outliers. It stays `null` until enough samples are available in
+The rough ETA uses recent batch timings and accounts for recipient counts.
+Preparation filters timing outliers; submission measures combined throughput
+across concurrent workers. It stays `null` until enough samples are available in
 the current phase and attempt, so short sends may finish without showing an ETA.
 Progress counts update independently of the estimate.
 

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -22,15 +22,15 @@ attempts, so a retried email reports submitting with frozen progress while it
 waits for its job, and `failed_during` is the same derivation applied to a
 failed email.
 
-The rough ETA extrapolates from a rolling window of recently completed batches:
-their creation times while preparing and their update times while submitting.
-It is `0` once nothing remains in the current phase, always `null` for failed
-emails, and otherwise `null` until at least two batches with distinct
-timestamps have completed in the current attempt. A batch that failed during
-the current attempt is only retried together with its email, so it does not
-count as remaining work; the ETA can therefore reach `0` while completed is
-still below total, and consumers should key completion on the status, never
-on the ETA.
+The rough ETA uses recent batch timings, accounts for recipient counts, and
+filters timing outliers. It stays `null` until enough samples are available in
+the current phase and attempt, so short sends may finish without showing an ETA.
+Progress counts update independently of the estimate.
+
+The ETA is always `null` for failed emails and `0` once no work remains in the
+current phase. Batches that failed during the current attempt are not remaining
+work until the email is retried, so the ETA can reach `0` while completed is
+still below total. Consumers should key completion on the status, never the ETA.
 
 Ghost does not record when a sending attempt or phase started, so the ETA uses
 the email's `updated_at` as a proxy for the start of the current attempt: the

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -22,9 +22,8 @@ attempts, so a retried email reports submitting with frozen progress while it
 waits for its job, and `failed_during` is the same derivation applied to a
 failed email.
 
-The rough ETA uses recent batch timings and accounts for recipient counts.
-Preparation filters timing outliers; submission measures combined throughput
-across concurrent workers. It stays `null` until enough samples are available in
+The rough ETA measures recent recipient throughput, including work completed by
+concurrent workers. It stays `null` until enough timing samples are available in
 the current phase and attempt, so short sends may finish without showing an ETA.
 Progress counts update independently of the estimate.
 

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { StoredSendingStatus } from './sending-status-schema';
 
-const ETA_BATCH_WINDOW = 20;
+const ETA_COMPLETION_WINDOW = 20;
 const ETA_MIN_INTERVALS = 5;
 
 export const SendingPhase = z.enum(['preparing', 'submitting']);
@@ -90,6 +90,7 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
       completed,
       total,
       estimatedSecondsRemaining: estimateSecondsRemaining({
+        phase,
         remaining,
         samples,
         attemptStartedAt,
@@ -112,10 +113,12 @@ function failedDuringAttempt(batch: SendingBatch, attemptStartedAt: number | nul
 }
 
 function estimateSecondsRemaining({
+  phase,
   remaining,
   samples,
   attemptStartedAt,
 }: {
+  phase: SendingPhase;
   remaining: number;
   samples: BatchSample[];
   attemptStartedAt: number | null;
@@ -124,19 +127,18 @@ function estimateSecondsRemaining({
     return 0;
   }
 
-  const window = samples
+  const sorted = samples
     .filter(
       (sample) =>
         sample.recipientCount > 0 &&
         (attemptStartedAt === null || sample.timestamp >= attemptStartedAt),
     )
-    .sort((a, b) => a.timestamp - b.timestamp)
-    .slice(-ETA_BATCH_WINDOW);
+    .sort((a, b) => a.timestamp - b.timestamp);
 
   // Coalesce completions sharing a timestamp so database timestamp precision does
   // not turn their recipients into zero-duration samples or make row order matter.
   const completions: BatchSample[] = [];
-  for (const sample of window) {
+  for (const sample of sorted) {
     const previous = completions.at(-1);
     if (previous?.timestamp === sample.timestamp) {
       previous.recipientCount += sample.recipientCount;
@@ -145,27 +147,34 @@ function estimateSecondsRemaining({
     }
   }
 
-  const intervals = completions.slice(1).map((sample, index) => {
-    const seconds = (sample.timestamp - completions[index].timestamp) / 1000;
+  // Limit usable timestamps, not rows: fast sends may finish many batches per timestamp.
+  const window = completions.slice(-ETA_COMPLETION_WINDOW);
+  const intervals = window.slice(1).map((sample, index) => {
+    const seconds = (sample.timestamp - window[index].timestamp) / 1000;
     return {
       recipientCount: sample.recipientCount,
       seconds,
       rate: seconds / sample.recipientCount,
     };
   });
-  // Avoid publishing a startup estimate before outlier filtering has enough evidence.
+  // Wait for enough timing evidence before publishing a startup estimate.
   if (intervals.length < ETA_MIN_INTERVALS) {
     return null;
   }
 
-  // Compare time per recipient, not batch duration: a larger batch is expected
-  // to take longer.
-  const rates = intervals.map((interval) => interval.rate).sort((a, b) => a - b);
-  const middle = Math.floor(rates.length / 2);
-  const median = rates.length % 2 === 0 ? (rates[middle - 1] + rates[middle]) / 2 : rates[middle];
-  const retained = intervals.filter(
-    (interval) => interval.rate >= median / 3 && interval.rate <= median * 3,
-  );
+  // Preparation is sequential, so each gap describes the next group's work.
+  // Submission workers overlap: a tiny gap can belong to a large batch that ran
+  // alongside another. Keep all submission completions to measure aggregate
+  // throughput rather than mistaking worker overlap for timing outliers.
+  let retained = intervals;
+  if (phase === 'preparing') {
+    const rates = intervals.map((interval) => interval.rate).sort((a, b) => a - b);
+    const middle = Math.floor(rates.length / 2);
+    const median = rates.length % 2 === 0 ? (rates[middle - 1] + rates[middle]) / 2 : rates[middle];
+    retained = intervals.filter(
+      (interval) => interval.rate >= median / 3 && interval.rate <= median * 3,
+    );
+  }
 
   // The first completion is only the time baseline; its recipients were
   // processed before the measured interval. Weight retained timings by recipients.

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { StoredSendingStatus } from './sending-status-schema';
 
 const ETA_BATCH_WINDOW = 20;
+const ETA_MIN_INTERVALS = 5;
 
 export const SendingPhase = z.enum(['preparing', 'submitting']);
 export type SendingPhase = z.infer<typeof SendingPhase>;
@@ -132,18 +133,43 @@ function estimateSecondsRemaining({
     .sort((a, b) => a.timestamp - b.timestamp)
     .slice(-ETA_BATCH_WINDOW);
 
-  if (window.length < 2) {
+  // Coalesce completions sharing a timestamp so database timestamp precision does
+  // not turn their recipients into zero-duration samples or make row order matter.
+  const completions: BatchSample[] = [];
+  for (const sample of window) {
+    const previous = completions.at(-1);
+    if (previous?.timestamp === sample.timestamp) {
+      previous.recipientCount += sample.recipientCount;
+    } else {
+      completions.push({ ...sample });
+    }
+  }
+
+  const intervals = completions.slice(1).map((sample, index) => {
+    const seconds = (sample.timestamp - completions[index].timestamp) / 1000;
+    return {
+      recipientCount: sample.recipientCount,
+      seconds,
+      rate: seconds / sample.recipientCount,
+    };
+  });
+  // Avoid publishing a startup estimate before outlier filtering has enough evidence.
+  if (intervals.length < ETA_MIN_INTERVALS) {
     return null;
   }
 
-  const elapsedSeconds = (window[window.length - 1].timestamp - window[0].timestamp) / 1000;
-  if (elapsedSeconds <= 0) {
-    return null;
-  }
+  // Compare time per recipient, not batch duration: a larger batch is expected
+  // to take longer.
+  const rates = intervals.map((interval) => interval.rate).sort((a, b) => a - b);
+  const middle = Math.floor(rates.length / 2);
+  const median = rates.length % 2 === 0 ? (rates[middle - 1] + rates[middle]) / 2 : rates[middle];
+  const retained = intervals.filter(
+    (interval) => interval.rate >= median / 3 && interval.rate <= median * 3,
+  );
 
-  const averageRecipientsPerBatch =
-    window.reduce((sum, sample) => sum + sample.recipientCount, 0) / window.length;
-  const recipientsPerSecond = (averageRecipientsPerBatch * (window.length - 1)) / elapsedSeconds;
-
-  return Math.ceil(remaining / recipientsPerSecond);
+  // The first completion is only the time baseline; its recipients were
+  // processed before the measured interval. Weight retained timings by recipients.
+  const seconds = retained.reduce((sum, interval) => sum + interval.seconds, 0);
+  const recipients = retained.reduce((sum, interval) => sum + interval.recipientCount, 0);
+  return Math.ceil((remaining * seconds) / recipients);
 }

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { StoredSendingStatus } from './sending-status-schema';
 
 const ETA_COMPLETION_WINDOW = 20;
-const ETA_MIN_INTERVALS = 5;
+const ETA_MIN_INTERVALS = 2;
 
 export const SendingPhase = z.enum(['preparing', 'submitting']);
 export type SendingPhase = z.infer<typeof SendingPhase>;
@@ -90,7 +90,6 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
       completed,
       total,
       estimatedSecondsRemaining: estimateSecondsRemaining({
-        phase,
         remaining,
         samples,
         attemptStartedAt,
@@ -113,12 +112,10 @@ function failedDuringAttempt(batch: SendingBatch, attemptStartedAt: number | nul
 }
 
 function estimateSecondsRemaining({
-  phase,
   remaining,
   samples,
   attemptStartedAt,
 }: {
-  phase: SendingPhase;
   remaining: number;
   samples: BatchSample[];
   attemptStartedAt: number | null;
@@ -149,36 +146,15 @@ function estimateSecondsRemaining({
 
   // Limit usable timestamps, not rows: fast sends may finish many batches per timestamp.
   const window = completions.slice(-ETA_COMPLETION_WINDOW);
-  const intervals = window.slice(1).map((sample, index) => {
-    const seconds = (sample.timestamp - window[index].timestamp) / 1000;
-    return {
-      recipientCount: sample.recipientCount,
-      seconds,
-      rate: seconds / sample.recipientCount,
-    };
-  });
-  // Wait for enough timing evidence before publishing a startup estimate.
-  if (intervals.length < ETA_MIN_INTERVALS) {
+  // Three distinct timestamps provide two measured intervals for an initial rate.
+  if (window.length < ETA_MIN_INTERVALS + 1) {
     return null;
   }
 
-  // Preparation is sequential, so each gap describes the next group's work.
-  // Submission workers overlap: a tiny gap can belong to a large batch that ran
-  // alongside another. Keep all submission completions to measure aggregate
-  // throughput rather than mistaking worker overlap for timing outliers.
-  let retained = intervals;
-  if (phase === 'preparing') {
-    const rates = intervals.map((interval) => interval.rate).sort((a, b) => a - b);
-    const middle = Math.floor(rates.length / 2);
-    const median = rates.length % 2 === 0 ? (rates[middle - 1] + rates[middle]) / 2 : rates[middle];
-    retained = intervals.filter(
-      (interval) => interval.rate >= median / 3 && interval.rate <= median * 3,
-    );
-  }
-
-  // The first completion is only the time baseline; its recipients were
-  // processed before the measured interval. Weight retained timings by recipients.
-  const seconds = retained.reduce((sum, interval) => sum + interval.seconds, 0);
-  const recipients = retained.reduce((sum, interval) => sum + interval.recipientCount, 0);
+  // Measure combined throughput across the window, including overlapping workers.
+  // The first completion is only the baseline: its recipients were processed
+  // before the measured time span.
+  const seconds = (window[window.length - 1].timestamp - window[0].timestamp) / 1000;
+  const recipients = window.slice(1).reduce((sum, sample) => sum + sample.recipientCount, 0);
   return Math.ceil((remaining * seconds) / recipients);
 }

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -133,7 +133,7 @@ describe('SendingStatusService', function () {
       id: 'email-id',
       sending: {
         status: 'submitting',
-        progress: { completed: 20, total: 25, estimatedSecondsRemaining: 5 },
+        progress: { completed: 20, total: 25, estimatedSecondsRemaining: null },
       },
     });
   });

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -45,11 +45,15 @@ describe('buildSendingStatus', function () {
     const batches = [
       batch({ status: 'pending', createdAt: '12:00:00' }),
       batch({ status: 'pending', createdAt: '12:00:10' }),
+      batch({ status: 'pending', createdAt: '12:00:20' }),
+      batch({ status: 'pending', createdAt: '12:00:30' }),
+      batch({ status: 'pending', createdAt: '12:00:40' }),
+      batch({ status: 'pending', createdAt: '12:00:50' }),
     ];
 
     assert.deepEqual(buildSendingStatus(email({ recipientCount: 100 }), batches), {
       status: 'preparing',
-      progress: { completed: 20, total: 100, estimatedSecondsRemaining: 80 },
+      progress: { completed: 60, total: 100, estimatedSecondsRemaining: 40 },
     });
   });
 
@@ -87,6 +91,10 @@ describe('buildSendingStatus', function () {
     const batches = [
       batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
       batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:20' }),
+      batch({ status: 'submitted', createdAt: '12:00:30', updatedAt: '12:01:30' }),
+      batch({ status: 'submitted', createdAt: '12:00:40', updatedAt: '12:01:40' }),
+      batch({ status: 'submitted', createdAt: '12:00:50', updatedAt: '12:01:50' }),
+      batch({ status: 'submitted', createdAt: '12:01:00', updatedAt: '12:02:00' }),
       batch({ status: 'pending', createdAt: '12:00:20' }),
     ];
 
@@ -94,7 +102,7 @@ describe('buildSendingStatus', function () {
       buildSendingStatus(email({ recipientCount: 50, attemptStartedAt: at('12:01:00') }), batches),
       {
         status: 'submitting',
-        progress: { completed: 20, total: 30, estimatedSecondsRemaining: 10 },
+        progress: { completed: 60, total: 70, estimatedSecondsRemaining: 10 },
       },
     );
   });
@@ -103,6 +111,10 @@ describe('buildSendingStatus', function () {
     const batches = [
       batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
       batch({ status: 'submitted', createdAt: '12:00:10', updatedAt: '12:01:10' }),
+      batch({ status: 'submitted', createdAt: '12:00:20', updatedAt: '12:01:20' }),
+      batch({ status: 'submitted', createdAt: '12:00:30', updatedAt: '12:01:30' }),
+      batch({ status: 'submitted', createdAt: '12:00:40', updatedAt: '12:01:40' }),
+      batch({ status: 'submitted', createdAt: '12:00:50', updatedAt: '12:01:50' }),
       batch({ status: 'failed', createdAt: '12:00:20', updatedAt: '12:01:15' }),
       batch({ status: 'pending', createdAt: '12:00:30' }),
     ];
@@ -112,8 +124,8 @@ describe('buildSendingStatus', function () {
       batches,
     );
     assert.deepEqual(result.progress, {
-      completed: 20,
-      total: 40,
+      completed: 60,
+      total: 80,
       estimatedSecondsRemaining: 10,
     });
   });
@@ -207,10 +219,14 @@ describe('buildSendingStatus', function () {
     const batches = [
       batch({ status: 'pending', createdAt: '12:00:00' }),
       batch({ status: 'pending', createdAt: '12:00:10' }),
+      batch({ status: 'pending', createdAt: '12:00:20' }),
+      batch({ status: 'pending', createdAt: '12:00:30' }),
+      batch({ status: 'pending', createdAt: '12:00:40' }),
+      batch({ status: 'pending', createdAt: '12:00:50' }),
     ];
 
     const result = buildSendingStatus(
-      email({ recipientCount: 30, attemptStartedAt: null }),
+      email({ recipientCount: 70, attemptStartedAt: null }),
       batches,
     );
     assert.equal(result.progress.estimatedSecondsRemaining, 10);
@@ -239,5 +255,84 @@ describe('buildSendingStatus', function () {
         progress: { completed: 10, total: 10, estimatedSecondsRemaining: 0 },
       },
     );
+  });
+  it('requires fresh intervals after the phase changes or an attempt restarts', function () {
+    const batches = Array.from({ length: 7 }, (_, index) =>
+      batch({ status: 'pending', createdAt: `12:00:${index}0`.replace('12:00:60', '12:01:00') }),
+    );
+    const currentEmail = email({ recipientCount: 100 });
+    assert.equal(buildSendingStatus(currentEmail, batches).progress.estimatedSecondsRemaining, 30);
+
+    for (let index = 0; index < 6; index += 1) {
+      batches[index].status = 'submitted';
+      batches[index].updatedAt = at(`12:02:${index}0`);
+      const result = buildSendingStatus(currentEmail, batches);
+      assert.equal(result.status, 'submitting');
+      assert.equal(result.progress.completed, (index + 1) * 10);
+      assert.equal(result.progress.estimatedSecondsRemaining, index < 5 ? null : 10);
+    }
+
+    assert.equal(
+      buildSendingStatus({ ...currentEmail, attemptStartedAt: at('12:02:10') }, batches).progress
+        .estimatedSecondsRemaining,
+      null,
+    );
+  });
+
+  describe('recipient-weighted estimates', function () {
+    function estimate(counts: number[], gaps: number[], remaining = 100) {
+      let timestamp = at('12:00:00').getTime();
+      const batches: SendingBatch[] = counts.map((recipientCount, index) => {
+        timestamp += (gaps[index] ?? 0) * 1000;
+        return {
+          status: 'pending',
+          recipientCount,
+          createdAt: new Date(timestamp),
+          updatedAt: new Date(timestamp),
+        };
+      });
+      return buildSendingStatus(
+        email({ recipientCount: counts.reduce((sum, count) => sum + count, remaining) }),
+        batches.reverse(),
+      ).progress.estimatedSecondsRemaining;
+    }
+
+    it('matches each interval to its recipients, excluding the baseline batch', function () {
+      assert.equal(estimate([1000, 10, 100, 10, 100, 10], [0, 1, 10, 1, 10, 1]), 10);
+      assert.equal(estimate([1, 100, 10, 100, 10, 100], [0, 10, 1, 10, 1, 10]), 10);
+    });
+
+    it('weights timings by recipient count rather than averaging rates', function () {
+      assert.equal(estimate([10, 10, 100, 10, 100, 10, 100], [0, 4, 20, 4, 20, 4, 20], 330), 72);
+    });
+
+    it('rejects isolated slow and fast per-recipient timings', function () {
+      assert.equal(estimate([10, 10, 10, 10, 10, 10, 10], [0, 10, 10, 100, 10, 0.1, 10]), 100);
+    });
+
+    it('retains large batches that take proportionally longer', function () {
+      assert.equal(estimate([10, 10, 10, 1000, 10, 10], [0, 10, 10, 1000, 10, 10]), 100);
+    });
+
+    it('withholds early estimates and filters the startup spike from the first estimate', function () {
+      const counts = [10, 10, 10, 10, 10, 10];
+      const gaps = [0, 100, 10, 10, 10, 10];
+      for (let completed = 1; completed < counts.length; completed += 1) {
+        assert.equal(estimate(counts.slice(0, completed), gaps.slice(0, completed)), null);
+      }
+      assert.equal(estimate(counts, gaps), 100);
+    });
+
+    it('combines simultaneous completions without losing their recipients', function () {
+      assert.equal(estimate([10, 20, 30, 50, 50, 50, 50], [0, 10, 0, 10, 10, 10, 10]), 20);
+      assert.equal(estimate([10, 20], [0, 0]), null);
+      assert.equal(estimate(Array(10).fill(10), [0, 10, 0, 10, 0, 10, 0, 10, 0, 0]), null);
+    });
+
+    it('adapts to sustained slowdowns as old batches leave the window', function () {
+      const counts = Array(40).fill(10);
+      const gaps = [...Array(20).fill(1), ...Array(20).fill(10)];
+      assert.equal(estimate(counts, gaps), 100);
+    });
   });
 });

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -279,6 +279,52 @@ describe('buildSendingStatus', function () {
     );
   });
 
+  it('retains overlapping worker completions when estimating submission throughput', function () {
+    // One worker completes small batches regularly; the other finishes a large
+    // batch just after one of them. Both workers' recipients count as throughput.
+    const batches = [
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:00' }),
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:10' }),
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:20' }),
+      batch({
+        status: 'submitted',
+        createdAt: '12:00:00',
+        updatedAt: '12:01:20.100',
+        recipientCount: 1000,
+      }),
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:30' }),
+      batch({ status: 'submitted', createdAt: '12:00:00', updatedAt: '12:01:40' }),
+      batch({ status: 'pending', createdAt: '12:00:00', recipientCount: 1040 }),
+    ];
+    assert.equal(
+      buildSendingStatus(email({ recipientCount: 2090 }), batches).progress
+        .estimatedSecondsRemaining,
+      40,
+    );
+  });
+
+  it('limits distinct completion samples rather than rows for high-throughput sends', function () {
+    for (const status of ['pending', 'submitted'] as const) {
+      const completed = Array.from({ length: 30 }, (_, index) =>
+        batch({ status, createdAt: `12:00:0${Math.floor(index / 5)}` }),
+      );
+      // Five batches per second gives 50 recipients/second. The last 20 rows
+      // alone only span four timestamps, despite six being available.
+      const batches =
+        status === 'pending'
+          ? completed
+          : [
+              ...completed,
+              batch({ status: 'pending', createdAt: '12:00:00', recipientCount: 100 }),
+            ];
+      assert.equal(
+        buildSendingStatus(email({ recipientCount: 400 }), batches.reverse()).progress
+          .estimatedSecondsRemaining,
+        2,
+      );
+    }
+  });
+
   describe('recipient-weighted estimates', function () {
     function estimate(counts: number[], gaps: number[], remaining = 100) {
       let timestamp = at('12:00:00').getTime();

--- a/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status.test.ts
@@ -269,11 +269,11 @@ describe('buildSendingStatus', function () {
       const result = buildSendingStatus(currentEmail, batches);
       assert.equal(result.status, 'submitting');
       assert.equal(result.progress.completed, (index + 1) * 10);
-      assert.equal(result.progress.estimatedSecondsRemaining, index < 5 ? null : 10);
+      assert.equal(result.progress.estimatedSecondsRemaining, index < 2 ? null : (6 - index) * 10);
     }
 
     assert.equal(
-      buildSendingStatus({ ...currentEmail, attemptStartedAt: at('12:02:10') }, batches).progress
+      buildSendingStatus({ ...currentEmail, attemptStartedAt: at('12:02:40') }, batches).progress
         .estimatedSecondsRemaining,
       null,
     );
@@ -306,10 +306,10 @@ describe('buildSendingStatus', function () {
   it('limits distinct completion samples rather than rows for high-throughput sends', function () {
     for (const status of ['pending', 'submitted'] as const) {
       const completed = Array.from({ length: 30 }, (_, index) =>
-        batch({ status, createdAt: `12:00:0${Math.floor(index / 5)}` }),
+        batch({ status, createdAt: `12:00:0${Math.floor(index / 10)}` }),
       );
-      // Five batches per second gives 50 recipients/second. The last 20 rows
-      // alone only span four timestamps, despite six being available.
+      // Ten batches per second gives 100 recipients/second. The last 20 rows
+      // alone only span two timestamps, despite three being available.
       const batches =
         status === 'pending'
           ? completed
@@ -320,7 +320,7 @@ describe('buildSendingStatus', function () {
       assert.equal(
         buildSendingStatus(email({ recipientCount: 400 }), batches.reverse()).progress
           .estimatedSecondsRemaining,
-        2,
+        1,
       );
     }
   });
@@ -352,27 +352,30 @@ describe('buildSendingStatus', function () {
       assert.equal(estimate([10, 10, 100, 10, 100, 10, 100], [0, 4, 20, 4, 20, 4, 20], 330), 72);
     });
 
-    it('rejects isolated slow and fast per-recipient timings', function () {
-      assert.equal(estimate([10, 10, 10, 10, 10, 10, 10], [0, 10, 10, 100, 10, 0.1, 10]), 100);
+    it('includes both slow and fast completions in aggregate throughput', function () {
+      assert.equal(estimate([10, 10, 10, 10, 10, 10, 10], [0, 10, 10, 100, 10, 0.1, 10]), 234);
     });
 
     it('retains large batches that take proportionally longer', function () {
       assert.equal(estimate([10, 10, 10, 1000, 10, 10], [0, 10, 10, 1000, 10, 10]), 100);
     });
 
-    it('withholds early estimates and filters the startup spike from the first estimate', function () {
-      const counts = [10, 10, 10, 10, 10, 10];
-      const gaps = [0, 100, 10, 10, 10, 10];
-      for (let completed = 1; completed < counts.length; completed += 1) {
-        assert.equal(estimate(counts.slice(0, completed), gaps.slice(0, completed)), null);
-      }
-      assert.equal(estimate(counts, gaps), 100);
+    it('starts estimating after two measured intervals', function () {
+      assert.equal(estimate([10], [0]), null);
+      assert.equal(estimate([10, 10], [0, 10]), null);
+      assert.equal(estimate([10, 10, 10], [0, 10, 10]), 100);
+      assert.equal(estimate([10, 10, 10], [0, 100, 10]), 550);
+    });
+
+    it('smooths a slow interval as more completions enter the window', function () {
+      assert.equal(estimate([10, 10, 10, 10, 10], [0, 100, 10, 10, 10]), 325);
+      assert.equal(estimate([10, 10, 10, 10, 10, 10], [0, 100, 10, 10, 10, 10]), 280);
     });
 
     it('combines simultaneous completions without losing their recipients', function () {
       assert.equal(estimate([10, 20, 30, 50, 50, 50, 50], [0, 10, 0, 10, 10, 10, 10]), 20);
       assert.equal(estimate([10, 20], [0, 0]), null);
-      assert.equal(estimate(Array(10).fill(10), [0, 10, 0, 10, 0, 10, 0, 10, 0, 0]), null);
+      assert.equal(estimate(Array(10).fill(10), [0, 10, 0, 0, 0, 0, 0, 0, 0, 0]), null);
     });
 
     it('adapts to sustained slowdowns as old batches leave the window', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3928/

Email sending estimates could jump when batches differed in size or timing, and small fluctuations could repeatedly switch the displayed time label.

Both preparation and submission estimate remaining time from recent recipient throughput, including concurrent worker completions. Completions sharing a timestamp are combined before limiting the sample window, so fast sends retain enough timing observations. Estimates start after two measured intervals (three distinct completion timestamps) in the current phase and attempt. The banner shows recipient counts immediately and adds the ETA once enough timing data is available; short sends may finish showing only counts.

The client adds a 10-second buffer around label thresholds to avoid bouncing between labels while still reflecting real slowdowns. Label history resets when the email, phase, or estimate availability changes.



