### PR TITLE
Improved the email sending status UI in post analytics

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -18,6 +18,16 @@
   }
 }
 
+@keyframes email-sending-fill-rise {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0%);
+  }
+}
+
 /* The shell owns rollout eligibility. Admin overlays mount beside #root, so
    mirror typography into Shade portals and the three legacy overlay hosts.
    Do not set body fonts or change component weights, sizes, or line heights. */
@@ -104,6 +114,7 @@
    settings/custom-fonts.css in the settings chunk. */
 @theme {
   --animate-email-sending-arrow-rise: email-sending-arrow-rise 1200ms linear infinite;
+  --animate-email-sending-fill-rise: email-sending-fill-rise 1200ms linear infinite;
   --font-cardo: Cardo;
   --font-manrope: Manrope;
   --font-merriweather: Merriweather;

--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -17,9 +17,28 @@ const formatEta = (seconds: number): string => {
   return 'Less than 1 minute left';
 };
 
-const HalfFullGlyph = () => (
+const FILL_CLIP_ID = 'email-sending-fill-clip';
+
+/** A grey level rising over a white face and dropping back, on the arrow's tempo. */
+const FillingGlyph = () => (
   <svg aria-hidden="true" fill="none" height="12" viewBox="0 0 12 12" width="12">
-    <path d="M1.2 6 A4.8 4.8 0 0 1 10.8 6 Z" fill="currentColor" />
+    {/* Wider than the 4.8 face: cut to the same radius, the two anti-aliased
+        edges stack and the white bleeds through as a pale ring. */}
+    <clipPath id={FILL_CLIP_ID}>
+      <circle cx="6" cy="6" r="5.1" />
+    </clipPath>
+    <circle cx="6" cy="6" fill="currentColor" r="4.8" />
+    {/* Clip on the group, animation on the child: a transform on a clipped
+        element carries its own clip path along with it. */}
+    <g clipPath={`url(#${FILL_CLIP_ID})`}>
+      <rect
+        className="animate-email-sending-fill-rise fill-muted-foreground motion-reduce:translate-y-1/2 motion-reduce:animate-none"
+        height="12"
+        width="12"
+        x="0"
+        y="0"
+      />
+    </g>
   </svg>
 );
 
@@ -27,7 +46,7 @@ const StatusGlyph = ({ sending }: { sending: EmailSendingState }) => {
   if (sending.status === 'preparing') {
     return (
       <span className="relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted-foreground text-white ring-1 ring-muted-foreground ring-offset-1 ring-offset-background">
-        <HalfFullGlyph />
+        <FillingGlyph />
       </span>
     );
   }
@@ -59,8 +78,7 @@ const activeDetail = (sending: Exclude<EmailSendingState, { status: 'failed' }>)
 
   return (
     <>
-      <span className="inline-block min-w-[7ch] text-right">{formatNumber(completed)}</span>
-      {` of ${formatNumber(total)}`}
+      {`${formatNumber(completed)} of ${formatNumber(total)}`}
       {estimate && ` · ${estimate}`}
     </>
   );

--- a/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
@@ -358,14 +358,15 @@ const Newsletter: React.FC = () => {
                   className={`grid ${chartHeaderClass} items-stretch border-b ${isNewsletterDataHidden ? 'pointer-events-none opacity-40' : ''}`}
                 >
                   <KpiCard className="group relative isolate grow p-3 md:px-6 md:py-5">
-                    <KpiCardMoreButton
-                      disabled={isNewsletterDataHidden}
-                      onClick={() => {
-                        navigateToMembers(`emails.post_id:${postId}`);
-                      }}
-                    >
-                      View members &rarr;
-                    </KpiCardMoreButton>
+                    {!isNewsletterDataHidden && (
+                      <KpiCardMoreButton
+                        onClick={() => {
+                          navigateToMembers(`emails.post_id:${postId}`);
+                        }}
+                      >
+                        View members &rarr;
+                      </KpiCardMoreButton>
+                    )}
                     <KpiCardLabel
                       onClick={() => {
                         navigateToMembers(`emails.post_id:${postId}`);
@@ -383,14 +384,15 @@ const Newsletter: React.FC = () => {
 
                   {emailTrackOpensEnabled && (
                     <KpiCard className="p-3 md:px-6 md:py-5">
-                      <KpiCardMoreButton
-                        disabled={isNewsletterDataHidden}
-                        onClick={() => {
-                          navigateToMembers(`opened_emails.post_id:${postId}`);
-                        }}
-                      >
-                        View members &rarr;
-                      </KpiCardMoreButton>
+                      {!isNewsletterDataHidden && (
+                        <KpiCardMoreButton
+                          onClick={() => {
+                            navigateToMembers(`opened_emails.post_id:${postId}`);
+                          }}
+                        >
+                          View members &rarr;
+                        </KpiCardMoreButton>
+                      )}
                       <KpiCardLabel
                         onClick={() => {
                           navigateToMembers(`opened_emails.post_id:${postId}`);
@@ -409,14 +411,15 @@ const Newsletter: React.FC = () => {
 
                   {emailTrackClicksEnabled && (
                     <KpiCard className="group relative isolate grow p-3 md:px-6 md:py-5">
-                      <KpiCardMoreButton
-                        disabled={isNewsletterDataHidden}
-                        onClick={() => {
-                          navigateToMembers(`clicked_links.post_id:${postId}`);
-                        }}
-                      >
-                        View members &rarr;
-                      </KpiCardMoreButton>
+                      {!isNewsletterDataHidden && (
+                        <KpiCardMoreButton
+                          onClick={() => {
+                            navigateToMembers(`clicked_links.post_id:${postId}`);
+                          }}
+                        >
+                          View members &rarr;
+                        </KpiCardMoreButton>
+                      )}
                       <KpiCardLabel
                         onClick={() => {
                           navigateToMembers(`clicked_links.post_id:${postId}`);

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -254,7 +254,9 @@ describe('Post analytics overview', () => {
     await expect
       .element(page.getByText('Sends, opens and clicks will appear once every email has been sent'))
       .toBeVisible();
-    await expect.element(page.getByRole('button', { name: /View members/ }).first()).toBeDisabled();
+    await expect
+      .element(page.getByRole('button', { name: /View members/ }).first())
+      .not.toBeInTheDocument();
 
     completeSending = true;
     const pendingStatusRequestCount = statusRequestCount;


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3928/design-cleanup

Animates the preparing glyph as a filling level so the state reads as underway, and drops the counter's reserved width so the figure sits where it lands. Stops rendering the newsletter card's View members buttons while sending, where disabling them made them permanently half-visible instead of hidden.
