### PR TITLE
Fixed timing races in email flow acceptance tests

### DIFF
--- a/apps/admin/src/editor/publish/publish-flow.acceptance.test.tsx
+++ b/apps/admin/src/editor/publish/publish-flow.acceptance.test.tsx
@@ -194,8 +194,8 @@ describe('Publish flow', () => {
   it(
     'holds the confirm button through the email poll so the publish cannot be dispatched twice',
     async () => {
-      // Two polls, so the flow is still waiting when the assertions run.
-      fakeEmailPolling({ status: 'pending' }, { status: 'submitted' });
+      const email = { status: 'pending' };
+      fakeEmailPolling(email);
       const { dispatch } = await renderPublishFlow();
 
       await publishScreen.continueButton().click();
@@ -211,6 +211,8 @@ describe('Publish flow', () => {
         .toBe(true);
       expect(dispatch).toHaveBeenCalledTimes(1);
 
+      // Keep polling pending until the running button has been observed.
+      email.status = 'submitted';
       await expect.element(publishScreen.complete()).toBeInTheDocument();
       expect(dispatch).toHaveBeenCalledTimes(1);
     },

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -284,35 +284,37 @@ describe('Post analytics overview', () => {
     } as const;
     seedPostAnalyticsWorld(postOverrides);
     fakeSubmittingBatches();
-    let statusRequestCount = 0;
+    let hasRetried = false;
+    let hasCompleted = false;
     fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, () => {
-      statusRequestCount += 1;
       return {
         email_statuses: [
           {
             id: EMAIL_ID,
-            sending:
-              statusRequestCount === 1
+            sending: !hasRetried
+              ? {
+                  status: 'failed',
+                  failed_during: 'submitting',
+                  progress: { completed: 250, total: 1000, estimated_seconds_remaining: null },
+                }
+              : !hasCompleted
                 ? {
-                    status: 'failed',
-                    failed_during: 'submitting',
-                    progress: { completed: 250, total: 1000, estimated_seconds_remaining: null },
+                    status: 'submitting',
+                    progress: { completed: 250, total: 1000, estimated_seconds_remaining: 30 },
                   }
-                : statusRequestCount === 2
-                  ? {
-                      status: 'submitting',
-                      progress: { completed: 250, total: 1000, estimated_seconds_remaining: 30 },
-                    }
-                  : {
-                      status: 'submitted',
-                      progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
-                    },
+                : {
+                    status: 'submitted',
+                    progress: { completed: 1000, total: 1000, estimated_seconds_remaining: 0 },
+                  },
           },
         ],
       };
     });
-    const retryApi = fakeAdminEndpoint('PUT', `/emails/${EMAIL_ID}/retry/`, {
-      emails: [{ id: EMAIL_ID, email_count: 250, opened_count: 0, status: 'submitting' }],
+    const retryApi = fakeAdminEndpoint('PUT', `/emails/${EMAIL_ID}/retry/`, () => {
+      hasRetried = true;
+      return {
+        emails: [{ id: EMAIL_ID, email_count: 250, opened_count: 0, status: 'submitting' }],
+      };
     });
 
     await renderAdminApp(`/posts/analytics/${POST_ID}`, {
@@ -329,7 +331,8 @@ describe('Post analytics overview', () => {
     await page.getByRole('button', { name: 'Send remaining emails' }).click();
     await expect.poll(() => retryApi.requests.length).toBe(1);
     await expect.element(page.getByText('Sending emails')).toBeVisible();
-    await expect.poll(() => statusRequestCount, { timeout: 3500 }).toBeGreaterThan(2);
+    // Keep submission visible until asserted, regardless of how many polls CI runs.
+    hasCompleted = true;
     await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
no issue

The publish confirmation and analytics retry acceptance tests advanced fake email status on successive polls. On a busy CI runner, submission could finish before either test observed the intermediate UI, causing intermittent failures.

Both fakes now stay pending or submitting until the test has checked the running button or sending banner, then explicitly allow completion. The analytics fake also starts submission only when the retry request arrives.
