### PR TITLE
Changed collected metafield writes to report failures to their caller

### DIFF
--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -942,7 +942,10 @@ function setupGhostApi({ siteUrl = window.location.origin, apiUrl, apiKey }) {
         body.cadence = cadence;
       }
 
-      return makeRequest({
+      // Thrown rather than returned: `fetch` treats a refusal as a response, so a
+      // caller that only awaits this would carry on and tell the member their plan
+      // changed when it did not.
+      const res = await makeRequest({
         url,
         method: 'PUT',
         headers: {
@@ -950,6 +953,12 @@ function setupGhostApi({ siteUrl = window.location.origin, apiUrl, apiKey }) {
         },
         body: JSON.stringify(body),
       });
+
+      if (!res.ok) {
+        throw new Error('Failed to update subscription');
+      }
+
+      return res;
     },
 
     async offers() {

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -523,3 +523,49 @@ describe('Portal API plan checkout', () => {
     expect(body.cancelUrl).toBe('https://example.com/custom-cancel/');
   });
 });
+
+// `fetch` treats a refusal as a response rather than a failure, so an endpoint whose
+// caller only awaits it reads every refusal as success. This one matters more than most:
+// a member is told their plan changed and sent back to their account.
+describe('Portal API subscription update', () => {
+  const mockSubscriptionFetch = (response) => {
+    vi.spyOn(window, 'fetch').mockImplementation((url) => {
+      if (url.includes('/members/api/session/')) {
+        return Promise.resolve(new Response('identity-token', { status: 200 }));
+      }
+
+      return Promise.resolve(response);
+    });
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('rejects when the server refuses the change', async () => {
+    const ghostApi = setupGhostApi({ siteUrl: 'https://example.com' });
+    mockSubscriptionFetch(new Response('Tier is archived.', { status: 403 }));
+
+    await expect(
+      ghostApi.member.updateSubscription({
+        subscriptionId: 'sub_123',
+        tierId: 'tier_123',
+        cadence: 'month',
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('resolves with the response when the change is accepted', async () => {
+    const ghostApi = setupGhostApi({ siteUrl: 'https://example.com' });
+    const accepted = new Response(null, { status: 204 });
+    mockSubscriptionFetch(accepted);
+
+    await expect(
+      ghostApi.member.updateSubscription({
+        subscriptionId: 'sub_123',
+        tierId: 'tier_123',
+        cadence: 'month',
+      }),
+    ).resolves.toBe(accepted);
+  });
+});

--- a/ghost/core/core/server/services/members-metafields/bindings-service.ts
+++ b/ghost/core/core/server/services/members-metafields/bindings-service.ts
@@ -3,7 +3,7 @@ import logging from '@tryghost/logging';
 import type { Knex } from 'knex';
 import type { FieldType } from '@tryghost/metafield-types';
 import { INTERNAL } from './access';
-import { DbBoundField, FIELD_STATUS } from './schema';
+import { DbBoundField, FIELD_STATUS, type WrittenBy } from './schema';
 import type { MetafieldValuesService, PlannedWrite } from './values-service';
 
 const FIELDS_TABLE = 'members_metafields';
@@ -16,6 +16,9 @@ export interface BoundField {
   key: string;
   type: FieldType;
 }
+
+/** What a value's provenance is, once the port it came through has been resolved. */
+type Attribution = (binding: BoundField) => WrittenBy;
 
 /**
  * Where a source sends what it collected: a `port` is the name that source uses for a
@@ -64,62 +67,98 @@ export class MetafieldBindingsService {
   }
 
   /**
-   * Values arrive in the order they are to be applied: where two land in one field, the
-   * last of them is what the field holds.
+   * Values a processor collected on Ghost's behalf and sent back.
+   *
+   * Nobody supplied these in a sense the site can name — a payment page asked, and a
+   * machine reported the answers — so what is recorded against them is the binding that
+   * routed each one. That resolves back to the tier that asked, what it was collected
+   * as, and the field it landed in, which is everything worth knowing about how the
+   * value arrived.
    */
   async writeCollected(
     memberId: string,
     productId: string,
     collected: Array<{ port: string; value: unknown }>,
   ): Promise<void> {
-    for (const { port, value } of collected) {
-      const destination = await this.resolve(productId, port);
-      if (!destination) {
-        continue;
+    return this.writeThrough(memberId, productId, collected, (binding) => ({
+      type: 'binding',
+      id: binding.bindingId,
+    }));
+  }
+
+  /**
+   * Values a member supplied about themselves, through the same ports a checkout uses.
+   *
+   * A member typing their own address into a form is answerable for it in a way no
+   * routing is, and a record saying a binding wrote it would be wrong. The member is the
+   * one whose record this is, so there is nobody else it could be.
+   */
+  async writeSuppliedByMember(
+    memberId: string,
+    productId: string,
+    supplied: Array<{ port: string; value: unknown }>,
+  ): Promise<void> {
+    return this.writeThrough(memberId, productId, supplied, () => ({
+      type: 'member',
+      id: memberId,
+    }));
+  }
+
+  /**
+   * Values arrive in the order they are to be applied: where two land in one field, the
+   * last of them is what the field holds.
+   *
+   * Every value is attempted, and then the first failure is raised. Attempting them all
+   * is this method's business: one refused answer must not cost a publisher the address
+   * a courier needs, and the values have nothing to do with each other beyond arriving
+   * together. Whether the failure is worth acting on is the caller's, which is why it
+   * leaves here rather than being logged and forgotten — a checkout webhook has already
+   * taken the money and must never fail, while a member filling in a form is owed the
+   * news.
+   */
+  private async writeThrough(
+    memberId: string,
+    productId: string,
+    values: Array<{ port: string; value: unknown }>,
+    attribute: Attribution,
+  ): Promise<void> {
+    let failure: unknown;
+
+    for (const { port, value } of values) {
+      try {
+        // Inside, because working out where a value goes can fail the same way storing
+        // it can, and a value nobody could place is no more reason to abandon the rest
+        // than one nobody could store.
+        const destination = await this.resolve(productId, port);
+        if (!destination) {
+          continue;
+        }
+        await this.writeOne(memberId, destination, value, attribute);
+      } catch (err) {
+        failure = failure ?? err;
       }
-      await this.writeOne(memberId, destination, value);
+    }
+
+    if (failure) {
+      throw failure;
     }
   }
 
-  private async writeOne(memberId: string, into: BoundField, value: unknown): Promise<void> {
-    let planned: PlannedWrite[];
-    try {
-      // Internal: a value collected by Stripe at checkout is written on nobody's
-      // behalf, and what may be set is bounded by the binding rather than by who
-      // is looking.
-      planned = await this.values.planWrite(
-        { [`${CUSTOM_NAMESPACE}.${into.key}`]: value },
-        INTERNAL,
-      );
-    } catch (err) {
-      logging.warn(
-        {
-          event: { name: 'members.metafields.collected_value_rejected' },
-          err,
-          memberId,
-          metafieldKey: into.key,
-        },
-        'A collected value could not be saved',
-      );
-      return;
-    }
+  private async writeOne(
+    memberId: string,
+    into: BoundField,
+    value: unknown,
+    attribute: Attribution,
+  ): Promise<void> {
+    // Internal: what may be set is bounded by the binding rather than by who is
+    // looking. A port exists because a publisher pointed it at a field, and that
+    // decision is what admits the value, whoever supplied it.
+    const planned: PlannedWrite[] = await this.values.planWrite(
+      { [`${CUSTOM_NAMESPACE}.${into.key}`]: value },
+      INTERNAL,
+    );
 
-    try {
-      await this.values.applyWrite(memberId, planned, {
-        writtenBy: { type: 'binding', id: into.bindingId },
-      });
-    } catch (err) {
-      logging.error(
-        {
-          event: { name: 'members.metafields.collected_value_write_failed' },
-          err,
-          memberId,
-          metafieldKey: into.key,
-          bindingId: into.bindingId,
-        },
-        'Failed to store a collected metafield value',
-      );
-    }
+    await this.values.applyWrite(memberId, planned, { writtenBy: attribute(into) });
   }
 
   private async resolve(productId: string, port: string): Promise<BoundField | null> {

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -1418,6 +1418,9 @@ describe('Members API', function () {
           },
         });
 
+        // The status matters as much as what was stored. Saving a value is allowed to
+        // fail, but failing the webhook is not: Stripe retries an event it could not
+        // deliver, which risks doing the payment work twice.
         await membersAgent
           .post('/webhooks/stripe/')
           .body(webhookPayload)
@@ -1428,7 +1431,8 @@ describe('Members API', function () {
               payload: webhookPayload,
               secret: process.env.WEBHOOK_SECRET,
             }),
-          );
+          )
+          .expectStatus(200);
 
         const { body } = await adminAgent.get(`/members/?search=${encodeURIComponent(email)}`);
         assert.equal(body.members.length, 1, 'The member was not created');
@@ -1534,6 +1538,30 @@ describe('Members API', function () {
         });
 
         assert.equal(member.metafields.custom[phone], '+447700900123');
+      });
+
+      // The values a session carries have nothing to do with each other beyond arriving
+      // together, so one the catalog refuses must not cost the publisher the rest. A
+      // shipping address is the case that matters: a courier needs it, and a t-shirt size
+      // typed too long is no reason to lose it.
+      it('keeps the values it can when one of them is refused', async function () {
+        const member = await sendCheckoutWebhook('checkout-partly-refused@email.com', {
+          custom_fields: [
+            { key: fieldKeys.question, type: 'text', text: { value: 'X'.repeat(300) } },
+          ],
+          shipping: { name: 'Bex Jones', address: { line1: '1 High Street', country: 'GB' } },
+        });
+
+        assert.equal(
+          member.metafields.custom[fieldKeys.question],
+          undefined,
+          'the answer too long to store was not stored',
+        );
+        assert.equal(member.metafields.custom[fieldKeys.recipient], 'Bex Jones');
+        assert.deepEqual(member.metafields.custom[fieldKeys.address], {
+          line1: '1 High Street',
+          country: 'GB',
+        });
       });
 
       // The member has already paid by the time this runs, so losing an answer must never

--- a/ghost/core/test/unit/server/services/members-metafields/bindings-service.test.ts
+++ b/ghost/core/test/unit/server/services/members-metafields/bindings-service.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import { MetafieldBindingsService } from '../../../../../core/server/services/members-metafields/bindings-service';
+
+// What a port resolves to. Every port here resolves to the same field, because where a
+// value lands is not what any of these are about.
+const BOUND_ROW = { binding_id: 'binding_1', key: 'delivery_address', type: 'short_text' };
+
+/**
+ * A stand-in for the query that resolves a port to the field it was bound to.
+ *
+ * Faked rather than run, because the resolving is not what is under test: these cover
+ * what the service does with a value once it knows where the value goes.
+ */
+const knexReturning = (row: unknown) => {
+  const chain = {
+    join: () => chain,
+    where: () => chain,
+    select: () => chain,
+    first: async () => row,
+  };
+  return (() => chain) as never;
+};
+
+interface Applied {
+  writtenBy: unknown;
+}
+
+/** Values the stubbed catalog refuses, named so a test can tell two refusals apart. */
+const REFUSED = /^refuse:/;
+
+/** Refuses anything named as refusable, and records everything it stores. */
+const recordingValues = (applied: Applied[]) =>
+  ({
+    planWrite: async (input: Record<string, unknown>) => {
+      const refused = Object.values(input).find(
+        (value) => typeof value === 'string' && REFUSED.test(value),
+      );
+      if (refused !== undefined) {
+        throw new Error(`the catalog refused ${refused}`);
+      }
+      return [];
+    },
+    applyWrite: async (_memberId: string, _planned: unknown[], options: Applied) => {
+      applied.push({ writtenBy: options.writtenBy });
+    },
+  }) as never;
+
+const serviceWriting = (applied: Applied[], row: unknown = BOUND_ROW) =>
+  new MetafieldBindingsService({ knex: knexReturning(row), values: recordingValues(applied) });
+
+const ADDRESS = { port: 'shipping_address', value: '1 High Street' };
+
+describe('MetafieldBindingsService', function () {
+  // Which of these a caller reaches for is how it states where a value came from, so
+  // there is no writer to pass, and none to get wrong.
+  describe('writeCollected', function () {
+    it('records the binding that routed the value', async function () {
+      const applied: Applied[] = [];
+
+      await serviceWriting(applied).writeCollected('member_1', 'tier_1', [ADDRESS]);
+
+      // The id resolves back to the tier that asked and the field it landed in, which
+      // is why only the service can supply it.
+      assert.deepEqual(applied, [{ writtenBy: { type: 'binding', id: 'binding_1' } }]);
+    });
+
+    it('attempts every value before raising a failure', async function () {
+      const applied: Applied[] = [];
+
+      await assert.rejects(
+        serviceWriting(applied).writeCollected('member_1', 'tier_1', [
+          { port: 'question', value: 'refuse:the answer' },
+          ADDRESS,
+        ]),
+        /refused refuse:the answer/,
+      );
+
+      // The point of raising afterwards rather than at once: the values have nothing to
+      // do with each other, so the good one is still stored.
+      assert.equal(applied.length, 1, 'the value that could be stored was stored');
+    });
+
+    it('attempts later values when working out where one of them goes fails', async function () {
+      const applied: Applied[] = [];
+      let lookups = 0;
+      const chain = {
+        join: () => chain,
+        where: () => chain,
+        select: () => chain,
+        first: async () => {
+          lookups += 1;
+          if (lookups === 1) {
+            throw new Error('the lookup failed');
+          }
+          return BOUND_ROW;
+        },
+      };
+      const service = new MetafieldBindingsService({
+        knex: (() => chain) as never,
+        values: recordingValues(applied),
+      });
+
+      // Finding where a value goes is a database query, and it can fail the way storing
+      // one can. Neither is a reason to give up on the values either side of it.
+      await assert.rejects(
+        service.writeCollected('member_1', 'tier_1', [{ port: 'question', value: 'x' }, ADDRESS]),
+        /the lookup failed/,
+      );
+
+      assert.equal(applied.length, 1, 'the value whose port did resolve was still stored');
+    });
+
+    it('raises the first failure rather than the last', async function () {
+      const applied: Applied[] = [];
+
+      // Two refusals, so this says which one is kept. The first is the one that has
+      // any chance of explaining the rest, and the later ones are often its echo.
+      await assert.rejects(
+        serviceWriting(applied).writeCollected('member_1', 'tier_1', [
+          { port: 'question', value: 'refuse:the first' },
+          { port: 'shipping_name', value: 'refuse:the second' },
+        ]),
+        /refused refuse:the first/,
+      );
+    });
+
+    it('says nothing when every value is stored', async function () {
+      const applied: Applied[] = [];
+
+      await serviceWriting(applied).writeCollected('member_1', 'tier_1', [
+        { port: 'shipping_name', value: 'Bex Jones' },
+        ADDRESS,
+      ]);
+
+      assert.equal(applied.length, 2);
+    });
+
+    it('skips a port that resolves to nothing', async function () {
+      const applied: Applied[] = [];
+
+      // A publisher who turned collection off leaves the processor still sending the
+      // value, and nowhere for it to go is not a failure. The same recording stub as
+      // every other test here, so an unwanted write would show up rather than being
+      // impossible to see.
+      await serviceWriting(applied, null).writeCollected('member_1', 'tier_1', [ADDRESS]);
+
+      assert.deepEqual(applied, [], 'nothing was written');
+    });
+  });
+
+  describe('writeSuppliedByMember', function () {
+    it('records the member whose record it is', async function () {
+      const applied: Applied[] = [];
+
+      await serviceWriting(applied).writeSuppliedByMember('member_1', 'tier_1', [ADDRESS]);
+
+      assert.deepEqual(applied, [{ writtenBy: { type: 'member', id: 'member_1' } }]);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When someone pays for a Ghost subscription, Stripe's payment page can also ask them for a delivery address or a phone number. Stripe sends the answers back by calling Ghost, and a mapping the publisher set up says which answer belongs in which of their member fields.

The code that saves those answers made two decisions that belong to whoever calls it. It threw away any answer that failed to save, writing a log line instead of reporting the failure. And it always recorded the publisher's mapping as the source of an answer, never a person.

One of those decisions had already been made elsewhere. Stripe retries a call that fails, which risks subscribing someone twice, so the code handling that call already wraps this work to guarantee it never fails. The saving code enforced the same guarantee first, which left that wrapper unable to see a save failure at all.

A second caller is now coming that needs the opposite on both counts. When a member types a delivery address into a form to move onto a tier that ships something, they have to be told if it did not save, and they have to be recorded as its source.

Separately, Portal — the signup and account window on a Ghost site — reports a refused plan change as a successful one. Its network helper hands back the server's refusal as an ordinary answer rather than raising an error, and the plan change is the one caller that never inspects the result. A member whose switch the server rejects, because their tier was archived after the page loaded, is told their plan changed and sent back to their account.

## Solution

Failures now leave the saving code, and the caller states who supplied an answer by choosing which operation it calls: one for answers a payment page collected, one for answers a member supplied about themselves. There is no writer to pass, and so none to get wrong.

Payments behave exactly as before. Every answer is still attempted before the first failure is raised, so one rejected answer does not cost the publisher the delivery address that arrived with it, and Stripe's call is still guaranteed not to fail — by the wrapper that always meant to do it, now the only thing doing so.

Portal raises the refusal, so the error handling already sitting around that call runs.

New tests cover the ordering, which failure is kept, both sources of an answer, a lookup that fails partway, the webhook still succeeding when a value is refused, and the refused plan change.

## Context

Groundwork for collecting a delivery address when a member who already pays switches to a tier that ships something: https://linear.app/ghost/issue/BER-3893/collect-custom-fields-when-an-existing-paid-member-changes-tier
