### PR TITLE
Remove content backups when deleting a staff user

### DIFF
--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -71,12 +71,6 @@ export interface PasswordUpdateResponseType {
   ];
 }
 
-export interface DeleteUserResponse {
-  meta: {
-    filename: string;
-  };
-}
-
 // Requests
 
 const dataType = usersDataType;
@@ -129,7 +123,7 @@ export const useEditUser = createMutation<UsersResponseType, User>({
   },
 });
 
-export const useDeleteUser = createMutation<DeleteUserResponse, string>({
+export const useDeleteUser = createMutation<void, string>({
   method: 'DELETE',
   path: (id) => `/users/${id}/`,
   updateQueries: {

--- a/apps/admin/src/settings/general/staff-actions.acceptance.test.tsx
+++ b/apps/admin/src/settings/general/staff-actions.acceptance.test.tsx
@@ -52,7 +52,7 @@ describe('Staff actions', () => {
     const owner = user('Owner');
     const author = user('Author');
     const { boot } = fakeStaffWorld({ currentUser: owner, users: [owner, author] });
-    const deleteApi = fakeAdminEndpoint('DELETE', `/users/${author.id}/`, {});
+    const deleteApi = fakeAdminEndpoint('DELETE', `/users/${author.id}/`, null, { status: 204 });
     await renderAdminApp(`/settings/staff/${author.slug}`, { boot });
 
     await chooseAction('Delete user');

--- a/ghost/core/core/server/api/endpoints/authentication.js
+++ b/ghost/core/core/server/api/endpoints/authentication.js
@@ -7,11 +7,10 @@ const web = require('../../web');
 const models = require('../../models');
 const auth = require('../../services/auth');
 const invitations = require('../../services/invitations');
-const dbBackup = require('../../data/db/backup');
 const apiMail = require('./index').mail;
 const apiSettings = require('./index').settings;
 const UsersService = require('../../services/users');
-const userService = new UsersService({ dbBackup, models, auth, apiMail, apiSettings });
+const userService = new UsersService({ models, auth, apiMail, apiSettings });
 const adapterManager = require('../../services/adapter-manager').default;
 const schedulerAdapter = adapterManager.getAdapter('scheduling');
 

--- a/ghost/core/core/server/api/endpoints/users.js
+++ b/ghost/core/core/server/api/endpoints/users.js
@@ -2,13 +2,12 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const permissionsService = require('../../services/permissions');
-const dbBackup = require('../../data/db/backup');
 const auth = require('../../services/auth');
 const apiMail = require('./index').mail;
 const apiSettings = require('./index').settings;
 const { rejectAdminApiRestrictedFieldsTransformer } = require('./utils/api-filter-utils');
 const UsersService = require('../../services/users');
-const userService = new UsersService({ dbBackup, models, auth, apiMail, apiSettings });
+const userService = new UsersService({ models, auth, apiMail, apiSettings });
 const ALLOWED_INCLUDES = ['count.posts', 'permissions', 'roles', 'roles.permissions'];
 const UNSAFE_ATTRS = ['status', 'roles'];
 
@@ -191,6 +190,7 @@ const controller = {
   },
 
   destroy: {
+    statusCode: 204,
     headers: {
       cacheInvalidate: true,
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/users.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/users.js
@@ -6,16 +6,6 @@ const messages = {
 };
 
 module.exports = {
-  destroy(filename, apiConfig, frame) {
-    debug('destroy');
-
-    frame.response = {
-      meta: {
-        filename: filename,
-      },
-    };
-  },
-
   changePassword(models, apiConfig, frame) {
     debug('changePassword');
 

--- a/ghost/core/core/server/services/users.js
+++ b/ghost/core/core/server/services/users.js
@@ -1,16 +1,10 @@
 // @ts-check
-const path = require('path');
 const ObjectId = require('bson-objectid').default;
 
 /**
  * @TODO: pass these in as dependencies
  */
 const DomainEvents = require('@tryghost/domain-events/lib/DomainEvents');
-
-/**
- * @typedef {Object} IdbBackup
- * @prop {() => Promise<string>} backup
- */
 
 /**
  * @typedef {Object} IModels
@@ -40,14 +34,12 @@ const DomainEvents = require('@tryghost/domain-events/lib/DomainEvents');
 class Users {
   /**
    * @param {Object} dependencies
-   * @param {IdbBackup} dependencies.dbBackup
    * @param {IModels} dependencies.models
    * @param {IAuth} dependencies.auth
    * @param {Object} dependencies.apiMail
    * @param {Object} dependencies.apiSettings
    */
-  constructor({ dbBackup, models, auth, apiMail, apiSettings }) {
-    this.dbBackup = dbBackup;
+  constructor({ models, auth, apiMail, apiSettings }) {
     this.models = models;
     this.auth = auth;
     this.apiMail = apiMail;
@@ -183,14 +175,6 @@ class Users {
    * @returns
    */
   async destroyUser(frameOptions) {
-    let filename = null;
-    const backupPath = await this.dbBackup.backup();
-
-    if (backupPath) {
-      const parsedFileName = path.parse(backupPath);
-      filename = `${parsedFileName.name}${parsedFileName.ext}`;
-    }
-
     return this.models.Base.transaction(async (t) => {
       frameOptions.transacting = t;
 
@@ -234,8 +218,6 @@ class Users {
       }
 
       await this.models.User.destroy(Object.assign({ status: 'all' }, frameOptions));
-
-      return filename;
     });
   }
 }

--- a/ghost/core/test/e2e-api/admin/users.test.js
+++ b/ghost/core/test/e2e-api/admin/users.test.js
@@ -1,7 +1,9 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const config = require('../../../core/shared/config');
 const models = require('../../../core/server/models');
 const db = require('../../../core/server/data/db');
+const dbBackup = require('../../../core/server/data/db/backup');
 const {
   agentProvider,
   fixtureManager,
@@ -488,7 +490,7 @@ describe('User API', function () {
       .expect(cacheInvalidateHeaderNotSet());
   });
 
-  it('Can destroy an active user and transfer posts to the owner', async function () {
+  it('Can destroy an active user without a backup and transfer posts to the owner', async function () {
     // Use slimer-mcectoplasm user (index 3) who has a post in the fixtures
     const { id: userId, slug: userSlug } = fixtureManager.get('users', 3);
     const ownerId = fixtureManager.get('users', 0).id;
@@ -532,16 +534,14 @@ describe('User API', function () {
       .select();
     const initialUserPostCount = userPostsAuthorsModels.length;
 
-    // Delete the user
-    const deleteRes = await agent
-      .delete(`users/${userId}/`)
-      .expectStatus(200)
-      .expect(({ body }) => {
-        assert.ok(body.meta.filename);
-      });
-
-    // Check the backup file was created
-    await agent.get(`db/?filename=${deleteRes.body.meta.filename}`).expectStatus(200);
+    // Delete the user without creating a database backup
+    const backupStub = sinon.stub(dbBackup, 'backup');
+    try {
+      await agent.delete(`users/${userId}/`).expectStatus(204).expectEmptyBody();
+      sinon.assert.notCalled(backupStub);
+    } finally {
+      backupStub.restore();
+    }
 
     // Verify user was deleted
     await agent.get(`users/${userId}/`).expectStatus(404);

--- a/ghost/core/test/legacy/api/admin/users.test.js
+++ b/ghost/core/test/legacy/api/admin/users.test.js
@@ -131,10 +131,12 @@ describe('User API', function () {
           },
         });
 
-        await request
+        const res = await request
           .delete(localUtils.API.getApiQuery(`users/${otherAuthor.id}`))
           .set('Origin', config.get('url'))
-          .expect(200);
+          .expect(204);
+
+        assert.deepEqual(res.body, {});
 
         const tags = await otherAuthorPost.related('tags').fetch();
         assert.equal(tags.length, 3);

--- a/ghost/core/test/unit/server/services/users/users-service.test.js
+++ b/ghost/core/test/unit/server/services/users/users-service.test.js
@@ -38,7 +38,6 @@ describe('Users service', function () {
       const findAll = () => Promise.resolve({ models: users });
 
       return new Users({
-        dbBackup: { backup: sinon.stub().resolves() },
         models: {
           Base: { transaction: (cb) => cb('fake_transaction') },
           User: { findAll },
@@ -134,9 +133,6 @@ describe('Users service', function () {
 
     function createMockOptions({ userPostIds, alreadyTaggedPostIds, insertedRows, addActions }) {
       return {
-        dbBackup: {
-          backup: sinon.mock().resolves('backup/path/file.json'),
-        },
         models: {
           Base: {
             knex: (tableName) => {


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C09K9BSGYQM/p1787840921841429

- In older versions of Ghost, when a staff user was deleted, their posts were deleted too. As a precaution, a backup of the content was created and stored on disc
- A newer version of Ghost changed that behaviour so the posts were not deleted, but moved to the Owner user instead and a tag like `#author-slug` was added to the posts. The backup was still taken
- This PR removes that backup step, as the moving & tagging of posts has enough data to roll back, should the delete be a mistake. The backup was never easily surfaced to users anyway