### PR TITLE
Bumped mppx to 0.9.2 and load Stripe SPT via lightweight server entrypoints

### DIFF
--- a/ghost/core/core/server/services/machine-payments/adapters/mpp-adapter.ts
+++ b/ghost/core/core/server/services/machine-payments/adapters/mpp-adapter.ts
@@ -41,10 +41,27 @@ type MppxModule = {
       compose: (...entries: unknown[]) => (request: Request) => Promise<MppPaymentResult>;
     };
   };
-  tempo: { charge: (config: unknown) => unknown };
+  tempo?: { charge: (config: unknown) => unknown };
   stripe: { charge: (config: unknown) => unknown };
   Store: { memory: () => unknown };
 };
+
+/**
+ * Load mppx via lightweight entrypoints. Stripe SPT uses `mppx/stripe/server/spt`
+ * (no Tempo/EVM). Tempo still requires the full `mppx/server` barrel — there is
+ * no public Tempo-only server export — so only pull it when that rail is active.
+ */
+function requireMppxModule({ needsTempo }: { needsTempo: boolean }): MppxModule {
+  const { Mppx, Store } = require('mppx/server/core') as Pick<MppxModule, 'Mppx' | 'Store'>;
+  const { stripe } = require('mppx/stripe/server/spt') as Pick<MppxModule, 'stripe'>;
+
+  if (!needsTempo) {
+    return { Mppx, Store, stripe };
+  }
+
+  const { tempo } = require('mppx/server') as Pick<MppxModule, 'tempo'>;
+  return { Mppx, Store, stripe, tempo };
+}
 
 type MppAdapterDeps = {
   depositAddressStore: DepositAddressStoreLike;
@@ -139,13 +156,6 @@ export class MppAdapter implements PaymentAdapter {
   }
 
   async #run(request: Request, terms: PaymentAmountTerms): Promise<MppPaymentResult> {
-    const {
-      Mppx,
-      tempo,
-      stripe: mppStripe,
-      Store,
-    } = this.mppxFactory ? this.mppxFactory() : (require('mppx/server') as MppxModule);
-
     const profileId =
       this.settingsCache.get('machine_payments_stripe_profile_id') ||
       config.get('machinePayments:mpp:networkId');
@@ -168,6 +178,13 @@ export class MppAdapter implements PaymentAdapter {
       });
     }
 
+    const {
+      Mppx,
+      tempo,
+      stripe: mppStripe,
+      Store,
+    } = this.mppxFactory ? this.mppxFactory() : requireMppxModule({ needsTempo: hasTempo });
+
     if (!this.#replayStore) {
       this.#replayStore = Store.memory();
     }
@@ -180,6 +197,11 @@ export class MppAdapter implements PaymentAdapter {
     if (!this.#mppx || this.#mppxKey !== key) {
       const methods: unknown[] = [];
       if (hasTempo) {
+        if (!tempo) {
+          throw new errors.InternalServerError({
+            message: 'Machine payment Tempo rail is unavailable',
+          });
+        }
         methods.push(
           tempo.charge({
             currency: tempoCurrency,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,8 +492,8 @@ catalogs:
       specifier: 2.5.3
       version: 2.5.3
     mppx:
-      specifier: 0.6.20
-      version: 0.6.20
+      specifier: 0.9.2
+      version: 0.9.2
     msw:
       specifier: 2.14.6
       version: 2.14.6
@@ -2768,7 +2768,7 @@ importers:
         version: 0.5.45
       mppx:
         specifier: 'catalog:'
-        version: 0.6.20(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11)
+        version: 0.9.2(@x402/core@2.12.0)(@x402/hono@2.12.0(hono@4.12.18))(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11)
       multer:
         specifier: 2.2.0
         version: 2.2.0
@@ -5276,9 +5276,6 @@ packages:
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
-  '@cfworker/json-schema@4.1.1':
-    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
-
   '@cnakazawa/watch@1.0.4':
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
     engines: {node: '>=0.1.95'}
@@ -6871,10 +6868,6 @@ packages:
 
   '@miragejs/pretender-node-polyfill@0.1.2':
     resolution: {integrity: sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==}
-
-  '@modelcontextprotocol/server@2.0.0-alpha.4':
-    resolution: {integrity: sha512-/KEo3ZJ50HlagHp0lz2vPgfBZFtXHu6zTBXT9XqPc+4O9i4+IbBVWKq/a9yAfv/ifp0u3+mRo8SUk5kMKzhN8A==}
-    engines: {node: '>=20'}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -8532,10 +8525,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@scalar/openapi-types@0.8.0':
-    resolution: {integrity: sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==}
-    engines: {node: '>=22'}
-
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
@@ -9079,6 +9068,10 @@ packages:
       typescript:
         optional: true
 
+  '@stripe/stripe-js@9.13.0':
+    resolution: {integrity: sha512-/0c72BUgzzVkVTlsw5uBn8x3waTdVJ/PZGfQ6jY1eu6K7olUPf4d9lgDPA9/0sIdsR8j7o3QIG8fOCO6ItcL7A==}
+    engines: {node: '>=12.16'}
+
   '@svg-maps/world@2.0.0':
     resolution: {integrity: sha512-VmYYnyygJ5Zhr48xPqukFBoq4aCBgVNIjBzqBnWKXSdHhrRK3pntdvbCa8lMsxwVCFzEw9a+smIMEGI2sC1xcQ==}
 
@@ -9518,9 +9511,6 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
-  '@toon-format/toon@2.3.1':
-    resolution: {integrity: sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==}
 
   '@tootallnate/once@3.0.1':
     resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
@@ -14611,6 +14601,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -15877,11 +15871,6 @@ packages:
 
   include-path-searcher@0.1.0:
     resolution: {integrity: sha512-KlpXnsZOrBGo4PPKqPFi3Ft6dcRyh8fTaqgzqDRi8jKAsngJEWWOxeFIWC8EfZtXKaZqlsNf9XRwcQ49DVgl/g==}
-
-  incur@0.4.26:
-    resolution: {integrity: sha512-63lwOc8+o1VeFkIW3sWWMrDSP5Dd1NsvucUWyxLUk+DoNRiNl7cj481nlLdlboXkq+tqYPBSlV/7XbylS2S4BA==}
-    engines: {node: '>=22'}
-    hasBin: true
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -18182,23 +18171,41 @@ packages:
     resolution: {integrity: sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==}
     deprecated: This package is no longer supported.
 
-  mppx@0.6.20:
-    resolution: {integrity: sha512-RNXcY64QQVuDo3BqFEQAfp8ciF9O+DVIazDzZsf8vd9g4xqO1BRvTBLEcSO0WcEo6HcmQSL3Qsv3zgdM8vb3Eg==}
+  mppx@0.9.2:
+    resolution: {integrity: sha512-zKXIdKlFM6k9BS4Rt/f2CSKAbJr5a9DsITvSGtP9zDqjhdbCTzp377SuLNllaGX3yEGIh/vqD00hBacxZV0MEQ==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
+      '@x402/core': '>=2.22.0'
+      '@x402/express': '>=2.22.0'
+      '@x402/hono': '>=2.22.0'
+      '@x402/mcp': '>=2.22.0'
+      '@x402/next': '>=2.22.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.18'
-      viem: '>=2.47.5'
+      hono: '>=4.12.25'
+      next: '>=16.2.6'
+      viem: '>=2.54.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
+        optional: true
+      '@x402/core':
+        optional: true
+      '@x402/express':
+        optional: true
+      '@x402/hono':
+        optional: true
+      '@x402/mcp':
+        optional: true
+      '@x402/next':
         optional: true
       elysia:
         optional: true
       express:
         optional: true
       hono:
+        optional: true
+      next:
         optional: true
 
   mrmime@2.0.1:
@@ -18855,9 +18862,6 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
-
-  ox@0.14.20:
-    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
 
   ox@0.14.33:
     resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
@@ -21582,6 +21586,10 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  structured-headers@2.0.3:
+    resolution: {integrity: sha512-4g5yxhlDMClRwCcfKfLeS7Z8yAVdOWGDADwm80Poh1iReU2KVKLGBlqwpHWJ2qovq0+ZIf1atAEO1eua2o9Rgg==}
+    engines: {node: '>=18', npm: '>=6'}
+
   structured-source@4.0.0:
     resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
 
@@ -21980,9 +21988,6 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
-
-  tokenx@1.6.0:
-    resolution: {integrity: sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw==}
 
   tooltip.js@1.3.3:
     resolution: {integrity: sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==}
@@ -24550,8 +24555,6 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@cfworker/json-schema@4.1.1': {}
-
   '@cnakazawa/watch@1.0.4':
     dependencies:
       exec-sh: 0.3.6
@@ -26606,10 +26609,6 @@ snapshots:
 
   '@miragejs/pretender-node-polyfill@0.1.2': {}
 
-  '@modelcontextprotocol/server@2.0.0-alpha.4':
-    dependencies:
-      zod: 4.4.3
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -28006,8 +28005,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@scalar/openapi-types@0.8.0': {}
-
   '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.7.0':
@@ -28865,6 +28862,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@stripe/stripe-js@9.13.0': {}
+
   '@svg-maps/world@2.0.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@10.2.2))':
@@ -29309,8 +29308,6 @@ snapshots:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
-
-  '@toon-format/toon@2.3.1': {}
 
   '@tootallnate/once@3.0.1': {}
 
@@ -37325,6 +37322,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -39084,16 +39083,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   include-path-searcher@0.1.0: {}
-
-  incur@0.4.26:
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      '@modelcontextprotocol/server': 2.0.0-alpha.4
-      '@scalar/openapi-types': 0.8.0
-      '@toon-format/toon': 2.3.1
-      tokenx: 1.6.0
-      yaml: 2.9.0
-      zod: 4.4.3
 
   indent-string@4.0.0: {}
 
@@ -42169,13 +42158,17 @@ snapshots:
       rimraf: 2.7.1
       run-queue: 1.0.3
 
-  mppx@0.6.20(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11):
+  mppx@0.9.2(@x402/core@2.12.0)(@x402/hono@2.12.0(hono@4.12.18))(express@4.22.2(supports-color@10.2.2))(hono@4.12.18)(viem@2.55.11):
     dependencies:
-      incur: 0.4.26
-      ox: 0.14.20
+      '@stripe/stripe-js': 9.13.0
+      eventsource-parser: 3.1.1
+      ox: 0.14.33
+      structured-headers: 2.0.3
       viem: 2.55.11
       zod: 4.4.3
     optionalDependencies:
+      '@x402/core': 2.12.0
+      '@x402/hono': 2.12.0(hono@4.12.18)
       express: 4.22.2(supports-color@10.2.2)
       hono: 4.12.18
 
@@ -42997,17 +42990,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
-
-  ox@0.14.20:
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.3.0
-      eventemitter3: 5.0.1
 
   ox@0.14.33:
     dependencies:
@@ -46307,6 +46289,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  structured-headers@2.0.3: {}
+
   structured-source@4.0.0:
     dependencies:
       boundary: 2.0.0
@@ -46866,8 +46850,6 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
-
-  tokenx@1.6.0: {}
 
   tooltip.js@1.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -199,7 +199,7 @@ catalog:
   '@dnd-kit/utilities': 3.2.2
   shell-quote: 1.10.0
   unidecode: 1.1.0
-  mppx: 0.6.20
+  mppx: 0.9.2
   '@x402/core': 2.12.0
   '@x402/evm': 2.12.0
   '@x402/hono': 2.12.0


### PR DESCRIPTION
## Summary
- Bumps catalog `mppx` from `0.6.20` to `0.9.2` (includes upstream packaging fixes from [wevm/mppx#796](https://github.com/wevm/mppx/issues/796)).
- Loads machine payments via lightweight entrypoints: `mppx/server/core` + `mppx/stripe/server/spt`.
- Lazily requires the full `mppx/server` barrel only when a Tempo deposit address is available (no public Tempo-only server export yet).

Stripe-only challenges avoid evaluating the Tempo/`viem` graph; dual-rail / Tempo sites still load the full barrel for Tempo.

## Test plan
- [x] `pnpm test:single test/unit/server/services/machine-payments/adapters.test.js` (28 passed)
- [ ] Smoke Stripe-only MPP challenge/fulfill (deposit address unavailable)
- [ ] Smoke Tempo-only and dual-rail challenge/fulfill when deposit address is present