### PR TITLE
Added verified newsletter submission accounting and progress

### DIFF
--- a/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
+++ b/apps/admin/src/posts/analytics/email-sending-status/email-sending-status-banner.tsx
@@ -81,10 +81,11 @@ const failureDetail = (
   error?: string | null,
 ) => {
   const { completed, total } = sending.progress;
-  const sent = sending.failed_during === 'submitting' ? completed : 0;
+  // Submission progress includes exclusions, so it cannot be presented as emails sent.
+  const processed = sending.failed_during === 'submitting' ? completed : 0;
   const progress =
-    sent > 0
-      ? `${formatNumber(sent)} of ${formatNumber(total)} emails were sent.`
+    processed > 0
+      ? `${formatNumber(processed)} of ${formatNumber(total)} recipients processed.`
       : total > 0
         ? `None of the ${formatNumber(total)} emails were sent.`
         : 'No emails were sent.';
@@ -104,15 +105,8 @@ const EmailSendingStatusBanner = () => {
   }
 
   const isFailed = sending.status === 'failed';
-  const hasSentEmails = isFailed
-    ? !hasUnknownDeliveryOutcome &&
-      sending.failed_during === 'submitting' &&
-      sending.progress.completed > 0
-    : false;
   const title = isFailed
-    ? hasSentEmails
-      ? 'Some emails failed to send'
-      : 'Emails failed to send'
+    ? 'Emails failed to send'
     : sending.status === 'preparing'
       ? 'Preparing emails'
       : 'Sending emails';
@@ -121,7 +115,6 @@ const EmailSendingStatusBanner = () => {
       ? post?.email?.error || 'Something went wrong while sending this email.'
       : failureDetail(sending, post?.email?.error)
     : activeDetail(sending, estimate);
-  const retryLabel = hasSentEmails ? 'Send remaining emails' : 'Retry sending email';
 
   return (
     <Banner
@@ -153,7 +146,7 @@ const EmailSendingStatusBanner = () => {
             variant="outline"
             onClick={() => void retrySending()}
           >
-            {isRetrying ? 'Sending…' : retryLabel}
+            {isRetrying ? 'Sending…' : 'Retry sending email'}
           </Button>
         )}
       </Inline>

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -348,18 +348,55 @@ describe('Post analytics overview', () => {
       boot: webAnalyticsBootOverrides(),
     });
 
-    await expect.element(page.getByText('Some emails failed to send')).toBeVisible();
+    await expect.element(page.getByText('Emails failed to send')).toBeVisible();
     await expect.element(page.getByText(/^Published on your site on/)).toBeVisible();
     await expect.element(page.getByText(/^Published and sent on/)).not.toBeInTheDocument();
     await expect.element(page.getByText(/Mailgun rejected the batch/)).toBeVisible();
     await expect.element(page.getByText('No newsletter data available')).toBeVisible();
 
-    await page.getByRole('button', { name: 'Send remaining emails' }).click();
+    await page.getByRole('button', { name: 'Retry sending email' }).click();
     await expect.poll(() => retryApi.requests.length).toBe(1);
     await expect.element(page.getByText('Sending emails')).toBeVisible();
     // Keep submission visible until asserted, regardless of how many polls CI runs.
     hasCompleted = true;
     await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
+  });
+
+  it('does not describe completed exclusions as sent emails after a submission failure', async () => {
+    seedPostAnalyticsWorld({
+      email: {
+        id: EMAIL_ID,
+        email_count: 1000,
+        opened_count: 0,
+        status: 'failed',
+        error: 'Please retry sending your newsletter.',
+      },
+    });
+    fakeSubmittingBatches();
+    // The completed batch excluded all 250 recipients; the other batch failed.
+    // Progress includes exclusions and therefore cannot establish a sent count.
+    fakeAdminEndpoint('GET', `/emails/${EMAIL_ID}/status/`, {
+      email_statuses: [
+        {
+          id: EMAIL_ID,
+          sending: {
+            status: 'failed',
+            failed_during: 'submitting',
+            progress: { completed: 250, total: 1000, estimated_seconds_remaining: null },
+          },
+        },
+      ],
+    });
+    await renderAdminApp(`/posts/analytics/${POST_ID}`, {
+      labs: { improveSendingUI: true },
+      boot: webAnalyticsBootOverrides(),
+    });
+
+    const banner = postAnalyticsScreen.emailSendingStatusBanner();
+    await expect.element(banner).toHaveTextContent('250 of 1,000 recipients processed.');
+    await expect.element(banner).not.toHaveTextContent('emails were sent');
+    await expect.element(page.getByText('Emails failed to send')).toBeVisible();
+    await expect.element(page.getByRole('button', { name: 'Retry sending email' })).toBeVisible();
   });
 
   it('shows a generic failure without retry when a batch has an unknown delivery outcome', async () => {

--- a/ghost/core/core/server/services/email-service/CONTEXT.md
+++ b/ghost/core/core/server/services/email-service/CONTEXT.md
@@ -25,7 +25,7 @@ The completed and total recipient counts for the current sending phase.
 _Avoid_: Delivery progress, expected count
 
 **Submitted**:
-Every batch of a newsletter email has been accepted by the configured email provider. Submission does not mean that recipients have received the email.
+Every batch of a newsletter email has completed submission: the provider accepted its valid recipients, or validation explicitly excluded every recipient without a provider call. Submission does not mean that recipients have received the email.
 _Avoid_: Sent, delivered
 
 **Failed**:

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -111,8 +111,8 @@ from the dispatched list. Expected recipients must equal submitted recipients
 plus exclusions, and candidates must equal submitted recipients plus both kinds
 of exclusions. Complete the email with the verified submitted total as
 `email_count`. Integrity errors retain their distinct code through persisted
-batch errors and the final verification, so the Admin banner asks for
-investigation instead of another identical retry.
+batch errors and the final verification, so the Admin banner explains that sending stopped without recommending another
+identical retry.
 
 Emails spanning the preparation-only deployment may contain submitted batches
 whose submission counts are null. Verify their rows and statuses, preserve the

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -119,7 +119,6 @@ whose submission counts are null. Verify their rows and statuses, preserve the
 intended `email_count`, and emit an unverified-submission-counts event. Do not
 infer or backfill provider counts for those batches.
 
-
 ## Recipient accounting events
 
 Confirmed recipient-count discrepancies emit error-level records with
@@ -149,7 +148,7 @@ identifies a batch. Counts describe the failed check:
 | `batch_recipient_count`     | `expected`, `actual` recipient rows                                                                                                                                                                          |
 | `email_recipient_count` | `expected` prepared recipient total, `actual` persisted `email_count` |
 | `preparation_totals`        | `expected`, `actual`, `count_check` (`candidate_total` or `recipient_rows`), `candidate_count`, `preparation_excluded_count`, `recipient_count` (stored batch sum), `actual_count` (rows owned by the email) |
-| `batch_recovery_conflict`   | `expected`, `actual` rows; only unequal valid counts emit the count-mismatch event                                                                                                                                          |
+| `batch_recovery_conflict`   | `expected`, `actual` rows; only unequal valid counts emit the count-mismatch event                                                                                                                           |
 | `batch_recipient_read`      | `expected`, `actual` rows after read retries are exhausted                                                                                                                                                   |
 | `message_recipient_counts`  | `expected` loaded members, `actual` message recipients plus exclusions, `recipient_count`, `submission_excluded_count`                                                                                       |
 | `provider_payload_count`    | `expected`, `actual` unique provider address keys                                                                                                                                                            |

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -61,7 +61,10 @@ difference of at least 1% emits a warning and a Sentry message without failing
 preparation. Verification failures emit structured error logs with their reason
 and counts; the event contract below distinguishes confirmed count mismatches. The email job reports terminal verification failures to Sentry
 once, including during shutdown while leaving the email resumable. Failures during
-safely rebuildable preparation ask the user to retry; frozen or possibly submitted batches require investigation.
+safely rebuildable preparation ask the user to retry; frozen or possibly submitted
+batches require investigation. When shutdown leaves batches unstarted, check the
+persisted batch outcomes for integrity failures before exiting, without rescanning
+recipient rows.
 
 An interrupted preparation without `prepared_at` is discarded on retry, using
 bounded deletes of recipient rows followed by batches. Any non-pending batch

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -90,6 +90,33 @@ forward, that email cannot safely rebuild or complete preparation automatically;
 its recorded state requires reconciliation. Resending after a lost preparation
 boundary can also duplicate submissions already accepted by the provider.
 
+## Recipient submission
+
+Accounted batches verify their recipient read against `recipient_count` before
+constructing the provider payload. Existing invalid-address validation records
+explicit exclusions with error logging and Sentry reporting. A final payload
+whose address keys collapse multiple recipients fails before the provider call.
+Provider retries reuse the same intended recipients and exclusion counts.
+
+Persist `submitted_count` and `submission_excluded_count` as absolute values with
+the batch's submitted status and message ID. If every recipient is excluded,
+complete the batch with zero submitted and no message ID, without calling the
+provider. A corrupt zero expected count fails before reading recipients.
+
+After workers settle, verify every persisted batch, including batches omitted
+from the dispatched list. Expected recipients must equal submitted recipients
+plus exclusions, and candidates must equal submitted recipients plus both kinds
+of exclusions. Complete the email with the verified submitted total as
+`email_count`. Integrity errors retain their distinct code through persisted
+batch errors and the final verification, so the Admin banner asks for
+investigation instead of another identical retry.
+
+Emails spanning the preparation-only deployment may contain submitted batches
+whose submission counts are null. Verify their rows and statuses, preserve the
+intended `email_count`, and emit an unverified-submission-counts event. Do not
+infer or backfill provider counts for those batches.
+
+
 ## Recipient accounting events
 
 Confirmed recipient-count discrepancies emit error-level records with
@@ -149,11 +176,20 @@ derived on read. `sending-status.ts` owns the derivation from an email and its
 batches with their recipient counts; `SendingStatusService` reads those rows
 and `sending-status-serializers.ts` shapes the response. Submitted is terminal and the batch aggregation only
 describes a send that is still in progress or has failed, so submitted emails answer with the email's stored
-`email_count` as both completed and total; accounted preparation verifies that
-column against the recipient rows it built. Emails with null
-`preflight_email_count` retain their stored intended total. That also keeps reads of long-finished
+`email_count` as both completed and total. Fully accounted sends persist the
+verified submission total. Emails with null `preflight_email_count`, and emails
+with batches submitted before submission counts were recorded, retain the
+intended total. That also keeps reads of long-finished
 emails cheap, with no query over the batches or recipients. The endpoint is always available; Admin decides
 whether to poll it while a send is active.
+
+Active accounted sends read the small batch table: preparation progress sums
+`recipient_count`; submission progress sums submitted and excluded counts for
+submitted batches. Unknown preparation-era submission counts fall back to the
+batch's expected count at read time only. The submission total remains the sum
+of expected batch counts, so exclusions cannot leave progress short. Legacy
+sends retain their indexed recipient-count queries. Actual recipient verification
+runs at lifecycle boundaries, not on the polling path.
 
 The phase is read from the batches: an email is submitting once any batch has
 left `pending`, and preparing otherwise. Batch statuses persist across

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -211,8 +211,8 @@ Active accounted sends read the small batch table: preparation progress sums
 `recipient_count`; submission progress sums submitted and excluded counts for
 submitted batches. Unknown preparation-era submission counts fall back to the
 batch's expected count at read time only. The submission total remains the sum
-of expected batch counts, so exclusions cannot leave progress short. Legacy
-sends retain their indexed recipient-count queries. Actual recipient verification
+of expected batch counts, so exclusions cannot leave progress short. Emails with
+null `preflight_email_count` retain their indexed recipient-count queries. Actual recipient verification
 runs at lifecycle boundaries, not on the polling path.
 
 The phase is read from the batches: an email is submitting once any batch has

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -173,7 +173,9 @@ they do not imply that the provider accepted or delivered an email.
 
 The shared verification error factory emits the event immediately, including
 payload failures before the provider POST. A failed batch-status write cannot
-suppress that observation. Re-reading a persisted verification failure emits
+suppress that observation. If saving the batch failure also fails, the original
+terminal verification error still reaches the email job and Sentry, including
+during shutdown. Re-reading a persisted verification failure emits
 `batch_verification_failed` with the original details in `batch_error`; it is
 another observation of the same problem, not additional lost recipients.
 
@@ -211,7 +213,9 @@ Active accounted sends read the small batch table: preparation progress sums
 `recipient_count`; submission progress sums submitted and excluded counts for
 submitted batches. Unknown preparation-era submission counts fall back to the
 batch's expected count at read time only. The submission total remains the sum
-of expected batch counts, so exclusions cannot leave progress short. Emails with
+of expected batch counts, so exclusions cannot leave progress short. Failed-send
+UI describes this as processed recipients, because completed work includes
+exclusions and cannot establish how many emails were sent. Emails with
 null `preflight_email_count` retain their indexed recipient-count queries. Actual recipient verification
 runs at lifecycle boundaries, not on the polling path.
 

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -144,12 +144,18 @@ The event is the stable selector; do not match the human-readable message or par
 Every event has `code`, `email_id`, and `reason`, plus `batch_id` when the failure
 identifies a batch. Counts describe the failed check:
 
-| Reason                    | Count fields                                                                                                                                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `batch_recipient_count`   | `expected`, `actual` recipient rows                                                                                                                                                                          |
-| `email_recipient_count`   | `expected` prepared recipient total, `actual` persisted `email_count`                                                                                                                                        |
-| `preparation_totals`      | `expected`, `actual`, `count_check` (`candidate_total` or `recipient_rows`), `candidate_count`, `preparation_excluded_count`, `recipient_count` (stored batch sum), `actual_count` (rows owned by the email) |
-| `batch_recovery_conflict` | `expected`, `actual` rows; only unequal valid counts emit the count-mismatch event                                                                                                                           |
+| Reason                      | Count fields                                                                                                                                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `batch_recipient_count`     | `expected`, `actual` recipient rows                                                                                                                                                                          |
+| `email_recipient_count` | `expected` prepared recipient total, `actual` persisted `email_count` |
+| `preparation_totals`        | `expected`, `actual`, `count_check` (`candidate_total` or `recipient_rows`), `candidate_count`, `preparation_excluded_count`, `recipient_count` (stored batch sum), `actual_count` (rows owned by the email) |
+| `batch_recovery_conflict`   | `expected`, `actual` rows; only unequal valid counts emit the count-mismatch event                                                                                                                                          |
+| `batch_recipient_read`      | `expected`, `actual` rows after read retries are exhausted                                                                                                                                                   |
+| `message_recipient_counts`  | `expected` loaded members, `actual` message recipients plus exclusions, `recipient_count`, `submission_excluded_count`                                                                                       |
+| `provider_payload_count`    | `expected`, `actual` unique provider address keys                                                                                                                                                            |
+| `batch_submission_counts`   | `expected` stored intent, `actual` submitted plus excluded, `recipient_count`, `submitted_count`, `submission_excluded_count`                                                                                |
+| `batch_verification_failed` | `expected`, `actual`, optional `count_check` from the original failure; `batch_error` contains its full details                                                                                              |
+
 
 Unknown or invalid counts, conflicting identities with equal counts, and ownership
 or lifecycle failures use `email.verification.failed`. Both events retain the
@@ -165,6 +171,21 @@ Verification errors carry `retryable: false`, and their logged error details rec
 `emails.error`. Automatic database retries do not retry a
 terminal verification failure. These markers describe recovery within Ghost;
 they do not imply that the provider accepted or delivered an email.
+
+The shared verification error factory emits the event immediately, including
+payload failures before the provider POST. A failed batch-status write cannot
+suppress that observation. Re-reading a persisted verification failure emits
+`batch_verification_failed` with the original details in `batch_error`; it is
+another observation of the same problem, not additional lost recipients.
+
+Successful accounted batches emit `email.batch.submitted` at info level with
+`email_id`, `batch_id`, `recipient_count`, `submitted_count`,
+`submission_excluded_count`, and `mailgun_message_id` for provider correlation.
+An all-excluded batch has zero submitted and a null message ID. Final verified
+emails emit `email.submission.verified` with candidate, submitted, and exclusion
+totals. Preparation-era batches with unknown submission counts instead emit
+`email.submission.unverified` at info level, naming `unverified_batch_ids`;
+unknown historical counts alone are not a detected discrepancy.
 
 A legitimate preflight audience change emits `email.preparation.audience_drift`
 at warning level. An explicitly excluded invalid member has its own error log;

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -187,9 +187,10 @@ totals. Preparation-era batches with unknown submission counts instead emit
 unknown historical counts alone are not a detected discrepancy.
 
 A legitimate preflight audience change emits `email.preparation.audience_drift`
-at warning level. An explicitly excluded invalid member has its own error log;
-it does not trigger this discrepancy event because the recipient is accounted
-for. These records cover discrepancies Ghost can verify; they do not independently
+at warning level. Invalid members emit `email.preparation.excluded` or
+`email.submission.excluded` at error level, with `email_id`, `member_id`,
+`reason`, and the preparation attempt or submission batch ID. Exclusions do not
+trigger the discrepancy event because the recipient is accounted for. These records cover discrepancies Ghost can verify; they do not independently
 measure Mailgun acceptance or delivery, including uncertain POST outcomes.
 
 ## Sending status

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -79,7 +79,11 @@ independently establish frozen batch membership.
 After submission workers settle, re-read all persisted batches, verify recipient
 counts again, and require every batch submitted before completing the email.
 Frozen preparation also verifies that `email_count` equals the prepared recipient
-total so progress and statistics cannot silently retain an incorrect total.
+total so progress and statistics cannot silently retain an incorrect total. Once
+every batch has verified submission counts, the stored total may instead equal
+the submitted count written at completion, including zero when all recipients
+were excluded. Partially sent emails and emails with unavailable submission
+counts must retain the prepared total.
 
 These checks account for intended recipients, not delivered copies or global
 recipient uniqueness. Compensating omissions and duplicates can balance a count
@@ -146,7 +150,7 @@ identifies a batch. Counts describe the failed check:
 | Reason                      | Count fields                                                                                                                                                                                                 |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `batch_recipient_count`     | `expected`, `actual` recipient rows                                                                                                                                                                          |
-| `email_recipient_count` | `expected` prepared recipient total, `actual` persisted `email_count` |
+| `email_recipient_count`     | `expected` prepared or verified submitted total, `actual` persisted `email_count`                                                                                                                            |
 | `preparation_totals`        | `expected`, `actual`, `count_check` (`candidate_total` or `recipient_rows`), `candidate_count`, `preparation_excluded_count`, `recipient_count` (stored batch sum), `actual_count` (rows owned by the email) |
 | `batch_recovery_conflict`   | `expected`, `actual` rows; only unequal valid counts emit the count-mismatch event                                                                                                                           |
 | `batch_recipient_read`      | `expected`, `actual` rows after read retries are exhausted                                                                                                                                                   |
@@ -154,7 +158,6 @@ identifies a batch. Counts describe the failed check:
 | `provider_payload_count`    | `expected`, `actual` unique provider address keys                                                                                                                                                            |
 | `batch_submission_counts`   | `expected` stored intent, `actual` submitted plus excluded, `recipient_count`, `submitted_count`, `submission_excluded_count`                                                                                |
 | `batch_verification_failed` | `expected`, `actual`, optional `count_check` from the original failure; `batch_error` contains its full details                                                                                              |
-
 
 Unknown or invalid counts, conflicting identities with equal counts, and ownership
 or lifecycle failures use `email.verification.failed`. Both events retain the

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -3,6 +3,7 @@ const ObjectID = require('bson-objectid').default;
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const {
+  RECIPIENT_VERIFICATION_CODE: VERIFICATION_CODE,
   recipientVerificationError,
   excludedRecipientError,
   isCount,
@@ -18,6 +19,7 @@ const messages = {
 
 const MAX_SENDING_CONCURRENCY = 2;
 const SHUTDOWN_CODE = 'BULK_EMAIL_SHUTDOWN_IN_PROGRESS';
+const RECIPIENT_READ_MISMATCH = 'BULK_EMAIL_RECIPIENT_READ_MISMATCH';
 
 /**
  * @typedef {import('./sending-service')} SendingService
@@ -263,7 +265,7 @@ class BatchSendingService {
     email._retryCutOffTime = retryCutOffTime;
 
     try {
-      await this.sendEmail(email);
+      const submission = await this.sendEmail(email);
       await this.retryDb(
         async () => {
           await email.save(
@@ -271,6 +273,7 @@ class BatchSendingService {
               status: 'submitted',
               submitted_at: new Date(),
               error: null,
+              ...(submission ? { email_count: submission.submittedCount } : {}),
             },
             { patch: true, autoRefresh: false },
           );
@@ -378,7 +381,7 @@ class BatchSendingService {
     // Rebuild until prepared_at is saved. Emails with null preflight_email_count
     // whose submission has already started reuse their existing batches instead.
     const batches = await this.createBatches({ email, newsletter, post });
-    await this.sendBatches({ email, batches, post, newsletter });
+    return await this.sendBatches({ email, batches, post, newsletter });
   }
 
   /**
@@ -1154,25 +1157,32 @@ class BatchSendingService {
 
   async #verifySubmittedBatches(email) {
     const batches = await this.#verifyFrozenPreparation(email, this.#getAfterRetryConfig());
+    const submission = this.#verifySubmissionCounts(email, batches);
     if (batches.some((batch) => batch.get('status') === 'submitting')) {
       throw new errors.EmailError({
-        code: 'BULK_EMAIL_SUBMISSION_UNCERTAIN',
-        message: tpl(messages.submissionUncertain),
+        code: 'BULK_EMAIL_SUBMISSION_UNCERTAIN', message: tpl(messages.submissionUncertain),
       });
     }
-    this.#assertSubmissionComplete(
-      batches.filter((batch) => batch.get('status') === 'submitted').length,
-      batches.length,
-    );
-    logging.info(
-      {
-        event: { name: 'email.submission.unverified' },
-        email_id: email.id,
-        batch_count: batches.length,
-        reason: 'submission_counts_unavailable',
-      },
-      'All email batches submitted; submission recipient counts are unavailable',
-    );
+    this.#assertSubmissionComplete(batches.filter(batch => batch.get('status') === 'submitted').length, batches.length);
+    this.#reportSubmission(email, batches, submission);
+    return submission;
+  }
+
+  #reportSubmission(email, batches, submission) {
+    if (submission) {
+      logging.info({
+        event: { name: 'email.submission.verified' }, email_id: email.id,
+        candidate_count: email.get('candidate_count'),
+        preparation_excluded_count: email.get('preparation_excluded_count'),
+        submitted_count: submission.submittedCount,
+        submission_excluded_count: submission.submissionExcludedCount,
+      }, 'Email recipient submission verified');
+      return;
+    }
+    logging.info({
+      event: { name: 'email.submission.unverified' }, email_id: email.id,
+      batch_count: batches.length, reason: 'submission_counts_unavailable',
+    }, 'All email batches submitted; submission recipient counts are unavailable');
   }
 
   #assertSubmissionComplete(succeededCount, expectedBatchCount) {
@@ -1181,6 +1191,66 @@ class BatchSendingService {
         message: tpl(succeededCount > 0 ? messages.emailErrorPartialFailure : messages.emailError),
       });
     }
+  }
+
+  #verifySubmissionCounts(email, batches) {
+    let submittedCount = 0;
+    let submissionExcludedCount = 0;
+    let unknown = false;
+    for (const batch of batches) {
+      let errorData;
+      try {
+        errorData = JSON.parse(batch.get('error_data') ?? 'null');
+      } catch {
+        // Ordinary provider failures can contain non-JSON diagnostics.
+      }
+      if (errorData?.code === VERIFICATION_CODE) {
+        throw this.#verificationFailure(email, 'batch_verification_failed', {
+          batch_id: batch.id,
+          batch_error: errorData,
+        });
+      }
+      if (batch.get('status') !== 'submitted') {
+        unknown = true;
+        continue;
+      }
+      const submitted = batch.get('submitted_count');
+      const excluded = batch.get('submission_excluded_count');
+      if (submitted === null && excluded === null) {
+        // Preparation-only deployments recorded intent but no provider counts.
+        unknown = true;
+        continue;
+      }
+      if (
+        !Number.isSafeInteger(submitted) ||
+        submitted < 0 ||
+        !Number.isSafeInteger(excluded) ||
+        excluded < 0 ||
+        batch.get('recipient_count') !== submitted + excluded
+      ) {
+        throw this.#verificationFailure(email, 'batch_submission_counts', {
+          batch_id: batch.id,
+          recipient_count: batch.get('recipient_count'),
+          submitted_count: submitted,
+          submission_excluded_count: excluded,
+        });
+      }
+      submittedCount += submitted;
+      submissionExcludedCount += excluded;
+    }
+    if (unknown) {
+      return;
+    }
+    if (
+      email.get('candidate_count') !==
+      submittedCount + submissionExcludedCount + email.get('preparation_excluded_count')
+    ) {
+      throw this.#verificationFailure(email, 'submission_totals', {
+        submitted_count: submittedCount,
+        submission_excluded_count: submissionExcludedCount,
+      });
+    }
+    return { submittedCount, submissionExcludedCount };
   }
 
   /**
@@ -1233,9 +1303,20 @@ class BatchSendingService {
     let succeeded = false;
 
     try {
+      const expectedCount = batch.get('recipient_count');
+      const recipientAccounting =
+        this.#usesRecipientAccounting(email) && (expectedCount ?? null) !== null;
+      if (recipientAccounting && (!Number.isSafeInteger(expectedCount) || expectedCount < 1)) {
+        throw this.#verificationFailure(email, 'invalid_batch_recipient_count', {
+          batch_id: batch.id,
+          expected: expectedCount,
+        });
+      }
       let members = await this.retryDb(
         async () => {
-          const m = await this.getBatchMembers(batch.id);
+          const m = recipientAccounting
+            ? await this.getBatchMembers(batch.id, expectedCount)
+            : await this.getBatchMembers(batch.id);
 
           // If we receive 0 rows, there is a possibility that we switched to a secondary database and have replication lag
           // So we throw an error and we retry
@@ -1251,27 +1332,39 @@ class BatchSendingService {
           ...this.#getBeforeRetryConfig(email),
           description: `getBatchMembers batch ${originalBatch.id}`,
         },
-      );
+      ).catch((error) => {
+        if (error.code === RECIPIENT_READ_MISMATCH) {
+          throw this.#verificationFailure(email, 'batch_recipient_read', {
+            batch_id: batch.id,
+            ...JSON.parse(error.errorDetails),
+          });
+        }
+        throw error;
+      });
 
+      const messageData = {
+        emailId: email.id,
+        post,
+        newsletter,
+        segment: batch.get('member_segment'),
+        members,
+      };
+      const messageOptions = {
+        openTrackingEnabled: !!email.get('track_opens'),
+        clickTrackingEnabled: !!email.get('track_clicks'),
+        useFallbackAddress: batch.get('fallback_sending_domain'),
+        deliveryTime,
+        emailBodyCache,
+        ...(recipientAccounting ? { recipientAccounting: true, batchId: batch.id } : {}),
+      };
+      const message = recipientAccounting
+        ? await this.#sendingService.buildMessage(messageData, messageOptions)
+        : null;
       const response = await this.retryDb(
-        async () => {
-          return await this.#sendingService.send(
-            {
-              emailId: email.id,
-              post,
-              newsletter,
-              segment: batch.get('member_segment'),
-              members,
-            },
-            {
-              openTrackingEnabled: !!email.get('track_opens'),
-              clickTrackingEnabled: !!email.get('track_clicks'),
-              useFallbackAddress: batch.get('fallback_sending_domain'),
-              deliveryTime,
-              emailBodyCache,
-            },
-          );
-        },
+        () =>
+          recipientAccounting
+            ? this.#sendingService.sendMessage(message)
+            : this.#sendingService.send(messageData, messageOptions),
         {
           ...this.#getMailgunRetryConfig(),
           description: `Sending email batch ${originalBatch.id} ${deliveryTime ? `with delivery time ${deliveryTime}` : ''}`,
@@ -1285,6 +1378,12 @@ class BatchSendingService {
             {
               status: 'submitted',
               mailgun_message_id: response.id,
+              ...(recipientAccounting
+                ? {
+                    submitted_count: response.submittedCount,
+                    submission_excluded_count: response.submissionExcludedCount,
+                  }
+                : {}),
               // reset error fields when sending succeeds
               error_status_code: null,
               error_message: null,
@@ -1298,6 +1397,19 @@ class BatchSendingService {
           description: `save batch ${originalBatch.id} -> submitted`,
         },
       );
+      if (recipientAccounting) {
+        logging.info(
+          {
+            event: { name: 'email.batch.submitted' },
+            email_id: email.id,
+            batch_id: batch.id,
+            recipient_count: expectedCount,
+            submitted_count: response.submittedCount,
+            submission_excluded_count: response.submissionExcludedCount,
+          },
+          'Email batch submission accounted',
+        );
+      }
     } catch (err) {
       if (err.code && err.code === 'BULK_EMAIL_SEND_FAILED') {
         logging.error(err);
@@ -1370,13 +1482,20 @@ class BatchSendingService {
    * That keeps the sending service nicely separated so it isn't dependent on the batch sending data structure.
    * @returns {Promise<MemberLike[]>}
    */
-  async getBatchMembers(batchId) {
+  async getBatchMembers(batchId, expectedCount) {
     let models = await this.#models.EmailRecipient.findAll({
       filter: `batch_id:'${batchId}'`,
       withRelated: ['member', 'member.stripeSubscriptions', 'member.products'],
     });
 
     const BATCH_SIZE = this.#sendingService.getMaximumRecipients();
+    if (expectedCount !== undefined && models.length !== expectedCount) {
+      throw new errors.EmailError({
+        code: RECIPIENT_READ_MISMATCH,
+        message: `Email batch ${batchId} has ${models.length} recipients, expected ${expectedCount}`,
+        errorDetails: JSON.stringify({ expected: expectedCount, actual: models.length }),
+      });
+    }
     if (models.length > BATCH_SIZE) {
       throw new errors.EmailError({
         message: `Email batch ${batchId} has ${models.length} members, which exceeds the maximum of ${BATCH_SIZE} members per batch.`,

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1221,6 +1221,9 @@ class BatchSendingService {
         throw this.#verificationFailure(email, 'batch_verification_failed', {
           batch_id: batch.id,
           batch_error: errorData,
+          expected: errorData.expected,
+          actual: errorData.actual,
+          count_check: errorData.count_check,
         });
       }
       if (batch.get('status') !== 'submitted') {
@@ -1244,6 +1247,10 @@ class BatchSendingService {
         throw this.#verificationFailure(email, 'batch_submission_counts', {
           batch_id: batch.id,
           recipient_count: batch.get('recipient_count'),
+          expected: batch.get('recipient_count'),
+          actual: [submitted, excluded].every((count) => Number.isSafeInteger(count) && count >= 0)
+            ? submitted + excluded
+            : null,
           submitted_count: submitted,
           submission_excluded_count: excluded,
         });
@@ -1415,6 +1422,7 @@ class BatchSendingService {
             recipient_count: expectedCount,
             submitted_count: response.submittedCount,
             submission_excluded_count: response.submissionExcludedCount,
+            mailgun_message_id: response.id,
           },
           'Email batch submission accounted',
         );

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1410,7 +1410,8 @@ class BatchSendingService {
         const members = recipientAccounting
           ? await this.getBatchMembers(batch.id, expectedCount)
           : await this.getBatchMembers(batch.id);
-        // Preserve the legacy retry for an empty read after a database switch.
+        // Emails with null preflight_email_count have no verified expected count;
+        // retain their empty-read retry after a database switch.
         if (members.length === 0) {
           throw new errors.EmailError({
             message: `No members found for batch ${batch.id}, possible replication lag`,
@@ -1458,8 +1459,8 @@ class BatchSendingService {
       emailBodyCache,
       ...(recipientAccounting ? { recipientAccounting: true, batchId: batch.id } : {}),
     };
-    // Accounted payloads are built once before provider retries; legacy retries
-    // still render and submit together through send().
+    // With preflight_email_count set, build the payload once before provider retries.
+    // When it is null, each retry still renders and submits together through send().
     let submit = () => this.#sendingService.send(data, options);
     if (recipientAccounting) {
       const message = await this.retryDb(() => this.#sendingService.buildMessage(data, options), {

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -466,16 +466,25 @@ class BatchSendingService {
     return verified.batches;
   }
 
-  #verifyStoredEmailCount(email, { recipientCount }) {
+  #verifyStoredEmailCount(email, { batches, recipientCount }) {
     const actual = email.get('email_count');
-    if (actual !== recipientCount) {
-      throw this.#verificationFailure(
-        email,
-        'email_recipient_count',
-        { expected: recipientCount, actual },
-        countsDiffer(recipientCount, actual),
-      );
+    if (actual === recipientCount) {
+      return;
     }
+    // Preparation stores intent; completion replaces it with successful
+    // submissions. Accept that smaller total only when every batch has verified
+    // submission counts. Partially sent and preparation-only sends retain intent.
+    const submission = this.#verifySubmissionCounts(email, batches);
+    if (submission && actual === submission.submittedCount) {
+      return;
+    }
+    const expected = submission?.submittedCount ?? recipientCount;
+    throw this.#verificationFailure(
+      email,
+      'email_recipient_count',
+      { expected, actual },
+      countsDiffer(expected, actual),
+    );
   }
 
   async #startPreparation(email, attemptId) {

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1137,6 +1137,15 @@ class BatchSendingService {
       `Email ${email.id} send done: ${succeededCount}/${batches.length} batches succeeded, ${queue.length} unstarted`,
     );
 
+    // Preserve an integrity failure even if its status write failed. Another
+    // worker's database error or shutdown must not replace the original cause.
+    const failedWorkers = workerResults.filter((result) => result.status === 'rejected');
+    const failedWorker =
+      failedWorkers.find((result) => result.reason?.retryable === false) ?? failedWorkers[0];
+    if (failedWorker) {
+      await this.#rethrowWorkerFailure(email, failedWorker.reason);
+    }
+
     if (this.#shuttingDown && queue.length > 0) {
       if (this.#usesRecipientAccounting(email)) {
         // A worker may have persisted an integrity failure while shutdown left
@@ -1148,11 +1157,6 @@ class BatchSendingService {
         code: SHUTDOWN_CODE,
         message: 'Email send stopped because the container is shutting down',
       });
-    }
-
-    const failedWorker = workerResults.find((result) => result.status === 'rejected');
-    if (failedWorker) {
-      await this.#rethrowWorkerFailure(email, failedWorker.reason);
     }
 
     if (this.#usesRecipientAccounting(email)) {
@@ -1199,6 +1203,8 @@ class BatchSendingService {
     this.#assertSubmissionComplete(
       batches.filter((batch) => batch.get('status') === 'submitted').length,
       batches.length,
+      // Completed batches may contain only exclusions, not successful submissions.
+      messages.emailError,
     );
     this.#reportSubmission(email, batches, submission);
     return submission;
@@ -1237,10 +1243,13 @@ class BatchSendingService {
     );
   }
 
-  #assertSubmissionComplete(succeededCount, expectedBatchCount) {
+  #assertSubmissionComplete(succeededCount, expectedBatchCount, failureMessage) {
     if (succeededCount < expectedBatchCount) {
       throw new errors.EmailError({
-        message: tpl(succeededCount > 0 ? messages.emailErrorPartialFailure : messages.emailError),
+        message: tpl(
+          failureMessage ??
+            (succeededCount > 0 ? messages.emailErrorPartialFailure : messages.emailError),
+        ),
       });
     }
   }
@@ -1351,11 +1360,7 @@ class BatchSendingService {
     } catch (err) {
       this.#reportBatchError(batch, err);
       if (!succeeded) {
-        await this.#saveBatchStatus(batch, 'failed', {
-          error_status_code: err.statusCode ?? null,
-          error_message: err.message,
-          error_data: err.errorDetails ?? null,
-        });
+        await this.#saveBatchFailure(batch, err);
       } else if (this.#shuttingDown) {
         // Accepted, but the submitted write failed. Keep the email resumable;
         // never replace this uncertain outcome with a failed batch status.
@@ -1484,6 +1489,23 @@ class BatchSendingService {
         description: `save batch ${batch.id} -> ${status}`,
       },
     );
+  }
+
+  async #saveBatchFailure(batch, error) {
+    try {
+      await this.#saveBatchStatus(batch, 'failed', {
+        error_status_code: error.statusCode ?? null,
+        error_message: error.message,
+        error_data: error.errorDetails ?? null,
+      });
+    } catch (saveError) {
+      // The persisted-state lookup cannot recover metadata that was never saved.
+      // Keep the raw integrity error for the email banner and Sentry, including on shutdown.
+      if (error.retryable === false) {
+        throw error;
+      }
+      throw saveError;
+    }
   }
 
   #reportBatchSubmission(email, batch, response) {

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1172,30 +1172,49 @@ class BatchSendingService {
     const submission = this.#verifySubmissionCounts(email, batches);
     if (batches.some((batch) => batch.get('status') === 'submitting')) {
       throw new errors.EmailError({
-        code: 'BULK_EMAIL_SUBMISSION_UNCERTAIN', message: tpl(messages.submissionUncertain),
+        code: 'BULK_EMAIL_SUBMISSION_UNCERTAIN',
+        message: tpl(messages.submissionUncertain),
       });
     }
-    this.#assertSubmissionComplete(batches.filter(batch => batch.get('status') === 'submitted').length, batches.length);
+    this.#assertSubmissionComplete(
+      batches.filter((batch) => batch.get('status') === 'submitted').length,
+      batches.length,
+    );
     this.#reportSubmission(email, batches, submission);
     return submission;
   }
 
   #reportSubmission(email, batches, submission) {
     if (submission) {
-      logging.info({
-        event: { name: 'email.submission.verified' }, email_id: email.id,
-        candidate_count: email.get('candidate_count'),
-        preparation_excluded_count: email.get('preparation_excluded_count'),
-        submitted_count: submission.submittedCount,
-        submission_excluded_count: submission.submissionExcludedCount,
-      }, 'Email recipient submission verified');
+      logging.info(
+        {
+          event: { name: 'email.submission.verified' },
+          email_id: email.id,
+          candidate_count: email.get('candidate_count'),
+          preparation_excluded_count: email.get('preparation_excluded_count'),
+          submitted_count: submission.submittedCount,
+          submission_excluded_count: submission.submissionExcludedCount,
+        },
+        'Email recipient submission verified',
+      );
       return;
     }
-    logging.info({
-      event: { name: 'email.submission.unverified' }, email_id: email.id,
-      batch_count: batches.length, reason: 'submission_counts_unavailable',
-      unverified_batch_ids: batches.filter(batch => batch.get('submitted_count') === null && batch.get('submission_excluded_count') === null).map(batch => batch.id),
-    }, 'All email batches submitted; submission recipient counts are unavailable');
+    logging.info(
+      {
+        event: { name: 'email.submission.unverified' },
+        email_id: email.id,
+        batch_count: batches.length,
+        reason: 'submission_counts_unavailable',
+        unverified_batch_ids: batches
+          .filter(
+            (batch) =>
+              batch.get('submitted_count') === null &&
+              batch.get('submission_excluded_count') === null,
+          )
+          .map((batch) => batch.id),
+      },
+      'All email batches submitted; submission recipient counts are unavailable',
+    );
   }
 
   #assertSubmissionComplete(succeededCount, expectedBatchCount) {
@@ -1206,26 +1225,37 @@ class BatchSendingService {
     }
   }
 
-  #verifySubmissionCounts(email, batches) {
-    let submittedCount = 0;
-    let submissionExcludedCount = 0;
-    let unknown = false;
-    for (const batch of batches) {
-      let errorData;
-      try {
-        errorData = JSON.parse(batch.get('error_data') ?? 'null');
-      } catch {
-        // Ordinary provider failures can contain non-JSON diagnostics.
-      }
-      if (batch.get('status') === 'failed' && errorData?.code === VERIFICATION_CODE) {
-        throw this.#verificationFailure(email, 'batch_verification_failed', {
+  #throwPersistedVerificationFailure(email, batch) {
+    let errorData;
+    try {
+      errorData = JSON.parse(batch.get('error_data') ?? 'null');
+    } catch {
+      // Ordinary provider failures can contain non-JSON diagnostics.
+    }
+    if (batch.get('status') === 'failed' && errorData?.code === VERIFICATION_CODE) {
+      // Earlier submission deployments persisted counts without classification.
+      // Preserve their event semantics; new failures retain the explicit kind.
+      throw this.#verificationFailure(
+        email,
+        'batch_verification_failed',
+        {
           batch_id: batch.id,
           batch_error: errorData,
           expected: errorData.expected,
           actual: errorData.actual,
           count_check: errorData.count_check,
-        });
-      }
+        },
+        errorData.count_mismatch ?? countsDiffer(errorData.expected, errorData.actual),
+      );
+    }
+  }
+
+  #verifySubmissionCounts(email, batches) {
+    let submittedCount = 0;
+    let submissionExcludedCount = 0;
+    let unknown = false;
+    for (const batch of batches) {
+      this.#throwPersistedVerificationFailure(email, batch);
       if (batch.get('status') !== 'submitted') {
         unknown = true;
         continue;
@@ -1237,23 +1267,22 @@ class BatchSendingService {
         unknown = true;
         continue;
       }
-      if (
-        !Number.isSafeInteger(submitted) ||
-        submitted < 0 ||
-        !Number.isSafeInteger(excluded) ||
-        excluded < 0 ||
-        batch.get('recipient_count') !== submitted + excluded
-      ) {
-        throw this.#verificationFailure(email, 'batch_submission_counts', {
-          batch_id: batch.id,
-          recipient_count: batch.get('recipient_count'),
-          expected: batch.get('recipient_count'),
-          actual: [submitted, excluded].every((count) => Number.isSafeInteger(count) && count >= 0)
-            ? submitted + excluded
-            : null,
-          submitted_count: submitted,
-          submission_excluded_count: excluded,
-        });
+      const expected = batch.get('recipient_count');
+      const actual = isCount(submitted) && isCount(excluded) ? submitted + excluded : null;
+      if (actual === null || expected !== actual) {
+        throw this.#verificationFailure(
+          email,
+          'batch_submission_counts',
+          {
+            batch_id: batch.id,
+            recipient_count: batch.get('recipient_count'),
+            expected,
+            actual,
+            submitted_count: submitted,
+            submission_excluded_count: excluded,
+          },
+          countsDiffer(expected, actual),
+        );
       }
       submittedCount += submitted;
       submissionExcludedCount += excluded;
@@ -1319,7 +1348,7 @@ class BatchSendingService {
     try {
       const expectedCount = batch.get('recipient_count');
       const recipientAccounting = this.#usesRecipientAccounting(email);
-      if (recipientAccounting && (!Number.isSafeInteger(expectedCount) || expectedCount < 1)) {
+      if (recipientAccounting && (!isCount(expectedCount) || expectedCount === 0)) {
         throw this.#verificationFailure(email, 'invalid_batch_recipient_count', {
           batch_id: batch.id,
           expected: expectedCount,
@@ -1347,10 +1376,16 @@ class BatchSendingService {
         },
       ).catch((error) => {
         if (error.code === RECIPIENT_READ_MISMATCH) {
-          throw this.#verificationFailure(email, 'batch_recipient_read', {
-            batch_id: batch.id,
-            ...JSON.parse(error.errorDetails),
-          });
+          const details = JSON.parse(error.errorDetails);
+          throw this.#verificationFailure(
+            email,
+            'batch_recipient_read',
+            {
+              batch_id: batch.id,
+              ...details,
+            },
+            countsDiffer(details.expected, details.actual),
+          );
         }
         throw error;
       });

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1138,6 +1138,18 @@ class BatchSendingService {
     );
 
     if (this.#shuttingDown && queue.length > 0) {
+      if (this.#usesRecipientAccounting(email)) {
+        // A worker may have persisted an integrity failure while shutdown left
+        // other batches unstarted. Check the small batch rows before interrupting
+        // so emailJob still reports it; do not rescan recipients during the drain.
+        await this.retryDb(
+          async () => this.#verifySubmissionCounts(email, await this.getBatches(email)),
+          {
+            ...this.#getAfterRetryConfig(),
+            description: `verify interrupted batches for email ${email.id}`,
+          },
+        );
+      }
       throw new errors.InternalServerError({
         code: SHUTDOWN_CODE,
         message: 'Email send stopped because the container is shutting down',
@@ -1242,15 +1254,9 @@ class BatchSendingService {
     if (unknown) {
       return;
     }
-    if (
-      email.get('candidate_count') !==
-      submittedCount + submissionExcludedCount + email.get('preparation_excluded_count')
-    ) {
-      throw this.#verificationFailure(email, 'submission_totals', {
-        submitted_count: submittedCount,
-        submission_excluded_count: submissionExcludedCount,
-      });
-    }
+    // Before completion, preparation verification has already balanced candidates
+    // against these same batches. The per-batch identities above therefore also
+    // balance the email-wide submission and exclusion totals.
     return { submittedCount, submissionExcludedCount };
   }
 

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1142,13 +1142,7 @@ class BatchSendingService {
         // A worker may have persisted an integrity failure while shutdown left
         // other batches unstarted. Check the small batch rows before interrupting
         // so emailJob still reports it; do not rescan recipients during the drain.
-        await this.retryDb(
-          async () => this.#verifySubmissionCounts(email, await this.getBatches(email)),
-          {
-            ...this.#getAfterRetryConfig(),
-            description: `verify interrupted batches for email ${email.id}`,
-          },
-        );
+        await this.#verifyPersistedSubmissionCounts(email);
       }
       throw new errors.InternalServerError({
         code: SHUTDOWN_CODE,
@@ -1158,13 +1152,39 @@ class BatchSendingService {
 
     const failedWorker = workerResults.find((result) => result.status === 'rejected');
     if (failedWorker) {
-      throw failedWorker.reason;
+      await this.#rethrowWorkerFailure(email, failedWorker.reason);
     }
 
     if (this.#usesRecipientAccounting(email)) {
       return this.#verifySubmittedBatches(email);
     }
     this.#assertSubmissionComplete(succeededCount, batches.length);
+  }
+
+  async #verifyPersistedSubmissionCounts(email) {
+    return this.retryDb(
+      async () => this.#verifySubmissionCounts(email, await this.getBatches(email)),
+      {
+        ...this.#getAfterRetryConfig(),
+        description: `verify persisted submission counts for email ${email.id}`,
+      },
+    );
+  }
+
+  async #rethrowWorkerFailure(email, workerError) {
+    if (this.#usesRecipientAccounting(email)) {
+      try {
+        // A later processed_at write can fail after an integrity failure was saved.
+        // Prefer that recorded failure without rescanning the recipient table.
+        await this.#verifyPersistedSubmissionCounts(email);
+      } catch (error) {
+        if (error.retryable === false) {
+          throw error;
+        }
+        // The lookup can also fail; retain the original worker error in that case.
+      }
+    }
+    throw workerError;
   }
 
   async #verifySubmittedBatches(email) {

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1358,7 +1358,10 @@ class BatchSendingService {
         ...(recipientAccounting ? { recipientAccounting: true, batchId: batch.id } : {}),
       };
       const message = recipientAccounting
-        ? await this.#sendingService.buildMessage(messageData, messageOptions)
+        ? await this.retryDb(() => this.#sendingService.buildMessage(messageData, messageOptions), {
+            ...this.#getMailgunRetryConfig(),
+            description: `Constructing email batch ${originalBatch.id}`,
+          })
         : null;
       const response = await this.retryDb(
         () =>

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1204,7 +1204,7 @@ class BatchSendingService {
       } catch {
         // Ordinary provider failures can contain non-JSON diagnostics.
       }
-      if (errorData?.code === VERIFICATION_CODE) {
+      if (batch.get('status') === 'failed' && errorData?.code === VERIFICATION_CODE) {
         throw this.#verificationFailure(email, 'batch_verification_failed', {
           batch_id: batch.id,
           batch_error: errorData,
@@ -1304,8 +1304,7 @@ class BatchSendingService {
 
     try {
       const expectedCount = batch.get('recipient_count');
-      const recipientAccounting =
-        this.#usesRecipientAccounting(email) && (expectedCount ?? null) !== null;
+      const recipientAccounting = this.#usesRecipientAccounting(email);
       if (recipientAccounting && (!Number.isSafeInteger(expectedCount) || expectedCount < 1)) {
         throw this.#verificationFailure(email, 'invalid_batch_recipient_count', {
           batch_id: batch.id,
@@ -1359,7 +1358,7 @@ class BatchSendingService {
       };
       const message = recipientAccounting
         ? await this.retryDb(() => this.#sendingService.buildMessage(messageData, messageOptions), {
-            ...this.#getMailgunRetryConfig(),
+            ...this.#getBeforeRetryConfig(email),
             description: `Constructing email batch ${originalBatch.id}`,
           })
         : null;

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -1182,6 +1182,7 @@ class BatchSendingService {
     logging.info({
       event: { name: 'email.submission.unverified' }, email_id: email.id,
       batch_count: batches.length, reason: 'submission_counts_unavailable',
+      unverified_batch_ids: batches.filter(batch => batch.get('submitted_count') === null && batch.get('submission_excluded_count') === null).map(batch => batch.id),
     }, 'All email batches submitted; submission recipient counts are unavailable');
   }
 
@@ -1416,7 +1417,7 @@ class BatchSendingService {
       if (err.code && err.code === 'BULK_EMAIL_SEND_FAILED') {
         logging.error(err);
         if (this.#sentry) {
-          // Log the original error to Sentry
+          // Log the original provider error to Sentry.
           this.#sentry.captureException(err);
         }
       } else {
@@ -1428,8 +1429,8 @@ class BatchSendingService {
         });
 
         logging.error(ghostError);
-        if (this.#sentry) {
-          // Log the original error to Sentry
+        if (this.#sentry && err.code !== VERIFICATION_CODE) {
+          // Integrity failures are reported once by emailJob after persisted verification.
           this.#sentry.captureException(err);
         }
       }

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -3,7 +3,7 @@ const ObjectID = require('bson-objectid').default;
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const {
-  RECIPIENT_VERIFICATION_CODE: VERIFICATION_CODE,
+  RECIPIENT_VERIFICATION_CODE,
   recipientVerificationError,
   excludedRecipientError,
   isCount,
@@ -1232,9 +1232,7 @@ class BatchSendingService {
     } catch {
       // Ordinary provider failures can contain non-JSON diagnostics.
     }
-    if (batch.get('status') === 'failed' && errorData?.code === VERIFICATION_CODE) {
-      // Earlier submission deployments persisted counts without classification.
-      // Preserve their event semantics; new failures retain the explicit kind.
+    if (batch.get('status') === 'failed' && errorData?.code === RECIPIENT_VERIFICATION_CODE) {
       throw this.#verificationFailure(
         email,
         'batch_verification_failed',
@@ -1245,7 +1243,7 @@ class BatchSendingService {
           actual: errorData.actual,
           count_check: errorData.count_check,
         },
-        errorData.count_mismatch ?? countsDiffer(errorData.expected, errorData.actual),
+        errorData.count_mismatch === true,
       );
     }
   }
@@ -1303,229 +1301,218 @@ class BatchSendingService {
    */
   async sendBatch({ email, batch: originalBatch, post, newsletter, emailBodyCache, deliveryTime }) {
     logging.info(`Sending batch ${originalBatch.id} for email ${email.id}`);
-
-    // Check the status of the email batch in a 'for update' transaction
-
-    const batch = await this.retryDb(
-      async () => {
-        return await this.updateStatusLock(
-          this.#models.EmailBatch,
-          originalBatch.id,
-          'submitting',
-          ['pending', 'failed'],
-        );
-      },
-      {
-        ...this.#getBeforeRetryConfig(email),
-        description: `updateStatusLock batch ${originalBatch.id} -> submitting`,
-      },
-    );
+    const batch = await this.#lockBatch(email, originalBatch.id);
     if (!batch) {
-      // updateStatusLock returned undefined: the batch's current status is neither
-      // `pending` nor `failed`, so the lock didn't engage. Two distinct cases, and
-      // they need different handling — collapsing them is the bug this branch fixes.
-      const currentStatus = originalBatch.get('status');
-      if (currentStatus === 'submitted') {
-        // Mailgun accepted this batch on a prior run. Nothing to do; return true so
-        // the parent email's success counter stays accurate. Expected path during
-        // resume of an interrupted send where some batches finished before the crash.
-        logging.info(`Email batch ${originalBatch.id} already submitted on a prior run; skipping`);
-        return true;
-      }
-      // Otherwise currentStatus is `submitting`: orphan from a worker that crashed
-      // mid-batch. We have no record of Mailgun accepting it, and re-sending risks
-      // duplicates. Return false so the parent email is promoted to `failed` and an
-      // operator can reconcile against the Mailgun dashboard before retrying.
-      // Runbook: docs/newsletter-send-plan-v9.md.
-      logging.error(
-        `Email batch ${originalBatch.id} is stuck in status=${currentStatus} (orphan from a crashed worker); not re-sending — marking parent email as failed for operator review`,
-      );
-      return false;
+      return this.#reportUnclaimedBatch(originalBatch);
     }
-
     let succeeded = false;
-
     try {
-      const expectedCount = batch.get('recipient_count');
-      const recipientAccounting = this.#usesRecipientAccounting(email);
-      if (recipientAccounting && (!isCount(expectedCount) || expectedCount === 0)) {
-        throw this.#verificationFailure(email, 'invalid_batch_recipient_count', {
-          batch_id: batch.id,
-          expected: expectedCount,
-        });
-      }
-      let members = await this.retryDb(
-        async () => {
-          const m = recipientAccounting
-            ? await this.getBatchMembers(batch.id, expectedCount)
-            : await this.getBatchMembers(batch.id);
-
-          // If we receive 0 rows, there is a possibility that we switched to a secondary database and have replication lag
-          // So we throw an error and we retry
-          if (m.length === 0) {
-            throw new errors.EmailError({
-              message: `No members found for batch ${batch.id}, possible replication lag`,
-            });
-          }
-
-          return m;
-        },
-        {
-          ...this.#getBeforeRetryConfig(email),
-          description: `getBatchMembers batch ${originalBatch.id}`,
-        },
-      ).catch((error) => {
-        if (error.code === RECIPIENT_READ_MISMATCH) {
-          const details = JSON.parse(error.errorDetails);
-          throw this.#verificationFailure(
-            email,
-            'batch_recipient_read',
-            {
-              batch_id: batch.id,
-              ...details,
-            },
-            countsDiffer(details.expected, details.actual),
-          );
-        }
-        throw error;
-      });
-
-      const messageData = {
-        emailId: email.id,
+      const members = await this.#loadBatchRecipients(email, batch);
+      const response = await this.#submitBatchMessage(email, batch, members, {
         post,
         newsletter,
-        segment: batch.get('member_segment'),
-        members,
-      };
-      const messageOptions = {
-        openTrackingEnabled: !!email.get('track_opens'),
-        clickTrackingEnabled: !!email.get('track_clicks'),
-        useFallbackAddress: batch.get('fallback_sending_domain'),
-        deliveryTime,
         emailBodyCache,
-        ...(recipientAccounting ? { recipientAccounting: true, batchId: batch.id } : {}),
-      };
-      const message = recipientAccounting
-        ? await this.retryDb(() => this.#sendingService.buildMessage(messageData, messageOptions), {
-            ...this.#getBeforeRetryConfig(email),
-            description: `Constructing email batch ${originalBatch.id}`,
-          })
-        : null;
-      const response = await this.retryDb(
-        () =>
-          recipientAccounting
-            ? this.#sendingService.sendMessage(message)
-            : this.#sendingService.send(messageData, messageOptions),
-        {
-          ...this.#getMailgunRetryConfig(),
-          description: `Sending email batch ${originalBatch.id} ${deliveryTime ? `with delivery time ${deliveryTime}` : ''}`,
-        },
-      );
+        deliveryTime,
+      });
       succeeded = true;
-
-      await this.retryDb(
-        async () => {
-          await batch.save(
-            {
-              status: 'submitted',
-              mailgun_message_id: response.id,
-              ...(recipientAccounting
-                ? {
-                    submitted_count: response.submittedCount,
-                    submission_excluded_count: response.submissionExcludedCount,
-                  }
-                : {}),
-              // reset error fields when sending succeeds
-              error_status_code: null,
-              error_message: null,
-              error_data: null,
-            },
-            { patch: true, require: false, autoRefresh: false },
-          );
-        },
-        {
-          ...this.#getAfterRetryConfig(),
-          description: `save batch ${originalBatch.id} -> submitted`,
-        },
-      );
-      if (recipientAccounting) {
-        logging.info(
-          {
-            event: { name: 'email.batch.submitted' },
-            email_id: email.id,
-            batch_id: batch.id,
-            recipient_count: expectedCount,
-            submitted_count: response.submittedCount,
-            submission_excluded_count: response.submissionExcludedCount,
-            mailgun_message_id: response.id,
-          },
-          'Email batch submission accounted',
-        );
-      }
+      await this.#saveBatchStatus(batch, 'submitted', {
+        mailgun_message_id: response.id,
+        ...(this.#usesRecipientAccounting(email)
+          ? {
+              submitted_count: response.submittedCount,
+              submission_excluded_count: response.submissionExcludedCount,
+            }
+          : {}),
+        error_status_code: null,
+        error_message: null,
+        error_data: null,
+      });
+      this.#reportBatchSubmission(email, batch, response);
     } catch (err) {
-      if (err.code && err.code === 'BULK_EMAIL_SEND_FAILED') {
-        logging.error(err);
-        if (this.#sentry) {
-          // Log the original provider error to Sentry.
-          this.#sentry.captureException(err);
-        }
-      } else {
-        const ghostError = new errors.EmailError({
-          err,
-          code: 'BULK_EMAIL_SEND_FAILED',
-          message: `Error sending email batch ${batch.id}`,
-          context: err.message,
-        });
-
-        logging.error(ghostError);
-        if (this.#sentry && err.code !== VERIFICATION_CODE) {
-          // Integrity failures are reported once by emailJob after persisted verification.
-          this.#sentry.captureException(err);
-        }
-      }
-
+      this.#reportBatchError(batch, err);
       if (!succeeded) {
-        // We check succeeded because a Rare edge case where the batch was send, but we failed to set status to submitted, then we don't want to set it to failed
-        await this.retryDb(
-          async () => {
-            await batch.save(
-              {
-                status: 'failed',
-                error_status_code: err.statusCode ?? null,
-                error_message: err.message,
-                error_data: err.errorDetails ?? null,
-              },
-              { patch: true, require: false, autoRefresh: false },
-            );
-          },
-          {
-            ...this.#getAfterRetryConfig(),
-            description: `save batch ${originalBatch.id} -> failed`,
-          },
-        );
+        await this.#saveBatchStatus(batch, 'failed', {
+          error_status_code: err.statusCode ?? null,
+          error_message: err.message,
+          error_data: err.errorDetails ?? null,
+        });
       } else if (this.#shuttingDown) {
-        // Sent, but the `submitted` write didn't land in the collapsed budget.
-        // Returning success would mark the email submitted with this row left in
-        // `submitting`, which the boot resume scan never looks at.
+        // Accepted, but the submitted write failed. Keep the email resumable;
+        // never replace this uncertain outcome with a failed batch status.
         throw err;
       }
     }
+    // Mark as processed even when submission failed.
+    await this.#markBatchProcessed(batch);
+    return succeeded;
+  }
 
-    // Mark as processed, even when failed
-    await this.retryDb(
-      async () => {
-        await this.#models.EmailRecipient.where({ batch_id: batch.id }).save(
-          { processed_at: new Date() },
-          { patch: true, require: false, autoRefresh: false },
-        );
-      },
+  async #lockBatch(email, batchId) {
+    return this.retryDb(
+      () =>
+        this.updateStatusLock(this.#models.EmailBatch, batchId, 'submitting', [
+          'pending',
+          'failed',
+        ]),
       {
-        ...this.#getAfterRetryConfig(),
-        description: `save EmailRecipients ${originalBatch.id} processed_at`,
+        ...this.#getBeforeRetryConfig(email),
+        description: `updateStatusLock batch ${batchId} -> submitting`,
       },
     );
+  }
 
-    return succeeded;
+  #reportUnclaimedBatch(batch) {
+    const currentStatus = batch.get('status');
+    if (currentStatus === 'submitted') {
+      // A prior run submitted this batch; include it in the parent's success count.
+      logging.info(`Email batch ${batch.id} already submitted on a prior run; skipping`);
+      return true;
+    }
+    // An orphaned submitting batch has no recorded outcome. Preserve the existing
+    // reconciliation path instead of claiming success or resubmitting it here.
+    logging.error(
+      `Email batch ${batch.id} is stuck in status=${currentStatus} (orphan from a crashed worker); not re-sending — marking parent email as failed for operator review`,
+    );
+    return false;
+  }
+
+  async #loadBatchRecipients(email, batch) {
+    const recipientAccounting = this.#usesRecipientAccounting(email);
+    const expectedCount = batch.get('recipient_count');
+    if (recipientAccounting && (!isCount(expectedCount) || expectedCount === 0)) {
+      throw this.#verificationFailure(email, 'invalid_batch_recipient_count', {
+        batch_id: batch.id,
+        expected: expectedCount,
+      });
+    }
+    return this.retryDb(
+      async () => {
+        const members = recipientAccounting
+          ? await this.getBatchMembers(batch.id, expectedCount)
+          : await this.getBatchMembers(batch.id);
+        // Preserve the legacy retry for an empty read after a database switch.
+        if (members.length === 0) {
+          throw new errors.EmailError({
+            message: `No members found for batch ${batch.id}, possible replication lag`,
+          });
+        }
+        return members;
+      },
+      {
+        ...this.#getBeforeRetryConfig(email),
+        description: `getBatchMembers batch ${batch.id}`,
+      },
+    ).catch((error) => {
+      if (error.code !== RECIPIENT_READ_MISMATCH) {
+        throw error;
+      }
+      const details = JSON.parse(error.errorDetails);
+      throw this.#verificationFailure(
+        email,
+        'batch_recipient_read',
+        { batch_id: batch.id, ...details },
+        countsDiffer(details.expected, details.actual),
+      );
+    });
+  }
+
+  async #submitBatchMessage(
+    email,
+    batch,
+    members,
+    { post, newsletter, deliveryTime, emailBodyCache },
+  ) {
+    const recipientAccounting = this.#usesRecipientAccounting(email);
+    const data = {
+      emailId: email.id,
+      post,
+      newsletter,
+      segment: batch.get('member_segment'),
+      members,
+    };
+    const options = {
+      openTrackingEnabled: !!email.get('track_opens'),
+      clickTrackingEnabled: !!email.get('track_clicks'),
+      useFallbackAddress: batch.get('fallback_sending_domain'),
+      deliveryTime,
+      emailBodyCache,
+      ...(recipientAccounting ? { recipientAccounting: true, batchId: batch.id } : {}),
+    };
+    // Accounted payloads are built once before provider retries; legacy retries
+    // still render and submit together through send().
+    let submit = () => this.#sendingService.send(data, options);
+    if (recipientAccounting) {
+      const message = await this.retryDb(() => this.#sendingService.buildMessage(data, options), {
+        ...this.#getBeforeRetryConfig(email),
+        description: `Constructing email batch ${batch.id}`,
+      });
+      submit = () => this.#sendingService.sendMessage(message);
+    }
+    return this.retryDb(submit, {
+      ...this.#getMailgunRetryConfig(),
+      description: `Sending email batch ${batch.id} ${deliveryTime ? `with delivery time ${deliveryTime}` : ''}`,
+    });
+  }
+
+  async #saveBatchStatus(batch, status, attributes) {
+    await this.retryDb(
+      () =>
+        batch.save({ status, ...attributes }, { patch: true, require: false, autoRefresh: false }),
+      {
+        ...this.#getAfterRetryConfig(),
+        description: `save batch ${batch.id} -> ${status}`,
+      },
+    );
+  }
+
+  #reportBatchSubmission(email, batch, response) {
+    if (!this.#usesRecipientAccounting(email)) {
+      return;
+    }
+    logging.info(
+      {
+        event: { name: 'email.batch.submitted' },
+        email_id: email.id,
+        batch_id: batch.id,
+        recipient_count: batch.get('recipient_count'),
+        submitted_count: response.submittedCount,
+        submission_excluded_count: response.submissionExcludedCount,
+        mailgun_message_id: response.id,
+      },
+      'Email batch submission accounted',
+    );
+  }
+
+  #reportBatchError(batch, err) {
+    const loggedError =
+      err.code === 'BULK_EMAIL_SEND_FAILED'
+        ? err
+        : new errors.EmailError({
+            err,
+            code: 'BULK_EMAIL_SEND_FAILED',
+            message: `Error sending email batch ${batch.id}`,
+            context: err.message,
+          });
+    logging.error(loggedError);
+    if (this.#sentry && err.retryable !== false) {
+      // Read the raw error; integrity failures are reported once by emailJob
+      // after persisted verification. Provider errors retain their original data.
+      this.#sentry.captureException(err);
+    }
+  }
+
+  async #markBatchProcessed(batch) {
+    await this.retryDb(
+      () =>
+        this.#models.EmailRecipient.where({ batch_id: batch.id }).save(
+          { processed_at: new Date() },
+          { patch: true, require: false, autoRefresh: false },
+        ),
+      {
+        ...this.#getAfterRetryConfig(),
+        description: `save EmailRecipients ${batch.id} processed_at`,
+      },
+    );
   }
 
   /**

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -101,6 +101,7 @@ class EmailServiceWrapper {
       emailProvider: mailgunEmailProvider,
       emailRenderer,
       emailAddressService: emailAddressService.service,
+      sentry,
     });
 
     const emailSegmenter = new EmailSegmenter({

--- a/ghost/core/core/server/services/email-service/mailgun-email-provider.js
+++ b/ghost/core/core/server/services/email-service/mailgun-email-provider.js
@@ -2,6 +2,10 @@ const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const debug = require('@tryghost/debug')('email-service:mailgun-provider-service');
 const { escapeExpression } = require('handlebars');
+const {
+  RECIPIENT_VERIFICATION_CODE,
+  recipientVerificationError,
+} = require('./recipient-accounting');
 
 /**
  * @typedef {object} Config
@@ -26,6 +30,7 @@ const { escapeExpression } = require('handlebars');
  * @prop {boolean} clickTrackingEnabled
  * @prop {boolean} openTrackingEnabled
  * @prop {Date} deliveryTime
+ * @prop {number} [expectedRecipientCount]
  */
 
 /**
@@ -142,6 +147,15 @@ class MailgunEmailProvider {
         acc[recipient.email] = this.#createRecipientData(recipient.replacements, htmlEscapedIds);
         return acc;
       }, {});
+      if (
+        options.expectedRecipientCount !== undefined &&
+        Object.keys(recipientData).length !== options.expectedRecipientCount
+      ) {
+        throw recipientVerificationError(emailId, 'provider_payload_count', {
+          expected: options.expectedRecipientCount,
+          actual: Object.keys(recipientData).length,
+        });
+      }
 
       // update content to use Mailgun variable syntax for all replacements
       ['html', 'plaintext'].forEach((key) => {
@@ -166,6 +180,9 @@ class MailgunEmailProvider {
         id: response.id.trim().replace(/^<|>$/g, ''),
       };
     } catch (e) {
+      if (e.code === RECIPIENT_VERIFICATION_CODE) {
+        throw e;
+      }
       let ghostError;
       if (e.error && e.messageData) {
         const { error, messageData } = e;

--- a/ghost/core/core/server/services/email-service/mailgun-email-provider.js
+++ b/ghost/core/core/server/services/email-service/mailgun-email-provider.js
@@ -31,6 +31,7 @@ const {
  * @prop {boolean} openTrackingEnabled
  * @prop {Date} deliveryTime
  * @prop {number} [expectedRecipientCount]
+ * @prop {string} [batchId]
  */
 
 /**
@@ -152,6 +153,7 @@ class MailgunEmailProvider {
         Object.keys(recipientData).length !== options.expectedRecipientCount
       ) {
         throw recipientVerificationError(emailId, 'provider_payload_count', {
+          batch_id: options.batchId,
           expected: options.expectedRecipientCount,
           actual: Object.keys(recipientData).length,
         });

--- a/ghost/core/core/server/services/email-service/mailgun-email-provider.js
+++ b/ghost/core/core/server/services/email-service/mailgun-email-provider.js
@@ -5,6 +5,7 @@ const { escapeExpression } = require('handlebars');
 const {
   RECIPIENT_VERIFICATION_CODE,
   recipientVerificationError,
+  countsDiffer,
 } = require('./recipient-accounting');
 
 /**
@@ -152,11 +153,19 @@ class MailgunEmailProvider {
         options.expectedRecipientCount !== undefined &&
         Object.keys(recipientData).length !== options.expectedRecipientCount
       ) {
-        throw recipientVerificationError(emailId, 'provider_payload_count', {
-          batch_id: options.batchId,
-          expected: options.expectedRecipientCount,
-          actual: Object.keys(recipientData).length,
-        });
+        const actual = Object.keys(recipientData).length;
+        throw recipientVerificationError(
+          emailId,
+          'provider_payload_count',
+          {
+            batch_id: options.batchId,
+            expected: options.expectedRecipientCount,
+            actual,
+          },
+          {
+            countMismatch: countsDiffer(options.expectedRecipientCount, actual),
+          },
+        );
       }
 
       // update content to use Mailgun variable syntax for all replacements

--- a/ghost/core/core/server/services/email-service/sending-service.js
+++ b/ghost/core/core/server/services/email-service/sending-service.js
@@ -1,6 +1,7 @@
 const validator = require('@tryghost/validator');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
+const { recipientVerificationError } = require('./recipient-accounting');
 
 /**
  * @typedef {object} EmailData
@@ -139,11 +140,19 @@ class SendingService {
       }
     }
 
-    const recipients = this.buildRecipients(
+    const { recipients, excludedCount } = this.buildRecipients(
       members,
       emailBody.replacements,
       options.recipientAccounting ? { emailId, batchId: options.batchId } : undefined,
     );
+    if (options.recipientAccounting && members.length !== recipients.length + excludedCount) {
+      throw recipientVerificationError(emailId, 'message_recipient_counts', {
+        batch_id: options.batchId,
+        expected: members.length,
+        recipient_count: recipients.length,
+        submission_excluded_count: excludedCount,
+      });
+    }
     return {
       data: {
         subject: this.#emailRenderer.getSubject(post, isTestEmail),
@@ -165,11 +174,11 @@ class SendingService {
         openTrackingEnabled: !!options.openTrackingEnabled,
         useFallbackAddress: !!options.useFallbackAddress,
         ...(options.deliveryTime && { deliveryTime: options.deliveryTime }),
-        ...(options.recipientAccounting ? { expectedRecipientCount: recipients.length } : {}),
+        ...(options.recipientAccounting
+          ? { expectedRecipientCount: members.length - excludedCount }
+          : {}),
       },
-      ...(options.recipientAccounting
-        ? { submissionExcludedCount: members.length - recipients.length }
-        : {}),
+      ...(options.recipientAccounting ? { submissionExcludedCount: excludedCount } : {}),
     };
   }
 
@@ -197,10 +206,11 @@ class SendingService {
    * @param {MemberLike[]} members
    * @param {import("./email-renderer").ReplacementDefinition[]} replacementDefinitions
    * @param {{emailId: string|null, batchId?: string}} [accounting]
-   * @returns {Recipient[]}
+   * @returns {{recipients: Recipient[], excludedCount: number}}
    */
   buildRecipients(members, replacementDefinitions, accounting) {
-    return members
+    let excludedCount = 0;
+    const recipients = members
       .map((member) => {
         return {
           email: member.email?.trim(),
@@ -217,6 +227,7 @@ class SendingService {
         // Remove invalid recipient email addresses
         const isValidRecipient = validator.isEmail(recipient.email, { legacy: false });
         if (!isValidRecipient) {
+          excludedCount += 1;
           if (accounting) {
             const error = new errors.EmailError({
               code: 'BULK_EMAIL_INVALID_RECIPIENT',
@@ -239,6 +250,7 @@ class SendingService {
         }
         return isValidRecipient;
       });
+    return { recipients, excludedCount };
   }
 }
 

--- a/ghost/core/core/server/services/email-service/sending-service.js
+++ b/ghost/core/core/server/services/email-service/sending-service.js
@@ -149,6 +149,10 @@ class SendingService {
       throw recipientVerificationError(emailId, 'message_recipient_counts', {
         batch_id: options.batchId,
         expected: members.length,
+        actual:
+          Number.isSafeInteger(excludedCount) && excludedCount >= 0
+            ? recipients.length + excludedCount
+            : null,
         recipient_count: recipients.length,
         submission_excluded_count: excludedCount,
       });
@@ -175,7 +179,7 @@ class SendingService {
         useFallbackAddress: !!options.useFallbackAddress,
         ...(options.deliveryTime && { deliveryTime: options.deliveryTime }),
         ...(options.recipientAccounting
-          ? { expectedRecipientCount: members.length - excludedCount }
+          ? { expectedRecipientCount: members.length - excludedCount, batchId: options.batchId }
           : {}),
       },
       ...(options.recipientAccounting ? { submissionExcludedCount: excludedCount } : {}),

--- a/ghost/core/core/server/services/email-service/sending-service.js
+++ b/ghost/core/core/server/services/email-service/sending-service.js
@@ -1,7 +1,7 @@
 const validator = require('@tryghost/validator');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-const { recipientVerificationError } = require('./recipient-accounting');
+const { recipientVerificationError, isCount, countsDiffer } = require('./recipient-accounting');
 
 /**
  * @typedef {object} EmailData
@@ -146,16 +146,19 @@ class SendingService {
       options.recipientAccounting ? { emailId, batchId: options.batchId } : undefined,
     );
     if (options.recipientAccounting && members.length !== recipients.length + excludedCount) {
-      throw recipientVerificationError(emailId, 'message_recipient_counts', {
-        batch_id: options.batchId,
-        expected: members.length,
-        actual:
-          Number.isSafeInteger(excludedCount) && excludedCount >= 0
-            ? recipients.length + excludedCount
-            : null,
-        recipient_count: recipients.length,
-        submission_excluded_count: excludedCount,
-      });
+      const actual = isCount(excludedCount) ? recipients.length + excludedCount : null;
+      throw recipientVerificationError(
+        emailId,
+        'message_recipient_counts',
+        {
+          batch_id: options.batchId,
+          expected: members.length,
+          actual,
+          recipient_count: recipients.length,
+          submission_excluded_count: excludedCount,
+        },
+        { countMismatch: countsDiffer(members.length, actual) },
+      );
     }
     return {
       data: {

--- a/ghost/core/core/server/services/email-service/sending-service.js
+++ b/ghost/core/core/server/services/email-service/sending-service.js
@@ -1,7 +1,10 @@
 const validator = require('@tryghost/validator');
 const logging = require('@tryghost/logging');
-const errors = require('@tryghost/errors');
-const { recipientVerificationError, isCount, countsDiffer } = require('./recipient-accounting');
+const {
+  recipientVerificationError,
+  excludedRecipientError,
+  countsDiffer,
+} = require('./recipient-accounting');
 
 /**
  * @typedef {object} EmailData
@@ -9,7 +12,7 @@ const { recipientVerificationError, isCount, countsDiffer } = require('./recipie
  * @prop {string} plaintext
  * @prop {string} subject
  * @prop {string} from
- * @prop {string} emailId
+ * @prop {string|null} emailId
  * @prop {string} [replyTo]
  * @prop {string} [domainOverride]
  * @prop {Recipient[]} recipients
@@ -38,7 +41,7 @@ const { recipientVerificationError, isCount, countsDiffer } = require('./recipie
  * @prop {boolean} clickTrackingEnabled
  * @prop {boolean} openTrackingEnabled
  * @prop {boolean} useFallbackAddress
- * @prop {Date} deliveryTime
+ * @prop {Date} [deliveryTime]
  * @prop {Map<string, EmailBody>} [emailBodyCache]
  * @prop {boolean} [recipientAccounting]
  * @prop {string} [batchId]
@@ -65,6 +68,13 @@ const { recipientVerificationError, isCount, countsDiffer } = require('./recipie
  * @typedef {object} EmailProviderSuccessResponse
  * @prop {string|null} id
  * @prop {number} [submittedCount]
+ * @prop {number} [submissionExcludedCount]
+ */
+
+/**
+ * @typedef {object} BatchMessage
+ * @prop {EmailData} data
+ * @prop {EmailSendingOptions & {expectedRecipientCount?: number}} options
  * @prop {number} [submissionExcludedCount]
  */
 
@@ -116,8 +126,12 @@ class SendingService {
     return this.sendMessage(await this.buildMessage(data, options));
   }
 
-  // Construct once outside the provider retry loop so exclusions, recipient
-  // replacements, and the intended payload stay fixed across uncertain retries.
+  /**
+   * Construct once before provider retries so the payload and exclusions stay fixed.
+   * @param {{post: Post, newsletter: Newsletter, segment: string|null, members: MemberLike[], emailId: string|null}} data
+   * @param {EmailSendingOptions} options
+   * @returns {Promise<BatchMessage>}
+   */
   async buildMessage({ post, newsletter, segment, members, emailId }, options) {
     const cacheId = emailId + '-' + (segment ?? 'null');
     const isTestEmail = options.isTestEmail ?? false;
@@ -146,7 +160,7 @@ class SendingService {
       options.recipientAccounting ? { emailId, batchId: options.batchId } : undefined,
     );
     if (options.recipientAccounting && members.length !== recipients.length + excludedCount) {
-      const actual = isCount(excludedCount) ? recipients.length + excludedCount : null;
+      const actual = recipients.length + excludedCount;
       throw recipientVerificationError(
         emailId,
         'message_recipient_counts',
@@ -189,6 +203,10 @@ class SendingService {
     };
   }
 
+  /**
+   * @param {BatchMessage} message
+   * @returns {Promise<EmailProviderSuccessResponse>}
+   */
   async sendMessage(message) {
     if (message.submissionExcludedCount !== undefined && message.data.recipients.length === 0) {
       return {
@@ -236,18 +254,15 @@ class SendingService {
         if (!isValidRecipient) {
           excludedCount += 1;
           if (accounting) {
-            const error = new errors.EmailError({
-              code: 'BULK_EMAIL_INVALID_RECIPIENT',
-              message:
-                'Recipient excluded from newsletter submission due to an invalid email address',
-              errorDetails: JSON.stringify({
-                email_id: accounting.emailId,
+            const error = excludedRecipientError(
+              accounting.emailId,
+              'email.submission.excluded',
+              'invalid_email_address',
+              {
                 batch_id: accounting.batchId,
                 member_id: members[index].id,
-                reason: 'invalid_email_address',
-              }),
-            });
-            logging.error(error);
+              },
+            );
             this.#sentry?.captureException(error);
           } else {
             logging.warn(

--- a/ghost/core/core/server/services/email-service/sending-service.js
+++ b/ghost/core/core/server/services/email-service/sending-service.js
@@ -1,5 +1,6 @@
 const validator = require('@tryghost/validator');
 const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
 
 /**
  * @typedef {object} EmailData
@@ -38,6 +39,8 @@ const logging = require('@tryghost/logging');
  * @prop {boolean} useFallbackAddress
  * @prop {Date} deliveryTime
  * @prop {Map<string, EmailBody>} [emailBodyCache]
+ * @prop {boolean} [recipientAccounting]
+ * @prop {string} [batchId]
  */
 
 /**
@@ -59,24 +62,29 @@ const logging = require('@tryghost/logging');
 
 /**
  * @typedef {object} EmailProviderSuccessResponse
- * @prop {string} id
+ * @prop {string|null} id
+ * @prop {number} [submittedCount]
+ * @prop {number} [submissionExcludedCount]
  */
 
 class SendingService {
   #emailProvider;
   #emailRenderer;
   #emailAddressService;
+  #sentry;
 
   /**
    * @param {object} dependencies
    * @param {IEmailProviderService} dependencies.emailProvider
    * @param {EmailRenderer} dependencies.emailRenderer
    * @param {EmailAddressService} dependencies.emailAddressService
+   * @param {object} [dependencies.sentry]
    */
-  constructor({ emailProvider, emailRenderer, emailAddressService }) {
+  constructor({ emailProvider, emailRenderer, emailAddressService, sentry }) {
     this.#emailProvider = emailProvider;
     this.#emailRenderer = emailRenderer;
     this.#emailAddressService = emailAddressService;
+    this.#sentry = sentry;
   }
 
   getMaximumRecipients() {
@@ -103,7 +111,13 @@ class SendingService {
    * @param {EmailSendingOptions} options
    * @returns {Promise<EmailProviderSuccessResponse>}
    */
-  async send({ post, newsletter, segment, members, emailId }, options) {
+  async send(data, options) {
+    return this.sendMessage(await this.buildMessage(data, options));
+  }
+
+  // Construct once outside the provider retry loop so exclusions, recipient
+  // replacements, and the intended payload stay fixed across uncertain retries.
+  async buildMessage({ post, newsletter, segment, members, emailId }, options) {
     const cacheId = emailId + '-' + (segment ?? 'null');
     const isTestEmail = options.isTestEmail ?? false;
 
@@ -125,9 +139,13 @@ class SendingService {
       }
     }
 
-    const recipients = this.buildRecipients(members, emailBody.replacements);
-    return await this.#emailProvider.send(
-      {
+    const recipients = this.buildRecipients(
+      members,
+      emailBody.replacements,
+      options.recipientAccounting ? { emailId, batchId: options.batchId } : undefined,
+    );
+    return {
+      data: {
         subject: this.#emailRenderer.getSubject(post, isTestEmail),
         from: this.#emailRenderer.getFromAddress(post, newsletter, !!options.useFallbackAddress),
         replyTo:
@@ -142,22 +160,46 @@ class SendingService {
           ? this.#emailAddressService.fallbackDomain
           : undefined,
       },
-      {
+      options: {
         clickTrackingEnabled: !!options.clickTrackingEnabled,
         openTrackingEnabled: !!options.openTrackingEnabled,
         useFallbackAddress: !!options.useFallbackAddress,
         ...(options.deliveryTime && { deliveryTime: options.deliveryTime }),
+        ...(options.recipientAccounting ? { expectedRecipientCount: recipients.length } : {}),
       },
-    );
+      ...(options.recipientAccounting
+        ? { submissionExcludedCount: members.length - recipients.length }
+        : {}),
+    };
+  }
+
+  async sendMessage(message) {
+    if (message.submissionExcludedCount !== undefined && message.data.recipients.length === 0) {
+      return {
+        id: null,
+        submittedCount: 0,
+        submissionExcludedCount: message.submissionExcludedCount,
+      };
+    }
+    const response = await this.#emailProvider.send(message.data, message.options);
+    if (message.submissionExcludedCount === undefined) {
+      return response;
+    }
+    return {
+      ...response,
+      submittedCount: message.data.recipients.length,
+      submissionExcludedCount: message.submissionExcludedCount,
+    };
   }
 
   /**
    * @private
    * @param {MemberLike[]} members
    * @param {import("./email-renderer").ReplacementDefinition[]} replacementDefinitions
+   * @param {{emailId: string|null, batchId?: string}} [accounting]
    * @returns {Recipient[]}
    */
-  buildRecipients(members, replacementDefinitions) {
+  buildRecipients(members, replacementDefinitions, accounting) {
     return members
       .map((member) => {
         return {
@@ -171,13 +213,29 @@ class SendingService {
           }),
         };
       })
-      .filter((recipient) => {
+      .filter((recipient, index) => {
         // Remove invalid recipient email addresses
         const isValidRecipient = validator.isEmail(recipient.email, { legacy: false });
         if (!isValidRecipient) {
-          logging.warn(
-            `Removed recipient ${recipient.email} from list because it is not a valid email address`,
-          );
+          if (accounting) {
+            const error = new errors.EmailError({
+              code: 'BULK_EMAIL_INVALID_RECIPIENT',
+              message:
+                'Recipient excluded from newsletter submission due to an invalid email address',
+              errorDetails: JSON.stringify({
+                email_id: accounting.emailId,
+                batch_id: accounting.batchId,
+                member_id: members[index].id,
+                reason: 'invalid_email_address',
+              }),
+            });
+            logging.error(error);
+            this.#sentry?.captureException(error);
+          } else {
+            logging.warn(
+              `Removed recipient ${recipient.email} from list because it is not a valid email address`,
+            );
+          }
         }
         return isValidRecipient;
       });

--- a/ghost/core/core/server/services/email-service/sending-status-schema.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-schema.ts
@@ -20,7 +20,7 @@ export const DbBatchSendingRow = z.object({
   status: StoredSendingStatus,
   created_at: DbDate,
   updated_at: DbDate,
-  recipient_count: DbCount,
+  recipient_count: DbCount.nullable(),
   accounted_recipient_count: DbCount.optional(),
 });
 export type DbBatchSendingRow = z.output<typeof DbBatchSendingRow>;

--- a/ghost/core/core/server/services/email-service/sending-status-schema.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-schema.ts
@@ -11,6 +11,7 @@ export const DbEmailSendingRow = z.object({
   id: z.string(),
   status: StoredSendingStatus,
   email_count: DbCount,
+  preflight_email_count: DbCount.nullable(),
   updated_at: DbDate.nullable(),
 });
 export type DbEmailSendingRow = z.output<typeof DbEmailSendingRow>;
@@ -20,5 +21,6 @@ export const DbBatchSendingRow = z.object({
   created_at: DbDate,
   updated_at: DbDate,
   recipient_count: DbCount,
+  accounted_recipient_count: DbCount.optional(),
 });
 export type DbBatchSendingRow = z.output<typeof DbBatchSendingRow>;

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -52,9 +52,15 @@ export class SendingStatusService {
         // Corrupt or transitional null counts must not hide the failed-send status.
         // Verification rejects them; this read-only projection gives no credit for unknown rows.
         .select(this.#knex.raw('COALESCE(recipient_count, 0) AS recipient_count'))
+        // Both missing counts identify preparation-only deployments. A partially
+        // missing pair is invalid and earns no verified submission progress.
         .select(
           this.#knex.raw(
-            'COALESCE(submitted_count + submission_excluded_count, recipient_count, 0) AS accounted_recipient_count',
+            `CASE
+              WHEN submitted_count IS NULL AND submission_excluded_count IS NULL
+              THEN COALESCE(recipient_count, 0)
+              ELSE COALESCE(submitted_count + submission_excluded_count, 0)
+            END AS accounted_recipient_count`,
           ),
         )
         .where('email_id', emailId);

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -49,10 +49,9 @@ export class SendingStatusService {
   async #batchesFor(emailId: string, recipientAccounting: boolean): Promise<SendingBatch[]> {
     if (recipientAccounting) {
       const rows = await this.#knex('email_batches')
-        .select('status', 'created_at', 'updated_at')
-        // Corrupt or transitional null counts must not hide the failed-send status.
-        // Verification rejects them; this read-only projection gives no credit for unknown rows.
-        .select(this.#knex.raw('COALESCE(recipient_count, 0) AS recipient_count'))
+        // Retain unknown intent so progress can use the email's saved total as
+        // a lower bound instead of silently treating missing recipients as zero.
+        .select('status', 'created_at', 'updated_at', 'recipient_count')
         // Both missing counts identify preparation-only deployments. A partially
         // missing pair is invalid and earns no verified submission progress.
         .select(

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -48,10 +48,13 @@ export class SendingStatusService {
   async #batchesFor(emailId: string, recipientAccounting: boolean): Promise<SendingBatch[]> {
     if (recipientAccounting) {
       const rows = await this.#knex('email_batches')
-        .select('status', 'created_at', 'updated_at', 'recipient_count')
+        .select('status', 'created_at', 'updated_at')
+        // Corrupt or transitional null counts must not hide the failed-send status.
+        // Verification rejects them; this read-only projection gives no credit for unknown rows.
+        .select(this.#knex.raw('COALESCE(recipient_count, 0) AS recipient_count'))
         .select(
           this.#knex.raw(
-            'COALESCE(submitted_count + submission_excluded_count, recipient_count) AS accounted_recipient_count',
+            'COALESCE(submitted_count + submission_excluded_count, recipient_count, 0) AS accounted_recipient_count',
           ),
         )
         .where('email_id', emailId);

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -23,8 +23,9 @@ export class SendingStatusService {
     }
 
     const email = DbEmailSendingRow.parse(row);
-    // Completion persists the verified submitted count (legacy sends retain their
-    // intended count), so finished sends need no batch or recipient aggregation.
+    // Completion persists the verified submitted count. Emails with null
+    // preflight_email_count, or batches submitted before submission counts were
+    // recorded, retain their intended count. Neither needs aggregation once finished.
     const batches =
       email.status === 'submitted'
         ? []

--- a/ghost/core/core/server/services/email-service/sending-status-service.ts
+++ b/ghost/core/core/server/services/email-service/sending-status-service.ts
@@ -14,7 +14,7 @@ export class SendingStatusService {
 
   async statusFor(emailId: string): Promise<EmailSendingStatus | null> {
     const row = await this.#knex('emails')
-      .select('id', 'status', 'email_count', 'updated_at')
+      .select('id', 'status', 'email_count', 'preflight_email_count', 'updated_at')
       .where('id', emailId)
       .first();
 
@@ -23,9 +23,12 @@ export class SendingStatusService {
     }
 
     const email = DbEmailSendingRow.parse(row);
-    // A submitted email answers from its own count, and batch creation reconciles email_count
-    // to the recipient rows it built, so the batch query is skipped rather than run and ignored.
-    const batches = email.status === 'submitted' ? [] : await this.#batchesFor(emailId);
+    // Completion persists the verified submitted count (legacy sends retain their
+    // intended count), so finished sends need no batch or recipient aggregation.
+    const batches =
+      email.status === 'submitted'
+        ? []
+        : await this.#batchesFor(emailId, email.preflight_email_count !== null);
 
     return {
       id: email.id,
@@ -42,7 +45,18 @@ export class SendingStatusService {
     };
   }
 
-  async #batchesFor(emailId: string): Promise<SendingBatch[]> {
+  async #batchesFor(emailId: string, recipientAccounting: boolean): Promise<SendingBatch[]> {
+    if (recipientAccounting) {
+      const rows = await this.#knex('email_batches')
+        .select('status', 'created_at', 'updated_at', 'recipient_count')
+        .select(
+          this.#knex.raw(
+            'COALESCE(submitted_count + submission_excluded_count, recipient_count) AS accounted_recipient_count',
+          ),
+        )
+        .where('email_id', emailId);
+      return rows.map((batchRow) => camelKeys(DbBatchSendingRow.parse(batchRow)));
+    }
     // Correlated per-batch count stays on the batch_id index; grouping recipients by email_id scans every recipient row.
     const recipientCount = this.#knex('email_recipients as recipient')
       .count('*')

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -36,7 +36,7 @@ export interface SendingEmail {
 
 export interface SendingBatch {
   status: StoredSendingStatus;
-  recipientCount: number;
+  recipientCount: number | null;
   createdAt: Date;
   updatedAt: Date;
   accountedRecipientCount?: number;
@@ -70,8 +70,11 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
     (sum, batch) => sum + completedRecipients(batch, phase),
     0,
   );
+  const hasUnknownRecipients = batches.some((batch) => batch.recipientCount === null);
   const total =
-    phase === 'preparing' ? Math.max(email.recipientCount, preparedCount) : preparedCount;
+    phase === 'preparing' || hasUnknownRecipients
+      ? Math.max(email.recipientCount, preparedCount)
+      : preparedCount;
 
   if (email.status === 'failed') {
     return {
@@ -103,13 +106,13 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
 }
 
 function sumRecipients(batches: SendingBatch[]): number {
-  return batches.reduce((sum, batch) => sum + batch.recipientCount, 0);
+  return batches.reduce((sum, batch) => sum + (batch.recipientCount ?? 0), 0);
 }
 
 function completedRecipients(batch: SendingBatch, phase: SendingPhase): number {
   return phase === 'submitting'
-    ? (batch.accountedRecipientCount ?? batch.recipientCount)
-    : batch.recipientCount;
+    ? (batch.accountedRecipientCount ?? batch.recipientCount ?? 0)
+    : (batch.recipientCount ?? 0);
 }
 
 // A batch that fails is only retried together with its email, so within an attempt it is finished work.

--- a/ghost/core/core/server/services/email-service/sending-status.ts
+++ b/ghost/core/core/server/services/email-service/sending-status.ts
@@ -39,6 +39,7 @@ export interface SendingBatch {
   recipientCount: number;
   createdAt: Date;
   updatedAt: Date;
+  accountedRecipientCount?: number;
 }
 
 type BatchSample = { recipientCount: number; timestamp: number };
@@ -65,7 +66,10 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
   const preparedCount = sumRecipients(batches);
   const completedBatches =
     phase === 'preparing' ? batches : batches.filter((batch) => batch.status === 'submitted');
-  const completed = sumRecipients(completedBatches);
+  const completed = completedBatches.reduce(
+    (sum, batch) => sum + completedRecipients(batch, phase),
+    0,
+  );
   const total =
     phase === 'preparing' ? Math.max(email.recipientCount, preparedCount) : preparedCount;
 
@@ -80,7 +84,7 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
   const failedThisAttempt = batches.filter((batch) => failedDuringAttempt(batch, attemptStartedAt));
   const remaining = total - completed - sumRecipients(failedThisAttempt);
   const samples = completedBatches.map((batch) => ({
-    recipientCount: batch.recipientCount,
+    recipientCount: completedRecipients(batch, phase),
     timestamp: (phase === 'preparing' ? batch.createdAt : batch.updatedAt).getTime(),
   }));
 
@@ -100,6 +104,12 @@ export function buildSendingStatus(email: SendingEmail, batches: SendingBatch[])
 
 function sumRecipients(batches: SendingBatch[]): number {
   return batches.reduce((sum, batch) => sum + batch.recipientCount, 0);
+}
+
+function completedRecipients(batch: SendingBatch, phase: SendingPhase): number {
+  return phase === 'submitting'
+    ? (batch.accountedRecipientCount ?? batch.recipientCount)
+    : batch.recipientCount;
 }
 
 // A batch that fails is only retried together with its email, so within an attempt it is finished work.

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -7,6 +7,9 @@ const logging = require('@tryghost/logging');
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
 const dbUtils = require('../../../utils/db-utils');
+const {
+  SendingStatusService,
+} = require('../../../../core/server/services/email-service/sending-status-service');
 const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
 const SendingService = require('../../../../core/server/services/email-service/sending-service');
 const MailgunEmailProvider = require('../../../../core/server/services/email-service/mailgun-email-provider');
@@ -508,6 +511,80 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     } finally {
       db.knex.removeListener('query-response', stop);
     }
+  });
+
+  for (const status of ['submitting', 'submitted']) {
+    it(`ignores prior verification diagnostics on a ${status} batch`, async function () {
+      const batches = await service.createBatches(data);
+      await service.sendBatches({ ...data, batches });
+      await batches[0].save(
+        {
+          status,
+          error_data: JSON.stringify({
+            code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+            reason: 'previous_attempt',
+          }),
+        },
+        { patch: true },
+      );
+      if (status === 'submitted') {
+        await service.sendBatches({ ...data, batches: await service.getBatches(email) });
+      } else {
+        await assert.rejects(
+          service.sendBatches({ ...data, batches: await service.getBatches(email) }),
+          (error) => {
+            assert.notEqual(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+            assert.match(error.message, /only partially sent/);
+            return true;
+          },
+        );
+      }
+    });
+  }
+
+  it('reads active mixed-era progress from batch counts including all-excluded submissions', async function () {
+    const batches = await service.createBatches(data);
+    const full = batches.find((b) => b.get('recipient_count') === 2);
+    const singles = batches.filter((b) => b.get('recipient_count') === 1);
+    await email.save({ status: 'submitting' }, { patch: true });
+    await full.save({ status: 'submitted' }, { patch: true });
+    await singles[0].save(
+      { status: 'submitted', submitted_count: 0, submission_excluded_count: 1 },
+      { patch: true },
+    );
+    const statusService = new SendingStatusService({ knex: db.knex });
+    const queries = [];
+    const recordQuery = ({ sql }) => queries.push(sql);
+    db.knex.on('query', recordQuery);
+    try {
+      const active = await statusService.statusFor(email.id);
+      assert.equal(active.sending.status, 'submitting');
+      assert.equal(active.sending.progress.completed, 3);
+      assert.equal(active.sending.progress.total, 4);
+      assert.ok(queries.every((sql) => !sql.includes('email_recipients')));
+    } finally {
+      db.knex.removeListener('query', recordQuery);
+    }
+    await full.refresh();
+    assert.equal(full.get('submitted_count'), null);
+    assert.equal(singles[0].get('mailgun_message_id'), null);
+    await singles[1].save(
+      { status: 'submitted', submitted_count: 1, submission_excluded_count: 0 },
+      { patch: true },
+    );
+    const done = await statusService.statusFor(email.id);
+    assert.equal(done.sending.progress.completed, 4);
+    assert.equal(done.sending.progress.total, 4);
+  });
+
+  it('keeps failed progress readable when an accounted batch count is unexpectedly null', async function () {
+    const batches = await service.createBatches(data);
+    await email.save({ status: 'failed' }, { patch: true });
+    await batches[0].save({ status: 'failed', recipient_count: null }, { patch: true });
+    const result = await new SendingStatusService({ knex: db.knex }).statusFor(email.id);
+    assert.equal(result.sending.status, 'failed');
+    await batches[0].refresh();
+    assert.equal(batches[0].get('recipient_count'), null);
   });
 
   it('alerts on preflight drift without rejecting a valid candidate sweep', async function () {

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -1232,6 +1232,22 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(excludedBatch.get('status'), 'submitted');
     assert.equal(excludedBatch.get('submitted_count'), 0);
     assert.equal(excludedBatch.get('mailgun_message_id'), null);
+    sinon.assert.calledWithMatch(logging.info, {
+      event: { name: 'email.batch.submitted' },
+      email_id: email.id,
+      batch_id: excludedBatch.id,
+      submitted_count: 0,
+      submission_excluded_count: 1,
+      mailgun_message_id: null,
+    });
+    sinon.assert.calledWithMatch(logging.info, {
+      event: { name: 'email.batch.submitted' },
+      email_id: email.id,
+      mailgun_message_id: 'accepted',
+    });
+    sinon.assert.neverCalledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+    });
     const mapBatch = require('../../../../core/server/api/endpoints/utils/serializers/output/mappers/email-batches');
     const response = mapBatch(excludedBatch, { options: {} });
     assert.equal(response.status, 'submitted');
@@ -1268,6 +1284,59 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     sinon.assert.calledOnce(sentry.captureException);
     assert.match(email.get('error'), /recipient verification failed/);
     assert.ok(!email.get('error').toLowerCase().includes('retry'));
+    sinon.assert.calledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+      email_id: email.id,
+      batch_id: duplicateBatch.id,
+      reason: 'batch_verification_failed',
+      expected: 2,
+      actual: 1,
+    });
+  });
+
+  it('logs a payload discrepancy before a failed batch status write can hide it', async function () {
+    const batches = await service.createBatches(data);
+    const duplicateBatch = batches.find((batch) => batch.get('recipient_count') === 2);
+    await db
+      .knex('email_recipients')
+      .where({ batch_id: duplicateBatch.id })
+      .update({ member_email: 'duplicate@example.com' });
+    const client = { send: sinon.stub().resolves({ id: '<accepted>' }) };
+    const provider = new MailgunEmailProvider({
+      mailgunClient: client,
+      config: { get: () => undefined },
+    });
+    sender.send.callsFake(provider.send.bind(provider));
+    // Status persistence fails independently of the payload check. Disable backoff
+    // so the test exercises the exhausted-write outcome without waiting for retries.
+    sinon.stub(service, 'retryDb').callsFake(async (operation) => operation());
+    const save = models.EmailBatch.prototype.save;
+    sinon.stub(models.EmailBatch.prototype, 'save').callsFake(function (attributes, ...args) {
+      if (this.id === duplicateBatch.id && attributes?.status === 'failed') {
+        sinon.assert.calledWithMatch(logging.error, {
+          event: { name: 'email.recipient_count.mismatch' },
+          code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+          email_id: email.id,
+          batch_id: duplicateBatch.id,
+          reason: 'provider_payload_count',
+          expected: 2,
+          actual: 1,
+        });
+        throw new Error('Batch status write unavailable');
+      }
+      return save.call(this, attributes, ...args);
+    });
+    await assert.rejects(
+      service.sendBatches({ ...data, batches }),
+      /Batch status write unavailable/,
+    );
+    await duplicateBatch.refresh();
+    assert.equal(duplicateBatch.get('status'), 'submitting');
+    assert.equal(duplicateBatch.get('error_data'), null);
+    const alerts = logging.error
+      .getCalls()
+      .filter(({ args }) => args[0]?.event?.name === 'email.recipient_count.mismatch');
+    assert.equal(alerts.length, 1);
   });
 
   it('counts each consumed candidate once across lookahead pages and warming splits', async function () {
@@ -1302,6 +1371,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       event: { name: 'email.submission.unverified' },
       unverified_batch_ids: [batches[0].id],
     });
+    sinon.assert.neverCalledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+    });
     sinon.assert.calledTwice(sender.send);
   });
 
@@ -1320,6 +1392,38 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       },
     );
     sinon.assert.callCount(sender.send, 3);
+    sinon.assert.calledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+      code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+      email_id: email.id,
+      batch_id: batches[0].id,
+      reason: 'batch_submission_counts',
+      expected: batches[0].get('recipient_count'),
+      actual: batches[0].get('recipient_count') + 1,
+      recipient_count: batches[0].get('recipient_count'),
+      submitted_count: batches[0].get('recipient_count') + 1,
+      submission_excluded_count: 0,
+    });
+  });
+
+  it('reports partially missing submission metadata without a P1 count mismatch', async function () {
+    const batches = await service.createBatches(data);
+    await service.sendBatches({ ...data, batches });
+    await batches[0].save({ submitted_count: null }, { patch: true });
+    await assert.rejects(
+      service.sendBatches({ ...data, batches: await service.getBatches(email) }),
+      {
+        code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+      },
+    );
+    sinon.assert.calledWithMatch(logging.error, {
+      event: { name: 'email.verification.failed' },
+      reason: 'batch_submission_counts',
+      actual: null,
+    });
+    sinon.assert.neverCalledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+    });
   });
 
   it('keeps ordinary provider failures retry-oriented', async function () {

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -542,6 +542,30 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   }
 
+  it('reports persisted verification failures during shutdown with unstarted batches', async function () {
+    const {
+      recipientVerificationError,
+    } = require('../../../../core/server/services/email-service/recipient-accounting');
+    const batches = await service.createBatches(data);
+    sender.send.onFirstCall().callsFake(async () => {
+      service.onPreStop();
+      throw recipientVerificationError(email.id, 'provider_recipient_count');
+    });
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((jobEmail) => service.sendBatches({ ...data, email: jobEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    const reported = sentry.captureException
+      .getCalls()
+      .filter(({ args }) => args[0].code === 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+    assert.equal(reported.length, 1);
+    assert.equal(JSON.parse(reported[0].args[0].errorDetails).reason, 'batch_verification_failed');
+    await email.refresh();
+    assert.equal(email.get('status'), 'submitting');
+    assert.equal(email.get('error'), null);
+    assert.ok((await service.getBatches(email)).some((batch) => batch.get('status') === 'pending'));
+  });
+
   it('reads active mixed-era progress from batch counts including all-excluded submissions', async function () {
     const batches = await service.createBatches(data);
     const full = batches.find((b) => b.get('recipient_count') === 2);

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -367,7 +367,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal((await db.knex('email_recipients').where({ email_id: email.id })).length, 4);
     const sentIds = sender.send
       .getCalls()
-      .flatMap((call) => call.args[0].members.map((member: { id: string }) => member.id));
+      .flatMap((call) =>
+        call.args[0].recipients.map((recipient: { email: string }) => recipient.email),
+      );
     assert.equal(sentIds.length, 4);
     assert.equal(new Set(sentIds).size, 4);
   });
@@ -1325,6 +1327,41 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(response.mailgun_message_id, null);
     sinon.assert.calledTwice(sender.send);
   });
+
+  for (const excludedCount of [1, 4]) {
+    it(`reuses completed batches with ${excludedCount} submission exclusions`, async function () {
+      stubEmailRelations();
+      const batches = await service.createBatches(data);
+      const recipients = await db
+        .knex('email_recipients')
+        .where({ email_id: email.id })
+        .limit(excludedCount);
+      await db
+        .knex('email_recipients')
+        .whereIn(
+          'id',
+          recipients.map((row) => row.id),
+        )
+        .update({ member_email: 'invalid' });
+      await service.emailJob({ emailId: email.id });
+      await email.refresh();
+      assert.equal(email.get('status'), 'submitted');
+      assert.equal(email.get('email_count'), 4 - excludedCount);
+
+      await email.save({ status: 'failed' }, { patch: true });
+      sinon.stub(models.Member, 'findPage').throws(new Error('Audience must stay frozen'));
+      sender.send.resetHistory();
+      await service.emailJob({ emailId: email.id });
+      await email.refresh();
+      assert.equal(email.get('status'), 'submitted');
+      assert.equal(email.get('email_count'), 4 - excludedCount);
+      assert.deepEqual(
+        (await service.getBatches(email)).map((batch) => batch.id),
+        batches.map((batch) => batch.id),
+      );
+      sinon.assert.notCalled(sender.send);
+    });
+  }
 
   it('preserves a duplicate-payload verification error through batch failure to the email banner', async function () {
     const batches = await service.createBatches(data);

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -8,6 +8,8 @@ const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
 const dbUtils = require('../../../utils/db-utils');
 const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
+const SendingService = require('../../../../core/server/services/email-service/sending-service');
+const MailgunEmailProvider = require('../../../../core/server/services/email-service/mailgun-email-provider');
 
 // The legacy Bookshelf models are untyped; keep that boundary separate from the test fixtures.
 type Email = InstanceType<typeof models.Email>;
@@ -106,7 +108,11 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       send: sinon.stub().resolves({ id: 'accepted' }),
     };
     renderer = { getSegments: sinon.stub().resolves([null]) };
-    segmenter = { getMemberFilterForSegment: sinon.stub().returns('status:free') };
+    segmenter = {
+      getMemberFilterForSegment: sinon.stub().callsFake((_newsletter, filter) =>
+        filter === 'all' ? 'status:free' : filter,
+      ),
+    };
     service = createService();
     data = { email, post: {}, newsletter: {} };
   });
@@ -135,7 +141,17 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       emailRenderer: renderer,
       emailSegmenter: segmenter,
       domainWarmingService: { isEnabled: () => true },
-      sendingService: sender,
+      sendingService: new SendingService({
+        emailProvider: sender,
+        emailRenderer: {
+          renderBody: async () => ({ html: 'Hello', plaintext: 'Hello', replacements: [] }),
+          getSubject: () => 'Hello',
+          getFromAddress: () => 'sender@example.com',
+          getReplyToAddress: () => null,
+        },
+        emailAddressService: {},
+        sentry,
+      }),
       BEFORE_RETRY_CONFIG: { maxRetries: 2, sleep: 0 },
     });
   }
@@ -404,7 +420,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.ok(batches.every((batch) => !partialIds.includes(batch.id)));
     const sentIds = sender.send
       .getCalls()
-      .flatMap((call) => call.args[0].members.map((member: { id: string }) => member.id));
+      .flatMap((call) => call.args[0].recipients.map((recipient: { email: string }) => recipient.email));
     assert.equal(sentIds.length, 4);
     assert.equal(new Set(sentIds).size, 4);
   });
@@ -457,7 +473,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     );
     const sentIds = sender.send
       .getCalls()
-      .flatMap((call) => call.args[0].members.map((member: { id: string }) => member.id));
+      .flatMap((call) => call.args[0].recipients.map((recipient: { email: string }) => recipient.email));
     assert.equal(sentIds.length, 4);
     assert.equal(new Set(sentIds).size, 4);
   });
@@ -1028,6 +1044,67 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   }
 
+  it('persists verified submission totals and exclusions when completing the email', async function () {
+    const batches = await service.createBatches(data);
+    const excludedBatch = batches.find((batch) => batch.get('recipient_count') === 1);
+    await db
+      .knex('email_recipients')
+      .where({ batch_id: excludedBatch.id })
+      .update({ member_email: 'invalid' });
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    await email.refresh();
+    assert.equal(email.get('status'), 'submitted');
+    assert.equal(email.get('email_count'), 3);
+    assert.equal(email.get('candidate_count'), 4);
+    const persisted = await service.getBatches(email);
+    assert.equal(
+      persisted.reduce((sum, b) => sum + b.get('submitted_count'), 0),
+      3,
+    );
+    assert.equal(
+      persisted.reduce((sum, b) => sum + b.get('submission_excluded_count'), 0),
+      1,
+    );
+    await excludedBatch.refresh();
+    assert.equal(excludedBatch.get('status'), 'submitted');
+    assert.equal(excludedBatch.get('submitted_count'), 0);
+    assert.equal(excludedBatch.get('mailgun_message_id'), null);
+    sinon.assert.calledTwice(sender.send);
+  });
+
+  it('preserves a duplicate-payload verification error through batch failure to the email banner', async function () {
+    const batches = await service.createBatches(data);
+    const duplicateBatch = batches.find((batch) => batch.get('recipient_count') === 2);
+    await db
+      .knex('email_recipients')
+      .where({ batch_id: duplicateBatch.id })
+      .update({ member_email: 'duplicate@example.com' });
+    const client = { send: sinon.stub().resolves({ id: '<accepted>' }) };
+    const provider = new MailgunEmailProvider({
+      mailgunClient: client,
+      config: { get: () => undefined },
+    });
+    sender.send.callsFake(provider.send.bind(provider));
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    await duplicateBatch.refresh();
+    assert.equal(duplicateBatch.get('status'), 'failed');
+    assert.equal(
+      JSON.parse(duplicateBatch.get('error_data')).code,
+      'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+    );
+    sinon.assert.calledTwice(client.send);
+    await email.refresh();
+    assert.equal(email.get('status'), 'failed');
+    assert.match(email.get('error'), /recipient verification failed/);
+    assert.ok(!email.get('error').toLowerCase().includes('retry'));
+  });
+
   it('counts each consumed candidate once across lookahead pages and warming splits', async function () {
     const batches = await service.createBatches(data);
     await email.refresh();
@@ -1041,6 +1118,68 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     const recipients = await db.knex('email_recipients').where({ email_id: email.id });
     assert.equal(recipients.length, 4);
     assert.equal(new Set(recipients.map((r) => r.member_id)).size, 4);
+  });
+
+  it('completes mixed preparation-era submissions without inventing historical counts', async function () {
+    const batches = await service.createBatches(data);
+    await batches[0].save({ status: 'submitted' }, { patch: true });
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    await email.refresh();
+    assert.equal(email.get('status'), 'submitted');
+    assert.equal(email.get('email_count'), 4);
+    await batches[0].refresh();
+    assert.equal(batches[0].get('submitted_count'), null);
+    assert.equal(batches[0].get('submission_excluded_count'), null);
+    sinon.assert.calledWithMatch(logging.info, { event: { name: 'email.submission.unverified' } });
+    sinon.assert.calledTwice(sender.send);
+  });
+
+  it('rejects inconsistent persisted submission counts even when all batches are submitted', async function () {
+    const batches = await service.createBatches(data);
+    await service.sendBatches({ ...data, batches });
+    await batches[0].refresh();
+    await batches[0].save(
+      { submitted_count: batches[0].get('recipient_count') + 1 },
+      { patch: true },
+    );
+    await assert.rejects(
+      service.sendBatches({ ...data, batches: await service.getBatches(email) }),
+      {
+        code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+      },
+    );
+    sinon.assert.callCount(sender.send, 3);
+  });
+
+  it('keeps ordinary provider failures retry-oriented', async function () {
+    const batches = await service.createBatches(data);
+    sender.send.rejects(new Error('Provider unavailable'));
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    await email.refresh();
+    assert.equal(email.get('status'), 'failed');
+    assert.match(email.get('error'), /retry/i);
+    assert.doesNotMatch(email.get('error'), /recipient verification failed/);
+  });
+
+  it('completes a zero-candidate email with verified zero submissions', async function () {
+    await email.save({ recipient_filter: "email:'nobody@example.com'" }, { patch: true });
+    const batches = await service.createBatches(data);
+    assert.equal(batches.length, 0);
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    await email.refresh();
+    assert.equal(email.get('status'), 'submitted');
+    assert.equal(email.get('candidate_count'), 0);
+    assert.equal(email.get('email_count'), 0);
+    sinon.assert.notCalled(sender.send);
   });
 
   it('does not complete preparation when persisted recipients are missing', async function () {

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -1310,6 +1310,35 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   });
 
+  it('preserves an explicit ownership diagnosis when replaying a persisted failure', async function () {
+    const batches = await service.createBatches(data);
+    await batches[0].save(
+      {
+        status: 'failed',
+        error_data: JSON.stringify({
+          code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+          reason: 'cross_email_recipient',
+          expected: 2,
+          actual: 1,
+          count_mismatch: false,
+        }),
+      },
+      { patch: true },
+    );
+    sinon.stub(service, 'sendBatch').resolves(false);
+    await assert.rejects(service.sendBatches({ ...data, batches }), (error) => {
+      assertVerificationError(error);
+      const details = JSON.parse(error.errorDetails);
+      assert.equal(details.reason, 'batch_verification_failed');
+      assert.equal(details.count_mismatch, false);
+      assert.equal(details.batch_error.reason, 'cross_email_recipient');
+      return true;
+    });
+    sinon.assert.neverCalledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+    });
+  });
+
   it('logs a payload discrepancy before a failed batch status write can hide it', async function () {
     const batches = await service.createBatches(data);
     const duplicateBatch = batches.find((batch) => batch.get('recipient_count') === 2);

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -566,6 +566,38 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   }
 
+  it('reports persisted verification failure when marking recipients processed subsequently fails', async function () {
+    const batches = await service.createBatches(data);
+    const failedBatch = batches.find((batch) => batch.get('recipient_count') === 2);
+    await db
+      .knex('email_recipients')
+      .where({ batch_id: failedBatch.id })
+      .update({ member_email: 'duplicate@example.com' });
+    useRealMailgunProvider();
+    // Exercise the exhausted-write result without retry backoff.
+    sinon.stub(service, 'retryDb').callsFake(async (operation) => operation());
+    const processedError = new Error('Unable to mark recipients processed');
+    const processedSave = sinon.stub().rejects(processedError);
+    sinon
+      .stub(models.EmailRecipient, 'where')
+      .callThrough()
+      .withArgs({ batch_id: failedBatch.id })
+      .returns({ save: processedSave });
+    await runEmailJob(batches);
+    sinon.assert.calledOnce(processedSave);
+    await failedBatch.refresh();
+    assert.equal(failedBatch.get('status'), 'failed');
+    assert.equal(JSON.parse(failedBatch.get('error_data')).reason, 'provider_payload_count');
+    await email.refresh();
+    assert.equal(email.get('status'), 'failed');
+    assert.match(email.get('error'), /checking your newsletter’s recipients/);
+    sinon.assert.calledOnce(sentry.captureException);
+    const details = verificationDetails(sentry.captureException.firstCall.args[0]);
+    assert.equal(details.reason, 'batch_verification_failed');
+    assert.equal(details.batch_id, failedBatch.id);
+    assert.equal(details.batch_error.reason, 'provider_payload_count');
+  });
+
   it('reports persisted verification failures during shutdown with unstarted batches', async function () {
     const batches = await service.createBatches(data);
     sender.send.onFirstCall().callsFake(async () => {

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -533,8 +533,8 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
         await assert.rejects(
           service.sendBatches({ ...data, batches: await service.getBatches(email) }),
           (error) => {
-            assert.notEqual(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
-            assert.match(error.message, /only partially sent/);
+            assert.equal(error.code, 'BULK_EMAIL_SUBMISSION_UNCERTAIN');
+            assert.match(error.message, /Contact support/);
             return true;
           },
         );
@@ -585,6 +585,65 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(result.sending.status, 'failed');
     await batches[0].refresh();
     assert.equal(batches[0].get('recipient_count'), null);
+  });
+
+  it('leaves legacy submission counts unknown and preserves the prepared email count', async function () {
+    await email.save({ preflight_email_count: null }, { patch: true });
+    const batches = await service.createBatches(data);
+    const intendedCount = email.get('email_count');
+    await db
+      .knex('email_recipients')
+      .where({ batch_id: batches.find((b) => b.get('fallback_sending_domain')).id })
+      .update({ member_email: 'invalid' });
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+    await email.refresh();
+    assert.equal(email.get('status'), 'submitted');
+    assert.equal(email.get('email_count'), intendedCount);
+    for (const batch of await service.getBatches(email)) {
+      assert.equal(batch.get('submitted_count'), null);
+      assert.equal(batch.get('submission_excluded_count'), null);
+    }
+  });
+
+  it('rejects changed candidate totals while every submitted batch remains internally consistent', async function () {
+    const batches = await service.createBatches(data);
+    await service.sendBatches({ ...data, batches });
+    sender.send.resetHistory();
+    await email.save({ candidate_count: 5 }, { patch: true });
+    await assert.rejects(
+      service.sendBatches({ ...data, batches: await service.getBatches(email) }),
+      (error) => {
+        assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+        // The preparation identity catches this before the redundant submission sum.
+        assert.equal(JSON.parse(error.errorDetails).reason, 'preparation_totals');
+        return true;
+      },
+    );
+    sinon.assert.notCalled(sender.send);
+  });
+
+  it('preserves a verified batch failure when another batch has an uncertain submission', async function () {
+    const batches = await service.createBatches(data);
+    await batches[0].save({ status: 'submitting' }, { patch: true });
+    await batches[1].save(
+      {
+        status: 'failed',
+        error_data: JSON.stringify({
+          code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+          reason: 'provider_payload_count',
+        }),
+      },
+      { patch: true },
+    );
+    sinon.stub(service, 'sendBatch').resolves(false);
+    await assert.rejects(service.sendBatches({ ...data, batches }), (error) => {
+      assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+      assert.equal(JSON.parse(error.errorDetails).batch_id, batches[1].id);
+      return true;
+    });
   });
 
   it('alerts on preflight drift without rejecting a valid candidate sweep', async function () {
@@ -1149,6 +1208,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(excludedBatch.get('status'), 'submitted');
     assert.equal(excludedBatch.get('submitted_count'), 0);
     assert.equal(excludedBatch.get('mailgun_message_id'), null);
+    const mapBatch = require('../../../../core/server/api/endpoints/utils/serializers/output/mappers/email-batches');
+    const response = mapBatch(excludedBatch, { options: {} });
+    assert.equal(response.status, 'submitted');
+    assert.equal(response.mailgun_message_id, null);
     sinon.assert.calledTwice(sender.send);
   });
 
@@ -1178,6 +1241,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     sinon.assert.calledTwice(client.send);
     await email.refresh();
     assert.equal(email.get('status'), 'failed');
+    sinon.assert.calledOnce(sentry.captureException);
     assert.match(email.get('error'), /recipient verification failed/);
     assert.ok(!email.get('error').toLowerCase().includes('retry'));
   });
@@ -1210,7 +1274,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await batches[0].refresh();
     assert.equal(batches[0].get('submitted_count'), null);
     assert.equal(batches[0].get('submission_excluded_count'), null);
-    sinon.assert.calledWithMatch(logging.info, { event: { name: 'email.submission.unverified' } });
+    sinon.assert.calledWithMatch(logging.info, {
+      event: { name: 'email.submission.unverified' },
+      unverified_batch_ids: [batches[0].id],
+    });
     sinon.assert.calledTwice(sender.send);
   });
 

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -1387,56 +1387,83 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   }
 
-  it('logs a payload discrepancy before a failed batch status write can hide it', async function () {
+  for (const shutdown of [false, true]) {
+    it(`preserves a verification failure when its batch status cannot be saved (shutdown: ${shutdown})`, async function () {
+      const batches = await service.createBatches(data);
+      const duplicateBatch = batches.find((batch) => batch.get('recipient_count') === 2);
+      await db
+        .knex('email_recipients')
+        .where({ batch_id: duplicateBatch.id })
+        .update({ member_email: 'duplicate@example.com' });
+      useRealMailgunProvider();
+      // Exercise exhausted writes without retry backoff.
+      sinon.stub(service, 'retryDb').callsFake(async (operation) => operation());
+      const save = models.EmailBatch.prototype.save;
+      sinon.stub(models.EmailBatch.prototype, 'save').callsFake(function (
+        this: Batch,
+        attributes,
+        ...args
+      ) {
+        if (
+          this.id === duplicateBatch.id &&
+          attributes &&
+          typeof attributes === 'object' &&
+          'status' in attributes &&
+          attributes.status === 'failed'
+        ) {
+          if (shutdown) {
+            service.onPreStop();
+          }
+          throw new Error('Batch status write unavailable');
+        }
+        return save.call(this, attributes, ...args);
+      });
+      await runEmailJob(batches);
+      await duplicateBatch.refresh();
+      assert.equal(duplicateBatch.get('status'), 'submitting');
+      assert.equal(duplicateBatch.get('error_data'), null);
+      sinon.assert.calledOnce(sentry.captureException);
+      const error = sentry.captureException.firstCall.args[0];
+      assert.equal(error.retryable, false);
+      assert.equal(verificationDetails(error).reason, 'provider_payload_count');
+      await email.refresh();
+      assert.equal(email.get('status'), shutdown ? 'submitting' : 'failed');
+      assert.equal(email.get('error'), shutdown ? null : error.message);
+      if (shutdown) {
+        assert.ok(
+          (await service.getBatches(email)).some((batch) => batch.get('status') === 'pending'),
+        );
+      }
+      const alerts = logging.error
+        .getCalls()
+        .filter(
+          ({ args }: sinon.SinonSpyCall) =>
+            args[0]?.event?.name === 'email.recipient_count.mismatch',
+        );
+      assert.equal(alerts.length, 1);
+    });
+  }
+
+  it('keeps exclusion progress without claiming a partially sent email when every provider request fails', async function () {
     const batches = await service.createBatches(data);
-    const duplicateBatch = batches.find((batch) => batch.get('recipient_count') === 2);
+    const excludedBatch = batches.find((batch) => batch.get('recipient_count') === 2);
     await db
       .knex('email_recipients')
-      .where({ batch_id: duplicateBatch.id })
-      .update({ member_email: 'duplicate@example.com' });
-    useRealMailgunProvider();
-    // Status persistence fails independently of the payload check. Disable backoff
-    // so the test exercises the exhausted-write outcome without waiting for retries.
+      .where({ batch_id: excludedBatch.id })
+      .update({ member_email: 'invalid-email' });
+    sender.send.rejects(new Error('Provider unavailable'));
     sinon.stub(service, 'retryDb').callsFake(async (operation) => operation());
-    const save = models.EmailBatch.prototype.save;
-    sinon.stub(models.EmailBatch.prototype, 'save').callsFake(function (
-      this: Batch,
-      attributes,
-      ...args
-    ) {
-      if (
-        this.id === duplicateBatch.id &&
-        attributes &&
-        typeof attributes === 'object' &&
-        'status' in attributes &&
-        attributes.status === 'failed'
-      ) {
-        sinon.assert.calledWithMatch(logging.error, {
-          event: { name: 'email.recipient_count.mismatch' },
-          code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
-          email_id: email.id,
-          batch_id: duplicateBatch.id,
-          reason: 'provider_payload_count',
-          expected: 2,
-          actual: 1,
-        });
-        throw new Error('Batch status write unavailable');
-      }
-      return save.call(this, attributes, ...args);
-    });
-    await assert.rejects(
-      service.sendBatches({ ...data, batches }),
-      /Batch status write unavailable/,
-    );
-    await duplicateBatch.refresh();
-    assert.equal(duplicateBatch.get('status'), 'submitting');
-    assert.equal(duplicateBatch.get('error_data'), null);
-    const alerts = logging.error
-      .getCalls()
-      .filter(
-        ({ args }: sinon.SinonSpyCall) => args[0]?.event?.name === 'email.recipient_count.mismatch',
-      );
-    assert.equal(alerts.length, 1);
+    await runEmailJob(batches);
+    await excludedBatch.refresh();
+    assert.equal(excludedBatch.get('status'), 'submitted');
+    assert.equal(excludedBatch.get('submitted_count'), 0);
+    assert.equal(excludedBatch.get('submission_excluded_count'), 2);
+    await email.refresh();
+    assert.equal(email.get('status'), 'failed');
+    assert.doesNotMatch(email.get('error'), /partially sent/);
+    const result = await new SendingStatusService({ knex: db.knex }).statusFor(email.id);
+    assert.equal(result?.sending.progress.completed, 2);
+    assert.equal(result?.sending.progress.total, 4);
   });
 
   it('counts each consumed candidate once across lookahead pages and warming splits', async function () {
@@ -1751,7 +1778,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     sinon.stub(service, 'sendBatch').resolves(true);
     await assert.rejects(
       service.sendBatches({ ...data, batches: dispatched }),
-      /only partially sent/,
+      /please retry sending your newsletter/,
     );
   });
 

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -3,13 +3,12 @@ import crypto from 'node:crypto';
 import ObjectID from 'bson-objectid';
 import sinon from 'sinon';
 import type { Knex } from 'knex';
+import { SendingStatusService } from '../../../../core/server/services/email-service/sending-status-service';
+
 const logging = require('@tryghost/logging');
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
 const dbUtils = require('../../../utils/db-utils');
-const {
-  SendingStatusService,
-} = require('../../../../core/server/services/email-service/sending-status-service');
 const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
 const SendingService = require('../../../../core/server/services/email-service/sending-service');
 const MailgunEmailProvider = require('../../../../core/server/services/email-service/mailgun-email-provider');
@@ -112,9 +111,11 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     };
     renderer = { getSegments: sinon.stub().resolves([null]) };
     segmenter = {
-      getMemberFilterForSegment: sinon.stub().callsFake((_newsletter, filter) =>
-        filter === 'all' ? 'status:free' : filter,
-      ),
+      getMemberFilterForSegment: sinon
+        .stub()
+        .callsFake((_newsletter: unknown, filter: string) =>
+          filter === 'all' ? 'status:free' : filter,
+        ),
     };
     service = createService();
     data = { email, post: {}, newsletter: {} };
@@ -533,6 +534,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
         await assert.rejects(
           service.sendBatches({ ...data, batches: await service.getBatches(email) }),
           (error) => {
+            assert.ok(error instanceof Error && 'code' in error);
             assert.equal(error.code, 'BULK_EMAIL_SUBMISSION_UNCERTAIN');
             assert.match(error.message, /Contact support/);
             return true;
@@ -557,7 +559,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await service.emailJob({ emailId: email.id });
     const reported = sentry.captureException
       .getCalls()
-      .filter(({ args }) => args[0].code === 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+      .filter(
+        ({ args }: sinon.SinonSpyCall) =>
+          args[0].code === 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+      );
     assert.equal(reported.length, 1);
     assert.equal(JSON.parse(reported[0].args[0].errorDetails).reason, 'batch_verification_failed');
     await email.refresh();
@@ -577,11 +582,12 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       { patch: true },
     );
     const statusService = new SendingStatusService({ knex: db.knex });
-    const queries = [];
-    const recordQuery = ({ sql }) => queries.push(sql);
+    const queries: string[] = [];
+    const recordQuery = ({ sql }: { sql: string }) => queries.push(sql);
     db.knex.on('query', recordQuery);
     try {
       const active = await statusService.statusFor(email.id);
+      assert.ok(active);
       assert.equal(active.sending.status, 'submitting');
       assert.equal(active.sending.progress.completed, 3);
       assert.equal(active.sending.progress.total, 4);
@@ -597,6 +603,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       { patch: true },
     );
     const done = await statusService.statusFor(email.id);
+    assert.ok(done);
     assert.equal(done.sending.progress.completed, 4);
     assert.equal(done.sending.progress.total, 4);
   });
@@ -606,6 +613,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await email.save({ status: 'failed' }, { patch: true });
     await batches[0].save({ status: 'failed', recipient_count: null }, { patch: true });
     const result = await new SendingStatusService({ knex: db.knex }).statusFor(email.id);
+    assert.ok(result);
     assert.equal(result.sending.status, 'failed');
     await batches[0].refresh();
     assert.equal(batches[0].get('recipient_count'), null);
@@ -640,6 +648,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await assert.rejects(
       service.sendBatches({ ...data, batches: await service.getBatches(email) }),
       (error) => {
+        assertVerificationError(error);
         assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
         // The preparation identity catches this before the redundant submission sum.
         assert.equal(JSON.parse(error.errorDetails).reason, 'preparation_totals');
@@ -664,6 +673,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     );
     sinon.stub(service, 'sendBatch').resolves(false);
     await assert.rejects(service.sendBatches({ ...data, batches }), (error) => {
+      assertVerificationError(error);
       assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
       assert.equal(JSON.parse(error.errorDetails).batch_id, batches[1].id);
       return true;
@@ -1311,8 +1321,18 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     // so the test exercises the exhausted-write outcome without waiting for retries.
     sinon.stub(service, 'retryDb').callsFake(async (operation) => operation());
     const save = models.EmailBatch.prototype.save;
-    sinon.stub(models.EmailBatch.prototype, 'save').callsFake(function (attributes, ...args) {
-      if (this.id === duplicateBatch.id && attributes?.status === 'failed') {
+    sinon.stub(models.EmailBatch.prototype, 'save').callsFake(function (
+      this: Batch,
+      attributes,
+      ...args
+    ) {
+      if (
+        this.id === duplicateBatch.id &&
+        attributes &&
+        typeof attributes === 'object' &&
+        'status' in attributes &&
+        attributes.status === 'failed'
+      ) {
         sinon.assert.calledWithMatch(logging.error, {
           event: { name: 'email.recipient_count.mismatch' },
           code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
@@ -1335,7 +1355,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(duplicateBatch.get('error_data'), null);
     const alerts = logging.error
       .getCalls()
-      .filter(({ args }) => args[0]?.event?.name === 'email.recipient_count.mismatch');
+      .filter(
+        ({ args }: sinon.SinonSpyCall) => args[0]?.event?.name === 'email.recipient_count.mismatch',
+      );
     assert.equal(alerts.length, 1);
   });
 

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -667,22 +667,38 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(batches[0].get('recipient_count'), null);
   });
 
-  it('leaves legacy submission counts unknown and preserves the prepared email count', async function () {
-    await email.save({ preflight_email_count: null }, { patch: true });
+  it('leaves already-started legacy submission counts unknown and preserves the intended count', async function () {
+    await createLegacyBatches(['submitted', 'pending', 'pending', 'pending']);
+    await email.save({ email_count: 4 }, { patch: true });
     const batches = await service.createBatches(data);
-    const intendedCount = email.get('email_count');
     await db
       .knex('email_recipients')
-      .where({ batch_id: batches.find((b) => b.get('fallback_sending_domain')).id })
+      .where({ batch_id: batches.find((batch) => batch.get('status') === 'pending').id })
       .update({ member_email: 'invalid' });
     await runEmailJob(batches);
     await email.refresh();
     assert.equal(email.get('status'), 'submitted');
-    assert.equal(email.get('email_count'), intendedCount);
+    assert.equal(email.get('email_count'), 4);
+    assert.equal(email.get('preflight_email_count'), null);
     for (const batch of await service.getBatches(email)) {
       assert.equal(batch.get('submitted_count'), null);
       assert.equal(batch.get('submission_excluded_count'), null);
     }
+  });
+
+  it('verifies submission counts for an unsent legacy email rebuilt with accounting', async function () {
+    await createLegacyBatches(['pending']);
+    await runEmailJob(await service.createBatches(data));
+    await email.refresh();
+    assert.equal(email.get('status'), 'submitted');
+    assert.equal(email.get('preflight_email_count'), 10);
+    assert.equal(email.get('email_count'), 4);
+    const batches = await service.getBatches(email);
+    assert.equal(
+      batches.reduce((sum, batch) => sum + batch.get('submitted_count'), 0),
+      4,
+    );
+    assert.ok(batches.every((batch) => batch.get('submission_excluded_count') === 0));
   });
 
   it('rejects changed candidate totals while every submitted batch remains internally consistent', async function () {

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -662,15 +662,30 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(done.sending.progress.total, 4);
   });
 
-  it('keeps failed progress readable when an accounted batch count is unexpectedly null', async function () {
+  it('preserves the failed progress total when an accounted batch count is unexpectedly null', async function () {
     const batches = await service.createBatches(data);
+    const corrupt = batches.find((batch) => batch.get('recipient_count') === 1);
     await email.save({ status: 'failed' }, { patch: true });
-    await batches[0].save({ status: 'failed', recipient_count: null }, { patch: true });
+    await db
+      .knex('email_batches')
+      .where({ email_id: email.id })
+      .whereNot({ id: corrupt.id })
+      .update({
+        status: 'submitted',
+        submitted_count: db.knex.ref('recipient_count'),
+        submission_excluded_count: 0,
+      });
+    await corrupt.save({ status: 'failed', recipient_count: null }, { patch: true });
     const result = await new SendingStatusService({ knex: db.knex }).statusFor(email.id);
     assert.ok(result);
     assert.equal(result.sending.status, 'failed');
-    await batches[0].refresh();
-    assert.equal(batches[0].get('recipient_count'), null);
+    assert.deepEqual(result.sending.progress, {
+      completed: 3,
+      total: 4,
+      estimatedSecondsRemaining: null,
+    });
+    await corrupt.refresh();
+    assert.equal(corrupt.get('recipient_count'), null);
   });
 
   it('leaves already-started legacy submission counts unknown and preserves the intended count', async function () {

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -443,7 +443,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.ok(batches.every((batch) => !partialIds.includes(batch.id)));
     const sentIds = sender.send
       .getCalls()
-      .flatMap((call) => call.args[0].recipients.map((recipient: { email: string }) => recipient.email));
+      .flatMap((call) =>
+        call.args[0].recipients.map((recipient: { email: string }) => recipient.email),
+      );
     assert.equal(sentIds.length, 4);
     assert.equal(new Set(sentIds).size, 4);
   });
@@ -496,7 +498,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     );
     const sentIds = sender.send
       .getCalls()
-      .flatMap((call) => call.args[0].recipients.map((recipient: { email: string }) => recipient.email));
+      .flatMap((call) =>
+        call.args[0].recipients.map((recipient: { email: string }) => recipient.email),
+      );
     assert.equal(sentIds.length, 4);
     assert.equal(new Set(sentIds).size, 4);
   });

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -3,8 +3,10 @@ import crypto from 'node:crypto';
 import ObjectID from 'bson-objectid';
 import sinon from 'sinon';
 import type { Knex } from 'knex';
+import { recipientVerificationError } from '../../../../core/server/services/email-service/recipient-accounting';
 import { SendingStatusService } from '../../../../core/server/services/email-service/sending-status-service';
 
+const mapBatch = require('../../../../core/server/api/endpoints/utils/serializers/output/mappers/email-batches');
 const logging = require('@tryghost/logging');
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
@@ -169,6 +171,23 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       }
       return found;
     });
+  }
+
+  async function runEmailJob(batches: Batch[]) {
+    sinon
+      .stub(service, 'sendEmail')
+      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
+    await service.emailJob({ emailId: email.id });
+  }
+
+  function useRealMailgunProvider() {
+    const client = { send: sinon.stub().resolves({ id: '<accepted>' }) };
+    const provider = new MailgunEmailProvider({
+      mailgunClient: client,
+      config: { get: () => undefined },
+    });
+    sender.send.callsFake(provider.send.bind(provider));
+    return client;
   }
 
   async function corruptMember(id: string, patch: Record<string, unknown>) {
@@ -548,18 +567,12 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
   }
 
   it('reports persisted verification failures during shutdown with unstarted batches', async function () {
-    const {
-      recipientVerificationError,
-    } = require('../../../../core/server/services/email-service/recipient-accounting');
     const batches = await service.createBatches(data);
     sender.send.onFirstCall().callsFake(async () => {
       service.onPreStop();
-      throw recipientVerificationError(email.id, 'provider_recipient_count');
+      throw recipientVerificationError(email.id, 'provider_payload_count');
     });
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((jobEmail) => service.sendBatches({ ...data, email: jobEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    await runEmailJob(batches);
     const reported = sentry.captureException
       .getCalls()
       .filter(
@@ -630,10 +643,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       .knex('email_recipients')
       .where({ batch_id: batches.find((b) => b.get('fallback_sending_domain')).id })
       .update({ member_email: 'invalid' });
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    await runEmailJob(batches);
     await email.refresh();
     assert.equal(email.get('status'), 'submitted');
     assert.equal(email.get('email_count'), intendedCount);
@@ -651,10 +661,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await assert.rejects(
       service.sendBatches({ ...data, batches: await service.getBatches(email) }),
       (error) => {
-        assertVerificationError(error);
-        assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+        const details = verificationDetails(error);
+        assert.equal(details.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
         // The preparation identity catches this before the redundant submission sum.
-        assert.equal(JSON.parse(error.errorDetails).reason, 'preparation_totals');
+        assert.equal(details.reason, 'preparation_totals');
         return true;
       },
     );
@@ -676,9 +686,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     );
     sinon.stub(service, 'sendBatch').resolves(false);
     await assert.rejects(service.sendBatches({ ...data, batches }), (error) => {
-      assertVerificationError(error);
-      assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
-      assert.equal(JSON.parse(error.errorDetails).batch_id, batches[1].id);
+      const details = verificationDetails(error);
+      assert.equal(details.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+      assert.equal(details.batch_id, batches[1].id);
       return true;
     });
   });
@@ -1224,10 +1234,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       .knex('email_recipients')
       .where({ batch_id: excludedBatch.id })
       .update({ member_email: 'invalid' });
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    await runEmailJob(batches);
     await email.refresh();
     assert.equal(email.get('status'), 'submitted');
     assert.equal(email.get('email_count'), 3);
@@ -1261,7 +1268,6 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     sinon.assert.neverCalledWithMatch(logging.error, {
       event: { name: 'email.recipient_count.mismatch' },
     });
-    const mapBatch = require('../../../../core/server/api/endpoints/utils/serializers/output/mappers/email-batches');
     const response = mapBatch(excludedBatch, { options: {} });
     assert.equal(response.status, 'submitted');
     assert.equal(response.mailgun_message_id, null);
@@ -1275,16 +1281,8 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       .knex('email_recipients')
       .where({ batch_id: duplicateBatch.id })
       .update({ member_email: 'duplicate@example.com' });
-    const client = { send: sinon.stub().resolves({ id: '<accepted>' }) };
-    const provider = new MailgunEmailProvider({
-      mailgunClient: client,
-      config: { get: () => undefined },
-    });
-    sender.send.callsFake(provider.send.bind(provider));
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    const client = useRealMailgunProvider();
+    await runEmailJob(batches);
     await duplicateBatch.refresh();
     assert.equal(duplicateBatch.get('status'), 'failed');
     assert.equal(
@@ -1310,34 +1308,36 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   });
 
-  it('preserves an explicit ownership diagnosis when replaying a persisted failure', async function () {
-    const batches = await service.createBatches(data);
-    await batches[0].save(
-      {
-        status: 'failed',
-        error_data: JSON.stringify({
-          code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
-          reason: 'cross_email_recipient',
-          expected: 2,
-          actual: 1,
-          count_mismatch: false,
-        }),
-      },
-      { patch: true },
-    );
-    sinon.stub(service, 'sendBatch').resolves(false);
-    await assert.rejects(service.sendBatches({ ...data, batches }), (error) => {
-      assertVerificationError(error);
-      const details = JSON.parse(error.errorDetails);
-      assert.equal(details.reason, 'batch_verification_failed');
-      assert.equal(details.count_mismatch, false);
-      assert.equal(details.batch_error.reason, 'cross_email_recipient');
-      return true;
+  for (const countMismatch of [false, undefined]) {
+    it(`does not infer a count mismatch from persisted ownership diagnostics (${countMismatch})`, async function () {
+      const batches = await service.createBatches(data);
+      await batches[0].save(
+        {
+          status: 'failed',
+          error_data: JSON.stringify({
+            code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+            reason: 'cross_email_recipient',
+            expected: 2,
+            actual: 1,
+            count_mismatch: countMismatch,
+          }),
+        },
+        { patch: true },
+      );
+      sinon.stub(service, 'sendBatch').resolves(false);
+      await assert.rejects(service.sendBatches({ ...data, batches }), (error) => {
+        const details = verificationDetails(error);
+
+        assert.equal(details.reason, 'batch_verification_failed');
+        assert.equal(details.count_mismatch, false);
+        assert.equal(details.batch_error.reason, 'cross_email_recipient');
+        return true;
+      });
+      sinon.assert.neverCalledWithMatch(logging.error, {
+        event: { name: 'email.recipient_count.mismatch' },
+      });
     });
-    sinon.assert.neverCalledWithMatch(logging.error, {
-      event: { name: 'email.recipient_count.mismatch' },
-    });
-  });
+  }
 
   it('logs a payload discrepancy before a failed batch status write can hide it', async function () {
     const batches = await service.createBatches(data);
@@ -1346,12 +1346,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       .knex('email_recipients')
       .where({ batch_id: duplicateBatch.id })
       .update({ member_email: 'duplicate@example.com' });
-    const client = { send: sinon.stub().resolves({ id: '<accepted>' }) };
-    const provider = new MailgunEmailProvider({
-      mailgunClient: client,
-      config: { get: () => undefined },
-    });
-    sender.send.callsFake(provider.send.bind(provider));
+    useRealMailgunProvider();
     // Status persistence fails independently of the payload check. Disable backoff
     // so the test exercises the exhausted-write outcome without waiting for retries.
     sinon.stub(service, 'retryDb').callsFake(async (operation) => operation());
@@ -1414,10 +1409,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
   it('completes mixed preparation-era submissions without inventing historical counts', async function () {
     const batches = await service.createBatches(data);
     await batches[0].save({ status: 'submitted' }, { patch: true });
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    await runEmailJob(batches);
     await email.refresh();
     assert.equal(email.get('status'), 'submitted');
     assert.equal(email.get('email_count'), 4);
@@ -1486,10 +1478,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
   it('keeps ordinary provider failures retry-oriented', async function () {
     const batches = await service.createBatches(data);
     sender.send.rejects(new Error('Provider unavailable'));
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    await runEmailJob(batches);
     await email.refresh();
     assert.equal(email.get('status'), 'failed');
     assert.match(email.get('error'), /retry/i);
@@ -1503,10 +1492,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await email.save({ recipient_filter: "email:'nobody@example.com'" }, { patch: true });
     const batches = await service.createBatches(data);
     assert.equal(batches.length, 0);
-    sinon
-      .stub(service, 'sendEmail')
-      .callsFake((lockedEmail) => service.sendBatches({ ...data, email: lockedEmail, batches }));
-    await service.emailJob({ emailId: email.id });
+    await runEmailJob(batches);
     await email.refresh();
     assert.equal(email.get('status'), 'submitted');
     assert.equal(email.get('candidate_count'), 0);

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -536,7 +536,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
           (error) => {
             assert.ok(error instanceof Error && 'code' in error);
             assert.equal(error.code, 'BULK_EMAIL_SUBMISSION_UNCERTAIN');
-            assert.match(error.message, /Contact support/);
+            assert.match(
+              error.message,
+              /We couldn’t confirm whether your newsletter finished sending/,
+            );
             return true;
           },
         );
@@ -1292,7 +1295,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await email.refresh();
     assert.equal(email.get('status'), 'failed');
     sinon.assert.calledOnce(sentry.captureException);
-    assert.match(email.get('error'), /recipient verification failed/);
+    assert.match(
+      email.get('error'),
+      /An error occurred while checking your newsletter’s recipients/,
+    );
     assert.ok(!email.get('error').toLowerCase().includes('retry'));
     sinon.assert.calledWithMatch(logging.error, {
       event: { name: 'email.recipient_count.mismatch' },
@@ -1458,7 +1464,10 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await email.refresh();
     assert.equal(email.get('status'), 'failed');
     assert.match(email.get('error'), /retry/i);
-    assert.doesNotMatch(email.get('error'), /recipient verification failed/);
+    assert.doesNotMatch(
+      email.get('error'),
+      /An error occurred while checking your newsletter’s recipients/,
+    );
   });
 
   it('completes a zero-candidate email with verified zero submissions', async function () {

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -885,7 +885,7 @@ describe('Batch Sending Service', function () {
         assert.equal(
           errorLog
             .getCalls()
-            .filter((call) => call.args[0]?.code === 'BULK_EMAIL_INVALID_RECIPIENT').length,
+            .filter((call) => call.args[0]?.event?.name === 'email.submission.excluded').length,
           1,
         );
       });

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -394,6 +394,40 @@ describe('Batch Sending Service', function () {
   });
 
   describe('sendBatches', function () {
+    for (const lookupFails of [false, true]) {
+      it(`preserves the worker error without a readable integrity failure (lookupFails=${lookupFails})`, async function () {
+        const service = new BatchSendingService({
+          sendingService: { getTargetDeliveryWindow: () => 0 },
+          AFTER_RETRY_CONFIG: { maxRetries: 0, sleep: 0 },
+        });
+        const email = createModel({ preflight_email_count: 1 });
+        const batch = createModel({
+          status: 'submitted',
+          recipient_count: 1,
+          submitted_count: 1,
+          submission_excluded_count: 0,
+        });
+        const originalError = new Error('Unable to mark recipients processed');
+        sinon.stub(service, 'sendBatch').rejects(originalError);
+        const getBatches = sinon.stub(service, 'getBatches');
+        if (lookupFails) {
+          getBatches.rejects(new Error('Batch lookup unavailable'));
+        } else {
+          getBatches.resolves([batch]);
+        }
+        await assert.rejects(
+          service.sendBatches({
+            email,
+            batches: [batch],
+            post: createModel({}),
+            newsletter: createModel({}),
+          }),
+          (error) => error === originalError,
+        );
+        sinon.assert.calledOnceWithExactly(getBatches, email);
+      });
+    }
+
     it('Works for a single batch', async function () {
       const service = new BatchSendingService({
         sendingService: {

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -755,6 +755,9 @@ describe('Batch Sending Service', function () {
     for (const renderFails of [false, true]) {
       it(`reuses the intended payload and persists absolute counts after ${renderFails ? 'render and provider retries' : 'a provider retry'}`, async function () {
         const batch = createModel({ status: 'pending', recipient_count: 2 });
+        const recipients = await EmailRecipient.findAll();
+        await recipients.models[0].save({ member_email: 'invalid-address' });
+        sinon.stub(EmailRecipient, 'findAll').resolves(recipients);
         const provider = {
           getMaximumRecipients: () => 5,
           send: sinon.stub().resolves({ id: 'accepted' }),
@@ -799,9 +802,15 @@ describe('Batch Sending Service', function () {
         sinon.assert.calledWithMatch(save, {
           status: 'submitted',
           mailgun_message_id: 'accepted',
-          submitted_count: 2,
-          submission_excluded_count: 0,
+          submitted_count: 1,
+          submission_excluded_count: 1,
         });
+        assert.equal(
+          errorLog
+            .getCalls()
+            .filter((call) => call.args[0]?.code === 'BULK_EMAIL_INVALID_RECIPIENT').length,
+          1,
+        );
       });
     }
 

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -752,49 +752,58 @@ describe('Batch Sending Service', function () {
       sinon.assert.notCalled(read);
     });
 
-    it('reuses the intended payload on provider retry and persists absolute counts with status', async function () {
-      const batch = createModel({ status: 'pending', recipient_count: 2 });
-      const provider = {
-        getMaximumRecipients: () => 5,
-        send: sinon.stub().resolves({ id: 'accepted' }),
-      };
-      provider.send.onFirstCall().rejects(new Error('Response lost'));
-      const renderer = {
-        renderBody: sinon.stub().resolves({ html: 'Hello', plaintext: 'Hello', replacements: [] }),
-        getSubject: () => 'Hello',
-        getFromAddress: () => 'sender@example.com',
-        getReplyToAddress: () => null,
-      };
-      const service = new BatchSendingService({
-        models: { EmailRecipient },
-        sendingService: new SendingService({
-          emailProvider: provider,
-          emailRenderer: renderer,
-          emailAddressService: {},
-        }),
-        MAILGUN_API_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
+    for (const renderFails of [false, true]) {
+      it(`reuses the intended payload and persists absolute counts after ${renderFails ? 'render and provider retries' : 'a provider retry'}`, async function () {
+        const batch = createModel({ status: 'pending', recipient_count: 2 });
+        const provider = {
+          getMaximumRecipients: () => 5,
+          send: sinon.stub().resolves({ id: 'accepted' }),
+        };
+        provider.send.onFirstCall().rejects(new Error('Response lost'));
+        const renderer = {
+          renderBody: sinon
+            .stub()
+            .resolves({ html: 'Hello', plaintext: 'Hello', replacements: [] }),
+          getSubject: () => 'Hello',
+          getFromAddress: () => 'sender@example.com',
+          getReplyToAddress: () => null,
+        };
+        if (renderFails) {
+          renderer.renderBody
+            .onFirstCall()
+            .rejects(new Error('Latest-post query temporarily unavailable'));
+        }
+        const service = new BatchSendingService({
+          models: { EmailRecipient },
+          sendingService: new SendingService({
+            emailProvider: provider,
+            emailRenderer: renderer,
+            emailAddressService: {},
+          }),
+          MAILGUN_API_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
+        });
+        sinon.stub(service, 'updateStatusLock').resolves(batch);
+        const save = sinon.spy(batch, 'save');
+        assert.equal(
+          await service.sendBatch({
+            email: createModel({ preflight_email_count: 2 }),
+            batch,
+            post: createModel({}),
+            newsletter: createModel({}),
+          }),
+          true,
+        );
+        sinon.assert.calledTwice(provider.send);
+        assert.equal(provider.send.firstCall.args[0], provider.send.secondCall.args[0]);
+        sinon.assert.callCount(renderer.renderBody, renderFails ? 2 : 1);
+        sinon.assert.calledWithMatch(save, {
+          status: 'submitted',
+          mailgun_message_id: 'accepted',
+          submitted_count: 2,
+          submission_excluded_count: 0,
+        });
       });
-      sinon.stub(service, 'updateStatusLock').resolves(batch);
-      const save = sinon.spy(batch, 'save');
-      assert.equal(
-        await service.sendBatch({
-          email: createModel({ preflight_email_count: 2 }),
-          batch,
-          post: createModel({}),
-          newsletter: createModel({}),
-        }),
-        true,
-      );
-      sinon.assert.calledTwice(provider.send);
-      assert.equal(provider.send.firstCall.args[0], provider.send.secondCall.args[0]);
-      sinon.assert.calledOnce(renderer.renderBody);
-      sinon.assert.calledWithMatch(save, {
-        status: 'submitted',
-        mailgun_message_id: 'accepted',
-        submitted_count: 2,
-        submission_excluded_count: 0,
-      });
-    });
+    }
 
     it('Does not send if already submitted', async function () {
       const EmailBatch = createModelClass({

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -1,5 +1,6 @@
 const { createModel, createModelClass, createDb, sleep } = require('./utils');
 const BatchSendingService = require('../../../../../core/server/services/email-service/batch-sending-service');
+const SendingService = require('../../../../../core/server/services/email-service/sending-service');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const logging = require('@tryghost/logging');
@@ -698,6 +699,100 @@ describe('Batch Sending Service', function () {
             }),
           },
         ],
+      });
+    });
+
+    for (const expected of [1, 3]) {
+      it(`fails after bounded reads of two rows when the expected count is ${expected}`, async function () {
+        const batch = createModel({ status: 'pending', recipient_count: expected });
+        const sender = {
+          send: sinon.stub().resolves({ id: 'provider' }),
+          getMaximumRecipients: () => 5,
+        };
+        const service = new BatchSendingService({
+          models: { EmailRecipient },
+          sendingService: sender,
+          BEFORE_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
+        });
+        sinon.stub(service, 'updateStatusLock').resolves(batch);
+        const read = sinon.spy(service, 'getBatchMembers');
+        const result = await service.sendBatch({
+          email: createModel({ preflight_email_count: expected }),
+          batch,
+          post: createModel({}),
+          newsletter: createModel({}),
+        });
+        assert.equal(result, false);
+        assert.equal(batch.get('status'), 'failed');
+        assert.equal(
+          JSON.parse(batch.get('error_data')).code,
+          'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+        );
+        sinon.assert.calledTwice(read);
+        sinon.assert.notCalled(sender.send);
+      });
+    }
+
+    it('rejects a corrupt zero recipient count before reading recipients', async function () {
+      const batch = createModel({ status: 'pending', recipient_count: 0 });
+      const service = new BatchSendingService({ models: { EmailRecipient } });
+      sinon.stub(service, 'updateStatusLock').resolves(batch);
+      const read = sinon.stub(service, 'getBatchMembers').resolves([{ email: 'a@example.com' }]);
+      await service.sendBatch({
+        email: createModel({ preflight_email_count: 0 }),
+        batch,
+        post: createModel({}),
+        newsletter: createModel({}),
+      });
+      assert.equal(batch.get('status'), 'failed');
+      assert.equal(
+        JSON.parse(batch.get('error_data')).code,
+        'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+      );
+      sinon.assert.notCalled(read);
+    });
+
+    it('reuses the intended payload on provider retry and persists absolute counts with status', async function () {
+      const batch = createModel({ status: 'pending', recipient_count: 2 });
+      const provider = {
+        getMaximumRecipients: () => 5,
+        send: sinon.stub().resolves({ id: 'accepted' }),
+      };
+      provider.send.onFirstCall().rejects(new Error('Response lost'));
+      const renderer = {
+        renderBody: sinon.stub().resolves({ html: 'Hello', plaintext: 'Hello', replacements: [] }),
+        getSubject: () => 'Hello',
+        getFromAddress: () => 'sender@example.com',
+        getReplyToAddress: () => null,
+      };
+      const service = new BatchSendingService({
+        models: { EmailRecipient },
+        sendingService: new SendingService({
+          emailProvider: provider,
+          emailRenderer: renderer,
+          emailAddressService: {},
+        }),
+        MAILGUN_API_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
+      });
+      sinon.stub(service, 'updateStatusLock').resolves(batch);
+      const save = sinon.spy(batch, 'save');
+      assert.equal(
+        await service.sendBatch({
+          email: createModel({ preflight_email_count: 2 }),
+          batch,
+          post: createModel({}),
+          newsletter: createModel({}),
+        }),
+        true,
+      );
+      sinon.assert.calledTwice(provider.send);
+      assert.equal(provider.send.firstCall.args[0], provider.send.secondCall.args[0]);
+      sinon.assert.calledOnce(renderer.renderBody);
+      sinon.assert.calledWithMatch(save, {
+        status: 'submitted',
+        mailgun_message_id: 'accepted',
+        submitted_count: 2,
+        submission_excluded_count: 0,
       });
     });
 

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -733,23 +733,52 @@ describe('Batch Sending Service', function () {
       });
     }
 
-    it('rejects a corrupt zero recipient count before reading recipients', async function () {
-      const batch = createModel({ status: 'pending', recipient_count: 0 });
-      const service = new BatchSendingService({ models: { EmailRecipient } });
-      sinon.stub(service, 'updateStatusLock').resolves(batch);
-      const read = sinon.stub(service, 'getBatchMembers').resolves([{ email: 'a@example.com' }]);
-      await service.sendBatch({
-        email: createModel({ preflight_email_count: 0 }),
-        batch,
-        post: createModel({}),
-        newsletter: createModel({}),
+    for (const expectedCount of [0, null]) {
+      it(`rejects a corrupt ${expectedCount} recipient count before reading recipients`, async function () {
+        const batch = createModel({ status: 'pending', recipient_count: expectedCount });
+        const service = new BatchSendingService({ models: { EmailRecipient } });
+        sinon.stub(service, 'updateStatusLock').resolves(batch);
+        const read = sinon.stub(service, 'getBatchMembers').resolves([{ email: 'a@example.com' }]);
+        await service.sendBatch({
+          email: createModel({ preflight_email_count: 0 }),
+          batch,
+          post: createModel({}),
+          newsletter: createModel({}),
+        });
+        assert.equal(batch.get('status'), 'failed');
+        assert.equal(
+          JSON.parse(batch.get('error_data')).code,
+          'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+        );
+        sinon.assert.notCalled(read);
       });
-      assert.equal(batch.get('status'), 'failed');
+    }
+
+    it('uses the pre-send retry budget when constructing an accounted message', async function () {
+      const batch = createModel({ status: 'pending', recipient_count: 2 });
+      const sender = {
+        getMaximumRecipients: () => 5,
+        buildMessage: sinon.stub().rejects(new Error('Render query unavailable')),
+        sendMessage: sinon.stub(),
+      };
+      const service = new BatchSendingService({
+        models: { EmailRecipient },
+        sendingService: sender,
+        BEFORE_RETRY_CONFIG: { maxRetries: 0, sleep: 0 },
+        MAILGUN_API_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
+      });
+      sinon.stub(service, 'updateStatusLock').resolves(batch);
       assert.equal(
-        JSON.parse(batch.get('error_data')).code,
-        'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+        await service.sendBatch({
+          email: createModel({ preflight_email_count: 2 }),
+          batch,
+          post: createModel({}),
+          newsletter: createModel({}),
+        }),
+        false,
       );
-      sinon.assert.notCalled(read);
+      sinon.assert.calledOnce(sender.buildMessage);
+      sinon.assert.notCalled(sender.sendMessage);
     });
 
     for (const renderFails of [false, true]) {
@@ -783,6 +812,7 @@ describe('Batch Sending Service', function () {
             emailRenderer: renderer,
             emailAddressService: {},
           }),
+          BEFORE_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
           MAILGUN_API_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
         });
         sinon.stub(service, 'updateStatusLock').resolves(batch);

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -729,9 +729,49 @@ describe('Batch Sending Service', function () {
           'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
         );
         sinon.assert.calledTwice(read);
+        sinon.assert.calledWithMatch(errorLog, {
+          event: { name: 'email.recipient_count.mismatch' },
+          reason: 'batch_recipient_read',
+          expected,
+          actual: 2,
+        });
         sinon.assert.notCalled(sender.send);
       });
     }
+
+    it('does not emit a count mismatch incident when a recipient read recovers on retry', async function () {
+      const recipients = await EmailRecipient.findAll();
+      const findAll = sinon.stub(EmailRecipient, 'findAll').resolves(recipients);
+      findAll.onFirstCall().resolves({ length: 1 });
+      const batch = createModel({ status: 'pending', recipient_count: 2 });
+      const sender = {
+        buildMessage: sinon.stub().resolves({}),
+        sendMessage: sinon
+          .stub()
+          .resolves({ id: 'provider', submittedCount: 2, submissionExcludedCount: 0 }),
+        getMaximumRecipients: () => 5,
+      };
+      const service = new BatchSendingService({
+        models: { EmailRecipient },
+        sendingService: sender,
+        BEFORE_RETRY_CONFIG: { maxRetries: 1, sleep: 0 },
+      });
+      sinon.stub(service, 'updateStatusLock').resolves(batch);
+      assert.equal(
+        await service.sendBatch({
+          email: createModel({ preflight_email_count: 2 }),
+          batch,
+          post: createModel({}),
+          newsletter: createModel({}),
+        }),
+        true,
+      );
+      sinon.assert.calledTwice(findAll);
+      sinon.assert.calledOnce(sender.sendMessage);
+      sinon.assert.neverCalledWithMatch(errorLog, {
+        event: { name: 'email.recipient_count.mismatch' },
+      });
+    });
 
     for (const expectedCount of [0, null]) {
       it(`rejects a corrupt ${expectedCount} recipient count before reading recipients`, async function () {
@@ -751,6 +791,13 @@ describe('Batch Sending Service', function () {
           'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
         );
         sinon.assert.notCalled(read);
+        sinon.assert.calledWithMatch(errorLog, {
+          event: { name: 'email.verification.failed' },
+          reason: 'invalid_batch_recipient_count',
+        });
+        sinon.assert.neverCalledWithMatch(errorLog, {
+          event: { name: 'email.recipient_count.mismatch' },
+        });
       });
     }
 

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -2214,6 +2214,38 @@ describe('Batch Sending Service', function () {
       sinon.assert.callCount(func, 1);
     });
 
+    for (const shutdown of [false, true]) {
+      it(`preserves an unpersisted verification error over another worker failure (shutdown: ${shutdown})`, async function () {
+        const service = new BatchSendingService({
+          sendingService: { getTargetDeliveryWindow: () => 0 },
+        });
+        const error = Object.assign(new Error('Recipient verification failed'), {
+          retryable: false,
+        });
+        sinon.stub(service, 'getBatches').resolves([]);
+        sinon
+          .stub(service, 'sendBatch')
+          .onFirstCall()
+          .rejects(new Error('Database unavailable'))
+          .onSecondCall()
+          .callsFake(async () => {
+            if (shutdown) {
+              service.onPreStop();
+            }
+            throw error;
+          });
+        await assert.rejects(
+          service.sendBatches({
+            email: createModel({ preflight_email_count: 3 }),
+            batches: Array.from({ length: 3 }, () => createModel({ status: 'pending' })),
+            post: createModel({}),
+            newsletter: createModel({}),
+          }),
+          (failure) => failure === error,
+        );
+      });
+    }
+
     it('waits for every worker to settle when one throws', async function () {
       const service = new BatchSendingService({
         sendingService: {

--- a/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
+++ b/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
@@ -25,6 +25,25 @@ describe('Mailgun Email Provider', function () {
       sinon.restore();
     });
 
+    it('rejects duplicate recipient keys before an accounted provider request', async function () {
+      const provider = new MailgunEmailProvider({ mailgunClient, config });
+      await assert.rejects(
+        provider.send(
+          {
+            emailId: 'email',
+            recipients: [
+              { email: 'same@example.com', replacements: [] },
+              { email: 'same@example.com', replacements: [] },
+            ],
+            replacementDefinitions: [],
+          },
+          { expectedRecipientCount: 2 },
+        ),
+        { code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED' },
+      );
+      sinon.assert.notCalled(sendStub);
+    });
+
     it('calls mailgun client with correct data', async function () {
       config.get.withArgs('bulkEmail:mailgun:tag').returns('newsletter-email');
 

--- a/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
+++ b/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
@@ -1,5 +1,6 @@
 const MailgunEmailProvider = require('../../../../../core/server/services/email-service/mailgun-email-provider');
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
 const assert = require('node:assert/strict');
 
 describe('Mailgun Email Provider', function () {
@@ -26,6 +27,7 @@ describe('Mailgun Email Provider', function () {
     });
 
     it('rejects duplicate recipient keys before an accounted provider request', async function () {
+      sinon.stub(logging, 'error');
       const provider = new MailgunEmailProvider({ mailgunClient, config });
       await assert.rejects(
         provider.send(
@@ -37,11 +39,20 @@ describe('Mailgun Email Provider', function () {
             ],
             replacementDefinitions: [],
           },
-          { expectedRecipientCount: 2 },
+          { expectedRecipientCount: 2, batchId: 'batch' },
         ),
         { code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED' },
       );
       sinon.assert.notCalled(sendStub);
+      sinon.assert.calledOnceWithMatch(logging.error, {
+        event: { name: 'email.recipient_count.mismatch' },
+        code: 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED',
+        email_id: 'email',
+        batch_id: 'batch',
+        reason: 'provider_payload_count',
+        expected: 2,
+        actual: 1,
+      });
     });
 
     it('calls mailgun client with correct data', async function () {

--- a/ghost/core/test/unit/server/services/email-service/sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/sending-service.test.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
+const logging = require('@tryghost/logging');
 
 const SendingService = require('../../../../../core/server/services/email-service/sending-service');
 
@@ -50,6 +51,60 @@ describe('Sending service', function () {
 
     afterEach(function () {
       sinon.restore();
+    });
+
+    it('accounts for invalid addresses when constructing a reusable batch message', async function () {
+      sinon.stub(logging, 'error');
+      const sentry = { captureException: sinon.stub() };
+      const sendingService = new SendingService({
+        emailRenderer,
+        emailProvider,
+        emailAddressService,
+        sentry,
+      });
+      const message = await sendingService.buildMessage(
+        {
+          post: {},
+          newsletter: {},
+          segment: null,
+          emailId: 'email',
+          members: [
+            { id: 'valid', email: 'a@example.com' },
+            { id: 'invalid', email: 'not-an-address' },
+          ],
+        },
+        { recipientAccounting: true },
+      );
+      const response = await sendingService.sendMessage(message);
+      assert.deepEqual(response, {
+        id: 'provider-123',
+        submittedCount: 1,
+        submissionExcludedCount: 1,
+      });
+      assert.equal(sendStub.firstCall.args[1].expectedRecipientCount, 1);
+      sinon.assert.calledOnce(sentry.captureException);
+      sinon.assert.calledOnce(logging.error);
+    });
+
+    it('completes an all-excluded accounted message without calling the provider', async function () {
+      sinon.stub(logging, 'error');
+      const sendingService = new SendingService({
+        emailRenderer,
+        emailProvider,
+        emailAddressService,
+      });
+      const response = await sendingService.send(
+        {
+          post: {},
+          newsletter: {},
+          segment: null,
+          emailId: 'email',
+          members: [{ id: 'invalid', email: 'not-an-address' }],
+        },
+        { recipientAccounting: true },
+      );
+      assert.deepEqual(response, { id: null, submittedCount: 0, submissionExcludedCount: 1 });
+      sinon.assert.notCalled(sendStub);
     });
 
     it('calls mailgun client with correct data', async function () {

--- a/ghost/core/test/unit/server/services/email-service/sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/sending-service.test.js
@@ -83,7 +83,12 @@ describe('Sending service', function () {
       });
       assert.equal(sendStub.firstCall.args[1].expectedRecipientCount, 1);
       sinon.assert.calledOnce(sentry.captureException);
-      sinon.assert.calledOnce(logging.error);
+      sinon.assert.calledOnceWithMatch(logging.error, {
+        event: { name: 'email.submission.excluded' },
+        email_id: 'email',
+        member_id: 'invalid',
+        reason: 'invalid_email_address',
+      });
     });
 
     it('completes an all-excluded accounted message without calling the provider', async function () {

--- a/ghost/core/test/unit/server/services/email-service/sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/sending-service.test.js
@@ -107,6 +107,33 @@ describe('Sending service', function () {
       sinon.assert.notCalled(sendStub);
     });
 
+    it('rejects an unexplained omission before treating a message as all excluded', async function () {
+      const sendingService = new SendingService({
+        emailRenderer,
+        emailProvider,
+        emailAddressService,
+      });
+      sinon.stub(sendingService, 'buildRecipients').returns({ recipients: [], excludedCount: 0 });
+      await assert.rejects(
+        sendingService.send(
+          {
+            post: {},
+            newsletter: {},
+            segment: null,
+            emailId: 'email',
+            members: [{ id: 'valid', email: 'a@example.com' }],
+          },
+          { recipientAccounting: true },
+        ),
+        (error) => {
+          assert.equal(error.code, 'BULK_EMAIL_RECIPIENT_VERIFICATION_FAILED');
+          assert.equal(JSON.parse(error.errorDetails).reason, 'message_recipient_counts');
+          return true;
+        },
+      );
+      sinon.assert.notCalled(sendStub);
+    });
+
     it('calls mailgun client with correct data', async function () {
       const sendingService = new SendingService({
         emailRenderer,

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -120,8 +120,8 @@ describe('SendingStatusService', function () {
   });
 
   it('reads accounted progress and historical submission fallbacks without scanning recipients', async function () {
-    await addEmail({ status: 'submitting', emailCount: 25, updatedAt: '2026-09-02 12:01:00' });
-    await knex('emails').update({ preflight_email_count: 30 });
+    await addEmail({ status: 'submitting', emailCount: 35, updatedAt: '2026-09-02 12:01:00' });
+    await knex('emails').update({ preflight_email_count: 40 });
     await addBatch({
       status: 'submitted',
       createdAt: '2026-09-02 12:00:00',
@@ -132,20 +132,26 @@ describe('SendingStatusService', function () {
       createdAt: '2026-09-02 12:00:10',
       updatedAt: '2026-09-02 12:01:20',
     });
-    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20', recipientCount: 5 });
+    // Three distinct completions provide the two measured intervals required for an ETA.
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:20',
+      updatedAt: '2026-09-02 12:01:30',
+    });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:30', recipientCount: 5 });
     await knex('email_batches')
-      .whereIn('id', ['batch-1', 'batch-2'])
+      .whereIn('id', ['batch-1', 'batch-2', 'batch-3'])
       .update({ recipient_count: 10 });
     await knex('email_batches')
       .where('id', 'batch-1')
       .update({ submitted_count: 7, submission_excluded_count: 3 });
-    await knex('email_batches').where('id', 'batch-3').update({ recipient_count: 5 });
+    await knex('email_batches').where('id', 'batch-4').update({ recipient_count: 5 });
     aggregateCountsAsStrings = true;
     const queries: string[] = [];
     knex.on('query', ({ sql }: { sql: string }) => queries.push(sql));
     assert.deepEqual((await service.statusFor('email-id'))?.sending, {
       status: 'submitting',
-      progress: { completed: 20, total: 25, estimatedSecondsRemaining: 5 },
+      progress: { completed: 30, total: 35, estimatedSecondsRemaining: 5 },
     });
     assert.ok(queries.every((sql) => !sql.includes('email_recipients')));
     assert.equal(

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -23,7 +23,7 @@ describe('SendingStatusService', function () {
 
         return result.map((row) => {
           if (row && typeof row === 'object') {
-            for (const key of ['recipient_count']) {
+            for (const key of ['recipient_count', 'accounted_recipient_count']) {
               const value = Reflect.get(row, key);
               if (typeof value === 'number') {
                 Reflect.set(row, key, String(value));
@@ -39,6 +39,7 @@ describe('SendingStatusService', function () {
       table.string('id').primary();
       table.string('status').notNullable();
       table.integer('email_count').notNullable();
+      table.integer('preflight_email_count').nullable();
       table.dateTime('updated_at').nullable();
     });
     await knex.schema.createTable('email_batches', (table) => {
@@ -47,6 +48,9 @@ describe('SendingStatusService', function () {
       table.string('status').notNullable();
       table.dateTime('created_at').notNullable();
       table.dateTime('updated_at').notNullable();
+      table.integer('recipient_count').nullable();
+      table.integer('submitted_count').nullable();
+      table.integer('submission_excluded_count').nullable();
     });
     await knex.schema.createTable('email_recipients', (table) => {
       table.string('id').primary();
@@ -113,6 +117,41 @@ describe('SendingStatusService', function () {
 
   it('returns null when the email does not exist', async function () {
     assert.equal(await service.statusFor('missing-email'), null);
+  });
+
+  it('reads accounted progress and historical submission fallbacks without scanning recipients', async function () {
+    await addEmail({ status: 'submitting', emailCount: 25, updatedAt: '2026-09-02 12:01:00' });
+    await knex('emails').update({ preflight_email_count: 30 });
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:00',
+      updatedAt: '2026-09-02 12:01:10',
+    });
+    await addBatch({
+      status: 'submitted',
+      createdAt: '2026-09-02 12:00:10',
+      updatedAt: '2026-09-02 12:01:20',
+    });
+    await addBatch({ status: 'pending', createdAt: '2026-09-02 12:00:20', recipientCount: 5 });
+    await knex('email_batches')
+      .whereIn('id', ['batch-1', 'batch-2'])
+      .update({ recipient_count: 10 });
+    await knex('email_batches')
+      .where('id', 'batch-1')
+      .update({ submitted_count: 7, submission_excluded_count: 3 });
+    await knex('email_batches').where('id', 'batch-3').update({ recipient_count: 5 });
+    aggregateCountsAsStrings = true;
+    const queries: string[] = [];
+    knex.on('query', ({ sql }: { sql: string }) => queries.push(sql));
+    assert.deepEqual((await service.statusFor('email-id'))?.sending, {
+      status: 'submitting',
+      progress: { completed: 20, total: 25, estimatedSecondsRemaining: 5 },
+    });
+    assert.ok(queries.every((sql) => !sql.includes('email_recipients')));
+    assert.equal(
+      (await knex('email_batches').where('id', 'batch-2').first()).submitted_count,
+      null,
+    );
   });
 
   it('derives the sending status of an unsubmitted email from its batches and their recipient counts', async function () {

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -160,6 +160,39 @@ describe('SendingStatusService', function () {
     );
   });
 
+  for (const { status, recipientCount, emailCount, total } of [
+    { status: 'failed', recipientCount: null, emailCount: 4, total: 4 },
+    { status: 'submitting', recipientCount: null, emailCount: 4, total: 4 },
+    { status: 'failed', recipientCount: null, emailCount: 2, total: 3 },
+    { status: 'failed', recipientCount: 0, emailCount: 4, total: 3 },
+  ]) {
+    it(`preserves progress totals with ${status} email, batch count ${recipientCount}, and email count ${emailCount}`, async function () {
+      await addEmail({ status, emailCount });
+      await knex('emails').update({ preflight_email_count: emailCount });
+      await addBatch({ status: 'submitted', createdAt: '2026-09-02 12:00:00', recipientCount: 3 });
+      await knex('email_batches').where('id', 'batch-1').update({
+        recipient_count: 3,
+        submitted_count: 3,
+        submission_excluded_count: 0,
+      });
+      await addBatch({ status: 'failed', createdAt: '2026-09-02 12:00:10', recipientCount: 0 });
+      await knex('email_batches')
+        .where('id', 'batch-2')
+        .update({ recipient_count: recipientCount });
+      const queries: string[] = [];
+      knex.on('query', ({ sql }: { sql: string }) => queries.push(sql));
+
+      const result = await service.statusFor('email-id');
+      assert.equal(result?.sending.status, status);
+      assert.deepEqual(result?.sending.progress, {
+        completed: 3,
+        total,
+        estimatedSecondsRemaining: null,
+      });
+      assert.ok(queries.every((sql) => !sql.includes('email_recipients')));
+    });
+  }
+
   for (const missingField of ['submitted_count', 'submission_excluded_count']) {
     it(`does not credit a submitted batch with missing ${missingField}`, async function () {
       await addEmail({ status: 'failed', emailCount: 10 });

--- a/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/sending-status-service.test.ts
@@ -160,6 +160,27 @@ describe('SendingStatusService', function () {
     );
   });
 
+  for (const missingField of ['submitted_count', 'submission_excluded_count']) {
+    it(`does not credit a submitted batch with missing ${missingField}`, async function () {
+      await addEmail({ status: 'failed', emailCount: 10 });
+      await knex('emails').update({ preflight_email_count: 10 });
+      await addBatch({ status: 'submitted', createdAt: '2026-09-02 12:00:00' });
+      await knex('email_batches').update({
+        recipient_count: 10,
+        submitted_count: 7,
+        submission_excluded_count: 3,
+        [missingField]: null,
+      });
+      const result = await service.statusFor('email-id');
+      assert.equal(result?.sending.status, 'failed');
+      assert.deepEqual(result?.sending.progress, {
+        completed: 0,
+        total: 10,
+        estimatedSecondsRemaining: null,
+      });
+    });
+  }
+
   it('derives the sending status of an unsubmitted email from its batches and their recipient counts', async function () {
     await addEmail({ status: 'submitting', emailCount: 50, updatedAt: '2026-09-02 12:01:00' });
     await addBatch({


### PR DESCRIPTION
A newsletter could finish with fewer recipients in its Mailgun payload than in its prepared batches, without accounting for the difference. This PR verifies the payload, records explicit exclusions, and completes the email only when persisted submission outcomes balance.

```mermaid
flowchart TD
    A[Load prepared recipients] --> B[Verify recipient row count]
    B --> C[Build message and count exclusions]
    C --> D[Verify unique-address payload count]
    D --> E{Any recipients remain?}
    E -->|Yes| F[Submit to Mailgun]
    F --> G[Save submitted status and counts]
    E -->|No| G
    G --> H[Verify all persisted batches before email completion]
```

Each batch records absolute submitted and excluded counts. An all-excluded batch completes with zero submitted and no provider message ID. Duplicate address-key collapse is detected before the Mailgun request. Provider retries reuse the intended payload.

Together with [preparation verification #30541](https://github.com/TryGhost/Ghost/pull/30541), this enforces:

```text
Each batch: recipient_count = submitted_count + submission_excluded_count

Whole email: candidate_count = SUM(submitted_count)
                             + SUM(submission_excluded_count)
                             + preparation_excluded_count
```

Completion checks all persisted batches, including any omitted from the worker queue, and sets `email_count` to the verified submitted total. Terminal integrity failures retain their original cause even if saving the batch failure also fails. They take precedence over incidental worker errors and reach the Admin banner and Sentry, including during shutdown while keeping unfinished sends resumable.

**Progress** comes from persisted batch counts, without scanning the recipient table on each poll. Submitted recipients plus exclusions count as completed work. Batches submitted during the preparation-only deployment retain their historical fallback when both submission counts are null; a partially null pair earns no progress credit. The failure banner describes processed recipients, which can include exclusions, without treating progress as a count of emails sent. This wording uses the existing API fields and works with older backends.

**Alerting:** verified count discrepancies emit `email.recipient_count.mismatch` at detection, before a status write can fail. Ownership conflicts and invalid metadata use `email.verification.failed`. Verification failures are non-retryable; expected exclusions and recovered retries do not trigger the mismatch signal.

**Rollout:** [schema #30540](https://github.com/TryGhost/Ghost/pull/30540) → [preparation #30541](https://github.com/TryGhost/Ghost/pull/30541) → **this PR**. Already-started legacy sends keep their existing submission behavior. Unsent legacy emails rebuilt by preparation accounting use the verified submission path. Preparation-era submissions with unknown counts complete under the preparation checks, retain their intended `email_count`, and log an unverified completion.

Counts describe recorded successful submissions, not delivered copies. An uncertain provider response can still lead to additional copies on retry; an accepted submission whose result could not be persisted requires reconciliation.

**Validation:** 85 MySQL accounting tests, 74 batch-sending unit tests, and 21 Admin post-analytics browser acceptance tests passed. Core source/test and Admin typechecks, changed-file linting, dependency-boundary checks, and documentation checks passed. Regression coverage includes all-excluded batches followed by provider failures, lost failure-status writes, competing worker errors, shutdown, and the corrected failure banner in Chromium. The original failures were reproduced before the fixes. The rebased sweep stack also passed 98 MySQL tests. Full `pnpm check` stops on formatting in six existing untracked planning documents.

ref https://linear.app/ghost/issue/BER-3929/verify-recipient-counts-during-sending-before-marking-an-email

- [x] Followed the Contributor Guide.
- [x] Explained the change.
- [x] Added automated coverage.
