### PR TITLE
Fixed the newsletter schema rejecting a null updated_at

### DIFF
--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -48,7 +48,8 @@ export const NewsletterSchema = z.object({
   // Older and current Core versions may omit this design setting.
   divider_style: z.string().nullish(),
   created_at: z.string(),
-  updated_at: z.string(),
+  // Core's newsletters.updated_at column is nullable.
+  updated_at: z.string().nullable(),
   count: z
     .object({
       posts: z.number().optional(),

--- a/apps/admin-x-framework/test/unit/api/newsletters.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/newsletters.test.tsx
@@ -4,56 +4,56 @@ import { NewslettersResponseSchema, useBrowseNewsletters } from '../../../src/ap
 import { renderHookWithProviders } from '../../../src/test/test-utils';
 import { withMockFetch } from '../../utils/mock-fetch';
 
+const newsletter = {
+  id: 'newsletter-1',
+  uuid: '0b71d5a2-bb5f-4d8d-8911-b4539d60e0f0',
+  name: 'Weekly digest',
+  description: null,
+  feedback_enabled: false,
+  slug: 'weekly-digest',
+  sender_name: null,
+  sender_email: null,
+  sender_reply_to: 'newsletter',
+  status: 'active',
+  visibility: 'members',
+  subscribe_on_signup: true,
+  sort_order: 0,
+  header_image: null,
+  show_header_icon: true,
+  show_header_title: true,
+  title_font_category: 'sans_serif',
+  title_font_weight: 'bold',
+  title_alignment: 'center',
+  show_excerpt: false,
+  show_feature_image: true,
+  body_font_category: 'sans_serif',
+  footer_content: null,
+  show_badge: true,
+  show_header_name: true,
+  show_post_title_section: true,
+  show_comment_cta: true,
+  show_share_button: false,
+  show_subscription_details: false,
+  show_latest_posts: false,
+  background_color: 'light',
+  header_background_color: 'transparent',
+  button_color: 'accent',
+  link_color: 'accent',
+  post_title_color: null,
+  section_title_color: null,
+  divider_color: null,
+  button_corners: 'rounded',
+  button_style: 'fill',
+  image_corners: 'square',
+  link_style: 'underline',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
 describe('newsletters api', () => {
   it('accepts the current Core newsletter response shape', () => {
     const result = NewslettersResponseSchema.parse({
-      newsletters: [
-        {
-          id: 'newsletter-1',
-          uuid: '0b71d5a2-bb5f-4d8d-8911-b4539d60e0f0',
-          name: 'Weekly digest',
-          description: null,
-          feedback_enabled: false,
-          slug: 'weekly-digest',
-          sender_name: null,
-          sender_email: null,
-          sender_reply_to: 'newsletter',
-          status: 'active',
-          visibility: 'members',
-          subscribe_on_signup: true,
-          sort_order: 0,
-          header_image: null,
-          show_header_icon: true,
-          show_header_title: true,
-          title_font_category: 'sans_serif',
-          title_font_weight: 'bold',
-          title_alignment: 'center',
-          show_excerpt: false,
-          show_feature_image: true,
-          body_font_category: 'sans_serif',
-          footer_content: null,
-          show_badge: true,
-          show_header_name: true,
-          show_post_title_section: true,
-          show_comment_cta: true,
-          show_share_button: false,
-          show_subscription_details: false,
-          show_latest_posts: false,
-          background_color: 'light',
-          header_background_color: 'transparent',
-          button_color: 'accent',
-          link_color: 'accent',
-          post_title_color: null,
-          section_title_color: null,
-          divider_color: null,
-          button_corners: 'rounded',
-          button_style: 'fill',
-          image_corners: 'square',
-          link_style: 'underline',
-          created_at: '2026-01-01T00:00:00.000Z',
-          updated_at: '2026-01-01T00:00:00.000Z',
-        },
-      ],
+      newsletters: [newsletter],
     });
 
     expect(result.newsletters[0].slug).toBe('weekly-digest');
@@ -75,5 +75,13 @@ describe('newsletters api', () => {
         expect(result.current.data).toBeUndefined();
       },
     );
+  });
+
+  it('accepts a null updated_at', () => {
+    const result = NewslettersResponseSchema.parse({
+      newsletters: [{ ...newsletter, updated_at: null }],
+    });
+
+    expect(result.newsletters[0].updated_at).toBeNull();
   });
 });


### PR DESCRIPTION
Core's `newsletters.updated_at` column is nullable with no default, so a newsletter row inserted outside the model layer has no value for it and comes back from the Admin API as `null`. The development data seeder inserts newsletters exactly that way — it sets `created_at` and omits `updated_at` — so seeded databases have null values on most of their newsletters.

The Zod schema declared the field as `z.string()`. Parsing a response containing one of those rows threw a `ZodError` out of `parseResponse`, which errors the whole `useBrowseNewsletters` query and leaves `data` undefined for every consumer of it: newsletter settings and the newsletter detail modal, member filters, bulk actions, member detail and the member newsletters field, the publish flow inputs, the post preview email tab, newsletter analytics, and the plan limiter's newsletter count.

The hand-written type this schema replaced claimed `updated_at: string` too, but nothing checked it at runtime. The mismatch only became a failure once the response started being parsed for real.

`updated_at` is now `z.string().nullable()`, which is what Core actually returns. Sibling API types in this package (`snippets`, `recommendations`, `automated-emails`, `automated-email-design`, `member-custom-fields`) already declare it as `string | null`. No code reads `newsletter.updated_at`, so nothing downstream needed to change.

No release-note emoji: rows with a null `updated_at` are not reachable through normal newsletter creation, which always goes through the model layer and sets the timestamp. This is a mismatch between the client schema and what the column permits, and it bites seeded development databases.

## Testing

- Added a unit test that parses a newsletter with `updated_at: null`, and lifted the existing inline newsletter into a shared fixture so both parse tests use one shape.

```
pnpm --dir apps/admin-x-framework exec vitest run test/unit/api/newsletters.test.tsx
```

- Verified the column definition on a live development database: `updated_at` is nullable with no default, so any insert that omits it stores null.
- `nx run @tryghost/admin-x-framework:build` and `nx run @tryghost/admin:typecheck` both pass, confirming the widened type has no fallout in Admin.