### PR TITLE
Added coverage for the permission read honouring the redirect opt-out

### DIFF
--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -48,7 +48,10 @@ type QueryHookOptions<ResponseData> = Omit<
 > & {
   searchParams?: Record<string, string>;
   defaultErrorHandler?: boolean;
-  /** Whether this query leaves an expired session for its caller to handle in place. */
+  /**
+   * Whether this query leaves an expired session for its caller to handle in place.
+   * Applies to fetches this call site initiates, not to shared cache entries it joins.
+   */
   requestOptions?: Pick<RequestOptions, 'sessionExpiryRedirect'>;
 };
 
@@ -121,7 +124,10 @@ type InfiniteQueryHookOptions<ResponseData, PageData = ResponseData> = Omit<
 > & {
   searchParams?: Record<string, string>;
   defaultErrorHandler?: boolean;
-  /** Whether this query leaves an expired session for its caller to handle in place. */
+  /**
+   * Whether this query leaves an expired session for its caller to handle in place.
+   * Applies to fetches this call site initiates, not to shared cache entries it joins.
+   */
   requestOptions?: Pick<RequestOptions, 'sessionExpiryRedirect'>;
   getNextPageParams?: (
     data: PageData,

--- a/apps/admin-x-framework/test/unit/utils/api/permission-session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/permission-session-expiry.test.tsx
@@ -1,0 +1,116 @@
+import { waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { withMockFetch } from '../../../utils/mock-fetch';
+import { restoreLocation, stubLocation } from '../../../utils/stub-location';
+
+const unauthorized = {
+  json: { errors: [{ type: 'UnauthorizedError', message: 'Authorization failed' }] },
+  headers: { 'content-type': 'application/json' },
+  status: 401,
+  ok: false,
+};
+
+const optedOut = { defaultErrorHandler: false, requestOptions: { sessionExpiryRedirect: false } };
+
+const readCurrentUser = (mock: { calls: unknown[][] }) =>
+  mock.calls.some(([url]) => String(url).includes('/users/me/'));
+
+// The redirect-once guard is module state, so each test re-imports a fresh
+// hooks module. test-utils is re-imported alongside it, otherwise its
+// FrameworkProvider comes from the previous registry and its context is a
+// different object than the one the hooks module reads.
+const loadModules = async () => {
+  const [{ createInfiniteQuery, createQuery, createQueryWithId }, testUtils] = await Promise.all([
+    import('../../../../src/utils/api/hooks'),
+    import('../../../../src/test/test-utils'),
+  ]);
+
+  return {
+    useTestQuery: createQuery<unknown>({ dataType: 'test', path: '/test/' }),
+    useTestInfiniteQuery: createInfiniteQuery<unknown>({
+      dataType: 'test-infinite',
+      path: '/test/',
+      returnData: (originalData) => originalData,
+    }),
+    useTestQueryWithId: createQueryWithId<unknown>({
+      dataType: 'test-with-id',
+      path: (id) => `/test/${id}/`,
+    }),
+    createTestQueryClient: testUtils.createTestQueryClient,
+    renderHookWithProviders: testUtils.renderHookWithProviders,
+  };
+};
+
+describe('permission read session expiry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    stubLocation();
+  });
+
+  afterEach(() => {
+    restoreLocation();
+  });
+
+  it('redirects on an expired session when a query omits the opt-out', async () => {
+    const { useTestQuery, createTestQueryClient, renderHookWithProviders } = await loadModules();
+
+    await withMockFetch(unauthorized, async (mock) => {
+      const { result } = renderHookWithProviders(
+        () => useTestQuery({ defaultErrorHandler: false }),
+        { queryClient: createTestQueryClient() },
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      await waitFor(() => expect(readCurrentUser(mock)).toBe(true));
+
+      expect(window.location.replace).toHaveBeenCalledExactlyOnceWith('/ghost/');
+    });
+  });
+
+  it('leaves an expired session to the caller when a query opts out', async () => {
+    const { useTestQuery, createTestQueryClient, renderHookWithProviders } = await loadModules();
+
+    await withMockFetch(unauthorized, async (mock) => {
+      const { result } = renderHookWithProviders(() => useTestQuery(optedOut), {
+        queryClient: createTestQueryClient(),
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      await waitFor(() => expect(readCurrentUser(mock)).toBe(true));
+
+      expect(window.location.replace).not.toHaveBeenCalled();
+    });
+  });
+
+  it('leaves an expired session to the caller when an infinite query opts out', async () => {
+    const { useTestInfiniteQuery, createTestQueryClient, renderHookWithProviders } =
+      await loadModules();
+
+    await withMockFetch(unauthorized, async (mock) => {
+      const { result } = renderHookWithProviders(() => useTestInfiniteQuery(optedOut), {
+        queryClient: createTestQueryClient(),
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      await waitFor(() => expect(readCurrentUser(mock)).toBe(true));
+
+      expect(window.location.replace).not.toHaveBeenCalled();
+    });
+  });
+
+  it('leaves an expired session to the caller when a query by id opts out', async () => {
+    const { useTestQueryWithId, createTestQueryClient, renderHookWithProviders } =
+      await loadModules();
+
+    await withMockFetch(unauthorized, async (mock) => {
+      const { result } = renderHookWithProviders(() => useTestQueryWithId('abc123', optedOut), {
+        queryClient: createTestQueryClient(),
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      await waitFor(() => expect(readCurrentUser(mock)).toBe(true));
+
+      expect(window.location.replace).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
+import { restoreLocation, stubLocation } from '../../../utils/stub-location';
 
 const unauthorizedBody = {
   errors: [
@@ -77,24 +78,13 @@ const loadModules = async () => {
 };
 
 describe('session expiry handling', () => {
-  let originalLocation: Location;
-
   beforeEach(() => {
     vi.resetModules();
-
-    originalLocation = window.location;
-    delete (window as any).location;
-    (window as any).location = {
-      href: 'http://localhost:3000/ghost/',
-      hash: '#/posts',
-      origin: 'http://localhost:3000',
-      pathname: '/ghost/',
-      replace: vi.fn(),
-    };
+    stubLocation();
   });
 
   afterEach(() => {
-    (window as any).location = originalLocation;
+    restoreLocation();
   });
 
   it('redirects to the admin root when an API request returns 403 Authorization failed', async () => {

--- a/apps/admin-x-framework/test/utils/stub-location.ts
+++ b/apps/admin-x-framework/test/utils/stub-location.ts
@@ -1,0 +1,22 @@
+/// <reference types="vitest/globals" />
+
+let originalLocation: Location;
+
+// jsdom's window.location cannot be spied on, so tests that assert against a
+// redirect swap in a plain object for the duration of the test
+export const stubLocation = () => {
+  originalLocation = window.location;
+  delete (window as unknown as { location?: Location }).location;
+
+  (window as unknown as { location: unknown }).location = {
+    href: 'http://localhost:3000/ghost/',
+    hash: '#/posts',
+    origin: 'http://localhost:3000',
+    pathname: '/ghost/',
+    replace: vi.fn(),
+  };
+};
+
+export const restoreLocation = () => {
+  (window as unknown as { location: Location }).location = originalLocation;
+};


### PR DESCRIPTION
A query hook's `requestOptions` already reach `usePermission` and, through it, the current-user observer that every `createQuery` and `createInfiniteQuery` mounts. Nothing held that wiring in place end to end, though: the existing tests assert only that the options object is handed to a mocked `useCurrentUser`, so they pass whether or not the flag survives the trip to the transport.

That gap matters because the inner observer initiates its own fetch, and TanStack applies fetch options per initiator. A regression in the threading would let a query that opted out of the session-expiry redirect still navigate away from an editor holding unsaved work, and no test would fail.

## Changes

- A behavioural test mounts an opted-out query, infinite query and query-by-id alone against a 401 on `/users/me/` and asserts the transport never replaced the location, plus the default case that still redirects to the admin root. It asserts the current-user request actually went out, so it cannot pass vacuously if the observer stops mounting.
- The redirect guard is module state that fires at most once per page load, so each case re-imports a fresh hooks module via `vi.resetModules()` and a `loadModules()` dynamic import. `src/test/test-utils` is re-imported in the same `Promise.all`, otherwise its `FrameworkProvider` comes from the previous module registry and the React context identity no longer matches the one the hooks module reads. The cases are independent of each other and of their order.
- The `window.location` stub that the sibling session expiry test already carried moves to `test/utils/stub-location.ts` and is shared by both files.
- The JSDoc on `requestOptions` for both query hook option types now names which fetches the flag reaches — the ones this call site initiates, not a shared cache entry it joins — matching the wording already on `useCurrentUser`.

No production behaviour changes: the only source edit is a comment.

## Verification

Two regression probes, each run with the redirecting case first in the file:

- Removing the `{ requestOptions }` argument from both `usePermission` calls in `apps/admin-x-framework/src/utils/api/hooks.ts` fails all three opt-out cases with `expected "vi.fn()" to not be called at all, but actually been called 1 times`; the redirecting case still passes.
- Dropping `requestOptions` from the rest spread in `createQueryWithId` fails the query-by-id case alone, with the other three passing.

Both were reverted afterwards.

- `@tryghost/admin-x-framework:test` (53 files, 626 tests, plus `test:types`) passes, as does eslint on the changed files.
- `@tryghost/admin:build` succeeds.
