### PR TITLE
Cleaned up types in URL service router filter

### DIFF
--- a/ghost/core/core/server/services/url/router-filter.ts
+++ b/ghost/core/core/server/services/url/router-filter.ts
@@ -1,5 +1,5 @@
-const nql = require('@tryghost/nql');
-const logging = require('@tryghost/logging');
+import nql from '@tryghost/nql';
+import logging from '@tryghost/logging';
 
 // NQL evaluation for routes.yaml collection filters, kept in one place so the
 // forward lookup, ownership check and reverse lookup all decide membership the
@@ -75,9 +75,3 @@ export function filterMatches(
     return false;
   }
 }
-
-module.exports = { EXPANSIONS, routerTypeOf, buildFilter, filterMatches };
-module.exports.EXPANSIONS = EXPANSIONS;
-module.exports.routerTypeOf = routerTypeOf;
-module.exports.buildFilter = buildFilter;
-module.exports.filterMatches = filterMatches;

--- a/ghost/core/test/unit/server/services/url/router-filter.test.ts
+++ b/ghost/core/test/unit/server/services/url/router-filter.test.ts
@@ -1,12 +1,12 @@
-const assert = require('node:assert/strict');
-const sinon = require('sinon');
-const logging = require('@tryghost/logging');
-const {
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import logging from '@tryghost/logging';
+import {
   EXPANSIONS,
   routerTypeOf,
   buildFilter,
   filterMatches,
-} = require('../../../../../core/server/services/url/router-filter');
+} from '../../../../../core/server/services/url/router-filter';
 
 describe('router-filter', function () {
   describe('routerTypeOf', function () {
@@ -41,7 +41,7 @@ describe('router-filter', function () {
 
     it('returns a compiled matcher for a non-empty filter', function () {
       const compiled = buildFilter('featured:true');
-      assert.equal(typeof compiled.queryJSON, 'function');
+      assert.equal(typeof compiled?.queryJSON, 'function');
     });
   });
 


### PR DESCRIPTION
no ref

This change should have no user impact.

Made two changes to the URL service router filter:

- Tidied imports and exports
- TypeScriptified tests
