### PR TITLE
Removed "UNIT" prefix from some spec titles

### DIFF
--- a/ghost/core/test/unit/frontend/services/routing/api-adapter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/api-adapter.test.js
@@ -5,7 +5,7 @@ const {
   resolveResourceRead,
 } = require('../../../../../core/frontend/services/routing/api-adapter');
 
-describe('UNIT - services/routing/api-adapter', function () {
+describe('services/routing/api-adapter', function () {
   describe('resolveApiCall - short form', function () {
     it('resolves tag shorthand to the public tags controller', function () {
       assert.deepEqual(resolveApiCall('tag.food'), {

--- a/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
@@ -5,7 +5,7 @@ const registry = require('../../../../../core/frontend/services/routing/registry
 
 const RESOURCE_CONFIG = { QUERY: { post: { controller: 'postsPublic', resource: 'posts' } } };
 
-describe('UNIT: services/routing/router-manager', function () {
+describe('services/routing/router-manager', function () {
   let routerUpdatedSpy;
   let routerCreatedSpy;
 

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -7,7 +7,7 @@ const controllers = require('../../../../../core/frontend/services/routing/contr
 const CollectionRouter = require('../../../../../core/frontend/services/routing/collection-router');
 const RESOURCE_CONFIG = { QUERY: { post: { controller: 'postsPublic', resource: 'posts' } } };
 
-describe('UNIT - services/routing/CollectionRouter', function () {
+describe('services/routing/CollectionRouter', function () {
   let req;
   let res;
   let next;

--- a/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
@@ -3,7 +3,7 @@ const express = require('express');
 const request = require('supertest');
 const middleware = require('../../../../../../core/frontend/services/routing/middleware');
 
-describe('UNIT: services/routing/middleware/page-param', function () {
+describe('services/routing/middleware/page-param', function () {
   const app = express();
   app.param('page', middleware.pageParam);
   app.get('/blog/page/:page/', (req, res) => {

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -5,7 +5,7 @@ const configUtils = require('../../../../utils/config-utils');
 const urlUtils = require('../../../../../core/shared/url-utils').default;
 const ParentRouter = require('../../../../../core/frontend/services/routing/parent-router');
 
-describe('UNIT - services/routing/ParentRouter', function () {
+describe('services/routing/ParentRouter', function () {
   let req;
   let res;
   let next;

--- a/ghost/core/test/unit/frontend/services/routing/permalink-adapter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/permalink-adapter.test.js
@@ -3,7 +3,7 @@ const {
   toExpressNotation,
 } = require('../../../../../core/frontend/services/routing/permalink-adapter');
 
-describe('UNIT - services/routing/permalink-adapter', function () {
+describe('services/routing/permalink-adapter', function () {
   describe('toExpressNotation', function () {
     it('converts a single {slug} placeholder to :slug', function () {
       assert.equal(toExpressNotation('/{slug}/'), '/:slug/');

--- a/ghost/core/test/unit/frontend/services/routing/registry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/registry.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const registry = require('../../../../../core/frontend/services/routing/registry');
 
-describe('UNIT: services/routing/registry', function () {
+describe('services/routing/registry', function () {
   beforeEach(function () {
     registry.clearAllRouters();
     registry.resetAllRoutes();

--- a/ghost/core/test/unit/frontend/services/routing/router-manager.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/router-manager.test.js
@@ -9,7 +9,7 @@ const routingEvents = require('../../../../../core/frontend/services/routing/eve
 // static pages, apps); only the settings-driven ones are asserted on here.
 const emptySettings = { routes: [], collections: [], taxonomies: {} };
 
-describe('UNIT: services/routing/RouterManager', function () {
+describe('services/routing/RouterManager', function () {
   let routerManager;
   let urlService;
 

--- a/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
@@ -6,7 +6,7 @@ const controllers = require('../../../../../core/frontend/services/routing/contr
 const RSSRouter = require('../../../../../core/frontend/services/routing/rss-router');
 const urlUtils = require('../../../../../core/shared/url-utils').default;
 
-describe('UNIT - services/routing/RSSRouter', function () {
+describe('services/routing/RSSRouter', function () {
   describe('instantiate', function () {
     beforeEach(function () {
       sinon.spy(RSSRouter.prototype, 'mountRoute');

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -5,7 +5,7 @@ const controllers = require('../../../../../core/frontend/services/routing/contr
 const StaticRoutesRouter = require('../../../../../core/frontend/services/routing/static-routes-router');
 const configUtils = require('../../../../utils/config-utils');
 
-describe('UNIT - services/routing/StaticRoutesRouter', function () {
+describe('services/routing/StaticRoutesRouter', function () {
   let req;
   let res;
   let next;

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -8,7 +8,7 @@ const TaxonomyRouter = require('../../../../../core/frontend/services/routing/ta
 const { QUERY, TAXONOMIES } = require('../../../../../core/frontend/services/routing/config');
 const RESOURCE_CONFIG = { QUERY, TAXONOMIES };
 
-describe('UNIT - services/routing/TaxonomyRouter', function () {
+describe('services/routing/TaxonomyRouter', function () {
   let req;
   let res;
   let next;

--- a/ghost/core/test/unit/server/adapters/redirects/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/redirects/file-store.test.ts
@@ -10,7 +10,7 @@ import { runStoreContract } from '../../services/custom-redirects/helpers/store-
 const writeJson = (filePath: string, data: unknown): Promise<void> =>
   fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
 
-describe('UNIT: FileStore', function () {
+describe('FileStore', function () {
   let basePath: string;
 
   beforeEach(async function () {

--- a/ghost/core/test/unit/server/adapters/redirects/s3-redirects-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/redirects/s3-redirects-store.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 
 import S3RedirectsStore from '../../../../../core/server/adapters/redirects/S3RedirectsStore';
 
-describe('UNIT: S3RedirectsStore', function () {
+describe('S3RedirectsStore', function () {
   describe('constructor validation', function () {
     it('throws when no bucket is provided', function () {
       assert.throws(() => new S3RedirectsStore({} as never), {

--- a/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
@@ -46,7 +46,7 @@ const sampleSettings = (): RouteSettings =>
 // bytes (comments, ordering, formatting) rather than a re-serialised model.
 const fromYaml = (yaml: string): RouteSettings => parseRouteSettings(parseYaml(yaml), yaml);
 
-describe('UNIT: route-settings FileStore', function () {
+describe('route-settings FileStore', function () {
   let basePath: string;
   let defaultsPath: string;
 

--- a/ghost/core/test/unit/server/adapters/route-settings/in-memory-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/in-memory-store.test.ts
@@ -1,7 +1,7 @@
 import { InMemoryStore } from './helpers/in-memory-store';
 import { runStoreContract } from './helpers/store-contract';
 
-describe('UNIT: InMemoryStore (validates the contract)', function () {
+describe('InMemoryStore (validates the contract)', function () {
   runStoreContract({
     createStore: () => new InMemoryStore(),
   });

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -100,7 +100,7 @@ const putCommands = (sent: S3Command[]): PutObjectCommand[] =>
 const copyCommands = (sent: S3Command[]): CopyObjectCommand[] =>
   sent.filter((c): c is CopyObjectCommand => c instanceof CopyObjectCommand);
 
-describe('UNIT: S3RouteSettingsStore', function () {
+describe('S3RouteSettingsStore', function () {
   afterEach(function () {
     sinon.restore();
   });

--- a/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it, vi } from 'vitest';
 
 import { getBackupRouteSettingsFilePath } from '../../../../../core/server/adapters/route-settings/utils';
 
-describe('UNIT: route-settings adapter utils', function () {
+describe('route-settings adapter utils', function () {
   describe('getBackupRouteSettingsFilePath', function () {
     afterEach(function () {
       vi.useRealTimers();

--- a/ghost/core/test/unit/server/services/adapter-manager/route-settings-wiring.test.ts
+++ b/ghost/core/test/unit/server/services/adapter-manager/route-settings-wiring.test.ts
@@ -16,7 +16,7 @@ const { RouteSettingsStoreBase } = require('@tryghost/adapter-base-route-setting
 const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
 const configUtils = require('../../../../utils/config-utils');
 
-describe('UNIT: adapter-manager route-settings wiring', function () {
+describe('adapter-manager route-settings wiring', function () {
   afterEach(async function () {
     await configUtils.restore();
     adapterManager.clearCache();

--- a/ghost/core/test/unit/server/services/custom-redirects/in-memory-store.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/in-memory-store.test.ts
@@ -1,7 +1,7 @@
 import { InMemoryStore } from './helpers/in-memory-store';
 import { runStoreContract } from './helpers/store-contract';
 
-describe('UNIT: InMemoryStore (validates the contract)', function () {
+describe('InMemoryStore (validates the contract)', function () {
   runStoreContract({
     createStore: () => new InMemoryStore(),
   });

--- a/ghost/core/test/unit/server/services/custom-redirects/redirect-config-parser.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/redirect-config-parser.test.ts
@@ -6,7 +6,7 @@ import {
   serializeToYaml,
 } from '../../../../../core/server/services/custom-redirects/redirect-config-parser';
 
-describe('UNIT: redirect-config-parser', function () {
+describe('redirect-config-parser', function () {
   describe('parseJson', function () {
     it('parses a JSON string into a RedirectConfig[]', function () {
       const content = JSON.stringify([

--- a/ghost/core/test/unit/server/services/custom-redirects/redirects-service.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/redirects-service.test.ts
@@ -5,7 +5,7 @@ import logging from '@tryghost/logging';
 import { RedirectsService } from '../../../../../core/server/services/custom-redirects/redirects-service';
 import { InMemoryStore } from './helpers/in-memory-store';
 
-describe('UNIT: RedirectsService', function () {
+describe('RedirectsService', function () {
   let store: InMemoryStore;
   let redirectManager: {
     removeAllRedirects: sinon.SinonStub;

--- a/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 
 const { validate } = require('../../../../../core/server/services/custom-redirects/validation');
 
-describe('UNIT: custom redirects validation', function () {
+describe('custom redirects validation', function () {
   it('passes validation for a valid redirects config', function () {
     const config = [
       {

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
@@ -74,7 +74,7 @@ function createLinkRedirectRepository(deps = {}) {
   });
 }
 
-describe('UNIT: LinkRedirectRepository class', function () {
+describe('LinkRedirectRepository class', function () {
   let linkRedirectRepository;
 
   afterEach(function () {

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
@@ -30,7 +30,7 @@ const linkClicks = [
   }),
 ];
 
-describe('UNIT: LinkClickRepository class', function () {
+describe('LinkClickRepository class', function () {
   let linkClickRepository;
   let memberStub;
   let memberLinkClickEventModelStub;

--- a/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const PostLinkRepository = require('../../../../../core/server/services/link-tracking/post-link-repository');
 
-describe('UNIT: PostLinkRepository class', function () {
+describe('PostLinkRepository class', function () {
   let postLinkRepository;
 
   beforeAll(function () {

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -25,7 +25,7 @@ taxonomies:
   tag: /tag/{slug}/
 `;
 
-describe('UNIT: DynamicRoutingService (store-backed)', function () {
+describe('DynamicRoutingService (store-backed)', function () {
   let service: InstanceType<typeof DynamicRoutingService>;
   let store: InMemoryStore;
 

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -8,7 +8,7 @@ import { buildRouteSettings } from './route-settings-fixture';
 // The raw objects here have no YAML text behind them, so an empty source is attached.
 const parse = (raw: unknown) => parseRouteSettings(raw, '');
 
-describe('UNIT: services/route-settings/route-settings-parser', function () {
+describe('services/route-settings/route-settings-parser', function () {
   describe('parseRouteSettings', function () {
     it('handles null/undefined input', function () {
       assert.deepEqual(parse(null), {

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -18,7 +18,7 @@ function throwsValidation(fn: () => void, expectedMessage?: string) {
   });
 }
 
-describe('UNIT: services/route-settings/validation (via parseRouteSettings)', function () {
+describe('services/route-settings/validation (via parseRouteSettings)', function () {
   it('accepts valid empty input', function () {
     assert.doesNotThrow(() => parse({}));
   });

--- a/ghost/core/test/unit/server/services/route-settings/validation-errors.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validation-errors.test.ts
@@ -9,7 +9,7 @@ import {
 
 const errorFor = (schema: z.ZodType, value: unknown) => schema.safeParse(value).error as z.ZodError;
 
-describe('UNIT: services/route-settings/validation-errors', function () {
+describe('services/route-settings/validation-errors', function () {
   describe('formatLocation', function () {
     it('names the file when there is no path', function () {
       assert.equal(formatLocation([]), 'routes.yaml');

--- a/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
@@ -6,7 +6,7 @@ const yaml = require('js-yaml');
 const path = require('path');
 const yamlParser = require('../../../../../core/server/services/route-settings/yaml-parser');
 
-describe('UNIT > Settings Service yaml parser:', function () {
+describe('Settings Service yaml parser', function () {
   let yamlSpy;
 
   beforeEach(function () {

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 1: [html 1] 1`] = `
+exports[`Settings BREAD Service edit setting members_support_address triggers email verification 1: [html 1] 1`] = `
 "
 <!doctype html>
 <html>
@@ -169,7 +169,7 @@ exports[`UNIT > Settings BREAD Service: edit setting members_support_address tri
 "
 `;
 
-exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 2: [text 1] 1`] = `
+exports[`Settings BREAD Service edit setting members_support_address triggers email verification 2: [text 1] 1`] = `
 "
                 Hey there,
 
@@ -186,7 +186,7 @@ exports[`UNIT > Settings BREAD Service: edit setting members_support_address tri
                 "
 `;
 
-exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 3: [metadata 1] 1`] = `
+exports[`Settings BREAD Service edit setting members_support_address triggers email verification 3: [metadata 1] 1`] = `
 Object {
   "encoding": "base64",
   "from": "\\"Ghost at 127.0.0.1\\" <noreply@example.com>",

--- a/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
+++ b/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
@@ -4,7 +4,7 @@ const {
   generatePrivateSiteAccessCode,
 } = require('../../../../../core/server/services/settings/private-site-access-code');
 
-describe('UNIT > private-site-access-code', function () {
+describe('private-site-access-code', function () {
   it('returns a curated word with a three-digit suffix', function () {
     for (let i = 0; i < 50; i++) {
       const code = generatePrivateSiteAccessCode();

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -6,7 +6,8 @@ const urlUtils = require('../../../../../core/shared/url-utils').default;
 const { mockManager } = require('../../../../utils/e2e-framework');
 const emailAddress = require('../../../../../core/server/services/email-address');
 const logging = require('@tryghost/logging');
-describe('UNIT > Settings BREAD Service:', function () {
+
+describe('Settings BREAD Service', function () {
   let emailMockReceiver;
 
   beforeEach(function () {

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -7,7 +7,7 @@ const { Settings } = require('../../../../../core/server/models/settings');
 const adapterManager = require('../../../../../core/server/services/adapter-manager').default;
 const limits = require('../../../../../core/server/services/limits');
 
-describe('UNIT: Settings Service', function () {
+describe('Settings Service', function () {
   let settingsService;
   let settingsCacheStub;
   let originalSettingsGetter = settingsCache.get;

--- a/ghost/core/test/unit/server/web/shared/middleware/url-redirects.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/url-redirects.test.js
@@ -4,7 +4,7 @@ const urlRedirects = require('../../../../../../core/server/web/shared/middlewar
 const { frontendSSLRedirect, adminSSLAndHostRedirect } = urlRedirects;
 const { getAdminRedirectUrl, getFrontendRedirectUrl, redirect } = urlRedirects;
 
-describe('UNIT: url redirects', function () {
+describe('url redirects', function () {
   let res;
   let req;
   let next;

--- a/ghost/core/test/unit/shared/sentry.test.js
+++ b/ghost/core/test/unit/shared/sentry.test.js
@@ -18,7 +18,7 @@ let sentry;
 const sentryModulePath = require.resolve('../../../core/shared/sentry');
 const originalSentryModule = require.cache[sentryModulePath];
 
-describe('UNIT: sentry', function () {
+describe('sentry', function () {
   afterEach(async function () {
     await configUtils.restore();
     sinon.restore();

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -18,7 +18,7 @@ function createCacheManager(settingsOverrides = {}) {
   return cache;
 }
 
-describe('UNIT: settings cache', function () {
+describe('settings cache', function () {
   let cache;
 
   beforeEach(function () {


### PR DESCRIPTION
no ref

This is a test-only change.

All of these tests are in `test/unit/`. No need for "UNIT" to precede the spec titles.

`git grep -w UNIT` returns no results after this change.
