### PR TITLE
Added E2E coverage for Cmd-S in the React editor

### DIFF
--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -7,6 +7,7 @@ import {
   editorConflictBanner,
   editorReauthBanner,
   editorSecondaryInstance,
+  editorStatus,
   editorTitleInput,
   postsBackLink,
 } from '@tryghost/test-data/selectors/editor';
@@ -154,8 +155,6 @@ class PublishFlow extends BasePage {
 export type PostEditorImplementation = 'ember' | 'react';
 
 export class PostEditorPage extends AdminPage {
-  private readonly implementation: PostEditorImplementation;
-
   readonly titleInput: Locator;
   readonly postStatus: Locator;
   readonly previewButton: Locator;
@@ -187,7 +186,6 @@ export class PostEditorPage extends AdminPage {
     { implementation = 'ember' }: { implementation?: PostEditorImplementation } = {},
   ) {
     super(page);
-    this.implementation = implementation;
     this.pageUrl = '/ghost/#/editor/post/';
 
     const react = implementation === 'react';
@@ -195,9 +193,10 @@ export class PostEditorPage extends AdminPage {
     this.titleInput = react
       ? page.getByTestId(editorTitleInput)
       : page.locator('[data-test-editor-title-input]');
-    // React has no save-state chip yet; `waitForSaved` refuses rather than
-    // resolving this against nothing.
-    this.postStatus = page.locator('[data-test-editor-post-status]');
+    // Both editors write the same chip text; only the attribute differs.
+    this.postStatus = react
+      ? page.getByTestId(editorStatus)
+      : page.locator('[data-test-editor-post-status]');
     this.previewButton = page.getByRole('button', { name: 'Preview' });
     this.previewModal = new PostPreviewModal(page);
     this.settingsToggleButton = page.getByTestId('settings-menu-toggle');
@@ -271,13 +270,8 @@ export class PostEditorPage extends AdminPage {
     await this.page.keyboard.type(body);
   }
 
+  /** React holds "Saving…" for a minimum display window, so this outlasts it. */
   async waitForSaved(): Promise<void> {
-    if (this.implementation === 'react') {
-      // The React editor renders no save-state chip, so there is nothing to
-      // read; wait on the save request or the persisted record instead.
-      throw new Error('waitForSaved reads the Ember status chip; the React editor has none');
-    }
-
     await this.postStatus.filter({ hasText: /Saved/ }).waitFor({ timeout: 30000 });
   }
 

--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -193,7 +193,7 @@ export class PostEditorPage extends AdminPage {
     this.titleInput = react
       ? page.getByTestId(editorTitleInput)
       : page.locator('[data-test-editor-title-input]');
-    // Both editors write the same chip text; only the attribute differs.
+    // Both chips settle on a "Saved" reading; only the attribute differs.
     this.postStatus = react
       ? page.getByTestId(editorStatus)
       : page.locator('[data-test-editor-post-status]');

--- a/e2e/tests/admin/posts/editor-react.test.ts
+++ b/e2e/tests/admin/posts/editor-react.test.ts
@@ -17,8 +17,8 @@ import type { Page } from '@playwright/test';
  * `/editor/post` with its hidden secondary instance) is already asserted
  * there, so it is not repeated.
  *
- * Autosaves are observed through the network, because the status chip reads
- * the same before and after one; only an explicit save is asserted on the chip.
+ * Autosaves are observed through the network: the chip says a save landed, not
+ * which edit it carried. Only the explicit save is asserted on the chip.
  */
 
 const POSTS_API = '/ghost/api/admin/posts/';

--- a/e2e/tests/admin/posts/editor-react.test.ts
+++ b/e2e/tests/admin/posts/editor-react.test.ts
@@ -48,6 +48,21 @@ function recordPostWrites(page: Page): PostWrite[] {
   return writes;
 }
 
+/** Requests are recorded at dispatch time so an in-flight duplicate cannot hide between waits. */
+function recordPostWriteRequests(page: Page): PostWrite[] {
+  const requests: PostWrite[] = [];
+
+  page.on('request', (request) => {
+    const method = request.method();
+
+    if ((method === 'POST' || method === 'PUT') && request.url().includes(POSTS_API)) {
+      requests.push({ method, url: request.url(), body: request.postData() ?? '' });
+    }
+  });
+
+  return requests;
+}
+
 function writesCarrying(writes: PostWrite[], text: string): PostWrite[] {
   return writes.filter((write) => write.body.includes(text));
 }
@@ -178,6 +193,7 @@ test.describe('Ghost Admin - Post editor (React)', () => {
 
     await editor.gotoPost(created.id);
     await expect(editor.lexicalEditor).toBeVisible();
+    const writeRequests = recordPostWriteRequests(page);
     await editor.appendToBody(` ${addition}`);
     // The edit is on screen, so the session holds it and the autosave is armed
     await expect(editor.lexicalEditor).toContainText(addition);
@@ -186,13 +202,14 @@ test.describe('Ghost Admin - Post editor (React)', () => {
 
     // The explicit save cancels the armed autosave rather than following it,
     // so the edit reaches the server once, carrying a revision
-    await expect.poll(() => writes.length, { timeout: 20000 }).toBe(1);
-    expect(writes[0].method).toBe('PUT');
-    expect(writes[0].url).toContain('save_revision=true');
-    expect(writes[0].body).toContain(addition);
+    await expect.poll(() => writeRequests.length, { timeout: 20000 }).toBe(1);
+    expect(writeRequests[0].method).toBe('PUT');
+    expect(writeRequests[0].url).toContain('save_revision=true');
+    expect(writeRequests[0].body).toContain(addition);
 
     await editor.waitForSaved();
     await expectNoFurtherWrites(page);
+    expect(writeRequests).toHaveLength(1);
 
     await page.reload();
     await expect(editor.titleInput).toHaveValue(created.title);

--- a/e2e/tests/admin/posts/editor-react.test.ts
+++ b/e2e/tests/admin/posts/editor-react.test.ts
@@ -17,9 +17,8 @@ import type { Page } from '@playwright/test';
  * `/editor/post` with its hidden secondary instance) is already asserted
  * there, so it is not repeated.
  *
- * Saves are observed through the network rather than through a save-state
- * chip: the React editor renders none. See the note on `waitForSaved` in the
- * page object.
+ * Autosaves are observed through the network, because the status chip reads
+ * the same before and after one; only an explicit save is asserted on the chip.
  */
 
 const POSTS_API = '/ghost/api/admin/posts/';
@@ -167,12 +166,7 @@ test.describe('Ghost Admin - Post editor (React)', () => {
     expect(post.lexical).toContain(addition);
   });
 
-  /**
-   * The React editor exposes `dispatchExplicit` on its session handle but
-   * nothing listens for the keystroke, so Cmd-S never reaches the save engine
-   * and no request asks for a revision.
-   */
-  test.fixme('explicit save - Cmd-S asks the server for a revision', async ({ page }) => {
+  test('explicit save - Cmd-S saves once, with a revision, and persists', async ({ page }) => {
     test.setTimeout(60000);
 
     const created = await postFactory.create({
@@ -185,15 +179,28 @@ test.describe('Ghost Admin - Post editor (React)', () => {
     await editor.gotoPost(created.id);
     await expect(editor.lexicalEditor).toBeVisible();
     await editor.appendToBody(` ${addition}`);
+    // The edit is on screen, so the session holds it and the autosave is armed
+    await expect(editor.lexicalEditor).toContainText(addition);
+
     await page.keyboard.press('ControlOrMeta+s');
 
-    await expect
-      .poll(() => writes.filter((write) => write.url.includes('save_revision=true')).length, {
-        timeout: 20000,
-      })
-      .toBeGreaterThan(0);
+    // The explicit save cancels the armed autosave rather than following it,
+    // so the edit reaches the server once, carrying a revision
+    await expect.poll(() => writes.length, { timeout: 20000 }).toBe(1);
+    expect(writes[0].method).toBe('PUT');
+    expect(writes[0].url).toContain('save_revision=true');
+    expect(writes[0].body).toContain(addition);
+
+    await editor.waitForSaved();
+    await expectNoFurtherWrites(page);
+
+    await page.reload();
+    await expect(editor.titleInput).toHaveValue(created.title);
+    await expect(editor.lexicalEditor).toContainText(addition);
 
     const post = await readPost(page, created.id);
+    expect(post.status).toBe('draft');
+    expect(post.title).toBe(created.title);
     expect(post.lexical).toContain(addition);
   });
 


### PR DESCRIPTION
The React post editor's Playwright spec had its explicit-save case parked as
`test.fixme`, because at the time nothing listened for the keystroke and the
editor rendered no save-state chip. Both exist now, so the case can assert the
whole path end to end.

## What changed

- Un-`fixme`s `explicit save - Cmd-S saves once, with a revision, and persists`
  in `e2e/tests/admin/posts/editor-react.test.ts`. On a dirty draft it now
  asserts that Cmd/Ctrl-S produces exactly one `PUT` carrying
  `save_revision=true` and the typed text, that the status chip settles on
  `Draft - Saved`, that nothing further is written, and that a reload plus a
  read back from the API show the saved title and body.
- Makes `PostEditorPage.postStatus` implementation-aware: React's chip carries
  the `editor-status` testid, Ember's the existing `data-test-editor-post-status`
  attribute. `waitForSaved` no longer has to refuse the React editor. The Ember
  locator and behaviour are unchanged.

The single-write assertion is the interesting one: the explicit save cancels
the armed 3s autosave rather than following it, so the edit reaches the server
once and with a revision, instead of twice with only the second one revisioned.

## Verification

Dev-mode stack, `pnpm --filter @tryghost/e2e test --workers=1` over every spec
in `tests/admin/posts/` that uses the editor page object, covering both the
Ember and React sides of it:

```
44 passed (7.9m)
```

`custom-views*.test.ts` fail in this local environment both with and without
this change, so they are left out of that list as pre-existing.

`eslint` is clean on both changed files.