### PR TITLE
Added the React editor publishing journeys to the E2E suite

### DIFF
--- a/e2e/data-factory/factories/member-factory.ts
+++ b/e2e/data-factory/factories/member-factory.ts
@@ -13,8 +13,8 @@ export interface Tier {
 
 /**
  * The *write/create* shape POSTed to /ghost/api/admin/members/ (`labels` are
- * plain names, `newsletters` are ids). The canonical *response* shape lives in
- * `@tryghost/test-data`; `build()` derives this payload from it.
+ * plain names, `newsletters` are `{id}` references). The canonical *response*
+ * shape lives in `@tryghost/test-data`; `build()` derives this payload from it.
  */
 export interface Member {
   id: string;
@@ -30,7 +30,9 @@ export interface Member {
   status: 'free' | 'paid' | 'comped' | 'gift';
   last_seen_at: Date | null;
   last_commented_at: Date | null;
-  newsletters: string[];
+  // The members API reads `newsletter.id` off each entry, so bare ids attach
+  // nothing and silently leave the member unsubscribed.
+  newsletters: { id: string }[];
   tiers?: Partial<Tier>[];
   created_at?: string; // ISO 8601 format for backdating
   complimentary_plan?: boolean;
@@ -40,7 +42,7 @@ export interface Member {
 
 /**
  * Derive the create payload from the canonical API response shape:
- * - labels flatten to names, newsletters flatten to ids
+ * - labels flatten to names, newsletters narrow to `{id}` references
  * - response-only fields are dropped (transient_id, subscribed, tiers,
  *   subscriptions, created_at, updated_at) — the Admin API sets those itself
  * - subscribed_to_emails is a write-lane extra (shared with CSV import) that
@@ -61,7 +63,7 @@ function toCreatePayload(canonical: CanonicalMember): Member {
     status: canonical.status,
     last_seen_at: canonical.last_seen_at ? new Date(canonical.last_seen_at) : null,
     last_commented_at: canonical.last_commented_at ? new Date(canonical.last_commented_at) : null,
-    newsletters: canonical.newsletters.map((newsletter) => newsletter.id),
+    newsletters: canonical.newsletters.map((newsletter) => ({ id: newsletter.id })),
     subscribed_to_emails: 'false',
   };
 }

--- a/e2e/helpers/pages/admin/posts/post/index.ts
+++ b/e2e/helpers/pages/admin/posts/post/index.ts
@@ -1,3 +1,4 @@
 export { PageEditorPage, PostEditorPage } from './post-editor-page';
 export { PostPreviewModal } from './post-preview-modal';
 export { DesktopPreviewFrame, EmailPreviewFrame } from './post-preview-frames';
+export type { PostPreviewImplementation } from './post-preview-frames';

--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -5,12 +5,45 @@ import { Locator, Page } from '@playwright/test';
 import {
   editorBody,
   editorConflictBanner,
+  editorHeaderActions,
+  editorPreviewButton,
+  editorPublishButton,
   editorReauthBanner,
+  editorSaveButton,
   editorSecondaryInstance,
   editorStatus,
   editorTitleInput,
+  editorUnpublishButton,
+  editorUnscheduleButton,
+  editorUpdateButton,
   postsBackLink,
+  publishAtScheduleOption,
+  publishCompleteBookmark,
+  publishConfirmButton,
+  publishContinueButton,
+  publishFlowComplete,
+  publishFlowConfirm,
+  publishFlowModal,
+  publishFlowOptions,
+  publishRevertToDraft,
+  publishScheduleDate,
+  publishScheduleTime,
+  publishSettingEmailRecipients,
+  publishSettingPublishAt,
+  publishSettingPublishType,
+  publishTypeEmailOnlyOption,
+  publishTypePublishAndEmailOption,
+  publishTypePublishOnlyOption,
 } from '@tryghost/test-data/selectors/editor';
+
+type PublishType = 'publish' | 'publish+send' | 'send';
+
+/** React labels its publish-type radios; Ember marks them with a test attribute. */
+const REACT_PUBLISH_TYPE_OPTIONS: Record<PublishType, string> = {
+  publish: publishTypePublishOnlyOption,
+  'publish+send': publishTypePublishAndEmailOption,
+  send: publishTypeEmailOnlyOption,
+};
 
 class SettingsMenu extends BasePage {
   readonly postUrlInput: Locator;
@@ -57,7 +90,13 @@ class ReAuthenticateModal extends BasePage {
 }
 
 class PublishFlow extends BasePage {
+  private readonly implementation: PostEditorImplementation;
+
+  readonly modal: Locator;
   readonly publishButton: Locator;
+  readonly optionsStep: Locator;
+  readonly confirmStep: Locator;
+  readonly completeStep: Locator;
   readonly publishTypeSetting: Locator;
   readonly publishTypeButton: Locator;
   readonly publishAtButton: Locator;
@@ -70,27 +109,68 @@ class PublishFlow extends BasePage {
   readonly closeButton: Locator;
   readonly completeBookmark: Locator;
 
-  constructor(page: Page) {
+  constructor(
+    page: Page,
+    { implementation = 'ember' }: { implementation?: PostEditorImplementation } = {},
+  ) {
     super(page);
+    this.implementation = implementation;
 
-    this.publishButton = page.locator('[data-test-button="publish-flow"]').first();
-    this.publishTypeSetting = page.locator('[data-test-setting="publish-type"]');
-    this.publishTypeButton = this.publishTypeSetting.locator('> button');
-    this.publishAtButton = page.locator('[data-test-setting="publish-at"] > button');
-    this.scheduleSummary = page.locator(
-      '[data-test-setting="publish-at"] [data-test-setting-title]',
-    );
-    this.scheduleDateInput = page.locator('[data-test-date-time-picker-date-input]');
-    this.scheduleTimeInput = page.locator('[data-test-date-time-picker-time-input]');
-    this.emailRecipientsSetting = page.locator('[data-test-setting="email-recipients"]');
-    this.continueButton = page.locator(
-      '[data-test-modal="publish-flow"] [data-test-button="continue"]',
-    );
-    this.confirmButton = page.locator(
-      '[data-test-modal="publish-flow"] [data-test-button="confirm-publish"]',
-    );
-    this.closeButton = page.locator('[data-test-button="close-publish-flow"]');
-    this.completeBookmark = page.locator('[data-test-complete-bookmark]');
+    const react = implementation === 'react';
+    const publishAtSetting = page.getByTestId(publishSettingPublishAt);
+
+    this.modal = react
+      ? page.getByTestId(publishFlowModal)
+      : page.locator('[data-test-modal="publish-flow"]');
+    this.publishButton = react
+      ? page
+          .getByTestId(editorHeaderActions)
+          .getByRole('button', { name: editorPublishButton, exact: true })
+      : page.locator('[data-test-button="publish-flow"]').first();
+    this.optionsStep = react
+      ? page.getByTestId(publishFlowOptions)
+      : page.locator('[data-test-publish-flow="options"]');
+    this.confirmStep = react
+      ? page.getByTestId(publishFlowConfirm)
+      : page.locator('[data-test-publish-flow="confirm"]');
+    this.completeStep = react
+      ? page.getByTestId(publishFlowComplete)
+      : page.locator('[data-test-publish-flow="complete"]');
+    this.publishTypeSetting = react
+      ? page.getByTestId(publishSettingPublishType)
+      : page.locator('[data-test-setting="publish-type"]');
+    this.publishTypeButton = react
+      ? this.publishTypeSetting.getByRole('button')
+      : this.publishTypeSetting.locator('> button');
+    this.publishAtButton = react
+      ? publishAtSetting.getByRole('button')
+      : page.locator('[data-test-setting="publish-at"] > button');
+    // React folds the summary into the row's toggle button rather than
+    // titling a separate element.
+    this.scheduleSummary = react
+      ? publishAtSetting.getByRole('button')
+      : page.locator('[data-test-setting="publish-at"] [data-test-setting-title]');
+    this.scheduleDateInput = react
+      ? page.getByTestId(publishScheduleDate)
+      : page.locator('[data-test-date-time-picker-date-input]');
+    this.scheduleTimeInput = react
+      ? page.getByTestId(publishScheduleTime)
+      : page.locator('[data-test-date-time-picker-time-input]');
+    this.emailRecipientsSetting = react
+      ? page.getByTestId(publishSettingEmailRecipients)
+      : page.locator('[data-test-setting="email-recipients"]');
+    this.continueButton = react
+      ? page.getByTestId(publishContinueButton)
+      : page.locator('[data-test-modal="publish-flow"] [data-test-button="continue"]');
+    this.confirmButton = react
+      ? page.getByTestId(publishConfirmButton)
+      : page.locator('[data-test-modal="publish-flow"] [data-test-button="confirm-publish"]');
+    this.closeButton = react
+      ? this.modal.getByRole('button', { name: 'Close', exact: true })
+      : page.locator('[data-test-button="close-publish-flow"]');
+    this.completeBookmark = react
+      ? page.getByTestId(publishCompleteBookmark)
+      : page.locator('[data-test-complete-bookmark]');
   }
 
   async open(): Promise<void> {
@@ -101,12 +181,25 @@ class PublishFlow extends BasePage {
     await this.closeButton.click();
   }
 
-  async selectPublishType(type: 'publish' | 'publish+send' | 'send'): Promise<void> {
+  async selectPublishType(type: PublishType): Promise<void> {
     await this.publishTypeButton.click();
+
+    if (this.implementation === 'react') {
+      await this.optionsStep
+        .getByRole('radio', { name: REACT_PUBLISH_TYPE_OPTIONS[type], exact: true })
+        .click();
+      return;
+    }
+
     await this.page.locator(`[data-test-publish-type="${type}"] + label`).click();
   }
 
   async schedule({ date, time }: { date?: string; time?: string }): Promise<void> {
+    if (this.implementation === 'react') {
+      await this.scheduleReact({ date, time });
+      return;
+    }
+
     await this.publishAtButton.click();
 
     const textBeforeScheduleToggle = await this.scheduleSummary.textContent();
@@ -119,6 +212,27 @@ class PublishFlow extends BasePage {
       await this.scheduleDateInput.blur();
       await this.waitForScheduleSummaryChange(textBeforeDateChange);
     }
+
+    if (time) {
+      await this.scheduleTimeInput.fill(time);
+      await this.scheduleTimeInput.blur();
+    }
+  }
+
+  /**
+   * React's date field is read-only behind a calendar popover, so the only
+   * reachable day is the default the schedule toggle picks.
+   */
+  private async scheduleReact({ date, time }: { date?: string; time?: string }): Promise<void> {
+    if (date) {
+      throw new Error('the React publish flow picks its date from a calendar, not a text field');
+    }
+
+    await this.publishAtButton.click();
+    await this.optionsStep
+      .getByRole('radio', { name: publishAtScheduleOption, exact: true })
+      .click();
+    await this.scheduleDateInput.waitFor({ state: 'visible' });
 
     if (time) {
       await this.scheduleTimeInput.fill(time);
@@ -190,6 +304,8 @@ export class PostEditorPage extends AdminPage {
 
     const react = implementation === 'react';
 
+    const headerActions = page.getByTestId(editorHeaderActions);
+
     this.titleInput = react
       ? page.getByTestId(editorTitleInput)
       : page.locator('[data-test-editor-title-input]');
@@ -197,10 +313,14 @@ export class PostEditorPage extends AdminPage {
     this.postStatus = react
       ? page.getByTestId(editorStatus)
       : page.locator('[data-test-editor-post-status]');
-    this.previewButton = page.getByRole('button', { name: 'Preview' });
-    this.previewModal = new PostPreviewModal(page);
+    // The publish flow carries a Preview button of its own, so React's is
+    // scoped to the header.
+    this.previewButton = react
+      ? headerActions.getByRole('button', { name: editorPreviewButton, exact: true })
+      : page.getByRole('button', { name: 'Preview' });
+    this.previewModal = new PostPreviewModal(page, { implementation });
     this.settingsToggleButton = page.getByTestId('settings-menu-toggle');
-    this.publishFlow = new PublishFlow(page);
+    this.publishFlow = new PublishFlow(page, { implementation });
     this.screenTitle = page.locator('[data-test-screen-title]');
     // Ember marks the Koenig container; React wraps each instance in its own
     // testid, and the contenteditable is the textbox inside the primary one.
@@ -210,9 +330,21 @@ export class PostEditorPage extends AdminPage {
     this.secondaryEditor = react
       ? page.getByTestId(editorSecondaryInstance)
       : page.locator('[data-secondary-instance="true"]');
-    this.publishSaveButton = page.locator('[data-test-button="publish-save"]').first();
-    this.updateFlowButton = page.locator('[data-test-button="update-flow"]').first();
-    this.revertToDraftButton = page.locator('[data-test-button="revert-to-draft"]');
+    // Ember labels one primary button Save or Update; React renders whichever
+    // of the two the post's status calls for.
+    this.publishSaveButton = react
+      ? headerActions.getByRole('button', {
+          name: new RegExp(`^(${editorSaveButton}|${editorUpdateButton})$`),
+        })
+      : page.locator('[data-test-button="publish-save"]').first();
+    this.updateFlowButton = react
+      ? headerActions.getByRole('button', {
+          name: new RegExp(`^(${editorUnpublishButton}|${editorUnscheduleButton})$`),
+        })
+      : page.locator('[data-test-button="update-flow"]').first();
+    this.revertToDraftButton = react
+      ? page.getByTestId(publishRevertToDraft)
+      : page.locator('[data-test-button="revert-to-draft"]');
     // Ember's back link carries the inlined arrow icon's title in its
     // accessible name; React's is a plain link named for the list.
     this.backButton = react

--- a/e2e/helpers/pages/admin/posts/post/post-preview-frames.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-preview-frames.ts
@@ -9,12 +9,19 @@ export type PostPreviewImplementation = 'ember' | 'react';
 
 class PreviewFrame {
   protected readonly page: Page;
+  private readonly implementation: PostPreviewImplementation;
 
-  constructor(page: Page) {
+  constructor(page: Page, implementation: PostPreviewImplementation) {
     this.page = page;
+    this.implementation = implementation;
   }
 
   protected async waitForEscapeScriptToBeReady(): Promise<void> {
+    // Only Ember injects the Escape handler into the preview document.
+    if (this.implementation === 'react') {
+      return;
+    }
+
     await this.page.waitForFunction(
       () => {
         const iframe = document.querySelector('iframe[title*="preview"]') as HTMLIFrameElement;
@@ -31,6 +38,7 @@ class PreviewFrame {
           return false;
         }
       },
+      undefined,
       { timeout: 5000 },
     );
   }
@@ -45,7 +53,7 @@ export class EmailPreviewFrame extends PreviewFrame {
     page: Page,
     { implementation = 'ember' }: { implementation?: PostPreviewImplementation } = {},
   ) {
-    super(page);
+    super(page, implementation);
     // Both implementations title the iframe "Email preview"; React also marks it.
     const selector =
       implementation === 'react'
@@ -72,7 +80,7 @@ export class DesktopPreviewFrame extends PreviewFrame {
     page: Page,
     { implementation = 'ember' }: { implementation?: PostPreviewImplementation } = {},
   ) {
-    super(page);
+    super(page, implementation);
     // React renders one preview iframe and changes the chrome around it; Ember
     // titles a separate iframe per device.
     const selector =

--- a/e2e/helpers/pages/admin/posts/post/post-preview-frames.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-preview-frames.ts
@@ -1,4 +1,11 @@
 import { FrameLocator, Locator, Page } from '@playwright/test';
+import {
+  postPreviewBrowserFrame,
+  postPreviewEmailFrame,
+} from '@tryghost/test-data/selectors/editor';
+
+/** Which implementation renders the preview — decided by the `editorReact` flag. */
+export type PostPreviewImplementation = 'ember' | 'react';
 
 class PreviewFrame {
   protected readonly page: Page;
@@ -34,10 +41,18 @@ export class EmailPreviewFrame extends PreviewFrame {
   readonly previewBody: Locator;
   readonly frameBody: Locator;
 
-  constructor(page: Page) {
+  constructor(
+    page: Page,
+    { implementation = 'ember' }: { implementation?: PostPreviewImplementation } = {},
+  ) {
     super(page);
-    this.frame = this.page.frameLocator('iframe[title="Email preview"]');
+    // Both implementations title the iframe "Email preview"; React also marks it.
+    const selector =
+      implementation === 'react'
+        ? `iframe[data-testid="${postPreviewEmailFrame}"]`
+        : 'iframe[title="Email preview"]';
 
+    this.frame = this.page.frameLocator(selector);
     this.previewBody = this.frame.getByTestId('email-preview-body');
     this.frameBody = this.frame.locator('body');
   }
@@ -50,10 +65,23 @@ export class EmailPreviewFrame extends PreviewFrame {
 
 export class DesktopPreviewFrame extends PreviewFrame {
   readonly desktopPreviewFrame: FrameLocator;
+  /** The iframe element itself, for reading the URL the preview was pointed at. */
+  readonly frameElement: Locator;
 
-  constructor(page: Page) {
+  constructor(
+    page: Page,
+    { implementation = 'ember' }: { implementation?: PostPreviewImplementation } = {},
+  ) {
     super(page);
-    this.desktopPreviewFrame = page.frameLocator('iframe[title="Desktop browser post preview"]');
+    // React renders one preview iframe and changes the chrome around it; Ember
+    // titles a separate iframe per device.
+    const selector =
+      implementation === 'react'
+        ? `iframe[data-testid="${postPreviewBrowserFrame}"]`
+        : 'iframe[title="Desktop browser post preview"]';
+
+    this.desktopPreviewFrame = page.frameLocator(selector);
+    this.frameElement = page.locator(selector);
   }
 
   async focus(): Promise<void> {

--- a/e2e/helpers/pages/admin/posts/post/post-preview-modal.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-preview-modal.ts
@@ -1,5 +1,11 @@
 import { DesktopPreviewFrame, EmailPreviewFrame } from '@/helpers/pages';
 import { Locator, Page } from '@playwright/test';
+import {
+  emailPreviewTab,
+  postPreviewModal,
+  webPreviewTab,
+} from '@tryghost/test-data/selectors/editor';
+import type { PostPreviewImplementation } from '@/helpers/pages';
 
 export class PostPreviewModal {
   private readonly page: Page;
@@ -13,17 +19,30 @@ export class PostPreviewModal {
   public readonly desktopPreview: DesktopPreviewFrame;
   public readonly emailPreview: EmailPreviewFrame;
 
-  constructor(page: Page) {
+  constructor(
+    page: Page,
+    { implementation = 'ember' }: { implementation?: PostPreviewImplementation } = {},
+  ) {
     this.page = page;
-    this.modal = this.page.getByRole('banner').filter({ hasText: 'Preview' });
+
+    const react = implementation === 'react';
+
+    this.modal = react
+      ? page.getByTestId(postPreviewModal)
+      : this.page.getByRole('banner').filter({ hasText: 'Preview' });
     this.header = this.modal.getByRole('heading', { name: 'Preview' });
     this.closeButton = this.modal.getByRole('button', { name: 'Close' });
 
-    this.desktopPreview = new DesktopPreviewFrame(page);
-    this.emailPreview = new EmailPreviewFrame(page);
+    this.desktopPreview = new DesktopPreviewFrame(page, { implementation });
+    this.emailPreview = new EmailPreviewFrame(page, { implementation });
 
-    this.webTabButton = this.modal.getByRole('button', { name: 'Web' });
-    this.emailTabButton = this.modal.getByRole('button', { name: 'Email' });
+    // React switches format with tabs; Ember with a pair of buttons.
+    this.webTabButton = react
+      ? this.modal.getByRole('tab', { name: webPreviewTab })
+      : this.modal.getByRole('button', { name: 'Web' });
+    this.emailTabButton = react
+      ? this.modal.getByRole('tab', { name: emailPreviewTab })
+      : this.modal.getByRole('button', { name: 'Email' });
   }
 
   async switchToEmailTab(): Promise<void> {

--- a/e2e/tests/admin/posts/newsletter-send.test.ts
+++ b/e2e/tests/admin/posts/newsletter-send.test.ts
@@ -21,7 +21,7 @@ test.describe('Ghost Admin - Newsletter Send', () => {
     const member = await memberFactory.create({
       name: 'Newsletter Recipient',
       email: 'newsletter-test@example.com',
-      newsletters: newsletters as never,
+      newsletters,
     });
 
     const postsPage = new PostsPage(page);

--- a/e2e/tests/admin/posts/publishing-react.test.ts
+++ b/e2e/tests/admin/posts/publishing-react.test.ts
@@ -181,6 +181,7 @@ test.describe('Ghost Admin - Publishing (React)', () => {
     const preview = editor.previewModal.desktopPreview;
     // The frame is rendered only once the save the preview waited on has landed
     await expect(preview.frameElement).toBeVisible();
+    await preview.waitForPreviewModalFrame();
 
     const post = await readPost(page, created.id);
     expect(post.lexical).toContain(addition);

--- a/e2e/tests/admin/posts/publishing-react.test.ts
+++ b/e2e/tests/admin/posts/publishing-react.test.ts
@@ -42,13 +42,7 @@ async function getNewsletters(request: APIRequestContext): Promise<{ id: string 
 async function addSubscribedMember(page: Page, email: string) {
   const memberFactory = createMemberFactory(page.request);
   const newsletters = await getNewsletters(page.request);
-  // The factory types `newsletters` as ids, but the Admin API attaches the
-  // relation only from objects; bare ids subscribe the member to nothing.
-  await memberFactory.create({
-    email,
-    name: 'React publishing member',
-    newsletters: newsletters as never,
-  });
+  await memberFactory.create({ email, name: 'React publishing member', newsletters });
 }
 
 async function startDraft(page: Page, { title, body }: { title: string; body: string }) {

--- a/e2e/tests/admin/posts/publishing-react.test.ts
+++ b/e2e/tests/admin/posts/publishing-react.test.ts
@@ -32,17 +32,23 @@ function waitForPostSave(page: Page, postId: string) {
   );
 }
 
-async function getNewsletters(request: APIRequestContext): Promise<string[]> {
+async function getNewsletters(request: APIRequestContext): Promise<{ id: string }[]> {
   const response = await request.get('/ghost/api/admin/newsletters/?status=active&limit=all');
   const data = await response.json();
-  return data.newsletters.map((newsletter: { id: string }) => newsletter.id);
+  return data.newsletters.map((newsletter: { id: string }) => ({ id: newsletter.id }));
 }
 
 /** A member on every active newsletter, so email is on offer in the publish flow. */
 async function addSubscribedMember(page: Page, email: string) {
   const memberFactory = createMemberFactory(page.request);
   const newsletters = await getNewsletters(page.request);
-  await memberFactory.create({ email, name: 'React publishing member', newsletters });
+  // The factory types `newsletters` as ids, but the Admin API attaches the
+  // relation only from objects; bare ids subscribe the member to nothing.
+  await memberFactory.create({
+    email,
+    name: 'React publishing member',
+    newsletters: newsletters as never,
+  });
 }
 
 async function startDraft(page: Page, { title, body }: { title: string; body: string }) {

--- a/e2e/tests/admin/posts/publishing-react.test.ts
+++ b/e2e/tests/admin/posts/publishing-react.test.ts
@@ -1,0 +1,303 @@
+import { APIRequestContext, Page } from '@playwright/test';
+import { LoginPage, PostEditorPage, PostsPage } from '@/admin-pages';
+import { PostFactory, createMemberFactory, createPostFactory } from '@/data-factory';
+import { PostPage } from '@/helpers/pages';
+import { expect, test, withIsolatedPage } from '@/helpers/playwright';
+
+/**
+ * The publishing journeys through the React post editor, behind the
+ * `editorReact` Labs flag. Each case pins the state the server ends up holding,
+ * not the layout the editor reaches it through. The draft autosave journeys
+ * stay in `editor-react.test.ts`.
+ */
+
+const POSTS_API = '/ghost/api/admin/posts/';
+
+async function readPost(page: Page, postId: string) {
+  const response = await page.request.get(`${POSTS_API}${postId}/?formats=lexical&include=email`);
+  expect(response.status()).toBe(200);
+  const {
+    posts: [post],
+  } = await response.json();
+
+  return post;
+}
+
+function waitForPostSave(page: Page, postId: string) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' &&
+      response.url().includes(`${POSTS_API}${postId}/`) &&
+      response.status() === 200,
+  );
+}
+
+async function getNewsletters(request: APIRequestContext): Promise<string[]> {
+  const response = await request.get('/ghost/api/admin/newsletters/?status=active&limit=all');
+  const data = await response.json();
+  return data.newsletters.map((newsletter: { id: string }) => newsletter.id);
+}
+
+/** A member on every active newsletter, so email is on offer in the publish flow. */
+async function addSubscribedMember(page: Page, email: string) {
+  const memberFactory = createMemberFactory(page.request);
+  const newsletters = await getNewsletters(page.request);
+  await memberFactory.create({ email, name: 'React publishing member', newsletters });
+}
+
+async function startDraft(page: Page, { title, body }: { title: string; body: string }) {
+  const postsPage = new PostsPage(page);
+  await postsPage.goto();
+  await postsPage.newPostButton.click();
+
+  const editor = new PostEditorPage(page, { implementation: 'react' });
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes(POSTS_API) &&
+        response.status() === 201,
+    ),
+    editor.createDraft({ title, body }),
+  ]);
+
+  return { editor, postId: await editor.getPostId(), postsPage };
+}
+
+test.describe('Ghost Admin - Publishing (React)', () => {
+  // Flag state belongs on the describe — `test.use` inside a test body has no
+  // effect on the fixtures that test already resolved.
+  test.use({ labs: { editorReact: true } });
+
+  let postFactory: PostFactory;
+
+  test.beforeEach(async ({ page }) => {
+    postFactory = createPostFactory(page.request);
+  });
+
+  test('draft - schedules, lists as scheduled, and unschedules back to a draft', async ({
+    page,
+  }) => {
+    // A schedule, a trip through the list and a revert do not fit the default
+    // budget
+    test.setTimeout(90000);
+
+    const title = `react-schedule-${Date.now()}`;
+    const body = 'This is my scheduled post body.';
+
+    const { editor, postId, postsPage } = await startDraft(page, { title, body });
+
+    await editor.publishFlow.open();
+    await expect(editor.publishFlow.optionsStep).toBeVisible();
+    // No date: the React picker takes its day from a calendar popover, and the
+    // default schedule is ten minutes out
+    await editor.publishFlow.schedule({});
+    await Promise.all([waitForPostSave(page, postId), editor.publishFlow.confirm()]);
+    await expect(editor.publishFlow.completeStep).toBeVisible();
+
+    const scheduled = await readPost(page, postId);
+    expect(scheduled.status).toBe('scheduled');
+
+    await postsPage.goto();
+    await postsPage.waitForPageToFullyLoad();
+    await expect(postsPage.getPostByTitle(title)).toContainText('Scheduled');
+
+    // The publish flow's complete modal outlives an in-app hash route change
+    await page.reload();
+    await postsPage.waitForPageToFullyLoad();
+    await postsPage.getPostByTitle(title).click();
+    await expect(editor.postStatus).toContainText('Scheduled');
+
+    await editor.revertToDraft();
+    await expect(editor.postStatus).toContainText('Draft');
+
+    const reverted = await readPost(page, postId);
+    expect(reverted.status).toBe('draft');
+    expect(reverted.published_at).toBeNull();
+  });
+
+  test('published - an edit reaches the server when Update is clicked', async ({ page }) => {
+    const created = await postFactory.create({
+      title: `react-update-${Date.now()}`,
+      status: 'published',
+    });
+    const addition = 'Edited after publishing.';
+
+    const editor = new PostEditorPage(page, { implementation: 'react' });
+    await editor.gotoPost(created.id);
+    await expect(editor.lexicalEditor).toBeVisible();
+
+    await editor.appendToBody(` ${addition}`);
+    // A published post never autosaves, so this click is the only save
+    await Promise.all([waitForPostSave(page, created.id), editor.publishSaveButton.click()]);
+
+    const updated = await readPost(page, created.id);
+    expect(updated.status).toBe('published');
+    expect(updated.lexical).toContain(addition);
+  });
+
+  test('published - unpublishing takes the post off the site', async ({ page }) => {
+    const title = `react-unpublish-${Date.now()}`;
+    const created = await postFactory.create({ title, status: 'published' });
+
+    const editor = new PostEditorPage(page, { implementation: 'react' });
+    await editor.gotoPost(created.id);
+    await expect(editor.postStatus).toContainText('Published');
+
+    await editor.revertToDraft();
+    await expect(editor.postStatus).toContainText('Draft');
+
+    const reverted = await readPost(page, created.id);
+    expect(reverted.status).toBe('draft');
+
+    const frontendPage = await page.context().newPage();
+    await expect
+      .poll(async () => (await frontendPage.request.get(`/${created.slug}/`)).status(), {
+        timeout: 20000,
+      })
+      .toBe(404);
+  });
+
+  test('draft - previewing saves the pending edit before it renders', async ({ page }) => {
+    // The save, the modal and the frontend render of the preview do not fit the
+    // default budget
+    test.setTimeout(60000);
+
+    const created = await postFactory.create({
+      title: `react-preview-${Date.now()}`,
+      status: 'draft',
+      featured: false,
+    });
+    const addition = 'Typed but not yet saved.';
+
+    const editor = new PostEditorPage(page, { implementation: 'react' });
+    await editor.gotoPost(created.id);
+    await expect(editor.lexicalEditor).toBeVisible();
+
+    await editor.appendToBody(` ${addition}`);
+    await editor.previewButton.click();
+    await expect(editor.previewModal.modal).toBeVisible();
+
+    const preview = editor.previewModal.desktopPreview;
+    // The frame is rendered only once the save the preview waited on has landed
+    await expect(preview.frameElement).toBeVisible();
+
+    const post = await readPost(page, created.id);
+    expect(post.lexical).toContain(addition);
+    await expect(preview.frameElement).toHaveAttribute('src', new RegExp(`/p/${post.uuid}/`));
+    await expect(preview.desktopPreviewFrame.getByRole('article').first()).toContainText(addition);
+  });
+
+  test('contributor - gets Save and Preview and no way to publish', async ({
+    browser,
+    baseURL,
+    page,
+    ghostAccountContributor,
+  }) => {
+    // Inviting the contributor and signing them in does not fit the default
+    // budget
+    test.setTimeout(90000);
+
+    const title = `react-contributor-${Date.now()}`;
+    // Authored through the API rather than the editor: the React editor's
+    // create payload omits `authors`, which a contributor's add permission needs
+    const created = await page.request.post(POSTS_API, {
+      data: {
+        posts: [{ title, status: 'draft', authors: [{ email: ghostAccountContributor.email }] }],
+      },
+    });
+    expect(created.status()).toBe(201);
+    const {
+      posts: [draft],
+    } = await created.json();
+
+    await withIsolatedPage(browser, { baseURL }, async ({ page: contributorPage }) => {
+      const loginPage = new LoginPage(contributorPage);
+      await loginPage.goto();
+      await loginPage.signIn(ghostAccountContributor.email, ghostAccountContributor.password);
+
+      const postsPage = new PostsPage(contributorPage);
+      await postsPage.waitForPageToFullyLoad();
+
+      const editor = new PostEditorPage(contributorPage, { implementation: 'react' });
+      await editor.gotoPost(draft.id);
+      await expect(editor.lexicalEditor).toBeVisible();
+
+      await expect(editor.publishSaveButton).toBeVisible();
+      await expect(editor.previewButton).toBeVisible();
+      await expect(editor.publishFlow.publishButton).toHaveCount(0);
+      await expect(editor.updateFlowButton).toHaveCount(0);
+    });
+  });
+
+  // Both cases need email genuinely on offer, so the publish type is a real
+  // choice rather than the only one left.
+  test.describe('with a newsletter', () => {
+    test.use({ mailgunEnabled: true });
+
+    test('draft - publish only puts the post on the site and sends no email', async ({ page }) => {
+      // A member, a draft and the three publish steps do not fit the default
+      // budget
+      test.setTimeout(90000);
+
+      const title = `react-publish-only-${Date.now()}`;
+      const body = 'This is my published post body.';
+
+      await addSubscribedMember(page, 'react-publish-only@example.com');
+
+      const { editor, postId } = await startDraft(page, { title, body });
+
+      await editor.publishFlow.open();
+      await expect(editor.publishFlow.optionsStep).toBeVisible();
+      await editor.publishFlow.selectPublishType('publish');
+      await editor.publishFlow.confirm();
+      await expect(editor.publishFlow.completeStep).toBeVisible();
+
+      const post = await readPost(page, postId);
+      expect(post.status).toBe('published');
+      // The send was on offer and the publish type declined it
+      expect(post.email).toBeNull();
+
+      const frontendPage = await page.context().newPage();
+      const publicPage = new PostPage(frontendPage);
+      await publicPage.gotoPost(post.slug);
+      await expect(publicPage.articleTitle).toHaveText(title);
+      await expect(publicPage.articleBody).toHaveText(body);
+    });
+
+    test('draft - publish and send delivers the email to the member', async ({
+      emailClient,
+      page,
+    }) => {
+      // A member, a publish flow and the send do not fit the default budget
+      test.setTimeout(90000);
+
+      const title = `react-publish-send-${Date.now()}`;
+      const body = 'This is my emailed post body.';
+      const memberEmail = 'react-publish-send@example.com';
+
+      await addSubscribedMember(page, memberEmail);
+
+      const { editor, postId } = await startDraft(page, { title, body });
+
+      await editor.publishFlow.open();
+      await expect(editor.publishFlow.optionsStep).toBeVisible();
+      await editor.publishFlow.selectPublishType('publish+send');
+      await editor.publishFlow.confirm();
+      await expect(editor.publishFlow.completeStep).toBeVisible();
+
+      const post = await readPost(page, postId);
+      expect(post.status).toBe('published');
+      expect(post.email).not.toBeNull();
+
+      const delivered = await emailClient.search(
+        { to: memberEmail, subject: title },
+        { timeoutMs: 30_000 },
+      );
+      expect(delivered.length).toBeGreaterThanOrEqual(1);
+
+      const detail = await emailClient.getMessageDetailed(delivered[0]);
+      expect(detail.HTML).toContain(body);
+    });
+  });
+});

--- a/e2e/tests/admin/posts/publishing.test.ts
+++ b/e2e/tests/admin/posts/publishing.test.ts
@@ -4,10 +4,10 @@ import { PostPage } from '@/helpers/pages';
 import { createMemberFactory, generateSlug } from '@/data-factory';
 import { expect, test } from '@/helpers/playwright';
 
-async function getNewsletters(request: APIRequestContext): Promise<string[]> {
+async function getNewsletters(request: APIRequestContext): Promise<{ id: string }[]> {
   const response = await request.get('/ghost/api/admin/newsletters/?status=active&limit=all');
   const data = await response.json();
-  return data.newsletters.map((n: { id: string }) => n.id);
+  return data.newsletters.map((n: { id: string }) => ({ id: n.id }));
 }
 
 async function expectFrontendStatus(page: Page, slug: string, status: number, timeout = 20000) {

--- a/e2e/tests/portal/member-actions.test.ts
+++ b/e2e/tests/portal/member-actions.test.ts
@@ -25,10 +25,7 @@ async function createNewsletter(request: APIRequestContext, name: string): Promi
 async function createSubscribedMember(request: APIRequestContext, memberFactory: MemberFactory) {
   const newsletterIds = await getNewsletterIds(request);
   const newsletters = newsletterIds.map((id) => ({ id }));
-  const member = await memberFactory.create({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    newsletters: newsletters as any,
-  });
+  const member = await memberFactory.create({ newsletters });
   return member;
 }
 

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -107,3 +107,7 @@ export const editorUpdateButton = 'Update';
 export const editorSaveButton = 'Save';
 export const editorUnpublishButton = 'Unpublish';
 export const editorUnscheduleButton = 'Unschedule';
+export const publishTypePublishAndEmailOption = 'Publish and email';
+export const publishTypePublishOnlyOption = 'Publish only';
+export const publishTypeEmailOnlyOption = 'Email only';
+export const publishAtScheduleOption = 'Schedule for later';


### PR DESCRIPTION
The E2E suite covers the publishing journeys against the Ember editor only. This adds the same journeys against the React editor behind the `editorReact` Labs flag, so the React editor has an end-to-end signal of its own.

## What this adds

`e2e/tests/admin/posts/publishing-react.test.ts` — seven journeys, each asserting the state the server ends up holding rather than the layout the editor reaches it through:

- draft → Publish → publish only → complete, and the post is live on the site with no email
- draft → Publish and email → the email is delivered to the member
- draft → schedule → listed as scheduled → Unschedule → draft
- published → edit → Update → the PUT lands
- published → Unpublish → draft, and the post 404s
- draft with a pending edit → Preview → the edit is saved first and the iframe loads `/p/:uuid/`
- contributor → Save and Preview only, with no Publish, Unpublish or Unschedule

All seven run. Nothing in the file is `fixme` or skipped.

Both publish-type journeys run with Mailgun on and a subscribed member, so email is genuinely on offer and the publish type is a real choice rather than the only one left. Publish-only picks `publish` and asserts the post carries no email; publish-and-email picks `publish+send` and asserts the message reaches the member through the Mailpit client.

The dual-implementation page objects gained React branches for the publish flow (modal, its three steps, publish type, schedule, continue and confirm), the update flow behind Unpublish and Unschedule, the preview modal and both of its frames, and the header's Preview button and primary Save/Update button. The Ember branches are unchanged.

Preview readiness is now per implementation. Only Ember injects the Escape handler into the preview document, so the shared readiness helper returns early for React instead of waiting five seconds for a handler that never arrives, and it passes its timeout through Playwright's options argument rather than as the polling argument.

The publish-type and schedule radios are reached with `getByRole('radio', { name })` scoped to the options step, using accessible names exported from `packages/testing/test-data/src/selectors/editor.ts`, rather than by the component's own element ids.

This PR is scoped to `e2e/**` and the shared editor selectors; it changes nothing under `apps/admin/src`.

## Findings

Writing the journeys turned up three things in the React editor.

**The publish settings response was rejected.** `apps/admin/src/editor/publish/use-publish-inputs.ts` parsed the settings browse response against a schema whose setting values could only be a string, boolean, number or null. Ghost's calculated `all_blocked_email_domains` setting is an array, so the parse failed against every real Ghost: the publish inputs never became ready, the header's Publish button stayed disabled behind "The publish settings response was invalid.", and the update flow behind Unpublish and Unschedule never mounted. That blocked publish only, publish and email, schedule/unschedule, and unpublish. The fix has since landed on main, and those four journeys are active here.

**Authors and Contributors could not create a post.** The React editor's create payload omitted `authors`, and Core refuses the add for both roles when the payload does not name them — `ghost/core/core/server/models/relations/authors.js` gates `(isContributor || isAuthor) && isAdd` on `isOwner()`, which returns false outright when `unsafeAttrs.authors` is absent. That fix has also landed on main. The contributor journey still opens a draft created through the API, which is the shortest setup for the header assertions it is about.

**The publish flow's complete modal outlives an in-app hash route change**, where the Ember flow closes its modal on transition. The scheduled journey reloads the page before reading the post row rather than navigating in-app. That is a workaround for the defect, not a fix for it.

## Verification

- `pnpm --filter @tryghost/e2e exec eslint` on the changed files and `tsc --noEmit` in `e2e` — clean.
- The live Docker run was skipped this round: a dev stack was already up and owned by another session, so the suite is left to CI's E2E shards.
- The file holds seven journeys, all running: 7 passed, 0 skipped.
