### PR TITLE
Fixed post creation from the React editor for Authors and Contributors

### DIFF
--- a/apps/admin/src/editor/editor-save.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-save.acceptance.test.tsx
@@ -4,6 +4,7 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentRoute,
+  currentUserResponse,
   fakeAdminEndpoint,
   fakeMembers,
   fakeNewsletters,
@@ -11,9 +12,11 @@ import {
   fakeSnippets,
   post,
   renderAdminApp,
+  staffRole,
   tag,
   type CapturedEndpointRequest,
   type EndpointCapture,
+  type RenderAdminAppOptions,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 import { OLD_SCHEMA_CORPUS } from '@/editor/engine/__fixtures__';
@@ -21,6 +24,7 @@ import { deferred } from '@/utils/deferred';
 
 const POST_ID = 'abc123';
 const NEW_POST_ID = 'new789';
+const CURRENT_USER_ID = '1';
 const FLAG_ON = { labs: { editorReact: true } };
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const CREATED_AT = '2026-01-01T00:00:05.000Z';
@@ -87,6 +91,36 @@ function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   });
 
   return saveApi;
+}
+
+/** A post that does not exist yet, with the create and the follow-up writes answered. */
+function fakeCreatablePost() {
+  editorChrome();
+  fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
+  let created = post({
+    id: NEW_POST_ID,
+    title: '(Untitled)',
+    slug: 'untitled',
+    status: 'draft',
+    updated_at: CREATED_AT,
+    published_at: null,
+    tags: [],
+  });
+  const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: CREATED_AT };
+    return { posts: [created] };
+  });
+  fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({ posts: [created] }));
+  fakeAdminEndpoint('PUT', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({ posts: [created] }));
+
+  return createApi;
+}
+
+function bootAs(role: 'Author' | 'Contributor'): RenderAdminAppOptions {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name: role })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
 }
 
 async function typeIntoBody(text: string) {
@@ -206,6 +240,24 @@ describe('Post editor saving', () => {
       await expect.poll(currentRoute).toBe(`/editor/post/${NEW_POST_ID}`);
       expect(bodyElement()).toBe(mountedBody);
       await expect.element(editorScreen.body()).toHaveTextContent('First words');
+    },
+    SLOW,
+  );
+
+  // Core refuses an Author's or Contributor's create unless the payload names
+  // them as the author, so these roles could not start a post without it.
+  it.each(['Contributor', 'Author'] as const)(
+    'names the writer as the author when the %s role creates a post',
+    async (role) => {
+      const createApi = fakeCreatablePost();
+
+      await renderAdminApp('/editor/post', bootAs(role));
+      await expect.element(editorScreen.body()).toBeVisible();
+
+      await typeIntoBody('First words');
+
+      await expect.poll(() => createApi.requests.length, SAVE_POLL).toBe(1);
+      expect(submittedPost(createApi).authors).toEqual([{ id: CURRENT_USER_ID }]);
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -126,7 +126,12 @@ function EditorContent({
   showExcerpt,
   snippetDialog,
 }: EditorContentProps) {
-  const session = useEditorSession({ postType, record, siteUrl: cardConfig.siteUrl });
+  const session = useEditorSession({
+    postType,
+    record,
+    siteUrl: cardConfig.siteUrl,
+    currentUserId: currentUser?.id,
+  });
   const [tkCount, setTkCount] = useState(0);
   const featureImage = useFeatureImageBinding(session, session.loadedRecord, session.contentKey);
   const leaveGuard = useEditorLeaveGuard(session, postType);

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -186,6 +186,18 @@ describe('createEditorSession', () => {
     expect(state.acquiredIds).toEqual(['created-id']);
   });
 
+  it('authors the create with the current user and leaves updates alone', async () => {
+    const { session, state } = harness({ currentUserId: 'user-1' });
+
+    session.patchLexical(body('First words'));
+    await session.dispatchExplicit();
+    session.patchLexical(body('More words'));
+    await session.dispatchExplicit();
+
+    expect(state.creates[0].authors).toEqual([{ id: 'user-1' }]);
+    expect(state.updates[0].payload).not.toHaveProperty('authors');
+  });
+
   it('keeps the excerpt it was given and clears it back to null', async () => {
     const { session, state } = harness({ record: record() });
 

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -61,6 +61,8 @@ export interface EditorSessionTransport {
 export interface EditorSessionOptions {
   record?: EditorRecord;
   siteUrl?: string;
+  /** Authors the create. Core rejects an Author's or Contributor's create without it. */
+  currentUserId?: string;
   saveFailureMessage: string;
   transport: EditorSessionTransport;
   /** Called once the create acknowledges; the caller replaces the URL. */
@@ -120,6 +122,7 @@ export function isOlderToken(candidate: string, held: string | null): boolean {
 export function createEditorSession({
   record,
   siteUrl,
+  currentUserId,
   saveFailureMessage,
   transport,
   onIdAcquired,
@@ -232,6 +235,11 @@ export function createEditorSession({
       status: request.target.status,
       published_at: request.target.publishedAt,
     };
+    // An Author's or Contributor's create is refused unless `authors` names them
+    // (core/server/models/relations/authors.js). Updates never resend it.
+    if (isCreate && currentUserId) {
+      payload.authors = [{ id: currentUserId }];
+    }
     if (!isCreate) {
       if (!projection.updated_at) {
         // Without the token the server skips its collision check entirely and the

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -116,6 +116,8 @@ export interface UseEditorSessionOptions {
   postType: PostType;
   record?: EditorRecord;
   siteUrl: string;
+  /** Authors a post this session creates. */
+  currentUserId?: string;
 }
 
 function reportError(error: unknown): void {
@@ -128,6 +130,7 @@ export function useEditorSession({
   postType,
   record,
   siteUrl,
+  currentUserId,
 }: UseEditorSessionOptions): EditorSessionHandle {
   const fetchApi = useFetchApi();
   const queryClient = useQueryClient();
@@ -155,6 +158,7 @@ export function useEditorSession({
     createEditorSession({
       record,
       siteUrl,
+      currentUserId,
       saveFailureMessage: `Couldn’t save this ${postType}.`,
       onIdAcquired: setPersistedId,
       onError: reportError,


### PR DESCRIPTION
The React editor built its create payload without `authors`. Core only lets an Author or Contributor add a post when the payload names them as its author (`ghost/core/core/server/models/relations/authors.js` — `isOwner()` returns false outright when `unsafeAttrs.authors` is absent), so for those two roles the editor's very first save was rejected and they could not start a post at all.

The editing session now seeds the create with the current user, the same way the Ember editor does (`createRecord(modelName, {authors: [this.session.user]})`). The current user is threaded in from the editor screen, which already holds it, rather than fetched inside the session.

Updates are untouched. The session sends a field only once it has edited one, and nothing in the editor edits authors, so an update never resends them — resending would risk overwriting authors changed elsewhere, and for the Author role Core rejects an edit that changes them.

Owners, Admins and Editors get the same seed. It is what Ember sends and it matches what Core would have set anyway.

## Verification

- `pnpm exec tsc -b` and `eslint` clean in `apps/admin`.
- `pnpm vitest run src/editor` — 911 passing.
- Browser-mode acceptance for `src/editor` and `src/layout` — 216 passing.
- Both new tests were confirmed to fail against the unfixed session: the unit test (`expected undefined to deeply equal [{id: 'user-1'}]`) and the two acceptance cases.

## Tests

- Unit: the create payload carries the current user's id and a following update carries no `authors`.
- Acceptance: creating a post as a Contributor and as an Author puts `authors: [{id}]` in the POST body.