### PR TITLE
Fixed the React editor rejecting a real publish settings response

### DIFF
--- a/apps/admin/src/editor/publish/use-publish-inputs.acceptance.test.tsx
+++ b/apps/admin/src/editor/publish/use-publish-inputs.acceptance.test.tsx
@@ -30,6 +30,8 @@ function fakeBoundaryInputs() {
       { key: 'members_signup_access', value: 'all' },
       { key: 'editor_default_email_recipients', value: 'visibility' },
       { key: 'timezone', value: 'Etc/UTC' },
+      // Core always includes this array-valued calculated setting in the members group.
+      { key: 'all_blocked_email_domains', value: [] },
     ],
   });
   const config = fakeAdminEndpoint('GET', /^\/config\/(?:\?.*)?$/, {

--- a/apps/admin/src/editor/publish/use-publish-inputs.test.ts
+++ b/apps/admin/src/editor/publish/use-publish-inputs.test.ts
@@ -54,6 +54,22 @@ describe('assemblePublishInputs', () => {
     });
   });
 
+  it.each([[[]], [['spam.xyz']]])(
+    'accepts the array-valued settings Core calculates (%j)',
+    (blockedDomains) => {
+      const data = boundary();
+      const settingsData = data.settingsData as {
+        settings: Array<{ key: string; value: unknown }>;
+      };
+      // Core always serves `all_blocked_email_domains` (members group) as a string array.
+      settingsData.settings.push({ key: 'all_blocked_email_domains', value: blockedDomains });
+
+      const assembled = assemblePublishInputs(data);
+      expect(assembled.isValid).toBe(true);
+      expect(assembled.timezone).toBe('Europe/Amsterdam');
+    },
+  );
+
   it('fails closed on an unknown default-recipient setting', () => {
     const data = boundary();
     const settingsData = data.settingsData as { settings: Array<{ key: string; value: unknown }> };

--- a/apps/admin/src/editor/publish/use-publish-inputs.ts
+++ b/apps/admin/src/editor/publish/use-publish-inputs.ts
@@ -8,7 +8,14 @@ import { z } from 'zod';
 import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
 import type { PublishSiteInput, PublishUserInput } from './publish-options';
 
-const settingValueSchema = z.union([z.string(), z.boolean(), z.number(), z.null()]);
+// Core's `all_blocked_email_domains` is array-valued, so a scalar-only union rejects a real response.
+const settingValueSchema = z.union([
+  z.string(),
+  z.boolean(),
+  z.number(),
+  z.null(),
+  z.array(z.string()),
+]);
 const settingSchema = z.looseObject({ key: z.string(), value: settingValueSchema });
 const defaultRecipientsSchema = z.enum(['disabled', 'visibility', 'filter']);
 const newsletterSchema = z

--- a/packages/testing/test-data/src/fixtures/data/settings.ts
+++ b/packages/testing/test-data/src/fixtures/data/settings.ts
@@ -1,6 +1,6 @@
 // Canned Ghost Admin API response data, ported from apps/admin-x-framework/src/test/responses — see fixtures/index.ts.
 
-export type SettingValue = string | boolean | number | null;
+export type SettingValue = string | boolean | number | null | string[];
 
 /**
  * Default value for every setting key the admin client reads. The `labs`
@@ -103,6 +103,8 @@ export const settingsDefaults: Record<string, SettingValue> = {
   firstpromoter_account: null,
   default_email_address: 'default@example.com',
   support_email_address: 'support@example.com',
+  // Calculated by Core, and array-valued — the shape a client's parser must accept.
+  all_blocked_email_domains: [],
   heading_font: null,
   body_font: null,
   require_email_mfa: false,

--- a/packages/testing/test-data/src/fixtures/index.ts
+++ b/packages/testing/test-data/src/fixtures/index.ts
@@ -76,7 +76,7 @@ export function settingsResponse({ labs, settings }: SettingsOverrides = {}): Se
   };
 
   return {
-    settings: Object.entries(merged).map(([key, value]) => ({ key, value })),
+    settings: Object.entries(clone(merged)).map(([key, value]) => ({ key, value })),
     meta: { filters: { ...settingsMeta.filters } },
   };
 }

--- a/packages/testing/test-data/test/fixtures.test.ts
+++ b/packages/testing/test-data/test/fixtures.test.ts
@@ -48,6 +48,23 @@ describe('boot fixtures', () => {
     expect(settingsResponse().settings.length).toBeGreaterThan(0);
   });
 
+  it('isolates array settings from other responses and caller-owned overrides', () => {
+    const first = settingsResponse();
+    const blockedDomains = getSetting(first, 'all_blocked_email_domains') as string[];
+    blockedDomains.push('spam.xyz');
+
+    expect(getSetting(settingsResponse(), 'all_blocked_email_domains')).toEqual([]);
+
+    const overrides = ['blocked.example'];
+    const overridden = settingsResponse({ settings: { all_blocked_email_domains: overrides } });
+    const overriddenDomains = getSetting(overridden, 'all_blocked_email_domains') as string[];
+    overriddenDomains.push('another.example');
+    expect(overrides).toEqual(['blocked.example']);
+
+    overrides.push('later.example');
+    expect(overriddenDomains).toEqual(['blocked.example', 'another.example']);
+  });
+
   it('serves one active casper theme with declarable gscan problems', () => {
     const errors = [{ code: 'GS001', details: 'boom' }];
     const response = activeThemeResponse({ errors });


### PR DESCRIPTION
Ghost's settings API always serves the calculated `all_blocked_email_domains` setting, and its value is a string array (`SettingsHelpers#getAllBlockedEmailDomains` returns `string[]`). It sits in the `members` group, which `useBrowseSettings` always requests, so it is present in every real response.

`usePublishInputs`' boundary schema only accepted scalar setting values (`string | boolean | number | null`), so `safeParse` failed against every real settings response. The consequences on a running Ghost:

- `isReady` never became true
- the editor header kept Publish disabled behind "The publish settings response was invalid."
- the publish and update flows never mounted

## What changed

- Widened the setting value union to include `string[]`, the only non-scalar shape the API sends. Every other value in Ghost's settings snapshot is a string, boolean, number, or null, so the union stays exact rather than dropping to `z.unknown()`. The keys the flow reads are still narrowed by `stringSetting` and the default-recipients enum.
- Added `all_blocked_email_domains: []` to the canned settings defaults in `@tryghost/test-data`, which is the single source every admin fixture builds its `/settings/` response from, and widened that package's local `SettingValue` type to match. The `SettingValue` in `admin-x-framework` is untouched; this is the test fixture's own type.
- Added the key to the one editor test that hand-rolls a settings array rather than going through the shared fixture.

## Why the tests were green

`editor-header.acceptance.test.tsx` builds its settings response from the shared defaults, which omitted the key. All 19 header tests passed over an app whose Publish button could never enable. With the key in the shared fixture, 14 of those 19 journeys fail without the schema fix, so the tier can no longer go blind on this.

## Verification

- `assemblePublishInputs` unit test covers both an empty and a populated `all_blocked_email_domains`; both fail on the pre-fix schema.
- `apps/admin` unit suite: 3060 passed.
- `apps/admin` browser-mode acceptance suite: 885 passed (183 of them under `src/editor`).
- `@tryghost/test-data` types and unit tests pass.
- `pnpm exec tsc -b` in `apps/admin` clean; eslint reports 0 errors.
