### PR TITLE
Added the Access section to the React editor's settings sidebar

### DIFF
--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -141,25 +141,26 @@ function EditorContent({
   const featureImage = useFeatureImageBinding(session, session.loadedRecord, session.contentKey);
   const leaveGuard = useEditorLeaveGuard(session, postType);
   const acceptedRecord = session.loadedRecord;
+  const liveVisibility = session.settings.visibility;
   const currentCardConfig = useMemo(() => {
-    if (!acceptedRecord || !cardConfig.post) {
+    if (!cardConfig.post) {
       return cardConfig;
     }
 
-    // Use the session's accepted metadata, which also rejects stale refetches,
-    // so cards describe the access of the document the editor now holds.
+    // The live settings field, not the saved record: a visibility the writer has
+    // only staged still decides what the cards describe.
     return {
       ...cardConfig,
       post: {
         ...cardConfig.post,
-        visibility: acceptedRecord.visibility ?? cardConfig.post.visibility,
+        visibility: liveVisibility || cardConfig.post.visibility,
         showTitleAndFeatureImage:
-          'show_title_and_feature_image' in acceptedRecord
+          acceptedRecord && 'show_title_and_feature_image' in acceptedRecord
             ? (acceptedRecord.show_title_and_feature_image ?? true)
-            : true,
+            : cardConfig.post.showTitleAndFeatureImage,
       },
     };
-  }, [acceptedRecord, cardConfig]);
+  }, [acceptedRecord, cardConfig, liveVisibility]);
 
   useSaveShortcut(session.dispatchExplicit);
 

--- a/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentUserResponse,
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePosts,
+  fakeSnippets,
+  fakeTiers,
+  post,
+  renderAdminApp,
+  settingsResponse,
+  staffRole,
+  tier,
+  unsavedChangesGuarded,
+  type EndpointCapture,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const NEW_POST_ID = 'new123';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+
+// A settings save waits on the engine's queue, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const POLL = { timeout: 10_000 };
+// Under the 3s autosave debounce, so only an undebounced field save can satisfy it.
+const FIELD_POLL = { timeout: 2_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+const GOLD = tier({ name: 'Gold', type: 'paid', active: true });
+const SILVER = tier({ name: 'Silver', type: 'paid', active: true });
+const BRONZE = tier({ name: 'Bronze', type: 'paid', active: false });
+const FREE = tier({ name: 'Free', type: 'free', active: true });
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}
+
+function asContributor() {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name: 'Contributor' })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+/** The site default the select stands in until a post carries its own visibility. */
+function withDefaultVisibility(visibility: string) {
+  return {
+    ...FLAG_ON,
+    boot: {
+      browseSettings: {
+        response: settingsResponse({ settings: { default_content_visibility: visibility } }),
+      },
+    },
+  };
+}
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+  // The header's publish inputs read the site's member total and newsletter list.
+  fakeMembers([]);
+  fakeNewsletters([]);
+  // After fakeMembers, which serves its filter bar an empty tier list of its own.
+  fakeTiers([GOLD, SILVER, BRONZE, FREE]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+}
+
+/** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    visibility: 'public',
+    tiers: [],
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+}
+
+async function openAccess() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await expect.element(editorScreen.settingsVisibility()).toBeVisible();
+}
+
+async function chooseVisibility(label: string) {
+  await editorScreen.settingsVisibility().click();
+  await editorScreen.settingsVisibilityOption(label).click();
+}
+
+/**
+ * The sidebar's Access section: the post's visibility and, for `Specific
+ * tier(s)`, the tiers that visibility grants.
+ */
+describe('Post settings access', () => {
+  it(
+    'persists a draft’s visibility on its own',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await expect.element(editorScreen.settingsVisibility()).toHaveTextContent('Public');
+
+      await chooseVisibility('Members only');
+
+      // A field save has no debounce, so it lands well inside the autosave's 3s.
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({ visibility: 'members' });
+      await expect.element(editorScreen.settingsVisibility()).toHaveTextContent('Members only');
+    },
+    SLOW,
+  );
+
+  it(
+    'sends the visibility and the tiers together once a tier is picked',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await chooseVisibility('Specific tier(s)');
+
+      // Nothing is selected yet, so the choice is held back rather than stripped.
+      await expect.element(editorScreen.settingsTiersError()).toBeVisible();
+      expect(saveApi.requests).toHaveLength(0);
+      // Archived paid tiers are offered after the active ones; free tiers are not.
+      await expect.element(editorScreen.settingsTier('Bronze')).toBeVisible();
+      await expect(editorScreen.settingsTier('Free')).toHaveCount(0);
+
+      await editorScreen.settingsTier('Gold').click();
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        visibility: 'tiers',
+        tiers: [{ id: GOLD.id }],
+      });
+      await expect(editorScreen.settingsTiersError()).toHaveCount(0);
+
+      await editorScreen.settingsTier('Silver').click();
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(2);
+      expect(submittedPost(saveApi).tiers).toEqual([{ id: GOLD.id }, { id: SILVER.id }]);
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a published post’s visibility until Update',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+
+      await chooseVisibility('Paid-members only');
+
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({ visibility: 'paid', status: 'published' });
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+    },
+    SLOW,
+  );
+
+  it(
+    'shows the site default for a post that carries no visibility yet',
+    async () => {
+      editorChrome();
+      let created = post({
+        id: NEW_POST_ID,
+        title: '(Untitled)',
+        status: 'draft',
+        visibility: 'paid',
+        tiers: [],
+        tags: [],
+      });
+      fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+        const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+        created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: LOADED_AT };
+        return { posts: [created] };
+      });
+
+      await renderAdminApp('/editor/post', withDefaultVisibility('paid'));
+      await openAccess();
+
+      await expect
+        .element(editorScreen.settingsVisibility())
+        .toHaveTextContent('Paid-members only');
+      // The default is the server's to apply on create, so nothing is sent for it.
+      await expect(editorScreen.settingsTiers()).toHaveCount(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'asks for a tier again when the last one is unpicked',
+    async () => {
+      const saveApi = fakeSavablePost({ visibility: 'tiers', tiers: [{ id: GOLD.id }] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await expect
+        .element(editorScreen.settingsTier('Gold'))
+        .toHaveAttribute('data-state', 'checked');
+      await expect(editorScreen.settingsTiersError()).toHaveCount(0);
+
+      await editorScreen.settingsTier('Gold').click();
+
+      await expect.element(editorScreen.settingsTiersError()).toBeVisible();
+      await expect
+        .element(editorScreen.settingsTier('Gold'))
+        .toHaveAttribute('data-state', 'unchecked');
+      expect(saveApi.requests).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves Access out for a role that cannot set it',
+    async () => {
+      fakeSavablePost({ authors: [{ id: '1' }] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, asContributor());
+      await editorScreen.settingsToggle().click();
+      await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+
+      await expect(editorScreen.settingsVisibility()).toHaveCount(0);
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
@@ -227,6 +227,9 @@ describe('Post settings access', () => {
       // Archived paid tiers are offered after the active ones; free tiers are not.
       await expect.element(editorScreen.settingsTier('Bronze')).toBeVisible();
       await expect(editorScreen.settingsTier('Free')).toHaveCount(0);
+      // Staged rather than refused, so the writer sees no save error for it.
+      await expect.element(editorScreen.status()).toHaveTextContent('Draft');
+      await expect(editorScreen.saveErrorBanner()).toHaveCount(0);
 
       await editorScreen.settingsTier('Gold').click();
 
@@ -330,7 +333,7 @@ describe('Post settings access', () => {
 
       await editorScreen.settingsTier('Tier 01').click();
 
-      // A tier the browse never returned must survive a toggle of another one.
+      // The last tier survives the toggle only because the browse loaded past page one.
       await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
       expect(submittedPost(saveApi).tiers).toEqual([{ id: MANY_TIERS[0].id }, { id: last.id }]);
     },

--- a/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
@@ -39,6 +39,11 @@ const GOLD = tier({ name: 'Gold', type: 'paid', active: true });
 const SILVER = tier({ name: 'Silver', type: 'paid', active: true });
 const BRONZE = tier({ name: 'Bronze', type: 'paid', active: false });
 const FREE = tier({ name: 'Free', type: 'free', active: true });
+const SITE_TIERS = [GOLD, SILVER, BRONZE, FREE];
+// More paid tiers than a browse's default page holds, so a single page loses some.
+const MANY_TIERS = Array.from({ length: 18 }, (_, index) =>
+  tier({ name: `Tier ${String(index + 1).padStart(2, '0')}`, type: 'paid', active: true }),
+);
 
 function submittedPost(capture: EndpointCapture): Record<string, unknown> {
   const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
@@ -63,22 +68,22 @@ function withDefaultVisibility(visibility: string) {
   };
 }
 
-function editorChrome() {
+function editorChrome(tiers = SITE_TIERS) {
   fakeSnippets([]);
   fakePosts([]);
   // The header's publish inputs read the site's member total and newsletter list.
   fakeMembers([]);
   fakeNewsletters([]);
   // After fakeMembers, which serves its filter bar an empty tier list of its own.
-  fakeTiers([GOLD, SILVER, BRONZE, FREE]);
+  fakeTiers(tiers);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));
 }
 
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
-function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
-  editorChrome();
+function fakeSavablePost(overrides: Partial<SavedPost> = {}, tiers = SITE_TIERS) {
+  editorChrome(tiers);
   let current = post({
     id: POST_ID,
     title: 'Hello from React',
@@ -108,6 +113,11 @@ async function openAccess() {
   await editorScreen.settingsToggle().click();
   await expect.element(editorScreen.settingsSidebar()).toBeVisible();
   await expect.element(editorScreen.settingsVisibility()).toBeVisible();
+}
+
+async function typeIntoBody(text: string) {
+  await editorScreen.body().click();
+  await userEvent.keyboard(`{End}${text}`);
 }
 
 async function chooseVisibility(label: string) {
@@ -208,11 +218,18 @@ describe('Post settings access', () => {
         tiers: [],
         tags: [],
       });
-      fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+      const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
         const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
         created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: LOADED_AT };
         return { posts: [created] };
       });
+      fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
+      // The autosave that follows the create can land before the test ends.
+      fakeAdminEndpoint('PUT', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
 
       await renderAdminApp('/editor/post', withDefaultVisibility('paid'));
       await openAccess();
@@ -220,8 +237,39 @@ describe('Post settings access', () => {
       await expect
         .element(editorScreen.settingsVisibility())
         .toHaveTextContent('Paid-members only');
-      // The default is the server's to apply on create, so nothing is sent for it.
       await expect(editorScreen.settingsTiers()).toHaveCount(0);
+
+      await typeIntoBody('First words');
+
+      // The default is the server's to apply on create, so nothing is sent for it.
+      await expect.poll(() => createApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(createApi)).not.toHaveProperty('visibility');
+      expect(submittedPost(createApi)).not.toHaveProperty('tiers');
+    },
+    SLOW,
+  );
+
+  it(
+    'offers every paid tier, past the first page of the browse',
+    async () => {
+      const last = MANY_TIERS[MANY_TIERS.length - 1];
+      const saveApi = fakeSavablePost(
+        { visibility: 'tiers', tiers: [{ id: last.id }] },
+        MANY_TIERS,
+      );
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await expect.element(editorScreen.settingsTier(last.name)).toBeVisible();
+      await expect
+        .element(editorScreen.settingsTier(last.name))
+        .toHaveAttribute('data-state', 'checked');
+
+      await editorScreen.settingsTier('Tier 01').click();
+
+      // A tier the browse never returned must survive a toggle of another one.
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).tiers).toEqual([{ id: MANY_TIERS[0].id }, { id: last.id }]);
     },
     SLOW,
   );
@@ -245,6 +293,35 @@ describe('Post settings access', () => {
         .element(editorScreen.settingsTier('Gold'))
         .toHaveAttribute('data-state', 'unchecked');
       expect(saveApi.requests).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'refuses an explicit save while no tier is picked',
+    async () => {
+      const saveApi = fakeSavablePost({
+        status: 'published',
+        published_at: PUBLISHED_AT,
+        visibility: 'tiers',
+        tiers: [{ id: GOLD.id }],
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await editorScreen.settingsTier('Gold').click();
+
+      // The empty selection is staged, so it is the writer's unsaved work.
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect
+        .element(editorScreen.saveErrorBanner())
+        .toHaveTextContent('Please select at least one tier');
+      expect(saveApi.requests).toHaveLength(0);
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
@@ -150,6 +150,69 @@ describe('Post settings access', () => {
   );
 
   it(
+    'keeps specific-tier access when the paid tier IDs have not changed',
+    async () => {
+      const saveApi = fakeSavablePost({ visibility: 'paid', tiers: [GOLD, SILVER] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await chooseVisibility('Specific tier(s)');
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        visibility: 'tiers',
+        tiers: [{ id: GOLD.id }, { id: SILVER.id }],
+      });
+      await expect.element(editorScreen.settingsVisibility()).toHaveTextContent('Specific tier(s)');
+    },
+    SLOW,
+  );
+
+  it(
+    'requires a paid tier when a public post only carries the free tier',
+    async () => {
+      const saveApi = fakeSavablePost({ visibility: 'public', tiers: [FREE] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAccess();
+
+      await chooseVisibility('Specific tier(s)');
+
+      await expect.element(editorScreen.settingsTiersError()).toBeVisible();
+      expect(saveApi.requests).toHaveLength(0);
+      await editorScreen.settingsTier('Gold').click();
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        visibility: 'tiers',
+        tiers: [{ id: GOLD.id }],
+      });
+    },
+    SLOW,
+  );
+
+  it(
+    'refuses the first save until an explicitly selected tier access has a tier',
+    async () => {
+      editorChrome();
+      const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, {
+        posts: [post({ id: NEW_POST_ID, visibility: 'public' })],
+      });
+      await renderAdminApp('/editor/post', FLAG_ON);
+      await openAccess();
+
+      await chooseVisibility('Specific tier(s)');
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect
+        .element(editorScreen.saveErrorBanner())
+        .toHaveTextContent('Please select at least one tier');
+      expect(createApi.requests).toHaveLength(0);
+      await expect.element(editorScreen.settingsVisibility()).toHaveTextContent('Specific tier(s)');
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+    },
+    SLOW,
+  );
+
+  it(
     'sends the visibility and the tiers together once a tier is picked',
     async () => {
       const saveApi = fakeSavablePost();

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -40,6 +40,9 @@ import {
   settingsExcerptInput,
   settingsFeaturedToggle,
   settingsMenuToggle,
+  settingsTiersError,
+  settingsTiersPicker,
+  settingsVisibilitySelect,
   stayInEditorButton,
   tkIndicator,
   toggleFeatureImageAltButton,
@@ -107,6 +110,13 @@ export const editorScreen = {
   settingsSidebar: () => page.getByTestId(postSettingsSidebar),
   settingsExcerpt: () => page.getByTestId(settingsExcerptInput),
   settingsFeatured: () => page.getByTestId(settingsFeaturedToggle),
+  settingsVisibility: () => page.getByTestId(settingsVisibilitySelect),
+  settingsVisibilityOption: (label: string) =>
+    page.getByRole('listbox').getByRole('option', { name: label, exact: true }),
+  settingsTiers: () => page.getByTestId(settingsTiersPicker),
+  settingsTier: (name: string) =>
+    page.getByTestId(settingsTiersPicker).getByRole('checkbox', { name }),
+  settingsTiersError: () => page.getByTestId(settingsTiersError),
 
   featureImage: () => page.getByTestId(editorFeatureImage),
   featureImageInput: () => page.getByLabelText(addFeatureImageLabel),

--- a/apps/admin/src/editor/session/access-save.test.ts
+++ b/apps/admin/src/editor/session/access-save.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { serializePostPayload } from '@tryghost/admin-x-framework/api/post-contract';
+import { createEditorSession, type EditorWritePayload } from './editor-session';
+import type { EditorRecord } from './projection';
+
+const TIERS = [{ id: 'gold' }, { id: 'silver' }];
+
+function accessSession(visibility: string | null, tiers = TIERS) {
+  let saved: EditorRecord = {
+    id: 'post-id',
+    uuid: 'post-uuid',
+    url: 'https://example.com/post/',
+    title: 'Post',
+    slug: 'post',
+    status: 'draft',
+    visibility: visibility ?? 'paid',
+    tiers,
+    lexical: null,
+    updated_at: '2026-01-01T00:00:00.000Z',
+    published_at: null,
+    tags: [],
+  };
+  let saves = 0;
+  const persist = (payload: EditorWritePayload) => {
+    // Exercise the same serialization as the post/page transports: an unpaired
+    // tier visibility disappears before the API sees it.
+    const serialized = serializePostPayload(payload);
+    saves += 1;
+    saved = { ...saved, ...serialized, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return Promise.resolve(saved);
+  };
+  const create = vi.fn(persist);
+  const update = vi.fn(persist);
+  const session = createEditorSession({
+    record: visibility === null ? undefined : saved,
+    saveFailureMessage: 'Saving failed',
+    onIdAcquired: vi.fn(),
+    onError: vi.fn(),
+    transport: { create, update, generateSlug: () => Promise.resolve('post') },
+  });
+  session.setBaseline(null);
+  return { session, create, update };
+}
+
+describe('saving post access', () => {
+  it.each(['public', 'members', 'paid'])(
+    'persists a change from %s to specific tiers with unchanged tier IDs',
+    async (visibility) => {
+      const { session, update } = accessSession(visibility);
+      session.patchFields({ visibility: 'tiers', tiers: TIERS.map(({ id }) => ({ id })) });
+
+      expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+      expect(session.getFields()).toMatchObject({ visibility: 'tiers', tiers: TIERS });
+      expect(session.isDirty()).toBe(false);
+
+      // Sending the pair must not retain ownership after the save succeeds.
+      session.patchFields({ featured: true });
+      await session.dispatchExplicit();
+      expect(update.mock.calls[1][0]).not.toHaveProperty('visibility');
+      expect(update.mock.calls[1][0]).not.toHaveProperty('tiers');
+      session.dispose();
+    },
+  );
+
+  it.each([null, 'tiers'])(
+    'refuses explicit saves and publishing with an empty tier selection (saved visibility: %s)',
+    async (visibility) => {
+      const { session, create, update } = accessSession(visibility);
+      session.patchFields({ visibility: 'tiers', tiers: [] });
+      session.commitField();
+
+      for (const save of [session.dispatchExplicit, session.dispatchPublish]) {
+        expect(await save()).toMatchObject({
+          kind: 'failed',
+          error: { kind: 'validation', message: 'Please select at least one tier' },
+        });
+      }
+      expect(create).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+      expect(session.getFields()).toMatchObject({ visibility: 'tiers', tiers: [] });
+      expect(session.hasUnsavedContent()).toBe(true);
+
+      // Correcting the selection must recover from the validation failure.
+      session.patchFields({ tiers: [TIERS[0]] });
+      expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+      expect(session.getFields()).toMatchObject({ visibility: 'tiers', tiers: [TIERS[0]] });
+      expect(session.isDirty()).toBe(false);
+      session.dispose();
+    },
+  );
+
+  it('lets the server apply untouched access defaults on create', async () => {
+    const { session, create } = accessSession(null);
+
+    expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+    expect(create.mock.calls[0][0]).not.toHaveProperty('visibility');
+    expect(create.mock.calls[0][0]).not.toHaveProperty('tiers');
+    expect(session.getFields()).toMatchObject({ visibility: 'paid', tiers: TIERS });
+    expect(session.isDirty()).toBe(false);
+    session.dispose();
+  });
+});

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -51,6 +51,8 @@ export interface PreparedSave extends SaveRequest<EditorSaveSnapshot> {
   projection: EditablePostPatch;
   /** What the live post held for the authored fields when the request was built. */
   authoredFrom: AuthoredFields;
+  /** Access values captured for validation of this request. */
+  access: Pick<EditablePostProjection, 'visibility' | 'tiers'>;
   /** The edit version the request was built at, for the settings adoption guard. */
   builtAtVersion: number;
   payload: EditorWritePayload;
@@ -329,6 +331,7 @@ export function createEditorSession({
       ...request,
       projection,
       authoredFrom: { title: live.title, slug: live.slug },
+      access: { visibility: live.visibility, tiers: live.tiers },
       builtAtVersion: version,
       payload,
       options: {
@@ -345,7 +348,7 @@ export function createEditorSession({
   async function execute(prepared: PreparedSave): Promise<SaveOutcome<EditorSaveResult>> {
     // Untouched creates carry null visibility and use the server's default.
     // An explicit tier selection needs a tier, including on the first save.
-    if (tiersIncomplete(prepared.settingsFrom)) {
+    if (tiersIncomplete(prepared.access)) {
       return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
     }
 

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -301,6 +301,15 @@ export function createEditorSession({
         payload[key] = live[key];
       }
     }
+    // The write contract requires the pair even when only one field changed.
+    // Reads include tier relations for Public and Paid posts too, so switching
+    // to specific tiers can leave the relation IDs unchanged.
+    if (live.visibility === 'tiers' && ('visibility' in payload || 'tiers' in payload)) {
+      projection.visibility = live.visibility;
+      payload.visibility = live.visibility;
+      projection.tiers = live.tiers;
+      payload.tiers = live.tiers;
+    }
     if (!isCreate) {
       if (!projection.updated_at) {
         // Without the token the server skips its collision check entirely and the
@@ -334,9 +343,9 @@ export function createEditorSession({
   // No abort signal: the transport owns its own controller and takes none. A
   // response arriving after disposal is dropped by the engine instead.
   async function execute(prepared: PreparedSave): Promise<SaveOutcome<EditorSaveResult>> {
-    // A create has no visibility of its own to preserve, so the server's default
-    // settles it; every later save is refused as Ember's validator refuses it.
-    if (!prepared.isCreate && tiersIncomplete(live)) {
+    // Untouched creates carry null visibility and use the server's default.
+    // An explicit tier selection needs a tier, including on the first save.
+    if (tiersIncomplete(prepared.settingsFrom)) {
       return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
     }
 

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -28,6 +28,8 @@ import { buildSaveSnapshot, type EditorSaveSnapshot } from './snapshot';
 import { latestRevisionOf, newPostProjection, projectionOf, type EditorRecord } from './projection';
 import {
   SETTINGS_FIELD_KEYS,
+  TIERS_REQUIRED,
+  tiersIncomplete,
   type EditorSettingsPatch,
   type SettingsFieldKey,
 } from './settings-fields';
@@ -332,6 +334,12 @@ export function createEditorSession({
   // No abort signal: the transport owns its own controller and takes none. A
   // response arriving after disposal is dropped by the engine instead.
   async function execute(prepared: PreparedSave): Promise<SaveOutcome<EditorSaveResult>> {
+    // A create has no visibility of its own to preserve, so the server's default
+    // settles it; every later save is refused as Ember's validator refuses it.
+    if (!prepared.isCreate && tiersIncomplete(live)) {
+      return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
+    }
+
     inFlightSince = prepared.builtAtVersion;
     try {
       const saved = prepared.isCreate
@@ -445,7 +453,9 @@ export function createEditorSession({
     // The one place the sidebar's save policy lives. A draft persists a settings
     // field the way the body does; every other status stages it until Update.
     commitField: () => {
-      if (status !== 'draft') {
+      // Ember validates the field before saving it, so an incomplete tier
+      // selection stays staged rather than failing a save the writer sees.
+      if (status !== 'draft' || tiersIncomplete(live)) {
         return;
       }
       void engine.dispatch('field');

--- a/apps/admin/src/editor/session/settings-fields.ts
+++ b/apps/admin/src/editor/session/settings-fields.ts
@@ -32,3 +32,13 @@ export type SettingsFieldKey = (typeof SETTINGS_FIELD_KEYS)[number];
 export type EditorSettingsFields = Pick<EditablePostProjection, SettingsFieldKey>;
 
 export type EditorSettingsPatch = Partial<EditorSettingsFields>;
+
+/** Ember's post validator refuses the same pairing (validators/post.js). */
+export const TIERS_REQUIRED = 'Please select at least one tier';
+
+/** `visibility: 'tiers'` with no tiers: the write contract drops the visibility. */
+export function tiersIncomplete(
+  fields: Pick<EditorSettingsFields, 'visibility' | 'tiers'>,
+): boolean {
+  return fields.visibility === 'tiers' && fields.tiers.length === 0;
+}

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -73,6 +73,28 @@ The excerpt is the one field with two homes. When the inline excerpt is on it
 renders under the title and the sidebar leaves it out; when it is off the
 sidebar owns it. Either way the same session binding is behind it.
 
+## Access
+
+Access is two coupled fields, `visibility` and `tiers`, and only an Owner,
+Administrator or Editor sees them. A post carries no visibility until its first
+save applies the site default, so the select shows `default_content_visibility`
+until then; choosing that same value explicitly is still an edit and still
+saves. Choosing anything other than `Specific tier(s)` clears the tiers it
+granted. The tier list is the site's paid tiers, active ones before archived,
+and it loads only while `Specific tier(s)` is the choice.
+
+The write contract drops `visibility: 'tiers'` whenever no tiers accompany it,
+so sending that pairing would be answered with the post's unchanged visibility
+and the writer's choice would snap back. The section therefore holds an empty
+tier selection locally, asking for at least one tier, and commits the visibility
+and the tiers together once one is picked. Everything that is committed goes
+through the same gate as the rest of the sidebar, so a draft saves it and every
+other status stages it.
+
+Koenig cards read the post's access from the editor's card config, which follows
+the live field rather than the saved record: a staged visibility changes what
+the cards describe before any save.
+
 ## Open and closed
 
 The toggle sits in the editor header, and the panel starts closed on every

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -80,16 +80,20 @@ Administrator or Editor sees them. A post carries no visibility until its first
 save applies the site default, so the select shows `default_content_visibility`
 until then; choosing that same value explicitly is still an edit and still
 saves. Choosing anything other than `Specific tier(s)` clears the tiers it
-granted. The tier list is the site's paid tiers, active ones before archived,
-and it loads only while `Specific tier(s)` is the choice.
+granted. The tier list is every one of the site's paid tiers, active ones
+before archived, and it loads only while `Specific tier(s)` is the choice.
 
 The write contract drops `visibility: 'tiers'` whenever no tiers accompany it,
 so sending that pairing would be answered with the post's unchanged visibility
-and the writer's choice would snap back. The section therefore holds an empty
-tier selection locally, asking for at least one tier, and commits the visibility
-and the tiers together once one is picked. Everything that is committed goes
-through the same gate as the rest of the sidebar, so a draft saves it and every
-other status stages it.
+and the writer's choice would snap back. An empty tier selection is therefore
+staged like any other edit but never sent: the section asks for at least one
+tier, a field change does not save while the pairing is incomplete, and a save
+the writer asks for is refused with the same message, which the status line and
+the save banner carry. Because the pairing is staged rather than held in the
+panel, it survives closing the sidebar, enables Update and is what the leave
+guard asks about. A create is exempt, as the server settles the visibility of a
+post that has none. Everything that is committed goes through the same gate as
+the rest of the sidebar, so a draft saves it and every other status stages it.
 
 Koenig cards read the post's access from the editor's card config, which follows
 the live field rather than the saved record: a staged visibility changes what

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -82,6 +82,8 @@ until then; choosing that same value explicitly is still an edit and still
 saves. Choosing anything other than `Specific tier(s)` clears the tiers it
 granted. The tier list is every one of the site's paid tiers, active ones
 before archived, and it loads only while `Specific tier(s)` is the choice.
+The free tier returned with Public and Members posts is excluded from the
+selection; a tier ID without type metadata is preserved.
 
 The write contract drops `visibility: 'tiers'` whenever no tiers accompany it,
 so sending that pairing would be answered with the post's unchanged visibility
@@ -91,9 +93,15 @@ tier, a field change does not save while the pairing is incomplete, and a save
 the writer asks for is refused with the same message, which the status line and
 the save banner carry. Because the pairing is staged rather than held in the
 panel, it survives closing the sidebar, enables Update and is what the leave
-guard asks about. A create is exempt, as the server settles the visibility of a
-post that has none. Everything that is committed goes through the same gate as
-the rest of the sidebar, so a draft saves it and every other status stages it.
+guard asks about. A create with untouched access settings still uses the server
+default; an explicit tier selection must include a tier even on the first save.
+Everything that is committed goes through the same gate as the rest of the
+sidebar, so a draft saves it and every other status stages it.
+
+When either access field changes to specific tiers, the save submits both
+visibility and the tier list, including unchanged tier IDs. The API also returns
+tier relations for Public and Paid posts, so changing visibility alone can leave
+those IDs unchanged. Once saved, an unrelated edit sends neither access field.
 
 Koenig cards read the post's access from the editor's card config, which follows
 the live field rather than the saved record: a staged visibility changes what

--- a/apps/admin/src/editor/settings/access-options.test.ts
+++ b/apps/admin/src/editor/settings/access-options.test.ts
@@ -61,6 +61,17 @@ describe('access options', () => {
   });
 
   describe('selection', () => {
+    it('excludes the free tier returned with public posts while preserving unknown tier IDs', () => {
+      const relations = [
+        { id: 'free', type: 'free' },
+        { id: 'paid', type: 'paid' },
+        { id: 'unlisted' },
+      ];
+
+      expect(selectedTierIds(relations)).toEqual(['paid', 'unlisted']);
+      expect(postTiers(relations)).toEqual([{ id: 'paid' }, { id: 'unlisted' }]);
+    });
+
     it('reads the post’s tier ids and drops relations without one', () => {
       expect(selectedTierIds([{ id: 'a' }, {}, { id: 'b' }])).toEqual(['a', 'b']);
       expect(postTiers([{ id: 'a' }, {}])).toEqual([{ id: 'a' }]);

--- a/apps/admin/src/editor/settings/access-options.test.ts
+++ b/apps/admin/src/editor/settings/access-options.test.ts
@@ -3,7 +3,6 @@ import { tier } from '@tryghost/test-data';
 import type { Tier } from '@tryghost/admin-x-framework/api/tiers';
 import {
   VISIBILITY_OPTIONS,
-  isCommittableAccess,
   postTiers,
   selectedTierIds,
   selectedVisibility,
@@ -76,18 +75,14 @@ describe('access options', () => {
 
       expect(tiersFromSelection(options, new Set(['c', 'a']))).toEqual([{ id: 'a' }, { id: 'c' }]);
     });
-  });
 
-  describe('isCommittableAccess', () => {
-    it('holds back a tiers choice with nothing selected', () => {
-      expect(isCommittableAccess('tiers', 0)).toBe(false);
-      expect(isCommittableAccess('tiers', 1)).toBe(true);
-    });
+    it('keeps a selected tier the options do not list', () => {
+      const options = [{ id: 'a', name: 'A', archived: false }];
 
-    it('lets every other visibility through', () => {
-      expect(isCommittableAccess('public', 0)).toBe(true);
-      expect(isCommittableAccess('members', 0)).toBe(true);
-      expect(isCommittableAccess('paid', 0)).toBe(true);
+      expect(tiersFromSelection(options, new Set(['unlisted', 'a']))).toEqual([
+        { id: 'a' },
+        { id: 'unlisted' },
+      ]);
     });
   });
 });

--- a/apps/admin/src/editor/settings/access-options.test.ts
+++ b/apps/admin/src/editor/settings/access-options.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { tier } from '@tryghost/test-data';
+import type { Tier } from '@tryghost/admin-x-framework/api/tiers';
+import {
+  VISIBILITY_OPTIONS,
+  isCommittableAccess,
+  postTiers,
+  selectedTierIds,
+  selectedVisibility,
+  tierOptions,
+  tiersFromSelection,
+} from './access-options';
+
+describe('access options', () => {
+  it('offers the four visibility choices in order', () => {
+    expect(VISIBILITY_OPTIONS.map((option) => option.value)).toEqual([
+      'public',
+      'members',
+      'paid',
+      'tiers',
+    ]);
+    expect(VISIBILITY_OPTIONS.map((option) => option.label)).toEqual([
+      'Public',
+      'Members only',
+      'Paid-members only',
+      'Specific tier(s)',
+    ]);
+  });
+
+  describe('selectedVisibility', () => {
+    it('shows the post’s own visibility', () => {
+      expect(selectedVisibility('members', 'paid')).toBe('members');
+    });
+
+    it('stands in the site default while the post carries none', () => {
+      expect(selectedVisibility(null, 'paid')).toBe('paid');
+      expect(selectedVisibility(undefined, 'tiers')).toBe('tiers');
+    });
+
+    it('falls back to public when neither is set', () => {
+      expect(selectedVisibility(null, null)).toBe('public');
+    });
+  });
+
+  describe('tierOptions', () => {
+    it('keeps paid tiers only, active before archived', () => {
+      const gold: Tier = tier({ name: 'Gold', type: 'paid', active: true });
+      const free: Tier = tier({ name: 'Free', type: 'free', active: true });
+      const bronze: Tier = tier({ name: 'Bronze', type: 'paid', active: false });
+      const silver: Tier = tier({ name: 'Silver', type: 'paid', active: true });
+
+      expect(tierOptions([gold, free, bronze, silver])).toEqual([
+        { id: gold.id, name: 'Gold', archived: false },
+        { id: silver.id, name: 'Silver', archived: false },
+        { id: bronze.id, name: 'Bronze', archived: true },
+      ]);
+    });
+
+    it('has no options before the tiers have loaded', () => {
+      expect(tierOptions(undefined)).toEqual([]);
+    });
+  });
+
+  describe('selection', () => {
+    it('reads the post’s tier ids and drops relations without one', () => {
+      expect(selectedTierIds([{ id: 'a' }, {}, { id: 'b' }])).toEqual(['a', 'b']);
+      expect(postTiers([{ id: 'a' }, {}])).toEqual([{ id: 'a' }]);
+    });
+
+    it('writes the selection in option order, not the order it was ticked', () => {
+      const options = [
+        { id: 'a', name: 'A', archived: false },
+        { id: 'b', name: 'B', archived: false },
+        { id: 'c', name: 'C', archived: true },
+      ];
+
+      expect(tiersFromSelection(options, new Set(['c', 'a']))).toEqual([{ id: 'a' }, { id: 'c' }]);
+    });
+  });
+
+  describe('isCommittableAccess', () => {
+    it('holds back a tiers choice with nothing selected', () => {
+      expect(isCommittableAccess('tiers', 0)).toBe(false);
+      expect(isCommittableAccess('tiers', 1)).toBe(true);
+    });
+
+    it('lets every other visibility through', () => {
+      expect(isCommittableAccess('public', 0)).toBe(true);
+      expect(isCommittableAccess('members', 0)).toBe(true);
+      expect(isCommittableAccess('paid', 0)).toBe(true);
+    });
+  });
+});

--- a/apps/admin/src/editor/settings/access-options.ts
+++ b/apps/admin/src/editor/settings/access-options.ts
@@ -43,13 +43,18 @@ export function tierOptions(tiers: Tier[] | undefined): TierOption[] {
   }));
 }
 
-/** The post's tiers as ids, dropping the relations the server sent without one. */
-export function selectedTierIds(tiers: ReadonlyArray<PostRelationLike>): string[] {
-  return tiers.map((tier) => tier.id).filter((id): id is string => !!id);
+type PostTier = PostRelationLike & { type?: string };
+
+/** Public/member reads include the free tier, which cannot grant specific-tier access. */
+export function selectedTierIds(tiers: ReadonlyArray<PostTier>): string[] {
+  return tiers
+    .filter((tier) => tier.type !== 'free')
+    .map((tier) => tier.id)
+    .filter((id): id is string => !!id);
 }
 
 /** The post's own tiers as relations, for a write that keeps them as they are. */
-export function postTiers(tiers: ReadonlyArray<PostRelationLike>): PostRelationLike[] {
+export function postTiers(tiers: ReadonlyArray<PostTier>): PostRelationLike[] {
   return selectedTierIds(tiers).map((id) => ({ id }));
 }
 

--- a/apps/admin/src/editor/settings/access-options.ts
+++ b/apps/admin/src/editor/settings/access-options.ts
@@ -55,20 +55,16 @@ export function postTiers(tiers: ReadonlyArray<PostRelationLike>): PostRelationL
 
 /**
  * The tier relations a selection writes, in option order so the payload does
- * not depend on the order the writer ticked the boxes.
+ * not depend on the order the writer ticked the boxes. A selected tier the
+ * browse did not return is kept, so a partial list cannot drop it.
  */
 export function tiersFromSelection(
   options: TierOption[],
   selected: ReadonlySet<string>,
 ): PostRelationLike[] {
-  return options.filter((option) => selected.has(option.id)).map((option) => ({ id: option.id }));
-}
+  const offered = new Set(options.map((option) => option.id));
+  const listed = options.filter((option) => selected.has(option.id)).map((option) => option.id);
+  const unlisted = [...selected].filter((id) => !offered.has(id));
 
-/**
- * Whether a visibility choice can be saved. The write contract drops
- * `visibility: 'tiers'` when no tiers accompany it, so that pairing is held
- * back rather than sent and answered with the post's unchanged visibility.
- */
-export function isCommittableAccess(visibility: string, tierCount: number): boolean {
-  return visibility !== 'tiers' || tierCount > 0;
+  return [...listed, ...unlisted].map((id) => ({ id }));
 }

--- a/apps/admin/src/editor/settings/access-options.ts
+++ b/apps/admin/src/editor/settings/access-options.ts
@@ -1,0 +1,74 @@
+import { getPaidActiveTiers, type Tier } from '@tryghost/admin-x-framework/api/tiers';
+import type { PostRelationLike } from '@/editor/engine/change-tracker';
+
+export interface VisibilityOption {
+  value: 'public' | 'members' | 'paid' | 'tiers';
+  label: string;
+}
+
+export const VISIBILITY_OPTIONS: readonly VisibilityOption[] = [
+  { value: 'public', label: 'Public' },
+  { value: 'members', label: 'Members only' },
+  { value: 'paid', label: 'Paid-members only' },
+  { value: 'tiers', label: 'Specific tier(s)' },
+];
+
+/**
+ * The visibility the select shows. A post carries none until its first save
+ * applies the site default, so the setting stands in until then.
+ */
+export function selectedVisibility(
+  postVisibility: string | null | undefined,
+  defaultContentVisibility: string | null | undefined,
+): string {
+  return postVisibility || defaultContentVisibility || 'public';
+}
+
+export interface TierOption {
+  id: string;
+  name: string;
+  archived: boolean;
+}
+
+/** The pickable tiers: paid only, active before archived, as the tier pickers order them. */
+export function tierOptions(tiers: Tier[] | undefined): TierOption[] {
+  const paid = (tiers ?? []).filter((tier) => tier.type === 'paid');
+  const active = getPaidActiveTiers(paid);
+  const archived = paid.filter((tier) => !tier.active);
+
+  return [...active, ...archived].map((tier) => ({
+    id: tier.id,
+    name: tier.name,
+    archived: !tier.active,
+  }));
+}
+
+/** The post's tiers as ids, dropping the relations the server sent without one. */
+export function selectedTierIds(tiers: ReadonlyArray<PostRelationLike>): string[] {
+  return tiers.map((tier) => tier.id).filter((id): id is string => !!id);
+}
+
+/** The post's own tiers as relations, for a write that keeps them as they are. */
+export function postTiers(tiers: ReadonlyArray<PostRelationLike>): PostRelationLike[] {
+  return selectedTierIds(tiers).map((id) => ({ id }));
+}
+
+/**
+ * The tier relations a selection writes, in option order so the payload does
+ * not depend on the order the writer ticked the boxes.
+ */
+export function tiersFromSelection(
+  options: TierOption[],
+  selected: ReadonlySet<string>,
+): PostRelationLike[] {
+  return options.filter((option) => selected.has(option.id)).map((option) => ({ id: option.id }));
+}
+
+/**
+ * Whether a visibility choice can be saved. The write contract drops
+ * `visibility: 'tiers'` when no tiers accompany it, so that pairing is held
+ * back rather than sent and answered with the post's unchanged visibility.
+ */
+export function isCommittableAccess(visibility: string, tierCount: number): boolean {
+  return visibility !== 'tiers' || tierCount > 0;
+}

--- a/apps/admin/src/editor/settings/access-section.tsx
+++ b/apps/admin/src/editor/settings/access-section.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useId } from 'react';
 import {
   Checkbox,
   Label,
@@ -18,10 +18,11 @@ import {
 } from '@tryghost/test-data/selectors/editor';
 import type { PostType } from '@/editor/card-config';
 import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
+import { TIERS_REQUIRED, tiersIncomplete } from '@/editor/session/settings-fields';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import { SettingsSection } from './settings-section';
 import {
   VISIBILITY_OPTIONS,
-  isCommittableAccess,
   postTiers,
   selectedTierIds,
   selectedVisibility,
@@ -55,7 +56,7 @@ function TierGroup({
   selected,
   onToggle,
 }: {
-  heading?: string;
+  heading: string;
   options: TierOption[];
   selected: ReadonlySet<string>;
   onToggle: (id: string) => void;
@@ -66,11 +67,9 @@ function TierGroup({
 
   return (
     <Stack gap="sm">
-      {heading ? (
-        <Text size="sm" tone="secondary" weight="medium">
-          {heading}
-        </Text>
-      ) : null}
+      <Text size="sm" tone="secondary" weight="medium">
+        {heading}
+      </Text>
       {options.map((option) => (
         <TierCheckbox
           key={option.id}
@@ -101,45 +100,34 @@ export function AccessSection({ session, postType }: AccessSectionProps) {
     'default_content_visibility',
   );
 
-  // The write contract drops `visibility: 'tiers'` when no tiers accompany it,
-  // so that pairing is held here until a tier is picked rather than sent.
-  const [tiersPending, setTiersPending] = useState(false);
-
-  const visibility = tiersPending
-    ? 'tiers'
-    : selectedVisibility(session.settings.visibility, defaultContentVisibility);
-  const selected = new Set(tiersPending ? [] : selectedTierIds(session.settings.tiers));
+  const visibility = selectedVisibility(session.settings.visibility, defaultContentVisibility);
+  const selected = new Set(selectedTierIds(session.settings.tiers));
 
   const { data: tiersData } = useBrowseTiers({
+    defaultErrorHandler: false,
     enabled: visibility === 'tiers',
     requestOptions: EDITOR_REQUEST_OPTIONS,
+    searchParams: { filter: 'type:paid', limit: 'all' },
   });
   const options = tierOptions(tiersData?.tiers);
 
-  const commit = (nextVisibility: string, tiers: ReturnType<typeof postTiers>) => {
-    if (!isCommittableAccess(nextVisibility, tiers.length)) {
-      setTiersPending(true);
-      return;
-    }
-
-    setTiersPending(false);
-    session.editSettings({ visibility: nextVisibility, tiers });
-  };
-
   // Leaving `tiers` clears the tiers it granted, as the tier pickers do.
   const changeVisibility = (next: string) =>
-    commit(next, next === 'tiers' ? postTiers(session.settings.tiers) : []);
+    session.editSettings({
+      visibility: next,
+      tiers: next === 'tiers' ? postTiers(session.settings.tiers) : [],
+    });
 
   const toggleTier = (id: string) => {
     const next = new Set(selected);
     if (!next.delete(id)) {
       next.add(id);
     }
-    commit('tiers', tiersFromSelection(options, next));
+    session.editSettings({ visibility: 'tiers', tiers: tiersFromSelection(options, next) });
   };
 
   return (
-    <>
+    <SettingsSection>
       <Label htmlFor={selectId}>{postType === 'page' ? 'Page' : 'Post'} access</Label>
       <Select value={visibility} onValueChange={changeVisibility}>
         <SelectTrigger data-testid={settingsVisibilitySelect} id={selectId}>
@@ -155,8 +143,9 @@ export function AccessSection({ session, postType }: AccessSectionProps) {
       </Select>
 
       {visibility === 'tiers' ? (
-        <Stack className="pt-1" data-testid={settingsTiersPicker} gap="md">
+        <Stack data-testid={settingsTiersPicker} gap="md">
           <TierGroup
+            heading="Active tiers"
             options={options.filter((option) => !option.archived)}
             selected={selected}
             onToggle={toggleTier}
@@ -167,13 +156,13 @@ export function AccessSection({ session, postType }: AccessSectionProps) {
             selected={selected}
             onToggle={toggleTier}
           />
-          {tiersPending ? (
+          {tiersIncomplete(session.settings) ? (
             <Text className="text-destructive" data-testid={settingsTiersError} size="sm">
-              Please select at least one tier
+              {TIERS_REQUIRED}
             </Text>
           ) : null}
         </Stack>
       ) : null}
-    </>
+    </SettingsSection>
   );
 }

--- a/apps/admin/src/editor/settings/access-section.tsx
+++ b/apps/admin/src/editor/settings/access-section.tsx
@@ -94,7 +94,10 @@ export interface AccessSectionProps {
  */
 export function AccessSection({ session, postType }: AccessSectionProps) {
   const selectId = useId();
-  const { data: settingsData } = useBrowseSettings({ requestOptions: EDITOR_REQUEST_OPTIONS });
+  const { data: settingsData } = useBrowseSettings({
+    defaultErrorHandler: false,
+    requestOptions: EDITOR_REQUEST_OPTIONS,
+  });
   const defaultContentVisibility = getSettingValue<string>(
     settingsData?.settings ?? null,
     'default_content_visibility',

--- a/apps/admin/src/editor/settings/access-section.tsx
+++ b/apps/admin/src/editor/settings/access-section.tsx
@@ -1,0 +1,179 @@
+import { useId, useState } from 'react';
+import {
+  Checkbox,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tryghost/shade/components';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
+import { useBrowseTiers } from '@tryghost/admin-x-framework/api/tiers';
+import {
+  settingsTiersError,
+  settingsTiersPicker,
+  settingsVisibilitySelect,
+} from '@tryghost/test-data/selectors/editor';
+import type { PostType } from '@/editor/card-config';
+import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
+import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import {
+  VISIBILITY_OPTIONS,
+  isCommittableAccess,
+  postTiers,
+  selectedTierIds,
+  selectedVisibility,
+  tierOptions,
+  tiersFromSelection,
+  type TierOption,
+} from './access-options';
+
+function TierCheckbox({
+  option,
+  checked,
+  onToggle,
+}: {
+  option: TierOption;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  const inputId = useId();
+
+  return (
+    <Inline gap="sm">
+      <Checkbox checked={checked} id={inputId} onCheckedChange={onToggle} />
+      <Label htmlFor={inputId}>{option.name}</Label>
+    </Inline>
+  );
+}
+
+function TierGroup({
+  heading,
+  options,
+  selected,
+  onToggle,
+}: {
+  heading?: string;
+  options: TierOption[];
+  selected: ReadonlySet<string>;
+  onToggle: (id: string) => void;
+}) {
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap="sm">
+      {heading ? (
+        <Text size="sm" tone="secondary" weight="medium">
+          {heading}
+        </Text>
+      ) : null}
+      {options.map((option) => (
+        <TierCheckbox
+          key={option.id}
+          checked={selected.has(option.id)}
+          option={option}
+          onToggle={() => onToggle(option.id)}
+        />
+      ))}
+    </Stack>
+  );
+}
+
+export interface AccessSectionProps {
+  session: EditorSessionHandle;
+  postType: PostType;
+}
+
+/**
+ * Who can read the post: one of four visibility choices, plus the tiers that
+ * `Specific tier(s)` grants. Both are settings fields, so the sidebar's save
+ * policy decides when they are persisted.
+ */
+export function AccessSection({ session, postType }: AccessSectionProps) {
+  const selectId = useId();
+  const { data: settingsData } = useBrowseSettings({ requestOptions: EDITOR_REQUEST_OPTIONS });
+  const defaultContentVisibility = getSettingValue<string>(
+    settingsData?.settings ?? null,
+    'default_content_visibility',
+  );
+
+  // The write contract drops `visibility: 'tiers'` when no tiers accompany it,
+  // so that pairing is held here until a tier is picked rather than sent.
+  const [tiersPending, setTiersPending] = useState(false);
+
+  const visibility = tiersPending
+    ? 'tiers'
+    : selectedVisibility(session.settings.visibility, defaultContentVisibility);
+  const selected = new Set(tiersPending ? [] : selectedTierIds(session.settings.tiers));
+
+  const { data: tiersData } = useBrowseTiers({
+    enabled: visibility === 'tiers',
+    requestOptions: EDITOR_REQUEST_OPTIONS,
+  });
+  const options = tierOptions(tiersData?.tiers);
+
+  const commit = (nextVisibility: string, tiers: ReturnType<typeof postTiers>) => {
+    if (!isCommittableAccess(nextVisibility, tiers.length)) {
+      setTiersPending(true);
+      return;
+    }
+
+    setTiersPending(false);
+    session.editSettings({ visibility: nextVisibility, tiers });
+  };
+
+  // Leaving `tiers` clears the tiers it granted, as the tier pickers do.
+  const changeVisibility = (next: string) =>
+    commit(next, next === 'tiers' ? postTiers(session.settings.tiers) : []);
+
+  const toggleTier = (id: string) => {
+    const next = new Set(selected);
+    if (!next.delete(id)) {
+      next.add(id);
+    }
+    commit('tiers', tiersFromSelection(options, next));
+  };
+
+  return (
+    <>
+      <Label htmlFor={selectId}>{postType === 'page' ? 'Page' : 'Post'} access</Label>
+      <Select value={visibility} onValueChange={changeVisibility}>
+        <SelectTrigger data-testid={settingsVisibilitySelect} id={selectId}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {VISIBILITY_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {visibility === 'tiers' ? (
+        <Stack className="pt-1" data-testid={settingsTiersPicker} gap="md">
+          <TierGroup
+            options={options.filter((option) => !option.archived)}
+            selected={selected}
+            onToggle={toggleTier}
+          />
+          <TierGroup
+            heading="Archived tiers"
+            options={options.filter((option) => option.archived)}
+            selected={selected}
+            onToggle={toggleTier}
+          />
+          {tiersPending ? (
+            <Text className="text-destructive" data-testid={settingsTiersError} size="sm">
+              Please select at least one tier
+            </Text>
+          ) : null}
+        </Stack>
+      ) : null}
+    </>
+  );
+}

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tryghost/test-data/selectors/editor';
 import type { PostType } from '@/editor/card-config';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import { AccessSection } from './access-section';
 import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
 
 function SettingsSection({ children }: { children: ReactNode }) {
@@ -83,10 +84,16 @@ export function PostSettingsSidebar({
   hasInlineExcerpt = false,
 }: PostSettingsSidebarProps) {
   const canFeature = !!currentUser && !isAuthorOrContributor(currentUser);
+  const canSetAccess = !!currentUser && !isAuthorOrContributor(currentUser);
 
   const sections: Partial<Record<SettingsSectionId, ReactNode>> = {
     excerpt: hasInlineExcerpt ? null : <ExcerptSection session={session} />,
     featured: canFeature ? <FeaturedSection postType={postType} session={session} /> : null,
+    access: canSetAccess ? (
+      <SettingsSection>
+        <AccessSection postType={postType} session={session} />
+      </SettingsSection>
+    ) : null,
   };
 
   return (

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -1,7 +1,7 @@
 import { Fragment, type ReactNode, useId } from 'react';
 import { Label, Separator, Switch, Textarea } from '@tryghost/shade/components';
-import { Inline, Stack, Text } from '@tryghost/shade/primitives';
-import { isAuthorOrContributor, type User } from '@tryghost/admin-x-framework/api/users';
+import { Inline, Text } from '@tryghost/shade/primitives';
+import { canAccessSettings, type User } from '@tryghost/admin-x-framework/api/users';
 import {
   postSettingsSidebar,
   settingsExcerptInput,
@@ -11,17 +11,7 @@ import type { PostType } from '@/editor/card-config';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
 import { AccessSection } from './access-section';
 import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
-
-function SettingsSection({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <Stack className="px-5 py-4" gap="sm">
-        {children}
-      </Stack>
-      <Separator />
-    </>
-  );
-}
+import { SettingsSection } from './settings-section';
 
 function ExcerptSection({ session }: { session: EditorSessionHandle }) {
   const inputId = useId();
@@ -83,17 +73,13 @@ export function PostSettingsSidebar({
   currentUser,
   hasInlineExcerpt = false,
 }: PostSettingsSidebarProps) {
-  const canFeature = !!currentUser && !isAuthorOrContributor(currentUser);
-  const canSetAccess = !!currentUser && !isAuthorOrContributor(currentUser);
+  // Owner, Administrator and Editor: the roles Ember shows these sections to.
+  const canManagePost = !!currentUser && canAccessSettings(currentUser);
 
   const sections: Partial<Record<SettingsSectionId, ReactNode>> = {
     excerpt: hasInlineExcerpt ? null : <ExcerptSection session={session} />,
-    featured: canFeature ? <FeaturedSection postType={postType} session={session} /> : null,
-    access: canSetAccess ? (
-      <SettingsSection>
-        <AccessSection postType={postType} session={session} />
-      </SettingsSection>
-    ) : null,
+    featured: canManagePost ? <FeaturedSection postType={postType} session={session} /> : null,
+    access: canManagePost ? <AccessSection postType={postType} session={session} /> : null,
   };
 
   return (

--- a/apps/admin/src/editor/settings/settings-section.tsx
+++ b/apps/admin/src/editor/settings/settings-section.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import { Separator } from '@tryghost/shade/components';
+import { Stack } from '@tryghost/shade/primitives';
+
+/** One block of the settings panel, with the rule that closes it. */
+export function SettingsSection({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Stack className="px-5 py-4" gap="sm">
+        {children}
+      </Stack>
+      <Separator />
+    </>
+  );
+}

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -41,6 +41,9 @@ export const postSettingsSidebar = 'post-settings-sidebar';
 export const settingsMenuToggle = 'settings-menu-toggle';
 export const settingsExcerptInput = 'settings-excerpt-input';
 export const settingsFeaturedToggle = 'settings-featured-toggle';
+export const settingsVisibilitySelect = 'settings-visibility-select';
+export const settingsTiersPicker = 'settings-tiers-picker';
+export const settingsTiersError = 'settings-tiers-error';
 
 // publish flow testids
 export const publishFlowModal = 'publish-flow-modal';


### PR DESCRIPTION
Adds Post/Page access controls to the React editor’s settings sidebar for Owners, Administrators, and Editors. Writers can choose Public, Members only, Paid-members only, or Specific tier(s). Draft changes save immediately; other statuses stage changes until Update or Cmd-S.

The tier picker fetches all paid tiers, groups active tiers before archived ones, and preserves selected IDs that are absent from the options. Free-tier relations returned with Public and Members posts are excluded from the selection. Koenig card access follows the live visibility, including staged edits.

Visibility and tiers are submitted together whenever either field changes under specific-tier access. This preserves a switch from Public, Members, or Paid access even when its tier IDs are unchanged. After a successful save, unrelated edits no longer send either access field.

An empty specific-tier selection stays staged and blocks saving or publishing with `Please select at least one tier`, including the first save of a new post. The error remains visible, unsaved-change protection stays active, and selecting a tier allows saving again. New posts with untouched access settings still use the server’s defaults. A background autosave refused for an incomplete tier pairing surfaces `Please select at least one tier` in the status line while the writer keeps typing, where the previous editor dropped that autosave silently; the post is not saved in either case.

## Validation

- Editor unit suite: 952 tests passed.
- Editor and layout Chromium acceptance suites: 234 tests passed, including 11 Access journeys.
- Admin TypeScript checking and changed-file ESLint passed.
- Repository formatting check passed.
- Regression tests were first run against the unfixed code and failed for the reported save bugs and free-tier selection case.
- `pnpm check` passed formatting and the Nx lint/boundary tasks, then stopped in documentation link validation on the pre-existing `e2e/README.md` link to the missing `development-setup.md#stripe-webhooks` heading. Its subsequent test phase did not run; the focused unit and browser suites above were run separately.

