### PR TITLE
Switched to `type`, not `interface`, in automations backend code

### DIFF
--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -1,44 +1,44 @@
 import type { ReadonlyDeep } from 'type-fest';
 import type { Knex } from 'knex';
 
-export interface Pagination {
+export type Pagination = {
   page: number;
   pages: number;
   limit: number | 'all';
   total: number;
   prev: number | null;
   next: number | null;
-}
+};
 
-export interface Page<T> {
+export type Page<T> = {
   data: T[];
   meta: {
     pagination: Pagination;
   };
-}
+};
 
-export interface WaitAction {
+export type WaitAction = {
   id: string;
   type: 'wait';
   data: {
     wait_hours: number;
   };
-}
+};
 
-export interface AutomationEmailStats {
+export type AutomationEmailStats = {
   email_clicked_count: number;
   email_sent_count: number;
   email_opened_count: number;
   opened_rate: number | null;
   clicked_rate: number | null;
-}
+};
 
-export interface AutomationActionLink {
+export type AutomationActionLink = {
   url: string;
   clicked_count: number;
-}
+};
 
-export interface SendEmailAction {
+export type SendEmailAction = {
   id: string;
   type: 'send_email';
   data: {
@@ -47,42 +47,42 @@ export interface SendEmailAction {
     email_design_setting_id: string;
   };
   stats?: AutomationEmailStats;
-}
+};
 
 export type AutomationAction = WaitAction | SendEmailAction;
 
-export interface AutomationEdge {
+export type AutomationEdge = {
   source_action_id: string;
   target_action_id: string;
-}
+};
 
-export interface AutomationSummary {
+export type AutomationSummary = {
   id: string;
   slug: string;
   name: string;
   status: string;
   created_at: string;
   updated_at: string;
-}
+};
 
-export interface AutomationBrowseResult extends AutomationSummary {
+export type AutomationBrowseResult = AutomationSummary & {
   stats?: {
     last_run_created_at: Date | null;
     total_run_count: number;
     in_progress_run_count: number;
   };
-}
+};
 
-export interface Automation extends AutomationSummary {
+export type Automation = AutomationSummary & {
   actions: AutomationAction[];
   edges: AutomationEdge[];
-}
+};
 
-export interface EditAutomationData {
+export type EditAutomationData = {
   status: string;
   actions: AutomationAction[];
   edges: AutomationEdge[];
-}
+};
 
 export type AutomatedEmailRecipientWithMailgunId = {
   id: string;
@@ -147,7 +147,7 @@ export type AutomationStepTerminalStatus =
   | 'member changed status'
   | 'member unsubscribed';
 
-export interface AutomationsRepository {
+export type AutomationsRepository = {
   browse(): Promise<Page<AutomationBrowseResult>>;
   getById(id: string): Promise<Automation | null>;
   getAutomationActionLinks(
@@ -233,4 +233,4 @@ export interface AutomationsRepository {
       transacting?: Knex.Transaction;
     },
   ): Promise<void>;
-}
+};

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -53,29 +53,29 @@ const messages = {
 
 const DEFAULT_EMAIL_DESIGN_SETTING_REFERENCE = DEFAULT_EMAIL_DESIGN_SETTING_SLUG;
 
-interface AutomationRow {
+type AutomationRow = {
   id: string;
   slug: string;
   name: string;
   status: string;
   created_at: DatabaseDate;
   updated_at: DatabaseDate;
-}
+};
 
-interface AutomationBrowseRow extends AutomationRow {
+type AutomationBrowseRow = AutomationRow & {
   last_run_created_at: DatabaseDate | null;
   total_run_count: string | number | null;
   in_progress_run_count: string | number | null;
-}
+};
 
-interface ActionRow {
+type ActionRow = {
   id: string;
   type: 'wait' | 'send_email';
   wait_hours: number | null;
   email_subject: string | null;
   email_lexical: string | null;
   email_design_setting_id: string | null;
-}
+};
 
 type ActionStatsRow = {
   action_id: string;
@@ -98,10 +98,10 @@ type ActionRevisionRow = {
   email_design_setting_id: string | null;
 };
 
-interface EdgeRow {
+type EdgeRow = {
   source_action_id: string;
   target_action_id: string;
-}
+};
 
 type NextActionRevisionRow = {
   automation_id: string;


### PR DESCRIPTION
no ref

This is a types-only change that should have no user impact. It just makes things consistent.
