### PR TITLE
Added the Template section to the React editor's settings sidebar

### DIFF
--- a/apps/admin-x-framework/src/api/themes.ts
+++ b/apps/admin-x-framework/src/api/themes.ts
@@ -3,6 +3,17 @@ import { customThemeSettingsDataType } from './custom-theme-settings';
 
 // Types
 
+/** A theme's custom template. Only the active theme carries these. */
+export type ThemeTemplate = {
+  /** The template file without its extension, e.g. `custom-full-feature`. */
+  filename: string;
+  name: string;
+  /** The content types the template applies to, e.g. `['post']` for `post-*.hbs`. */
+  for?: string[];
+  /** The slug a `post-*.hbs`/`page-*.hbs` template is bound to; null for `custom-*.hbs`. */
+  slug?: string | null;
+};
+
 export type Theme = {
   active: boolean;
   name: string;
@@ -14,7 +25,7 @@ export type Theme = {
       name?: string;
     };
   };
-  templates?: string[];
+  templates?: ThemeTemplate[];
 };
 
 export type InstalledTheme = Theme & {

--- a/apps/admin/src/editor/editor-settings-template.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-template.acceptance.test.tsx
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePosts,
+  fakeSnippets,
+  fakeThemes,
+  post,
+  renderAdminApp,
+  theme,
+  unsavedChangesGuarded,
+  type EndpointCapture,
+  type ThemeTemplate,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+const POST_ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+
+// A settings save waits on the engine's queue, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const POLL = { timeout: 10_000 };
+// Under the 3s autosave debounce, so only an undebounced field save can satisfy it.
+const FIELD_POLL = { timeout: 2_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+// The shapes the themes API reports for `custom-*.hbs`, `post-*.hbs` and `page-*.hbs`.
+const SHARED_TEMPLATE = {
+  filename: 'custom-full-feature',
+  name: 'Full Feature',
+  for: ['page', 'post'],
+  slug: null,
+};
+const LONGREAD_TEMPLATE = {
+  filename: 'custom-longread',
+  name: 'Longread',
+  for: ['page', 'post'],
+  slug: null,
+};
+const SLUG_TEMPLATE = {
+  filename: 'post-hello-from-react',
+  name: 'Hello From React',
+  for: ['post'],
+  slug: 'hello-from-react',
+};
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}
+
+/** The active theme's templates, alongside an installed theme whose templates never count. */
+function fakeSiteThemes(templates: ThemeTemplate[]) {
+  fakeThemes([
+    theme({ name: 'casper', templates: [SHARED_TEMPLATE, LONGREAD_TEMPLATE] }),
+    theme({ name: 'edition', active: true, templates }),
+  ]);
+}
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+  // The header's publish inputs read the site's member total and newsletter list.
+  fakeMembers([]);
+  fakeNewsletters([]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+}
+
+/** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    custom_template: null,
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', POST_ROUTE, () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', POST_ROUTE, ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+}
+
+async function openTemplate() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await expect.element(editorScreen.settingsTemplate()).toBeVisible();
+}
+
+async function chooseTemplate(label: string) {
+  await editorScreen.settingsTemplate().click();
+  await editorScreen.settingsTemplateOption(label).click();
+}
+
+/**
+ * The sidebar's Template section: the active theme's custom templates, and the
+ * one a post's own URL already picks.
+ */
+describe('Post settings template', () => {
+  it(
+    'persists a draft’s template on its own',
+    async () => {
+      fakeSiteThemes([SHARED_TEMPLATE, LONGREAD_TEMPLATE]);
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openTemplate();
+
+      await expect.element(editorScreen.settingsTemplate()).toHaveTextContent('Default');
+
+      await chooseTemplate('Longread');
+
+      // A field save has no debounce, so it lands well inside the autosave's 3s.
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({ custom_template: 'custom-longread' });
+      await expect.element(editorScreen.settingsTemplate()).toHaveTextContent('Longread');
+    },
+    SLOW,
+  );
+
+  it(
+    'clears the template when the default is chosen again',
+    async () => {
+      fakeSiteThemes([SHARED_TEMPLATE, LONGREAD_TEMPLATE]);
+      const saveApi = fakeSavablePost({ custom_template: 'custom-longread' });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openTemplate();
+
+      await expect.element(editorScreen.settingsTemplate()).toHaveTextContent('Longread');
+
+      await chooseTemplate('Default');
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).custom_template).toBeNull();
+      await expect.element(editorScreen.settingsTemplate()).toHaveTextContent('Default');
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves the section out when the active theme offers no templates',
+    async () => {
+      // Slug templates are the theme's, never the writer's, to pick.
+      fakeSiteThemes([SLUG_TEMPLATE]);
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await editorScreen.settingsToggle().click();
+      await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+      await expect.element(editorScreen.settingsExcerpt()).toBeVisible();
+
+      await expect(editorScreen.settingsTemplate()).toHaveCount(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'hands the choice to the theme when the post’s URL matches a template',
+    async () => {
+      fakeSiteThemes([SHARED_TEMPLATE, SLUG_TEMPLATE]);
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openTemplate();
+
+      await expect
+        .element(editorScreen.settingsTemplateSlugMatch())
+        .toHaveTextContent('Post URL matches post-hello-from-react');
+      await expect.element(editorScreen.settingsTemplate()).toBeDisabled();
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a published post’s template until Update',
+    async () => {
+      fakeSiteThemes([SHARED_TEMPLATE, LONGREAD_TEMPLATE]);
+      const saveApi = fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openTemplate();
+
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+
+      await chooseTemplate('Full Feature');
+
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        custom_template: 'custom-full-feature',
+        status: 'published',
+      });
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -48,6 +48,8 @@ import {
   settingsTagsInput,
   settingsTagsList,
   settingsTagsToken,
+  settingsTemplateSelect,
+  settingsTemplateSlugMatch,
   settingsTiersError,
   settingsTiersPicker,
   settingsUrlPreview,
@@ -143,6 +145,10 @@ export const editorScreen = {
     page
       .getByTestId(settingsTagsField)
       .getByRole('button', { name: `Remove ${name}`, exact: true }),
+  settingsTemplate: () => page.getByTestId(settingsTemplateSelect),
+  settingsTemplateOption: (label: string) =>
+    page.getByRole('listbox').getByRole('option', { name: label, exact: true }),
+  settingsTemplateSlugMatch: () => page.getByTestId(settingsTemplateSlugMatch),
 
   featureImage: () => page.getByTestId(editorFeatureImage),
   featureImageInput: () => page.getByLabelText(addFeatureImageLabel),

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -153,6 +153,20 @@ Koenig cards read the post's access from the editor's card config, which follows
 the live field rather than the saved record: a staged visibility changes what
 the cards describe before any save.
 
+## Template
+
+The theme decides which templates a post may render with, so the section is the
+active theme's list and nothing else: its slugless templates, by name, under a
+Default that stands for the post carrying no template. A template the theme no
+longer offers reads as the default. A theme with no such templates leaves the
+section out entirely, and every role that can open the sidebar sees it.
+
+A theme may also bind a template to one post URL. Where the post's slug matches
+one, the theme applies that template whatever the field holds, so the select is
+disabled and names the template the URL picked. The field is committed through
+the same gate as the rest of the sidebar: a draft saves it, every other status
+stages it until Update.
+
 ## Show title and feature image
 
 A page can render without its own title and feature image, and only a page: the

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -18,6 +18,7 @@ import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
 import { SettingsSection } from './settings-section';
 import { ShowTitleSection } from './show-title-section';
 import { TagsSection } from './tags-section';
+import { TemplateSection } from './template-section';
 import { UrlSection } from './url-section';
 
 function ExcerptSection({ session }: { session: EditorSessionHandle }) {
@@ -95,6 +96,7 @@ export function PostSettingsSidebar({
     access: canManagePost ? <AccessSection postType={postType} session={session} /> : null,
     'show-title-and-feature-image':
       postType === 'page' ? <ShowTitleSection currentUser={currentUser} session={session} /> : null,
+    template: <TemplateSection postType={postType} session={session} />,
   };
 
   return (

--- a/apps/admin/src/editor/settings/template-options.test.ts
+++ b/apps/admin/src/editor/settings/template-options.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { Theme, ThemeTemplate } from '@tryghost/admin-x-framework/api/themes';
+import {
+  DEFAULT_TEMPLATE_VALUE,
+  activeThemeTemplates,
+  selectedTemplate,
+  slugTemplate,
+  templateOptions,
+} from './template-options';
+
+const CUSTOM: ThemeTemplate = {
+  filename: 'custom-full-feature',
+  name: 'Full Feature',
+  for: ['page', 'post'],
+  slug: null,
+};
+const CUSTOM_EARLIER: ThemeTemplate = {
+  filename: 'custom-brief',
+  name: 'Brief',
+  for: ['page', 'post'],
+  slug: null,
+};
+const POST_SLUG: ThemeTemplate = {
+  filename: 'post-welcome',
+  name: 'Welcome',
+  for: ['post'],
+  slug: 'welcome',
+};
+const PAGE_SLUG: ThemeTemplate = {
+  filename: 'page-welcome',
+  name: 'Welcome',
+  for: ['page'],
+  slug: 'welcome',
+};
+
+function theme(overrides: Partial<Theme>): Theme {
+  return { active: false, name: 'casper', package: {}, ...overrides };
+}
+
+describe('template options', () => {
+  describe('activeThemeTemplates', () => {
+    it('reads the active theme’s templates', () => {
+      const themes = [
+        theme({ name: 'casper', templates: [POST_SLUG] }),
+        theme({ name: 'edition', active: true, templates: [CUSTOM] }),
+      ];
+
+      expect(activeThemeTemplates(themes)).toEqual([CUSTOM]);
+    });
+
+    it('has no templates without an active theme, or before the browse lands', () => {
+      expect(activeThemeTemplates([theme({ templates: [CUSTOM] })])).toEqual([]);
+      expect(activeThemeTemplates([theme({ active: true })])).toEqual([]);
+      expect(activeThemeTemplates(undefined)).toEqual([]);
+    });
+  });
+
+  describe('templateOptions', () => {
+    it('offers the slugless templates by name', () => {
+      expect(
+        templateOptions([CUSTOM, POST_SLUG, CUSTOM_EARLIER]).map((option) => option.filename),
+      ).toEqual([CUSTOM_EARLIER.filename, CUSTOM.filename]);
+    });
+
+    it('offers nothing when the theme has only slug templates', () => {
+      expect(templateOptions([POST_SLUG, PAGE_SLUG])).toEqual([]);
+    });
+  });
+
+  describe('slugTemplate', () => {
+    it('matches the post’s slug for its own content type', () => {
+      expect(slugTemplate([POST_SLUG, PAGE_SLUG], 'post', 'welcome')).toBe(POST_SLUG);
+      expect(slugTemplate([POST_SLUG, PAGE_SLUG], 'page', 'welcome')).toBe(PAGE_SLUG);
+    });
+
+    it('matches nothing for another slug, or before the post has one', () => {
+      expect(slugTemplate([POST_SLUG], 'post', 'goodbye')).toBeUndefined();
+      expect(slugTemplate([POST_SLUG], 'post', '')).toBeUndefined();
+    });
+
+    it('ignores the slugless templates', () => {
+      expect(slugTemplate([CUSTOM], 'post', 'custom-full-feature')).toBeUndefined();
+    });
+  });
+
+  describe('selectedTemplate', () => {
+    it('shows the post’s template', () => {
+      expect(selectedTemplate([CUSTOM], CUSTOM.filename)).toBe(CUSTOM.filename);
+    });
+
+    it('falls back to the default for no template, or one the theme dropped', () => {
+      expect(selectedTemplate([CUSTOM], null)).toBe(DEFAULT_TEMPLATE_VALUE);
+      expect(selectedTemplate([CUSTOM], 'custom-gone')).toBe(DEFAULT_TEMPLATE_VALUE);
+    });
+  });
+});

--- a/apps/admin/src/editor/settings/template-options.ts
+++ b/apps/admin/src/editor/settings/template-options.ts
@@ -1,0 +1,43 @@
+import type { Theme, ThemeTemplate } from '@tryghost/admin-x-framework/api/themes';
+import type { PostType } from '@/editor/card-config';
+
+/** The select's stand-in for no custom template; every theme filename is prefixed. */
+export const DEFAULT_TEMPLATE_VALUE = 'default';
+
+export const DEFAULT_TEMPLATE_LABEL = 'Default';
+
+/** Only the active theme reports its templates, so it is the only one to read. */
+export function activeThemeTemplates(themes: Theme[] | undefined): ThemeTemplate[] {
+  return themes?.find((theme) => theme.active)?.templates ?? [];
+}
+
+function appliesTo(template: ThemeTemplate, postType: PostType): boolean {
+  return !template.for || template.for.includes(postType);
+}
+
+/** The templates a writer may pick: those bound to no slug, by name. */
+export function templateOptions(templates: ThemeTemplate[]): ThemeTemplate[] {
+  return templates
+    .filter((template) => !template.slug)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** The template the post's own URL already selects, whatever the field holds. */
+export function slugTemplate(
+  templates: ThemeTemplate[],
+  postType: PostType,
+  slug: string | null | undefined,
+): ThemeTemplate | undefined {
+  return slug
+    ? templates.find(
+        (template) => !!template.slug && appliesTo(template, postType) && template.slug === slug,
+      )
+    : undefined;
+}
+
+/** The option the select shows; a template the theme no longer offers falls back to the default. */
+export function selectedTemplate(options: ThemeTemplate[], customTemplate: string | null): string {
+  return options.some((option) => option.filename === customTemplate) && customTemplate
+    ? customTemplate
+    : DEFAULT_TEMPLATE_VALUE;
+}

--- a/apps/admin/src/editor/settings/template-section.tsx
+++ b/apps/admin/src/editor/settings/template-section.tsx
@@ -1,0 +1,85 @@
+import { useId } from 'react';
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tryghost/shade/components';
+import { Text } from '@tryghost/shade/primitives';
+import { useBrowseThemes } from '@tryghost/admin-x-framework/api/themes';
+import {
+  settingsTemplateSelect,
+  settingsTemplateSlugMatch,
+} from '@tryghost/test-data/selectors/editor';
+import type { PostType } from '@/editor/card-config';
+import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
+import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import { SettingsSection } from './settings-section';
+import {
+  DEFAULT_TEMPLATE_LABEL,
+  DEFAULT_TEMPLATE_VALUE,
+  activeThemeTemplates,
+  selectedTemplate,
+  slugTemplate,
+  templateOptions,
+} from './template-options';
+
+export interface TemplateSectionProps {
+  session: EditorSessionHandle;
+  postType: PostType;
+}
+
+/**
+ * The theme template the post renders with. A settings field, so the sidebar's
+ * save policy decides when it is persisted.
+ */
+export function TemplateSection({ session, postType }: TemplateSectionProps) {
+  const selectId = useId();
+  const { data } = useBrowseThemes({
+    defaultErrorHandler: false,
+    requestOptions: EDITOR_REQUEST_OPTIONS,
+  });
+
+  const templates = activeThemeTemplates(data?.themes);
+  const options = templateOptions(templates);
+  const matched = slugTemplate(templates, postType, session.slug);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  const chooseTemplate = (value: string) =>
+    session.editSettings({
+      custom_template: value === DEFAULT_TEMPLATE_VALUE ? null : value,
+    });
+
+  return (
+    <SettingsSection>
+      <Label htmlFor={selectId}>Template</Label>
+      <Select
+        disabled={!!matched}
+        value={selectedTemplate(options, session.settings.custom_template)}
+        onValueChange={chooseTemplate}
+      >
+        <SelectTrigger data-testid={settingsTemplateSelect} id={selectId}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={DEFAULT_TEMPLATE_VALUE}>{DEFAULT_TEMPLATE_LABEL}</SelectItem>
+          {options.map((option) => (
+            <SelectItem key={option.filename} value={option.filename}>
+              {option.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {matched ? (
+        <Text data-testid={settingsTemplateSlugMatch} size="sm" tone="secondary">
+          {postType === 'page' ? 'Page' : 'Post'} URL matches {matched.filename}
+        </Text>
+      ) : null}
+    </SettingsSection>
+  );
+}

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -4,6 +4,7 @@ import {
   browseResponse,
   configResponse,
   currentUserResponse,
+  defaultThemesResponse,
   settingsResponse,
   siteResponse,
 } from '@tryghost/test-data';
@@ -63,6 +64,11 @@ export function defaultBootRequests() {
       method: 'GET',
       path: '/themes/active/',
       response: activeThemeResponse(),
+    },
+    browseThemes: {
+      method: 'GET',
+      path: '/themes/',
+      response: defaultThemesResponse(),
     },
     editUserPreferences: {
       method: 'PUT',

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -147,6 +147,7 @@ export type {
   SubscriptionStat,
   Tag,
   Theme,
+  ThemeTemplate,
   Tier,
   TinybirdPipeName,
   TinybirdPipeRows,

--- a/packages/testing/test-data/src/builders/theme.ts
+++ b/packages/testing/test-data/src/builders/theme.ts
@@ -19,11 +19,19 @@ export interface ThemePackage {
   };
 }
 
+/** A custom template the theme service derives from a `custom-*`/`post-*`/`page-*` file. */
+export interface ThemeTemplate {
+  filename: string;
+  name: string;
+  for?: string[];
+  slug?: string | null;
+}
+
 export interface Theme {
   name: string;
   package: ThemePackage;
   active: boolean;
-  templates: unknown[];
+  templates: ThemeTemplate[];
   /** gscan problems surfaced by install/activate flows and the admin sidebar's theme-error banner. */
   errors: unknown[];
   warnings: unknown[];

--- a/packages/testing/test-data/src/index.ts
+++ b/packages/testing/test-data/src/index.ts
@@ -20,7 +20,7 @@ export type { Offer } from './builders/offer';
 export { newsletter } from './builders/newsletter';
 export type { Newsletter } from './builders/newsletter';
 export { defaultThemesResponse, theme } from './builders/theme';
-export type { Theme, ThemePackage, ThemesResponse } from './builders/theme';
+export type { Theme, ThemePackage, ThemeTemplate, ThemesResponse } from './builders/theme';
 export { post } from './builders/post';
 export type { Post } from './builders/post';
 export { staffInvite, staffRole, staffUser } from './builders/staff-user';

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -53,6 +53,8 @@ export const settingsTagsField = 'settings-tags-field';
 export const settingsTagsInput = 'settings-tags-input';
 export const settingsTagsList = 'settings-tags-list';
 export const settingsTagsToken = 'settings-tags-token';
+export const settingsTemplateSelect = 'settings-template-select';
+export const settingsTemplateSlugMatch = 'settings-template-slug-match';
 
 // publish flow testids
 export const publishFlowModal = 'publish-flow-modal';


### PR DESCRIPTION
The React editor's settings sidebar had no way to choose the theme template a post renders with. This fills the `template` slot in `SETTINGS_SECTION_ORDER`.

## What it does

- Reads the **active** theme's templates from the themes browse (`GET /themes/`) — the only theme the API reports templates for — with the editor's request options and no default error handler, as the sidebar's other reads do.
- **Options**: the templates bound to no slug (`custom-*.hbs`), sorted by name, under a `Default` option that stands for no template. A template the theme no longer offers reads as the default.
- **Hidden**: a theme with no such templates leaves the section out entirely.
- **Slug-matched templates**: a template bound to the post's own slug (`post-<slug>.hbs` / `page-<slug>.hbs`, matched on `for` + `slug`) is applied by the theme whatever the field holds, so the select is disabled and the section names the template the URL picked. The match reads the session's slug, so an edit in the URL section moves it.
- **Role gating**: none — every role that can open the sidebar can browse themes and set this field.
- **Saving**: `custom_template` (null for the default) goes through the sidebar's existing `commitField` gate, so a draft saves it on its own and every other status stages it until Update. The key was already in `SETTINGS_FIELD_KEYS` and the change tracker's projection, so nothing in the session needed to change.

The themes API type declared the active theme's `templates` as file-name strings; they are the `{filename, name, for, slug}` objects the theme service builds, so the type now describes them. Nothing consumed the old type.

Since gscan derives `for` and `slug` from the same filename, a slugless template always applies to both content types; only the slug lookup needs the `for` check, to tell `post-welcome` from `page-welcome`.

Every editor screen now makes the themes browse, so the acceptance boot table answers it by default with the canned themes list; a spec that needs particular templates still declares them with `fakeThemes`.

## Verification

`pnpm --filter @tryghost/admin exec vitest run src/editor` — 37 files, 1004 tests pass (9 unit cases in `template-options.test.ts`).
Browser-mode acceptance for `src/editor src/layout src/posts` — 27 files, 413 tests pass (5 new); `src/settings` — 41 files, 374 tests pass, covering the specs that declare their own themes.
`eslint src test-utils`, `tsc -b` (admin), `tsc --noEmit` (admin-x-framework, test-data), `test-data` unit tests (3 files, 23 tests), `nx run @tryghost/admin:build`, root `format:check`, `lint:boundaries`, `lint:markdown` — all clean.

### Revert probes

Each acceptance case was re-run with the hunk it pins reverted:

| Reverted hunk | Case that fails |
| --- | --- |
| Section registration in the sidebar `sections` map | persists a draft's template on its own; clears the template when the default is chosen again; hands the choice to the theme when the post's URL matches a template; stages a published post's template until Update (4 of 5; the hidden-section case correctly still passes) |
| `options.length === 0` early return | leaves the section out when the active theme offers no templates |
| `slugTemplate(...)` lookup | hands the choice to the theme when the post's URL matches a template |
| `value === DEFAULT_TEMPLATE_VALUE ? null : value` | clears the template when the default is chosen again |

Removing the status check from `commitField` did **not** fail the staging case: the save engine independently refuses background saves for anything that is not a draft, so that policy is doubly enforced and the gate cannot be isolated by a probe. That case is pinned by the registration hunk.
