### PR TITLE
Added the Publish date section to the React editor's settings sidebar

### DIFF
--- a/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import { describe, expect, it } from 'vitest';
-import { userEvent } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
@@ -117,6 +117,37 @@ async function setTime(value: string) {
 
 /** The sidebar's Publish date section: when the post is published, in site time. */
 describe('Post settings publish date', () => {
+  it.each(['untouched time', 'retyped time', 'reselected day'] as const)(
+    'leaves a draft’s publish time unset with an unchanged picker (%s)',
+    async (interaction) => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      if (interaction === 'reselected day') {
+        await editorScreen.settingsPublishDate().click();
+        await page.getByRole('gridcell', { selected: true }).click();
+        await userEvent.keyboard('{Escape}');
+      } else {
+        await editorScreen.settingsPublishTime().click();
+        if (interaction === 'retyped time') {
+          const displayed = (editorScreen.settingsPublishTime().element() as HTMLInputElement)
+            .value;
+          await editorScreen.settingsPublishTime().fill('');
+          await editorScreen.settingsPublishTime().fill(displayed);
+        }
+        await userEvent.tab();
+      }
+
+      // Save another field to observe the date carried by the session.
+      await editorScreen.titleInput().fill('Changed title');
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+      await expect.poll(() => submittedPost(saveApi).title, POLL).toBe('Changed title');
+      expect(submittedPost(saveApi).published_at).toBeNull();
+    },
+    SLOW,
+  );
+
   it(
     'shows a published post’s publish time in the site’s timezone',
     async () => {
@@ -137,20 +168,21 @@ describe('Post settings publish date', () => {
   it(
     'persists a draft’s publish time on its own, as a UTC instant',
     async () => {
+      const timezone = middayTimezone();
       const saveApi = fakeSavablePost();
-      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(timezone));
       await openPublishDate();
 
       // A draft carries no publish time, so the field stands at today in site time.
-      // Midnight is the one time of day that is never ahead of the clock.
+      // With the clock around midday, midnight is always a different, past time.
       const chosen = (editorScreen.settingsPublishDate().element() as HTMLInputElement).value;
 
       await setTime('00:00');
 
       await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
-      // 00:00 in Sydney is the same instant as the ISO string the payload carries.
+      // Site-local midnight is the same instant as the ISO string the payload carries.
       expect(submittedPost(saveApi)).toMatchObject({
-        published_at: moment.tz(`${chosen} 00:00`, SYDNEY).toISOString(),
+        published_at: moment.tz(`${chosen} 00:00`, timezone).toISOString(),
         status: 'draft',
       });
       await expect.element(editorScreen.settingsPublishTime()).toHaveValue('00:00');
@@ -167,7 +199,7 @@ describe('Post settings publish date', () => {
 
       await expect.element(editorScreen.settingsPublishTime()).toHaveValue('21:00');
 
-      // Tabbing out commits the minute the field already shows.
+      // Tabbing through the field leaves the stored timestamp alone.
       await editorScreen.settingsPublishTime().click();
       await userEvent.tab();
       await expect.element(editorScreen.updateButton()).toBeDisabled();

--- a/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
@@ -25,6 +25,8 @@ const FLAG_ON = { labs: { editorReact: true } };
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 // 2025-12-01 10:00 UTC is 2025-12-01 21:00 in Sydney: a date the offset moves.
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+// What a real publish stamps: seconds the minute-granular fields cannot show.
+const STAMPED_AT = '2025-12-01T10:00:37.000Z';
 const SYDNEY = 'Australia/Sydney';
 const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 
@@ -151,6 +153,32 @@ describe('Post settings publish date', () => {
         status: 'draft',
       });
       await expect.element(editorScreen.settingsPublishTime()).toHaveValue('06:30');
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves the seconds a publish stamped alone while the minute stands',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'published', published_at: STAMPED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      await expect.element(editorScreen.settingsPublishTime()).toHaveValue('21:00');
+
+      // Tabbing out commits the minute the field already shows.
+      await editorScreen.settingsPublishTime().click();
+      await userEvent.tab();
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+
+      // A move away and back lands on that minute again, seconds intact.
+      await setTime('21:05');
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await setTime('21:00');
+
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+      expect(unsavedChangesGuarded()).toBe(false);
+      expect(saveApi.requests).toHaveLength(0);
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
@@ -1,0 +1,278 @@
+import moment from 'moment-timezone';
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentUserResponse,
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePosts,
+  fakeSnippets,
+  fakeTiers,
+  post,
+  renderAdminApp,
+  settingsResponse,
+  staffRole,
+  unsavedChangesGuarded,
+  type EndpointCapture,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+// 2025-12-01 10:00 UTC is 2025-12-01 21:00 in Sydney: a date the offset moves.
+const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+const SYDNEY = 'Australia/Sydney';
+const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+
+const SLOW = 20_000;
+const POLL = { timeout: 10_000 };
+const FIELD_POLL = { timeout: 2_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}
+
+/**
+ * A fixed-offset zone in which the current instant is around midday, so a later
+ * hour on the same day is reliably still to come whenever this suite runs.
+ */
+function middayTimezone(): string {
+  const offset = Math.max(-12, Math.min(14, 12 - new Date().getUTCHours()));
+  return `Etc/GMT${offset >= 0 ? '-' : '+'}${Math.abs(offset)}`;
+}
+
+function withTimezone(timezone: string) {
+  return {
+    ...FLAG_ON,
+    boot: {
+      browseSettings: { response: settingsResponse({ settings: { timezone } }) },
+    },
+  };
+}
+
+function asContributor() {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name: 'Contributor' })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+  fakeMembers([]);
+  fakeNewsletters([]);
+  fakeTiers([]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+}
+
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    visibility: 'public',
+    tiers: [],
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+}
+
+async function openPublishDate() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await expect.element(editorScreen.settingsPublishDate()).toBeVisible();
+}
+
+async function setTime(value: string) {
+  await editorScreen.settingsPublishTime().fill(value);
+  // The field commits on blur, as the publish flow's does.
+  await userEvent.tab();
+}
+
+/** The sidebar's Publish date section: when the post is published, in site time. */
+describe('Post settings publish date', () => {
+  it(
+    'shows a published post’s publish time in the site’s timezone',
+    async () => {
+      fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      // 10:00 UTC is 21:00 the same day in Sydney, not 10:00.
+      await expect.element(editorScreen.settingsPublishDate()).toHaveValue('2025-12-01');
+      await expect.element(editorScreen.settingsPublishTime()).toHaveValue('21:00');
+      await expect
+        .element(editorScreen.settingsPublishDateLabel())
+        .toHaveTextContent('Publish date');
+    },
+    SLOW,
+  );
+
+  it(
+    'persists a draft’s publish time on its own, as a UTC instant',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      // A draft carries no publish time, so the field stands at today in site time.
+      const chosen = (editorScreen.settingsPublishDate().element() as HTMLInputElement).value;
+
+      await setTime('06:30');
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      // 06:30 in Sydney is the same instant as the ISO string the payload carries.
+      expect(submittedPost(saveApi)).toMatchObject({
+        published_at: moment.tz(`${chosen} 06:30`, SYDNEY).toISOString(),
+        status: 'draft',
+      });
+      await expect.element(editorScreen.settingsPublishTime()).toHaveValue('06:30');
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a published post’s backdate until Update',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+
+      await setTime('08:15');
+
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        published_at: moment.tz('2025-12-01 08:15', SYDNEY).toISOString(),
+        status: 'published',
+      });
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+    },
+    SLOW,
+  );
+
+  it(
+    'refuses a published post a publish time that has not passed',
+    async () => {
+      const timezone = middayTimezone();
+      // Published an hour ago, so the field already shows today in that zone.
+      const anHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const saveApi = fakeSavablePost({ status: 'published', published_at: anHourAgo });
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(timezone));
+      await openPublishDate();
+
+      await expect
+        .element(editorScreen.settingsPublishDate())
+        .toHaveValue(moment.tz(timezone).format('YYYY-MM-DD'));
+
+      // The same day, but an hour still to come.
+      await setTime('23:59');
+
+      await expect
+        .element(editorScreen.settingsPublishDateError())
+        .toHaveTextContent('Please choose a past date and time.');
+      await expect.element(editorScreen.settingsPublishTime()).toHaveAttribute('aria-invalid');
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect
+        .element(editorScreen.saveErrorBanner())
+        .toHaveTextContent('Please choose a past date and time.');
+      expect(saveApi.requests).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'sends a scheduled post to the publish menu to be re-timed',
+    async () => {
+      const scheduledAt = moment().add(2, 'days').toISOString();
+      fakeSavablePost({ status: 'scheduled', published_at: scheduledAt });
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      await expect
+        .element(editorScreen.settingsPublishDateLabel())
+        .toHaveTextContent('Scheduled date');
+      await expect.element(editorScreen.settingsPublishDate()).toBeDisabled();
+      await expect.element(editorScreen.settingsPublishTime()).toBeDisabled();
+      await expect
+        .element(editorScreen.settingsPublishDateNote())
+        .toHaveTextContent('Use the publish menu to re-schedule');
+    },
+    SLOW,
+  );
+
+  it(
+    'lets a sent post be re-timed, as every other published one is',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'sent', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, withTimezone(SYDNEY));
+      await openPublishDate();
+
+      await expect.element(editorScreen.settingsPublishDate()).not.toBeDisabled();
+      await expect(editorScreen.settingsPublishDateNote()).toHaveCount(0);
+
+      await setTime('07:45');
+
+      // A sent post stages like a published one, so nothing is sent until Update.
+      expect(saveApi.requests).toHaveLength(0);
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        published_at: moment.tz('2025-12-01 07:45', SYDNEY).toISOString(),
+        status: 'sent',
+      });
+    },
+    SLOW,
+  );
+
+  it(
+    'offers the publish date to a role that cannot set the other fields',
+    async () => {
+      fakeSavablePost({ authors: [{ id: '1' }] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, asContributor());
+      await editorScreen.settingsToggle().click();
+      await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+
+      // Access is an Owner/Administrator/Editor field; the publish date is not.
+      await expect(editorScreen.settingsVisibility()).toHaveCount(0);
+      await expect.element(editorScreen.settingsPublishDate()).toBeVisible();
+      await expect.element(editorScreen.settingsPublishDate()).not.toBeDisabled();
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
@@ -142,17 +142,18 @@ describe('Post settings publish date', () => {
       await openPublishDate();
 
       // A draft carries no publish time, so the field stands at today in site time.
+      // Midnight is the one time of day that is never ahead of the clock.
       const chosen = (editorScreen.settingsPublishDate().element() as HTMLInputElement).value;
 
-      await setTime('06:30');
+      await setTime('00:00');
 
       await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
-      // 06:30 in Sydney is the same instant as the ISO string the payload carries.
+      // 00:00 in Sydney is the same instant as the ISO string the payload carries.
       expect(submittedPost(saveApi)).toMatchObject({
-        published_at: moment.tz(`${chosen} 06:30`, SYDNEY).toISOString(),
+        published_at: moment.tz(`${chosen} 00:00`, SYDNEY).toISOString(),
         status: 'draft',
       });
-      await expect.element(editorScreen.settingsPublishTime()).toHaveValue('06:30');
+      await expect.element(editorScreen.settingsPublishTime()).toHaveValue('00:00');
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
@@ -239,6 +239,13 @@ describe('Post settings publish date', () => {
         .element(editorScreen.saveErrorBanner())
         .toHaveTextContent('Please choose a past date and time.');
       expect(saveApi.requests).toHaveLength(0);
+
+      // The banner outlives the panel: closing it does not hide the reason.
+      await editorScreen.settingsToggle().click();
+      await expect(editorScreen.settingsPublishDateError()).toHaveCount(0);
+      await expect
+        .element(editorScreen.saveErrorBanner())
+        .toHaveTextContent('Please choose a past date and time.');
     },
     SLOW,
   );
@@ -276,6 +283,7 @@ describe('Post settings publish date', () => {
       await setTime('07:45');
 
       // A sent post stages like a published one, so nothing is sent until Update.
+      await expect.poll(unsavedChangesGuarded).toBe(true);
       expect(saveApi.requests).toHaveLength(0);
       await userEvent.keyboard('{Meta>}s{/Meta}');
 

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -40,6 +40,10 @@ import {
   settingsExcerptInput,
   settingsFeaturedToggle,
   settingsMenuToggle,
+  settingsPublishDate,
+  settingsPublishDateError,
+  settingsPublishDateNote,
+  settingsPublishTime,
   settingsShowTitleToggle,
   settingsShowTitleWarning,
   settingsSlugError,
@@ -149,6 +153,12 @@ export const editorScreen = {
   settingsTemplateOption: (label: string) =>
     page.getByRole('listbox').getByRole('option', { name: label, exact: true }),
   settingsTemplateSlugMatch: () => page.getByTestId(settingsTemplateSlugMatch),
+  settingsPublishDate: () => page.getByTestId(settingsPublishDate),
+  settingsPublishTime: () => page.getByTestId(settingsPublishTime),
+  settingsPublishDateError: () => page.getByTestId(settingsPublishDateError),
+  settingsPublishDateNote: () => page.getByTestId(settingsPublishDateNote),
+  settingsPublishDateLabel: () =>
+    page.getByTestId(postSettingsSidebar).getByText(/^(Publish|Scheduled) date$/),
 
   featureImage: () => page.getByTestId(editorFeatureImage),
   featureImageInput: () => page.getByLabelText(addFeatureImageLabel),

--- a/apps/admin/src/editor/publish/README.md
+++ b/apps/admin/src/editor/publish/README.md
@@ -108,6 +108,7 @@ Times are ISO 8601 strings with milliseconds zeroed, because the API stores seco
 - `scheduledAt` starts at that floor.
 - `setIsScheduled(true)` snaps a time that is earlier than ten minutes ahead of now forward to exactly that default; calling it with no argument toggles.
 - `setScheduledAt()` zeroes milliseconds and clamps anything before the floor up to it. An unparseable date is ignored.
+- The date and time fields commit at minute granularity, so a time the writer chooses carries no seconds of its own; an untouched default still carries the floor's.
 - `resetPastScheduledAt()` turns scheduling off when the chosen time has fallen into the past. It leaves the stale time in place: re-enabling scheduling snaps it forward to the default, so the stale value is never offered.
 
 ## Producing a save command

--- a/apps/admin/src/editor/publish/components/date-time-picker.tsx
+++ b/apps/admin/src/editor/publish/components/date-time-picker.tsx
@@ -29,6 +29,8 @@ export interface DateTimePickerProps {
   timeTestId: string;
   invalid?: boolean;
   describedBy?: string;
+  /** Names the pair as a group, for a caller whose own label is not on a field. */
+  labelledBy?: string;
   onChange: (date: Date) => void;
 }
 
@@ -48,6 +50,7 @@ export function DateTimePicker({
   timeTestId,
   invalid = false,
   describedBy,
+  labelledBy,
   onChange,
 }: DateTimePickerProps) {
   const current = moment.tz(value, timezone);
@@ -92,7 +95,7 @@ export function DateTimePicker({
   const describedByProps = describedBy ? { 'aria-describedby': describedBy } : {};
 
   return (
-    <Inline gap="sm">
+    <Inline aria-labelledby={labelledBy} gap="sm" role={labelledBy ? 'group' : undefined}>
       <Popover open={calendarOpen && !disabled} onOpenChange={setCalendarOpen}>
         <PopoverTrigger asChild>
           <Input

--- a/apps/admin/src/editor/publish/components/date-time-picker.tsx
+++ b/apps/admin/src/editor/publish/components/date-time-picker.tsx
@@ -74,17 +74,27 @@ export function DateTimePicker({
     });
 
     setCalendarOpen(false);
-    onChange(next.toDate());
+    if (!next.isSame(current, 'minute')) {
+      onChange(next.toDate());
+    }
   };
 
   const commitTime = (input: string) => {
+    if (timeDraft === null) {
+      return;
+    }
     const normalized = /^\d:\d\d$/.test(input) ? `0${input}` : input;
     const [hour, minute] = normalized.split(':').map((part) => parseInt(part, 10));
 
     // An unparseable time reverts to the current one, as the Ember field does.
     setTimeDraft(null);
 
-    if (!/^\d\d:\d\d$/.test(normalized) || hour > 23 || minute > 59) {
+    if (
+      !/^\d\d:\d\d$/.test(normalized) ||
+      hour > 23 ||
+      minute > 59 ||
+      normalized === current.format(TIME_FORMAT)
+    ) {
       return;
     }
 

--- a/apps/admin/src/editor/publish/components/date-time-picker.tsx
+++ b/apps/admin/src/editor/publish/components/date-time-picker.tsx
@@ -1,0 +1,141 @@
+import moment from 'moment-timezone';
+import {
+  Calendar,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@tryghost/shade/components';
+import { Inline, Text } from '@tryghost/shade/primitives';
+import { LucideIcon } from '@tryghost/shade/utils';
+import { useState } from 'react';
+import { siteCalendarDay } from '@/editor/publish/publish-copy';
+
+const DATE_FORMAT = 'YYYY-MM-DD';
+const TIME_FORMAT = 'HH:mm';
+
+export interface DateTimePickerProps {
+  /** The moment being edited, as an ISO instant. */
+  value: string;
+  timezone: string;
+  /** Calendar days before this instant's site-timezone day are not selectable. */
+  minDate?: string | null;
+  /** Calendar days after this instant's site-timezone day are not selectable. */
+  maxDate?: string | null;
+  disabled?: boolean;
+  dateLabel: string;
+  timeLabel: string;
+  dateTestId: string;
+  timeTestId: string;
+  invalid?: boolean;
+  describedBy?: string;
+  onChange: (date: Date) => void;
+}
+
+/**
+ * A date field, a time field and the site's timezone abbreviation. The writer
+ * edits in the site's timezone; the caller is handed a real instant.
+ */
+export function DateTimePicker({
+  value,
+  timezone,
+  minDate,
+  maxDate,
+  disabled = false,
+  dateLabel,
+  timeLabel,
+  dateTestId,
+  timeTestId,
+  invalid = false,
+  describedBy,
+  onChange,
+}: DateTimePickerProps) {
+  const current = moment.tz(value, timezone);
+  // Null while the field is not being edited, so caller-side changes show through.
+  const [timeDraft, setTimeDraft] = useState<string | null>(null);
+  const [calendarOpen, setCalendarOpen] = useState(false);
+
+  const commitDate = (selected: Date | undefined) => {
+    if (!selected) {
+      return;
+    }
+
+    // Read back the same way `siteCalendarDay` writes: local fields carry the
+    // site-timezone day.
+    const next = current.clone().set({
+      year: selected.getFullYear(),
+      month: selected.getMonth(),
+      date: selected.getDate(),
+      second: 0,
+      millisecond: 0,
+    });
+
+    setCalendarOpen(false);
+    onChange(next.toDate());
+  };
+
+  const commitTime = (input: string) => {
+    const normalized = /^\d:\d\d$/.test(input) ? `0${input}` : input;
+    const [hour, minute] = normalized.split(':').map((part) => parseInt(part, 10));
+
+    // An unparseable time reverts to the current one, as the Ember field does.
+    setTimeDraft(null);
+
+    if (!/^\d\d:\d\d$/.test(normalized) || hour > 23 || minute > 59) {
+      return;
+    }
+
+    onChange(current.clone().set({ hour, minute, second: 0, millisecond: 0 }).toDate());
+  };
+
+  const invalidProps = invalid ? { 'aria-invalid': true } : {};
+  const describedByProps = describedBy ? { 'aria-describedby': describedBy } : {};
+
+  return (
+    <Inline gap="sm">
+      <Popover open={calendarOpen && !disabled} onOpenChange={setCalendarOpen}>
+        <PopoverTrigger asChild>
+          <Input
+            aria-label={dateLabel}
+            data-testid={dateTestId}
+            disabled={disabled}
+            value={current.format(DATE_FORMAT)}
+            readOnly
+            {...invalidProps}
+            {...describedByProps}
+          />
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0">
+          <Calendar
+            captionLayout="dropdown-months"
+            // Opening on the selected date's month, never today's.
+            defaultMonth={siteCalendarDay(value, timezone)}
+            disabled={[
+              ...(minDate ? [{ before: siteCalendarDay(minDate, timezone) }] : []),
+              ...(maxDate ? [{ after: siteCalendarDay(maxDate, timezone) }] : []),
+            ]}
+            mode="single"
+            selected={siteCalendarDay(value, timezone)}
+            onSelect={commitDate}
+          />
+        </PopoverContent>
+      </Popover>
+      <Input
+        aria-label={timeLabel}
+        data-testid={timeTestId}
+        disabled={disabled}
+        value={timeDraft ?? current.format(TIME_FORMAT)}
+        onBlur={(event) => commitTime(event.target.value)}
+        onChange={(event) => setTimeDraft(event.target.value)}
+        {...invalidProps}
+        {...describedByProps}
+      />
+      <Inline className="shrink-0" gap="xs">
+        <LucideIcon.Clock className="size-4" />
+        <Text size="sm" tone="secondary">
+          {current.format('z')}
+        </Text>
+      </Inline>
+    </Inline>
+  );
+}

--- a/apps/admin/src/editor/publish/components/publish-at-options.tsx
+++ b/apps/admin/src/editor/publish/components/publish-at-options.tsx
@@ -34,18 +34,16 @@ export function PublishAtOptions({
       </RadioGroup>
 
       {state.isScheduled ? (
-        <Stack gap="sm">
-          <DateTimePicker
-            dateLabel="Publish date"
-            dateTestId={publishScheduleDate}
-            minDate={state.minScheduledAt}
-            timeLabel="Publish time"
-            timeTestId={publishScheduleTime}
-            timezone={timezone}
-            value={state.scheduledAt}
-            onChange={onSetScheduledAt}
-          />
-        </Stack>
+        <DateTimePicker
+          dateLabel="Publish date"
+          dateTestId={publishScheduleDate}
+          minDate={state.minScheduledAt}
+          timeLabel="Publish time"
+          timeTestId={publishScheduleTime}
+          timezone={timezone}
+          value={state.scheduledAt}
+          onChange={onSetScheduledAt}
+        />
       ) : null}
     </Stack>
   );

--- a/apps/admin/src/editor/publish/components/publish-at-options.tsx
+++ b/apps/admin/src/editor/publish/components/publish-at-options.tsx
@@ -1,23 +1,8 @@
-import moment from 'moment-timezone';
-import {
-  Calendar,
-  Input,
-  Label,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  RadioGroup,
-  RadioGroupItem,
-} from '@tryghost/shade/components';
-import { Inline, Stack, Text } from '@tryghost/shade/primitives';
-import { LucideIcon } from '@tryghost/shade/utils';
-import { useState } from 'react';
+import { Label, RadioGroup, RadioGroupItem } from '@tryghost/shade/components';
+import { Inline, Stack } from '@tryghost/shade/primitives';
 import { publishScheduleDate, publishScheduleTime } from '@tryghost/test-data/selectors/editor';
-import { siteCalendarDay } from '@/editor/publish/publish-copy';
+import { DateTimePicker } from '@/editor/publish/components/date-time-picker';
 import type { PublishOptionsState } from '@/editor/publish/publish-options';
-
-const DATE_FORMAT = 'YYYY-MM-DD';
-const TIME_FORMAT = 'HH:mm';
 
 export interface PublishAtOptionsProps {
   state: PublishOptionsState;
@@ -26,53 +11,12 @@ export interface PublishAtOptionsProps {
   onSetScheduledAt: (date: Date) => void;
 }
 
-/** The picker works in the site's timezone; the machine stores UTC. */
-function inSiteTimezone(iso: string, timezone: string): moment.Moment {
-  return moment.tz(iso, timezone);
-}
-
 export function PublishAtOptions({
   state,
   timezone,
   onToggleScheduled,
   onSetScheduledAt,
 }: PublishAtOptionsProps) {
-  const scheduled = inSiteTimezone(state.scheduledAt, timezone);
-  // Null while the field is not being edited, so machine-side changes show through.
-  const [timeDraft, setTimeDraft] = useState<string | null>(null);
-  const [calendarOpen, setCalendarOpen] = useState(false);
-
-  const commitDate = (selected: Date | undefined) => {
-    if (!selected) {
-      return;
-    }
-
-    // Read back the same way `siteCalendarDay` writes: local fields carry the
-    // site-timezone day.
-    const next = scheduled.clone().set({
-      year: selected.getFullYear(),
-      month: selected.getMonth(),
-      date: selected.getDate(),
-    });
-
-    setCalendarOpen(false);
-    onSetScheduledAt(next.toDate());
-  };
-
-  const commitTime = (value: string) => {
-    const normalized = /^\d:\d\d$/.test(value) ? `0${value}` : value;
-    const [hour, minute] = normalized.split(':').map((part) => parseInt(part, 10));
-
-    // An unparseable time reverts to the scheduled one, as the Ember field does.
-    setTimeDraft(null);
-
-    if (!/^\d\d:\d\d$/.test(normalized) || hour > 23 || minute > 59) {
-      return;
-    }
-
-    onSetScheduledAt(scheduled.clone().set({ hour, minute }).toDate());
-  };
-
   return (
     <Stack gap="md">
       <RadioGroup
@@ -91,42 +35,16 @@ export function PublishAtOptions({
 
       {state.isScheduled ? (
         <Stack gap="sm">
-          <Inline gap="sm">
-            <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
-              <PopoverTrigger asChild>
-                <Input
-                  aria-label="Publish date"
-                  data-testid={publishScheduleDate}
-                  value={scheduled.format(DATE_FORMAT)}
-                  readOnly
-                />
-              </PopoverTrigger>
-              <PopoverContent className="w-auto p-0">
-                <Calendar
-                  captionLayout="dropdown-months"
-                  // Opening on the selected date's month, never today's.
-                  defaultMonth={siteCalendarDay(state.scheduledAt, timezone)}
-                  disabled={{ before: siteCalendarDay(state.minScheduledAt, timezone) }}
-                  mode="single"
-                  selected={siteCalendarDay(state.scheduledAt, timezone)}
-                  onSelect={commitDate}
-                />
-              </PopoverContent>
-            </Popover>
-            <Input
-              aria-label="Publish time"
-              data-testid={publishScheduleTime}
-              value={timeDraft ?? scheduled.format(TIME_FORMAT)}
-              onBlur={(event) => commitTime(event.target.value)}
-              onChange={(event) => setTimeDraft(event.target.value)}
-            />
-            <Inline className="shrink-0" gap="xs">
-              <LucideIcon.Clock className="size-4" />
-              <Text size="sm" tone="secondary">
-                {scheduled.format('z')}
-              </Text>
-            </Inline>
-          </Inline>
+          <DateTimePicker
+            dateLabel="Publish date"
+            dateTestId={publishScheduleDate}
+            minDate={state.minScheduledAt}
+            timeLabel="Publish time"
+            timeTestId={publishScheduleTime}
+            timezone={timezone}
+            value={state.scheduledAt}
+            onChange={onSetScheduledAt}
+          />
         </Stack>
       ) : null}
     </Stack>

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -112,7 +112,7 @@ export interface EditorSession {
    * Stages the publish time. It is the save engine's command target rather than
    * a settings field, so it has its own writer instead of `patchFields`.
    */
-  editPublishedAt: (publishedAt: string | null) => void;
+  editPublishedAt: (publishedAt: string) => void;
   /** The publish time the writer is looking at, staged edit included. */
   getPublishedAt: () => string | null;
   /** The one save policy gate for settings fields; see the README. */
@@ -139,6 +139,19 @@ export interface EditorSession {
   reauthAbandoned: () => void;
   leaveRequested: () => Promise<LeaveDecision>;
   dispose: () => void;
+}
+
+/**
+ * Whether two publish times name the same minute. The fields commit at minute
+ * granularity, so the seconds a save stamped are not a difference the writer made.
+ */
+function sameMinute(left: string | null, right: string | null): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  const a = Date.parse(left);
+  const b = Date.parse(right);
+  return !Number.isNaN(a) && !Number.isNaN(b) && Math.floor(a / 60000) === Math.floor(b / 60000);
 }
 
 /** Whether a record's collision token predates the one already held. */
@@ -170,7 +183,7 @@ export function createEditorSession({
   let status: PostStatus = record?.status ?? 'draft';
   let publishedAt: string | null = record?.published_at ?? null;
   // The publish time the writer moved to, or null when they have not moved it.
-  let stagedPublishedAt: { value: string | null } | null = null;
+  let stagedPublishedAt: string | null = null;
   let publishedAtEditedAt = 0;
   let live: EditablePostProjection = record ? projectionOf(record) : newPostProjection();
   let latestRevision: RevisionProjection | null = latestRevisionOf(record);
@@ -185,7 +198,7 @@ export function createEditorSession({
   let inFlightSince: number | null = null;
 
   function livePublishedAt(): string | null {
-    return stagedPublishedAt ? stagedPublishedAt.value : publishedAt;
+    return stagedPublishedAt ?? publishedAt;
   }
 
   const tracker = createChangeTracker({ siteUrl });
@@ -583,9 +596,13 @@ export function createEditorSession({
     // Staged rather than patched: the engine reads the publish time off the
     // snapshot, so a status command's own target still wins over this.
     editPublishedAt: (next) => {
-      const normalized = zeroMilliseconds(next);
-      stagedPublishedAt =
-        normalized === zeroMilliseconds(publishedAt) ? null : { value: normalized };
+      // The saved seconds are kept when the chosen minute is the one already
+      // saved, so returning to it is not an edit and cannot backdate the post.
+      const staged = sameMinute(next, publishedAt) ? null : zeroMilliseconds(next);
+      if (staged === stagedPublishedAt) {
+        return;
+      }
+      stagedPublishedAt = staged;
       version += 1;
       publishedAtEditedAt = version;
       dirtyChanged();
@@ -633,7 +650,7 @@ export function createEditorSession({
       identity = { id: next.id, updatedAt };
       status = next.status ?? status;
       publishedAt = next.published_at ?? null;
-      if (stagedPublishedAt && stagedPublishedAt.value === zeroMilliseconds(publishedAt)) {
+      if (sameMinute(stagedPublishedAt, publishedAt)) {
         stagedPublishedAt = null;
       }
       latestRevision = latestRevisionOf(next);

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_TITLE,
   createSaveEngine,
   isCollisionToken,
+  isStatusIntent,
+  zeroMilliseconds,
   type LeaveDecision,
   type PersistedIdentity,
   type PostStatus,
@@ -28,8 +30,10 @@ import { createSlugPort } from './slug-port';
 import { buildSaveSnapshot, type EditorSaveSnapshot } from './snapshot';
 import { latestRevisionOf, newPostProjection, projectionOf, type EditorRecord } from './projection';
 import {
+  PUBLISHED_AT_MUST_BE_PAST,
   SETTINGS_FIELD_KEYS,
   TIERS_REQUIRED,
+  publishedAtInFuture,
   tiersIncomplete,
   type EditorSettingsPatch,
   type SettingsFieldKey,
@@ -104,6 +108,13 @@ export interface EditorSession {
   patchFields: (patch: EditorSettingsPatch) => void;
   /** The live value of every settings field, for the sidebar's inputs. */
   getFields: () => EditablePostProjection;
+  /**
+   * Stages the publish time. It is the save engine's command target rather than
+   * a settings field, so it has its own writer instead of `patchFields`.
+   */
+  editPublishedAt: (publishedAt: string | null) => void;
+  /** The publish time the writer is looking at, staged edit included. */
+  getPublishedAt: () => string | null;
   /** The one save policy gate for settings fields; see the README. */
   commitField: () => void;
   /** The slug the machine holds, which a title commit moves without a field patch. */
@@ -158,6 +169,9 @@ export function createEditorSession({
     : { id: null, updatedAt: null };
   let status: PostStatus = record?.status ?? 'draft';
   let publishedAt: string | null = record?.published_at ?? null;
+  // The publish time the writer moved to, or null when they have not moved it.
+  let stagedPublishedAt: { value: string | null } | null = null;
+  let publishedAtEditedAt = 0;
   let live: EditablePostProjection = record ? projectionOf(record) : newPostProjection();
   let latestRevision: RevisionProjection | null = latestRevisionOf(record);
   let version = 0;
@@ -169,6 +183,10 @@ export function createEditorSession({
   const writerEdits = new Map<SettingsFieldKey, number>();
   // The version the in-flight request was built at, or null when none is.
   let inFlightSince: number | null = null;
+
+  function livePublishedAt(): string | null {
+    return stagedPublishedAt ? stagedPublishedAt.value : publishedAt;
+  }
 
   const tracker = createChangeTracker({ siteUrl });
   tracker.load(identity.id, live);
@@ -281,7 +299,8 @@ export function createEditorSession({
     return buildSaveSnapshot({
       identity,
       status,
-      publishedAt,
+      publishedAt: livePublishedAt(),
+      publishedAtDirty: stagedPublishedAt !== null,
       title: live.title,
       slug: machine.getState().slug,
       slugIsCustom: machine.getState().mode === 'custom',
@@ -381,6 +400,14 @@ export function createEditorSession({
     if (tiersIncomplete(prepared.access)) {
       return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
     }
+    // A status command carries its own deliberate publish time; only the time
+    // the sidebar staged is checked here.
+    if (
+      !isStatusIntent(prepared.command.kind) &&
+      publishedAtInFuture(prepared.target.status, prepared.target.publishedAt)
+    ) {
+      return { ok: false, error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST } };
+    }
 
     inFlightSince = prepared.builtAtVersion;
     try {
@@ -442,6 +469,9 @@ export function createEditorSession({
     identity = { id: result.id, updatedAt: result.updatedAt };
     status = result.status;
     publishedAt = result.post.published_at ?? null;
+    if (publishedAtEditedAt <= prepared.builtAtVersion) {
+      stagedPublishedAt = null;
+    }
     latestRevision = latestRevisionOf(result.post);
     live = { ...live, updated_at: result.updatedAt };
 
@@ -473,7 +503,11 @@ export function createEditorSession({
   function commitField(): void {
     // execute() refuses an incomplete tier pairing on every path; this only
     // keeps a field save from being dispatched for it.
-    if (status !== 'draft' || tiersIncomplete(live)) {
+    if (
+      status !== 'draft' ||
+      tiersIncomplete(live) ||
+      publishedAtInFuture(status, livePublishedAt())
+    ) {
       return;
     }
     void engine.dispatch('field');
@@ -529,6 +563,7 @@ export function createEditorSession({
     getSaveSnapshot: getSnapshot,
     isDirty: () => getSnapshot().isDirty,
     hasUnsavedContent: () =>
+      stagedPublishedAt !== null ||
       pendingSlugEdits.size > 0 ||
       tracker.verdict().reasons.some((reason) => reason.code !== 'POST_HAS_ERROR'),
 
@@ -544,6 +579,18 @@ export function createEditorSession({
     commitField,
     getSlug: () => machine.getState().slug,
     editSlug,
+
+    // Staged rather than patched: the engine reads the publish time off the
+    // snapshot, so a status command's own target still wins over this.
+    editPublishedAt: (next) => {
+      const normalized = zeroMilliseconds(next);
+      stagedPublishedAt =
+        normalized === zeroMilliseconds(publishedAt) ? null : { value: normalized };
+      version += 1;
+      publishedAtEditedAt = version;
+      dirtyChanged();
+    },
+    getPublishedAt: livePublishedAt,
     patchLexical: (lexical) => patchLive({ lexical: JSON.stringify(lexical) }),
     setBaseline: (lexical) => {
       tracker.setBaseline(identity.id, lexical);
@@ -586,6 +633,9 @@ export function createEditorSession({
       identity = { id: next.id, updatedAt };
       status = next.status ?? status;
       publishedAt = next.published_at ?? null;
+      if (stagedPublishedAt && stagedPublishedAt.value === zeroMilliseconds(publishedAt)) {
+        stagedPublishedAt = null;
+      }
       latestRevision = latestRevisionOf(next);
       dirtyChanged();
       return true;
@@ -612,6 +662,8 @@ export function createEditorSession({
       publishedAt = next.published_at ?? null;
       latestRevision = latestRevisionOf(next);
       live = projectionOf(next);
+      stagedPublishedAt = null;
+      publishedAtEditedAt = 0;
       pendingSlugEdits.clear();
       writerEdits.clear();
       inFlightSince = null;

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_TITLE,
   createSaveEngine,
   isCollisionToken,
-  isStatusIntent,
   zeroMilliseconds,
   type LeaveDecision,
   type PersistedIdentity,
@@ -413,12 +412,10 @@ export function createEditorSession({
     if (tiersIncomplete(prepared.access)) {
       return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
     }
-    // A status command carries its own deliberate publish time; only the time
-    // the sidebar staged is checked here.
-    if (
-      !isStatusIntent(prepared.command.kind) &&
-      publishedAtInFuture(prepared.target.status, prepared.target.publishedAt)
-    ) {
+    // Every request, a status command included: a publish or revert with no
+    // explicit time of its own falls back to whatever the sidebar staged, and
+    // Core validates the publish time for scheduled posts only.
+    if (publishedAtInFuture(prepared.target.status, prepared.target.publishedAt)) {
       return { ok: false, error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST } };
     }
 

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -181,7 +181,7 @@ export function createEditorSession({
     : { id: null, updatedAt: null };
   let status: PostStatus = record?.status ?? 'draft';
   let publishedAt: string | null = record?.published_at ?? null;
-  // The publish time the writer moved to, or null when they have not moved it.
+  // Retain the writer's choice through older saves, even when it matches a refetch.
   let stagedPublishedAt: string | null = null;
   let publishedAtEditedAt = 0;
   let live: EditablePostProjection = record ? projectionOf(record) : newPostProjection();
@@ -198,6 +198,15 @@ export function createEditorSession({
 
   function livePublishedAt(): string | null {
     return stagedPublishedAt ?? publishedAt;
+  }
+
+  function releaseSavedPublishTime(): void {
+    if (
+      sameMinute(stagedPublishedAt, publishedAt) &&
+      (inFlightSince === null || publishedAtEditedAt <= inFlightSince)
+    ) {
+      stagedPublishedAt = null;
+    }
   }
 
   const tracker = createChangeTracker({ siteUrl });
@@ -429,6 +438,7 @@ export function createEditorSession({
 
       if (!saved) {
         inFlightSince = null;
+        releaseSavedPublishTime();
         return { ok: false, error: { kind: 'unknown', message: saveFailureMessage } };
       }
 
@@ -443,6 +453,7 @@ export function createEditorSession({
       };
     } catch (error) {
       inFlightSince = null;
+      releaseSavedPublishTime();
       return { ok: false, error: toSaveError(error, saveFailureMessage) };
     }
   }
@@ -484,6 +495,7 @@ export function createEditorSession({
     if (publishedAtEditedAt <= prepared.builtAtVersion) {
       stagedPublishedAt = null;
     }
+    releaseSavedPublishTime();
     latestRevision = latestRevisionOf(result.post);
     live = { ...live, updated_at: result.updatedAt };
 
@@ -595,15 +607,15 @@ export function createEditorSession({
     // Staged rather than patched: the engine reads the publish time off the
     // snapshot, so a status command's own target still wins over this.
     editPublishedAt: (next) => {
-      // The saved seconds are kept when the chosen minute is the one already
-      // saved, so returning to it is not an edit and cannot backdate the post.
-      const staged = sameMinute(next, publishedAt) ? null : zeroMilliseconds(next);
-      if (staged === stagedPublishedAt) {
+      if (sameMinute(next, livePublishedAt())) {
         return;
       }
-      stagedPublishedAt = staged;
+      // The saved seconds are kept when the chosen minute is the one already
+      // saved. An undo still needs its value until an older save has settled.
+      stagedPublishedAt = sameMinute(next, publishedAt) ? publishedAt : zeroMilliseconds(next);
       version += 1;
       publishedAtEditedAt = version;
+      releaseSavedPublishTime();
       dirtyChanged();
     },
     getPublishedAt: livePublishedAt,
@@ -649,9 +661,7 @@ export function createEditorSession({
       identity = { id: next.id, updatedAt };
       status = next.status ?? status;
       publishedAt = next.published_at ?? null;
-      if (sameMinute(stagedPublishedAt, publishedAt)) {
-        stagedPublishedAt = null;
-      }
+      releaseSavedPublishTime();
       latestRevision = latestRevisionOf(next);
       dirtyChanged();
       return true;

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -412,10 +412,12 @@ export function createEditorSession({
     if (tiersIncomplete(prepared.access)) {
       return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
     }
-    // Every request, a status command included: a publish or revert with no
-    // explicit time of its own falls back to whatever the sidebar staged, and
-    // Core validates the publish time for scheduled posts only.
-    if (publishedAtInFuture(prepared.target.status, prepared.target.publishedAt)) {
+    // A status command with no time of its own carries whatever the sidebar
+    // staged; Core validates the publish time for scheduled posts only.
+    if (
+      prepared.target.publishedAt !== publishedAt &&
+      publishedAtInFuture(prepared.target.status, prepared.target.publishedAt)
+    ) {
       return { ok: false, error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST } };
     }
 

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -185,6 +185,53 @@ describe('staging the publish time', () => {
     });
   });
 
+  it('publishes at a staged time the writer backdated to', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+
+    session.editPublishedAt(PAST);
+
+    expect(await session.dispatchPublish()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[0][0]).toMatchObject({ published_at: PAST, status: 'published' });
+  });
+
+  it('refuses to publish at a staged time that has not passed', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+
+    session.editPublishedAt(future());
+
+    expect(await session.dispatchPublish()).toMatchObject({
+      kind: 'failed',
+      error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST },
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to unpublish into a staged time that has not passed', async () => {
+    const { session, update } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(future());
+
+    expect(await session.dispatchRevert()).toMatchObject({
+      kind: 'failed',
+      error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST },
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('schedules at the flow’s time and releases the one the sidebar staged', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+    const scheduledAt = future();
+
+    session.editPublishedAt(PAST);
+    expect(await session.dispatchSchedule({ publishedAt: scheduledAt })).toMatchObject({
+      kind: 'saved',
+    });
+
+    expect(update.mock.calls[0][0]).toMatchObject({ published_at: scheduledAt });
+    expect(session.getPublishedAt()).toBe(scheduledAt);
+    expect(session.isDirty()).toBe(false);
+  });
+
   it('keeps a staged time through a refetch that does not carry it', () => {
     const { session } = publishTimeSession('published', PAST);
 

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -206,6 +206,17 @@ describe('staging the publish time', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('publishes a scheduled post at the time it already carries', async () => {
+    const scheduledAt = future();
+    const { session, update } = publishTimeSession('scheduled', scheduledAt);
+
+    expect(await session.dispatchPublish()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[0][0]).toMatchObject({
+      published_at: scheduledAt,
+      status: 'published',
+    });
+  });
+
   it('refuses to unpublish into a staged time that has not passed', async () => {
     const { session, update } = publishTimeSession('published', PAST);
 

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEditorSession, type EditorWritePayload } from './editor-session';
+import type { EditorRecord } from './projection';
+import { PUBLISHED_AT_MUST_BE_PAST, publishedAtInFuture } from './settings-fields';
+
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const PAST = '2020-06-01T10:00:00.000Z';
+const OLDER = '2019-03-04T08:30:00.000Z';
+
+/** Milliseconds zeroed, as the engine's own target is. */
+function future(): string {
+  const time = Date.now() + 60 * 60 * 1000;
+  return new Date(time - (time % 1000)).toISOString();
+}
+
+function publishTimeSession(status: EditorRecord['status'], publishedAt: string | null) {
+  let saved: EditorRecord = {
+    id: 'post-id',
+    uuid: 'post-uuid',
+    url: 'https://example.com/post/',
+    title: 'Post',
+    slug: 'post',
+    status,
+    visibility: 'public',
+    tiers: [],
+    lexical: null,
+    updated_at: LOADED_AT,
+    published_at: publishedAt,
+    tags: [],
+  };
+  let saves = 0;
+  const persist = (payload: EditorWritePayload) => {
+    saves += 1;
+    saved = { ...saved, ...payload, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return Promise.resolve(saved);
+  };
+  const create = vi.fn(persist);
+  const update = vi.fn(persist);
+  const session = createEditorSession({
+    record: saved,
+    saveFailureMessage: 'Saving failed',
+    onIdAcquired: vi.fn(),
+    onError: vi.fn(),
+    transport: { create, update, generateSlug: () => Promise.resolve('post') },
+  });
+  session.setBaseline(null);
+  return { session, create, update };
+}
+
+describe('publishedAtInFuture', () => {
+  it.each(['draft', 'published'] as const)(
+    'refuses a %s post a publish time yet to come',
+    (status) => {
+      expect(publishedAtInFuture(status, '2026-01-02T00:00:00.000Z', Date.parse(LOADED_AT))).toBe(
+        true,
+      );
+    },
+  );
+
+  it.each(['draft', 'published'] as const)(
+    'accepts a %s post a publish time in the past',
+    (status) => {
+      expect(publishedAtInFuture(status, PAST, Date.parse(LOADED_AT))).toBe(false);
+    },
+  );
+
+  it('refuses the current instant, as Ember’s isSameOrAfter does', () => {
+    expect(publishedAtInFuture('draft', LOADED_AT, Date.parse(LOADED_AT))).toBe(true);
+  });
+
+  it.each(['scheduled', 'sent'] as const)('leaves a %s post’s publish time alone', (status) => {
+    expect(publishedAtInFuture(status, '2026-01-02T00:00:00.000Z', Date.parse(LOADED_AT))).toBe(
+      false,
+    );
+  });
+
+  it('has nothing to check without a publish time', () => {
+    expect(publishedAtInFuture('draft', null, Date.parse(LOADED_AT))).toBe(false);
+  });
+});
+
+describe('staging the publish time', () => {
+  it('sends a draft’s edited publish time as a UTC instant', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+
+    session.editPublishedAt(PAST);
+    expect(session.getPublishedAt()).toBe(PAST);
+    expect(session.isDirty()).toBe(true);
+
+    expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[0][0]).toMatchObject({ published_at: PAST, status: 'draft' });
+    expect(session.isDirty()).toBe(false);
+  });
+
+  it('re-times a published post without moving its status', async () => {
+    const { session, update } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(OLDER);
+
+    expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[0][0]).toMatchObject({ published_at: OLDER, status: 'published' });
+  });
+
+  it('is clean again once the writer returns the saved time', () => {
+    const { session } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(OLDER);
+    expect(session.isDirty()).toBe(true);
+
+    session.editPublishedAt(PAST);
+    expect(session.isDirty()).toBe(false);
+    expect(session.hasUnsavedContent()).toBe(false);
+  });
+
+  it('counts a staged time as the writer’s unsaved work', () => {
+    const { session } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(OLDER);
+
+    expect(session.hasUnsavedContent()).toBe(true);
+  });
+
+  it('refuses a save whose publish time has not passed', async () => {
+    const { session, update } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(future());
+
+    expect(await session.dispatchExplicit()).toMatchObject({
+      kind: 'failed',
+      error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST },
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('holds back a draft’s field save while the publish time has not passed', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+
+    session.editPublishedAt(future());
+    session.commitField();
+    await Promise.resolve();
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('leaves a status command’s own publish time untouched', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+    const scheduledAt = future();
+
+    expect(await session.dispatchSchedule({ publishedAt: scheduledAt })).toMatchObject({
+      kind: 'saved',
+    });
+    expect(update.mock.calls[0][0]).toMatchObject({
+      published_at: scheduledAt,
+      status: 'scheduled',
+    });
+  });
+
+  it('keeps a staged time through a refetch that does not carry it', () => {
+    const { session } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(OLDER);
+    session.recordRefetched({
+      id: 'post-id',
+      uuid: 'post-uuid',
+      url: 'https://example.com/post/',
+      title: 'Post',
+      slug: 'post',
+      status: 'published',
+      lexical: null,
+      updated_at: '2026-01-01T00:00:05.000Z',
+      published_at: PAST,
+      tags: [],
+    });
+
+    expect(session.getPublishedAt()).toBe(OLDER);
+    expect(session.isDirty()).toBe(true);
+  });
+
+  it('releases a staged time a refetch has caught up with', () => {
+    const { session } = publishTimeSession('published', PAST);
+
+    session.editPublishedAt(OLDER);
+    session.recordRefetched({
+      id: 'post-id',
+      uuid: 'post-uuid',
+      url: 'https://example.com/post/',
+      title: 'Post',
+      slug: 'post',
+      status: 'published',
+      lexical: null,
+      updated_at: '2026-01-01T00:00:05.000Z',
+      published_at: OLDER,
+      tags: [],
+    });
+
+    expect(session.isDirty()).toBe(false);
+  });
+});

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -6,6 +6,9 @@ import { PUBLISHED_AT_MUST_BE_PAST, publishedAtInFuture } from './settings-field
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PAST = '2020-06-01T10:00:00.000Z';
 const OLDER = '2019-03-04T08:30:00.000Z';
+// What a real publish stamps: the same minute as PAST, with seconds of its own.
+const STAMPED = '2020-06-01T10:00:37.000Z';
+const NEXT_MINUTE = '2020-06-01T10:01:00.000Z';
 
 /** Milliseconds zeroed, as the engine's own target is. */
 function future(): string {
@@ -110,6 +113,31 @@ describe('staging the publish time', () => {
     session.editPublishedAt(PAST);
     expect(session.isDirty()).toBe(false);
     expect(session.hasUnsavedContent()).toBe(false);
+  });
+
+  it('keeps the stored seconds when the field returns the minute already saved', async () => {
+    const { session, update } = publishTimeSession('published', STAMPED);
+
+    // What the field commits on blur: the same minute, with seconds zeroed.
+    session.editPublishedAt(PAST);
+
+    expect(session.getPublishedAt()).toBe(STAMPED);
+    expect(session.isDirty()).toBe(false);
+    expect(session.hasUnsavedContent()).toBe(false);
+
+    session.commitField();
+    await Promise.resolve();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('sends the chosen minute once the writer moves off the saved one', async () => {
+    const { session, update } = publishTimeSession('published', STAMPED);
+
+    session.editPublishedAt(NEXT_MINUTE);
+    expect(session.isDirty()).toBe(true);
+
+    expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[0][0]).toMatchObject({ published_at: NEXT_MINUTE });
   });
 
   it('counts a staged time as the writer’s unsaved work', () => {

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -140,6 +140,8 @@ describe('staging the publish time', () => {
     await Promise.resolve();
 
     expect(update).not.toHaveBeenCalled();
+    // Staged, not attempted: no save the writer did not ask for may fail.
+    expect(session.getState().kind).toBe('idle');
   });
 
   it('leaves a status command’s own publish time untouched', async () => {

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createEditorSession, type EditorWritePayload } from './editor-session';
 import type { EditorRecord } from './projection';
 import { PUBLISHED_AT_MUST_BE_PAST, publishedAtInFuture } from './settings-fields';
+import { deferred } from '@/utils/deferred';
 
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PAST = '2020-06-01T10:00:00.000Z';
@@ -128,6 +129,126 @@ describe('staging the publish time', () => {
     session.commitField();
     await Promise.resolve();
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('preserves an undo and its stored seconds through an older save', async () => {
+    const { session, update } = publishTimeSession('published', STAMPED);
+    const pending = deferred<void>();
+    const persist = update.getMockImplementation()!;
+    update.mockImplementationOnce(async (payload) => {
+      await pending.promise;
+      return persist(payload);
+    });
+
+    session.editPublishedAt(OLDER);
+    const save = session.dispatchExplicit();
+    await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    session.editPublishedAt(PAST);
+
+    expect(session.hasUnsavedContent()).toBe(true);
+    pending.resolve();
+    expect(await save).toMatchObject({ kind: 'saved' });
+    expect(session.getPublishedAt()).toBe(STAMPED);
+    expect(session.isDirty()).toBe(true);
+
+    expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[1][0].published_at).toBe(STAMPED);
+    expect(session.isDirty()).toBe(false);
+  });
+
+  it('retains a newer time through a matching refetch and an older save', async () => {
+    const { session, update } = publishTimeSession('published', PAST);
+    const pending = deferred<void>();
+    const persist = update.getMockImplementation()!;
+    update.mockImplementationOnce(async (payload) => {
+      await pending.promise;
+      return persist(payload);
+    });
+
+    session.patchFields({ custom_excerpt: 'An unrelated edit' });
+    const save = session.dispatchExplicit();
+    await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    session.editPublishedAt(OLDER);
+    session.recordRefetched({
+      id: 'post-id',
+      uuid: 'post-uuid',
+      url: 'https://example.com/post/',
+      title: 'Post',
+      slug: 'post',
+      status: 'published',
+      lexical: null,
+      updated_at: '2026-01-01T00:00:01.000Z',
+      published_at: OLDER,
+      tags: [],
+    });
+
+    pending.resolve();
+    expect(await save).toMatchObject({ kind: 'saved' });
+    expect(session.getPublishedAt()).toBe(OLDER);
+    expect(session.isDirty()).toBe(true);
+
+    expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+    expect(update.mock.calls[1][0].published_at).toBe(OLDER);
+    expect(session.isDirty()).toBe(false);
+  });
+
+  it('releases a newer edit when the save already carries its time', async () => {
+    const { session, update } = publishTimeSession('published', PAST);
+    const pending = deferred<void>();
+    const persist = update.getMockImplementation()!;
+    update.mockImplementationOnce(async (payload) => {
+      await pending.promise;
+      return persist(payload);
+    });
+
+    session.editPublishedAt(OLDER);
+    const save = session.dispatchExplicit();
+    await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    session.editPublishedAt(PAST);
+    session.editPublishedAt(OLDER);
+
+    pending.resolve();
+    expect(await save).toMatchObject({ kind: 'saved' });
+    expect(session.getPublishedAt()).toBe(OLDER);
+    expect(session.isDirty()).toBe(false);
+    expect(session.hasUnsavedContent()).toBe(false);
+  });
+
+  it('releases an undo when the older save fails', async () => {
+    const { session, update } = publishTimeSession('published', STAMPED);
+    const pending = deferred<EditorRecord>();
+    update.mockImplementationOnce(() => pending.promise);
+
+    session.editPublishedAt(OLDER);
+    const save = session.dispatchExplicit();
+    await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    session.editPublishedAt(PAST);
+
+    pending.reject(new Error('Offline'));
+    expect(await save).toMatchObject({ kind: 'failed' });
+    expect(session.getPublishedAt()).toBe(STAMPED);
+    expect(session.hasUnsavedContent()).toBe(false);
+  });
+
+  it('does not let an unchanged sidebar value override an in-flight schedule', async () => {
+    const { session, update } = publishTimeSession('draft', null);
+    const scheduledAt = future();
+    const pending = deferred<void>();
+    const persist = update.getMockImplementation()!;
+    update.mockImplementationOnce(async (payload) => {
+      await pending.promise;
+      return persist(payload);
+    });
+
+    session.editPublishedAt(PAST);
+    const save = session.dispatchSchedule({ publishedAt: scheduledAt });
+    await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    session.editPublishedAt(PAST);
+
+    pending.resolve();
+    expect(await save).toMatchObject({ kind: 'saved' });
+    expect(session.getPublishedAt()).toBe(scheduledAt);
+    expect(session.isDirty()).toBe(false);
   });
 
   it('sends the chosen minute once the writer moves off the saved one', async () => {

--- a/apps/admin/src/editor/session/settings-fields.ts
+++ b/apps/admin/src/editor/session/settings-fields.ts
@@ -1,4 +1,5 @@
 import type { EditablePostProjection } from '@/editor/engine/change-tracker';
+import type { PostStatus } from '@/editor/engine/save-engine';
 
 /**
  * The projection keys the settings sidebar may write. Slug, status and publish
@@ -40,4 +41,20 @@ export function tiersIncomplete(
   fields: Pick<EditorSettingsFields, 'visibility' | 'tiers'>,
 ): boolean {
   return fields.visibility === 'tiers' && fields.tiers.length === 0;
+}
+
+/** Ember's post validator refuses the same publish time (validators/post.js). */
+export const PUBLISHED_AT_MUST_BE_PAST = 'Please choose a past date and time.';
+
+/** A draft's or published post's publish time may not be now or later. */
+export function publishedAtInFuture(
+  status: PostStatus,
+  publishedAt: string | null,
+  now: number = Date.now(),
+): boolean {
+  if (publishedAt === null || (status !== 'draft' && status !== 'published')) {
+    return false;
+  }
+  const time = Date.parse(publishedAt);
+  return !Number.isNaN(time) && time >= now;
 }

--- a/apps/admin/src/editor/session/snapshot.test.ts
+++ b/apps/admin/src/editor/session/snapshot.test.ts
@@ -14,6 +14,7 @@ function sources(overrides: Partial<SnapshotSources> = {}): SnapshotSources {
     identity: { id: 'abc', updatedAt: '2026-01-01T00:00:00.000Z' },
     status: 'draft',
     publishedAt: null,
+    publishedAtDirty: false,
     title: 'Hello',
     slug: 'hello',
     slugIsCustom: false,

--- a/apps/admin/src/editor/session/snapshot.ts
+++ b/apps/admin/src/editor/session/snapshot.ts
@@ -10,6 +10,8 @@ export interface SnapshotSources {
   identity: PersistedIdentity;
   status: PostStatus;
   publishedAt: string | null;
+  /** The writer moved the publish time past the saved one; the tracker does not carry it. */
+  publishedAtDirty: boolean;
   title: string;
   slug: string;
   slugIsCustom: boolean;
@@ -22,6 +24,7 @@ export function buildSaveSnapshot({
   identity,
   status,
   publishedAt,
+  publishedAtDirty,
   title,
   slug,
   slugIsCustom,
@@ -35,7 +38,7 @@ export function buildSaveSnapshot({
     title,
     slug,
     slugIsCustom,
-    isDirty: verdict.dirty,
+    isDirty: verdict.dirty || publishedAtDirty,
     titleDirty: verdict.reasons.some((reason) => reason.code === 'POST_TITLE_DIVERGED'),
     changedSinceLastRevision,
     version,

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -33,6 +33,7 @@ import {
   isCollisionToken,
   type LeaveDecision,
   type SaveCompletion,
+  type PostStatus,
   type SaveEngineState,
 } from '@/editor/engine/save-engine';
 import type { LexicalInput } from '@/editor/engine/lexical-compare';
@@ -109,6 +110,10 @@ export interface EditorSessionHandle {
   slug: string;
   /** Routes a manual slug edit through the slug machine, then the save policy. */
   editSlug: EditorSession['editSlug'];
+  /** The status and publish time the sidebar's date field reads. */
+  publishTime: PublishTimeView;
+  /** Stages the publish time, then applies the sidebar's save policy. */
+  editPublishedAt: (publishedAt: string | null) => void;
   /** The post as the engine reads it: identity, status, publish time and title. */
   getSaveSnapshot: EditorSession['getSaveSnapshot'];
   /** The body the writer is looking at, which a save has not necessarily seen yet. */
@@ -131,6 +136,20 @@ export interface UseEditorSessionOptions {
   siteUrl: string;
   /** Authors a post this session creates. */
   currentUserId?: string;
+}
+
+export interface PublishTimeView {
+  status: PostStatus;
+  publishedAt: string | null;
+}
+
+function publishTimeOf(session: EditorSession): PublishTimeView {
+  const snapshot = session.getSaveSnapshot();
+  return { status: snapshot.status, publishedAt: snapshot.publishedAt };
+}
+
+function samePublishTime(a: PublishTimeView, b: PublishTimeView): boolean {
+  return a.status === b.status && a.publishedAt === b.publishedAt;
 }
 
 function settingsFieldsOf(projection: EditorSettingsFields): EditorSettingsFields {
@@ -247,10 +266,23 @@ export function useEditorSession({
     settingsFieldsOf(session.getFields()),
   );
 
+  // The engine's own status and publish time, mirrored for the same reason the
+  // settings fields are: an edit is not an engine state change.
+  const [publishTime, setPublishTime] = useState<PublishTimeView>(() => publishTimeOf(session));
+
   const editSettings = useCallback(
     (patch: EditorSettingsPatch) => {
       session.patchFields(patch);
       setSettings(settingsFieldsOf(session.getFields()));
+      session.commitField();
+    },
+    [session],
+  );
+
+  const editPublishedAt = useCallback(
+    (next: string | null) => {
+      session.editPublishedAt(next);
+      setPublishTime(publishTimeOf(session));
       session.commitField();
     },
     [session],
@@ -264,6 +296,8 @@ export function useEditorSession({
       SETTINGS_FIELD_KEYS.every((key) => current[key] === next[key]) ? current : next,
     );
     setExcerpt(next.custom_excerpt ?? '');
+    const time = publishTimeOf(session);
+    setPublishTime((current) => (samePublishTime(current, time) ? current : time));
   }, [session, state]);
 
   // The saved record: the same query key the screen loaded with, so an existing
@@ -293,6 +327,7 @@ export function useEditorSession({
       const fields = session.getFields();
       setSettings(settingsFieldsOf(fields));
       setExcerpt(fields.custom_excerpt ?? '');
+      setPublishTime(publishTimeOf(session));
     }
   }, [saved, session]);
 
@@ -344,6 +379,7 @@ export function useEditorSession({
     setTitle(fresh.title === DEFAULT_TITLE ? '' : fresh.title);
     setExcerpt(fresh.custom_excerpt ?? '');
     setSettings(settingsFieldsOf(session.getFields()));
+    setPublishTime(publishTimeOf(session));
     setInitialLexical(fresh.lexical ?? null);
     setLoadedRecord(fresh);
     setContentKey((key) => key + 1);
@@ -435,6 +471,8 @@ export function useEditorSession({
     editSettings,
     slug,
     editSlug: session.editSlug,
+    publishTime,
+    editPublishedAt,
     getSaveSnapshot: session.getSaveSnapshot,
     getLiveLexical: session.getLiveLexical,
     dispatchField: session.dispatchField,

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -113,7 +113,7 @@ export interface EditorSessionHandle {
   /** The status and publish time the sidebar's date field reads. */
   publishTime: PublishTimeView;
   /** Stages the publish time, then applies the sidebar's save policy. */
-  editPublishedAt: (publishedAt: string | null) => void;
+  editPublishedAt: (publishedAt: string) => void;
   /** The post as the engine reads it: identity, status, publish time and title. */
   getSaveSnapshot: EditorSession['getSaveSnapshot'];
   /** The body the writer is looking at, which a save has not necessarily seen yet. */
@@ -280,9 +280,15 @@ export function useEditorSession({
   );
 
   const editPublishedAt = useCallback(
-    (next: string | null) => {
+    (next: string) => {
+      const before = publishTimeOf(session);
       session.editPublishedAt(next);
-      setPublishTime(publishTimeOf(session));
+      const after = publishTimeOf(session);
+      // The field commits on blur, so most commits carry the time already held.
+      if (samePublishTime(before, after)) {
+        return;
+      }
+      setPublishTime(after);
       session.commitField();
     },
     [session],

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -131,13 +131,18 @@ an edit stages a value, so an untouched draft still leaves the time to the
 server. The date is chosen from a calendar and the time typed as `HH:mm`; an
 unparseable time returns to the value already held. Both fields commit at minute
 granularity, and the seconds a publish stamped are kept whenever the committed
-minute is the one already saved, so tabbing through the fields or returning to
-that minute is not an edit and cannot backdate the post by up to a minute.
+minute is the one already saved. Tabbing through an untouched time, retyping it,
+or choosing the displayed calendar day does not commit a value.
 
 A staged time is the writer's unsaved work like any other field: the post reads
 dirty, Update enables and the leave guard asks. What persists it is the same
 gate as the rest of the sidebar, so a draft saves it on its own and every other
 status holds it until Update.
+
+An edit made during a save stays staged until that save settles, even if the
+writer returns to the saved minute or a refetch already carries the chosen time.
+An older response cannot discard that choice. Once the saved time agrees and no
+older save can overwrite it, the staged edit is released.
 
 The calendar stops at today, and a draft's or published post's time may not be
 the current moment or later. Choosing one leaves the value staged and shown with

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -15,6 +15,13 @@ What that gate does depends on the post's status.
 | `draft`                          | dispatches the save engine's `field` intent, as a title or excerpt commit does | the field save itself                  |
 | `published`, `scheduled`, `sent` | nothing — the value is staged in the live document                             | the next explicit save (Update, Cmd-S) |
 
+The gate also holds a draft's field save back while a value it would send is not
+yet valid: an incomplete tier pairing, or a publish time that has not passed. The
+value stays staged, the section says why, and the next save the writer asks for
+is refused with the same message. A draft's body autosave is refused for that
+reason too while such a value stands, and the save banner carries the message
+whether or not the sidebar is open, so closing the panel does not hide it.
+
 Staging is not a weaker form of saving. A staged value lives in the same live
 document as the body, so it counts everywhere unsaved work counts: the post
 reads dirty, the Update button enables, and the leave guard asks before the

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -123,7 +123,9 @@ instant. A post that has no publish time yet shows the current moment, and only
 an edit stages a value, so an untouched draft still leaves the time to the
 server. The date is chosen from a calendar and the time typed as `HH:mm`; an
 unparseable time returns to the value already held. Both fields commit at minute
-granularity, so a change never leaves stale seconds behind.
+granularity, and the seconds a publish stamped are kept whenever the committed
+minute is the one already saved, so tabbing through the fields or returning to
+that minute is not an edit and cannot backdate the post by up to a minute.
 
 A staged time is the writer's unsaved work like any other field: the post reads
 dirty, Update enables and the leave guard asks. What persists it is the same

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -139,6 +139,14 @@ it stands, and a save the writer asks for is refused with the same message, whic
 the status line and the save banner carry. A sent post is exempt from the rule
 and is re-timed like a published one.
 
+A status command cannot carry a time the section refuses either. Publishing and
+unpublishing take the staged time when they have none of their own, so both are
+refused with the same message while it is still to come; a staged time already in
+the past is carried, and the post is backdated to it. Scheduling carries the
+publish flow's own time and releases whatever the sidebar staged. The flow's
+picker is not pre-filled from a staged time: its floor is ahead of now and a
+staged time is always in the past, so there would be nothing left to keep.
+
 A scheduled post's fields are disabled and carry `Use the publish menu to
 re-schedule`: its time is the publish flow's to move, and the section says so
 rather than offering a second route to it. Once a scheduled time has passed the

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -51,12 +51,13 @@ against a disagreeing acknowledgement and enter the next save. A matching
 acknowledgement still releases the edit and supplies server-owned relation metadata.
 
 Three fields are deliberately absent from the settings projection. Status and
-publish time belong to the save engine's command target, which the publish flow
-owns; a publish-date section reads and writes them through that command, not
-through a field patch. The slug belongs to the slug machine, which authors it on
-every save; the URL section routes a manual edit through the machine's
-`slugEdited`, so a slug written as a field patch would be dropped before the
-request is built.
+publish time belong to the save engine's command target: every request reads the
+publish time off the session's snapshot rather than the projection, so a field
+patch would be overwritten before the request is built. The Publish date section
+therefore stages the publish time on the session itself, which the snapshot then
+reports. The slug belongs to the slug machine, which authors it on every save;
+the URL section routes a manual edit through the machine's `slugEdited`, so a
+slug written as a field patch would be dropped before the request is built.
 
 ## Sections
 
@@ -114,6 +115,36 @@ removed by clicking it, or with Backspace on an empty field.
 The excerpt is the one field with two homes. When the inline excerpt is on it
 renders under the title and the sidebar leaves it out; when it is off the
 sidebar owns it. Either way the same session binding is behind it.
+
+## Publish date
+
+When the post is published, edited in the site's timezone and carried as a UTC
+instant. A post that has no publish time yet shows the current moment, and only
+an edit stages a value, so an untouched draft still leaves the time to the
+server. The date is chosen from a calendar and the time typed as `HH:mm`; an
+unparseable time returns to the value already held. Both fields commit at minute
+granularity, so a change never leaves stale seconds behind.
+
+A staged time is the writer's unsaved work like any other field: the post reads
+dirty, Update enables and the leave guard asks. What persists it is the same
+gate as the rest of the sidebar, so a draft saves it on its own and every other
+status holds it until Update.
+
+The calendar stops at today, and a draft's or published post's time may not be
+the current moment or later. Choosing one leaves the value staged and shown with
+`Please choose a past date and time.` beside the fields; no field save runs while
+it stands, and a save the writer asks for is refused with the same message, which
+the status line and the save banner carry. A sent post is exempt from the rule
+and is re-timed like a published one.
+
+A scheduled post's fields are disabled and carry `Use the publish menu to
+re-schedule`: its time is the publish flow's to move, and the section says so
+rather than offering a second route to it. Once a scheduled time has passed the
+section reads `Publish date` again and drops the note, though the fields stay
+disabled until the server moves the post to published.
+
+Every role that can open the sidebar can set the publish date. It is not one of
+the Owner, Administrator and Editor fields.
 
 ## Access
 

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -14,6 +14,7 @@ import {
 import type { PostType } from '@/editor/card-config';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
 import { AccessSection } from './access-section';
+import { PublishDateSection } from './publish-date-section';
 import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
 import { SettingsSection } from './settings-section';
 import { ShowTitleSection } from './show-title-section';
@@ -90,6 +91,7 @@ export function PostSettingsSidebar({
 
   const sections: Partial<Record<SettingsSectionId, ReactNode>> = {
     url: <UrlSection postType={postType} session={session} siteUrl={siteUrl} />,
+    'publish-date': <PublishDateSection session={session} />,
     tags: canTag ? <TagsSection session={session} /> : null,
     excerpt: hasInlineExcerpt ? null : <ExcerptSection session={session} />,
     featured: canManagePost ? <FeaturedSection postType={postType} session={session} /> : null,

--- a/apps/admin/src/editor/settings/publish-date-section.tsx
+++ b/apps/admin/src/editor/settings/publish-date-section.tsx
@@ -1,0 +1,80 @@
+import { useId, useState } from 'react';
+import { Label } from '@tryghost/shade/components';
+import { Text } from '@tryghost/shade/primitives';
+import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
+import {
+  settingsPublishDate,
+  settingsPublishDateError,
+  settingsPublishDateNote,
+  settingsPublishTime,
+} from '@tryghost/test-data/selectors/editor';
+import { DateTimePicker } from '@/editor/publish/components/date-time-picker';
+import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
+import { PUBLISHED_AT_MUST_BE_PAST, publishedAtInFuture } from '@/editor/session/settings-fields';
+import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import { SettingsSection } from './settings-section';
+
+/** A scheduled post is re-timed from the publish menu, not from here. */
+const RESCHEDULE_NOTE = 'Use the publish menu to re-schedule';
+
+export interface PublishDateSectionProps {
+  session: EditorSessionHandle;
+}
+
+/**
+ * When the post is published, in the site's timezone. A post that carries no
+ * publish time yet shows now, and only an edit stages a value.
+ */
+export function PublishDateSection({ session }: PublishDateSectionProps) {
+  const errorId = useId();
+  const { data: settingsData } = useBrowseSettings({
+    defaultErrorHandler: false,
+    requestOptions: EDITOR_REQUEST_OPTIONS,
+  });
+  const timezone = getSettingValue<string>(settingsData?.settings ?? null, 'timezone') ?? 'Etc/UTC';
+
+  const { status, publishedAt } = session.publishTime;
+  // Held so the writer sees, and can correct, a time the session refuses.
+  const [now] = useState(() => new Date().toISOString());
+  const value = publishedAt ?? now;
+
+  const isScheduled = status === 'scheduled';
+  const isPastScheduled = isScheduled && !!publishedAt && Date.parse(publishedAt) < Date.now();
+  const invalid = publishedAtInFuture(status, publishedAt);
+
+  return (
+    <SettingsSection>
+      <Label>{isScheduled && !isPastScheduled ? 'Scheduled date' : 'Publish date'}</Label>
+      <DateTimePicker
+        dateLabel="Publish date"
+        dateTestId={settingsPublishDate}
+        describedBy={invalid ? errorId : undefined}
+        disabled={isScheduled}
+        invalid={invalid}
+        // Ember caps the calendar at today; a past publish time is the rule.
+        maxDate={now}
+        timeLabel="Publish time"
+        timeTestId={settingsPublishTime}
+        timezone={timezone}
+        value={value}
+        onChange={(date) => session.editPublishedAt(date.toISOString())}
+      />
+      {invalid ? (
+        <Text
+          className="text-destructive"
+          data-testid={settingsPublishDateError}
+          id={errorId}
+          role="alert"
+          size="sm"
+        >
+          {PUBLISHED_AT_MUST_BE_PAST}
+        </Text>
+      ) : null}
+      {isScheduled && !isPastScheduled ? (
+        <Text data-testid={settingsPublishDateNote} size="sm" tone="secondary">
+          {RESCHEDULE_NOTE}
+        </Text>
+      ) : null}
+    </SettingsSection>
+  );
+}

--- a/apps/admin/src/editor/settings/publish-date-section.tsx
+++ b/apps/admin/src/editor/settings/publish-date-section.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useId } from 'react';
 import { Label } from '@tryghost/shade/components';
 import { Text } from '@tryghost/shade/primitives';
 import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/api/settings';
@@ -27,6 +27,7 @@ export interface PublishDateSectionProps {
  */
 export function PublishDateSection({ session }: PublishDateSectionProps) {
   const errorId = useId();
+  const labelId = useId();
   const { data: settingsData } = useBrowseSettings({
     defaultErrorHandler: false,
     requestOptions: EDITOR_REQUEST_OPTIONS,
@@ -34,8 +35,9 @@ export function PublishDateSection({ session }: PublishDateSectionProps) {
   const timezone = getSettingValue<string>(settingsData?.settings ?? null, 'timezone') ?? 'Etc/UTC';
 
   const { status, publishedAt } = session.publishTime;
-  // Held so the writer sees, and can correct, a time the session refuses.
-  const [now] = useState(() => new Date().toISOString());
+  // Read per render: a value fixed at mount goes stale, and the calendar's cap
+  // with it, as soon as the site's day turns over.
+  const now = new Date().toISOString();
   const value = publishedAt ?? now;
 
   const isScheduled = status === 'scheduled';
@@ -44,13 +46,16 @@ export function PublishDateSection({ session }: PublishDateSectionProps) {
 
   return (
     <SettingsSection>
-      <Label>{isScheduled && !isPastScheduled ? 'Scheduled date' : 'Publish date'}</Label>
+      <Label id={labelId}>
+        {isScheduled && !isPastScheduled ? 'Scheduled date' : 'Publish date'}
+      </Label>
       <DateTimePicker
         dateLabel="Publish date"
         dateTestId={settingsPublishDate}
         describedBy={invalid ? errorId : undefined}
         disabled={isScheduled}
         invalid={invalid}
+        labelledBy={labelId}
         // Ember caps the calendar at today; a past publish time is the rule.
         maxDate={now}
         timeLabel="Publish time"

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -55,6 +55,10 @@ export const settingsTagsList = 'settings-tags-list';
 export const settingsTagsToken = 'settings-tags-token';
 export const settingsTemplateSelect = 'settings-template-select';
 export const settingsTemplateSlugMatch = 'settings-template-slug-match';
+export const settingsPublishDate = 'settings-publish-date';
+export const settingsPublishTime = 'settings-publish-time';
+export const settingsPublishDateError = 'settings-publish-date-error';
+export const settingsPublishDateNote = 'settings-publish-date-note';
 
 // publish flow testids
 export const publishFlowModal = 'publish-flow-modal';


### PR DESCRIPTION
Adds the settings sidebar's Publish date section to the React editor, matching what the Ember post settings menu does per status.

## What Ember does, and what this does

| Status | Ember | Here |
| --- | --- | --- |
| Draft | Editable, calendar capped at today; the time must be in the past; an edit saves the post immediately | Same, except the save follows the sidebar's existing policy (a draft's field save) |
| Published | Editable, same past-time rule; an edit saves immediately | Same rule, but staged until Update, like every other sidebar field |
| Scheduled | Fields disabled, note reads `Use the publish menu to re-schedule` | Same |
| Sent | Editable, and exempt from the past/future rule | Same, staged until Update |
| Contributor | No role gate on this field | Same: visible and editable for every role that can open the sidebar |

Label follows Ember: `Scheduled date` for a scheduled post whose time is still ahead, `Publish date` otherwise. Validation copy is Ember's verbatim: `Please choose a past date and time.`, rendered inline with `role="alert"`, `aria-invalid` and `aria-describedby` on both fields. The section's own label names the pair as a group, since neither input is what it labels.

## Session API decision

`published_at` is excluded from `SETTINGS_FIELD_KEYS`, and adding it back would not have worked. The save engine resolves every request's `published_at` from the session's snapshot (`resolveTarget`), not from the settings projection, so a field patch would be overwritten before the request was built — and where the projection loop does reach the payload it would have clobbered a `schedule` or `publish` command's own deliberate target with a stale sidebar value.

So the section gets a dedicated writer, `editPublishedAt`, which stages the time on the session behind the snapshot:

- `getSnapshot()` reports the staged time, so non-status intents (field, autosave, explicit, leave) carry it and status commands still win with their own target.
- `buildSaveSnapshot` ORs a `publishedAtDirty` flag into `isDirty`, so a staged time enables Update, reads dirty and is what the leave guard asks about.
- `reconcile` releases the staged time once a request has carried it; a refetch keeps the writer's outstanding edit and drops it only once the server agrees.
- A committed time that names the minute already saved is not an edit at all. The fields carry minutes and a publish stamps `published_at` with real seconds, so comparing the two exactly would make tabbing through the time field dirty a published post and move its time back by up to 59 seconds on the next save. Ember's post model keeps the stored seconds for the same reason.

## Validation

The rule lives in `settings-fields.ts` next to the tiers rule and is enforced the same way: `commitField()` holds a draft's field save back, and `execute()` refuses a save with the message, which the status line and the save banner carry.

That check runs for every intent, status commands included. A `publish` or `revert` with no publish time of its own falls back to whatever the sidebar staged, and Core validates `published_at` for scheduled posts only, so an unguarded status command would leave a published post dated in the future — a state Ember's validator refuses before any save runs. `schedule` carries its own target and the rule does not apply to scheduled posts, so it is unaffected. A time the post already carries is exempt, so a status command on a scheduled post keeps its own future time rather than being refused for it.

A staged time the rule refuses is held, not discarded, exactly as the Access section holds an incomplete tier pairing: the section shows the message, no field save runs, a draft's body autosave is refused for the same reason, and the save banner carries the message whether or not the sidebar is open. Closing the panel therefore hides the inline alert but not the reason.

Scheduling from the publish flow carries the flow's own time and releases whatever the sidebar staged. The flow's picker is not pre-filled from a staged time: its floor is five seconds ahead of now and a staged time is always in the past, so there would be nothing left to keep.

## Picker

The schedule step's date/time row is extracted into a shared `DateTimePicker` (controlled value, optional min/max date, disabled, invalid/`aria-describedby`, optional group label) and reused; no second picker. `PublishAtOptions` keeps its testids, aria-labels and DOM, and its spec is unchanged. Both fields commit at minute granularity in both callers, so a time the writer chooses carries no seconds of its own; the schedule step's untouched default still carries the floor's.

The section reads the clock on every render rather than once at mount, so an editor left open past midnight in the site's timezone still offers today and still caps the calendar there.

## Deviations

- **Scheduled is not a reschedule.** Ember disables the fields and points at the publish menu; it does not route a sidebar date change through a schedule command. This matches Ember rather than adding a second path to the publish flow's own semantics.
- **Sent is not disabled.** Ember's only `@disabled` is `isScheduled`; a sent post's date is editable there, and the validator's past/future branches do not fire for `sent`.
- **Contributors are not gated.** The contributor gate in the Ember template starts below this field, at Tags.
- **Draft is also held to the past rule.** Ember's validator refuses a future time for `draft` as well as `published`, so the calendar caps at today for both.
- **Published stages instead of saving immediately.** Ember autosaves the field for every status; the React sidebar's documented policy is draft-saves / everything-else-stages, and this follows the sidebar.
- **A refused publish time blocks a status command.** Ember's validator runs before the save and refuses the same time, so the writer never reaches a publish that would carry it. Here the guard sits in the session's `execute`, and the writer sees the same message rather than a silently accepted future date.
- **No `minutes from now` message.** No such string exists in Ember's validator; the scheduled-lead-time message is server-side only. The client rule ported here is the past/future one.
- **Time-format errors.** The shared picker reverts an unparseable time rather than showing Ember's `Must be in format: "15:00"`, keeping the publish flow's existing behaviour.
- **Timezone abbreviation** is read at the selected instant rather than at now (pre-existing publish-flow behaviour).

## Revert probes

Each row: hunk reverted, tests that then fail.

| Hunk | Failing tests |
| --- | --- |
| Snapshot reports the staged time | 3 unit (draft instant, published re-time, future refusal) |
| `isDirty` ORs `publishedAtDirty` | 3 unit + 2 acceptance (draft persist, stages until Update) |
| Minute-granular compare in `editPublishedAt` | 1 unit + 1 acceptance (stored seconds kept while the minute stands) |
| Past-time check applied to status intents | 2 unit (publish refused, unpublish refused) |
| Save banner renders the engine's error | 1 acceptance (message survives closing the sidebar) |
| `commitField()` future guard | 1 unit (field save held back) |
| Fields disabled when scheduled | 1 acceptance (scheduled points at publish menu) |
| Picker reads the site timezone | 5 acceptance |
| Inline validation message | 1 acceptance (future time refused) |
| Publish date ungated by role | 1 acceptance (contributor) |
| Section registered in the sidebar | 8 acceptance (all) |

## Verification

- `vitest run src/editor` — 37 files, 1019 passed
- Browser-mode acceptance, `src/editor src/layout` — 18 files, 279 tests
- `eslint src`, `tsc -b`, `pnpm format:check`, `pnpm lint:boundaries`, `pnpm run lint:markdown` — all clean



