### PR TITLE
Added the Authors section to the React editor's settings sidebar

### DIFF
--- a/apps/admin/src/editor/editor-settings-authors.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-authors.acceptance.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { userEvent } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
@@ -127,6 +127,37 @@ async function openAuthorList() {
  * from the site's existing staff.
  */
 describe('Post settings authors', () => {
+  it(
+    'reports a failed staff lookup and lets the writer retry without losing authors',
+    async () => {
+      const saveApi = fakeSavablePost();
+      fakeAdminEndpoint(
+        'GET',
+        /^\/users\/\?/,
+        { errors: [{ message: 'Authorization failed', type: 'UnauthorizedError' }] },
+        { status: 401 },
+      );
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+      await editorScreen.settingsAuthorsInput().click();
+
+      await expect.element(page.getByRole('alert')).toHaveTextContent('Couldn’t load authors.');
+      expect(editorScreen.settingsAuthorNames()).toEqual(['Owner User']);
+      expect(saveApi.requests).toHaveLength(0);
+
+      // Once the session is restored, retry the lookup in the existing editor.
+      fakeUsers([NADIA, JOSE]);
+      await page.getByRole('button', { name: 'Retry', exact: true }).click();
+      await expect.element(editorScreen.settingsAuthorOption('Nadia Ahmed')).toBeVisible();
+      await expect.element(editorScreen.settingsAuthorsInput()).toHaveFocus();
+      await userEvent.keyboard('nadia{Enter}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }, { id: NADIA.id }]);
+    },
+    SLOW,
+  );
+
   it(
     'credits another author on a draft as soon as one is picked',
     async () => {

--- a/apps/admin/src/editor/editor-settings-authors.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-authors.acceptance.test.tsx
@@ -1,0 +1,464 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentUserResponse,
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePosts,
+  fakeSnippets,
+  fakeUsers,
+  post,
+  renderAdminApp,
+  staffRole,
+  staffUser,
+  unsavedChangesGuarded,
+  type EndpointCapture,
+  type StaffRoleName,
+  type StaffUser,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+import { publishScreen } from '@/editor/publish/publish.screen';
+
+const POST_ID = 'abc123';
+const NEW_POST_ID = 'new123';
+const OWNER_ID = '1';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+
+// A settings save waits on the engine's queue, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const POLL = { timeout: 10_000 };
+// Under the 3s autosave debounce, so only an undebounced field save can satisfy it.
+const FIELD_POLL = { timeout: 2_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+const OWNER = { id: OWNER_ID, name: 'Owner User', email: 'owner@test.com' };
+const NADIA = staffUser({ name: 'Nadia Ahmed', slug: 'nadia', email: 'nadia@test.com' });
+const JOSE = staffUser({ name: 'José García', slug: 'jose', email: 'jose@test.com' });
+
+const STAFF_RECORDS = new Map(
+  [OWNER, NADIA, JOSE].map(
+    (person) => [person.id, { id: person.id, name: person.name, email: person.email }] as const,
+  ),
+);
+
+/** Ghost answers with the author relations filled in, not the identities it was sent. */
+function hydrateAuthors(authors: unknown): unknown[] {
+  return ((authors ?? []) as Array<{ id?: string }>).map(
+    (author) => STAFF_RECORDS.get(author.id ?? '') ?? author,
+  );
+}
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}
+
+function asRole(name: StaffRoleName) {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+function editorChrome(staff: StaffUser[] = [NADIA, JOSE]) {
+  fakeSnippets([]);
+  fakePosts([]);
+  // The header's publish inputs read the site's member total and newsletter list.
+  fakeMembers([]);
+  fakeNewsletters([]);
+  fakeUsers([...(currentUserResponse().users as unknown as StaffUser[]), ...staff]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+}
+
+/** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
+function fakeSavablePost(overrides: Partial<SavedPost> = {}, staff?: StaffUser[]) {
+  editorChrome(staff);
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    authors: [OWNER],
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = {
+      ...current,
+      ...submitted,
+      authors: hydrateAuthors(submitted.authors ?? current.authors),
+      updated_at: `2026-01-01T00:00:0${saves}.000Z`,
+    };
+    return { posts: [current] };
+  });
+}
+
+async function openAuthors() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await expect.element(editorScreen.settingsAuthors()).toBeVisible();
+}
+
+/** Opens the list, which is where the staff browse starts. */
+async function openAuthorList() {
+  await editorScreen.settingsAuthorsInput().click();
+  await expect.element(editorScreen.settingsAuthorsList()).toBeVisible();
+}
+
+/**
+ * The sidebar's Authors section: who the post is credited to, in order, picked
+ * from the site's existing staff.
+ */
+describe('Post settings authors', () => {
+  it(
+    'credits another author on a draft as soon as one is picked',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      expect(editorScreen.settingsAuthorNames()).toEqual(['Owner User']);
+
+      await openAuthorList();
+      await expect.element(editorScreen.settingsAuthorOption('Nadia Ahmed')).toBeVisible();
+      // Someone already credited is not offered a second time.
+      await expect(editorScreen.settingsAuthorOption('Owner User')).toHaveCount(0);
+      await editorScreen.settingsAuthorOption('Nadia Ahmed').click();
+
+      // A field save has no debounce, so it lands well inside the autosave's 3s.
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }, { id: NADIA.id }]);
+      await expect.poll(editorScreen.settingsAuthorNames).toEqual(['Owner User', 'Nadia Ahmed']);
+    },
+    SLOW,
+  );
+
+  it(
+    'removes an author the writer no longer credits',
+    async () => {
+      const saveApi = fakeSavablePost({
+        authors: [OWNER, { id: NADIA.id, name: NADIA.name, email: NADIA.email }],
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      expect(editorScreen.settingsAuthorNames()).toEqual(['Owner User', 'Nadia Ahmed']);
+
+      await editorScreen.removeAuthor('Nadia Ahmed').click();
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }]);
+      await expect.poll(editorScreen.settingsAuthorNames).toEqual(['Owner User']);
+    },
+    SLOW,
+  );
+
+  it(
+    'keeps naming the authors a removal left behind',
+    async () => {
+      const saveApi = fakeSavablePost({
+        status: 'published',
+        published_at: PUBLISHED_AT,
+        authors: [OWNER, { id: NADIA.id, name: NADIA.name, email: NADIA.email }],
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      // The list is never opened, so the staff browse never answers.
+      await editorScreen.removeAuthor('Owner User').click();
+
+      await expect.poll(editorScreen.settingsAuthorNames).toEqual(['Nadia Ahmed']);
+      await expect
+        .element(editorScreen.removeAuthor('Nadia Ahmed'))
+        .toHaveAttribute('aria-label', 'Remove Nadia Ahmed');
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: NADIA.id }]);
+      await expect.poll(editorScreen.settingsAuthorNames).toEqual(['Nadia Ahmed']);
+    },
+    SLOW,
+  );
+
+  it(
+    'refuses to save a post nobody is credited with',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      await expect(editorScreen.settingsAuthorsError()).toHaveCount(0);
+
+      await editorScreen.removeAuthor('Owner User').click();
+
+      // Staged rather than saved: the field gate holds an empty list back.
+      await expect.element(editorScreen.settingsAuthorsError()).toBeVisible();
+      await expect
+        .element(editorScreen.settingsAuthorsInput())
+        .toHaveAttribute('aria-invalid', 'true');
+      expect(saveApi.requests).toHaveLength(0);
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect
+        .element(editorScreen.saveErrorBanner())
+        .toHaveTextContent('At least one author is required.');
+      expect(saveApi.requests).toHaveLength(0);
+
+      // Crediting someone again recovers from the refusal.
+      await openAuthorList();
+      await editorScreen.settingsAuthorOption('Nadia Ahmed').click();
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: NADIA.id }]);
+      await expect(editorScreen.settingsAuthorsError()).toHaveCount(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a published post’s authors until Update',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+
+      await openAuthorList();
+      await editorScreen.settingsAuthorOption('Nadia Ahmed').click();
+
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }, { id: NADIA.id }]);
+      await expect.element(editorScreen.updateButton()).toBeDisabled();
+    },
+    SLOW,
+  );
+
+  it(
+    'searches the staff by name, credits the highlighted one with Tab and drops the last with Backspace',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+      await openAuthorList();
+
+      // An unaccented term still finds the accented name.
+      await userEvent.keyboard('garcia');
+
+      await expect(editorScreen.settingsAuthorOption('Nadia Ahmed')).toHaveCount(0);
+      await expect.element(editorScreen.settingsAuthorOption('José García')).toBeVisible();
+
+      await userEvent.keyboard('{Tab}');
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }, { id: JOSE.id }]);
+
+      await userEvent.keyboard('{Backspace}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(2);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }]);
+    },
+    SLOW,
+  );
+
+  it(
+    'keeps the keyboard on a row after picking one further down the list',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+      await openAuthorList();
+
+      // Nothing typed, so the pick is the second row rather than the first.
+      await userEvent.keyboard('{ArrowDown}{Enter}');
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).authors).toEqual([{ id: OWNER_ID }, { id: JOSE.id }]);
+
+      // The list shrank under the highlight; Enter still takes what it points at.
+      await expect
+        .element(editorScreen.settingsAuthorsInput())
+        .toHaveAttribute('aria-activedescendant');
+
+      await userEvent.keyboard('{Enter}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(2);
+      expect(submittedPost(saveApi).authors).toEqual([
+        { id: OWNER_ID },
+        { id: JOSE.id },
+        { id: NADIA.id },
+      ]);
+    },
+    SLOW,
+  );
+
+  it(
+    'closes the list when focus leaves the field',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+      await openAuthorList();
+
+      // Nothing typed, so Tab keeps its own job and moves focus on.
+      await userEvent.keyboard('{Tab}');
+
+      await expect(editorScreen.settingsAuthorsList()).toHaveCount(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'keeps the term on Escape and drops it on a click away',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+      await openAuthorList();
+
+      await userEvent.keyboard('nadia');
+      await expect.element(editorScreen.settingsAuthorOption('Nadia Ahmed')).toBeVisible();
+
+      await userEvent.keyboard('{Escape}');
+
+      // The writer closed the list, not the search.
+      await expect(editorScreen.settingsAuthorsList()).toHaveCount(0);
+      await expect.element(editorScreen.settingsAuthorsInput()).toHaveValue('nadia');
+
+      await openAuthorList();
+      await editorScreen.status().click();
+
+      await expect(editorScreen.settingsAuthorsList()).toHaveCount(0);
+      await expect.element(editorScreen.settingsAuthorsInput()).toHaveValue('');
+    },
+    SLOW,
+  );
+
+  it(
+    'credits a new post to the writer who started it',
+    async () => {
+      editorChrome();
+      let created = post({ id: NEW_POST_ID, title: '(Untitled)', status: 'draft', tags: [] });
+      const createApi = fakeAdminEndpoint('POST', /^\/posts\/\?/, ({ body }) => {
+        const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+        created = { ...created, ...submitted, id: NEW_POST_ID, updated_at: LOADED_AT };
+        return { posts: [created] };
+      });
+      fakeAdminEndpoint('GET', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
+      // The autosave that follows the create can land before the test ends.
+      fakeAdminEndpoint('PUT', new RegExp(`^/posts/${NEW_POST_ID}/\\?`), () => ({
+        posts: [created],
+      }));
+
+      await renderAdminApp('/editor/post', FLAG_ON);
+      await openAuthors();
+
+      expect(editorScreen.settingsAuthorNames()).toEqual(['Owner User']);
+      await expect(editorScreen.settingsAuthorsError()).toHaveCount(0);
+
+      await editorScreen.body().click();
+      await userEvent.keyboard('{End}First words');
+
+      await expect.poll(() => createApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(createApi).authors).toEqual([{ id: OWNER_ID }]);
+    },
+    SLOW,
+  );
+
+  it(
+    'refuses a publish while nobody is credited',
+    async () => {
+      const saveApi = fakeSavablePost();
+      // The publish machine reads the site's member total, which the boot entry
+      // counts in a different shape.
+      fakeAdminEndpoint('GET', /^\/members\/\?.*order=id/, {
+        members: [],
+        meta: { pagination: { page: 1, limit: 1, pages: 1, total: 20, next: null, prev: null } },
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      await editorScreen.removeAuthor('Owner User').click();
+      await expect.element(editorScreen.settingsAuthorsError()).toBeVisible();
+
+      await editorScreen.publishButton().click();
+      await expect.element(publishScreen.options()).toBeVisible();
+      await publishScreen.continueButton().click();
+      await publishScreen.confirmButton().click();
+
+      await expect
+        .element(publishScreen.confirmError())
+        .toHaveTextContent('At least one author is required.');
+      await expect(publishScreen.complete()).toHaveCount(0);
+      expect(saveApi.requests).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'shows the section in the page editor too',
+    async () => {
+      editorChrome();
+      fakeAdminEndpoint('GET', new RegExp(`^/pages/${POST_ID}/\\?`), () => ({
+        pages: [
+          post({
+            id: POST_ID,
+            title: 'Hello from React',
+            slug: 'hello-from-react',
+            status: 'draft',
+            updated_at: LOADED_AT,
+            published_at: null,
+            authors: [OWNER],
+            tags: [],
+          }),
+        ],
+      }));
+      await renderAdminApp(`/editor/page/${POST_ID}`, FLAG_ON);
+      await openAuthors();
+
+      expect(editorScreen.settingsAuthorNames()).toEqual(['Owner User']);
+    },
+    SLOW,
+  );
+
+  it.each(['Author', 'Contributor'] as StaffRoleName[])(
+    'leaves Authors out for a %s',
+    async (role) => {
+      fakeSavablePost({ authors: [OWNER] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, asRole(role));
+      await editorScreen.settingsToggle().click();
+      await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+
+      await expect(editorScreen.settingsAuthors()).toHaveCount(0);
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -37,6 +37,10 @@ import {
   postSettingsSidebar,
   postsBackLink,
   removeFeatureImageButton,
+  settingsAuthorChip,
+  settingsAuthorsError,
+  settingsAuthorsList,
+  settingsAuthorsPicker,
   settingsExcerptInput,
   settingsFeaturedToggle,
   settingsMenuToggle,
@@ -159,6 +163,20 @@ export const editorScreen = {
   settingsPublishDateNote: () => page.getByTestId(settingsPublishDateNote),
   settingsPublishDateLabel: () =>
     page.getByTestId(postSettingsSidebar).getByText(/^(Publish|Scheduled) date$/),
+  settingsAuthors: () => page.getByTestId(settingsAuthorsPicker),
+  settingsAuthorsInput: () => page.getByTestId(settingsAuthorsPicker).getByRole('combobox'),
+  settingsAuthorsList: () => page.getByTestId(settingsAuthorsList),
+  settingsAuthorOption: (name: string) =>
+    page.getByTestId(settingsAuthorsList).getByRole('option', { name }),
+  removeAuthor: (name: string) =>
+    page.getByTestId(settingsAuthorsPicker).getByRole('button', { name: `Remove ${name}` }),
+  settingsAuthorsError: () => page.getByTestId(settingsAuthorsError),
+  /** The author chips in the order the field lists them. */
+  settingsAuthorNames: (): string[] =>
+    page
+      .getByTestId(settingsAuthorChip)
+      .elements()
+      .map((chip) => chip.textContent?.trim() ?? ''),
 
   featureImage: () => page.getByTestId(editorFeatureImage),
   featureImageInput: () => page.getByLabelText(addFeatureImageLabel),

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -1281,6 +1281,89 @@ describe('createEditorSession', () => {
       expect(reloaded).toBe(true);
       expect(session.getFields().featured).toBe(false);
     });
+
+    describe('authors', () => {
+      const AUTHORS = [{ id: 'author-1' }, { id: 'author-2' }];
+      const NAMED = [
+        { id: 'author-2', name: 'Nadia Ahmed' },
+        { id: 'author-1', name: 'Owner User' },
+      ];
+
+      it('credits a new post to the current user without dirtying it', async () => {
+        const { session, state } = harness({ currentUserId: 'author-1' });
+
+        expect(session.getFields().authors).toEqual([{ id: 'author-1' }]);
+        expect(session.isDirty()).toBe(false);
+
+        session.patchLexical(body('First words'));
+        await session.dispatchExplicit();
+
+        expect(state.creates[0].authors).toEqual([{ id: 'author-1' }]);
+      });
+
+      it('submits the writer\u2019s authors as identity alone, in their order', async () => {
+        const { session, state } = harness({ record: record({ authors: [{ id: 'author-1' }] }) });
+
+        session.patchFields({ authors: NAMED });
+
+        // The field keeps the whole record so a chip stays named; only the
+        // request is reduced to identities.
+        expect(session.getFields().authors).toEqual(NAMED);
+
+        await session.dispatchExplicit();
+
+        expect(state.updates[0].payload.authors).toEqual([{ id: 'author-2' }, { id: 'author-1' }]);
+      });
+
+      it('refuses a save that would leave the post without an author', async () => {
+        const { session, state } = harness({ record: record({ authors: AUTHORS }) });
+
+        session.patchFields({ authors: [] });
+        session.commitField();
+
+        // The gate holds the field save back, as an incomplete tier pairing is.
+        expect(engineSpy.dispatched).toEqual([]);
+        expect(await session.dispatchExplicit()).toMatchObject({
+          kind: 'failed',
+          error: { kind: 'validation', message: 'At least one author is required.' },
+        });
+        expect(state.updates).toHaveLength(0);
+        expect(session.hasUnsavedContent()).toBe(true);
+
+        session.patchFields({ authors: [AUTHORS[1]] });
+
+        expect(await session.dispatchExplicit()).toMatchObject({ kind: 'saved' });
+        expect(state.updates[0].payload.authors).toEqual([{ id: 'author-2' }]);
+      });
+
+      it('keeps an author the writer dropped while a save was in flight', async () => {
+        const built = harness(
+          { record: record({ authors: AUTHORS }) },
+          {
+            duringSave: once(() => {
+              built.session.patchFields({ authors: [AUTHORS[0]] });
+              // The server has not seen the removal yet, so its copy still has both.
+              built.session.recordRefetched(
+                record({ authors: AUTHORS, updated_at: '2026-01-01T00:00:00.500Z' }),
+              );
+            }),
+            acknowledge: (acknowledged) => ({ ...acknowledged, authors: AUTHORS }),
+          },
+        );
+
+        built.session.patchLexical(body('Changed'));
+        await built.session.dispatchExplicit();
+
+        expect(built.state.updates[0].payload).not.toHaveProperty('authors');
+        expect(built.session.getFields().authors).toEqual([AUTHORS[0]]);
+        expect(built.session.isDirty()).toBe(true);
+
+        await built.session.dispatchExplicit();
+
+        expect(built.state.updates[1].payload.authors).toEqual([AUTHORS[0]]);
+        expect(built.session.isDirty()).toBe(false);
+      });
+    });
   });
 
   describe('slug', () => {

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -23,15 +23,16 @@ import type {
 } from '@/editor/engine/change-tracker';
 import type { LexicalInput } from '@/editor/engine/lexical-compare';
 import type { PostWriteOptions } from '@tryghost/admin-x-framework/api/post-contract';
-import { tagIdentities } from '@/shared/tags/tag-selection';
 import { toSaveError } from './error-mapping';
 import { createSlugPort } from './slug-port';
 import { buildSaveSnapshot, type EditorSaveSnapshot } from './snapshot';
 import { latestRevisionOf, newPostProjection, projectionOf, type EditorRecord } from './projection';
 import {
+  AUTHORS_REQUIRED,
   PUBLISHED_AT_MUST_BE_PAST,
   SETTINGS_FIELD_KEYS,
   TIERS_REQUIRED,
+  identityFor,
   publishedAtInFuture,
   tiersIncomplete,
   type EditorSettingsPatch,
@@ -184,7 +185,9 @@ export function createEditorSession({
   // Retain the writer's choice through older saves, even when it matches a refetch.
   let stagedPublishedAt: string | null = null;
   let publishedAtEditedAt = 0;
-  let live: EditablePostProjection = record ? projectionOf(record) : newPostProjection();
+  let live: EditablePostProjection = record
+    ? projectionOf(record)
+    : newPostProjection(currentUserId);
   let latestRevision: RevisionProjection | null = latestRevisionOf(record);
   let version = 0;
   let disposed = false;
@@ -315,6 +318,11 @@ export function createEditorSession({
     tracker.setLive(identity.id, patch);
   }
 
+  /** The writer removed every author the post had; Ember's validator refuses it too. */
+  function authorsEmptied(): boolean {
+    return live.authors.length === 0 && tracker.isFieldDirty('authors');
+  }
+
   function getSnapshot(): EditorSaveSnapshot {
     const verdict = tracker.verdict();
     return buildSaveSnapshot({
@@ -368,9 +376,7 @@ export function createEditorSession({
     for (const key of SETTINGS_FIELD_KEYS) {
       if (tracker.isFieldDirty(key)) {
         staged[key] = live[key];
-        // The field holds the tag records the field displays; the relation is
-        // written by identity alone.
-        payload[key] = key === 'tags' ? tagIdentities(live.tags) : live[key];
+        payload[key] = identityFor(key, live[key]);
       }
     }
     // The write contract requires the pair even when only one field changed.
@@ -428,6 +434,11 @@ export function createEditorSession({
       publishedAtInFuture(prepared.target.status, prepared.target.publishedAt)
     ) {
       return { ok: false, error: { kind: 'validation', message: PUBLISHED_AT_MUST_BE_PAST } };
+    }
+    // Only an emptied list reaches the request; an untouched create is credited
+    // to the current user by `prepare` instead.
+    if (prepared.projection.authors?.length === 0) {
+      return { ok: false, error: { kind: 'validation', message: AUTHORS_REQUIRED } };
     }
 
     inFlightSince = prepared.builtAtVersion;
@@ -530,6 +541,7 @@ export function createEditorSession({
     if (
       status !== 'draft' ||
       tiersIncomplete(live) ||
+      authorsEmptied() ||
       publishedAtInFuture(status, livePublishedAt())
     ) {
       return;

--- a/apps/admin/src/editor/session/projection.ts
+++ b/apps/admin/src/editor/session/projection.ts
@@ -4,7 +4,8 @@ import type { EditablePostProjection, RevisionProjection } from '@/editor/engine
 
 export type EditorRecord = PostEditorRecord | PageEditorRecord;
 
-export function newPostProjection(): EditablePostProjection {
+/** A post the writer has not saved yet, credited to whoever is creating it. */
+export function newPostProjection(currentUserId?: string): EditablePostProjection {
   return {
     title: '',
     slug: '',
@@ -17,7 +18,7 @@ export function newPostProjection(): EditablePostProjection {
     featured: false,
     visibility: null,
     tiers: [],
-    authors: [],
+    authors: currentUserId ? [{ id: currentUserId }] : [],
     meta_title: null,
     meta_description: null,
     canonical_url: null,

--- a/apps/admin/src/editor/session/settings-fields.ts
+++ b/apps/admin/src/editor/session/settings-fields.ts
@@ -1,5 +1,6 @@
-import type { EditablePostProjection } from '@/editor/engine/change-tracker';
+import type { EditablePostProjection, PostRelationLike } from '@/editor/engine/change-tracker';
 import type { PostStatus } from '@/editor/engine/save-engine';
+import { tagIdentities, type TagLike } from '@/shared/tags/tag-selection';
 
 /**
  * The projection keys the settings sidebar may write. Slug, status and publish
@@ -35,6 +36,25 @@ export type EditorSettingsFields = Pick<EditablePostProjection, SettingsFieldKey
 export type EditorSettingsPatch = Partial<EditorSettingsFields>;
 
 export const TIERS_REQUIRED = 'Please select at least one tier';
+
+/** Ember's post validator refuses an empty author list (validators/post.js). */
+export const AUTHORS_REQUIRED = 'At least one author is required.';
+
+/**
+ * What a settings field writes. A relation travels as identity alone, so the
+ * field can hold the whole record and still send nothing but order.
+ */
+export function identityFor(key: SettingsFieldKey, value: unknown): unknown {
+  if (key === 'authors') {
+    return (value as ReadonlyArray<PostRelationLike>).map(({ id }) => ({ id }));
+  }
+  // The field holds the tag records the field displays; the relation is
+  // written by identity alone.
+  if (key === 'tags') {
+    return tagIdentities(value as ReadonlyArray<TagLike>);
+  }
+  return value;
+}
 
 /** `visibility: 'tiers'` with no tiers: the write contract drops the visibility. */
 export function tiersIncomplete(

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -216,6 +216,9 @@ opened, rather than on every editor entry, and the chips are named from the
 post's own relations until then — including the chips an edit leaves behind, so
 removing one never leaves the rest reading as bare ids.
 
+A failed staff lookup shows an error and a Retry action in the list. Retrying
+keeps the selected authors and returns focus to the search field.
+
 The list narrows as the writer types, matching a name, slug or email and
 ignoring case and accents, and it leaves out anyone already credited. Arrow keys
 move the highlight, Enter takes the highlighted row and so does Tab once

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -206,6 +206,36 @@ Koenig cards read the post's access from the editor's card config, which follows
 the live field rather than the saved record: a staged visibility changes what
 the cards describe before any save.
 
+## Authors
+
+Authors is a token field: a chip per credited staff member and a list of
+everyone else, and everyone except an Author or Contributor sees it, in the
+page editor as well as the post editor. Users are never created here, so the list only
+offers people the site already has. It is read once, when the list is first
+opened, rather than on every editor entry, and the chips are named from the
+post's own relations until then — including the chips an edit leaves behind, so
+removing one never leaves the rest reading as bare ids.
+
+The list narrows as the writer types, matching a name, slug or email and
+ignoring case and accents, and it leaves out anyone already credited. Arrow keys
+move the highlight, Enter takes the highlighted row and so does Tab once
+something has been typed, Escape closes the list and keeps the term, and both
+clicking away and moving focus out of the field close it and discard the term. A
+chip goes with its own remove button, and Backspace in an empty field drops the
+last one and opens the list on the staff it can offer again. A pick that empties
+the row under the highlight moves it to the last row rather than losing it.
+
+Order is meaningful and the field keeps it: a new author joins the end of the
+list, and the post is written with its authors' identities alone, in that order.
+The whole staff record stays in the field and the request is what reduces it.
+A post always needs one. A new post is credited to whoever started it, which is
+what the first save sends; emptying the list instead leaves the field asking for
+an author, holds a field save back and refuses a save the writer asks for with
+the same message, which the save banner and the publish flow both carry. The
+field itself is marked invalid and points at that message. The list is otherwise committed
+through the same gate as the rest of the sidebar, so a draft saves it and every
+other status stages it.
+
 ## Template
 
 The theme decides which templates a post may render with, so the section is the

--- a/apps/admin/src/editor/settings/authors-options.test.ts
+++ b/apps/admin/src/editor/settings/authors-options.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@tryghost/admin-x-framework/api/users';
+import { authorSuggestions, matchesAuthor, selectedAuthors } from './authors-options';
+
+function user(overrides: Partial<User>): User {
+  return {
+    id: 'user-1',
+    name: 'Jane Doe',
+    slug: 'jane-doe',
+    email: 'jane@example.com',
+    ...overrides,
+  } as User;
+}
+
+const JANE = user({ id: '1', name: 'Jane Doe', slug: 'jane-doe', email: 'jane@example.com' });
+const JOSE = user({ id: '2', name: 'José García', slug: 'jose-garcia', email: 'jose@example.com' });
+const NAMELESS = user({ id: '3', name: '', slug: 'ghost-writer', email: 'ghost@example.com' });
+
+describe('matchesAuthor', () => {
+  it.each([
+    ['a name', 'jane'],
+    ['a slug', 'jane-d'],
+    ['an email', 'example.com'],
+    ['any case', 'JANE DOE'],
+  ])('matches on %s', (_label, term) => {
+    expect(matchesAuthor(JANE, term)).toBe(true);
+  });
+
+  it('matches an accented name from an unaccented term', () => {
+    expect(matchesAuthor(JOSE, 'jose garcia')).toBe(true);
+    expect(matchesAuthor(JOSE, 'José')).toBe(true);
+  });
+
+  it('rejects a term no field carries', () => {
+    expect(matchesAuthor(JANE, 'zzz')).toBe(false);
+  });
+});
+
+describe('authorSuggestions', () => {
+  it('offers everyone who is not already an author', () => {
+    const suggestions = authorSuggestions(
+      [JANE, JOSE],
+      [{ id: '1', name: 'Jane Doe', email: '' }],
+      '',
+    );
+
+    expect(suggestions.map(({ id }) => id)).toEqual(['2']);
+  });
+
+  it('narrows the offer by the typed term', () => {
+    expect(authorSuggestions([JANE, JOSE], [], 'jane').map(({ id }) => id)).toEqual(['1']);
+  });
+
+  it('falls back to the email when a staff member has no name', () => {
+    expect(authorSuggestions([NAMELESS], [], '')).toEqual([
+      { id: '3', name: 'ghost@example.com', email: 'ghost@example.com' },
+    ]);
+  });
+
+  it('answers with nothing before the staff browse has loaded', () => {
+    expect(authorSuggestions(undefined, [], '')).toEqual([]);
+  });
+});
+
+describe('selectedAuthors', () => {
+  it('keeps the post’s own order rather than the browse order', () => {
+    const selected = selectedAuthors([{ id: '2' }, { id: '1' }], [JANE, JOSE]);
+
+    expect(selected.map(({ id }) => id)).toEqual(['2', '1']);
+  });
+
+  it('names an author from the relation while the browse is still loading', () => {
+    expect(selectedAuthors([{ id: '1', name: 'Jane Doe' }], undefined)).toEqual([
+      { id: '1', name: 'Jane Doe', email: '' },
+    ]);
+  });
+
+  it('keeps an author the browse never returned', () => {
+    expect(selectedAuthors([{ id: '9' }], [JANE])).toEqual([{ id: '9', name: '9', email: '' }]);
+  });
+});

--- a/apps/admin/src/editor/settings/authors-options.ts
+++ b/apps/admin/src/editor/settings/authors-options.ts
@@ -1,0 +1,77 @@
+import type { PostAuthor } from '@tryghost/admin-x-framework/api/posts';
+import type { User } from '@tryghost/admin-x-framework/api/users';
+
+/** One staff member, as the field shows and writes them. */
+export interface AuthorOption {
+  id: string;
+  name: string;
+  email: string;
+}
+
+/** The browse the field reads: every staff member, most published first. */
+export const AUTHORS_SEARCH_PARAMS = {
+  include: 'count.posts',
+  limit: 'all',
+  order: 'count.posts desc, name asc',
+} as const;
+
+function fold(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+}
+
+function toOption(user: Pick<User, 'id' | 'name' | 'email'>): AuthorOption {
+  return { id: user.id, name: user.name || user.email, email: user.email };
+}
+
+/**
+ * Matches a search term against a name, slug or email, ignoring case and
+ * accents so an unaccented term still finds an accented name.
+ */
+export function matchesAuthor(user: Pick<User, 'name' | 'slug' | 'email'>, term: string): boolean {
+  const needle = fold(term);
+  return [user.name, user.slug, user.email].some((field) => fold(field ?? '').includes(needle));
+}
+
+/** The rows the list offers: everyone not already an author, narrowed by the term. */
+export function authorSuggestions(
+  users: User[] | undefined,
+  selected: ReadonlyArray<AuthorOption>,
+  term: string,
+): AuthorOption[] {
+  const chosen = new Set(selected.map(({ id }) => id));
+  const trimmed = term.trim();
+  return (users ?? [])
+    .filter((user) => !chosen.has(user.id) && (!trimmed || matchesAuthor(user, trimmed)))
+    .map(toOption);
+}
+
+/**
+ * The chips, in the post's own order. A saved post carries its authors' names,
+ * so a chip is named whether or not the staff browse has run.
+ */
+export function selectedAuthors(
+  authors: ReadonlyArray<PostAuthor>,
+  users: User[] | undefined,
+): AuthorOption[] {
+  const known = new Map((users ?? []).map((user) => [user.id, user]));
+  const options: AuthorOption[] = [];
+  for (const author of authors) {
+    if (!author.id) {
+      continue;
+    }
+    const user = known.get(author.id);
+    options.push(
+      user
+        ? toOption(user)
+        : {
+            id: author.id,
+            name: author.name || author.email || author.id,
+            email: author.email ?? '',
+          },
+    );
+  }
+  return options;
+}

--- a/apps/admin/src/editor/settings/authors-picker.tsx
+++ b/apps/admin/src/editor/settings/authors-picker.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
-import { Badge, inputSurface } from '@tryghost/shade/components';
+import { Badge, Button, inputSurface } from '@tryghost/shade/components';
+import { Stack, Text } from '@tryghost/shade/primitives';
 import { cn, LucideIcon } from '@tryghost/shade/utils';
 import {
   settingsAuthorChip,
@@ -18,6 +19,8 @@ export interface AuthorsPickerProps {
   /** Everyone else, already narrowed by the typed term. */
   suggestions: AuthorOption[];
   loading: boolean;
+  loadError: boolean;
+  onRetry: () => void;
   onChange: (next: AuthorOption[]) => void;
   /** The first open; the staff browse starts here rather than on every editor entry. */
   onOpen: () => void;
@@ -37,6 +40,8 @@ export function AuthorsPicker({
   selected,
   suggestions,
   loading,
+  loadError,
+  onRetry,
   onChange,
   onOpen,
   onSearch,
@@ -49,6 +54,7 @@ export function AuthorsPicker({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const showLoadError = loadError && !loading;
 
   // The term goes with the list when the writer leaves the field: left behind,
   // it reads as an edit that nothing will ever commit.
@@ -147,7 +153,7 @@ export function AuthorsPicker({
     }
 
     const commits = event.key === 'Enter' || (event.key === 'Tab' && term.trim().length > 0);
-    if (commits && open && suggestions[highlightedIndex]) {
+    if (commits && open && !showLoadError && suggestions[highlightedIndex]) {
       event.preventDefault();
       choose(suggestions[highlightedIndex]);
     }
@@ -193,7 +199,9 @@ export function AuthorsPicker({
         <input
           ref={inputRef}
           aria-activedescendant={
-            open && suggestions[highlightedIndex] ? optionId(highlightedIndex) : undefined
+            open && !showLoadError && suggestions[highlightedIndex]
+              ? optionId(highlightedIndex)
+              : undefined
           }
           aria-autocomplete="list"
           aria-controls={listId}
@@ -214,46 +222,60 @@ export function AuthorsPicker({
         <LucideIcon.ChevronDown className="size-4 shrink-0 text-muted-foreground" />
       </div>
       {open && (
-        <div
-          ref={listRef}
-          className="absolute top-full left-0 z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-border/60 bg-surface-elevated-2 p-1 text-popover-foreground shadow-md dark:border-border/30"
-          data-testid={settingsAuthorsList}
-          id={listId}
-          role="listbox"
-        >
-          {suggestions.length === 0 && (
-            <div className="px-2 py-1.5 text-sm text-muted-foreground">
-              {loading ? 'Loading authors...' : 'No authors found'}
-            </div>
-          )}
-          {suggestions.map((option, index) => {
-            const isHighlighted = index === highlightedIndex;
-
-            return (
-              <div
-                key={option.id}
-                // Never true: the list leaves out everyone the post already credits.
-                aria-selected={false}
-                className={cn(
-                  'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
-                  isHighlighted && 'bg-accent text-accent-foreground',
-                )}
-                data-highlighted={isHighlighted}
-                id={optionId(index)}
-                role="option"
-                onClick={() => choose(option)}
-                // Keeps focus in the input, which clicking a plain div would
-                // otherwise drop, so the writer can keep typing after picking.
-                onMouseDown={(event) => event.preventDefault()}
-                onMouseEnter={() => setHighlighted(index)}
+        <div className="absolute top-full left-0 z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-border/60 bg-surface-elevated-2 p-1 text-popover-foreground shadow-md dark:border-border/30">
+          {showLoadError && (
+            <Stack align="start" className="p-2" gap="sm">
+              <Text role="alert" size="sm">
+                Couldn’t load authors.
+              </Text>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  inputRef.current?.focus();
+                  onRetry();
+                }}
               >
-                <span className="truncate">{option.name}</span>
-                <span className="ms-auto truncate text-xs text-muted-foreground">
-                  {option.email}
-                </span>
+                Retry
+              </Button>
+            </Stack>
+          )}
+          <div ref={listRef} data-testid={settingsAuthorsList} id={listId} role="listbox">
+            {!showLoadError && suggestions.length === 0 && (
+              <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                {loading ? 'Loading authors...' : 'No authors found'}
               </div>
-            );
-          })}
+            )}
+            {!showLoadError &&
+              suggestions.map((option, index) => {
+                const isHighlighted = index === highlightedIndex;
+
+                return (
+                  <div
+                    key={option.id}
+                    // Never true: the list leaves out everyone the post already credits.
+                    aria-selected={false}
+                    className={cn(
+                      'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
+                      isHighlighted && 'bg-accent text-accent-foreground',
+                    )}
+                    data-highlighted={isHighlighted}
+                    id={optionId(index)}
+                    role="option"
+                    onClick={() => choose(option)}
+                    // Keeps focus in the input, which clicking a plain div would
+                    // otherwise drop, so the writer can keep typing after picking.
+                    onMouseDown={(event) => event.preventDefault()}
+                    onMouseEnter={() => setHighlighted(index)}
+                  >
+                    <span className="truncate">{option.name}</span>
+                    <span className="ms-auto truncate text-xs text-muted-foreground">
+                      {option.email}
+                    </span>
+                  </div>
+                );
+              })}
+          </div>
         </div>
       )}
     </div>

--- a/apps/admin/src/editor/settings/authors-picker.tsx
+++ b/apps/admin/src/editor/settings/authors-picker.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import { Badge, inputSurface } from '@tryghost/shade/components';
+import { cn, LucideIcon } from '@tryghost/shade/utils';
+import {
+  settingsAuthorChip,
+  settingsAuthorsList,
+  settingsAuthorsPicker,
+} from '@tryghost/test-data/selectors/editor';
+import type { AuthorOption } from './authors-options';
+
+export interface AuthorsPickerProps {
+  inputId: string;
+  describedBy?: string;
+  invalid: boolean;
+  /** The post's authors, in order. */
+  selected: AuthorOption[];
+  /** Everyone else, already narrowed by the typed term. */
+  suggestions: AuthorOption[];
+  loading: boolean;
+  onChange: (next: AuthorOption[]) => void;
+  /** The first open; the staff browse starts here rather than on every editor entry. */
+  onOpen: () => void;
+  onSearch: (term: string) => void;
+  term: string;
+}
+
+/**
+ * The authors token field: chips for the post's authors and a list of the
+ * staff who could join them. Users are never created here, so the list only
+ * ever offers people who already exist.
+ */
+export function AuthorsPicker({
+  inputId,
+  describedBy,
+  invalid,
+  selected,
+  suggestions,
+  loading,
+  onChange,
+  onOpen,
+  onSearch,
+  term,
+}: AuthorsPickerProps) {
+  const listId = useId();
+  const optionId = (index: number) => `${listId}-${index}`;
+  const [open, setOpen] = useState(false);
+  const [highlighted, setHighlighted] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // The term goes with the list when the writer leaves the field: left behind,
+  // it reads as an edit that nothing will ever commit.
+  const closeAndDiscard = useCallback(() => {
+    setOpen(false);
+    onSearch('');
+  }, [onSearch]);
+
+  // Dismissal on `pointerdown` without preventing the default, so the click
+  // that follows still reaches whatever the writer aimed at.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        closeAndDiscard();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [closeAndDiscard, open]);
+
+  // Back to the first row whenever the list narrows, so the highlight never
+  // points past the end of what is on screen.
+  useEffect(() => {
+    setHighlighted(0);
+  }, [term]);
+
+  // A pick can shrink the list under the highlight, which leaves the stored
+  // index past the end until the next arrow key moves it.
+  const highlightedIndex = Math.min(highlighted, Math.max(suggestions.length - 1, 0));
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector('[data-highlighted="true"]')
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex, open]);
+
+  const reveal = () => {
+    setOpen(true);
+    onOpen();
+  };
+
+  const choose = (option: AuthorOption) => {
+    onChange([...selected, option]);
+    // Cleared either way: leaving the term in the field means the next thing
+    // typed appends to a search already acted on.
+    onSearch('');
+  };
+
+  const remove = (option: AuthorOption) => {
+    onChange(selected.filter((author) => author.id !== option.id));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    // IME confirmation and candidate navigation belong to the input method.
+    // Safari can end composition before its confirmation keydown, reporting 229.
+    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+      return;
+    }
+
+    if (event.key === 'Backspace' && !term && selected.length > 0) {
+      remove(selected[selected.length - 1]);
+      // The list comes back with the removed author in it (gh-token-input.js).
+      reveal();
+      return;
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+
+      if (!open) {
+        reveal();
+        return;
+      }
+
+      if (suggestions.length > 0) {
+        const step = event.key === 'ArrowDown' ? 1 : -1;
+
+        setHighlighted((highlightedIndex + step + suggestions.length) % suggestions.length);
+      }
+
+      return;
+    }
+
+    // Escape keeps the term: the writer closed the list, not the search.
+    if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+      return;
+    }
+
+    const commits = event.key === 'Enter' || (event.key === 'Tab' && term.trim().length > 0);
+    if (commits && open && suggestions[highlightedIndex]) {
+      event.preventDefault();
+      choose(suggestions[highlightedIndex]);
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          closeAndDiscard();
+        }
+      }}
+    >
+      <div
+        className={cn(
+          inputSurface('within'),
+          'flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 px-3 py-1 text-control',
+        )}
+        data-testid={settingsAuthorsPicker}
+        onClick={() => {
+          inputRef.current?.focus();
+          reveal();
+        }}
+      >
+        {selected.map((author) => (
+          <Badge key={author.id} className="gap-1 pr-1" data-testid={settingsAuthorChip}>
+            {author.name}
+            <button
+              aria-label={`Remove ${author.name}`}
+              className="rounded-full hover:opacity-70"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                remove(author);
+              }}
+            >
+              <LucideIcon.X className="size-3" />
+            </button>
+          </Badge>
+        ))}
+        <input
+          ref={inputRef}
+          aria-activedescendant={
+            open && suggestions[highlightedIndex] ? optionId(highlightedIndex) : undefined
+          }
+          aria-autocomplete="list"
+          aria-controls={listId}
+          aria-describedby={describedBy}
+          aria-expanded={open}
+          aria-invalid={invalid}
+          className="min-w-20 flex-1 bg-transparent text-control outline-hidden placeholder:text-muted-foreground"
+          id={inputId}
+          placeholder={selected.length === 0 ? 'Select authors...' : ''}
+          role="combobox"
+          value={term}
+          onChange={(event) => {
+            onSearch(event.target.value);
+            reveal();
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        <LucideIcon.ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+      </div>
+      {open && (
+        <div
+          ref={listRef}
+          className="absolute top-full left-0 z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-border/60 bg-surface-elevated-2 p-1 text-popover-foreground shadow-md dark:border-border/30"
+          data-testid={settingsAuthorsList}
+          id={listId}
+          role="listbox"
+        >
+          {suggestions.length === 0 && (
+            <div className="px-2 py-1.5 text-sm text-muted-foreground">
+              {loading ? 'Loading authors...' : 'No authors found'}
+            </div>
+          )}
+          {suggestions.map((option, index) => {
+            const isHighlighted = index === highlightedIndex;
+
+            return (
+              <div
+                key={option.id}
+                // Never true: the list leaves out everyone the post already credits.
+                aria-selected={false}
+                className={cn(
+                  'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
+                  isHighlighted && 'bg-accent text-accent-foreground',
+                )}
+                data-highlighted={isHighlighted}
+                id={optionId(index)}
+                role="option"
+                onClick={() => choose(option)}
+                // Keeps focus in the input, which clicking a plain div would
+                // otherwise drop, so the writer can keep typing after picking.
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setHighlighted(index)}
+              >
+                <span className="truncate">{option.name}</span>
+                <span className="ms-auto truncate text-xs text-muted-foreground">
+                  {option.email}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/editor/settings/authors-section.tsx
+++ b/apps/admin/src/editor/settings/authors-section.tsx
@@ -32,7 +32,7 @@ export function AuthorsSection({ session, currentUser }: AuthorsSectionProps) {
   const [browsing, setBrowsing] = useState(false);
   const [term, setTerm] = useState('');
 
-  const { data, isLoading } = useBrowseUsers({
+  const { data, isFetching, isError, refetch } = useBrowseUsers({
     defaultErrorHandler: false,
     enabled: browsing,
     requestOptions: EDITOR_REQUEST_OPTIONS,
@@ -57,12 +57,14 @@ export function AuthorsSection({ session, currentUser }: AuthorsSectionProps) {
         describedBy={invalid ? errorId : undefined}
         inputId={inputId}
         invalid={invalid}
-        loading={isLoading}
+        loadError={isError}
+        loading={isFetching}
         selected={selected}
         suggestions={authorSuggestions(data?.users, selected, term)}
         term={term}
         onChange={change}
         onOpen={() => setBrowsing(true)}
+        onRetry={() => void refetch()}
         onSearch={setTerm}
       />
       {invalid ? (

--- a/apps/admin/src/editor/settings/authors-section.tsx
+++ b/apps/admin/src/editor/settings/authors-section.tsx
@@ -1,0 +1,81 @@
+import { useId, useState } from 'react';
+import { Label } from '@tryghost/shade/components';
+import { Text } from '@tryghost/shade/primitives';
+import { useBrowseUsers, type User } from '@tryghost/admin-x-framework/api/users';
+import type { PostAuthor } from '@tryghost/admin-x-framework/api/posts';
+import { settingsAuthorsError } from '@tryghost/test-data/selectors/editor';
+import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
+import { AUTHORS_REQUIRED } from '@/editor/session/settings-fields';
+import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import { SettingsSection } from './settings-section';
+import { AuthorsPicker } from './authors-picker';
+import {
+  AUTHORS_SEARCH_PARAMS,
+  authorSuggestions,
+  selectedAuthors,
+  type AuthorOption,
+} from './authors-options';
+
+export interface AuthorsSectionProps {
+  session: EditorSessionHandle;
+  currentUser?: User;
+}
+
+/**
+ * Who the post is credited to. Authors are a settings field, so the sidebar's
+ * save policy decides when the list is persisted, and the post keeps the order
+ * the field lists them in.
+ */
+export function AuthorsSection({ session, currentUser }: AuthorsSectionProps) {
+  const inputId = useId();
+  const errorId = useId();
+  const [browsing, setBrowsing] = useState(false);
+  const [term, setTerm] = useState('');
+
+  const { data, isLoading } = useBrowseUsers({
+    defaultErrorHandler: false,
+    enabled: browsing,
+    requestOptions: EDITOR_REQUEST_OPTIONS,
+    searchParams: AUTHORS_SEARCH_PARAMS,
+  });
+
+  const authors = session.settings.authors as ReadonlyArray<PostAuthor>;
+  // A post this session created carries its author's identity alone, and the
+  // browse only runs once the list is opened.
+  const known = [...(data?.users ?? []), ...(currentUser ? [currentUser] : [])];
+  const selected = selectedAuthors(authors, known);
+  const invalid = selected.length === 0;
+
+  // The whole record stays in the field: reduced to identities here, a chip the
+  // browse has not named would fall back to its id.
+  const change = (next: AuthorOption[]) => session.editSettings({ authors: next });
+
+  return (
+    <SettingsSection>
+      <Label htmlFor={inputId}>Authors</Label>
+      <AuthorsPicker
+        describedBy={invalid ? errorId : undefined}
+        inputId={inputId}
+        invalid={invalid}
+        loading={isLoading}
+        selected={selected}
+        suggestions={authorSuggestions(data?.users, selected, term)}
+        term={term}
+        onChange={change}
+        onOpen={() => setBrowsing(true)}
+        onSearch={setTerm}
+      />
+      {invalid ? (
+        <Text
+          className="text-destructive"
+          data-testid={settingsAuthorsError}
+          id={errorId}
+          role="alert"
+          size="sm"
+        >
+          {AUTHORS_REQUIRED}
+        </Text>
+      ) : null}
+    </SettingsSection>
+  );
+}

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -3,6 +3,7 @@ import { Label, Separator, Switch, Textarea } from '@tryghost/shade/components';
 import { Inline, Text } from '@tryghost/shade/primitives';
 import {
   canAccessSettings,
+  isAuthorOrContributor,
   isContributorUser,
   type User,
 } from '@tryghost/admin-x-framework/api/users';
@@ -15,6 +16,7 @@ import type { PostType } from '@/editor/card-config';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
 import { AccessSection } from './access-section';
 import { PublishDateSection } from './publish-date-section';
+import { AuthorsSection } from './authors-section';
 import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
 import { SettingsSection } from './settings-section';
 import { ShowTitleSection } from './show-title-section';
@@ -88,6 +90,8 @@ export function PostSettingsSidebar({
   // Owner, Administrator and Editor manage featured and access.
   const canManagePost = !!currentUser && canAccessSettings(currentUser);
   const canTag = !!currentUser && !isContributorUser(currentUser);
+  // Ember hides the authors field from Authors and Contributors alike.
+  const canCreditOthers = !!currentUser && !isAuthorOrContributor(currentUser);
 
   const sections: Partial<Record<SettingsSectionId, ReactNode>> = {
     url: <UrlSection postType={postType} session={session} siteUrl={siteUrl} />,
@@ -96,6 +100,9 @@ export function PostSettingsSidebar({
     excerpt: hasInlineExcerpt ? null : <ExcerptSection session={session} />,
     featured: canManagePost ? <FeaturedSection postType={postType} session={session} /> : null,
     access: canManagePost ? <AccessSection postType={postType} session={session} /> : null,
+    authors: canCreditOthers ? (
+      <AuthorsSection currentUser={currentUser} session={session} />
+    ) : null,
     'show-title-and-feature-image':
       postType === 'page' ? <ShowTitleSection currentUser={currentUser} session={session} /> : null,
     template: <TemplateSection postType={postType} session={session} />,

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -59,6 +59,10 @@ export const settingsPublishDate = 'settings-publish-date';
 export const settingsPublishTime = 'settings-publish-time';
 export const settingsPublishDateError = 'settings-publish-date-error';
 export const settingsPublishDateNote = 'settings-publish-date-note';
+export const settingsAuthorsPicker = 'settings-authors-picker';
+export const settingsAuthorsList = 'settings-authors-list';
+export const settingsAuthorsError = 'settings-authors-error';
+export const settingsAuthorChip = 'settings-author-chip';
 
 // publish flow testids
 export const publishFlowModal = 'publish-flow-modal';


### PR DESCRIPTION
The React editor's settings sidebar had no way to change who a post is credited
to, so it could only ever save the author it was opened with. This adds the
Authors section in its slot in the running order.

## What it does

Authors is a token field over the site's existing staff: a chip per credited
person in the post's own order, and a list that opens on demand and narrows as
the writer types. Users are never created here, so the list only offers people
the site already has, and anyone already credited is left out of it.

- **Role gate** — Authors and Contributors do not see the field at all; everyone
  else does. Both post and page editors show it.
- **Payload** — the field holds the whole staff record, and the request is what
  reduces it: `authors: [{id}, {id}]`, ordered. Order is meaningful (it decides
  the primary author), so a new author joins the end and the spec asserts the
  exact array. Keeping the record in the field is what lets a chip stay named
  after a removal, before the staff browse has ever run.
- **At least one author** — a new post is credited to whoever started it, which
  is what its first save sends. Emptying the list leaves the field asking for an
  author (`role="alert"`, with `aria-invalid` and `aria-describedby` on the
  `combobox` input), holds the field save back, and refuses an explicit save and
  a publish with the same message, through the save banner and the publish flow's
  own error. Adding someone again recovers.
- **Save policy** — the same `commitField` gate as the rest of the sidebar: a
  draft saves the list on the spot, every other status stages it until Update.
- **Staff browse** — `useBrowseUsers` with the editor's request options and
  `defaultErrorHandler: false`, `{limit: 'all', include: 'count.posts', order:
  'count.posts desc, name asc'}`, started when the list is first opened rather
  than on every editor entry. Until then the chips are named from the post's own
  relations. No sibling call site browses users with these params, so this query
  key is the section's own.
- **Keyboard** — arrow keys move the highlight, Enter takes the highlighted row
  and so does Tab once something is typed, Escape closes the list and keeps the
  term, clicking away or moving focus out closes it and discards the term,
  Backspace in an empty field drops the last chip and reopens the list on the
  staff it can offer again, and each chip has its own remove button. A pick that
  empties the row under the highlight moves it to the last row rather than
  losing it. Matching is on name, slug or email, ignoring case and accents. Key
  handling stands aside while an IME is composing.

## Reused vs built

- **Reused**: `useBrowseUsers` and `isAuthorOrContributor` from the framework;
  Shade's `Badge`, `Label`, `Text`, `inputSurface`, `cn` and `LucideIcon`; the
  sidebar's `SettingsSection`, `commitField` gate and settings projection
  (`authors` was already a settings field key, and the change tracker already
  compares relations by ordered ids).
- **Surveyed and not reused**: Shade's `MultiSelectCombobox` (+ `Combobox`
  trigger) is the settings area's picker, but it is cmdk-driven with the search
  input inside the list, so it cannot host chips in the field the way this
  control needs. `apps/admin/src/shared/` has no user picker. The posts list's
  bulk tag picker is the one other chips-in-a-field control in the repo and this
  field follows its proven mechanics (pointerdown dismissal, blur discard, focus
  retention on row click, highlight clamping and scrolling), but it is
  tag-specific — it offers a create row and renders tag visibility — so
  generalising it would mean reworking the bulk-tag dialog, which belongs in its
  own change.
- **Built**: `authors-picker.tsx` (the field) and `authors-options.ts` (matching,
  suggestion and chip helpers), plus `identityFor` on the settings fields, which
  is where the write contract reduces a relation to identities. The tags
  reduction the request already did inline moves onto it, so one function
  answers what every relation field writes.

## Revert probes

Every test was checked against a revert of the hunk it pins.

| Reverted hunk | Fails |
| --- | --- |
| Role gate (`!isAuthorOrContributor`) | both "leaves Authors out for a …" acceptance cases |
| The field keeping whole records | "keeps naming the authors a removal left behind" |
| `identityFor` reducing the payload | the session's "identity alone, in their order" case |
| The highlight clamp | "keeps the keyboard on a row after picking one further down the list" |
| The container's blur discard | "closes the list when focus leaves the field" |
| `aria-invalid` on the combobox | "refuses to save a post nobody is credited with" |
| New post seeded with the current user | "credits a new post to the writer who started it" + the session seeding case |
| Save refusal for an emptied list | "refuses to save a post nobody is credited with" + its session case |
| `commitField`'s emptied-authors gate | the session case's `dispatched` assertion |
| Tab commits the highlighted row | the keyboard acceptance case |
| Backspace drops the last chip | the keyboard acceptance case |
| Excluding already-credited staff | "credits another author…" + the suggestion unit case |
| Accent folding in the matcher | the `matchesAuthor` unit case |
| The adoption guard on a dirty field | "keeps an author the writer dropped while a save was in flight" |

## Verification

- `vitest run src/editor src/shared` — 58 files, 1342 tests
- acceptance `src/editor src/layout` — 17 files, 272 tests
- `eslint src` (0 errors, 41 pre-existing warnings), `tsc -b`, `format:check`,
  `lint:boundaries`, `lint:markdown`

## Deviations

Reordering by drag is not included. The Ember field reorders with a mouse-only
drag library and no keyboard path; a sortable chip row needs `@dnd-kit/core`,
which Admin does not depend on today, so it is left to its own change. Order is
otherwise preserved end to end and asserted on the payload.

The staff list is one `limit: 'all'` fetch, filtered in the browser, where the
Ember field pages the server as the writer types. Staff lists are small and the
whole list is wanted the moment the field opens, so a single read costs one
request instead of one per keystroke; a site large enough to feel it would want
a server-side search here.

