### PR TITLE
Added the Meta data section to the React editor's settings sidebar

### DIFF
--- a/apps/admin/src/editor/editor-screen.tsx
+++ b/apps/admin/src/editor/editor-screen.tsx
@@ -206,6 +206,7 @@ function EditorContent({
             featureImage={featureImage}
             postType={postType}
             showExcerpt={showExcerpt}
+            onExcerptBlur={session.commitSettings}
             onTkCountChange={setTkCount}
           />
         </div>

--- a/apps/admin/src/editor/editor-settings-meta-data.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-meta-data.acceptance.test.tsx
@@ -177,6 +177,29 @@ describe('Post settings meta data', () => {
     SLOW,
   );
 
+  it.each(['title', 'description'] as const)(
+    'saves the focused meta %s edit when Escape closes the pane',
+    async (field) => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      const input =
+        field === 'title'
+          ? editorScreen.settingsMetaTitle()
+          : editorScreen.settingsMetaDescription();
+      await input.fill('Saved when the pane closes');
+      await userEvent.keyboard('{Escape}');
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewRow('Meta data')).toHaveFocus();
+      await expect
+        .poll(() => submittedPost(saveApi)[`meta_${field}`], FIELD_POLL)
+        .toBe('Saved when the pane closes');
+    },
+    SLOW,
+  );
+
   it(
     'moves focus into the pane and back to the row it was opened from',
     async () => {

--- a/apps/admin/src/editor/editor-settings-meta-data.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-meta-data.acceptance.test.tsx
@@ -1,0 +1,380 @@
+import { describe, expect, it } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentUserResponse,
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePosts,
+  fakeSnippets,
+  fakeTiers,
+  post,
+  renderAdminApp,
+  staffRole,
+  unsavedChangesGuarded,
+  type EndpointCapture,
+  type StaffRoleName,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+import { previewScreen } from '@/editor/preview/preview.screen';
+
+const POST_ID = 'abc123';
+const CURRENT_USER_ID = '1';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+const BACK_LABEL = 'Close meta data panel';
+const PLACEHOLDER =
+  'Search engines will automatically show a custom preview of content related to the search term here if no custom meta description is set.';
+
+// A settings save waits on the engine's queue, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const POLL = { timeout: 10_000 };
+// Under the 3s autosave debounce, so only an undebounced field save can satisfy it.
+const FIELD_POLL = { timeout: 2_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}
+
+function asRole(name: StaffRoleName) {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+  // The header's publish inputs and preview read these beyond the boot table.
+  fakeMembers([]);
+  fakeNewsletters([]);
+  fakeTiers([]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+}
+
+/** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    custom_excerpt: null,
+    meta_title: null,
+    meta_description: null,
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+}
+
+async function openMetaData() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await editorScreen.settingsSubviewRow('Meta data').click();
+  await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+}
+
+/** Whether the countdown is showing the writer they are past the recommendation. */
+function countdownIsOver(): boolean {
+  return !!editorScreen.settingsSubviewPane().element().querySelector('span.text-red');
+}
+
+/**
+ * The sidebar's Meta data pane: the title and description search engines are
+ * given instead of the post's own, and the result they produce.
+ */
+describe('Post settings meta data', () => {
+  it(
+    'opens the pane over the section list and comes back from it',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      // The pane replaces the list it was opened from.
+      await expect(editorScreen.settingsExcerpt()).toHaveCount(0);
+      await expect.element(editorScreen.settingsMetaTitle()).toBeVisible();
+
+      await editorScreen.settingsSubviewBack(BACK_LABEL).click();
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsExcerpt()).toBeVisible();
+      await expect.element(editorScreen.settingsSubviewRow('Meta data')).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'names the panel after the pane it is showing',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await expect
+        .element(editorScreen.settingsSidebar())
+        .toHaveAttribute('aria-label', 'Meta data');
+      await expect
+        .element(page.getByRole('heading', { level: 2, name: 'Meta data' }))
+        .toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'closes the pane on Escape',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await userEvent.keyboard('{Escape}');
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewRow('Meta data')).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'leaves the pane open for an Escape the preview has already answered',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await editorScreen.previewButton().click();
+      await expect.element(previewScreen.modal()).toBeVisible();
+
+      await userEvent.keyboard('{Escape}');
+
+      await expect(previewScreen.modal()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'moves focus into the pane and back to the row it was opened from',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await expect
+        .poll(
+          () => document.activeElement === editorScreen.settingsSubviewBack(BACK_LABEL).element(),
+        )
+        .toBe(true);
+
+      await editorScreen.settingsSubviewBack(BACK_LABEL).click();
+
+      await expect.element(editorScreen.settingsSubviewRow('Meta data')).toBeVisible();
+      await expect
+        .poll(
+          () => document.activeElement === editorScreen.settingsSubviewRow('Meta data').element(),
+        )
+        .toBe(true);
+    },
+    SLOW,
+  );
+
+  it(
+    'reopens the sidebar on the section list rather than the pane',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await editorScreen.settingsToggle().click();
+      await expect(editorScreen.settingsSidebar()).toHaveCount(0);
+      await editorScreen.settingsToggle().click();
+
+      await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewRow('Meta data')).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'persists a draft’s meta title and description on the blur that ends each edit',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await editorScreen.settingsMetaTitle().fill('A better title for search');
+      await editorScreen.settingsMetaDescription().click();
+
+      // A field save has no debounce, so it lands well inside the autosave's 3s.
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({ meta_title: 'A better title for search' });
+
+      await editorScreen.settingsMetaDescription().fill('What this post is about');
+      await editorScreen.settingsMetaTitle().click();
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(2);
+      expect(submittedPost(saveApi)).toMatchObject({
+        meta_description: 'What this post is about',
+      });
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a published post’s meta title until Update',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await editorScreen.settingsMetaTitle().fill('A better title for search');
+      await editorScreen.settingsMetaDescription().click();
+
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        meta_title: 'A better title for search',
+        status: 'published',
+      });
+    },
+    SLOW,
+  );
+
+  it(
+    'counts the characters used against the recommendation',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await expect
+        .element(editorScreen.settingsSubviewPane())
+        .toHaveTextContent("Recommended: 60 characters. You've used 0");
+      await expect
+        .element(editorScreen.settingsSubviewPane())
+        .toHaveTextContent("Recommended: 145 characters. You've used 0");
+      expect(countdownIsOver()).toBe(false);
+
+      await editorScreen.settingsMetaTitle().fill('a'.repeat(61));
+
+      await expect
+        .element(editorScreen.settingsSubviewPane())
+        .toHaveTextContent("Recommended: 60 characters. You've used 61");
+      expect(countdownIsOver()).toBe(true);
+    },
+    SLOW,
+  );
+
+  it(
+    'refuses to save a meta title longer than the field holds',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await editorScreen.settingsMetaTitle().fill('a'.repeat(301));
+      await editorScreen.settingsMetaDescription().click();
+
+      await expect
+        .element(editorScreen.settingsSubviewPane().getByRole('alert'))
+        .toHaveTextContent('Meta Title cannot be longer than 300 characters.');
+      await expect
+        .element(editorScreen.settingsMetaTitle())
+        .toHaveAttribute('aria-invalid', 'true');
+      // Refused where the writer is typing rather than as a save they did not ask for.
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      await expect(editorScreen.saveErrorBanner()).toHaveCount(0);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect
+        .element(editorScreen.saveErrorBanner())
+        .toHaveTextContent('Meta Title cannot be longer than 300 characters.');
+      expect(saveApi.requests).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'previews the post’s own title and excerpt until the meta fields carry their own',
+    async () => {
+      fakeSavablePost({ custom_excerpt: 'The excerpt this post already has' });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      const preview = editorScreen.settingsSerpPreview();
+      await expect.element(preview).toHaveTextContent('hello-from-react');
+      await expect.element(preview).toHaveTextContent('Hello from React');
+      await expect.element(preview).toHaveTextContent('The excerpt this post already has');
+
+      await editorScreen.settingsMetaTitle().fill('A better title for search');
+      await editorScreen.settingsMetaDescription().fill('What this post is about');
+
+      await expect.element(preview).toHaveTextContent('A better title for search');
+      await expect.element(preview).toHaveTextContent('What this post is about');
+      await expect.element(preview).not.toHaveTextContent('The excerpt this post already has');
+    },
+    SLOW,
+  );
+
+  it(
+    'explains the result a post with no description of its own gets',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openMetaData();
+
+      await expect.element(editorScreen.settingsSerpPreview()).toHaveTextContent(PLACEHOLDER);
+    },
+    SLOW,
+  );
+
+  it(
+    'gives a contributor the pane their role can write',
+    async () => {
+      // A contributor may only open a draft they authored.
+      const saveApi = fakeSavablePost({ authors: [{ id: CURRENT_USER_ID }] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, asRole('Contributor'));
+      await openMetaData();
+
+      await editorScreen.settingsMetaTitle().fill('A contributor’s meta title');
+      await editorScreen.settingsMetaDescription().click();
+
+      await expect
+        .poll(() => submittedPost(saveApi).meta_title, POLL)
+        .toBe('A contributor’s meta title');
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -53,10 +53,14 @@ import {
   settingsPublishDateError,
   settingsPublishDateNote,
   settingsPublishTime,
+  settingsMetaDescriptionInput,
+  settingsMetaTitleInput,
+  settingsSerpPreview,
   settingsShowTitleToggle,
   settingsShowTitleWarning,
   settingsSlugError,
   settingsSlugInput,
+  settingsSubviewPane,
   settingsTagsField,
   settingsTagsInput,
   settingsTagsList,
@@ -193,6 +197,14 @@ export const editorScreen = {
       .getByTestId(settingsDeleteDialog)
       .getByRole('button', { name: settingsDeleteCancelButton, exact: true }),
   settingsDeleteError: () => page.getByTestId(settingsDeleteError),
+  /** The row in the section list that opens a subview pane. */
+  settingsSubviewRow: (label: string) =>
+    page.getByTestId(postSettingsSidebar).getByRole('button', { name: label, exact: true }),
+  settingsSubviewPane: () => page.getByTestId(settingsSubviewPane),
+  settingsSubviewBack: (label: string) => page.getByRole('button', { name: label, exact: true }),
+  settingsMetaTitle: () => page.getByTestId(settingsMetaTitleInput),
+  settingsMetaDescription: () => page.getByTestId(settingsMetaDescriptionInput),
+  settingsSerpPreview: () => page.getByTestId(settingsSerpPreview),
 
   featureImage: () => page.getByTestId(editorFeatureImage),
   featureImageInput: () => page.getByLabelText(addFeatureImageLabel),

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -31,12 +31,12 @@ import {
   AUTHORS_REQUIRED,
   PUBLISHED_AT_MUST_BE_PAST,
   SETTINGS_FIELD_KEYS,
-  TIERS_REQUIRED,
   identityFor,
   publishedAtInFuture,
-  tiersIncomplete,
+  settingsFieldError,
   type EditorSettingsPatch,
   type SettingsFieldKey,
+  type ValidatedSettingsFields,
 } from './settings-fields';
 
 export type EditorWritePayload = Record<string, unknown>;
@@ -59,8 +59,8 @@ export interface PreparedSave extends SaveRequest<EditorSaveSnapshot> {
   projection: EditablePostPatch;
   /** What the live post held for the authored fields when the request was built. */
   authoredFrom: AuthoredFields;
-  /** Access values captured for validation of this request. */
-  access: Pick<EditablePostProjection, 'visibility' | 'tiers'>;
+  /** Field values captured for validation of this request. */
+  validated: ValidatedSettingsFields;
   /** The edit version the request was built at, for the settings adoption guard. */
   builtAtVersion: number;
   payload: EditorWritePayload;
@@ -407,7 +407,12 @@ export function createEditorSession({
       ...request,
       projection,
       authoredFrom: { title: live.title, slug: live.slug },
-      access: { visibility: live.visibility, tiers: live.tiers },
+      validated: {
+        visibility: live.visibility,
+        tiers: live.tiers,
+        meta_title: live.meta_title,
+        meta_description: live.meta_description,
+      },
       builtAtVersion: version,
       payload,
       options: {
@@ -422,10 +427,11 @@ export function createEditorSession({
   // No abort signal: the transport owns its own controller and takes none. A
   // response arriving after disposal is dropped by the engine instead.
   async function execute(prepared: PreparedSave): Promise<SaveOutcome<EditorSaveResult>> {
-    // Untouched creates carry null visibility and use the server's default.
-    // An explicit tier selection needs a tier, including on the first save.
-    if (tiersIncomplete(prepared.access)) {
-      return { ok: false, error: { kind: 'validation', message: TIERS_REQUIRED } };
+    // The post validator runs before every save: an explicit tier selection
+    // needs a tier even on the first save, and an over-long field is not sent.
+    const invalid = settingsFieldError(prepared.validated);
+    if (invalid) {
+      return { ok: false, error: { kind: 'validation', message: invalid } };
     }
     // A status command with no time of its own carries whatever the sidebar
     // staged; Core validates the publish time for scheduled posts only.
@@ -536,11 +542,10 @@ export function createEditorSession({
   // The one place the sidebar's save policy lives. A draft persists a settings
   // field the way the body does; every other status stages it until Update.
   function commitField(): void {
-    // execute() refuses an incomplete tier pairing on every path; this only
-    // keeps a field save from being dispatched for it.
+    // Invalid settings stay staged rather than dispatching a field save.
     if (
       status !== 'draft' ||
-      tiersIncomplete(live) ||
+      settingsFieldError(live) ||
       authorsEmptied() ||
       publishedAtInFuture(status, livePublishedAt())
     ) {

--- a/apps/admin/src/editor/session/settings-fields.test.ts
+++ b/apps/admin/src/editor/session/settings-fields.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  META_DESCRIPTION_MAX,
+  META_DESCRIPTION_TOO_LONG,
+  META_TITLE_MAX,
+  META_TITLE_TOO_LONG,
+  TIERS_REQUIRED,
+  overLength,
+  settingsFieldError,
+} from './settings-fields';
+
+const VALID = { visibility: 'public', tiers: [], meta_title: null, meta_description: null };
+
+describe('overLength', () => {
+  it('counts a multibyte character once', () => {
+    expect(overLength('𝔘𝔘𝔘', 3)).toBe(false);
+    expect(overLength('𝔘𝔘𝔘𝔘', 3)).toBe(true);
+  });
+
+  it('treats no value as empty', () => {
+    expect(overLength(null, 0)).toBe(false);
+  });
+});
+
+describe('settingsFieldError', () => {
+  it('passes fields that break no rule', () => {
+    expect(settingsFieldError(VALID)).toBeNull();
+  });
+
+  it('refuses specific-tier access without a tier', () => {
+    expect(settingsFieldError({ ...VALID, visibility: 'tiers' })).toBe(TIERS_REQUIRED);
+  });
+
+  it('refuses a meta title past the column width', () => {
+    expect(settingsFieldError({ ...VALID, meta_title: 'a'.repeat(META_TITLE_MAX) })).toBeNull();
+    expect(settingsFieldError({ ...VALID, meta_title: 'a'.repeat(META_TITLE_MAX + 1) })).toBe(
+      META_TITLE_TOO_LONG,
+    );
+  });
+
+  it('refuses a meta description past the column width', () => {
+    expect(
+      settingsFieldError({ ...VALID, meta_description: 'a'.repeat(META_DESCRIPTION_MAX) }),
+    ).toBeNull();
+    expect(
+      settingsFieldError({ ...VALID, meta_description: 'a'.repeat(META_DESCRIPTION_MAX + 1) }),
+    ).toBe(META_DESCRIPTION_TOO_LONG);
+  });
+
+  it('names the field the message is about', () => {
+    expect(META_TITLE_TOO_LONG).toBe('Meta Title cannot be longer than 300 characters.');
+    expect(META_DESCRIPTION_TOO_LONG).toBe(
+      'Meta Description cannot be longer than 500 characters.',
+    );
+  });
+});

--- a/apps/admin/src/editor/session/settings-fields.ts
+++ b/apps/admin/src/editor/session/settings-fields.ts
@@ -56,6 +56,13 @@ export function identityFor(key: SettingsFieldKey, value: unknown): unknown {
   return value;
 }
 
+/** The column widths the schema gives these fields. */
+export const META_TITLE_MAX = 300;
+export const META_DESCRIPTION_MAX = 500;
+
+export const META_TITLE_TOO_LONG = `Meta Title cannot be longer than ${META_TITLE_MAX} characters.`;
+export const META_DESCRIPTION_TOO_LONG = `Meta Description cannot be longer than ${META_DESCRIPTION_MAX} characters.`;
+
 /** `visibility: 'tiers'` with no tiers: the write contract drops the visibility. */
 export function tiersIncomplete(
   fields: Pick<EditorSettingsFields, 'visibility' | 'tiers'>,
@@ -77,4 +84,28 @@ export function publishedAtInFuture(
   }
   const time = Date.parse(publishedAt);
   return !Number.isNaN(time) && time >= now;
+}
+
+/** Counted as symbols, so a multibyte character counts once. */
+export function overLength(value: string | null, max: number): boolean {
+  return Array.from(value ?? '').length > max;
+}
+
+export type ValidatedSettingsFields = Pick<
+  EditorSettingsFields,
+  'visibility' | 'tiers' | 'meta_title' | 'meta_description'
+>;
+
+/** The first rule the settings fields break, in the post validator's order. */
+export function settingsFieldError(fields: ValidatedSettingsFields): string | null {
+  if (tiersIncomplete(fields)) {
+    return TIERS_REQUIRED;
+  }
+  if (overLength(fields.meta_title, META_TITLE_MAX)) {
+    return META_TITLE_TOO_LONG;
+  }
+  if (overLength(fields.meta_description, META_DESCRIPTION_MAX)) {
+    return META_DESCRIPTION_TOO_LONG;
+  }
+  return null;
 }

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -79,7 +79,6 @@ export interface EditorSessionBinding {
   onTitleChange: (title: string) => void;
   onTitleBlur: () => void;
   onExcerptChange: (excerpt: string) => void;
-  onExcerptBlur: () => void;
   onLexicalChange: (lexical: unknown) => void;
   onSecondaryChange: (lexical: unknown) => void;
   onSecondaryError: (error: unknown) => void;
@@ -106,6 +105,13 @@ export interface EditorSessionHandle {
   settings: EditorSettingsFields;
   /** Stages a settings field, then applies the sidebar's save policy. */
   editSettings: (patch: EditorSettingsPatch) => void;
+  /** Stages a settings field the writer is still typing into, committing nothing. */
+  stageSettings: (patch: EditorSettingsPatch) => void;
+  /**
+   * Applies the sidebar's save policy to what is staged, on the blur that ends
+   * an edit. The excerpt is a settings field wherever it is rendered.
+   */
+  commitSettings: () => void;
   /** The slug the machine holds, which the URL section's input reads. */
   slug: string;
   /** Routes a manual slug edit through the slug machine, then the save policy. */
@@ -272,11 +278,10 @@ export function useEditorSession({
   // settings fields are: an edit is not an engine state change.
   const [publishTime, setPublishTime] = useState<PublishTimeView>(() => publishTimeOf(session));
 
-  const editSettings = useCallback(
+  const stageSettings = useCallback(
     (patch: EditorSettingsPatch) => {
       session.patchFields(patch);
       setSettings(settingsFieldsOf(session.getFields()));
-      session.commitField();
     },
     [session],
   );
@@ -294,6 +299,16 @@ export function useEditorSession({
       session.commitField();
     },
     [session],
+  );
+
+  const commitSettings = useCallback(() => session.commitField(), [session]);
+
+  const editSettings = useCallback(
+    (patch: EditorSettingsPatch) => {
+      stageSettings(patch);
+      session.commitField();
+    },
+    [session, stageSettings],
   );
 
   // An acknowledgement adopts the server's copy of the fields nobody edited
@@ -421,10 +436,6 @@ export function useEditorSession({
     session.dispatchField();
   }, [session, title]);
 
-  // The excerpt is a settings field wherever it is rendered, so it goes through
-  // the same policy gate as the rest of the sidebar.
-  const onExcerptBlur = useCallback(() => session.commitField(), [session]);
-
   const onLexicalChange = useCallback(
     (lexical: unknown) => {
       session.patchLexical(lexical);
@@ -461,7 +472,6 @@ export function useEditorSession({
       onTitleChange,
       onTitleBlur,
       onExcerptChange,
-      onExcerptBlur,
       onLexicalChange,
       onSecondaryChange,
       onSecondaryError,
@@ -477,6 +487,8 @@ export function useEditorSession({
     patchFeatureImage: session.patchFeatureImage,
     settings,
     editSettings,
+    stageSettings,
+    commitSettings,
     slug,
     editSlug: session.editSlug,
     publishTime,

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -168,6 +168,31 @@ disabled until the server moves the post to published.
 Every role that can open the sidebar can set the publish date. It is not one of
 the Owner, Administrator and Editor fields.
 
+## Subviews
+
+Some sections are a row that opens a pane over the rest of the panel rather than
+fields in the list. `SettingsSubview` in `settings-subview.tsx` is both halves:
+give it the section's own id, an icon and a label for the row, a title and a
+back-button label for the pane, and the pane's fields as children. Two props
+adjust the shell around them: `wide` widens the panel for a pane that needs the
+room, and `contentClassName` overrides the pane body's default padding for a pane
+that runs full-bleed. Without either, the shell renders the pane as it renders
+this one.
+
+Only one pane is open at a time. While it is, the panel shows that section
+alone: its heading, the other sections and their rows are all out of the way,
+and the back button or Escape brings them back. The pane's title is the panel's
+heading and its accessible name, and the pane's header stays in place while the
+fields under it scroll. Opening a pane moves focus to its back button, and
+closing one returns focus to the row it was opened from.
+
+An Escape something inside the pane has already answered — a dialog, a select,
+an uploader — leaves the pane open, so the writer dismisses one layer at a time.
+A pane whose section renders nothing, as a role-gated section does for a role
+that cannot write it, falls back to the section list rather than an empty panel.
+The panel owns which pane is open, so closing the panel or leaving the editor
+drops it and the panel is next opened on the section list.
+
 ## Access
 
 Access is two coupled fields, `visibility` and `tiers`, and only an Owner,
@@ -291,6 +316,32 @@ The list the delete lands on is refetched rather than served from the cache it
 was left with, which would still carry the deleted row. The refetch is left to
 the list's own mount: the editor's read of the post it just deleted is still
 mounted at that moment, and refetching that would answer 404.
+
+## Meta data
+
+Meta data is a pane, and every role that can open the panel can open it. The
+meta title and description are settings fields like any other: staged as the
+writer types, committed on the blur that ends the edit, and persisted or held
+back by the panel's save policy. A field cleared back to empty is stored as no
+value, as the excerpt is.
+
+Neither field is required, and the character counts beside them are a
+recommendation rather than a limit: 60 for the title, 145 for the description,
+counted as symbols so a multibyte character counts once, and coloured once the
+writer is past the recommendation. The lengths that are limits are the column
+widths, 300 and 500. Past one of those the field says so where the writer is
+typing and nothing is saved — not the field itself, and not a save the writer
+asks for, which is refused with the same message rather than sent and answered
+with a server error.
+
+The preview under them is the result the post would produce. Each line falls
+back rather than emptying: the title is the meta title, else the title the
+writer is looking at, else `(Untitled)`; the description is the meta
+description, else the post's excerpt, else a sentence explaining that search
+engines will compose their own. The address is the canonical URL when the post
+carries one, else the site's own host and path with the post's slug. Titles and
+descriptions are truncated to what a result shows, the ellipsis counting toward
+the limit.
 
 ## Open and closed
 

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -184,7 +184,9 @@ alone: its heading, the other sections and their rows are all out of the way,
 and the back button or Escape brings them back. The pane's title is the panel's
 heading and its accessible name, and the pane's header stays in place while the
 fields under it scroll. Opening a pane moves focus to its back button, and
-closing one returns focus to the row it was opened from.
+closing one returns focus to the row it was opened from. Closing also blurs the
+focused field before removing it, so Escape commits the edit as the back button
+does.
 
 An Escape something inside the pane has already answered — a dialog, a select,
 an uploader — leaves the pane open, so the writer dismisses one layer at a time.
@@ -340,8 +342,8 @@ writer is looking at, else `(Untitled)`; the description is the meta
 description, else the post's excerpt, else a sentence explaining that search
 engines will compose their own. The address is the canonical URL when the post
 carries one, else the site's own host and path with the post's slug. Titles and
-descriptions are truncated to what a result shows, the ellipsis counting toward
-the limit.
+descriptions are truncated to what a result shows, counting whole Unicode
+characters and the ellipsis toward the limit.
 
 ## Open and closed
 

--- a/apps/admin/src/editor/settings/meta-data-fields.test.ts
+++ b/apps/admin/src/editor/settings/meta-data-fields.test.ts
@@ -30,6 +30,11 @@ describe('truncate', () => {
   it('spends the last three characters on the ellipsis', () => {
     expect(truncate('a'.repeat(58), 60)).toBe(`${'a'.repeat(57)}...`);
   });
+
+  it('counts whole Unicode characters without splitting a surrogate pair', () => {
+    expect(truncate('😀'.repeat(57), 60)).toBe('😀'.repeat(57));
+    expect(truncate('😀'.repeat(58), 60)).toBe(`${'😀'.repeat(57)}...`);
+  });
 });
 
 describe('seoTitle', () => {

--- a/apps/admin/src/editor/settings/meta-data-fields.test.ts
+++ b/apps/admin/src/editor/settings/meta-data-fields.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SERP_DESCRIPTION_PLACEHOLDER,
+  characterCount,
+  metaDescriptionPlaceholder,
+  seoDescription,
+  seoTitle,
+  seoUrl,
+  serpDate,
+  serpDescription,
+  serpTitle,
+  truncate,
+} from './meta-data-fields';
+
+describe('characterCount', () => {
+  it('counts a multibyte character once', () => {
+    expect(characterCount('a𝔘b')).toBe(3);
+  });
+
+  it('counts nothing in an empty field', () => {
+    expect(characterCount('')).toBe(0);
+  });
+});
+
+describe('truncate', () => {
+  it('leaves a value the ellipsis would still fit inside', () => {
+    expect(truncate('a'.repeat(57), 60)).toBe('a'.repeat(57));
+  });
+
+  it('spends the last three characters on the ellipsis', () => {
+    expect(truncate('a'.repeat(58), 60)).toBe(`${'a'.repeat(57)}...`);
+  });
+});
+
+describe('seoTitle', () => {
+  it('prefers the meta title', () => {
+    expect(seoTitle('Meta', 'Title')).toBe('Meta');
+  });
+
+  it('falls back to the post title', () => {
+    expect(seoTitle('', 'Title')).toBe('Title');
+  });
+
+  it('falls back to the untitled placeholder', () => {
+    expect(seoTitle('', '')).toBe('(Untitled)');
+  });
+});
+
+describe('seoDescription', () => {
+  it('prefers the meta description', () => {
+    expect(seoDescription('Meta', 'Excerpt')).toBe('Meta');
+  });
+
+  it('falls back to the custom excerpt', () => {
+    expect(seoDescription('', 'Excerpt')).toBe('Excerpt');
+  });
+
+  it('has nothing to fall back to without either', () => {
+    expect(seoDescription('', '')).toBe('');
+  });
+});
+
+describe('seoUrl', () => {
+  it('reads the host and the slug off the site', () => {
+    expect(seoUrl({ siteUrl: 'https://example.com/', slug: 'a-post', canonicalUrl: '' })).toBe(
+      'example.com › a-post',
+    );
+  });
+
+  it('keeps a subdirectory site’s path segments', () => {
+    expect(seoUrl({ siteUrl: 'https://example.com/blog/', slug: 'a-post', canonicalUrl: '' })).toBe(
+      'example.com › blog › a-post',
+    );
+  });
+
+  it('replaces the whole address with the canonical URL', () => {
+    expect(
+      seoUrl({
+        siteUrl: 'https://example.com/',
+        slug: 'a-post',
+        canonicalUrl: 'https://elsewhere.com/syndicated/story',
+      }),
+    ).toBe('elsewhere.com › syndicated › story');
+  });
+
+  it('shows nothing for a canonical URL it cannot parse', () => {
+    expect(
+      seoUrl({ siteUrl: 'https://example.com/', slug: 'a-post', canonicalUrl: 'nonsense' }),
+    ).toBe('');
+  });
+});
+
+describe('serpTitle', () => {
+  it('truncates to what a result shows', () => {
+    expect(serpTitle('a'.repeat(80))).toBe(`${'a'.repeat(57)}...`);
+  });
+});
+
+describe('serpDescription', () => {
+  it('truncates the description a result shows', () => {
+    expect(serpDescription('a'.repeat(200))).toBe(`${'a'.repeat(146)}...`);
+  });
+
+  it('explains itself when there is no description', () => {
+    expect(serpDescription('')).toBe(SERP_DESCRIPTION_PLACEHOLDER);
+  });
+});
+
+describe('metaDescriptionPlaceholder', () => {
+  it('truncates further than the result does', () => {
+    expect(metaDescriptionPlaceholder('a'.repeat(200))).toBe(`${'a'.repeat(147)}...`);
+  });
+});
+
+describe('serpDate', () => {
+  it('pads the day and shortens the month', () => {
+    expect(serpDate(new Date(2026, 8, 7))).toBe('07 Sep 2026');
+  });
+});

--- a/apps/admin/src/editor/settings/meta-data-fields.ts
+++ b/apps/admin/src/editor/settings/meta-data-fields.ts
@@ -21,7 +21,8 @@ export function characterCount(value: string): number {
 /** Ellipsis included in the limit, as the truncation this ports is. */
 export function truncate(value: string, characterLimit: number): string {
   const limit = characterLimit - 3;
-  return value.length > limit ? `${value.substring(0, limit)}...` : value;
+  const characters = Array.from(value);
+  return characters.length > limit ? `${characters.slice(0, limit).join('')}...` : value;
 }
 
 /** The meta title, else the title the writer is looking at. */

--- a/apps/admin/src/editor/settings/meta-data-fields.ts
+++ b/apps/admin/src/editor/settings/meta-data-fields.ts
@@ -1,0 +1,82 @@
+/** The lengths the countdown recommends; neither one is a limit. */
+export const META_TITLE_RECOMMENDED = 60;
+export const META_DESCRIPTION_RECOMMENDED = 145;
+
+const SERP_TITLE_LENGTH = 60;
+const SERP_DESCRIPTION_LENGTH = 149;
+const META_DESCRIPTION_PLACEHOLDER_LENGTH = 150;
+
+const UNTITLED = '(Untitled)';
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export const SERP_DESCRIPTION_PLACEHOLDER =
+  'Search engines will automatically show a custom preview of content related to the search term here if no custom meta description is set.';
+
+/** Counted as symbols, so a multibyte character counts once. */
+export function characterCount(value: string): number {
+  return Array.from(value).length;
+}
+
+/** Ellipsis included in the limit, as the truncation this ports is. */
+export function truncate(value: string, characterLimit: number): string {
+  const limit = characterLimit - 3;
+  return value.length > limit ? `${value.substring(0, limit)}...` : value;
+}
+
+/** The meta title, else the title the writer is looking at. */
+export function seoTitle(metaTitle: string, title: string): string {
+  return metaTitle || title || UNTITLED;
+}
+
+/** The meta description, else the excerpt the writer wrote. */
+export function seoDescription(metaDescription: string, customExcerpt: string): string {
+  return metaDescription || customExcerpt || '';
+}
+
+/** The canonical URL when there is one, else the post's own address. */
+export function seoUrl({
+  siteUrl,
+  slug,
+  canonicalUrl,
+}: {
+  siteUrl: string;
+  slug: string;
+  canonicalUrl: string;
+}): string {
+  const parts: string[] = [];
+
+  if (canonicalUrl) {
+    try {
+      const url = new URL(canonicalUrl);
+      parts.push(url.host, ...url.pathname.split('/').filter(Boolean));
+    } catch {
+      return '';
+    }
+  } else {
+    const url = new URL(siteUrl);
+    parts.push(url.host, ...url.pathname.split('/').filter(Boolean), slug);
+  }
+
+  return parts.join(' › ');
+}
+
+export function serpTitle(title: string): string {
+  return truncate(title, SERP_TITLE_LENGTH);
+}
+
+export function serpDescription(description: string): string {
+  return description
+    ? truncate(description, SERP_DESCRIPTION_LENGTH)
+    : SERP_DESCRIPTION_PLACEHOLDER;
+}
+
+export function metaDescriptionPlaceholder(description: string): string {
+  return truncate(description, META_DESCRIPTION_PLACEHOLDER_LENGTH);
+}
+
+/** The date a result carries, as the search engines render it. */
+export function serpDate(now: Date): string {
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${day} ${MONTHS[now.getMonth()]} ${now.getFullYear()}`;
+}

--- a/apps/admin/src/editor/settings/meta-data-section.tsx
+++ b/apps/admin/src/editor/settings/meta-data-section.tsx
@@ -1,7 +1,7 @@
 import { useId } from 'react';
 import { Input, Label, Textarea } from '@tryghost/shade/components';
 import { Stack, Text } from '@tryghost/shade/primitives';
-import { LucideIcon, cn } from '@tryghost/shade/utils';
+import { LucideIcon, cn, formatNumber } from '@tryghost/shade/utils';
 import {
   settingsMetaDescriptionInput,
   settingsMetaTitleInput,
@@ -34,9 +34,9 @@ function Countdown({ id, value, recommended }: { id: string; value: string; reco
 
   return (
     <Text id={id} size="sm" tone="secondary">
-      Recommended: <b>{recommended}</b> characters. You&apos;ve used{' '}
+      Recommended: <b>{formatNumber(recommended)}</b> characters. You&apos;ve used{' '}
       <span className={cn('font-bold', used > recommended ? 'text-red' : 'text-green')}>
-        {used}
+        {formatNumber(used)}
       </span>
     </Text>
   );

--- a/apps/admin/src/editor/settings/meta-data-section.tsx
+++ b/apps/admin/src/editor/settings/meta-data-section.tsx
@@ -1,0 +1,174 @@
+import { useId } from 'react';
+import { Input, Label, Textarea } from '@tryghost/shade/components';
+import { Stack, Text } from '@tryghost/shade/primitives';
+import { LucideIcon, cn } from '@tryghost/shade/utils';
+import {
+  settingsMetaDescriptionInput,
+  settingsMetaTitleInput,
+  settingsSerpPreview,
+} from '@tryghost/test-data/selectors/editor';
+import {
+  META_DESCRIPTION_MAX,
+  META_DESCRIPTION_TOO_LONG,
+  META_TITLE_MAX,
+  META_TITLE_TOO_LONG,
+  overLength,
+} from '@/editor/session/settings-fields';
+import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import {
+  META_DESCRIPTION_RECOMMENDED,
+  META_TITLE_RECOMMENDED,
+  characterCount,
+  metaDescriptionPlaceholder,
+  seoDescription,
+  seoTitle,
+  seoUrl,
+  serpDate,
+  serpDescription,
+  serpTitle,
+} from './meta-data-fields';
+import { SettingsSubview } from './settings-subview';
+
+function Countdown({ id, value, recommended }: { id: string; value: string; recommended: number }) {
+  const used = characterCount(value);
+
+  return (
+    <Text id={id} size="sm" tone="secondary">
+      Recommended: <b>{recommended}</b> characters. You&apos;ve used{' '}
+      <span className={cn('font-bold', used > recommended ? 'text-red' : 'text-green')}>
+        {used}
+      </span>
+    </Text>
+  );
+}
+
+function FieldError({ id, message }: { id: string; message: string }) {
+  return (
+    <Text className="text-red" id={id} role="alert" size="sm">
+      {message}
+    </Text>
+  );
+}
+
+function SearchPreview({
+  url,
+  title,
+  description,
+}: {
+  url: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <Stack
+      className="rounded-md border border-border p-4"
+      data-testid={settingsSerpPreview}
+      gap="xs"
+    >
+      <Text size="sm" tone="secondary">
+        {url}
+      </Text>
+      <Text size="md" weight="medium">
+        {serpTitle(title)}
+      </Text>
+      <Text size="sm" tone="secondary">
+        {serpDate(new Date())} — {serpDescription(description)}
+      </Text>
+    </Stack>
+  );
+}
+
+export interface MetaDataSectionProps {
+  session: EditorSessionHandle;
+  siteUrl: string;
+}
+
+/**
+ * The post's search-engine metadata: a meta title and description that stand in
+ * for the post's own, and the result they produce.
+ */
+export function MetaDataSection({ session, siteUrl }: MetaDataSectionProps) {
+  const titleId = useId();
+  const titleHintId = useId();
+  const titleErrorId = useId();
+  const descriptionId = useId();
+  const descriptionHintId = useId();
+  const descriptionErrorId = useId();
+
+  const metaTitle = session.settings.meta_title ?? '';
+  const metaDescription = session.settings.meta_description ?? '';
+  const titleError = overLength(metaTitle, META_TITLE_MAX) ? META_TITLE_TOO_LONG : null;
+  const descriptionError = overLength(metaDescription, META_DESCRIPTION_MAX)
+    ? META_DESCRIPTION_TOO_LONG
+    : null;
+
+  const previewTitle = seoTitle(metaTitle, session.bind.title);
+  const previewDescription = seoDescription(metaDescription, session.settings.custom_excerpt ?? '');
+  const previewUrl = seoUrl({
+    siteUrl,
+    slug: session.getSaveSnapshot().slug,
+    canonicalUrl: session.settings.canonical_url ?? '',
+  });
+
+  return (
+    <SettingsSubview
+      closeLabel="Close meta data panel"
+      icon={<LucideIcon.Search />}
+      id="meta-data"
+      label="Meta data"
+      title="Meta data"
+      wide
+    >
+      <Stack gap="sm">
+        <Label htmlFor={titleId}>Meta title</Label>
+        <Input
+          aria-describedby={titleError ? `${titleHintId} ${titleErrorId}` : titleHintId}
+          aria-invalid={!!titleError}
+          data-testid={settingsMetaTitleInput}
+          id={titleId}
+          placeholder={previewTitle}
+          value={metaTitle}
+          onBlur={session.commitSettings}
+          // A cleared field is stored as no value, the way the excerpt is.
+          onChange={(event) => session.stageSettings({ meta_title: event.target.value || null })}
+        />
+        <Countdown id={titleHintId} recommended={META_TITLE_RECOMMENDED} value={metaTitle} />
+        {titleError ? <FieldError id={titleErrorId} message={titleError} /> : null}
+      </Stack>
+
+      <Stack gap="sm">
+        <Label htmlFor={descriptionId}>Meta description</Label>
+        <Textarea
+          aria-describedby={
+            descriptionError ? `${descriptionHintId} ${descriptionErrorId}` : descriptionHintId
+          }
+          aria-invalid={!!descriptionError}
+          data-testid={settingsMetaDescriptionInput}
+          id={descriptionId}
+          placeholder={metaDescriptionPlaceholder(previewDescription)}
+          rows={3}
+          value={metaDescription}
+          onBlur={session.commitSettings}
+          onChange={(event) =>
+            session.stageSettings({ meta_description: event.target.value || null })
+          }
+        />
+        <Countdown
+          id={descriptionHintId}
+          recommended={META_DESCRIPTION_RECOMMENDED}
+          value={metaDescription}
+        />
+        {descriptionError ? (
+          <FieldError id={descriptionErrorId} message={descriptionError} />
+        ) : null}
+      </Stack>
+
+      <Stack gap="sm">
+        <Text size="sm" weight="medium">
+          Search Engine Result Preview
+        </Text>
+        <SearchPreview description={previewDescription} title={previewTitle} url={previewUrl} />
+      </Stack>
+    </SettingsSubview>
+  );
+}

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -1,6 +1,7 @@
-import { Fragment, type ReactNode, useId } from 'react';
+import { Fragment, type ReactNode, useEffect, useId } from 'react';
 import { Label, Separator, Switch, Textarea } from '@tryghost/shade/components';
 import { Inline, Text } from '@tryghost/shade/primitives';
+import { cn } from '@tryghost/shade/utils';
 import {
   canAccessSettings,
   isAuthorOrContributor,
@@ -18,8 +19,10 @@ import { AccessSection } from './access-section';
 import { PublishDateSection } from './publish-date-section';
 import { AuthorsSection } from './authors-section';
 import { DeleteSection } from './delete-section';
+import { MetaDataSection } from './meta-data-section';
 import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
 import { SettingsSection } from './settings-section';
+import { SubviewContext, useSubviewController } from './settings-subview-context';
 import { ShowTitleSection } from './show-title-section';
 import { TagsSection } from './tags-section';
 import { TemplateSection } from './template-section';
@@ -36,7 +39,7 @@ function ExcerptSection({ session }: { session: EditorSessionHandle }) {
         id={inputId}
         rows={3}
         value={session.bind.excerpt}
-        onBlur={session.bind.onExcerptBlur}
+        onBlur={session.commitSettings}
         onChange={(event) => session.bind.onExcerptChange(event.target.value)}
       />
     </SettingsSection>
@@ -93,6 +96,7 @@ export function PostSettingsSidebar({
   const canTag = !!currentUser && !isContributorUser(currentUser);
   // Ember hides the authors field from Authors and Contributors alike.
   const canCreditOthers = !!currentUser && !isAuthorOrContributor(currentUser);
+  const subviews = useSubviewController();
 
   const sections: Partial<Record<SettingsSectionId, ReactNode>> = {
     url: <UrlSection postType={postType} session={session} siteUrl={siteUrl} />,
@@ -108,21 +112,41 @@ export function PostSettingsSidebar({
       postType === 'page' ? <ShowTitleSection currentUser={currentUser} session={session} /> : null,
     template: <TemplateSection postType={postType} session={session} />,
     delete: <DeleteSection postType={postType} session={session} />,
+    'meta-data': <MetaDataSection session={session} siteUrl={siteUrl} />,
   };
 
+  // A pane whose section renders nothing would leave an empty panel with no way
+  // back, so the panel falls back to the section list.
+  const open = subviews.open && sections[subviews.open.id] ? subviews.open : null;
+  useEffect(() => {
+    if (subviews.open && !open) {
+      subviews.close();
+    }
+  }, [open, subviews]);
+  const panelLabel = `${postType === 'page' ? 'Page' : 'Post'} settings`;
+
   return (
-    <aside
-      aria-label={`${postType === 'page' ? 'Page' : 'Post'} settings`}
-      className="absolute inset-y-0 right-0 z-10 w-[350px] overflow-y-auto border-l border-border bg-background shadow-lg max-[500px]:w-screen lg:static lg:shrink-0 lg:shadow-none"
-      data-testid={postSettingsSidebar}
-    >
-      <Text as="h2" className="px-5 py-4" size="md" weight="semibold">
-        {postType === 'page' ? 'Page' : 'Post'} settings
-      </Text>
-      <Separator />
-      {SETTINGS_SECTION_ORDER.map((id) => (
-        <Fragment key={id}>{sections[id] ?? null}</Fragment>
-      ))}
-    </aside>
+    <SubviewContext.Provider value={subviews}>
+      <aside
+        aria-label={open?.title ?? panelLabel}
+        className={cn(
+          'absolute inset-y-0 right-0 z-10 w-[350px] overflow-y-auto border-l border-border bg-background shadow-lg max-[500px]:w-screen lg:static lg:shrink-0 lg:shadow-none',
+          open?.wide && 'w-[500px]',
+        )}
+        data-testid={postSettingsSidebar}
+      >
+        {open ? null : (
+          <>
+            <Text as="h2" className="px-5 py-4" size="md" weight="semibold">
+              {panelLabel}
+            </Text>
+            <Separator />
+          </>
+        )}
+        {SETTINGS_SECTION_ORDER.map((id) => (
+          <Fragment key={id}>{open && open.id !== id ? null : (sections[id] ?? null)}</Fragment>
+        ))}
+      </aside>
+    </SubviewContext.Provider>
   );
 }

--- a/apps/admin/src/editor/settings/settings-subview-context.ts
+++ b/apps/admin/src/editor/settings/settings-subview-context.ts
@@ -1,0 +1,56 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { SettingsSectionId } from './sections';
+
+export interface OpenSubview {
+  id: SettingsSectionId;
+  /** The pane's heading, which names the panel while the pane is open. */
+  title: string;
+  /** The pane needs more room than the section list does. */
+  wide: boolean;
+}
+
+export interface SubviewController {
+  open: OpenSubview | null;
+  show: (subview: OpenSubview) => void;
+  close: () => void;
+}
+
+export const SubviewContext = createContext<SubviewController | null>(null);
+
+/**
+ * The sidebar's one open pane. The panel owns it, so closing the panel or
+ * leaving the editor unmounts the state rather than carrying it forward.
+ */
+export function useSubviewController(): SubviewController {
+  const [open, setOpen] = useState<OpenSubview | null>(null);
+  const close = useCallback(() => setOpen(null), []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      // A dialog, select or uploader inside the pane answers Escape first, and
+      // Radix marks that by preventing the default rather than stopping here.
+      if (event.key === 'Escape' && !event.defaultPrevented) {
+        close();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [close, open]);
+
+  return useMemo(() => ({ open, show: setOpen, close }), [close, open]);
+}
+
+export function useSubviews(): SubviewController {
+  const controller = useContext(SubviewContext);
+
+  if (!controller) {
+    throw new Error('A settings subview must be rendered inside the settings panel.');
+  }
+
+  return controller;
+}

--- a/apps/admin/src/editor/settings/settings-subview-context.ts
+++ b/apps/admin/src/editor/settings/settings-subview-context.ts
@@ -23,7 +23,15 @@ export const SubviewContext = createContext<SubviewController | null>(null);
  */
 export function useSubviewController(): SubviewController {
   const [open, setOpen] = useState<OpenSubview | null>(null);
-  const close = useCallback(() => setOpen(null), []);
+  const close = useCallback(() => {
+    // Removing a focused field does not fire blur. Commit it before the pane
+    // unmounts, just as clicking the back button does.
+    const focused = document.activeElement;
+    if (focused instanceof HTMLElement) {
+      focused.blur();
+    }
+    setOpen(null);
+  }, []);
 
   useEffect(() => {
     if (!open) {

--- a/apps/admin/src/editor/settings/settings-subview.tsx
+++ b/apps/admin/src/editor/settings/settings-subview.tsx
@@ -1,0 +1,99 @@
+import { type ReactNode, useEffect, useRef } from 'react';
+import { Button, Separator } from '@tryghost/shade/components';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { LucideIcon, cn } from '@tryghost/shade/utils';
+import { settingsSubviewPane } from '@tryghost/test-data/selectors/editor';
+import type { SettingsSectionId } from './sections';
+import { useSubviews } from './settings-subview-context';
+
+export interface SettingsSubviewProps {
+  /** The section's own id: the panel shows this section alone while its pane is open. */
+  id: SettingsSectionId;
+  icon: ReactNode;
+  /** The row in the section list, and the accessible name of the button that opens the pane. */
+  label: string;
+  /** The pane's heading, which also names the panel while the pane is open. */
+  title: string;
+  /** The accessible name of the pane's back button. */
+  closeLabel: string;
+  wide?: boolean;
+  /** Overrides the pane body's default padding, for a pane that runs full-bleed. */
+  contentClassName?: string;
+  children: ReactNode;
+}
+
+/**
+ * A section that opens a pane over the rest of the panel: the row while it is
+ * closed, the pane with its own header while it is open.
+ */
+export function SettingsSubview({
+  id,
+  icon,
+  label,
+  title,
+  closeLabel,
+  wide = false,
+  contentClassName,
+  children,
+}: SettingsSubviewProps) {
+  const { open, show, close } = useSubviews();
+  const isOpen = open?.id === id;
+  const backRef = useRef<HTMLButtonElement>(null);
+  const rowRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
+
+  // Opening moves the writer into the pane; closing puts them back on the row
+  // they opened it from, rather than at the top of the document.
+  useEffect(() => {
+    if (isOpen) {
+      backRef.current?.focus();
+    } else if (wasOpen.current) {
+      rowRef.current?.focus();
+    }
+
+    wasOpen.current = isOpen;
+  }, [isOpen]);
+
+  if (isOpen) {
+    return (
+      <>
+        <div className="sticky top-0 z-10 bg-background">
+          <Inline align="center" className="p-3" gap="sm">
+            <Button ref={backRef} aria-label={closeLabel} size="sm" variant="ghost" onClick={close}>
+              <LucideIcon.ArrowLeft />
+            </Button>
+            <Text as="h2" size="md" weight="semibold">
+              {title}
+            </Text>
+          </Inline>
+          <Separator />
+        </div>
+        <Stack
+          className={cn('px-5 py-4', contentClassName)}
+          data-testid={settingsSubviewPane}
+          gap="lg"
+        >
+          {children}
+        </Stack>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <button
+        ref={rowRef}
+        className="flex w-full items-center gap-2 px-5 py-3 text-left hover:bg-interactive-hover focus-visible:ring-1 focus-visible:ring-focus-ring focus-visible:outline-hidden [&>svg]:size-4 [&>svg]:shrink-0"
+        type="button"
+        onClick={() => show({ id, title, wide })}
+      >
+        {icon}
+        <Text as="span" className="flex-1" size="sm">
+          {label}
+        </Text>
+        <LucideIcon.ChevronRight className="size-4 shrink-0 text-text-tertiary" />
+      </button>
+      <Separator />
+    </>
+  );
+}

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -66,6 +66,10 @@ export const settingsAuthorChip = 'settings-author-chip';
 export const settingsDeleteButton = 'settings-delete-button';
 export const settingsDeleteDialog = 'settings-delete-dialog';
 export const settingsDeleteError = 'settings-delete-error';
+export const settingsSubviewPane = 'settings-subview-pane';
+export const settingsMetaTitleInput = 'settings-meta-title-input';
+export const settingsMetaDescriptionInput = 'settings-meta-description-input';
+export const settingsSerpPreview = 'settings-serp-preview';
 
 // publish flow testids
 export const publishFlowModal = 'publish-flow-modal';


### PR DESCRIPTION
The settings sidebar needed a second shape of section: a row that opens a pane over the rest of the panel, the way the meta data, card and code injection settings are reached. This adds that mechanism and its first consumer.

## The subview mechanism

`SettingsSubview` in `settings-subview.tsx` is both halves of such a section. A section renders it with its own id, an icon and label for the row, a title and back-button label for the pane, and the pane's fields as children:

```tsx
<SettingsSubview
  closeLabel="Close meta data panel"
  icon={<LucideIcon.Search />}
  id="meta-data"
  label="Meta data"
  title="Meta data"
  wide
>
  {/* the pane's fields */}
</SettingsSubview>
```

Two props adjust the shell around those children: `wide` widens the panel for a pane that needs more room than the section list, and `contentClassName` overrides the pane body's default padding for a pane that runs full-bleed. Without either, the shell renders the pane as it renders this one.

While a pane is open the panel shows that section alone — its heading, the other sections and their rows are all out of the way — and the back button or Escape brings them back. The pane's title is the panel's heading and its accessible name, so the heading level does not skip and a screen reader names the panel after what it is showing, and the pane's header stays in place while the fields under it scroll. Opening a pane moves focus to its back button; closing one returns focus to the row it was opened from.

Escape only closes the pane when nothing inside it has already answered: a dialog, select or uploader marks the key handled by preventing the default, so dismissing the preview modal or a select leaves the pane open. A pane whose section renders nothing, as a role-gated section would for a role that cannot write it, falls back to the section list rather than an empty panel with no way back.

The panel owns which pane is open, so closing the panel or leaving the editor drops it and the panel is next opened on the section list. The panel's own open and close behaviour, including the overlay rules on a narrow viewport, is unchanged. Adding the remaining panes is a matter of rendering `SettingsSubview` inside the section.

## Meta data

The meta title and description are settings fields like any other: staged as the writer types, committed on the blur that ends the edit, and persisted or held back by the panel's save policy — a draft saves, every other status stages until Update. A cleared field is stored as no value, as the excerpt is. The character counts beside them are a recommendation rather than a limit, 60 and 145, counted as symbols so a multibyte character counts once, and coloured once the writer is past it.

The lengths that are limits are the column widths, 300 and 500. Those are now checked before a save rather than after one, alongside the tier pairing the post validator already refused, so an over-long field is refused where the writer is typing instead of being sent and answered with a server error. The field says so inline, and a save the writer asks for is refused with the same message.

The preview under them is the result the post would produce, each line falling back rather than emptying: the title is the meta title, else the title the writer is looking at, else `(Untitled)`; the description is the meta description, else the post's excerpt, else a sentence explaining that search engines will compose their own; the address is the canonical URL when the post carries one, else the site's host and path with the post's slug. Titles and descriptions are truncated to what a result shows, the ellipsis counting toward the limit.

Every role that can open the panel can open this pane — the row sits outside the role gate the Authors and Featured sections sit inside.

The excerpt's blur and the sidebar's settings commit were the same call under two names on the session handle; they are one member now, `commitSettings`, which both homes of the excerpt and the meta fields use.

Out of scope here: the canonical URL field, which belongs to the URL section, and the remaining four panes.

## Verification

`pnpm --filter @tryghost/admin exec vitest run src/editor` (38 files, 1021 tests), browser-mode acceptance over `src/editor src/layout` (18 files, 284 tests), `eslint src`, `tsc -b`, `pnpm format:check`, `pnpm lint:boundaries`, `pnpm run lint:markdown`.

Each new test was run against a reverted version of the change it pins:

| Test | Reverted | Result |
| --- | --- | --- |
| opens the pane over the section list and comes back from it | panel keeps rendering every section while a pane is open | fails |
| names the panel after the pane it is showing | the pane's title as the panel's heading and accessible name | fails |
| closes the pane on Escape | the Escape listener | fails |
| leaves the pane open for an Escape the preview has already answered | the `defaultPrevented` check in the Escape listener | fails |
| moves focus into the pane and back to the row it was opened from | the pane's focus effect | fails |
| reopens the sidebar on the section list rather than the pane | the open pane kept outside the panel's lifetime | fails |
| persists a draft's meta title and description on the blur that ends each edit | the inputs' `onBlur` commit | fails |
| stages a published post's meta title until Update | the inputs' `onChange` staging | fails |
| counts the characters used against the recommendation | the countdown's threshold colour | fails |
| counts the characters used against the recommendation | the recommended length | fails |
| refuses to save a meta title longer than the field holds | the inline message | fails |
| refuses to save a meta title longer than the field holds | the length check before a save | fails |
| refuses to save a meta title longer than the field holds | the length check before a field commit | fails |
| previews the post's own title and excerpt until the meta fields carry their own | the preview's title and description fallbacks | fails |
| explains the result a post with no description of its own gets | the preview's description placeholder | fails |
| gives a contributor the pane their role can write | the section gated behind the roles that may manage the post | fails |



