### PR TITLE
Stopped unlikely generation of invalid passwords

### DIFF
--- a/ghost/core/core/server/lib/generate-password.ts
+++ b/ghost/core/core/server/lib/generate-password.ts
@@ -1,0 +1,19 @@
+import * as errors from '@tryghost/errors';
+// @ts-expect-error This module lacks type definitions.
+import * as security from '@tryghost/security';
+import { validatePassword } from './validate-password';
+
+export const generatePassword = (email: string): string => {
+  for (let i = 0; i < 1000; i++) {
+    // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+    const password = security.identifier.uid(50);
+    if (validatePassword(password, email).isValid) {
+      return password;
+    }
+  }
+
+  throw new errors.InternalServerError({
+    message: 'Unable to generate a valid password after 1000 iterations',
+    context: 'generatePassword',
+  });
+};

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -7,6 +7,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const security = require('@tryghost/security');
 const { validatePassword } = require('../lib/validate-password');
+const { generatePassword } = require('../lib/generate-password');
 const permissions = require('../services/permissions');
 const urlUtils = require('../../shared/url-utils').default;
 const { setIsRoles } = require('./role-utils');
@@ -66,8 +67,7 @@ User = ghostBookshelf.Model.extend(
 
     defaults: function defaults() {
       return {
-        // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
-        password: security.identifier.uid(50),
+        password: generatePassword(''),
         visibility: 'public',
         status: 'active',
         comment_notifications: true,
@@ -208,8 +208,7 @@ User = ghostBookshelf.Model.extend(
      */
     lock: function lock(options) {
       const update = {
-        // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
-        password: security.identifier.uid(50),
+        password: generatePassword(this.get('email') || ''),
       };
       if (this.get('status') !== 'inactive') {
         update.status = 'locked';
@@ -306,8 +305,8 @@ User = ghostBookshelf.Model.extend(
         }
 
         if (options.importing) {
-          // always set password to a random uid when importing
-          this.set('password', security.identifier.uid(50));
+          // generate a random password when importing
+          this.set('password', generatePassword(this.get('email') || ''));
 
           // lock users so they have to follow the password reset flow
           if (this.get('status') !== 'inactive') {

--- a/ghost/core/test/unit/lib/generate-password.test.ts
+++ b/ghost/core/test/unit/lib/generate-password.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import * as sinon from 'sinon';
+// @ts-expect-error This module lacks type definitions.
+import * as security from '@tryghost/security';
+import { generatePassword } from '../../../core/server/lib/generate-password';
+
+describe('password generation', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('returns a 50-character password', function () {
+    const result = generatePassword('user@example.com');
+
+    assert.equal(result.length, 50);
+    assert.match(result, /^[a-zA-Z0-9]+$/);
+  });
+
+  it('retries invalid generated passwords', function () {
+    const uid = sinon
+      .stub(security.identifier, 'uid')
+      .onFirstCall()
+      .returns('password')
+      .onSecondCall()
+      .returns('TY7VZkRwCcUKhJP9');
+
+    assert.equal(generatePassword('user@example.com'), 'TY7VZkRwCcUKhJP9');
+    sinon.assert.callCount(uid, 2);
+  });
+});

--- a/ghost/core/test/unit/lib/generate-password.test.ts
+++ b/ghost/core/test/unit/lib/generate-password.test.ts
@@ -27,4 +27,13 @@ describe('password generation', function () {
     assert.equal(generatePassword('user@example.com'), 'TY7VZkRwCcUKhJP9');
     sinon.assert.callCount(uid, 2);
   });
+
+  it('throws after exhausting invalid password retries', function () {
+    const uid = sinon.stub(security.identifier, 'uid').returns('password');
+
+    assert.throws(() => generatePassword('user@example.com'), {
+      message: 'Unable to generate a valid password after 1000 iterations',
+    });
+    sinon.assert.callCount(uid, 1000);
+  });
 });

--- a/ghost/core/test/unit/lib/generate-password.test.ts
+++ b/ghost/core/test/unit/lib/generate-password.test.ts
@@ -17,14 +17,34 @@ describe('password generation', function () {
   });
 
   it('retries invalid generated passwords', function () {
+    const rejectedPassword = 'passwordABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop';
+    const acceptedPassword = 'ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedZ';
     const uid = sinon
       .stub(security.identifier, 'uid')
       .onFirstCall()
-      .returns('password')
+      .returns(rejectedPassword)
       .onSecondCall()
-      .returns('TY7VZkRwCcUKhJP9');
+      .returns(acceptedPassword);
 
-    assert.equal(generatePassword('user@example.com'), 'TY7VZkRwCcUKhJP9');
+    const result = generatePassword('user@example.com');
+
+    assert.equal(result, acceptedPassword);
+    assert.equal(result.length, 50);
+    sinon.assert.callCount(uid, 2);
+  });
+
+  it('retries passwords matching email local part', function () {
+    const email = 'user@example.com';
+    const rejectedPassword = email;
+    const acceptedPassword = 'ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedZ';
+    const uid = sinon
+      .stub(security.identifier, 'uid')
+      .onFirstCall()
+      .returns(rejectedPassword)
+      .onSecondCall()
+      .returns(acceptedPassword);
+
+    assert.equal(generatePassword(email), acceptedPassword);
     sinon.assert.callCount(uid, 2);
   });
 

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -116,6 +116,22 @@ describe('Unit: models/user', function () {
           });
       });
     });
+
+    it('retries until the generated default password is secure', function () {
+      const insecurePassword = 'password';
+      const securePassword = 'reOakhgmofLBGy5H';
+      sinon
+        .stub(security.identifier, 'uid')
+        .withArgs(50)
+        .onFirstCall()
+        .returns(insecurePassword)
+        .onSecondCall()
+        .returns(securePassword);
+
+      const defaults = models.User.prototype.defaults();
+
+      assert.equal(defaults.password, securePassword);
+    });
   });
 
   describe('add', function () {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/34147219898/job/101822163010#step:6:308

We generate random passwords for users in some cases. In rare cases, this random password would trip up our password validation--for example, if it generated a password with the string "password" inside.

This hardens our code against that. This has happened in tests [at least once][0], and possibly in production too.

[0]: https://github.com/TryGhost/Ghost/actions/runs/34147219898/job/101822163010#step:6:308