### PR TITLE
Added a members API read of what each tier asks a member for

### DIFF
--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -320,6 +320,10 @@ module.exports = {
     return apiFramework.pipeline(require('./member-metafields-members'), localUtils, 'members');
   },
 
+  get tiersCheckoutRequirements() {
+    return apiFramework.pipeline(require('./tiers-checkout-requirements'), localUtils, 'members');
+  },
+
   get giftsMembers() {
     return apiFramework.pipeline(require('./gifts-members'), localUtils, 'members');
   },

--- a/ghost/core/core/server/api/endpoints/tiers-checkout-requirements.ts
+++ b/ghost/core/core/server/api/endpoints/tiers-checkout-requirements.ts
@@ -1,0 +1,43 @@
+import type { TierCheckoutConfig } from '../../services/tier-checkout-config';
+
+const tiersService = require('../../services/tiers');
+
+/**
+ * What each tier needs from a member, as the member being asked.
+ *
+ * The same rows as the publisher's `tiers_checkout_config`, and a resource of its own
+ * rather than that one re-authorised, because the two carry different things. A
+ * publisher's version says which field each collected value is kept in; a member has no
+ * use for that and is never told it. What is left is only what they will be asked for,
+ * which is why this is named for the requirement rather than for the configuration.
+ *
+ * Its own name rather than the same one because a response shape follows the `docName`.
+ * Sharing the name would mean sharing the payload, and a member would be handed field
+ * keys, a tax number Ghost never stores, and questions this path does not draw.
+ *
+ * Every configured tier at once, rather than one named tier. The plan page shows them all,
+ * and a member deciding between two tiers wants to know which of them will ask for a
+ * delivery address before they pick one, not after. It also has to answer for a tier the
+ * member is not on, which is the only case that matters here.
+ *
+ * Signed in, but not about any particular member: a tier asks the same of everyone. The
+ * route settles who is asking and refuses an unknown caller, because what a publisher
+ * collects is their configuration rather than something the site announces.
+ */
+
+const controller = {
+  docName: 'tiers_checkout_requirements',
+
+  browse: {
+    headers: { cacheInvalidate: false },
+    permissions: false,
+    query(): Promise<TierCheckoutConfig[]> {
+      // Only tiers a publisher has set up come back, so a site collecting nothing
+      // answers with an empty list rather than a row per tier saying "nothing".
+      return tiersService.checkout.browse();
+    },
+  },
+};
+
+export default controller;
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -88,6 +88,10 @@ module.exports = {
     return require('./tiers');
   },
 
+  get tiers_checkout_requirements() {
+    return require('./tiers-checkout-requirements');
+  },
+
   get tiers_checkout_config() {
     return require('./tiers-checkout-config');
   },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/tiers-checkout-requirements.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/tiers-checkout-requirements.ts
@@ -1,0 +1,15 @@
+import { toCheckoutRequirementsResponse } from '../../../../../services/tier-checkout-config';
+import type { TierCheckoutConfig } from '../../../../../services/tier-checkout-config';
+
+interface Frame {
+  response?: unknown;
+}
+
+const serialize = (configs: TierCheckoutConfig[], _apiConfig: unknown, frame: Frame): void => {
+  frame.response = toCheckoutRequirementsResponse.parse(configs);
+};
+
+// module.exports (not export): the API framework loads serializers via require().
+module.exports = {
+  browse: serialize,
+};

--- a/ghost/core/core/server/services/tier-checkout-config/index.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/index.ts
@@ -21,4 +21,4 @@ export {
   TierCheckoutConfig,
 } from './models';
 
-export { toCheckoutConfigResponse } from './serializers';
+export { toCheckoutConfigResponse, toCheckoutRequirementsResponse } from './serializers';

--- a/ghost/core/core/server/services/tier-checkout-config/serializers.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/serializers.ts
@@ -149,3 +149,71 @@ export const toCheckoutConfigResponse = z
     })),
   }))
   .pipe(CheckoutConfigResponse);
+
+/**
+ * The same settings, as the member they will be asked of.
+ *
+ * A publisher is deciding where collected values are kept, and a member is being asked to
+ * supply them, so the two answer different questions about the same rows. What is dropped
+ * is everything about where a value lands: the binding between a collected thing and the
+ * field holding it is the publisher's business, and a member could do nothing with it but
+ * write to that field directly.
+ *
+ * The tax number goes too, because the processor keeps one against the customer it
+ * invoices and Ghost never stores it, so nothing here could ask for it. So do the
+ * checkout questions, because a tier change does not draw them.
+ *
+ * Note what this deliberately does not borrow: `Collection` in this domain means a
+ * collected thing together with the field it lands in, which is the half a member never
+ * sees. Naming this after it would say the opposite of what it holds.
+ */
+const CheckoutRequirementsResource = z.object({
+  tier_id: z.string(),
+  /**
+   * A block appears only when the tier asks for that thing, and says so as well, the same
+   * way the publisher's resource does. Presence and the flag agree, so a client may read
+   * whichever it finds clearer.
+   *
+   * Neither says whether a thing may be skipped, because nothing here may be: every entry
+   * in a list of requirements is required. Collection a member could decline is the change
+   * that would need a field of its own rather than a new reading of these two, which is
+   * why the answer is not left resting on presence alone.
+   */
+  shipping: z
+    .object({
+      collect: z.literal(true),
+      /** Absent means everywhere the processor ships, the same as for a publisher. */
+      allowed_countries: z.array(z.string()).optional(),
+    })
+    .optional(),
+  phone: z.object({ collect: z.literal(true) }).optional(),
+});
+
+const CheckoutRequirementsResponse = z.object({
+  tiers_checkout_requirements: z.array(CheckoutRequirementsResource),
+});
+
+export const toCheckoutRequirementsResponse = z
+  .array(TierCheckoutConfig)
+  .transform((configs): z.input<typeof CheckoutRequirementsResponse> => ({
+    // A tier that has been set up but asks the member for nothing does not belong in a
+    // list of what tiers will ask for. The case that produces one is a tier collecting
+    // only a tax number, which the processor asks for and keeps to itself.
+    tiers_checkout_requirements: configs
+      .filter((config) => config.shipping ?? config.phone)
+      .map((config) => ({
+        tier_id: config.tierId,
+        ...(config.shipping
+          ? {
+              shipping: {
+                collect: true as const,
+                ...(config.shipping.allowedCountries
+                  ? { allowed_countries: config.shipping.allowedCountries }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(config.phone ? { phone: { collect: true as const } } : {}),
+      })),
+  }))
+  .pipe(CheckoutRequirementsResponse);

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -11,6 +11,8 @@ const errorHandler = require('@tryghost/mw-error-handler');
 const { http } = require('@tryghost/api-framework');
 const api = require('../../api').endpoints;
 
+const labs = require('../../../shared/labs');
+
 const accountRoutes = require('./account');
 const commentRouter = require('../comments');
 const announcementRouter = require('../announcement');
@@ -126,6 +128,18 @@ module.exports = function setupMembersApp() {
       return membersService.api.middleware.createBillingPortalSession(req, res, next);
     },
   );
+  // What each tier will ask a member for, so their client can ask before sending them
+  // into a plan change that would otherwise be refused for missing it. Signed in, because
+  // what a publisher collects is their configuration rather than something the site
+  // announces to anyone who asks.
+  membersApp.get(
+    '/api/tiers/checkout_requirements',
+    labs.enabledMiddleware('stripeCheckoutCollection'),
+    middleware.loadMemberIdentity,
+    middleware.rejectWhenAnonymous,
+    http(api.tiersCheckoutRequirements.browse),
+  );
+
   membersApp.put('/api/subscriptions/:id', function lazyUpdateSubscriptionMw(req, res, next) {
     return membersService.api.middleware.updateSubscription(req, res, next);
   });

--- a/ghost/core/test/e2e-api/members/tiers-checkout-requirements.test.ts
+++ b/ghost/core/test/e2e-api/members/tiers-checkout-requirements.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+
+const { agentProvider, fixtureManager, mockManager } = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+
+interface Agent {
+  get: (_url: string) => any;
+  put: (_url: string) => any;
+  post: (_url: string) => any;
+}
+
+interface MembersAgent extends Agent {
+  loginAs: (_email: string) => Promise<void>;
+  duplicate: () => MembersAgent;
+}
+
+interface AdminAgent extends Agent {
+  loginAsOwner: () => Promise<void>;
+}
+
+const MEMBER_EMAIL = 'member1@test.com';
+
+/**
+ * What a tier will ask a member for, read by the member who is about to be asked.
+ *
+ * Everything here is set up through the Admin API, the way a publisher sets it up, and
+ * read through the members API, the way a member's client reads it. Nothing touches a
+ * table, so none of it is pinned to how these settings happen to be stored.
+ */
+describe('Tier checkout requirements Members API', function () {
+  let adminAgent: AdminAgent;
+  let membersAgent: MembersAgent;
+  let paidTier: { id: string };
+  let secondTier: { id: string };
+
+  async function defineField(name: string, type: string): Promise<string> {
+    const { body } = await adminAgent
+      .post('members/metafields/custom/')
+      .body({ members_metafields: [{ name, type }] })
+      .expectStatus(201);
+    return body.members_metafields[0].key;
+  }
+
+  async function collectInto(tierId: string, body: Record<string, unknown>): Promise<void> {
+    await adminAgent
+      .put(`tiers/${tierId}/checkout_config/`)
+      .body({ tiers_checkout_config: [body] })
+      .expectStatus(200);
+  }
+
+  async function readRequirements() {
+    const { body } = await membersAgent.get('/api/tiers/checkout_requirements/').expectStatus(200);
+    return body.tiers_checkout_requirements;
+  }
+
+  beforeAll(async function () {
+    ({ adminAgent, membersAgent } = await agentProvider.getAgentsForMembers());
+    await fixtureManager.init('members', 'tiers:extra');
+    await adminAgent.loginAsOwner();
+    await membersAgent.loginAs(MEMBER_EMAIL);
+  });
+
+  beforeEach(async function () {
+    mockManager.mockLabsEnabled('stripeCheckoutCollection');
+    mockManager.mockLabsEnabled('membersCustomFields');
+
+    const { body } = await adminAgent.get('tiers/?limit=all');
+    [paidTier, secondTier] = body.tiers.filter((tier: { type: string }) => tier.type === 'paid');
+  });
+
+  afterEach(async function () {
+    await models.Base.knex('products_checkout_fields').del();
+    await models.Base.knex('products_checkout_config').del();
+    await models.Base.knex('members_metafield_bindings').del();
+    await models.Base.knex('members_metafields').del();
+    mockManager.restore();
+  });
+
+  it('says nothing when no tier collects anything', async function () {
+    assert.deepEqual(await readRequirements(), []);
+  });
+
+  it('names the tiers that collect, and what they collect', async function () {
+    const address = await defineField('Delivery address', 'address');
+    const phone = await defineField('Contact number', 'short_text');
+
+    await collectInto(paidTier.id, {
+      shipping: {
+        collect: true,
+        allowed_countries: ['GB', 'IE'],
+        name: { custom_field_key: 'shipping_name' },
+        address: { custom_field_key: address },
+      },
+      phone: { collect: true, custom_field_key: phone },
+    });
+
+    assert.deepEqual(await readRequirements(), [
+      {
+        tier_id: paidTier.id,
+        shipping: { collect: true, allowed_countries: ['GB', 'IE'] },
+        phone: { collect: true },
+      },
+    ]);
+  });
+
+  it('leaves the countries out when a tier ships anywhere', async function () {
+    const address = await defineField('Delivery address', 'address');
+
+    await collectInto(paidTier.id, {
+      shipping: {
+        collect: true,
+        name: { custom_field_key: 'shipping_name' },
+        address: { custom_field_key: address },
+      },
+    });
+
+    const [tier] = await readRequirements();
+    // Ghost stores "everywhere" as no countries at all, so an absent list is the answer
+    // rather than every country the processor happens to ship to today. The tier still
+    // says it collects, so an absent list cannot be read as collecting nowhere.
+    assert.deepEqual(tier.shipping, { collect: true });
+  });
+
+  it('says nothing about a tier that only collects a tax number', async function () {
+    // The processor keeps a tax number against the customer it invoices and Ghost never
+    // stores one, so there is nothing a member could be asked for here.
+    await collectInto(paidTier.id, { tax_number: { collect: true } });
+
+    assert.deepEqual(await readRequirements(), []);
+  });
+
+  it('answers for a tier the member is not on', async function () {
+    // The whole point: a member reads this to decide whether to move onto a tier, so an
+    // answer that depended on already holding it would be useless.
+    const address = await defineField('Delivery address', 'address');
+    await collectInto(secondTier.id, {
+      shipping: {
+        collect: true,
+        allowed_countries: ['GB'],
+        name: { custom_field_key: 'shipping_name' },
+        address: { custom_field_key: address },
+      },
+    });
+
+    const required = await readRequirements();
+    assert.deepEqual(
+      required.map((tier: { tier_id: string }) => tier.tier_id),
+      [secondTier.id],
+    );
+  });
+
+  it('never names the fields a value is kept in', async function () {
+    // A member supplies a delivery address, not a value for a field. Where it lands is
+    // the publisher's business, and naming it here would invite a client to write there
+    // directly.
+    const address = await defineField('Delivery address', 'address');
+    await collectInto(paidTier.id, {
+      shipping: {
+        collect: true,
+        name: { custom_field_key: 'shipping_name' },
+        address: { custom_field_key: address },
+      },
+    });
+
+    const answer = JSON.stringify(await readRequirements());
+    assert.ok(!answer.includes(address), 'the destination field is not named');
+    assert.ok(!answer.includes('shipping_name'), 'nor the one the name goes into');
+  });
+
+  // Three different nothings, and a client has to tell them apart. A site with the
+  // feature turned off has no such endpoint; a site that has it but collects nowhere
+  // answers with an empty list; a tier that collects nothing is simply not in it.
+  it('does not exist on a site without the feature', async function () {
+    mockManager.mockLabsDisabled('stripeCheckoutCollection');
+
+    const { statusCode } = await membersAgent.get('/api/tiers/checkout_requirements/');
+
+    assert.equal(statusCode, 404);
+  });
+
+  it('will not tell someone who is not signed in', async function () {
+    const address = await defineField('Delivery address', 'address');
+    await collectInto(paidTier.id, {
+      shipping: {
+        collect: true,
+        name: { custom_field_key: 'shipping_name' },
+        address: { custom_field_key: address },
+      },
+    });
+
+    const signedOut = membersAgent.duplicate();
+    const { statusCode, body } = await signedOut.get('/api/tiers/checkout_requirements/');
+
+    assert.equal(statusCode, 401);
+    assert.equal(Object.hasOwn(body, 'tiers_checkout_requirements'), false);
+  });
+});


### PR DESCRIPTION
## Problem

A publisher can set a tier up to ask a buyer for a delivery address or a phone number while they pay. A member who already pays and switches to such a tier never goes through a payment page, so nothing asks them, and Portal is about to have to ask instead.

Portal cannot ask without knowing which tiers want what. The publisher's own read of those settings is on the Admin API and requires a staff token, so Portal cannot use it. The public content API, where Portal already reads tiers, is the wrong home: Ghost deliberately refuses to name what a publisher collects to a caller it cannot identify, and there is a test pinning that.

## Solution

A read on the members API, for a signed-in member, answering what each tier will ask them for. It answers for every configured tier at once rather than one named tier, because the plan page shows them all and a member choosing between two wants to know which will ask for an address before they pick. It also answers for tiers the member is not on, which is the only case that matters here.

It is a resource of its own rather than the publisher's one re-authorised, because the two carry different things. A publisher's version says which of their fields each collected value is kept in. A member has no use for that and is never told it: they supply a delivery address, not a value for a named field, and where it lands is the publisher's business. The tax number is dropped too, since the payment processor keeps that against the customer it invoices and Ghost never stores one. So are the checkout questions, which this path does not draw. A tier that has been set up but asks the member for nothing does not appear at all.

That difference forces the separate name, because a response shape follows the resource name — sharing the name would mean sharing the payload. It is named for the requirement rather than for the collection on purpose: a collection in this domain means a collected thing together with the field it lands in, and that second half is exactly the part a member never sees, so the word would say the opposite of what this holds.

Nothing calls this yet. It is the half of the work that unblocks the Portal form, which is why it is separate from the write that will accept the answers.

## Context

https://linear.app/ghost/issue/BER-3942/collect-what-a-tier-needs-when-a-member-changes-onto-it
