### PR TITLE
Added what a tier asks a member for to the content API tier payload

### DIFF
--- a/ghost/core/core/server/api/endpoints/tiers-public.js
+++ b/ghost/core/core/server/api/endpoints/tiers-public.js
@@ -1,4 +1,38 @@
+const logging = require('@tryghost/logging');
+const labs = require('../../../shared/labs');
 const tiersService = require('../../services/tiers');
+const { requirementsByTier } = require('../../services/tier-checkout-config');
+
+/**
+ * What each tier asks a member for, or nothing when the site does not do that.
+ *
+ * Looked up per request rather than kept with the tier, because a tier is loaded into
+ * memory once at boot and these rows change underneath it: deleting a custom field
+ * cascades a tier's binding away without that repository ever hearing about it, so a copy
+ * taken at boot would go on promising to ask for a field the site no longer has.
+ *
+ * One lookup per response, and only for this payload. Staff read these settings through a
+ * resource of their own that carries them in full, and the payloads carrying tiers in
+ * bulk each build their own reduced projection of a tier, so none of them pays for this.
+ *
+ * A failure costs the requirements and nothing else. A tier a reader cannot see the price
+ * of is worse than one whose delivery question they meet a moment later.
+ */
+async function requirements() {
+  if (!labs.isSet('stripeCheckoutCollection')) {
+    return undefined;
+  }
+
+  try {
+    return requirementsByTier(await tiersService.checkout.browse());
+  } catch (err) {
+    logging.error(
+      { event: { name: 'tiers.requirements.read_failed' }, err },
+      'Failed to read what tiers ask a member for',
+    );
+    return undefined;
+  }
+}
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -13,7 +47,10 @@ const controller = {
     async query(frame) {
       const page = await tiersService.api.browse(frame.options);
 
-      return page;
+      // Carried on the page rather than fetched while serializing, so the serializer
+      // renders what it was handed. The admin controller looks none up, which is what
+      // keeps them off the admin payload — no serializer needs to ask who is calling.
+      return { ...page, requirements: await requirements() };
     },
   },
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/tiers.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/tiers.js
@@ -20,7 +20,7 @@ module.exports = {
 function paginatedTiers(page, _apiConfig, frame) {
   return {
     tiers: page.data.map((model) => {
-      return serializeTier(model, frame.options);
+      return serializeTier(model, frame.options, page.requirements);
     }),
     meta: page.meta,
   };
@@ -45,7 +45,7 @@ function singleTier(model, _apiConfig, frame) {
  *
  * @returns {SerializedTier}
  */
-function serializeTier(tier, options) {
+function serializeTier(tier, options, requirements = null) {
   const json = tier.toJSON(options);
 
   const serialized = {
@@ -68,6 +68,14 @@ function serializeTier(tier, options) {
 
   if (!Array.isArray(serialized.benefits)) {
     serialized.benefits = null;
+  }
+
+  // Only the payload that was asked for these carries them, so a response that did not
+  // look them up says nothing rather than saying every tier asks for nothing. Where they
+  // were looked up, every tier carries the key and an empty one means it asks for
+  // nothing.
+  if (requirements) {
+    serialized.requirements = requirements.get(json.id) ?? {};
   }
 
   if (serialized.type === 'free') {

--- a/ghost/core/core/server/services/tier-checkout-config/index.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/index.ts
@@ -21,4 +21,4 @@ export {
   TierCheckoutConfig,
 } from './models';
 
-export { toCheckoutConfigResponse } from './serializers';
+export { toCheckoutConfigResponse, requirementsByTier, type TierRequirements } from './serializers';

--- a/ghost/core/core/server/services/tier-checkout-config/serializers.ts
+++ b/ghost/core/core/server/services/tier-checkout-config/serializers.ts
@@ -149,3 +149,64 @@ export const toCheckoutConfigResponse = z
     })),
   }))
   .pipe(CheckoutConfigResponse);
+
+/**
+ * What a tier asks a member for, as the tier payload carries it.
+ *
+ * The same rows as the publisher's resource above, minus everything about where a value
+ * lands. A member supplies a delivery address rather than a value for a named field, and
+ * which field holds it is the publisher's business; naming it here would invite a client
+ * to write there directly. The tax number goes too, because the processor keeps one
+ * against the customer it invoices and Ghost never stores it. So do the checkout
+ * questions, which a tier change does not draw.
+ *
+ * Not named for the collection, deliberately: a collection in this domain is a collected
+ * thing together with the field it lands in, and that second half is exactly the part
+ * this drops.
+ */
+const TierRequirements = z.object({
+  /**
+   * A block appears only when the tier asks for that thing, and says so as well, the same
+   * way the publisher's resource does. Presence and the flag agree, so a client may read
+   * whichever it finds clearer.
+   *
+   * Neither says whether a thing may be skipped, because nothing here may be: everything
+   * a tier requires is required. Collection a member could decline is the change that
+   * would need a field of its own rather than a new reading of these two.
+   */
+  shipping: z
+    .object({
+      collect: z.literal(true),
+      /** Absent means everywhere the processor ships, the same as for a publisher. */
+      allowed_countries: z.array(z.string()).optional(),
+    })
+    .optional(),
+  phone: z.object({ collect: z.literal(true) }).optional(),
+});
+export type TierRequirements = z.infer<typeof TierRequirements>;
+
+/**
+ * Keyed by tier, because the payload this joins onto is a list of tiers and a lookup is
+ * the only thing it needs. Tiers a publisher has never set up are absent, and a tier that
+ * collects only a tax number resolves to nothing asked.
+ */
+export function requirementsByTier(configs: TierCheckoutConfig[]): Map<string, TierRequirements> {
+  return new Map(
+    configs.map((config) => [
+      config.tierId,
+      TierRequirements.parse({
+        ...(config.shipping
+          ? {
+              shipping: {
+                collect: true as const,
+                ...(config.shipping.allowedCountries
+                  ? { allowed_countries: config.shipping.allowedCountries }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(config.phone ? { phone: { collect: true as const } } : {}),
+      }),
+    ]),
+  );
+}

--- a/ghost/core/test/e2e-api/content/tiers.test.js
+++ b/ghost/core/test/e2e-api/content/tiers.test.js
@@ -1,4 +1,11 @@
-const { agentProvider, fixtureManager, matchers } = require('../../utils/e2e-framework');
+const assert = require('node:assert/strict');
+const {
+  agentProvider,
+  fixtureManager,
+  matchers,
+  mockManager,
+} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
 
 describe('Tiers Content API', function () {
   let agent;
@@ -7,6 +14,17 @@ describe('Tiers Content API', function () {
     agent = await agentProvider.getContentAPIAgent();
     await fixtureManager.init('members', 'api_keys', 'tiers:archived', 'tiers:hidden');
     await agent.authenticate();
+  });
+
+  // Stated rather than assumed. A tier carries what it asks a member for only where that
+  // feature is on, so these say which world they are describing instead of recording
+  // whatever the environment happened to have enabled.
+  beforeEach(function () {
+    mockManager.mockLabsDisabled('stripeCheckoutCollection');
+  });
+
+  afterEach(function () {
+    mockManager.restore();
   });
 
   it('Can request only active tiers', async function () {
@@ -41,5 +59,126 @@ describe('Tiers Content API', function () {
           updated_at: matchers.anyISODate,
         }),
       });
+  });
+});
+
+// What a tier asks a member for, carried by the tier itself. A themed pricing or
+// plan-change page reads tiers through this API and cannot reach a members-only one, so
+// this is the only place the answer can reach one.
+describe('Tier requirements Content API', function () {
+  let contentAgent;
+  let adminAgent;
+  let paidTier;
+  let otherTier;
+
+  async function defineField(name, type) {
+    const { body } = await adminAgent
+      .post('members/metafields/custom/')
+      .body({ members_metafields: [{ name, type }] })
+      .expectStatus(201);
+    return body.members_metafields[0].key;
+  }
+
+  async function collectShipping(tierId, allowedCountries) {
+    const address = await defineField('Delivery address', 'address');
+    await adminAgent
+      .put(`tiers/${tierId}/checkout_config/`)
+      .body({
+        tiers_checkout_config: [
+          {
+            shipping: {
+              collect: true,
+              ...(allowedCountries ? { allowed_countries: allowedCountries } : {}),
+              name: { custom_field_key: 'shipping_name' },
+              address: { custom_field_key: address },
+            },
+          },
+        ],
+      })
+      .expectStatus(200);
+    return address;
+  }
+
+  async function readTiers() {
+    const { body } = await contentAgent.get('/tiers/').expectStatus(200);
+    return body.tiers;
+  }
+
+  const find = (tiers, id) => tiers.find((tier) => tier.id === id);
+
+  beforeAll(async function () {
+    contentAgent = await agentProvider.getContentAPIAgent();
+    adminAgent = await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('members', 'api_keys', 'tiers:extra');
+    await contentAgent.authenticate();
+    await adminAgent.loginAsOwner();
+
+    const { body } = await adminAgent.get('tiers/?limit=all');
+    [paidTier, otherTier] = body.tiers.filter((tier) => tier.type === 'paid');
+  });
+
+  beforeEach(function () {
+    mockManager.mockLabsEnabled('stripeCheckoutCollection');
+    mockManager.mockLabsEnabled('membersCustomFields');
+  });
+
+  afterEach(async function () {
+    await models.Base.knex('products_checkout_fields').del();
+    await models.Base.knex('products_checkout_config').del();
+    await models.Base.knex('members_metafield_bindings').del();
+    await models.Base.knex('members_metafields').del();
+    mockManager.restore();
+  });
+
+  it('says what a tier asks for, on the tier', async function () {
+    await collectShipping(paidTier.id, ['GB', 'IE']);
+
+    const tiers = await readTiers();
+
+    assert.deepEqual(find(tiers, paidTier.id).requirements, {
+      shipping: { collect: true, allowed_countries: ['GB', 'IE'] },
+    });
+  });
+
+  it('says a tier asks for nothing rather than staying silent', async function () {
+    await collectShipping(paidTier.id, ['GB']);
+
+    const tiers = await readTiers();
+
+    // Empty rather than absent, so a client tells "this tier wants nothing" apart from
+    // "this Ghost cannot tell you" without looking at anything but the key.
+    assert.deepEqual(find(tiers, otherTier.id).requirements, {});
+  });
+
+  it('leaves the countries out when a tier ships anywhere', async function () {
+    await collectShipping(paidTier.id, null);
+
+    const tiers = await readTiers();
+
+    // Ghost stores "everywhere" as no countries at all, and the tier still says it
+    // collects, so an absent list cannot be read as shipping nowhere.
+    assert.deepEqual(find(tiers, paidTier.id).requirements.shipping, { collect: true });
+  });
+
+  it('never names the field a value is kept in', async function () {
+    const address = await collectShipping(paidTier.id, ['GB']);
+
+    const answer = JSON.stringify(await readTiers());
+
+    // A member supplies a delivery address, not a value for a field. Where it lands is
+    // the publisher's business, and naming it would invite a client to write there.
+    assert.ok(!answer.includes(address), 'the destination field is not named');
+    assert.ok(!answer.includes('shipping_name'), 'nor the one the recipient name goes into');
+  });
+
+  it('says nothing at all on a site without the feature', async function () {
+    await collectShipping(paidTier.id, ['GB']);
+    mockManager.mockLabsDisabled('stripeCheckoutCollection');
+
+    const tiers = await readTiers();
+
+    // Absent rather than empty: a Ghost that does not do this should not imply every
+    // tier asks for nothing, which is a different claim.
+    assert.equal(Object.hasOwn(find(tiers, paidTier.id), 'requirements'), false);
   });
 });


### PR DESCRIPTION
## Problem

Ghost can ask a buyer for a delivery address or a phone number while they pay, and keep the answer on their member record. A publisher turns that on per tier.

A member who already pays and switches tier never goes through a payment page — Ghost updates their subscription directly — so nothing asks them for anything. A publisher launches a print tier, turns on shipping, and their existing paid subscribers move onto it from the account panel. Every one of those switches records no address. They find out when they try to post the first issue.

Fixing that means a client must know, before the switch, what the destination tier will ask for. Nothing exposed that.

Where the answer lives is the part that needed deciding. Themes reach data through the `{{#get}}` helper, which maps a fixed list of names onto public controllers. A members-only endpoint is not in that list and cannot be added to it. So a themed pricing or plan-change page could never render "ships to UK and Ireland" if the answer lived on the members API. Portal could, at the cost of a second request and a client-side merge. A theme could not at any cost.

## Proposal

What a tier collects now rides on the content API tier payload, read when that endpoint serves.

Portal already fetches content API tiers on load, so it gains this with no new request and nothing to merge. Themes get it in the same payload they already use.

Read live, not cached, and deliberately not added to the in-memory tier repository. That repository is loaded once at boot and holds the tier aggregate — name, price, benefits — which is what the hot paths need. Deleting a custom field cascades a tier's binding away without that repository ever hearing about it, so a copy taken at boot would go on promising to ask for a field the site no longer has.

The lookup happens in the content controller, which hands the answer to the serializer along with the tiers. The serializer renders what it is given and asks nobody anything, so nothing in it needs to know which API is calling.

That is also what keeps this off the admin payload: the admin controller looks none up. Staff already have a resource carrying these settings in full, including where each collected value is kept, so a reduced copy beside it would say the same thing twice and less completely.

The cost falls on this one endpoint. Every payload that carries tiers in bulk — posts, pages, emails, previews — builds its own reduced projection of a tier and never reaches this code, so none of them pays for the read.

## Not Doing

Removing the in-memory tier repository. It is stale across instances today — a second Ghost's tier edit is invisible until reboot — but that is a pre-existing problem with the aggregate, not with this data, and it deserves its own argument.

Adding the missing cache-invalidation events. Archiving or deleting a custom field emits no invalidation despite cascading a tier's binding away. That only matters once something caches this, and reading live means nothing does.

Collecting the values when a member changes tier, and the Portal form that asks for them. Both are separate.

## Trade-offs

The tier payload gains a key, and a public API surface is hard to retract. It appears only where the feature flag is on, so theme authors cannot rely on it until the flag goes.

The content tiers endpoint gains a database read per request. Small and bounded, but it is a public endpoint.

If this is ever cached, the invalidation gap becomes real and has to be closed first. Reading live defers that rather than solving it.

## Rollback

**Easy.** A flag-gated lookup in one controller, and one key on one serializer. No migration, nothing stored.

## Blast Radius

Content API tier consumers: Portal, themes, and anything reading tiers with a content key. Admin tier responses are untouched. The bulk tier payloads are untouched.

Two existing content tier tests now state which side of the flag they describe, rather than recording whatever the environment had enabled.

## Context

https://linear.app/ghost/issue/BER-3942/collect-what-a-tier-needs-when-a-member-changes-onto-it

Supersedes #30585, which put this behind a members-only endpoint that themes cannot reach.
