### PR TITLE
Rejected stacked history import PRs

### DIFF
--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -211,8 +211,9 @@ copyable `--confirm` command containing the actual PR number and recorded source
 split tip plus the exact head SHA reported by the dry run; do not leave
 placeholders for the administrator to infer. Include the successful dry-run
 evidence and explain that the command rejects a changed head, temporarily
-enables merge commits, merges the pinned PR head, restores the original setting
-and verifies the ancestry. Explicitly say not to use GitHub's normal
+enables merge commits, requests and waits for GitHub's asynchronous direct
+merge of the pinned PR head, restores the original setting and verifies the
+ancestry. Explicitly say not to use GitHub's normal
 squash/rebase buttons and not to remove `[Don't merge]` manually.
 
 Wait for the administrator to report that the command completed. Afterward,

--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -211,10 +211,14 @@ copyable `--confirm` command containing the actual PR number and recorded source
 split tip plus the exact head SHA reported by the dry run; do not leave
 placeholders for the administrator to infer. Include the successful dry-run
 evidence and explain that the command rejects a changed head, temporarily
-enables merge commits, requests and waits for GitHub's asynchronous direct
-merge of the pinned PR head, restores the original setting and verifies the
-ancestry. Explicitly say not to use GitHub's normal
+enables merge commits, merges the pinned PR head, restores the original setting
+and verifies the ancestry. Explicitly say not to use GitHub's normal
 squash/rebase buttons and not to remove `[Don't merge]` manually.
+
+The history-import PR must not belong to a GitHub pull-request stack. The
+preflight must stop and ask the contributor to unstack it before the human
+checkpoint; do not use GitHub's asynchronous stack merge while the repository's
+merge-commit setting is temporarily enabled.
 
 Wait for the administrator to report that the command completed. Afterward,
 independently fetch `main` and confirm the source split tip is an ancestor, then

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -202,11 +202,12 @@ The script:
 1. verifies authentication, PR state, checks and imported-history reachability;
 2. records the current `allow_merge_commit` setting;
 3. enables merge commits only when necessary;
-4. rejects any head other than the SHA validated by the dry run and merges with
-   `--merge --match-head-commit`;
-5. restores the setting through an exit trap;
-6. verifies the merged commit has two parents;
-7. verifies the source split tip remains an ancestor of the merged result.
+4. rejects any head other than the SHA validated by the dry run;
+5. requests GitHub's asynchronous direct-merge endpoint with the pinned head
+   and `merge` method, as required for stacked PRs, and waits for completion;
+6. restores the setting through an exit trap;
+7. verifies the merged commit has two parents;
+8. verifies the source split tip remains an ancestor of the merged result.
 
 If branch protection or a merge queue blocks the operation, report the exact
 blocker. Do not add `--admin` or bypass policy.

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -199,15 +199,20 @@ manually remove the `[Don't merge]` prefix.
 
 The script:
 
-1. verifies authentication, PR state, checks and imported-history reachability;
-2. records the current `allow_merge_commit` setting;
-3. enables merge commits only when necessary;
-4. rejects any head other than the SHA validated by the dry run;
-5. requests GitHub's asynchronous direct-merge endpoint with the pinned head
-   and `merge` method, as required for stacked PRs, and waits for completion;
+1. verifies authentication and rejects PRs that belong to a GitHub stack;
+2. verifies PR state, checks and imported-history reachability;
+3. records the current `allow_merge_commit` setting;
+4. enables merge commits only when necessary;
+5. rejects any head other than the SHA validated by the dry run and merges with
+   `--merge --match-head-commit`;
 6. restores the setting through an exit trap;
 7. verifies the merged commit has two parents;
 8. verifies the source split tip remains an ancestor of the merged result.
+
+GitHub requires stacked PRs to use an asynchronous merge operation. Do not use
+that path for a history import: it would leave the repository-wide merge-commit
+setting enabled while waiting for a background operation. Unstack the import PR
+and rerun the preflight instead.
 
 If branch protection or a merge queue blocks the operation, report the exact
 blocker. Do not add `--admin` or bypass policy.

--- a/.agents/skills/migrate-internal-package/scripts/merge-history-pr
+++ b/.agents/skills/migrate-internal-package/scripts/merge-history-pr
@@ -53,8 +53,6 @@ fi
     fail "--confirm requires the full PR head SHA reported by --dry-run"
 
 command -v gh >/dev/null || fail "gh is required"
-command -v jq >/dev/null || fail "jq is required"
-
 printf 'Checking GitHub authentication...\n'
 gh auth status >/dev/null
 
@@ -63,6 +61,11 @@ is_draft=$(gh pr view "$pr_number" --repo "$repo" --json isDraft --jq '.isDraft'
 mergeable=$(gh pr view "$pr_number" --repo "$repo" --json mergeable --jq '.mergeable')
 merge_state=$(gh pr view "$pr_number" --repo "$repo" --json mergeStateStatus --jq '.mergeStateStatus')
 head_sha=$(gh pr view "$pr_number" --repo "$repo" --json headRefOid --jq '.headRefOid')
+is_stacked=$(gh api \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2026-03-10' \
+    "repos/$repo/pulls/$pr_number" \
+    --jq 'has("stack") and .stack != null')
 
 if [[ $mode == --confirm && $head_sha != "$expected_head" ]]; then
     fail "PR head changed after dry-run (expected: $expected_head, current: $head_sha)"
@@ -72,6 +75,8 @@ fi
 [[ $is_draft == false ]] || fail "PR is still a draft"
 [[ $mergeable == MERGEABLE ]] ||
     fail "PR is not currently mergeable (mergeable: $mergeable)"
+[[ $is_stacked == false ]] ||
+    fail "PR is part of a GitHub stack; unstack it before rerunning the preflight"
 
 printf 'Checking PR checks...\n'
 gh pr checks "$pr_number" --repo "$repo"
@@ -135,51 +140,9 @@ if [[ $original_setting == false ]]; then
         -F allow_merge_commit=true >/dev/null
 fi
 
-printf 'Requesting an asynchronous merge commit for PR %s...\n' "$pr_number"
-merge_request=$(gh api --method PUT \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2026-03-10' \
-    "repos/$repo/pulls/$pr_number/merge-async" \
-    -f "sha=$head_sha" \
-    -f merge_method=merge \
-    -f merge_action=direct_merge)
-
-merge_status=$(jq -r '.status // empty' <<<"$merge_request")
-merge_sha=''
-
-if [[ $merge_status == merged ]]; then
-    merge_sha=$(jq -r '.details.sha // empty' <<<"$merge_request")
-else
-    merge_uuid=$(jq -r '.details.uuid // empty' <<<"$merge_request")
-    [[ -n $merge_uuid ]] ||
-        fail "asynchronous merge request did not return a UUID: $merge_request"
-
-    printf 'Waiting for asynchronous merge request %s...\n' "$merge_uuid"
-    for _ in {1..150}; do
-        merge_result=$(gh api \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$repo/pulls/$pr_number/merge-async/$merge_uuid")
-        merge_status=$(jq -r '.status // empty' <<<"$merge_result")
-
-        case $merge_status in
-            merged)
-                merge_sha=$(jq -r '.details.sha // empty' <<<"$merge_result")
-                break
-                ;;
-            pending | queued)
-                sleep 2
-                ;;
-            *)
-                merge_message=$(jq -r '.details.message // .message // "unknown failure"' <<<"$merge_result")
-                fail "asynchronous merge failed ($merge_status): $merge_message"
-                ;;
-        esac
-    done
-fi
-
-[[ $merge_sha =~ ^[0-9a-fA-F]{40}$ ]] ||
-    fail "asynchronous merge did not complete with a merge commit SHA"
+printf 'Merging PR %s with a merge commit...\n' "$pr_number"
+gh pr merge "$pr_number" --repo "$repo" --merge \
+    --match-head-commit "$head_sha"
 
 restore_setting
 
@@ -188,7 +151,9 @@ restored_setting=$(gh api "repos/$repo" --jq '.allow_merge_commit')
     fail "repository merge setting was not restored"
 
 merged_at=$(gh pr view "$pr_number" --repo "$repo" --json mergedAt --jq '.mergedAt')
+merge_sha=$(gh pr view "$pr_number" --repo "$repo" --json mergeCommit --jq '.mergeCommit.oid')
 [[ -n $merged_at && $merged_at != null ]] || fail "PR does not report as merged"
+[[ $merge_sha =~ ^[0-9a-fA-F]{40}$ ]] || fail "could not determine merge commit SHA"
 
 parent_count=$(gh api "repos/$repo/commits/$merge_sha" --jq '.parents | length')
 [[ $parent_count == 2 ]] ||

--- a/.agents/skills/migrate-internal-package/scripts/merge-history-pr
+++ b/.agents/skills/migrate-internal-package/scripts/merge-history-pr
@@ -53,6 +53,7 @@ fi
     fail "--confirm requires the full PR head SHA reported by --dry-run"
 
 command -v gh >/dev/null || fail "gh is required"
+command -v jq >/dev/null || fail "jq is required"
 
 printf 'Checking GitHub authentication...\n'
 gh auth status >/dev/null
@@ -134,9 +135,51 @@ if [[ $original_setting == false ]]; then
         -F allow_merge_commit=true >/dev/null
 fi
 
-printf 'Merging PR %s with a merge commit...\n' "$pr_number"
-gh pr merge "$pr_number" --repo "$repo" --merge \
-    --match-head-commit "$head_sha"
+printf 'Requesting an asynchronous merge commit for PR %s...\n' "$pr_number"
+merge_request=$(gh api --method PUT \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2026-03-10' \
+    "repos/$repo/pulls/$pr_number/merge-async" \
+    -f "sha=$head_sha" \
+    -f merge_method=merge \
+    -f merge_action=direct_merge)
+
+merge_status=$(jq -r '.status // empty' <<<"$merge_request")
+merge_sha=''
+
+if [[ $merge_status == merged ]]; then
+    merge_sha=$(jq -r '.details.sha // empty' <<<"$merge_request")
+else
+    merge_uuid=$(jq -r '.details.uuid // empty' <<<"$merge_request")
+    [[ -n $merge_uuid ]] ||
+        fail "asynchronous merge request did not return a UUID: $merge_request"
+
+    printf 'Waiting for asynchronous merge request %s...\n' "$merge_uuid"
+    for _ in {1..150}; do
+        merge_result=$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$repo/pulls/$pr_number/merge-async/$merge_uuid")
+        merge_status=$(jq -r '.status // empty' <<<"$merge_result")
+
+        case $merge_status in
+            merged)
+                merge_sha=$(jq -r '.details.sha // empty' <<<"$merge_result")
+                break
+                ;;
+            pending | queued)
+                sleep 2
+                ;;
+            *)
+                merge_message=$(jq -r '.details.message // .message // "unknown failure"' <<<"$merge_result")
+                fail "asynchronous merge failed ($merge_status): $merge_message"
+                ;;
+        esac
+    done
+fi
+
+[[ $merge_sha =~ ^[0-9a-fA-F]{40}$ ]] ||
+    fail "asynchronous merge did not complete with a merge commit SHA"
 
 restore_setting
 
@@ -145,9 +188,7 @@ restored_setting=$(gh api "repos/$repo" --jq '.allow_merge_commit')
     fail "repository merge setting was not restored"
 
 merged_at=$(gh pr view "$pr_number" --repo "$repo" --json mergedAt --jq '.mergedAt')
-merge_sha=$(gh pr view "$pr_number" --repo "$repo" --json mergeCommit --jq '.mergeCommit.oid')
 [[ -n $merged_at && $merged_at != null ]] || fail "PR does not report as merged"
-[[ $merge_sha =~ ^[0-9a-fA-F]{40}$ ]] || fail "could not determine merge commit SHA"
 
 parent_count=$(gh api "repos/$repo/commits/$merge_sha" --jq '.parents | length')
 [[ $parent_count == 2 ]] ||

--- a/docs/contributing/internal-package-migrations.md
+++ b/docs/contributing/internal-package-migrations.md
@@ -85,8 +85,10 @@ restores the original setting, and verifies that the resulting commit has two
 parents and still contains the imported ancestry. If the head changed, return
 to the skill for another review and preflight rather than updating the SHA
 manually. GitHub requires stacked pull requests to use its asynchronous merge
-API, so the script submits a direct merge-commit request and waits for it to
-finish before restoring the repository setting.
+API, which would leave the repository-wide merge-commit setting enabled while a
+background operation runs. The script therefore rejects stacked migrations;
+the contributor must unstack the import PR and rerun the preflight before the
+administrator checkpoint.
 
 This operation requires repository administration permission because Ghost
 normally has merge commits disabled. It is intentionally performed by a human

--- a/docs/contributing/internal-package-migrations.md
+++ b/docs/contributing/internal-package-migrations.md
@@ -1,16 +1,15 @@
 # Move an internal package into Ghost
 
-Packages in TryGhost repositories such as SDK and framework can be moved into
-Ghost when Ghost is their real owner and they no longer need independent
-releases. Use the `migrate-internal-package` skill to preserve the package's Git
-history, integrate it into the Ghost workspace and coordinate the cleanup work
-across repositories.
+Use the `migrate-internal-package` skill when Ghost should take ownership of a
+package from another TryGhost repository, such as SDK or framework. The skill
+preserves its Git history and coordinates the work across both repositories.
 
-Any contributor can run the skill. Repository administration permission is not
-needed for preparing the import or completing the follow-up work; it is needed
-only for the short merge checkpoint described below.
+Any contributor can run the skill. A Ghost repository administrator is needed
+only to merge the history-import PR.
 
-Start the skill from the Ghost repository with the source package URL:
+## 1. Ask the AI to prepare the migration
+
+From the Ghost repository, provide the package URL:
 
 ```text
 Use $migrate-internal-package to move
@@ -18,56 +17,24 @@ https://github.com/TryGhost/<source>/tree/main/packages/<package>
 into Ghost as an internal-only package.
 ```
 
-The skill first checks the package's consumers, npm status, dependencies and
-release configuration. It stops if the package still needs to be independently
-versioned or supported for external use, because that requires a different
-publishing model.
+The skill audits current consumers, prepares and tests the Ghost import, and
+opens a PR. It stops when the PR is ready for its exceptional merge.
 
-## What the skill produces
+Expect the handoff to include:
 
-The migration is split into focused pull requests so the history import remains
-reviewable:
+- a green, unstacked PR titled `[Don't merge] ...`;
+- a successful read-only preflight;
+- the source-history and reviewed-head SHAs;
+- a complete administrator command with no placeholders.
 
-1. A Ghost import PR containing the original package history and the minimum
-   workspace integration.
-2. After the import is merged and verified, a source-repository PR removing the
-   old package and its publishing configuration.
-3. When applicable, follow-up PRs for migration-only configuration cleanup and
-   package modernization.
+Do not merge this PR with GitHub's squash, rebase, merge queue, or stacked-PR
+controls. Those paths either discard the imported history or require a
+background merge while Ghost's repository-wide merge-commit setting is enabled.
 
-The import PR keeps behavior changes and modernization out of the move. It
-switches Ghost consumers to `workspace:*`, marks the package private, maps its
-dependencies into the Ghost workspace and verifies the real production package
-path and release archive.
+## 2. Ask an administrator to merge it
 
-## Run the migration
-
-### 1. Let the skill prepare the import
-
-The skill extracts the package-only history and imports it with an unsquashed
-Git subtree merge. The resulting Ghost PR must:
-
-- have a title beginning `[Don't merge]`;
-- warn against using GitHub's normal merge controls;
-- record the full source split SHA and subtree commit SHA;
-- include a ready-to-run `--confirm` command with no placeholders;
-- have green CI before reaching the merge checkpoint.
-
-`[Don't merge]` means that the PR must not use Ghost's normal squash or rebase
-merge. Keep the prefix in place until the guarded command performs the
-history-preserving merge.
-
-The skill also runs the guarded merge script in read-only mode. This verifies
-the PR state, CI, reviewed head, repository setting and imported ancestry
-without changing GitHub. It resolves preparation failures where possible and
-includes the successful preflight evidence in its handoff.
-
-### 2. Ask a repository administrator to merge it
-
-The skill stops at the only manual checkpoint and gives the contributor a
-complete handoff for one of the Ghost repository administrators. The
-administrator runs the command provided in the PR from the Ghost repository
-root:
+Send the command from the skill's handoff to a Ghost repository administrator.
+They run it from an up-to-date Ghost checkout:
 
 ```bash
 .agents/skills/migrate-internal-package/scripts/merge-history-pr \
@@ -78,55 +45,21 @@ root:
     --confirm
 ```
 
-The script first checks that the PR still has the exact head SHA validated by
-the skill's dry run. It then records Ghost's merge-commit setting, temporarily
-enables merge commits if required, merges with that reviewed head pinned,
-restores the original setting, and verifies that the resulting commit has two
-parents and still contains the imported ancestry. If the head changed, return
-to the skill for another review and preflight rather than updating the SHA
-manually. GitHub requires stacked pull requests to use its asynchronous merge
-API, which would leave the repository-wide merge-commit setting enabled while a
-background operation runs. The script therefore rejects stacked migrations;
-the contributor must unstack the import PR and rerun the preflight before the
-administrator checkpoint.
+The command pins the reviewed PR head, briefly enables merge commits, performs
+the merge, restores the original repository setting, and verifies the imported
+history. Never replace the values supplied by the skill.
 
-This operation requires repository administration permission because Ghost
-normally has merge commits disabled. It is intentionally performed by a human
-administrator rather than by the skill.
+If the command fails, stop and give its complete output back to the skill. In
+particular, unstack a stacked PR or rerun the preflight after any head change.
 
-Do not substitute a manual `gh pr merge`, GitHub squash merge, rebase merge, or
-merge queue. If the script reports a protection or permission failure, resolve
-that specific blocker rather than bypassing it.
+## 3. Ask the AI to continue
 
-### 3. Let the skill complete the migration
+After the administrator command succeeds, tell the skill to continue. It
+independently verifies the history on `main`, then handles the source-repository
+removal, npm deprecation where appropriate, migration cleanup, and a separate
+modernization PR when needed.
 
-After the administrator reports that the command completed, the contributor
-asks the skill to continue. It fetches Ghost `main` and confirms that the
-recorded source split SHA is an ancestor before removing anything from the
-source repository. It then automates or prepares the remaining work:
+Do not remove the source package before the skill verifies the Ghost merge.
 
-1. Remove the package and its publishing configuration from the source
-   repository in a normal PR.
-2. Decide whether the public npm versions should be deprecated for new direct
-   use. Existing versions remain published for old Ghost releases.
-3. Remove migration-only catalog or Renovate configuration from Ghost.
-4. Modernize the internal package in a focused PR when necessary.
-
-Source cleanup must not start before the history-preserving Ghost merge is
-verified. This ordering prevents a period where neither repository owns the
-package.
-
-## If the merge cannot proceed
-
-- If CI or another commit changes the PR head, ask the skill to rerun its
-  preflight and produce a new handoff; the script pins the merge to the current
-  reviewed head.
-- If the source split SHA is missing or ambiguous, ask the skill to verify the
-  subtree topology and update the PR instructions. Do not infer it.
-- If the repository merge setting cannot be restored, restore its original
-  value before continuing.
-- If the consumer audit finds supported external use, stop the internal-only
-  migration and keep an appropriate independent publishing path.
-
-The detailed agent procedure is in the
+The detailed agent procedure lives in the
 [`migrate-internal-package` skill](../../.agents/skills/migrate-internal-package/SKILL.md).

--- a/docs/contributing/internal-package-migrations.md
+++ b/docs/contributing/internal-package-migrations.md
@@ -84,7 +84,9 @@ enables merge commits if required, merges with that reviewed head pinned,
 restores the original setting, and verifies that the resulting commit has two
 parents and still contains the imported ancestry. If the head changed, return
 to the skill for another review and preflight rather than updating the SHA
-manually.
+manually. GitHub requires stacked pull requests to use its asynchronous merge
+API, so the script submits a direct merge-commit request and waits for it to
+finish before restoring the repository setting.
 
 This operation requires repository administration permission because Ghost
 normally has merge commits disabled. It is intentionally performed by a human


### PR DESCRIPTION
## Summary

- Rejects stacked history-import PRs during preflight so the administrator checkpoint remains a short, synchronous repository-setting exception.
- Tells contributors to unstack the import and rerun preflight instead of using GitHub's asynchronous stack merge.
- Reduces the human migration guide to the two AI interactions, the administrator command, and essential failure handling.

## Testing

- [x] `bash -n .agents/skills/migrate-internal-package/scripts/merge-history-pr`
- [x] `pnpm lint:agent-skills`
- [x] `pnpm exec oxfmt --check .agents/skills/migrate-internal-package/SKILL.md .agents/skills/migrate-internal-package/references/history-and-merge.md docs/contributing/internal-package-migrations.md`
- [x] `pnpm exec markdownlint-cli2 .agents/skills/migrate-internal-package/SKILL.md .agents/skills/migrate-internal-package/references/history-and-merge.md docs/contributing/internal-package-migrations.md`
- [x] `pnpm exec remark --frail --no-stdout .agents/skills/migrate-internal-package/SKILL.md .agents/skills/migrate-internal-package/references/history-and-merge.md docs/contributing/internal-package-migrations.md`
- [x] Live read-only preflight against unstacked #30510
- [x] #30510 merged synchronously with its imported history preserved and the repository setting restored
