### PR TITLE
Added concurrent newsletter preparation from an upfront recipient sweep

### DIFF
--- a/ghost/core/core/server/lib/promise-pool.ts
+++ b/ghost/core/core/server/lib/promise-pool.ts
@@ -1,12 +1,13 @@
 import errors from '@tryghost/errors';
 import type { Promisable } from 'type-fest';
 
-const validateMaxConcurrency = (maxConcurrency: number) => {
+export const validateMaxConcurrency = (maxConcurrency: number, name = 'Concurrency'): number => {
   if (maxConcurrency < 1 || !Number.isSafeInteger(maxConcurrency)) {
     throw new errors.IncorrectUsageError({
-      message: 'Concurrency must be a positive integer',
+      message: `${name} must be a positive integer`,
     });
   }
+  return maxConcurrency;
 };
 
 /**

--- a/ghost/core/core/server/services/email-service/CONTEXT.md
+++ b/ghost/core/core/server/services/email-service/CONTEXT.md
@@ -40,8 +40,12 @@ _Avoid_: Failure step
 A member selected for a newsletter email's audience before preparation exclusions. Selection does not mean the member has been prepared or submitted.
 _Avoid_: Subscriber count, delivered recipient
 
+**Prepared recipient**:
+A candidate whose address and personalization data have been recorded for a newsletter email. Preparation does not mean submission or delivery.
+_Avoid_: Candidate recipient, delivered recipient
+
 **Preparation exclusion**:
-A candidate explicitly omitted from a newsletter email's prepared audience because required recipient data is unavailable.
+A candidate omitted from preparation because the member can no longer be found or required recipient data is missing. Candidates equal prepared recipients plus preparation exclusions.
 _Avoid_: Failed delivery, silently skipped recipient
 
 **Accounted email**:

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -54,13 +54,8 @@ in one transaction. Warming allocation follows selected candidate order,
 including exclusions, rather than transaction completion order. Each nonempty
 batch stores `recipient_count` atomically with its recipients.
 
-Member lookup happens outside the write transaction. A bounded primary-key range
-read avoids the repeated primary-key lookups of a large ID list for dense pages;
-local lookup measurements favor it for dense audiences. Results are filtered
-against the page's selected IDs. If the range contains more than eight times the
-page size, that page falls back to an ID-list query and the segment remembers
-that choice for its remaining pages. Concurrent range reads already started may
-still finish their own probes. Each new segment starts with the range strategy. Required member data
+Member lookup happens outside the write transaction. Each page loads its selected
+IDs in one query and restores candidate order before preparation. Required member data
 missing from an existing record is an explicit exclusion with error logging and
 Sentry reporting. A selected member no longer found is a `member_not_found`
 exclusion logged at information level. Database failures are not exclusions.
@@ -273,10 +268,10 @@ between free and paid segments to exercise the combined audience selection.
 It measures the full audience, discard and rebuild after a complete pending attempt, and a label
 audience containing every fifth member. JSON output includes database settings,
 query counts, elapsed times, sweep and discard durations, and sampled memory.
-Member lookups also report query count, rows transferred (including range probes),
+Member lookups also report query count, rows transferred,
 and summed query duration. These query durations overlap under concurrency and
 are not the phase's wall-clock duration. Compare both the full and label-filtered
-audiences when changing the lookup strategy.
+audiences when measuring preparation.
 
 Repeat at 500,000 and 1,000,000 members with concurrency 1, 2, and 4 to compare
 settings. RSS and heap samples every 10 ms may miss peaks during synchronous

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -27,14 +27,20 @@ rebuilding may refresh the eligible audience even if preparation finished
 immediately before a crash. No submission has started. After `prepared_at` is
 saved, the audience stays frozen.
 
-Select ordered member IDs upfront for each segment, using the existing audience
-filter and the email's member-ID cutoff. Failed sweeps retry within the existing
-database budget; only a complete successful result contributes candidates.
-Collapse adjacent duplicate IDs in memory and count candidates before dividing
-them into pages. Choose each page's domain and cap its size at the remaining
-warming capacity before dispatching it; after that capacity is exhausted, use
-full-size fallback pages. Segments are prepared sequentially and do not share a
-snapshot.
+Select member IDs for every segment upfront in one `UNION ALL` statement, using
+the existing audience filters and the email's member-ID cutoff. The statement
+gives all segments the same database view without holding a transaction open
+across selection queries or batch writes. Failed selections retry as a whole
+within the existing database budget, before any batches are written. Only a
+complete successful result contributes candidates.
+
+Order the result by segment and descending member ID, collapse adjacent duplicate
+IDs within each segment, and count candidates before dividing them into pages.
+Choose each page's domain and cap its size at the remaining warming capacity
+before dispatching it; after that capacity is exhausted, use full-size fallback
+pages. Prepare the selected segments sequentially. All segments' candidate IDs
+remain in memory until preparation finishes; the combined ordering can require a
+database sort over the full audience.
 
 `bulkEmail:batchCreationConcurrency` defaults to 2 and directly bounds active
 pages per email, independently of database pool settings. Explicit per-site
@@ -51,18 +57,13 @@ missing from an existing record is an explicit exclusion with error logging and
 Sentry reporting. A selected member no longer found is a `member_not_found`
 exclusion logged at information level. Database failures are not exclusions.
 
-Selection fixes eligibility for that segment: unsubscribing, disabling email, or
-changing audience attributes after selection does not remove a candidate whose
-data remains valid. Newly eligible members are not added. Earlier paged preparation
-rechecked eligibility per page; submission validation remains unchanged. Faster
-preparation can shorten this window, but retries can extend it. Members changing
-segment between sweeps can still be selected twice or missed by both segments.
-
-Each segment's sweep reads current member filter attributes. The member-ID
-cutoff excludes newer members but does not freeze those attributes across
-segments or preparation attempts. The candidate/recipient/exclusion equation
-accounts for IDs selected during that attempt; it does not establish a single
-point-in-time audience snapshot across all segments.
+Selection fixes eligibility and segment assignment for the whole email:
+unsubscribing, disabling email, or changing audience attributes after selection
+does not remove a candidate whose data remains valid. Newly eligible members are
+not added. Earlier paged preparation rechecked eligibility per page; submission
+validation remains unchanged. Retries of incomplete preparation select a fresh
+audience. The member-ID cutoff excludes newer members across those attempts,
+but does not freeze existing members' attributes between attempts.
 
 Each batch creation operation retains its ID and intended recipient data across
 database retries of that operation. Restarting incomplete preparation before
@@ -250,8 +251,9 @@ NODE_OPTIONS=--conditions=source node --expose-gc scripts/benchmark-recipient-pr
 
 The arguments are member count and preparation concurrency. The harness creates
 and drops its own database on `127.0.0.1:3306`, uses Ghost's schema and preparation
-service with a pool of five, and never submits email. It measures the full
-audience, discard and rebuild after a complete pending attempt, and a label
+service with a pool of five, and never submits email. Members are split evenly
+between free and paid segments to exercise the combined audience selection.
+It measures the full audience, discard and rebuild after a complete pending attempt, and a label
 audience containing every fifth member. JSON output includes database settings,
 query counts, elapsed times, sweep and discard durations, and sampled memory.
 

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -27,18 +27,42 @@ rebuilding may refresh the eligible audience even if preparation finished
 immediately before a crash. No submission has started. After `prepared_at` is
 saved, the audience stays frozen.
 
-Choose each page's size and sending domain before fetching it. While warming
-capacity remains, cap the page at that capacity; afterward use the full batch
-size on the fallback domain. Each page creates at most one batch. Count candidates
-once per consumed page, excluding the lookahead row and before exclusions or
-database retries. Invalid member data is an explicit
-preparation exclusion with error logging and Sentry reporting. Every nonempty
-batch stores `recipient_count` in the same transaction as its recipients.
+Select ordered member IDs upfront for each segment, using the existing audience
+filter and the email's member-ID cutoff. Failed sweeps retry within the existing
+database budget; only a complete successful result contributes candidates.
+Collapse adjacent duplicate IDs in memory and count candidates before dividing
+them into pages. Choose each page's domain and cap its size at the remaining
+warming capacity before dispatching it; after that capacity is exhausted, use
+full-size fallback pages. Segments are prepared sequentially and do not share a
+snapshot.
 
-Audience pages read live member data. The member-ID cutoff excludes newer
-members but does not freeze filter attributes. The candidate/recipient/exclusion
-equation accounts for candidates consumed during that preparation attempt; it
-does not establish a point-in-time snapshot of everyone matching the filter.
+`bulkEmail:batchCreationConcurrency` defaults to 2 and directly bounds active
+pages per email, independently of database pool settings. Explicit per-site
+overrides can raise it after measuring database load. A worker owns its page
+through member lookup, writes, and retries. Each page creates at most one batch
+in one transaction. Warming allocation follows selected candidate order,
+including exclusions, rather than transaction completion order. Each nonempty
+batch stores `recipient_count` atomically with its recipients.
+
+Member lookup happens outside the write transaction. A bounded primary-key range
+read filters against the page's selected IDs, falling back to an ID-list query when
+the range contains more than eight times the page size. Required member data
+missing from an existing record is an explicit exclusion with error logging and
+Sentry reporting. A selected member no longer found is a `member_not_found`
+exclusion logged at information level. Database failures are not exclusions.
+
+Selection fixes eligibility for that segment: unsubscribing, disabling email, or
+changing audience attributes after selection does not remove a candidate whose
+data remains valid. Newly eligible members are not added. Earlier paged preparation
+rechecked eligibility per page; submission validation remains unchanged. Faster
+preparation can shorten this window, but retries can extend it. Members changing
+segment between sweeps can still be selected twice or missed by both segments.
+
+Each segment's sweep reads current member filter attributes. The member-ID
+cutoff excludes newer members but does not freeze those attributes across
+segments or preparation attempts. The candidate/recipient/exclusion equation
+accounts for IDs selected during that attempt; it does not establish a single
+point-in-time audience snapshot across all segments.
 
 Each batch creation operation retains its ID and intended recipient data across
 database retries of that operation. Restarting incomplete preparation before
@@ -51,6 +75,14 @@ recipient data match. A retry insert uses the same primary key, including when
 the first recovery read failed. The transaction must settle or roll back before
 the recovery read; a lock-wait timeout is not evidence that the original insert
 failed.
+
+Workers stop claiming pages when shutdown or a terminal preparation failure
+occurs. An attempt-scoped abort signal wakes preparation retry backoffs and prevents
+further attempts; it does not cancel in-flight transactions or their recovery reads.
+All workers drain before preparation verification or returning a failure. Submission
+does not use this signal and retains its retry policy. Failed partial preparation
+is kept until the next attempt performs bounded cleanup; cleanup time is separate
+from the cost of rebuilding and can dominate a large retry.
 
 Before saving `prepared_at`, verify actual recipient rows against stored counts,
 per batch and for the email, reject cross-email ownership even when swapped rows
@@ -90,6 +122,14 @@ recipient uniqueness. Compensating omissions and duplicates can balance a count
 equation. Provider retries after an uncertain response can cause additional
 accepted submissions, and database failover can lose preparation or submission
 records. This protocol does not provide exactly-once delivery.
+
+Persisted batch-list order is unspecified and may differ from audience order.
+Delivery-time spreading follows that list; individual recipients' time slots may
+change without changing warming allocation. A draining process and a new process
+resuming the same email can overlap: batch status locks prevent concurrent claims
+of the same batch, but do not prevent duplicate batch sets with different IDs.
+Verification can detect conflicts; per-process draining is not a cross-process
+ownership fence.
 
 Rolling back to code without recipient accounting can start submitting an
 accounted email without establishing its preparation boundary. After rolling
@@ -197,6 +237,30 @@ at warning level. Invalid members emit `email.preparation.excluded` or
 `reason`, and the preparation attempt or submission batch ID. Exclusions do not
 trigger the discrepancy event because the recipient is accounted for. These records cover discrepancies Ghost can verify; they do not independently
 measure Mailgun acceptance or delivery, including uncertain POST outcomes.
+
+## Benchmarking preparation
+
+From `ghost/core`, run the synthetic MySQL benchmark with the local database
+password in `database__connection__password` (and user in
+`database__connection__user`, default `root`):
+
+```sh
+NODE_OPTIONS=--conditions=source node --expose-gc scripts/benchmark-recipient-preparation.js 500000 2
+```
+
+The arguments are member count and preparation concurrency. The harness creates
+and drops its own database on `127.0.0.1:3306`, uses Ghost's schema and preparation
+service with a pool of five, and never submits email. It measures the full
+audience, discard and rebuild after a complete pending attempt, and a label
+audience containing every fifth member. JSON output includes database settings,
+query counts, elapsed times, sweep and discard durations, and sampled memory.
+
+Repeat at 500,000 and 1,000,000 members with concurrency 1, 2, and 4 to compare
+settings. RSS and heap samples every 10 ms may miss peaks during synchronous
+driver work; retained heap is measured after preparation and GC, when the sweep
+array has been released. A fresh local database does not model a production
+recipient table's history or concurrent site traffic. Production capacity and
+contention require separate measurements.
 
 ## Sending status
 

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -44,15 +44,23 @@ database sort over the full audience.
 
 `bulkEmail:batchCreationConcurrency` defaults to 2 and directly bounds active
 pages per email, independently of database pool settings. Explicit per-site
-overrides can raise it after measuring database load. A worker owns its page
+overrides can raise it after measuring database load. The value must be a positive
+integer JSON number; invalid configuration stops boot with a configuration error.
+Validation happens in the `BatchSendingService` constructor. SQLite uses one database
+connection, so raising the worker limit does not add database concurrency there.
+A worker owns its page
 through member lookup, writes, and retries. Each page creates at most one batch
 in one transaction. Warming allocation follows selected candidate order,
 including exclusions, rather than transaction completion order. Each nonempty
 batch stores `recipient_count` atomically with its recipients.
 
 Member lookup happens outside the write transaction. A bounded primary-key range
-read filters against the page's selected IDs, falling back to an ID-list query when
-the range contains more than eight times the page size. Required member data
+read avoids the repeated primary-key lookups of a large ID list for dense pages;
+local lookup measurements favor it for dense audiences. Results are filtered
+against the page's selected IDs. If the range contains more than eight times the
+page size, that page falls back to an ID-list query and the segment remembers
+that choice for its remaining pages. Concurrent range reads already started may
+still finish their own probes. Each new segment starts with the range strategy. Required member data
 missing from an existing record is an explicit exclusion with error logging and
 Sentry reporting. A selected member no longer found is a `member_not_found`
 exclusion logged at information level. Database failures are not exclusions.
@@ -72,15 +80,20 @@ database retries of that operation. Restarting incomplete preparation before
 
 After a transaction error, recovery reads through the normal
 database pool and accepts a committed batch only if its metadata and exact
-recipient data match. A retry insert uses the same primary key, including when
-the first recovery read failed. The transaction must settle or roll back before
+recipient data match. While retries remain allowed, a retry insert uses the same
+primary key, including after a failed recovery read. The transaction must settle or roll back before
 the recovery read; a lock-wait timeout is not evidence that the original insert
 failed.
 
 Workers stop claiming pages when shutdown or a terminal preparation failure
-occurs. An attempt-scoped abort signal wakes preparation retry backoffs and prevents
-further attempts; it does not cancel in-flight transactions or their recovery reads.
-All workers drain before preparation verification or returning a failure. Submission
+occurs. A per-segment abort signal wakes preparation retry backoffs and stops
+further tries. It does not interrupt an in-flight transaction or recovery read,
+but prevents retrying a failed recovery read. A batch that committed without an
+acknowledgement can therefore remain unverified and pending until the next
+attempt's cleanup. All workers drain before verification or returning a failure.
+If shutdown starts after all pages finish, complete verification and save
+`prepared_at` using the shutdown retry budget, preserving the finished work.
+Submission
 does not use this signal and retains its retry policy. Failed partial preparation
 is kept until the next attempt performs bounded cleanup; cleanup time is separate
 from the cost of rebuilding and can dominate a large retry.
@@ -233,17 +246,21 @@ totals. Preparation-era batches with unknown submission counts instead emit
 unknown historical counts alone are not a detected discrepancy.
 
 A legitimate preflight audience change emits `email.preparation.audience_drift`
-at warning level. Invalid members emit `email.preparation.excluded` or
-`email.submission.excluded` at error level, with `email_id`, `member_id`,
-`reason`, and the preparation attempt or submission batch ID. Exclusions do not
+at warning level. Members with invalid required data emit
+`email.preparation.excluded` or `email.submission.excluded` at error level and
+are reported to Sentry. A selected member no longer found instead emits
+`email.preparation.excluded` with reason `member_not_found` at info level, without
+Sentry reporting. Both paths include `email_id`, `member_id`, `reason`, and the
+preparation attempt or submission batch ID. Exclusions do not
 trigger the discrepancy event because the recipient is accounted for. These records cover discrepancies Ghost can verify; they do not independently
 measure Mailgun acceptance or delivery, including uncertain POST outcomes.
 
 ## Benchmarking preparation
 
-From `ghost/core`, run the synthetic MySQL benchmark with the local database
-password in `database__connection__password` (and user in
-`database__connection__user`, default `root`):
+From `ghost/core`, run the synthetic MySQL benchmark. Credentials default to
+`root` / `root`, matching `testing-mysql`; override them with
+`database__connection__user` and `database__connection__password` for a different
+local database (an explicitly empty password is preserved):
 
 ```sh
 NODE_OPTIONS=--conditions=source node --expose-gc scripts/benchmark-recipient-preparation.js 500000 2
@@ -256,6 +273,10 @@ between free and paid segments to exercise the combined audience selection.
 It measures the full audience, discard and rebuild after a complete pending attempt, and a label
 audience containing every fifth member. JSON output includes database settings,
 query counts, elapsed times, sweep and discard durations, and sampled memory.
+Member lookups also report query count, rows transferred (including range probes),
+and summed query duration. These query durations overlap under concurrency and
+are not the phase's wall-clock duration. Compare both the full and label-filtered
+audiences when changing the lookup strategy.
 
 Repeat at 500,000 and 1,000,000 members with concurrency 1, 2, and 4 to compare
 settings. RSS and heap samples every 10 ms may miss peaks during synchronous

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -12,7 +12,7 @@ const {
 } = require('./recipient-accounting');
 const {
   validatePreparationConcurrency,
-  selectedMemberIds,
+  selectPreparationCandidates,
   resolvePreparationMembers,
   runPreparationWorkers,
   preparationPages,
@@ -458,7 +458,7 @@ class BatchSendingService {
     const attemptId = ObjectID().toHexString();
     const startedAt = Date.now();
     await this.#startPreparation(email, attemptId);
-    const counts = await this.#sweepPreparationSegments({ email, post, newsletter, attemptId });
+    const counts = await this.#prepareAudience({ email, post, newsletter, attemptId });
     this.#checkPreparationActive();
     const batches = await this.#completePreparation(email, { ...counts, attemptId });
     logging.info(
@@ -489,48 +489,56 @@ class BatchSendingService {
     }
   }
 
-  async #sweepPreparationSegments({ email, post, newsletter, attemptId }) {
+  async #selectPreparationAudience({ email, newsletter, segments, attemptId }) {
+    const startedAt = Date.now();
+    const candidates = await this.retryDb(
+      () => {
+        this.#checkPreparationActive();
+        const queries = segments.map((segment) => {
+          const filter = this.#emailSegmenter.getMemberFilterForSegment(
+            newsletter,
+            email.get('recipient_filter'),
+            segment,
+          );
+          return this.#models.Member.getFilteredCollectionQuery({
+            filter: filter + `+id:<'${email.id}'`,
+          });
+        });
+        return selectPreparationCandidates(this.#db.knex, queries);
+      },
+      {
+        ...this.#getBeforeRetryConfig(email),
+        description: `sweep audience for email ${email.id}`,
+      },
+    );
+    this.#checkPreparationActive();
+    logging.info(
+      {
+        event: { name: 'email.preparation.swept' },
+        email_id: email.id,
+        attempt_id: attemptId,
+        candidate_count: candidates.reduce((total, ids) => total + ids.length, 0),
+        duration_ms: Date.now() - startedAt,
+      },
+      'Selected newsletter candidate recipients',
+    );
+    return candidates;
+  }
+
+  async #prepareAudience({ email, post, newsletter, attemptId }) {
     const segments = await this.#emailRenderer.getSegments(post);
+    const candidates = await this.#selectPreparationAudience({
+      email,
+      newsletter,
+      segments,
+      attemptId,
+    });
     const batchSize = this.#sendingService.getMaximumRecipients();
     const warmupLimit = this.#getDomainWarmupLimit(email);
     let candidateCount = 0;
     let excludedCount = 0;
-    for (const segment of segments) {
-      const segmentFilter = this.#emailSegmenter.getMemberFilterForSegment(
-        newsletter,
-        email.get('recipient_filter'),
-        segment,
-      );
-      const startedAt = Date.now();
-      const ids = await this.retryDb(
-        async () => {
-          this.#checkPreparationActive();
-          // Each segment reads current filter attributes; the ID cutoff only excludes newer members.
-          // Counts cover this attempt's selected IDs, not one snapshot shared by all segments.
-          const rows = await this.#models.Member.getFilteredCollectionQuery({
-            filter: segmentFilter + `+id:<'${email.id}'`,
-          })
-            .orderByRaw('members.id DESC')
-            .select('members.id');
-          return selectedMemberIds(rows);
-        },
-        {
-          ...this.#getBeforeRetryConfig(email),
-          description: `sweep audience for email ${email.id} segment ${segment}`,
-        },
-      );
-      this.#checkPreparationActive();
-      logging.info(
-        {
-          event: { name: 'email.preparation.swept' },
-          email_id: email.id,
-          attempt_id: attemptId,
-          segment,
-          candidate_count: ids.length,
-          duration_ms: Date.now() - startedAt,
-        },
-        'Selected newsletter candidate recipients',
-      );
+    for (const [index, ids] of candidates.entries()) {
+      const segment = segments[index];
       const remainingCapacity = warmupLimit - candidateCount;
       candidateCount += ids.length;
       if (ids.length === 0) {

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -13,7 +13,7 @@ const {
 } = require('./recipient-accounting');
 const {
   selectPreparationCandidates,
-  createPreparationMemberResolver,
+  resolvePreparationMembers,
   runPreparationWorkers,
   preparationPages,
   waitForPreparationRetry,
@@ -548,7 +548,6 @@ class BatchSendingService {
       if (ids.length === 0) {
         continue;
       }
-      const resolveMembers = createPreparationMemberResolver(this.#db.knex);
       await runPreparationWorkers(
         preparationPages(ids, batchSize, remainingCapacity),
         // Avoid allocating idle workers for a small audience and a large configured limit.
@@ -562,7 +561,6 @@ class BatchSendingService {
               segment,
               attemptId,
               page,
-              resolveMembers,
             },
             signal,
           );
@@ -575,11 +573,11 @@ class BatchSendingService {
     return { candidateCount, excludedCount };
   }
 
-  async #prepareSweptPage({ email, segment, attemptId, page, resolveMembers }, signal) {
+  async #prepareSweptPage({ email, segment, attemptId, page }, signal) {
     const rows = await this.retryDb(
       () => {
         this.#checkPreparationActive(signal);
-        return resolveMembers(page.ids);
+        return resolvePreparationMembers(this.#db.knex, page.ids);
       },
       {
         ...this.#getBeforeRetryConfig(email),

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -10,6 +10,14 @@ const {
   countsDiffer,
   missingRecipientFields,
 } = require('./recipient-accounting');
+const {
+  validatePreparationConcurrency,
+  selectedMemberIds,
+  resolvePreparationMembers,
+  runPreparationWorkers,
+  preparationPages,
+  waitForPreparationRetry,
+} = require('./recipient-preparation');
 const messages = {
   emailErrorPartialFailure:
     'An error occurred, and your newsletter was only partially sent. Please retry sending the remaining emails.',
@@ -44,6 +52,7 @@ class BatchSendingService {
   #db;
   #sentry;
   #getRequiredUrlRelations;
+  #batchCreationConcurrency;
   #shuttingDown = false;
   #inFlight = new Set();
 
@@ -74,6 +83,7 @@ class BatchSendingService {
    * @param {object} dependencies.db
    * @param {() => string[]} [dependencies.getRequiredUrlRelations] Post relations the live routes need loaded to generate URLs (lazy routing); defaults to none
    * @param {object} [dependencies.sentry]
+   * @param {number} [dependencies.batchCreationConcurrency] Maximum active preparation pages
    * @param {object} [dependencies.BEFORE_RETRY_CONFIG]
    * @param {object} [dependencies.AFTER_RETRY_CONFIG]
    * @param {object} [dependencies.MAILGUN_API_RETRY_CONFIG]
@@ -88,6 +98,7 @@ class BatchSendingService {
     db,
     sentry,
     getRequiredUrlRelations = () => [],
+    batchCreationConcurrency = 2,
     BEFORE_RETRY_CONFIG,
     AFTER_RETRY_CONFIG,
     MAILGUN_API_RETRY_CONFIG,
@@ -101,6 +112,7 @@ class BatchSendingService {
     this.#db = db;
     this.#sentry = sentry;
     this.#getRequiredUrlRelations = getRequiredUrlRelations;
+    this.#batchCreationConcurrency = validatePreparationConcurrency(batchCreationConcurrency);
 
     if (BEFORE_RETRY_CONFIG) {
       this.#BEFORE_RETRY_CONFIG = BEFORE_RETRY_CONFIG;
@@ -444,9 +456,149 @@ class BatchSendingService {
 
   async #rebuildPreparation({ email, post, newsletter }) {
     const attemptId = ObjectID().toHexString();
+    const startedAt = Date.now();
     await this.#startPreparation(email, attemptId);
-    const counts = await this.#prepareSegments({ email, post, newsletter, attemptId });
-    return this.#completePreparation(email, { ...counts, attemptId });
+    const counts = await this.#sweepPreparationSegments({ email, post, newsletter, attemptId });
+    this.#checkPreparationActive();
+    const batches = await this.#completePreparation(email, { ...counts, attemptId });
+    logging.info(
+      {
+        event: { name: 'email.batches.created' },
+        email_id: email.id,
+        attempt_id: attemptId,
+        duration_ms: Date.now() - startedAt,
+        batches_total: batches.length,
+        email_count: email.get('email_count'),
+        candidate_count: counts.candidateCount,
+        preparation_excluded_count: counts.excludedCount,
+        concurrency: this.#batchCreationConcurrency,
+        recipient_filter: email.get('recipient_filter'),
+      },
+      'Created newsletter batches',
+    );
+    return batches;
+  }
+
+  #checkPreparationActive(signal) {
+    signal?.throwIfAborted();
+    if (this.#shuttingDown) {
+      throw new errors.InternalServerError({
+        code: SHUTDOWN_CODE,
+        message: 'Email batch creation stopped because the container is shutting down',
+      });
+    }
+  }
+
+  async #sweepPreparationSegments({ email, post, newsletter, attemptId }) {
+    const segments = await this.#emailRenderer.getSegments(post);
+    const batchSize = this.#sendingService.getMaximumRecipients();
+    const warmupLimit = this.#getDomainWarmupLimit(email);
+    let candidateCount = 0;
+    let excludedCount = 0;
+    for (const segment of segments) {
+      const segmentFilter = this.#emailSegmenter.getMemberFilterForSegment(
+        newsletter,
+        email.get('recipient_filter'),
+        segment,
+      );
+      const startedAt = Date.now();
+      const ids = await this.retryDb(
+        async () => {
+          this.#checkPreparationActive();
+          // Each segment reads current filter attributes; the ID cutoff only excludes newer members.
+          // Counts cover this attempt's selected IDs, not one snapshot shared by all segments.
+          const rows = await this.#models.Member.getFilteredCollectionQuery({
+            filter: segmentFilter + `+id:<'${email.id}'`,
+          })
+            .orderByRaw('members.id DESC')
+            .select('members.id');
+          return selectedMemberIds(rows);
+        },
+        {
+          ...this.#getBeforeRetryConfig(email),
+          description: `sweep audience for email ${email.id} segment ${segment}`,
+        },
+      );
+      this.#checkPreparationActive();
+      logging.info(
+        {
+          event: { name: 'email.preparation.swept' },
+          email_id: email.id,
+          attempt_id: attemptId,
+          segment,
+          candidate_count: ids.length,
+          duration_ms: Date.now() - startedAt,
+        },
+        'Selected newsletter candidate recipients',
+      );
+      const remainingCapacity = warmupLimit - candidateCount;
+      candidateCount += ids.length;
+      if (ids.length === 0) {
+        continue;
+      }
+      await runPreparationWorkers(
+        preparationPages(ids, batchSize, remainingCapacity),
+        // Warming can introduce one additional partial page.
+        Math.min(this.#batchCreationConcurrency, Math.ceil(ids.length / batchSize) + 1),
+        () => this.#checkPreparationActive(),
+        async (page, signal) => {
+          const pageExcludedCount = await this.#prepareSweptPage(
+            {
+              email,
+              segment,
+              attemptId,
+              page,
+            },
+            signal,
+          );
+          // Read the aggregate only after awaiting: compound assignment across
+          // an await would overwrite another worker's completed exclusions.
+          excludedCount += pageExcludedCount;
+        },
+      );
+    }
+    return { candidateCount, excludedCount };
+  }
+
+  async #prepareSweptPage({ email, segment, attemptId, page }, signal) {
+    const rows = await this.retryDb(
+      () => {
+        this.#checkPreparationActive(signal);
+        return resolvePreparationMembers(this.#db.knex, page.ids);
+      },
+      {
+        ...this.#getBeforeRetryConfig(email),
+        signal,
+        description: `resolve members for email ${email.id} segment ${segment} page ${page.offset}`,
+      },
+    );
+    this.#checkPreparationActive(signal);
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    // Retain missing IDs so the page's exclusion count includes them.
+    const candidates = page.ids.map((id) => {
+      const member = byId.get(id);
+      if (!member) {
+        logging.info(
+          {
+            event: { name: 'email.preparation.excluded' },
+            email_id: email.id,
+            attempt_id: attemptId,
+            member_id: id,
+            reason: 'member_not_found',
+          },
+          'Member no longer found during newsletter preparation',
+        );
+      }
+      return member ?? { id, missing: true };
+    });
+    return this.#preparePage({
+      email,
+      segment,
+      members: candidates,
+      attemptId,
+      useFallbackDomain: page.useFallbackDomain,
+      signal,
+    });
   }
 
   async #verifyFrozenPreparation(email, retryOptions) {
@@ -497,6 +649,7 @@ class BatchSendingService {
         event: { name: 'email.preparation.started' },
         email_id: email.id,
         attempt_id: attemptId,
+        concurrency: this.#batchCreationConcurrency,
       },
       'Starting email preparation',
     );
@@ -510,105 +663,19 @@ class BatchSendingService {
     return Infinity;
   }
 
-  async #prepareSegments({ email, post, newsletter, attemptId }) {
-    const segments = await this.#emailRenderer.getSegments(post);
-    const batchSize = this.#sendingService.getMaximumRecipients();
-    const domainWarmupLimit = this.#getDomainWarmupLimit(email);
-    let candidateCount = 0;
-    let excludedCount = 0;
-    for (const segment of segments) {
-      const prepared = await this.#prepareSegment({
-        email,
-        newsletter,
-        segment,
-        attemptId,
-        batchSize,
-        remainingCustomDomainCapacity: domainWarmupLimit - candidateCount,
-      });
-      candidateCount += prepared.candidateCount;
-      excludedCount += prepared.excludedCount;
-    }
-    return { candidateCount, excludedCount };
-  }
-
-  async #prepareSegment({
-    email,
-    newsletter,
-    segment,
-    attemptId,
-    batchSize,
-    remainingCustomDomainCapacity,
-  }) {
-    logging.info(`Creating batches for email ${email.id} segment ${segment}`);
-    const segmentFilter = this.#emailSegmenter.getMemberFilterForSegment(
-      newsletter,
-      email.get('recipient_filter'),
-      segment,
+  async #preparePage({ email, segment, members, attemptId, useFallbackDomain, signal }) {
+    this.#checkPreparationActive(signal);
+    const snapshot = this.#snapshotPreparationMembers(
+      email,
+      members.filter((member) => !member.missing),
+      attemptId,
     );
-    let candidateCount = 0;
-    let excludedCount = 0;
-    // ObjectIds exclude members created after the email, even with backdated imports.
-    let lastId = email.id;
-    do {
-      const useFallbackDomain = remainingCustomDomainCapacity <= 0;
-      const pageSize = useFallbackDomain
-        ? batchSize
-        : Math.min(remainingCustomDomainCapacity, batchSize);
-      const members = await this.#fetchPreparationPage(
-        email,
-        segment,
-        segmentFilter,
-        lastId,
-        pageSize,
-      );
-      const candidates = members.slice(0, pageSize);
-      // Count the consumed page once, before exclusions or retries, without lookahead.
-      candidateCount += candidates.length;
-      excludedCount += await this.#preparePage({
-        email,
-        segment,
-        members: candidates,
-        attemptId,
-        useFallbackDomain,
-      });
-      // Warming capacity counts candidates, including explicit exclusions.
-      remainingCustomDomainCapacity -= candidates.length;
-      if (members.length <= pageSize) {
-        break;
-      }
-      lastId = candidates[candidates.length - 1].id;
-    } while (lastId);
-    return { candidateCount, excludedCount };
-  }
-
-  async #fetchPreparationPage(email, segment, segmentFilter, lastId, batchSize) {
-    // Stop only at an atomic batch boundary; shutdown leaves the send resumable.
-    if (this.#shuttingDown) {
-      throw new errors.InternalServerError({
-        code: SHUTDOWN_CODE,
-        message: 'Email batch creation stopped because the container is shutting down',
-      });
-    }
-    const filter = segmentFilter + `+id:<'${lastId}'`;
-    logging.info(
-      `Fetching members batch for email ${email.id} segment ${segment}, lastId: ${lastId} ${filter}`,
-    );
-    // Each page reads live filter attributes; the ID cutoff only excludes newer members.
-    // Counts cover candidates consumed in this attempt, not a point-in-time audience snapshot.
-    // Avoid Bookshelf on the audience read for performance.
-    return this.#models.Member.getFilteredCollectionQuery({ filter })
-      .orderByRaw('id DESC')
-      .select('members.id', 'members.uuid', 'members.email', 'members.name')
-      .limit(batchSize + 1);
-  }
-
-  async #preparePage({ email, segment, members, attemptId, useFallbackDomain }) {
-    const snapshot = this.#snapshotPreparationMembers(email, members, attemptId);
     if (snapshot.length > 0) {
       await this.#createBatchWithRecovery(
         email,
         { segment, members: snapshot, useFallbackDomain },
         attemptId,
+        signal,
       );
     }
     return members.length - snapshot.length;
@@ -628,6 +695,7 @@ class BatchSendingService {
       email_count: verified.recipientCount,
       prepared_at: new Date(),
     };
+    this.#checkPreparationActive();
     await this.retryDb(
       () => email.save(preparation, { patch: true, require: false, autoRefresh: false }),
       {
@@ -870,7 +938,12 @@ class BatchSendingService {
     );
   }
 
-  async #createBatchWithRecovery(email, { segment, members, useFallbackDomain }, attemptId) {
+  async #createBatchWithRecovery(
+    email,
+    { segment, members, useFallbackDomain },
+    attemptId,
+    signal,
+  ) {
     // Retain this operation's identity and recipient snapshot across its database retries.
     // Restarting preparation reselects the audience until prepared_at freezes membership.
     const operation = {
@@ -883,6 +956,7 @@ class BatchSendingService {
     };
     const batch = await this.retryDb(() => this.#createOrRecoverBatch(operation), {
       ...this.#getBeforeRetryConfig(email),
+      signal,
       description: `createBatch email ${email.id} segment ${segment}${useFallbackDomain ? ' (fallback domain)' : ' (custom domain)'}`,
     });
     logging.info(
@@ -1652,9 +1726,11 @@ class BatchSendingService {
    * @param {number} [options.retryCount] (internal) Amount of retries already done. 0 intially.
    * @param {number} [options.maxTime] (ms)
    * @param {Date} [options.stopAfterDate]
+   * @param {AbortSignal} [options.signal] Stops preparation retries, not an in-flight operation
    * @returns {Promise<T>}
    */
   async retryDb(func, options) {
+    options.signal?.throwIfAborted();
     options = this.#resolveRetryOptions(options);
     const retryCount = options.retryCount ?? 0;
 
@@ -1678,6 +1754,7 @@ class BatchSendingService {
       if (e.retryable === false) {
         throw e;
       }
+      options.signal?.throwIfAborted();
       // Shutdown may have started while this attempt was pending — re-resolve so
       // the collapsed budget decides whether we retry at all
       options = this.#resolveRetryOptions(options);
@@ -1710,9 +1787,7 @@ class BatchSendingService {
       logging.error(ghostError);
 
       if (sleep) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, sleep);
-        });
+        await waitForPreparationRetry(sleep, options.signal);
       }
 
       // Budget is only checked after a failure, so recursing always spends another

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -2,6 +2,7 @@ const logging = require('@tryghost/logging');
 const ObjectID = require('bson-objectid').default;
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
+const { validateMaxConcurrency } = require('../../lib/promise-pool');
 const {
   RECIPIENT_VERIFICATION_CODE,
   recipientVerificationError,
@@ -11,9 +12,8 @@ const {
   missingRecipientFields,
 } = require('./recipient-accounting');
 const {
-  validatePreparationConcurrency,
   selectPreparationCandidates,
-  resolvePreparationMembers,
+  createPreparationMemberResolver,
   runPreparationWorkers,
   preparationPages,
   waitForPreparationRetry,
@@ -112,7 +112,10 @@ class BatchSendingService {
     this.#db = db;
     this.#sentry = sentry;
     this.#getRequiredUrlRelations = getRequiredUrlRelations;
-    this.#batchCreationConcurrency = validatePreparationConcurrency(batchCreationConcurrency);
+    this.#batchCreationConcurrency = validateMaxConcurrency(
+      batchCreationConcurrency,
+      'bulkEmail:batchCreationConcurrency',
+    );
 
     if (BEFORE_RETRY_CONFIG) {
       this.#BEFORE_RETRY_CONFIG = BEFORE_RETRY_CONFIG;
@@ -459,7 +462,6 @@ class BatchSendingService {
     const startedAt = Date.now();
     await this.#startPreparation(email, attemptId);
     const counts = await this.#prepareAudience({ email, post, newsletter, attemptId });
-    this.#checkPreparationActive();
     const batches = await this.#completePreparation(email, { ...counts, attemptId });
     logging.info(
       {
@@ -491,19 +493,21 @@ class BatchSendingService {
 
   async #selectPreparationAudience({ email, newsletter, segments, attemptId }) {
     const startedAt = Date.now();
+    this.#checkPreparationActive();
+    // Parse once outside retries: malformed filters and newsletter settings cannot recover.
+    const queries = segments.map((segment) => {
+      const filter = this.#emailSegmenter.getMemberFilterForSegment(
+        newsletter,
+        email.get('recipient_filter'),
+        segment,
+      );
+      return this.#models.Member.getFilteredCollectionQuery({
+        filter: filter + `+id:<'${email.id}'`,
+      });
+    });
     const candidates = await this.retryDb(
       () => {
         this.#checkPreparationActive();
-        const queries = segments.map((segment) => {
-          const filter = this.#emailSegmenter.getMemberFilterForSegment(
-            newsletter,
-            email.get('recipient_filter'),
-            segment,
-          );
-          return this.#models.Member.getFilteredCollectionQuery({
-            filter: filter + `+id:<'${email.id}'`,
-          });
-        });
         return selectPreparationCandidates(this.#db.knex, queries);
       },
       {
@@ -544,8 +548,10 @@ class BatchSendingService {
       if (ids.length === 0) {
         continue;
       }
+      const resolveMembers = createPreparationMemberResolver(this.#db.knex);
       await runPreparationWorkers(
         preparationPages(ids, batchSize, remainingCapacity),
+        // Avoid allocating idle workers for a small audience and a large configured limit.
         // Warming can introduce one additional partial page.
         Math.min(this.#batchCreationConcurrency, Math.ceil(ids.length / batchSize) + 1),
         () => this.#checkPreparationActive(),
@@ -556,6 +562,7 @@ class BatchSendingService {
               segment,
               attemptId,
               page,
+              resolveMembers,
             },
             signal,
           );
@@ -568,11 +575,11 @@ class BatchSendingService {
     return { candidateCount, excludedCount };
   }
 
-  async #prepareSweptPage({ email, segment, attemptId, page }, signal) {
+  async #prepareSweptPage({ email, segment, attemptId, page, resolveMembers }, signal) {
     const rows = await this.retryDb(
       () => {
         this.#checkPreparationActive(signal);
-        return resolvePreparationMembers(this.#db.knex, page.ids);
+        return resolveMembers(page.ids);
       },
       {
         ...this.#getBeforeRetryConfig(email),
@@ -581,11 +588,9 @@ class BatchSendingService {
       },
     );
     this.#checkPreparationActive(signal);
-    const byId = new Map(rows.map((row) => [row.id, row]));
-    // Retain missing IDs so the page's exclusion count includes them.
-    const candidates = page.ids.map((id) => {
-      const member = byId.get(id);
-      if (!member) {
+    const foundIds = new Set(rows.map((row) => row.id));
+    for (const id of page.ids) {
+      if (!foundIds.has(id)) {
         logging.info(
           {
             event: { name: 'email.preparation.excluded' },
@@ -597,16 +602,16 @@ class BatchSendingService {
           'Member no longer found during newsletter preparation',
         );
       }
-      return member ?? { id, missing: true };
-    });
-    return this.#preparePage({
+    }
+    const excludedCount = await this.#preparePage({
       email,
       segment,
-      members: candidates,
+      members: rows,
       attemptId,
       useFallbackDomain: page.useFallbackDomain,
       signal,
     });
+    return page.ids.length - rows.length + excludedCount;
   }
 
   async #verifyFrozenPreparation(email, retryOptions) {
@@ -673,11 +678,7 @@ class BatchSendingService {
 
   async #preparePage({ email, segment, members, attemptId, useFallbackDomain, signal }) {
     this.#checkPreparationActive(signal);
-    const snapshot = this.#snapshotPreparationMembers(
-      email,
-      members.filter((member) => !member.missing),
-      attemptId,
-    );
+    const snapshot = this.#snapshotPreparationMembers(email, members, attemptId);
     if (snapshot.length > 0) {
       await this.#createBatchWithRecovery(
         email,
@@ -703,7 +704,8 @@ class BatchSendingService {
       email_count: verified.recipientCount,
       prepared_at: new Date(),
     };
-    this.#checkPreparationActive();
+    // Finish freezing fully prepared recipients during shutdown. The retry policy
+    // limits this final save to one attempt, avoiding a needless discard and rebuild.
     await this.retryDb(
       () => email.save(preparation, { patch: true, require: false, autoRefresh: false }),
       {

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -24,6 +24,7 @@ class EmailServiceWrapper {
     const EmailRenderer = require('./email-renderer');
     const SendingService = require('./sending-service');
     const BatchSendingService = require('./batch-sending-service');
+    const { validatePreparationConcurrency } = require('./recipient-preparation');
     const { SendingStatusService } = require('./sending-status-service');
     const EmailSegmenter = require('./email-segmenter');
     const MailgunEmailProvider = require('./mailgun-email-provider');
@@ -34,6 +35,9 @@ class EmailServiceWrapper {
     const getRequiredUrlRelations = () => urlService.getRequiredRelations();
     const MailgunClient = require('../lib/mailgun-client');
     const configService = require('../../../shared/config');
+    const batchCreationConcurrency = validatePreparationConcurrency(
+      configService.get('bulkEmail:batchCreationConcurrency'),
+    );
     const settingsCache = require('../../../shared/settings-cache');
     const settingsHelpers = require('../settings-helpers');
     const jobsService = require('../jobs');
@@ -128,6 +132,7 @@ class EmailServiceWrapper {
       db,
       sentry,
       getRequiredUrlRelations,
+      batchCreationConcurrency,
     });
     const sendingStatusService = new SendingStatusService({ knex: db.knex });
 

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -24,7 +24,6 @@ class EmailServiceWrapper {
     const EmailRenderer = require('./email-renderer');
     const SendingService = require('./sending-service');
     const BatchSendingService = require('./batch-sending-service');
-    const { validatePreparationConcurrency } = require('./recipient-preparation');
     const { SendingStatusService } = require('./sending-status-service');
     const EmailSegmenter = require('./email-segmenter');
     const MailgunEmailProvider = require('./mailgun-email-provider');
@@ -35,9 +34,7 @@ class EmailServiceWrapper {
     const getRequiredUrlRelations = () => urlService.getRequiredRelations();
     const MailgunClient = require('../lib/mailgun-client');
     const configService = require('../../../shared/config');
-    const batchCreationConcurrency = validatePreparationConcurrency(
-      configService.get('bulkEmail:batchCreationConcurrency'),
-    );
+    const batchCreationConcurrency = configService.get('bulkEmail:batchCreationConcurrency');
     const settingsCache = require('../../../shared/settings-cache');
     const settingsHelpers = require('../settings-helpers');
     const jobsService = require('../jobs');

--- a/ghost/core/core/server/services/email-service/recipient-preparation.ts
+++ b/ghost/core/core/server/services/email-service/recipient-preparation.ts
@@ -1,0 +1,116 @@
+import type { Knex } from 'knex';
+import { IncorrectUsageError } from '@tryghost/errors';
+import { RECIPIENT_VERIFICATION_CODE } from './recipient-accounting';
+
+export function validatePreparationConcurrency(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+    throw new IncorrectUsageError({
+      message: 'bulkEmail:batchCreationConcurrency must be a positive integer',
+    });
+  }
+  return value;
+}
+
+/** The filtered query is already ordered; avoid DISTINCT or a second full-size set. */
+export function selectedMemberIds(rows: { id: string }[]): string[] {
+  const ids: string[] = [];
+  for (const { id } of rows) {
+    if (id !== ids[ids.length - 1]) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+export type PreparationMember = { id: string; uuid: string; email: string; name: string | null };
+
+/** Resolve only selected IDs. The extra range row distinguishes sparse from complete reads. */
+export async function resolvePreparationMembers(
+  knex: Knex,
+  ids: string[],
+): Promise<PreparationMember[]> {
+  if (ids.length === 0) {
+    return [];
+  }
+  const columns = ['id', 'uuid', 'email', 'name'];
+  const limit = ids.length * 8;
+  let rows: PreparationMember[] = await knex('members')
+    .select(columns)
+    .whereBetween('id', [ids[ids.length - 1]!, ids[0]!])
+    .orderBy('id', 'desc')
+    .limit(limit + 1);
+  if (rows.length > limit) {
+    // Do not retain the truncated range while the fallback is materialized.
+    rows = [];
+    rows = await knex('members').select(columns).whereIn('id', ids);
+  }
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return ids.flatMap((id) => {
+    const row = byId.get(id);
+    return row ? [row] : [];
+  });
+}
+
+/** Only waits are abortable: callers must settle writes and recovery before returning. */
+export function waitForPreparationRetry(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const finish = () => {
+      signal?.removeEventListener('abort', abort);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    const abort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', abort);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+}
+
+/** Fixed workers claim lazily; every exit drains them, including dispatcher failures. */
+export async function runPreparationWorkers<T>(
+  items: Iterable<T>,
+  concurrency: number,
+  beforeWork: () => void,
+  work: (item: T, signal: AbortSignal) => Promise<void>,
+): Promise<void> {
+  validatePreparationConcurrency(concurrency);
+  const controller = new AbortController();
+  const iterator = items[Symbol.iterator]();
+  const failures: unknown[] = [];
+  const worker = async () => {
+    try {
+      while (!controller.signal.aborted) {
+        beforeWork();
+        const next = iterator.next();
+        if (next.done) {
+          return;
+        }
+        await work(next.value, controller.signal);
+      }
+    } catch (error) {
+      failures.push(error);
+      controller.abort(error);
+    }
+  };
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  const verification = failures.find(
+    (error) =>
+      error instanceof Error && 'code' in error && error.code === RECIPIENT_VERIFICATION_CODE,
+  );
+  if (failures.length > 0) {
+    throw verification ?? failures[0];
+  }
+}
+
+export function* preparationPages(ids: string[], batchSize: number, warmingCapacity = Infinity) {
+  for (let offset = 0; offset < ids.length;) {
+    const remainingCapacity = warmingCapacity - offset;
+    const useFallbackDomain = remainingCapacity <= 0;
+    const pageSize = useFallbackDomain ? batchSize : Math.min(remainingCapacity, batchSize);
+    yield { ids: ids.slice(offset, offset + pageSize), offset, useFallbackDomain };
+    offset += pageSize;
+  }
+}

--- a/ghost/core/core/server/services/email-service/recipient-preparation.ts
+++ b/ghost/core/core/server/services/email-service/recipient-preparation.ts
@@ -2,15 +2,6 @@ import type { Knex } from 'knex';
 import { IncorrectUsageError } from '@tryghost/errors';
 import { RECIPIENT_VERIFICATION_CODE } from './recipient-accounting';
 
-export function validatePreparationConcurrency(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
-    throw new IncorrectUsageError({
-      message: 'bulkEmail:batchCreationConcurrency must be a positive integer',
-    });
-  }
-  return value;
-}
-
 /** One statement gives all segments the same audience snapshot, without a spanning transaction. */
 export async function selectPreparationCandidates(
   knex: Knex,
@@ -23,7 +14,7 @@ export async function selectPreparationCandidates(
   const rows: { id: string; segment_index: number }[] = await knex
     .unionAll(
       queries.map((query, index) =>
-        query.select('members.id', knex.raw('? as segment_index', [index])),
+        query.clone().select('members.id', knex.raw('? as segment_index', [index])),
       ),
     )
     .orderBy('segment_index')
@@ -40,31 +31,38 @@ export async function selectPreparationCandidates(
 
 export type PreparationMember = { id: string; uuid: string; email: string; name: string | null };
 
-/** Resolve only selected IDs. The extra range row distinguishes sparse from complete reads. */
-export async function resolvePreparationMembers(
-  knex: Knex,
-  ids: string[],
-): Promise<PreparationMember[]> {
-  if (ids.length === 0) {
-    return [];
-  }
-  const columns = ['id', 'uuid', 'email', 'name'];
-  const limit = ids.length * 8;
-  let rows: PreparationMember[] = await knex('members')
-    .select(columns)
-    .whereBetween('id', [ids[ids.length - 1]!, ids[0]!])
-    .orderBy('id', 'desc')
-    .limit(limit + 1);
-  if (rows.length > limit) {
-    // Do not retain the truncated range while the fallback is materialized.
-    rows = [];
-    rows = await knex('members').select(columns).whereIn('id', ids);
-  }
-  const byId = new Map(rows.map((row) => [row.id, row]));
-  return ids.flatMap((id) => {
-    const row = byId.get(id);
-    return row ? [row] : [];
-  });
+/** Keep range reads for dense pages; after a sparse page, use IDs for the rest of this segment. */
+export function createPreparationMemberResolver(knex: Knex) {
+  let useIdList = false;
+  return async function resolveMembers(ids: string[]): Promise<PreparationMember[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    const columns = ['id', 'uuid', 'email', 'name'];
+    let rows: PreparationMember[] = [];
+    if (useIdList) {
+      rows = await knex('members').select(columns).whereIn('id', ids);
+    } else {
+      const limit = ids.length * 8;
+      rows = await knex('members')
+        .select(columns)
+        .whereBetween('id', [ids[ids.length - 1]!, ids[0]!])
+        .orderBy('id', 'desc')
+        .limit(limit + 1);
+      if (rows.length > limit) {
+        // Monotonic across concurrent workers. Pages already reading a range may still finish it.
+        useIdList = true;
+        // Release the overfull range while the ID query is in flight.
+        rows = [];
+        rows = await knex('members').select(columns).whereIn('id', ids);
+      }
+    }
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    return ids.flatMap((id) => {
+      const row = byId.get(id);
+      return row ? [row] : [];
+    });
+  };
 }
 
 /** Only waits are abortable: callers must settle writes and recovery before returning. */
@@ -85,25 +83,24 @@ export function waitForPreparationRetry(ms: number, signal?: AbortSignal): Promi
   });
 }
 
-/** Fixed workers claim lazily; every exit drains them, including dispatcher failures. */
+/** The caller validates concurrency. Every exit drains workers, including dispatcher failures. */
 export async function runPreparationWorkers<T>(
   items: Iterable<T>,
   concurrency: number,
   beforeWork: () => void,
   work: (item: T, signal: AbortSignal) => Promise<void>,
 ): Promise<void> {
-  validatePreparationConcurrency(concurrency);
   const controller = new AbortController();
   const iterator = items[Symbol.iterator]();
   const failures: unknown[] = [];
   const worker = async () => {
     try {
       while (!controller.signal.aborted) {
-        beforeWork();
         const next = iterator.next();
         if (next.done) {
           return;
         }
+        beforeWork();
         await work(next.value, controller.signal);
       }
     } catch (error) {
@@ -121,12 +118,18 @@ export async function runPreparationWorkers<T>(
   }
 }
 
-export function* preparationPages(ids: string[], batchSize: number, warmingCapacity = Infinity) {
-  for (let offset = 0; offset < ids.length;) {
-    const remainingCapacity = warmingCapacity - offset;
-    const useFallbackDomain = remainingCapacity <= 0;
-    const pageSize = useFallbackDomain ? batchSize : Math.min(remainingCapacity, batchSize);
-    yield { ids: ids.slice(offset, offset + pageSize), offset, useFallbackDomain };
-    offset += pageSize;
+export function preparationPages(ids: string[], batchSize: number, warmingCapacity = Infinity) {
+  // Validate eagerly, before the caller uses batchSize to calculate the worker count.
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+    throw new IncorrectUsageError({ message: 'bulkEmail:batchSize must be a positive integer' });
   }
+  return (function* pages() {
+    for (let offset = 0; offset < ids.length;) {
+      const remainingCapacity = warmingCapacity - offset;
+      const useFallbackDomain = remainingCapacity <= 0;
+      const pageSize = useFallbackDomain ? batchSize : Math.min(remainingCapacity, batchSize);
+      yield { ids: ids.slice(offset, offset + pageSize), offset, useFallbackDomain };
+      offset += pageSize;
+    }
+  })();
 }

--- a/ghost/core/core/server/services/email-service/recipient-preparation.ts
+++ b/ghost/core/core/server/services/email-service/recipient-preparation.ts
@@ -31,38 +31,22 @@ export async function selectPreparationCandidates(
 
 export type PreparationMember = { id: string; uuid: string; email: string; name: string | null };
 
-/** Keep range reads for dense pages; after a sparse page, use IDs for the rest of this segment. */
-export function createPreparationMemberResolver(knex: Knex) {
-  let useIdList = false;
-  return async function resolveMembers(ids: string[]): Promise<PreparationMember[]> {
-    if (ids.length === 0) {
-      return [];
-    }
-    const columns = ['id', 'uuid', 'email', 'name'];
-    let rows: PreparationMember[] = [];
-    if (useIdList) {
-      rows = await knex('members').select(columns).whereIn('id', ids);
-    } else {
-      const limit = ids.length * 8;
-      rows = await knex('members')
-        .select(columns)
-        .whereBetween('id', [ids[ids.length - 1]!, ids[0]!])
-        .orderBy('id', 'desc')
-        .limit(limit + 1);
-      if (rows.length > limit) {
-        // Monotonic across concurrent workers. Pages already reading a range may still finish it.
-        useIdList = true;
-        // Release the overfull range while the ID query is in flight.
-        rows = [];
-        rows = await knex('members').select(columns).whereIn('id', ids);
-      }
-    }
-    const byId = new Map(rows.map((row) => [row.id, row]));
-    return ids.flatMap((id) => {
-      const row = byId.get(id);
-      return row ? [row] : [];
-    });
-  };
+/** Load only selected members and preserve candidate order, omitting members no longer present. */
+export async function resolvePreparationMembers(
+  knex: Knex,
+  ids: string[],
+): Promise<PreparationMember[]> {
+  if (ids.length === 0) {
+    return [];
+  }
+  const rows: PreparationMember[] = await knex('members')
+    .select('id', 'uuid', 'email', 'name')
+    .whereIn('id', ids);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return ids.flatMap((id) => {
+    const row = byId.get(id);
+    return row ? [row] : [];
+  });
 }
 
 /** Only waits are abortable: callers must settle writes and recovery before returning. */

--- a/ghost/core/core/server/services/email-service/recipient-preparation.ts
+++ b/ghost/core/core/server/services/email-service/recipient-preparation.ts
@@ -11,15 +11,31 @@ export function validatePreparationConcurrency(value: unknown): number {
   return value;
 }
 
-/** The filtered query is already ordered; avoid DISTINCT or a second full-size set. */
-export function selectedMemberIds(rows: { id: string }[]): string[] {
-  const ids: string[] = [];
-  for (const { id } of rows) {
+/** One statement gives all segments the same audience snapshot, without a spanning transaction. */
+export async function selectPreparationCandidates(
+  knex: Knex,
+  queries: Knex.QueryBuilder[],
+): Promise<string[][]> {
+  const candidates: string[][] = queries.map(() => []);
+  if (queries.length === 0) {
+    return candidates;
+  }
+  const rows: { id: string; segment_index: number }[] = await knex
+    .unionAll(
+      queries.map((query, index) =>
+        query.select('members.id', knex.raw('? as segment_index', [index])),
+      ),
+    )
+    .orderBy('segment_index')
+    .orderBy('id', 'desc');
+  for (const { id, segment_index: segmentIndex } of rows) {
+    const ids = candidates[segmentIndex]!;
+    // Ordered rows let us collapse duplicate IDs within a segment without another full-size set.
     if (id !== ids[ids.length - 1]) {
       ids.push(id);
     }
   }
-  return ids;
+  return candidates;
 }
 
 export type PreparationMember = { id: string; uuid: string; email: string; name: string | null };

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -364,6 +364,7 @@
   },
   "bulkEmail": {
     "batchSize": 1000,
+    "batchCreationConcurrency": 2,
     "captureLinkClickBadMemberUuid": false
   },
   "disableJSBackups": false,

--- a/ghost/core/scripts/benchmark-recipient-preparation.js
+++ b/ghost/core/scripts/benchmark-recipient-preparation.js
@@ -25,7 +25,7 @@ process.env.database__client = 'mysql2';
 process.env.database__connection__host = '127.0.0.1';
 process.env.database__connection__port = '3306';
 process.env.database__connection__user ||= 'root';
-process.env.database__connection__password ||= '';
+process.env.database__connection__password ??= 'root';
 process.env.database__connection__database = database;
 process.env.database__pool__min = '0';
 process.env.database__pool__max = '5';
@@ -123,8 +123,21 @@ async function main() {
     BEFORE_RETRY_CONFIG: { maxRetries: 0 },
   });
   let queries = 0;
-  db.knex.on('query', () => {
+  const memberLookupStarts = new Map();
+  db.knex.on('query', (query) => {
     queries += 1;
+    if (query.sql.includes('`uuid`') && query.sql.includes('from `members`')) {
+      memberLookupStarts.set(query.__knexQueryUid, performance.now());
+    }
+  });
+  db.knex.on('query-response', (rows, query) => {
+    const startedAt = memberLookupStarts.get(query.__knexQueryUid);
+    if (startedAt !== undefined) {
+      metrics.member_lookup_ms = (metrics.member_lookup_ms ?? 0) + performance.now() - startedAt;
+      metrics.member_lookup_queries = (metrics.member_lookup_queries ?? 0) + 1;
+      metrics.member_lookup_rows = (metrics.member_lookup_rows ?? 0) + rows.length;
+      memberLookupStarts.delete(query.__knexQueryUid);
+    }
   });
   async function measure(email, phase) {
     global.gc?.();

--- a/ghost/core/scripts/benchmark-recipient-preparation.js
+++ b/ghost/core/scripts/benchmark-recipient-preparation.js
@@ -89,7 +89,7 @@ async function main() {
       transient_id: crypto.randomUUID(),
       email: `member-${offset + i + 1}@example.com`,
       name: 'Benchmark Member',
-      status: 'free',
+      status: (offset + i) % 2 === 0 ? 'free' : 'paid',
       created_at: new Date(),
       updated_at: new Date(),
     }));
@@ -116,7 +116,7 @@ async function main() {
     db,
     models,
     batchCreationConcurrency: concurrency,
-    emailRenderer: { getSegments: async () => [null] },
+    emailRenderer: { getSegments: async () => ['status:free', 'status:-free'] },
     emailSegmenter: segmenter,
     domainWarmingService: { isEnabled: () => false },
     sendingService: { getMaximumRecipients: () => 1000 },

--- a/ghost/core/scripts/benchmark-recipient-preparation.js
+++ b/ghost/core/scripts/benchmark-recipient-preparation.js
@@ -1,0 +1,207 @@
+// Synthetic preparation benchmark. Creates and drops its own database on local MySQL.
+// Run from ghost/core with NODE_OPTIONS=--conditions=source and --expose-gc.
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { createRequire } = require('node:module');
+const root = path.resolve(__dirname, '..');
+const req = createRequire(path.join(root, 'package.json'));
+req('tsx/cjs');
+const size = Number(process.argv[2] || 500000);
+const concurrency = Number(process.argv[3] || 2);
+if (
+  !Number.isSafeInteger(size) ||
+  size < 1 ||
+  !Number.isSafeInteger(concurrency) ||
+  concurrency < 1
+) {
+  throw new (req('@tryghost/errors').IncorrectUsageError)({
+    message:
+      'Usage: node --expose-gc scripts/benchmark-recipient-preparation.js [members=500000] [concurrency=2]',
+  });
+}
+const database = `ghost_preparation_bench_${process.pid}_${crypto.randomBytes(3).toString('hex')}`;
+process.env.NODE_ENV = 'testing-mysql';
+process.env.database__client = 'mysql2';
+process.env.database__connection__host = '127.0.0.1';
+process.env.database__connection__port = '3306';
+process.env.database__connection__user ||= 'root';
+process.env.database__connection__password ||= '';
+process.env.database__connection__database = database;
+process.env.database__pool__min = '0';
+process.env.database__pool__max = '5';
+process.env.logging__level = 'error';
+const knexFactory = req('knex');
+const admin = knexFactory({
+  client: 'mysql2',
+  connection: {
+    host: '127.0.0.1',
+    user: process.env.database__connection__user,
+    password: process.env.database__connection__password,
+  },
+  pool: { min: 0, max: 1 },
+});
+let db;
+let created = false;
+const started = Date.now();
+const print = (data) => process.stdout.write(JSON.stringify(data) + '\n');
+async function main() {
+  await admin.raw('CREATE DATABASE ??', [database]);
+  created = true;
+  const [server] = await admin.raw(
+    'SELECT VERSION() AS version, @@innodb_buffer_pool_size AS buffer_pool_bytes, @@innodb_flush_log_at_trx_commit AS flush_log_at_commit, @@transaction_isolation AS isolation',
+  );
+  print({ phase: 'database', ...server[0] });
+  req('./core/server/overrides');
+  const KnexMigrator = req('knex-migrator');
+  const migrator = new KnexMigrator({ knexMigratorFilePath: root });
+  await migrator.init();
+  db = req('./core/server/data/db');
+  const models = req('./core/server/models');
+  const BatchSendingService = req('./core/server/services/email-service/batch-sending-service');
+  const ObjectID = req('bson-objectid').default;
+  const logging = req('@tryghost/logging');
+  let metrics = {};
+  let measureStart = 0;
+  logging.info = (event) => {
+    if (event?.event?.name === 'email.preparation.discarded') {
+      metrics.discard_ms = Date.now() - measureStart;
+    }
+    if (event?.event?.name === 'email.preparation.swept') {
+      metrics.sweep_ms = event.duration_ms;
+    }
+    if (event?.event?.name === 'email.batches.created') {
+      metrics.batches = event.batches_total;
+    }
+  };
+  logging.warn = () => {};
+  const newsletter = await db.knex('newsletters').first();
+  const labelId = ObjectID().toHexString();
+  await db.knex('labels').insert({
+    id: labelId,
+    name: 'benchmark-label',
+    slug: 'benchmark-label',
+    created_at: new Date(),
+  });
+  for (let offset = 0; offset < size; offset += 1000) {
+    const members = Array.from({ length: Math.min(1000, size - offset) }, (_, i) => ({
+      id: (offset + i + 1).toString(16).padStart(24, '0'),
+      uuid: crypto.randomUUID(),
+      transient_id: crypto.randomUUID(),
+      email: `member-${offset + i + 1}@example.com`,
+      name: 'Benchmark Member',
+      status: 'free',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }));
+    await db.knex('members').insert(members);
+    await db.knex('members_newsletters').insert(
+      members.map((m) => ({
+        id: ObjectID().toHexString(),
+        member_id: m.id,
+        newsletter_id: newsletter.id,
+      })),
+    );
+    const labelled = members.filter((_, i) => (offset + i) % 5 === 0);
+    await db
+      .knex('members_labels')
+      .insert(
+        labelled.map((m) => ({ id: ObjectID().toHexString(), member_id: m.id, label_id: labelId })),
+      );
+    if ((offset + 1000) % 100000 === 0) {
+      print({ phase: 'seed', members: offset + 1000, elapsed_ms: Date.now() - started });
+    }
+  }
+  const segmenter = new (req('./core/server/services/email-service/email-segmenter'))({});
+  const service = new BatchSendingService({
+    db,
+    models,
+    batchCreationConcurrency: concurrency,
+    emailRenderer: { getSegments: async () => [null] },
+    emailSegmenter: segmenter,
+    domainWarmingService: { isEnabled: () => false },
+    sendingService: { getMaximumRecipients: () => 1000 },
+    BEFORE_RETRY_CONFIG: { maxRetries: 0 },
+  });
+  let queries = 0;
+  db.knex.on('query', () => {
+    queries += 1;
+  });
+  async function measure(email, phase) {
+    global.gc?.();
+    const baseline = process.memoryUsage();
+    let peakRss = baseline.rss;
+    let peakHeap = baseline.heapUsed;
+    const sample = () => {
+      const m = process.memoryUsage();
+      peakRss = Math.max(peakRss, m.rss);
+      peakHeap = Math.max(peakHeap, m.heapUsed);
+    };
+    const timer = setInterval(sample, 10);
+    metrics = {};
+    queries = 0;
+    measureStart = Date.now();
+    try {
+      const batches = await service.createBatches({
+        email,
+        post: {},
+        newsletter: { id: newsletter.id, get: () => 'members' },
+      });
+      sample();
+      global.gc?.();
+      print({
+        phase,
+        size,
+        concurrency,
+        pool_max: 5,
+        duration_ms: Date.now() - measureStart,
+        ...metrics,
+        candidates: email.get('candidate_count'),
+        prepared: email.get('email_count'),
+        queries,
+        baseline_rss: baseline.rss,
+        peak_rss: peakRss,
+        rss_growth: peakRss - baseline.rss,
+        heap_growth: peakHeap - baseline.heapUsed,
+        retained_heap_growth: process.memoryUsage().heapUsed - baseline.heapUsed,
+      });
+      return batches;
+    } finally {
+      clearInterval(timer);
+    }
+  }
+  for (const filter of ['all', 'label:benchmark-label']) {
+    const email = await models.Email.add({
+      post_id: ObjectID().toHexString(),
+      submitted_at: new Date(),
+      email_count: filter === 'all' ? size : Math.ceil(size / 5),
+      preflight_email_count: filter === 'all' ? size : Math.ceil(size / 5),
+      recipient_filter: filter,
+    });
+    await measure(email, `prepare:${filter}`);
+    if (filter === 'all') {
+      // Model a crash after every pending batch committed but before the preparation marker.
+      await db
+        .knex('emails')
+        .where({ id: email.id })
+        .update({ prepared_at: null, candidate_count: null, preparation_excluded_count: null });
+      await email.refresh();
+      await measure(email, 'discard-and-rebuild:all');
+    }
+  }
+}
+main()
+  .catch((error) => {
+    print({ error: error.stack });
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    if (db) {
+      await db.knex.destroy();
+    }
+    if (created) {
+      await admin.raw('DROP DATABASE IF EXISTS ??', [database]);
+    }
+    await admin.destroy();
+    // Ghost's fixture/migration helpers may own auxiliary pools; the owned DB is gone.
+    process.exit(process.exitCode || 0);
+  });

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -159,6 +159,9 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
         sentry,
       }),
       BEFORE_RETRY_CONFIG: { maxRetries: 2, sleep: 0 },
+      // These transaction fault injections target one operation at a time.
+      // Concurrent scheduling is covered in recipient-preparation.test.ts.
+      batchCreationConcurrency: 1,
     });
   }
 
@@ -884,8 +887,6 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
   }
 
   it('excludes newly added members even when their creation timestamp is backdated', async function () {
-    const query = models.Member.getFilteredCollectionQuery.bind(models.Member);
-    const audience = sinon.stub(models.Member, 'getFilteredCollectionQuery').callsFake(query);
     const createBatch = service.createBatch.bind(service);
     let newMemberId: string;
     sinon.stub(service, 'createBatch').callsFake(async (...args) => {
@@ -896,14 +897,13 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       return batch;
     });
     await service.createBatches(data);
-    assert.ok(audience.callCount > 1);
     assert.equal(email.get('candidate_count'), 4);
     const recipients = await db.knex('email_recipients').where({ email_id: email.id });
     assert.equal(recipients.length, 4);
     assert.ok(recipients.every((row) => row.member_id !== newMemberId));
   });
 
-  it('keeps a large numeric member ID as a string at the pagination boundary', async function () {
+  it('preserves large numeric member IDs selected by the sweep', async function () {
     await addMember('650706040078550001536020');
     await addMember('65070957007855000153605b');
     await service.createBatches(data);
@@ -1522,7 +1522,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.equal(result?.sending.progress.total, 4);
   });
 
-  it('counts each consumed candidate once across lookahead pages and warming splits', async function () {
+  it('counts each selected candidate once across pages and warming splits', async function () {
     const batches = await service.createBatches(data);
     await email.refresh();
     assert.equal(email.get('candidate_count'), 4);
@@ -1739,15 +1739,23 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
   });
 
   it('discards incomplete preparation and rebuilds the complete audience on retry', async function () {
-    const query = models.Member.getFilteredCollectionQuery.bind(models.Member);
-    const audience = sinon.stub(models.Member, 'getFilteredCollectionQuery');
-    audience.onFirstCall().callsFake(query);
-    audience.onSecondCall().throws(new Error('Preparation interrupted'));
+    const createBatch = service.createBatch.bind(service);
+    let writes = 0;
+    const interrupted = Object.assign(new Error('Preparation interrupted'), { retryable: false });
+    const writer = sinon.stub(service, 'createBatch').callsFake((...args) => {
+      if (!args[3]?.transacting) {
+        writes += 1;
+        if (writes > 1) {
+          throw interrupted;
+        }
+      }
+      return createBatch(...args);
+    });
     await assert.rejects(service.createBatches(data), /Preparation interrupted/);
     const partial = await service.getBatches(email);
     assert.equal(partial.length, 1);
     assert.equal(email.get('prepared_at'), null);
-    audience.restore();
+    writer.restore();
 
     const rebuilt = await service.createBatches(data);
     assert.equal(rebuilt.length, 3);

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -886,21 +886,28 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     return id;
   }
 
-  it('excludes newly added members even when their creation timestamp is backdated', async function () {
-    const createBatch = service.createBatch.bind(service);
-    let newMemberId: string;
-    sinon.stub(service, 'createBatch').callsFake(async (...args) => {
-      const batch = await createBatch(...args);
-      if (!args[3]?.transacting && !newMemberId) {
-        newMemberId = await addMember();
-      }
-      return batch;
+  for (const batchSize of [0, -1]) {
+    it(`rejects configured batch size ${batchSize} before allocating preparation workers`, async function () {
+      sinon.stub(sender, 'getMaximumRecipients').returns(batchSize);
+      await assert.rejects(
+        service.createBatches(data),
+        /bulkEmail:batchSize must be a positive integer/,
+      );
+      assert.deepEqual(await service.getBatches(email), []);
     });
+  }
+
+  it('excludes members created at or after the email before its sweep, even with backdated timestamps', async function () {
+    const newerId = (BigInt(`0x${email.id}`) + 1n).toString(16).padStart(24, '0');
+    await addMember(email.id);
+    await addMember(newerId);
     await service.createBatches(data);
     assert.equal(email.get('candidate_count'), 4);
     const recipients = await db.knex('email_recipients').where({ email_id: email.id });
-    assert.equal(recipients.length, 4);
-    assert.ok(recipients.every((row) => row.member_id !== newMemberId));
+    assert.deepEqual(
+      recipients.map((row) => row.member_id).sort(),
+      [1, 2, 3, 4].map((n) => n.toString(16).padStart(24, '0')),
+    );
   });
 
   it('preserves large numeric member IDs selected by the sweep', async function () {

--- a/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import ObjectID from 'bson-objectid';
 import sinon from 'sinon';
 import type { Knex } from 'knex';
-import { resolvePreparationMembers } from '../../../../core/server/services/email-service/recipient-preparation';
+import { createPreparationMemberResolver } from '../../../../core/server/services/email-service/recipient-preparation';
 
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
@@ -31,6 +31,7 @@ describe('Upfront recipient preparation through MySQL', () => {
   let filter: string;
   let segments: (string | null)[];
   let queries: Knex.Sql[];
+  let resolveMembers: ReturnType<typeof createPreparationMemberResolver>;
   let sentry: { captureException: sinon.SinonStub; captureMessage: sinon.SinonStub };
   const queryListener = (query: Knex.Sql) => queries.push(query);
   const members = Array.from({ length: 80 }, (_, index) => ({
@@ -53,6 +54,7 @@ describe('Upfront recipient preparation through MySQL', () => {
     sinon.stub(logging, 'warn');
     sentry = { captureException: sinon.stub(), captureMessage: sinon.stub() };
     queries = [];
+    resolveMembers = createPreparationMemberResolver(db.knex);
     filter = `id:<='${id(4)}'`;
     segments = [null];
     email = await models.Email.add({
@@ -139,14 +141,14 @@ describe('Upfront recipient preparation through MySQL', () => {
   });
 
   it('resolves complete dense ranges and falls back for sparse or truncated ranges', async () => {
-    const dense = await resolvePreparationMembers(db.knex, [id(4), id(2)]);
+    const dense = await resolveMembers([id(4), id(2)]);
     assert.deepEqual(
       dense.map((member) => member.id),
       [id(4), id(2)],
     );
     assert.equal(queries.length, 1);
     queries.length = 0;
-    const sparse = await resolvePreparationMembers(db.knex, [id(80), id(1)]);
+    const sparse = await resolveMembers([id(80), id(1)]);
     assert.deepEqual(
       sparse.map((member) => member.id),
       [id(80), id(1)],
@@ -154,16 +156,33 @@ describe('Upfront recipient preparation through MySQL', () => {
     assert.equal(queries.length, 2);
     assert.match(queries[1]!.sql, /where `id` in/);
     queries.length = 0;
-    assert.deepEqual(await resolvePreparationMembers(db.knex, []), []);
+    assert.deepEqual(await resolveMembers([]), []);
     assert.equal(queries.length, 0);
   });
 
   it('uses a complete range at the threshold and falls back when the extra row exists', async () => {
-    await resolvePreparationMembers(db.knex, [id(16), id(1)]);
+    await resolveMembers([id(16), id(1)]);
     assert.equal(queries.length, 1);
     queries.length = 0;
-    await resolvePreparationMembers(db.knex, [id(17), id(1)]);
+    await resolveMembers([id(17), id(1)]);
     assert.equal(queries.length, 2);
+  });
+
+  it('remembers a sparse page for the segment and resets the strategy for the next segment', async () => {
+    await resolveMembers([id(80), id(1)]);
+    assert.equal(queries.length, 2);
+    queries.length = 0;
+    const rows = await resolveMembers([id(79), id(2)]);
+    assert.deepEqual(
+      rows.map((row) => row.id),
+      [id(79), id(2)],
+    );
+    assert.equal(queries.length, 1);
+    assert.match(queries[0]!.sql, /where `id` in/);
+    queries.length = 0;
+    await createPreparationMemberResolver(db.knex)([id(4), id(3)]);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0]!.sql, /between/);
   });
 
   it('accounts for disappearance without shifting domain-warming positions', async () => {
@@ -347,6 +366,47 @@ describe('Upfront recipient preparation through MySQL', () => {
       id(3),
     ]);
     assert.equal((await service.getBatches(email)).length, 2);
+  });
+
+  it('does not retry malformed audience filters', async () => {
+    filter = 'status:(';
+    const audience = sinon.spy(models.Member, 'getFilteredCollectionQuery');
+    await assert.rejects(prepare());
+    sinon.assert.calledOnce(audience);
+    assert.deepEqual(await service.getBatches(email), []);
+  });
+
+  it('persists verified preparation when shutdown starts during the final count read', async () => {
+    const stopDuringVerification = (query: Knex.Sql) => {
+      if (query.sql.includes('count(') && query.sql.includes('`email_recipients` as `recipient`')) {
+        service.onPreStop();
+      }
+    };
+    db.knex.on('query', stopDuringVerification);
+    try {
+      const batches = await prepare();
+      await email.refresh();
+      assert.ok(email.get('prepared_at'));
+      assert.equal(email.get('candidate_count'), 4);
+      assert.equal(email.get('email_count'), 4);
+      assert.equal(batches.length, 3);
+    } finally {
+      db.knex.removeListener('query', stopDuringVerification);
+    }
+  });
+
+  it('finishes preparation when shutdown starts after the last batch commit', async () => {
+    filter = `id:'${id(1)}'`;
+    const original = models.EmailBatch.transaction.bind(models.EmailBatch);
+    sinon.stub(batchTransactions, 'transaction').callsFake(async (handler) => {
+      const result = await original(handler);
+      service.onPreStop();
+      return result;
+    });
+    await prepare();
+    await email.refresh();
+    assert.ok(email.get('prepared_at'));
+    assert.equal(email.get('email_count'), 1);
   });
 
   it('does not begin preparation when shutdown starts during selection', async () => {

--- a/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
@@ -12,13 +12,6 @@ const logging = require('@tryghost/logging');
 const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
 const EmailSegmenter = require('../../../../core/server/services/email-service/email-segmenter');
 
-type SweepQuery = {
-  orderByRaw: (order: string) => {
-    select: (...columns: string[]) => PromiseLike<{ id: string }[]>;
-  };
-};
-const memberQueries: { getFilteredCollectionQuery: (options: { filter: string }) => SweepQuery } =
-  models.Member;
 type TransactionHandler = (trx: Knex.Transaction) => Promise<unknown>;
 const batchTransactions: { transaction: (handler: TransactionHandler) => Promise<unknown> } =
   models.EmailBatch;
@@ -109,18 +102,19 @@ describe('Upfront recipient preparation through MySQL', () => {
     db.knex('email_recipients').where({ 'email_recipients.email_id': email.id });
 
   function interceptSweep(after: (rows: { id: string }[]) => Promise<void>) {
-    const original = models.Member.getFilteredCollectionQuery.bind(models.Member);
-    return sinon
-      .stub(memberQueries, 'getFilteredCollectionQuery')
-      .callsFake((options: { filter: string }) => ({
-        orderByRaw: (order: string) => ({
-          select: async (...columns: string[]) => {
-            const rows = await original(options).orderByRaw(order).select(columns);
+    const original = db.knex.unionAll.bind(db.knex);
+    return sinon.stub(db.knex, 'unionAll').callsFake((...args) => {
+      const query = original(...args);
+      const execute = query.then.bind(query);
+      query.then = (resolve, reject) =>
+        execute()
+          .then(async (rows) => {
             await after(rows);
             return rows;
-          },
-        }),
-      }));
+          })
+          .then(resolve, reject);
+      return query;
+    });
   }
 
   it('sweeps once and resolves pages without the audience filter or lookahead', async () => {
@@ -242,24 +236,126 @@ describe('Upfront recipient preparation through MySQL', () => {
     assert.equal(email.get('candidate_count'), 3);
   });
 
-  it('retries a failed later segment sweep without recounting or rebuilding the first', async () => {
-    segments = [`id:>'${id(2)}'`, `id:<='${id(2)}'`];
-    const original = models.Member.getFilteredCollectionQuery.bind(models.Member);
-    let attempts = 0;
-    const audience = sinon
-      .stub(memberQueries, 'getFilteredCollectionQuery')
-      .callsFake((options: { filter: string }) => {
-        attempts += 1;
-        if (attempts === 2) {
-          throw new Error('transient sweep failure');
-        }
-        return original(options);
-      });
+  it('selects every segment before preparation so status changes cannot duplicate or omit members', async () => {
+    segments = ['status:free', 'status:-free'];
+    await db
+      .knex('members')
+      .where({ id: id(3) })
+      .update({ status: 'paid' });
+    const original = models.EmailBatch.transaction.bind(models.EmailBatch);
+    let changed = false;
+    sinon.stub(batchTransactions, 'transaction').callsFake(async (handler) => {
+      if (!changed) {
+        changed = true;
+        await db
+          .knex('members')
+          .where({ id: id(4) })
+          .update({ status: 'paid' });
+        await db
+          .knex('members')
+          .where({ id: id(3) })
+          .update({ status: 'free' });
+      }
+      return original(handler);
+    });
     await prepare();
-    sinon.assert.callCount(audience, 3);
+    const rows = await recipients()
+      .join('email_batches as b', 'b.id', 'email_recipients.batch_id')
+      .select('member_id', 'b.member_segment', 'b.fallback_sending_domain')
+      .orderBy('member_id');
+    assert.deepEqual(
+      rows.map((row) => row.member_id),
+      [id(1), id(2), id(3), id(4)],
+    );
+    for (const row of rows) {
+      assert.equal(row.member_segment, row.member_id === id(3) ? 'status:-free' : 'status:free');
+      assert.equal(Boolean(row.fallback_sending_domain), row.member_id === id(3));
+    }
     assert.equal(email.get('candidate_count'), 4);
-    assert.equal((await recipients()).length, 4);
-    assert.equal((await service.getBatches(email)).length, 3);
+    const sweeps = queries.filter((query) => query.sql.startsWith('select `members`.`id`'));
+    assert.equal(sweeps.length, 1);
+    assert.match(sweeps[0]!.sql, /union all/);
+  });
+
+  for (const separateFreeContent of [false, true]) {
+    it(`prepares tier access and its complement in ${separateFreeContent ? 'three' : 'two'} segments`, async () => {
+      const product = await models.Product.add({
+        name: 'Sweep tier',
+        slug: 'sweep-tier',
+        type: 'paid',
+        active: true,
+      });
+      try {
+        await db
+          .knex('members')
+          .whereIn('id', [id(3), id(4)])
+          .update({ status: 'paid' });
+        await db
+          .knex('members_products')
+          .insert({ id: ObjectID().toHexString(), member_id: id(4), product_id: product.id });
+        const access = `product:'${product.get('slug')}'`;
+        const noAccess = `product:-'${product.get('slug')}'`;
+        segments = separateFreeContent
+          ? ['status:free', `status:-free+(${access})`, `status:-free+(${noAccess})`]
+          : [access, noAccess];
+        await prepare();
+        const rows = await recipients()
+          .join('email_batches as b', 'b.id', 'email_recipients.batch_id')
+          .select('member_id', 'b.member_segment')
+          .orderBy('member_id');
+        const assignments = separateFreeContent
+          ? [segments[0], segments[0], segments[2], segments[1]]
+          : [segments[1], segments[1], segments[1], segments[0]];
+        assert.deepEqual(
+          rows,
+          assignments.map((segment, index) => ({
+            member_id: id(index + 1),
+            member_segment: segment,
+          })),
+        );
+        assert.equal(email.get('candidate_count'), 4);
+        assert.equal(email.get('email_count'), 4);
+      } finally {
+        await models.Product.destroy({ id: product.id });
+      }
+    });
+  }
+
+  it('retries the entire selection before writing any batches', async () => {
+    segments = ['status:free', 'status:-free'];
+    filter += '+email_disabled:0';
+    let attempts = 0;
+    const batchCounts: number[] = [];
+    const audience = interceptSweep(async () => {
+      attempts += 1;
+      batchCounts.push((await service.getBatches(email)).length);
+      if (attempts === 1) {
+        await db
+          .knex('members')
+          .where({ id: id(4) })
+          .update({ email_disabled: true });
+        throw new Error('transient sweep failure');
+      }
+    });
+    await prepare();
+    sinon.assert.callCount(audience, 2);
+    assert.deepEqual(batchCounts, [0, 0]);
+    assert.equal(email.get('candidate_count'), 3);
+    assert.deepEqual((await recipients()).map((row) => row.member_id).sort(), [
+      id(1),
+      id(2),
+      id(3),
+    ]);
+    assert.equal((await service.getBatches(email)).length, 2);
+  });
+
+  it('does not begin preparation when shutdown starts during selection', async () => {
+    segments = ['status:free', 'status:-free'];
+    interceptSweep(async () => service.onPreStop());
+    await assert.rejects(prepare(), { code: 'BULK_EMAIL_SHUTDOWN_IN_PROGRESS' });
+    assert.deepEqual(await service.getBatches(email), []);
+    assert.equal((await recipients()).length, 0);
+    assert.equal(email.get('prepared_at') ?? null, null);
   });
 
   it('drains concurrent transactions before freezing and preserves warming assignments', async () => {

--- a/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import ObjectID from 'bson-objectid';
 import sinon from 'sinon';
 import type { Knex } from 'knex';
-import { createPreparationMemberResolver } from '../../../../core/server/services/email-service/recipient-preparation';
+import { resolvePreparationMembers } from '../../../../core/server/services/email-service/recipient-preparation';
 
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
@@ -31,7 +31,6 @@ describe('Upfront recipient preparation through MySQL', () => {
   let filter: string;
   let segments: (string | null)[];
   let queries: Knex.Sql[];
-  let resolveMembers: ReturnType<typeof createPreparationMemberResolver>;
   let sentry: { captureException: sinon.SinonStub; captureMessage: sinon.SinonStub };
   const queryListener = (query: Knex.Sql) => queries.push(query);
   const members = Array.from({ length: 80 }, (_, index) => ({
@@ -54,7 +53,6 @@ describe('Upfront recipient preparation through MySQL', () => {
     sinon.stub(logging, 'warn');
     sentry = { captureException: sinon.stub(), captureMessage: sinon.stub() };
     queries = [];
-    resolveMembers = createPreparationMemberResolver(db.knex);
     filter = `id:<='${id(4)}'`;
     segments = [null];
     email = await models.Email.add({
@@ -140,49 +138,21 @@ describe('Upfront recipient preparation through MySQL', () => {
     });
   });
 
-  it('resolves complete dense ranges and falls back for sparse or truncated ranges', async () => {
-    const dense = await resolveMembers([id(4), id(2)]);
+  it('loads only selected IDs in one query, preserving order and omitting missing members', async () => {
+    const selectedIds = [id(2), id(80), id(81), id(4)];
+    const rows = await resolvePreparationMembers(db.knex, selectedIds);
     assert.deepEqual(
-      dense.map((member) => member.id),
-      [id(4), id(2)],
-    );
-    assert.equal(queries.length, 1);
-    queries.length = 0;
-    const sparse = await resolveMembers([id(80), id(1)]);
-    assert.deepEqual(
-      sparse.map((member) => member.id),
-      [id(80), id(1)],
-    );
-    assert.equal(queries.length, 2);
-    assert.match(queries[1]!.sql, /where `id` in/);
-    queries.length = 0;
-    assert.deepEqual(await resolveMembers([]), []);
-    assert.equal(queries.length, 0);
-  });
-
-  it('uses a complete range at the threshold and falls back when the extra row exists', async () => {
-    await resolveMembers([id(16), id(1)]);
-    assert.equal(queries.length, 1);
-    queries.length = 0;
-    await resolveMembers([id(17), id(1)]);
-    assert.equal(queries.length, 2);
-  });
-
-  it('remembers a sparse page for the segment and resets the strategy for the next segment', async () => {
-    await resolveMembers([id(80), id(1)]);
-    assert.equal(queries.length, 2);
-    queries.length = 0;
-    const rows = await resolveMembers([id(79), id(2)]);
-    assert.deepEqual(
-      rows.map((row) => row.id),
-      [id(79), id(2)],
+      rows.map((member) => member.id),
+      [id(2), id(80), id(4)],
     );
     assert.equal(queries.length, 1);
     assert.match(queries[0]!.sql, /where `id` in/);
-    queries.length = 0;
-    await createPreparationMemberResolver(db.knex)([id(4), id(3)]);
-    assert.equal(queries.length, 1);
-    assert.match(queries[0]!.sql, /between/);
+    assert.deepEqual(queries[0]!.bindings, selectedIds);
+  });
+
+  it('does not query members for an empty page', async () => {
+    assert.deepEqual(await resolvePreparationMembers(db.knex, []), []);
+    assert.equal(queries.length, 0);
   });
 
   it('accounts for disappearance without shifting domain-warming positions', async () => {

--- a/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-preparation.test.ts
@@ -1,0 +1,463 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import ObjectID from 'bson-objectid';
+import sinon from 'sinon';
+import type { Knex } from 'knex';
+import { resolvePreparationMembers } from '../../../../core/server/services/email-service/recipient-preparation';
+
+const models = require('../../../../core/server/models');
+const db: { knex: Knex } = require('../../../../core/server/data/db');
+const dbUtils = require('../../../utils/db-utils');
+const logging = require('@tryghost/logging');
+const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
+const EmailSegmenter = require('../../../../core/server/services/email-service/email-segmenter');
+
+type SweepQuery = {
+  orderByRaw: (order: string) => {
+    select: (...columns: string[]) => PromiseLike<{ id: string }[]>;
+  };
+};
+const memberQueries: { getFilteredCollectionQuery: (options: { filter: string }) => SweepQuery } =
+  models.Member;
+type TransactionHandler = (trx: Knex.Transaction) => Promise<unknown>;
+const batchTransactions: { transaction: (handler: TransactionHandler) => Promise<unknown> } =
+  models.EmailBatch;
+
+const id = (n: number) => n.toString(16).padStart(24, '0');
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('Upfront recipient preparation through MySQL', () => {
+  let email: InstanceType<typeof models.Email>;
+  let service: InstanceType<typeof BatchSendingService>;
+  let filter: string;
+  let segments: (string | null)[];
+  let queries: Knex.Sql[];
+  let sentry: { captureException: sinon.SinonStub; captureMessage: sinon.SinonStub };
+  const queryListener = (query: Knex.Sql) => queries.push(query);
+  const members = Array.from({ length: 80 }, (_, index) => ({
+    id: id(index + 1),
+    uuid: crypto.randomUUID(),
+    transient_id: crypto.randomUUID(),
+    email: `sweep-${index + 1}@example.com`,
+    status: 'free',
+    created_at: new Date(),
+    updated_at: new Date(),
+  }));
+
+  beforeAll(async () => {
+    await dbUtils.reset();
+    await db.knex('members').insert(members);
+  });
+  beforeEach(async () => {
+    sinon.stub(logging, 'info');
+    sinon.stub(logging, 'error');
+    sinon.stub(logging, 'warn');
+    sentry = { captureException: sinon.stub(), captureMessage: sinon.stub() };
+    queries = [];
+    filter = `id:<='${id(4)}'`;
+    segments = [null];
+    email = await models.Email.add({
+      submitted_at: new Date(),
+      post_id: ObjectID().toHexString(),
+      email_count: 4,
+      preflight_email_count: 4,
+      csd_email_count: 3,
+      recipient_filter: 'all',
+    });
+    service = new BatchSendingService({
+      models,
+      db,
+      sentry,
+      emailRenderer: { getSegments: async () => segments },
+      emailSegmenter: {
+        getMemberFilterForSegment: (
+          _newsletter: unknown,
+          _filter: unknown,
+          segment: string | null,
+        ) => (segment ? `${filter}+(${segment})` : filter),
+      },
+      domainWarmingService: { isEnabled: () => true },
+      sendingService: { getMaximumRecipients: () => 2 },
+      BEFORE_RETRY_CONFIG: { maxRetries: 2, sleep: 0 },
+    });
+    db.knex.on('query', queryListener);
+  });
+  afterEach(async () => {
+    db.knex.removeListener('query', queryListener);
+    sinon.restore();
+    await db.knex('email_recipients').where({ email_id: email.id }).del();
+    await db.knex('email_batches').where({ email_id: email.id }).del();
+    await db.knex('emails').where({ id: email.id }).del();
+    // Restore members changed or removed by a test, including their original UUIDs.
+    await db
+      .knex('members')
+      .whereIn(
+        'id',
+        members.map((member) => member.id),
+      )
+      .del();
+    await db.knex('members').insert(members);
+  });
+  const prepare = () => service.createBatches({ email, post: {}, newsletter: {} });
+  const recipients = () =>
+    db.knex('email_recipients').where({ 'email_recipients.email_id': email.id });
+
+  function interceptSweep(after: (rows: { id: string }[]) => Promise<void>) {
+    const original = models.Member.getFilteredCollectionQuery.bind(models.Member);
+    return sinon
+      .stub(memberQueries, 'getFilteredCollectionQuery')
+      .callsFake((options: { filter: string }) => ({
+        orderByRaw: (order: string) => ({
+          select: async (...columns: string[]) => {
+            const rows = await original(options).orderByRaw(order).select(columns);
+            await after(rows);
+            return rows;
+          },
+        }),
+      }));
+  }
+
+  it('sweeps once and resolves pages without the audience filter or lookahead', async () => {
+    const audience = sinon.spy(models.Member, 'getFilteredCollectionQuery');
+    await prepare();
+    sinon.assert.calledOnce(audience);
+    const sweep = queries.find((query) => query.sql.startsWith('select `members`.`id`'))!;
+    assert.ok(!/distinct|limit/i.test(sweep.sql));
+    assert.ok(sweep.bindings?.includes(email.id));
+    assert.equal(email.get('candidate_count'), 4);
+    assert.equal((await recipients()).length, 4);
+    assert.equal(email.get('email_count'), 4);
+    sinon.assert.calledWithMatch(logging.info, {
+      event: { name: 'email.preparation.started' },
+      concurrency: 2,
+    });
+    sinon.assert.calledWithMatch(logging.info, {
+      event: { name: 'email.batches.created' },
+      concurrency: 2,
+      batches_total: 3,
+    });
+  });
+
+  it('resolves complete dense ranges and falls back for sparse or truncated ranges', async () => {
+    const dense = await resolvePreparationMembers(db.knex, [id(4), id(2)]);
+    assert.deepEqual(
+      dense.map((member) => member.id),
+      [id(4), id(2)],
+    );
+    assert.equal(queries.length, 1);
+    queries.length = 0;
+    const sparse = await resolvePreparationMembers(db.knex, [id(80), id(1)]);
+    assert.deepEqual(
+      sparse.map((member) => member.id),
+      [id(80), id(1)],
+    );
+    assert.equal(queries.length, 2);
+    assert.match(queries[1]!.sql, /where `id` in/);
+    queries.length = 0;
+    assert.deepEqual(await resolvePreparationMembers(db.knex, []), []);
+    assert.equal(queries.length, 0);
+  });
+
+  it('uses a complete range at the threshold and falls back when the extra row exists', async () => {
+    await resolvePreparationMembers(db.knex, [id(16), id(1)]);
+    assert.equal(queries.length, 1);
+    queries.length = 0;
+    await resolvePreparationMembers(db.knex, [id(17), id(1)]);
+    assert.equal(queries.length, 2);
+  });
+
+  it('accounts for disappearance without shifting domain-warming positions', async () => {
+    interceptSweep(async () => {
+      await db
+        .knex('members')
+        .where({ id: id(4) })
+        .del();
+    });
+    await prepare();
+    assert.equal(email.get('candidate_count'), 4);
+    assert.equal(email.get('preparation_excluded_count'), 1);
+    const rows = await recipients()
+      .join('email_batches as b', 'b.id', 'email_recipients.batch_id')
+      .select('member_id', 'b.fallback_sending_domain');
+    assert.equal(rows.length, 3);
+    for (const row of rows) {
+      assert.equal(Boolean(row.fallback_sending_domain), row.member_id === id(1));
+    }
+    sinon.assert.calledWithMatch(logging.info, {
+      event: { name: 'email.preparation.excluded' },
+      reason: 'member_not_found',
+      member_id: id(4),
+    });
+    sinon.assert.notCalled(sentry.captureException);
+    sinon.assert.neverCalledWithMatch(logging.error, {
+      event: { name: 'email.recipient_count.mismatch' },
+    });
+  });
+
+  it('creates no batches when every selected member disappears', async () => {
+    interceptSweep(async (rows) => {
+      await db
+        .knex('members')
+        .whereIn(
+          'id',
+          rows.map((row) => row.id),
+        )
+        .del();
+    });
+    assert.deepEqual(await prepare(), []);
+    assert.equal(email.get('candidate_count'), 4);
+    assert.equal(email.get('preparation_excluded_count'), 4);
+    assert.equal(email.get('email_count'), 0);
+    assert.ok(email.get('prepared_at'));
+  });
+
+  it('retains selected members who become email-disabled and excludes newly eligible ones', async () => {
+    filter += '+email_disabled:0';
+    await db
+      .knex('members')
+      .where({ id: id(4) })
+      .update({ email_disabled: true });
+    interceptSweep(async () => {
+      await db
+        .knex('members')
+        .where({ id: id(4) })
+        .update({ email_disabled: false });
+      await db
+        .knex('members')
+        .where({ id: id(3) })
+        .update({ email_disabled: true });
+    });
+    await prepare();
+    assert.deepEqual((await recipients()).map((row) => row.member_id).sort(), [
+      id(1),
+      id(2),
+      id(3),
+    ]);
+    assert.equal(email.get('candidate_count'), 3);
+  });
+
+  it('retries a failed later segment sweep without recounting or rebuilding the first', async () => {
+    segments = [`id:>'${id(2)}'`, `id:<='${id(2)}'`];
+    const original = models.Member.getFilteredCollectionQuery.bind(models.Member);
+    let attempts = 0;
+    const audience = sinon
+      .stub(memberQueries, 'getFilteredCollectionQuery')
+      .callsFake((options: { filter: string }) => {
+        attempts += 1;
+        if (attempts === 2) {
+          throw new Error('transient sweep failure');
+        }
+        return original(options);
+      });
+    await prepare();
+    sinon.assert.callCount(audience, 3);
+    assert.equal(email.get('candidate_count'), 4);
+    assert.equal((await recipients()).length, 4);
+    assert.equal((await service.getBatches(email)).length, 3);
+  });
+
+  it('drains concurrent transactions before freezing and preserves warming assignments', async () => {
+    const firstWriting = deferred();
+    const releaseFirst = deferred();
+    const laterCommitted = deferred();
+    const original = models.EmailBatch.transaction.bind(models.EmailBatch);
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    sinon
+      .stub(batchTransactions, 'transaction')
+      .callsFake(async (handler: (trx: Knex.Transaction) => Promise<unknown>) => {
+        const position = calls;
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        try {
+          const result = await original(async (trx: Knex.Transaction) => {
+            const batch = await handler(trx);
+            if (position === 0) {
+              firstWriting.resolve();
+              await releaseFirst.promise;
+            }
+            return batch;
+          });
+          if (position > 0) {
+            laterCommitted.resolve();
+          }
+          return result;
+        } finally {
+          active -= 1;
+        }
+      });
+    const run = prepare();
+    try {
+      await firstWriting.promise;
+      await laterCommitted.promise;
+      assert.equal(email.get('prepared_at') ?? null, null);
+      assert.ok(active >= 1 && active <= 2);
+    } finally {
+      releaseFirst.resolve();
+    }
+    const batches = await run;
+    assert.equal(maxActive, 2);
+    assert.equal(batches.length, 3);
+    assert.ok(email.get('prepared_at'));
+    assert.equal((await recipients()).length, 4);
+  });
+
+  it('settles a committed write and recovers its original data after acknowledgement loss', async () => {
+    const original = models.EmailBatch.transaction.bind(models.EmailBatch);
+    let lost = false;
+    sinon
+      .stub(batchTransactions, 'transaction')
+      .callsFake(async (handler: (trx: Knex.Transaction) => Promise<unknown>) => {
+        const result = await original(handler);
+        if (!lost) {
+          lost = true;
+          await db
+            .knex('members')
+            .whereIn('id', [id(3), id(4)])
+            .update({ email: db.knex.raw("concat('changed-', email)") });
+          throw new Error('commit response lost');
+        }
+        return result;
+      });
+    await prepare();
+    const rows = await recipients();
+    assert.equal(rows.length, 4);
+    assert.equal(rows.find((row) => row.member_id === id(4))!.member_email, 'sweep-4@example.com');
+    sinon.assert.calledWithMatch(logging.info, { event: { name: 'email.batch.recovered' } });
+  });
+
+  it('does not start page writes when shutdown occurs during the sweep', async () => {
+    interceptSweep(async () => {
+      service.onPreStop();
+    });
+    const write = sinon.spy(service, 'createBatch');
+    await assert.rejects(prepare(), { code: 'BULK_EMAIL_SHUTDOWN_IN_PROGRESS' });
+    sinon.assert.notCalled(write);
+    assert.equal((await recipients()).length, 0);
+  });
+
+  it('drains and recovers a sibling commit after terminal failure without freezing', async () => {
+    const firstWriting = deferred();
+    const releaseFirst = deferred();
+    const terminalFailure = deferred();
+    const original = models.EmailBatch.transaction.bind(models.EmailBatch);
+    const error = Object.assign(new Error('terminal page failure'), { retryable: false });
+    let calls = 0;
+    let settled = false;
+    let committedIds: string[] = [];
+    sinon.stub(batchTransactions, 'transaction').callsFake(async (handler) => {
+      calls += 1;
+      if (calls === 1) {
+        await original(async (trx: Knex.Transaction) => {
+          const result = await handler(trx);
+          committedIds = await trx('email_recipients')
+            .where({ email_id: email.id })
+            .pluck('member_id');
+          firstWriting.resolve();
+          await releaseFirst.promise;
+          return result;
+        });
+        throw new Error('commit response lost');
+      }
+      await firstWriting.promise;
+      throw error;
+    });
+    // The failed worker has finished its recovery lookup before retryDb rejects it.
+    const retry = service.retryDb.bind(service);
+    sinon.stub(service, 'retryDb').callsFake(async (...args: unknown[]) => {
+      try {
+        return await retry(...args);
+      } catch (failure) {
+        if (failure === error) {
+          terminalFailure.resolve();
+        }
+        throw failure;
+      }
+    });
+    const result = assert
+      .rejects(prepare(), (failure) => failure === error)
+      .then(() => {
+        settled = true;
+      });
+    try {
+      await terminalFailure.promise;
+      await Promise.resolve();
+      assert.equal(settled, false);
+      assert.equal(email.get('prepared_at') ?? null, null);
+    } finally {
+      releaseFirst.resolve();
+    }
+    await result;
+    assert.equal(calls, 2);
+    assert.ok(committedIds.length > 0);
+    assert.deepEqual((await recipients()).map((row) => row.member_id).sort(), committedIds.sort());
+    assert.equal(email.get('prepared_at') ?? null, null);
+    sinon.assert.calledWithMatch(logging.info, { event: { name: 'email.batch.recovered' } });
+    sinon.assert.neverCalledWithMatch(logging.info, {
+      event: { name: 'email.preparation.completed' },
+    });
+  });
+
+  it('uses relation subqueries without DISTINCT for overlapping labels and tiers', () => {
+    const segmenter = new EmailSegmenter({});
+    const memberFilter = segmenter.getMemberFilterForSegment(
+      { id: id(99), get: () => 'members' },
+      '(label:[one,two],products:[gold,silver])',
+      null,
+    );
+    const sql = models.Member.getFilteredCollectionQuery({ filter: memberFilter })
+      .orderByRaw('members.id DESC')
+      .select('members.id')
+      .toSQL().sql;
+    assert.match(sql, /in \(select/i);
+    assert.doesNotMatch(sql, /select distinct/i);
+  });
+
+  it('returns a member only once when multiple selected labels match', async () => {
+    const newsletter = await db.knex('newsletters').first();
+    const labelIds = [ObjectID().toHexString(), ObjectID().toHexString()];
+    try {
+      await db.knex('labels').insert(
+        labelIds.map((labelId, index) => ({
+          id: labelId,
+          name: `sweep-label-${index}`,
+          slug: `sweep-label-${index}`,
+          created_at: new Date(),
+        })),
+      );
+      await db.knex('members_labels').insert(
+        labelIds.map((labelId) => ({
+          id: ObjectID().toHexString(),
+          member_id: id(4),
+          label_id: labelId,
+        })),
+      );
+      await db.knex('members_newsletters').insert({
+        id: ObjectID().toHexString(),
+        member_id: id(4),
+        newsletter_id: newsletter.id,
+      });
+      const segmenter = new EmailSegmenter({});
+      const memberFilter = segmenter.getMemberFilterForSegment(
+        { id: newsletter.id, get: () => 'members' },
+        'label:[sweep-label-0,sweep-label-1]',
+        null,
+      );
+      const rows = await models.Member.getFilteredCollectionQuery({ filter: memberFilter })
+        .orderByRaw('members.id DESC')
+        .select('members.id');
+      assert.deepEqual(rows, [{ id: id(4) }]);
+    } finally {
+      await db.knex('members_labels').whereIn('label_id', labelIds).del();
+      await db.knex('labels').whereIn('id', labelIds).del();
+    }
+  });
+});

--- a/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
@@ -5,7 +5,7 @@ import {
   preparationPages,
   resolvePreparationMembers,
   runPreparationWorkers,
-  selectedMemberIds,
+  selectPreparationCandidates,
   validatePreparationConcurrency,
   waitForPreparationRetry,
 } from '../../../../../core/server/services/email-service/recipient-preparation';
@@ -40,8 +40,8 @@ describe('Recipient preparation workers', () => {
     }
   });
 
-  it('counts ordered candidate IDs once and pages without lookahead', () => {
-    const ids = selectedMemberIds([{ id: 'c' }, { id: 'c' }, { id: 'b' }, { id: 'a' }]);
+  it('pages selected candidates without lookahead', () => {
+    const ids = ['c', 'b', 'a'];
     assert.deepEqual(
       [...preparationPages(ids, 2)],
       [
@@ -49,6 +49,43 @@ describe('Recipient preparation workers', () => {
         { ids: ['a'], offset: 2, useFallbackDomain: false },
       ],
     );
+  });
+
+  it('selects ordered candidates for every segment in one statement, including empty segments', async () => {
+    const db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    try {
+      await db.schema.createTable('members', (table) => {
+        table.string('id').primary();
+        table.string('status');
+      });
+      await db.schema.createTable('matches', (table) => table.string('member_id'));
+      await db('members').insert([
+        { id: 'a', status: 'free' },
+        { id: 'b', status: 'paid' },
+        { id: 'c', status: 'free' },
+      ]);
+      await db('matches').insert([{ member_id: 'c' }, { member_id: 'c' }]);
+      const queries: string[] = [];
+      db.on('query', (query) => queries.push(query.sql));
+      assert.deepEqual(
+        await selectPreparationCandidates(db, [
+          db('members').where('status', 'comped'),
+          db('members').where('status', 'free'),
+          db('members').where('status', 'paid'),
+          db('members').join('matches', 'matches.member_id', 'members.id'),
+        ]),
+        [[], ['c', 'a'], ['b'], ['c']],
+      );
+      assert.equal(queries.length, 1);
+      assert.deepEqual(await selectPreparationCandidates(db, []), []);
+      assert.equal(queries.length, 1);
+    } finally {
+      await db.destroy();
+    }
   });
 
   it('ends a page at the warming boundary and fills the next on the fallback domain', () => {

--- a/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import knex from 'knex';
+import { vi } from 'vitest';
+import {
+  preparationPages,
+  resolvePreparationMembers,
+  runPreparationWorkers,
+  selectedMemberIds,
+  validatePreparationConcurrency,
+  waitForPreparationRetry,
+} from '../../../../../core/server/services/email-service/recipient-preparation';
+import { RECIPIENT_VERIFICATION_CODE } from '../../../../../core/server/services/email-service/recipient-accounting';
+
+const BatchSendingService = require('../../../../../core/server/services/email-service/batch-sending-service');
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('Recipient preparation workers', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('accepts explicit concurrency independently of the database pool', () => {
+    for (const value of [1, 2, 4]) {
+      assert.equal(validatePreparationConcurrency(value), value);
+      assert.doesNotThrow(
+        () =>
+          new BatchSendingService({
+            batchCreationConcurrency: value,
+            db: { knex: { client: { pool: { max: 1 } } } },
+          }),
+      );
+    }
+    for (const value of [0, -1, 1.5, Infinity, NaN, '2', null]) {
+      assert.throws(() => validatePreparationConcurrency(value), /must be a positive integer/);
+    }
+  });
+
+  it('counts ordered candidate IDs once and pages without lookahead', () => {
+    const ids = selectedMemberIds([{ id: 'c' }, { id: 'c' }, { id: 'b' }, { id: 'a' }]);
+    assert.deepEqual(
+      [...preparationPages(ids, 2)],
+      [
+        { ids: ['c', 'b'], offset: 0, useFallbackDomain: false },
+        { ids: ['a'], offset: 2, useFallbackDomain: false },
+      ],
+    );
+  });
+
+  it('ends a page at the warming boundary and fills the next on the fallback domain', () => {
+    assert.deepEqual(
+      [...preparationPages(['d', 'c', 'b', 'a'], 3, 1)],
+      [
+        { ids: ['d'], offset: 0, useFallbackDomain: false },
+        { ids: ['c', 'b', 'a'], offset: 1, useFallbackDomain: true },
+      ],
+    );
+  });
+
+  it('holds an exact bound while later pages finish before earlier pages', async () => {
+    const gates = Array.from({ length: 4 }, deferred);
+    const twoStarted = deferred();
+    const thirdStarted = deferred();
+    const started: number[] = [];
+    const completed: number[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const run = runPreparationWorkers(
+      [0, 1, 2, 3],
+      2,
+      () => {},
+      async (index) => {
+        started.push(index);
+        active += 1;
+        maxActive = Math.max(active, maxActive);
+        if (started.length === 2) {
+          twoStarted.resolve();
+        }
+        if (started.length === 3) {
+          thirdStarted.resolve();
+        }
+        await gates[index]!.promise;
+        active -= 1;
+        completed.push(index);
+      },
+    );
+    await twoStarted.promise;
+    assert.deepEqual(started, [0, 1]);
+    gates[1]!.resolve();
+    await thirdStarted.promise;
+    assert.deepEqual(completed, [1]);
+    assert.deepEqual(started, [0, 1, 2]);
+    gates.forEach((gate) => gate.resolve());
+    await run;
+    assert.equal(maxActive, 2);
+    assert.equal(active, 0);
+    assert.equal(completed.length, 4);
+  });
+
+  it('queues concurrent page reads and writes through one SQLite connection', async () => {
+    const db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+      pool: { min: 1, max: 1 },
+      acquireConnectionTimeout: 1000,
+    });
+    try {
+      await db.schema.createTable('members', (table) => {
+        table.string('id').primary();
+        table.string('uuid');
+        table.string('email');
+        table.string('name');
+      });
+      await db.schema.createTable('prepared', (table) => table.string('member_id').primary());
+      const ids = ['d', 'c', 'b', 'a'];
+      await db('members').insert(
+        ids.map((id) => ({ id, uuid: `uuid-${id}`, email: `${id}@example.com`, name: null })),
+      );
+      await runPreparationWorkers(
+        preparationPages(ids, 2),
+        2,
+        () => {},
+        async (page) => {
+          const members = await resolvePreparationMembers(db, page.ids);
+          await db.transaction(async (trx) => {
+            await trx('prepared').insert(members.map((member) => ({ member_id: member.id })));
+          });
+        },
+      );
+      assert.deepEqual(await db('prepared').orderBy('member_id', 'desc').pluck('member_id'), ids);
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it('wakes sibling retry waits and drains an in-flight operation after failure', async () => {
+    vi.useFakeTimers();
+    const fail = deferred();
+    const finishWrite = deferred();
+    const allStarted = deferred();
+    const error = new Error('terminal write failure');
+    const started: number[] = [];
+    let settled = false;
+    const run = runPreparationWorkers(
+      [0, 1, 2, 3],
+      3,
+      () => {},
+      async (index, signal) => {
+        started.push(index);
+        if (index === 0) {
+          await fail.promise;
+          throw error;
+        }
+        if (index === 1) {
+          await waitForPreparationRetry(600_000, signal);
+        }
+        if (index === 2) {
+          allStarted.resolve();
+          await finishWrite.promise;
+        }
+      },
+    );
+    const result = assert
+      .rejects(run, (candidate) => candidate === error)
+      .then(() => {
+        settled = true;
+      });
+    await allStarted.promise;
+    assert.equal(vi.getTimerCount(), 1);
+    fail.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    assert.equal(vi.getTimerCount(), 0);
+    assert.equal(settled, false);
+    assert.deepEqual(started, [0, 1, 2]);
+    finishWrite.resolve();
+    await result;
+  });
+
+  it('drains workers after a dispatcher error and preserves a later integrity failure', async () => {
+    const finishWrite = deferred();
+    const error = new Error('shutdown');
+    const integrity = Object.assign(new Error('corrupt committed batch'), {
+      code: RECIPIENT_VERIFICATION_CODE,
+    });
+    let claims = 0;
+    let settled = false;
+    const run = runPreparationWorkers(
+      [0, 1],
+      2,
+      () => {
+        claims += 1;
+        if (claims === 2) {
+          throw error;
+        }
+      },
+      async () => {
+        await finishWrite.promise;
+        throw integrity;
+      },
+    );
+    const result = assert
+      .rejects(run, (candidate) => candidate === integrity)
+      .then(() => {
+        settled = true;
+      });
+    await Promise.resolve();
+    assert.equal(settled, false);
+    finishWrite.resolve();
+    await result;
+  });
+
+  it('does not dispatch after an iterator throws', async () => {
+    const error = new Error('cannot select next page');
+    function* pages() {
+      yield 1;
+      throw error;
+    }
+    const finish = deferred();
+    const started: number[] = [];
+    const run = runPreparationWorkers(
+      pages(),
+      2,
+      () => {},
+      async (value) => {
+        started.push(value);
+        await finish.promise;
+      },
+    );
+    const result = assert.rejects(run, (candidate) => candidate === error);
+    finish.resolve();
+    await result;
+    assert.deepEqual(started, [1]);
+  });
+
+  it('checks an already aborted retry signal before calling the operation', async () => {
+    const controller = new AbortController();
+    const error = new Error('another page failed');
+    controller.abort(error);
+    const service = new BatchSendingService({});
+    const operation = vi.fn();
+    await assert.rejects(
+      service.retryDb(operation, { signal: controller.signal }),
+      (candidate) => candidate === error,
+    );
+    assert.equal(operation.mock.calls.length, 0);
+  });
+
+  it('does not start another database attempt when aborted during backoff', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const service = new BatchSendingService({});
+    const operation = vi.fn().mockRejectedValue(new Error('transient database error'));
+    const error = new Error('another page failed');
+    const result = assert.rejects(
+      service.retryDb(operation, {
+        maxRetries: 5,
+        sleep: 600_000,
+        signal: controller.signal,
+        description: 'test page',
+      }),
+      (candidate) => candidate === error,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    assert.equal(vi.getTimerCount(), 1);
+    controller.abort(error);
+    await result;
+    assert.equal(operation.mock.calls.length, 1);
+    assert.equal(vi.getTimerCount(), 0);
+  });
+
+  it('settles an operation already started when its signal is aborted', async () => {
+    const controller = new AbortController();
+    const finishWrite = deferred();
+    const service = new BatchSendingService({});
+    const run = service.retryDb(
+      async () => {
+        await finishWrite.promise;
+        return 'committed';
+      },
+      {
+        signal: controller.signal,
+        description: 'test commit',
+      },
+    );
+    controller.abort(new Error('sibling failed'));
+    finishWrite.resolve();
+    assert.equal(await run, 'committed');
+  });
+
+  it('removes the abort listener when the backoff completes normally', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    const wait = waitForPreparationRetry(10, controller.signal);
+    await vi.advanceTimersByTimeAsync(10);
+    await wait;
+    assert.equal(remove.mock.calls.length, 1);
+    assert.equal(vi.getTimerCount(), 0);
+  });
+});

--- a/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
@@ -3,7 +3,7 @@ import knex from 'knex';
 import { vi } from 'vitest';
 import {
   preparationPages,
-  createPreparationMemberResolver,
+  resolvePreparationMembers,
   runPreparationWorkers,
   selectPreparationCandidates,
   waitForPreparationRetry,
@@ -184,13 +184,12 @@ describe('Recipient preparation workers', () => {
       await db('members').insert(
         ids.map((id) => ({ id, uuid: `uuid-${id}`, email: `${id}@example.com`, name: null })),
       );
-      const resolveMembers = createPreparationMemberResolver(db);
       await runPreparationWorkers(
         preparationPages(ids, 2),
         2,
         () => {},
         async (page) => {
-          const members = await resolveMembers(page.ids);
+          const members = await resolvePreparationMembers(db, page.ids);
           await db.transaction(async (trx) => {
             await trx('prepared').insert(members.map((member) => ({ member_id: member.id })));
           });

--- a/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
+++ b/ghost/core/test/unit/server/services/email-service/recipient-preparation.test.ts
@@ -3,10 +3,9 @@ import knex from 'knex';
 import { vi } from 'vitest';
 import {
   preparationPages,
-  resolvePreparationMembers,
+  createPreparationMemberResolver,
   runPreparationWorkers,
   selectPreparationCandidates,
-  validatePreparationConcurrency,
   waitForPreparationRetry,
 } from '../../../../../core/server/services/email-service/recipient-preparation';
 import { RECIPIENT_VERIFICATION_CODE } from '../../../../../core/server/services/email-service/recipient-accounting';
@@ -26,7 +25,6 @@ describe('Recipient preparation workers', () => {
 
   it('accepts explicit concurrency independently of the database pool', () => {
     for (const value of [1, 2, 4]) {
-      assert.equal(validatePreparationConcurrency(value), value);
       assert.doesNotThrow(
         () =>
           new BatchSendingService({
@@ -36,7 +34,10 @@ describe('Recipient preparation workers', () => {
       );
     }
     for (const value of [0, -1, 1.5, Infinity, NaN, '2', null]) {
-      assert.throws(() => validatePreparationConcurrency(value), /must be a positive integer/);
+      assert.throws(
+        () => new BatchSendingService({ batchCreationConcurrency: value }),
+        /bulkEmail:batchCreationConcurrency must be a positive integer/,
+      );
     }
   });
 
@@ -95,6 +96,31 @@ describe('Recipient preparation workers', () => {
         { ids: ['d'], offset: 0, useFallbackDomain: false },
         { ids: ['c', 'b', 'a'], offset: 1, useFallbackDomain: true },
       ],
+    );
+  });
+
+  for (const batchSize of [0, -1, 1.5, NaN, Infinity]) {
+    it(`rejects batch size ${batchSize} before yielding a page`, () => {
+      assert.throws(
+        () => preparationPages(['a'], batchSize).next(),
+        /batchSize must be a positive integer/,
+      );
+    });
+  }
+
+  it('finishes completed work without another shutdown check when there are no pages left', async () => {
+    let shuttingDown = false;
+    await runPreparationWorkers(
+      [1],
+      1,
+      () => {
+        if (shuttingDown) {
+          throw new Error('shutdown');
+        }
+      },
+      async () => {
+        shuttingDown = true;
+      },
     );
   });
 
@@ -158,12 +184,13 @@ describe('Recipient preparation workers', () => {
       await db('members').insert(
         ids.map((id) => ({ id, uuid: `uuid-${id}`, email: `${id}@example.com`, name: null })),
       );
+      const resolveMembers = createPreparationMemberResolver(db);
       await runPreparationWorkers(
         preparationPages(ids, 2),
         2,
         () => {},
         async (page) => {
-          const members = await resolvePreparationMembers(db, page.ids);
+          const members = await resolveMembers(page.ids);
           await db.transaction(async (trx) => {
             await trx('prepared').insert(members.map((member) => ({ member_id: member.id })));
           });


### PR DESCRIPTION
Large newsletters currently repeat the audience filter for each page of recipients and write batches sequentially. Expensive filters can greatly increase preparation time. This PR selects candidate IDs and their content segments **in one query for the whole email**, then resolves member data and writes pages with **two concurrent workers** by default to limit use of the shared connection pool.

Stack: TryGhost/Ghost#30540 (migrations) → TryGhost/Ghost#30541 (preparation accounting) → TryGhost/Ghost#30542 (submission accounting) → **this PR**.

```mermaid
flowchart TD
    A["Select IDs for all segments in one query"] --> B["Take the next selected segment and assign page domains"]
    B --> C
    subgraph workers["Up to two active pages"]
        C["Load selected members"] --> D["Write batch and recipients in one transaction"]
    end
    D --> E["Wait for all pages in this segment to settle"]
    E -->|Next selected segment| B
    E -->|All segments complete| F["Verify persisted recipients and counts"]
    F --> G["Save prepared_at"]
    G --> H["Submit the frozen batch set"]
```

The query combines the existing segment filters with `UNION ALL` and orders results by segment and descending member ID. All segments see the same database view, without an explicit transaction spanning queries. Candidates are counted before their pages are dispatched. Each page uses one sending domain and creates at most one batch. Pages end at the domain-warming boundary, so warming allocation follows candidate order even when writes finish out of order. Selected members that disappear or lack required data become explicit exclusions.

Eligibility and content segment are fixed together when the audience is selected. A member changing status during preparation keeps their original assignment, avoiding the duplicate or omission possible with separate segment sweeps. Later unsubscribes or audience changes do not remove selected members whose data remains valid, and newly eligible members are not added.

Failed database selection retries the entire query before any batches are written; malformed filters fail immediately. A terminal worker failure or shutdown stops new page dispatch and interrupts retry waits. In-flight writes and recovery reads settle before the attempt returns, although abort stops further recovery retries. After all pages finish, shutdown alone no longer prevents verification or the `prepared_at` save. Their database retries use the shutdown budget. The accounting protocol from the preceding PRs remains in place: retrying incomplete preparation discards it and rebuilds; retrying after `prepared_at` reuses the frozen batches. Submission retains its existing retry policy.

`bulkEmail.batchCreationConcurrency` controls the worker limit independently of the database pool. Member data is loaded outside write transactions. Each page loads only its selected IDs in one query, preserving candidate order without range probes or per-segment lookup state. All segments’ candidate IDs remain in memory together, and the combined ordering can require a database sort over the whole audience. Per-process draining does not prevent overlapping processes from creating separate batch sets.

Automated coverage includes status changes between selection and preparation, tier access across two and three segments, whole-query retries before any writes, shutdown during selection, worker bounds, exclusions at warming boundaries, and commit recovery after a sibling worker fails.

Validation: 506 email-service unit tests pass in UTC; 115 MySQL preparation/accounting checks and source/test type checks pass. The full repository check stops at formatting in six existing untracked planning documents.

Local MySQL measurements use a 100,000-member fixture split evenly between free and paid segments, concurrency 2, a pool of 5, and a 128 MiB InnoDB buffer pool:

| Audience | Candidates | Prepare | Lookup queries | Summed lookup time |
| --- | --- | --- | --- | --- |
| Full | 100,000 | 3.84 s | 100 | 1,852 ms |
| Label-filtered | 20,000 | 1.36 s | 20 | 385 ms |

Every candidate was prepared and verified. Member lookups transferred exactly the selected audience: 100,000 rows for the full case and 20,000 for the label case. Lookup times overlap under concurrency and are not wall-clock phase durations. Discard-and-rebuild also verified the full audience. These are individual local samples, not production measurements or proof of an old-versus-new speedup. The [email-service README](https://github.com/TryGhost/Ghost/blob/jonatan-ber-3930-recipient-sweep/ghost/core/core/server/services/email-service/README.md#benchmarking-preparation) documents the harness and measurement limits.

ref [BER-3930](https://linear.app/ghost/issue/BER-3930/create-email-batches-from-an-upfront-recipient-sweep-with-concurrent)

- [X] Read and followed the contributor guide
- [X] Explained the change
- [X] Added automated tests