### PR TITLE
Preferred stored auto_excerpt and reading_time behind labs flag

### DIFF
--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -129,6 +129,12 @@ const features: Feature[] = [
       'Let AI agents pay for access to paid-members markdown (.md) URLs via Stripe Machine Payments Protocol',
     flag: 'machinePayments',
   },
+  {
+    title: 'Stored post metadata',
+    description:
+      'Prefer persisted auto_excerpt and reading_time on Posts/Pages API responses instead of recomputing them on every request',
+    flag: 'storedPostMetadata',
+  },
 ];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const utils = require('../../..');
 const url = require('../utils/url');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
+const { resolveAutoExcerpt } = require('../utils/extra-attrs');
 
 const commentFields = [
   'id',
@@ -118,11 +119,16 @@ const commentMapper = (model, frame) => {
     url.forPost(jsonModel.post.id, jsonModel.post, frame, routerType);
     response.post = _.pick(jsonModel.post, postFields);
 
-    // Compute excerpt from custom_excerpt or plaintext (same logic as post serializer)
+    // Same excerpt resolution as Posts/Pages (custom_excerpt wins; stored
+    // auto_excerpt preferred behind storedPostMetadata; else plaintext slice).
     if (jsonModel.post.custom_excerpt) {
       response.post.excerpt = jsonModel.post.custom_excerpt;
-    } else if (jsonModel.post.plaintext) {
-      response.post.excerpt = jsonModel.post.plaintext.substring(0, 500);
+    } else {
+      response.post.excerpt = resolveAutoExcerpt({
+        get(attr) {
+          return jsonModel.post[attr];
+        },
+      });
     }
   }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -121,14 +121,19 @@ const commentMapper = (model, frame) => {
 
     // Same excerpt resolution as Posts/Pages (custom_excerpt wins; stored
     // auto_excerpt preferred behind storedPostMetadata; else plaintext slice).
+    // Omit the key when unresolved so comments/activity-feed payloads stay
+    // unchanged for posts without excerpt sources.
     if (jsonModel.post.custom_excerpt) {
       response.post.excerpt = jsonModel.post.custom_excerpt;
     } else {
-      response.post.excerpt = resolveAutoExcerpt({
+      const excerpt = resolveAutoExcerpt({
         get(attr) {
           return jsonModel.post[attr];
         },
       });
+      if (excerpt !== null && excerpt !== undefined) {
+        response.post.excerpt = excerpt;
+      }
     }
   }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
@@ -21,6 +21,8 @@ function resolveAutoExcerpt(model) {
   return computeAutoExcerpt(model.get('plaintext'));
 }
 
+module.exports.resolveAutoExcerpt = resolveAutoExcerpt;
+
 /**
  *
  * @param {Object} options - frame options

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
@@ -3,7 +3,8 @@ const { computeAutoExcerpt, computeReadingTime } = require('../../../../../../li
 
 /**
  * Automatic excerpt for API output.
- * When storedPostMetadata is on, prefer the persisted column (no plaintext read).
+ * When storedPostMetadata is on, prefer the persisted column; fall back to the
+ * plaintext slice when still null (partial backfill / fixture holes).
  * When off, keep today's request-time plaintext slice.
  *
  * @param {import('../../../../../../models/post')} model
@@ -12,7 +13,9 @@ const { computeAutoExcerpt, computeReadingTime } = require('../../../../../../li
 function resolveAutoExcerpt(model) {
   if (labs.isSet('storedPostMetadata')) {
     const stored = model.get('auto_excerpt');
-    return stored === undefined ? null : stored;
+    if (stored !== null && stored !== undefined) {
+      return stored;
+    }
   }
 
   return computeAutoExcerpt(model.get('plaintext'));

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
@@ -91,4 +91,10 @@ module.exports.forPost = (options, model, attrs) => {
       attrs.reading_time = computeReadingTime(attrs.html, attrs.feature_image);
     }
   }
+
+  // html is stripped by the formats keep-list when not requested; feature_image is not a
+  // format, so drop it when it was only force-loaded for reading_time compute fallback.
+  if (columnsIncludesReadingTime && options.columns && !options.columns.includes('feature_image')) {
+    delete attrs.feature_image;
+  }
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
@@ -1,4 +1,22 @@
+const labs = require('../../../../../../../shared/labs');
 const { computeAutoExcerpt, computeReadingTime } = require('../../../../../../lib/post-meta');
+
+/**
+ * Automatic excerpt for API output.
+ * When storedPostMetadata is on, prefer the persisted column (no plaintext read).
+ * When off, keep today's request-time plaintext slice.
+ *
+ * @param {import('../../../../../../models/post')} model
+ * @returns {string|null}
+ */
+function resolveAutoExcerpt(model) {
+  if (labs.isSet('storedPostMetadata')) {
+    const stored = model.get('auto_excerpt');
+    return stored === undefined ? null : stored;
+  }
+
+  return computeAutoExcerpt(model.get('plaintext'));
+}
 
 /**
  *
@@ -19,11 +37,12 @@ module.exports.forPost = (options, model, attrs) => {
 
   // no columns requested
   const noColumnsRequested = !Object.prototype.hasOwnProperty.call(options, 'columns');
+  const useStoredPostMetadata = labs.isSet('storedPostMetadata');
 
   // 1. Gets excerpt from post's plaintext. If custom_excerpt exists, it overrides the excerpt but the key remains excerpt.
   if (columnsIncludesExcerpt) {
     if (!attrs.custom_excerpt) {
-      attrs.excerpt = computeAutoExcerpt(model.get('plaintext'));
+      attrs.excerpt = resolveAutoExcerpt(model);
     } else {
       attrs.excerpt = attrs.custom_excerpt;
     }
@@ -49,16 +68,21 @@ module.exports.forPost = (options, model, attrs) => {
     if (customExcerpt !== null) {
       attrs.excerpt = customExcerpt;
     } else {
-      attrs.excerpt = computeAutoExcerpt(model.get('plaintext'));
+      attrs.excerpt = resolveAutoExcerpt(model);
     }
   }
 
   // 4. Add `reading_time` if no columns were requested, or if `reading_time` was requested via `columns`
   // reading_time is also a DB column now; drop the raw value so we only expose it when
-  // computed below (avoids leaking `reading_time: null` into APIs/webhooks).
+  // we intentionally return a stored or computed value (avoids leaking `reading_time: null`).
+  const storedReadingTime = attrs.reading_time;
   delete attrs.reading_time;
   if (noColumnsRequested || columnsIncludesReadingTime) {
-    if (attrs.html) {
+    if (useStoredPostMetadata && storedReadingTime !== null && storedReadingTime !== undefined) {
+      // Prefer persisted value even when html was not selected (enables later query narrowing).
+      attrs.reading_time = storedReadingTime;
+    } else if (attrs.html) {
+      // Flag off, or stored null during partial backfill — compute from html.
       attrs.reading_time = computeReadingTime(attrs.html, attrs.feature_image);
     }
   }

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -27,6 +27,22 @@ const requiredForExcerpt = (requestedColumns) => {
   }
 };
 
+// reading_time is a real column now, but compute fallback (flag off, or flag on
+// with a still-null stored value during partial backfill) needs html + feature_image.
+// Frame.options.columns stays as the caller's list; only the fetch clone is expanded.
+const requiredForReadingTime = (requestedColumns) => {
+  if (!requestedColumns || !requestedColumns.includes('reading_time')) {
+    return;
+  }
+
+  if (!requestedColumns.includes('html')) {
+    requestedColumns.push('html');
+  }
+  if (!requestedColumns.includes('feature_image')) {
+    requestedColumns.push('feature_image');
+  }
+};
+
 const parsePositiveInteger = (value, defaultValue) => {
   const parsedValue = Number.parseInt(value, 10);
 
@@ -129,6 +145,7 @@ module.exports = function (Bookshelf) {
         const requestedColumns = options.columns;
         // Ensure DB columns needed to build computed `excerpt` are selected/kept
         requiredForExcerpt(requestedColumns);
+        requiredForReadingTime(requestedColumns);
 
         // Set this to true or pass ?debug=true as an API option to get output
         itemCollection.debug = unfilteredOptions.debug && process.env.NODE_ENV !== 'production';
@@ -229,6 +246,7 @@ module.exports = function (Bookshelf) {
         const requestedColumns = options.columns;
         // Ensure DB columns needed to build computed `excerpt` are selected/kept
         requiredForExcerpt(requestedColumns);
+        requiredForReadingTime(requestedColumns);
 
         // @NOTE: The API layer decides if this option is allowed
         if (options.filter) {

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -7,18 +7,23 @@ const messages = {
   couldNotUnderstandRequest: 'Could not understand request.',
 };
 
-// If user requested an excerpt we need to ensure plaintext and custom_excerpt is also included so we can include it when we query the database.
+// If user requested an excerpt we need to ensure the DB columns used to build
+// it are selected (and kept through findPage's attribute pick). `excerpt` itself
+// is computed — not a column.
 const requiredForExcerpt = (requestedColumns) => {
-  if (requestedColumns) {
-    if (
-      (requestedColumns.includes('excerpt') &&
-        !requestedColumns.includes('plaintext') &&
-        !requestedColumns.includes('plaintext')) ||
-      !requestedColumns
-    ) {
-      requestedColumns.push('plaintext');
-      requestedColumns.push('custom_excerpt');
-    }
+  if (!requestedColumns || !requestedColumns.includes('excerpt')) {
+    return;
+  }
+
+  if (!requestedColumns.includes('plaintext')) {
+    requestedColumns.push('plaintext');
+  }
+  if (!requestedColumns.includes('custom_excerpt')) {
+    requestedColumns.push('custom_excerpt');
+  }
+  // Needed when storedPostMetadata prefers persisted auto_excerpt over plaintext.
+  if (!requestedColumns.includes('auto_excerpt')) {
+    requestedColumns.push('auto_excerpt');
   }
 };
 
@@ -122,7 +127,7 @@ module.exports = function (Bookshelf) {
 
         const itemCollection = this.getFilteredCollection(options);
         const requestedColumns = options.columns;
-        // make sure we include plaintext and custom_excerpt if excerpt is requested
+        // Ensure DB columns needed to build computed `excerpt` are selected/kept
         requiredForExcerpt(requestedColumns);
 
         // Set this to true or pass ?debug=true as an API option to get output
@@ -222,7 +227,7 @@ module.exports = function (Bookshelf) {
         data = this.filterData(data);
         const model = this.forge(data);
         const requestedColumns = options.columns;
-        // make sure we include plaintext and custom_excerpt if excerpt is requested
+        // Ensure DB columns needed to build computed `excerpt` are selected/kept
         requiredForExcerpt(requestedColumns);
 
         // @NOTE: The API layer decides if this option is allowed

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -61,6 +61,7 @@ const PRIVATE_FEATURES = [
   'machinePayments',
   'postsListReact',
   'editorReact',
+  'storedPostMetadata',
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
@@ -142,7 +142,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
         assert.equal(attrs.excerpt, 'custom excerpt');
       });
 
-      it('returns null excerpt when stored auto_excerpt is missing (no plaintext fallback)', function () {
+      it('falls back to computing excerpt when stored auto_excerpt is missing', function () {
         modelGetStub.withArgs('auto_excerpt').returns(null);
         modelGetStub.withArgs('custom_excerpt').returns(null);
         modelGetStub.withArgs('plaintext').returns(new Array(5000).join('A'));
@@ -150,7 +150,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
 
         extraAttrsUtil.forPost({}, model, attrs);
 
-        assert.equal(attrs.excerpt, null);
+        assert.equal(attrs.excerpt, new Array(501).join('A'));
       });
 
       it('prefers stored reading_time even when html is absent', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
@@ -195,6 +195,77 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
 
         assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'reading_time'), false);
       });
+
+      it('strips force-loaded feature_image when only reading_time was requested', function () {
+        const attrs = {
+          reading_time: null,
+          html: `<p>${'word '.repeat(390)}</p>`,
+          feature_image: 'https://example.com/feature.jpg',
+        };
+
+        extraAttrsUtil.forPost(
+          {
+            columns: ['reading_time'],
+          },
+          model,
+          attrs,
+        );
+
+        assert.equal(attrs.reading_time, 2);
+        assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'feature_image'), false);
+      });
+
+      it('keeps feature_image when it was explicitly requested with reading_time', function () {
+        const attrs = {
+          reading_time: 7,
+          feature_image: 'https://example.com/feature.jpg',
+        };
+
+        extraAttrsUtil.forPost(
+          {
+            columns: ['reading_time', 'feature_image'],
+          },
+          model,
+          attrs,
+        );
+
+        assert.equal(attrs.reading_time, 7);
+        assert.equal(attrs.feature_image, 'https://example.com/feature.jpg');
+      });
+
+      it('uses feature_image when falling back to compute reading_time', function () {
+        // ~380–410 words is just under 1.5 minutes; +1 image rounds to 2.
+        const html = `<p>${'word '.repeat(390)}</p>`;
+        const withoutImage = { reading_time: null, html };
+        const withImage = {
+          reading_time: null,
+          html,
+          feature_image: 'https://example.com/feature.jpg',
+        };
+
+        extraAttrsUtil.forPost({}, model, withoutImage);
+        extraAttrsUtil.forPost({}, model, withImage);
+
+        assert.equal(withoutImage.reading_time, 1);
+        assert.equal(withImage.reading_time, 2);
+        assert.ok(withImage.reading_time > withoutImage.reading_time);
+      });
+    });
+
+    it('uses feature_image when computing reading_time with flag off', function () {
+      const html = `<p>${'word '.repeat(390)}</p>`;
+      const withoutImage = { html };
+      const withImage = {
+        html,
+        feature_image: 'https://example.com/feature.jpg',
+      };
+
+      extraAttrsUtil.forPost({}, model, withoutImage);
+      extraAttrsUtil.forPost({}, model, withImage);
+
+      assert.equal(withoutImage.reading_time, 1);
+      assert.equal(withImage.reading_time, 2);
+      assert.ok(withImage.reading_time > withoutImage.reading_time);
     });
 
     it('ignores divergent stored values when storedPostMetadata is off', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
+const labs = require('../../../../../../../../core/shared/labs');
 const extraAttrsUtil = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/utils/extra-attrs');
 
 describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function () {
@@ -9,11 +10,17 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
 
   let model;
   let modelGetStub;
+  let labsStub;
 
   beforeEach(function () {
     model = sinon.stub();
     modelGetStub = sinon.stub(model, 'get');
     modelGetStub.withArgs('plaintext').returns(new Array(5000).join('A'));
+    labsStub = sinon.stub(labs, 'isSet').returns(false);
+  });
+
+  afterEach(function () {
+    sinon.restore();
   });
 
   describe('for post', function () {
@@ -67,6 +74,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
     });
 
     it('has excerpt when no columns are passed', function () {
+      modelGetStub.withArgs('custom_excerpt').returns(null);
       const attrs = {};
       extraAttrsUtil.forPost({}, model, attrs);
       sinon.assert.called(modelGetStub);
@@ -101,6 +109,92 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
       };
       extraAttrsUtil.forPost({}, model, attrs);
       assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'reading_time'), false);
+    });
+
+    describe('storedPostMetadata labs flag', function () {
+      beforeEach(function () {
+        labsStub.withArgs('storedPostMetadata').returns(true);
+      });
+
+      it('prefers stored auto_excerpt over plaintext when columns include excerpt', function () {
+        modelGetStub.withArgs('auto_excerpt').returns('stored excerpt');
+        modelGetStub.withArgs('plaintext').returns('plaintext that should be ignored');
+        const attrs = {};
+
+        extraAttrsUtil.forPost(
+          {
+            columns: ['excerpt'],
+          },
+          model,
+          attrs,
+        );
+
+        assert.equal(attrs.excerpt, 'stored excerpt');
+        sinon.assert.neverCalledWith(modelGetStub, 'plaintext');
+      });
+
+      it('still lets custom_excerpt win over stored auto_excerpt', function () {
+        modelGetStub.withArgs('auto_excerpt').returns('stored excerpt');
+        const attrs = { custom_excerpt: 'custom excerpt' };
+
+        extraAttrsUtil.forPost(options, model, attrs);
+
+        assert.equal(attrs.excerpt, 'custom excerpt');
+      });
+
+      it('returns null excerpt when stored auto_excerpt is missing (no plaintext fallback)', function () {
+        modelGetStub.withArgs('auto_excerpt').returns(null);
+        modelGetStub.withArgs('custom_excerpt').returns(null);
+        modelGetStub.withArgs('plaintext').returns(new Array(5000).join('A'));
+        const attrs = {};
+
+        extraAttrsUtil.forPost({}, model, attrs);
+
+        assert.equal(attrs.excerpt, null);
+      });
+
+      it('prefers stored reading_time even when html is absent', function () {
+        const attrs = {
+          reading_time: 7,
+        };
+
+        extraAttrsUtil.forPost({}, model, attrs);
+
+        assert.equal(attrs.reading_time, 7);
+      });
+
+      it('keeps stored reading_time of 0', function () {
+        const attrs = {
+          reading_time: 0,
+          html: '<p>short</p>',
+        };
+
+        extraAttrsUtil.forPost({}, model, attrs);
+
+        assert.equal(attrs.reading_time, 0);
+      });
+
+      it('falls back to computing reading_time when stored value is null', function () {
+        const attrs = {
+          reading_time: null,
+          html: '<p>html</p>',
+        };
+
+        extraAttrsUtil.forPost({}, model, attrs);
+
+        assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'reading_time'), true);
+        assert.equal(typeof attrs.reading_time, 'number');
+      });
+
+      it('does not expose reading_time when stored is null and html is absent', function () {
+        const attrs = {
+          reading_time: null,
+        };
+
+        extraAttrsUtil.forPost({}, model, attrs);
+
+        assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'reading_time'), false);
+      });
     });
   });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
@@ -196,5 +196,23 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
         assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'reading_time'), false);
       });
     });
+
+    it('ignores divergent stored values when storedPostMetadata is off', function () {
+      labsStub.withArgs('storedPostMetadata').returns(false);
+      modelGetStub.withArgs('auto_excerpt').returns('stored-should-be-ignored');
+      modelGetStub.withArgs('custom_excerpt').returns(null);
+      modelGetStub.withArgs('plaintext').returns('computed from plaintext body');
+
+      const attrs = {
+        reading_time: 99,
+        html: `<p>${'word '.repeat(390)}</p>`,
+      };
+
+      extraAttrsUtil.forPost({}, model, attrs);
+
+      assert.equal(attrs.excerpt, 'computed from plaintext body');
+      assert.equal(attrs.reading_time, 1);
+      assert.notEqual(attrs.reading_time, 99);
+    });
   });
 });

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/mappers/comments.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/mappers/comments.test.js
@@ -88,4 +88,85 @@ describe('Unit: endpoints/utils/serializers/output/mappers/comments', function (
     const [resource] = getUrlForResourceStub.firstCall.args;
     assert.equal(resource.type, 'posts');
   });
+
+  describe('post excerpt', function () {
+    let labsStub;
+
+    beforeEach(function () {
+      const labs = require('../../../../../../../../../core/shared/labs');
+      labsStub = sinon.stub(labs, 'isSet').returns(false);
+    });
+
+    it('prefers custom_excerpt over plaintext and stored auto_excerpt', function () {
+      const mapped = commentMapper(
+        makeComment({
+          id: 'post-id',
+          uuid: 'post-uuid',
+          title: 'A post',
+          type: 'post',
+          custom_excerpt: 'custom wins',
+          plaintext: 'plaintext body',
+          auto_excerpt: 'stored should not win',
+        }),
+        makeFrame(),
+      );
+
+      assert.equal(mapped.post.excerpt, 'custom wins');
+    });
+
+    it('slices plaintext when storedPostMetadata is off', function () {
+      labsStub.withArgs('storedPostMetadata').returns(false);
+      const plaintext = 'a'.repeat(600);
+
+      const mapped = commentMapper(
+        makeComment({
+          id: 'post-id',
+          uuid: 'post-uuid',
+          title: 'A post',
+          type: 'post',
+          plaintext,
+          auto_excerpt: 'stored should be ignored',
+        }),
+        makeFrame(),
+      );
+
+      assert.equal(mapped.post.excerpt, 'a'.repeat(500));
+    });
+
+    it('prefers stored auto_excerpt when storedPostMetadata is on', function () {
+      labsStub.withArgs('storedPostMetadata').returns(true);
+
+      const mapped = commentMapper(
+        makeComment({
+          id: 'post-id',
+          uuid: 'post-uuid',
+          title: 'A post',
+          type: 'post',
+          plaintext: 'plaintext body that should be ignored',
+          auto_excerpt: 'stored excerpt for comments',
+        }),
+        makeFrame(),
+      );
+
+      assert.equal(mapped.post.excerpt, 'stored excerpt for comments');
+    });
+
+    it('falls back to plaintext when stored auto_excerpt is null with flag on', function () {
+      labsStub.withArgs('storedPostMetadata').returns(true);
+
+      const mapped = commentMapper(
+        makeComment({
+          id: 'post-id',
+          uuid: 'post-uuid',
+          title: 'A post',
+          type: 'post',
+          plaintext: 'fallback plaintext excerpt',
+          auto_excerpt: null,
+        }),
+        makeFrame(),
+      );
+
+      assert.equal(mapped.post.excerpt, 'fallback plaintext excerpt');
+    });
+  });
 });

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/mappers/comments.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/mappers/comments.test.js
@@ -168,5 +168,19 @@ describe('Unit: endpoints/utils/serializers/output/mappers/comments', function (
 
       assert.equal(mapped.post.excerpt, 'fallback plaintext excerpt');
     });
+
+    it('omits excerpt when no excerpt source is available', function () {
+      const mapped = commentMapper(
+        makeComment({
+          id: 'post-id',
+          uuid: 'post-uuid',
+          title: 'A post',
+          type: 'post',
+        }),
+        makeFrame(),
+      );
+
+      assert.equal(Object.prototype.hasOwnProperty.call(mapped.post, 'excerpt'), false);
+    });
   });
 });

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -140,6 +140,26 @@ describe('Models: crud', function () {
         'auto_excerpt',
       ]);
     });
+
+    it('selects html and feature_image when columns include reading_time', async function () {
+      const data = {
+        id: 671,
+      };
+      const unfilteredOptions = {
+        columns: ['reading_time'],
+      };
+      const model = Base.Model.forge({});
+      const fetchedModel = Base.Model.forge({});
+      sinon.stub(Base.Model, 'forge').returns(model);
+      sinon
+        .stub(Base.Model.prototype, 'permittedAttributes')
+        .returns(['reading_time', 'html', 'feature_image']);
+      const fetchStub = sinon.stub(model, 'fetch').resolves(fetchedModel);
+
+      await Base.Model.findOne(data, unfilteredOptions);
+
+      assert.deepEqual(fetchStub.args[0][0].columns, ['reading_time', 'html', 'feature_image']);
+    });
   });
 
   describe('edit', function () {

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -115,6 +115,31 @@ describe('Models: crud', function () {
 
       assert.equal(fetchStub.args[0][0].lock, 'forUpdate');
     });
+
+    it('selects plaintext, custom_excerpt, and auto_excerpt when columns include excerpt', async function () {
+      const data = {
+        id: 670,
+      };
+      const unfilteredOptions = {
+        columns: ['excerpt'],
+      };
+      const model = Base.Model.forge({});
+      const fetchedModel = Base.Model.forge({});
+      sinon.stub(Base.Model, 'forge').returns(model);
+      sinon
+        .stub(Base.Model.prototype, 'permittedAttributes')
+        .returns(['excerpt', 'plaintext', 'custom_excerpt', 'auto_excerpt']);
+      const fetchStub = sinon.stub(model, 'fetch').resolves(fetchedModel);
+
+      await Base.Model.findOne(data, unfilteredOptions);
+
+      assert.deepEqual(fetchStub.args[0][0].columns, [
+        'excerpt',
+        'plaintext',
+        'custom_excerpt',
+        'auto_excerpt',
+      ]);
+    });
   });
 
   describe('edit', function () {


### PR DESCRIPTION
## Summary
- Adds private labs flag `storedPostMetadata` and prefers persisted `auto_excerpt` / `reading_time` in Posts/Pages serializers when it is enabled.
- Flag off keeps today’s request-time compute path (unchanged production default). Flag on prefers stored values when present; if still null, falls back to compute (`auto_excerpt` ← plaintext slice, `reading_time` ← html + feature_image) for posts not yet populated. `custom_excerpt` still wins for `excerpt`.
- `?fields=excerpt` also selects `auto_excerpt` (plus existing plaintext/custom_excerpt); `?fields=reading_time` force-loads `html` + `feature_image` so compute fallback works when stored values are still null, and strips force-loaded `feature_image` when it was not requested.
- Comments API post.excerpt uses the same stored/compute resolution and only sets `excerpt` when non-null.
- Stacked on the populate PR (#30593). Fleet-wide backfill is deferred to Ghost 7 (#30598).

## Test plan
- [ ] With flag **off**, Content/Admin post responses match prior `excerpt` / `reading_time` behavior
- [ ] With flag **on**, stored `auto_excerpt` / `reading_time` are used; `custom_excerpt` still wins for `excerpt`
- [ ] With flag **on** and null stored `auto_excerpt` / `reading_time`, serializer falls back to compute when plaintext/html is available
- [ ] With flag **on**, stored `reading_time` is returned even when `html` is absent; `0` is preserved; null without html does not leak
- [ ] With flag **on**, `?fields=excerpt` returns real excerpts (not null) for posts with and without custom excerpts
- [ ] With flag **on**, `?fields=reading_time` works for stored and null-fallback paths (including feature_image in compute)
- [ ] Manual: edit a post and confirm stored meta refreshes on save
- [ ] Manual: post with only one of `auto_excerpt` / `reading_time` populated — filled field is used, null field falls back to compute
- [ ] Comments: excerpt matches Posts/Pages resolution; unresolved excerpt is omitted (not `null`)
- [ ] `pnpm test:single test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js`
- [ ] `pnpm test:single test/unit/server/models/base/crud.test.js`