### PR TITLE
🐛 Fixed analytics breaking layout on mobile devices

### DIFF
--- a/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
+++ b/apps/admin/src/analytics/views/stats/newsletters/newsletters.tsx
@@ -264,10 +264,7 @@ const TopNewslettersTable: React.FC<{
   const [sortBy, setSortBy] = useState<TopNewslettersOrder>('open_rate desc');
 
   return (
-    <Card
-      className="w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]"
-      data-testid="top-newsletters-card"
-    >
+    <Card className="w-full max-w-full overflow-x-auto" data-testid="top-newsletters-card">
       <CardContent>
         <Table>
           <NewsletterTableHeader range={range} setSortBy={setSortBy} sortBy={sortBy} />

--- a/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
@@ -147,7 +147,7 @@ const LatestPost: React.FC<LatestPostProps> = ({ latestPostStats, isLoading }) =
               )}
               <div className="flex grow flex-col items-start justify-center self-stretch">
                 <div
-                  className="text-md leading-tighter font-semibold tracking-tight hover:cursor-pointer hover:opacity-75"
+                  className="text-md leading-tighter font-semibold tracking-tight wrap-anywhere hover:cursor-pointer hover:opacity-75"
                   onClick={() => {
                     if (!isLoading && latestPostStats) {
                       navigate(postDestination, { crossApp: destinationIsEmberOwned });

--- a/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/latest-post.tsx
@@ -212,8 +212,8 @@ const LatestPost: React.FC<LatestPostProps> = ({ latestPostStats, isLoading }) =
               </div>
             </div>
 
-            <div className="-ml-4 flex w-full flex-col items-stretch gap-2 pr-6 xl:h-full xl:max-w-none">
-              <div className="grid grid-cols-2 gap-6 pl-10 lg:border-l xl:h-full">
+            <div className="flex w-full flex-col items-stretch gap-2 px-6 lg:-ml-4 lg:pr-6 lg:pl-0 xl:h-full xl:max-w-none">
+              <div className="grid grid-cols-2 gap-6 lg:border-l lg:pl-10 xl:h-full">
                 {/* Web metrics - only for published posts */}
                 {metricsToShow.showWebMetrics && webAnalytics && (
                   <div

--- a/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
@@ -12,7 +12,6 @@ import {
 import {
   LucideIcon,
   abbreviateNumber,
-  cn,
   formatDisplayDate,
   formatNumber,
 } from '@tryghost/shade/utils';
@@ -40,18 +39,15 @@ interface PostlistTooptipProps {
     label: string;
     metric: React.ReactNode;
   }>;
-  className?: string;
 }
 
-const PostListTooltip: React.FC<PostlistTooptipProps> = ({ className, metrics, title }) => {
+const PostListTooltip: React.FC<PostlistTooptipProps> = ({ metrics, title }) => {
   return (
     <>
-      <div
-        className={cn(
-          'pointer-events-none absolute bottom-[calc(100%+2px)] left-1/2 z-50 min-w-[160px] -translate-x-1/2 rounded-md bg-background p-3 text-sm opacity-0 shadow-md transition-all group-hover/tooltip:bottom-[calc(100%+12px)] group-hover/tooltip:opacity-100',
-          className,
-        )}
-      >
+      {/* Right-aligned, not centred: the metrics stack flush to the row's right edge
+          below md, so a centred tooltip overhangs the page and makes it scroll
+          sideways while staying invisible at opacity-0. */}
+      <div className="pointer-events-none absolute right-0 bottom-[calc(100%+2px)] z-50 min-w-[160px] rounded-md bg-background p-3 text-sm opacity-0 shadow-md transition-all group-hover/tooltip:bottom-[calc(100%+12px)] group-hover/tooltip:opacity-100">
         <div className="mb-1.5 border-b pr-10 pb-1.5 font-medium whitespace-nowrap text-muted-foreground">
           {title}
         </div>
@@ -199,7 +195,6 @@ const TopPosts: React.FC<TopPostsProps> = ({ topPostsData, isLoading }) => {
                         }}
                       >
                         <PostListTooltip
-                          className={`${!membersTrackSources ? 'right-0 left-auto translate-x-0' : ''}`}
                           metrics={[
                             // Always show sent
                             {
@@ -302,7 +297,6 @@ const TopPosts: React.FC<TopPostsProps> = ({ topPostsData, isLoading }) => {
                         }}
                       >
                         <PostListTooltip
-                          className="right-0 left-auto translate-x-0"
                           metrics={[
                             {
                               icon: (

--- a/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/top-posts.tsx
@@ -142,7 +142,12 @@ const TopPosts: React.FC<TopPostsProps> = ({ topPostsData, isLoading }) => {
                       <FeatureImagePlaceholder className="hidden aspect-[16/10] w-[80px] shrink-0 group-hover:bg-muted-foreground/10 sm:visible! sm:flex! lg:w-[100px]" />
                     )}
                     <div className="flex flex-col gap-0.5">
-                      <span className="line-clamp-2 text-md font-semibold">{post.title}</span>
+                      {/* wrap-anywhere, not break-words: a title can be one unbroken
+                          word wider than the column, and only `anywhere` also shrinks
+                          the intrinsic width the layout reserves for it. */}
+                      <span className="line-clamp-2 text-md font-semibold wrap-anywhere">
+                        {post.title}
+                      </span>
                       <span className="text text-muted-foreground">
                         By {post.authors} &ndash;{' '}
                         {formatDisplayDate(post.published_at, siteTimezone)}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1209/analytics-breaks-layout-on-mobile-devices

### Why are you making it?

A customer reported that Analytics scrolls sideways on a phone when it shouldn't. Their words were that the layout *looks* fine but pans horizontally anyway, which is the tell that whatever is overflowing is invisible.

### What does it do?

**The reported bug: hidden tooltips (Overview → Top posts).**

Each metric in a Top posts row has a hover tooltip that is absolutely positioned, at least 160px wide, and was centred on a parent only 66px wide — so it overhung its row by roughly 50px each side. Below `md` the metrics stack flush to the row's right edge, which put that overhang past the right edge of the page. Nothing in the card or the analytics layout clips it, so it reached the document and made the whole page scroll. At `opacity-0` it is invisible but still laid out, which is why nothing on screen explained the scrolling.

Two of the three tooltips already worked around this with a right-aligned override at the call site. The third never did, because on desktop the metrics sit in a row and it is never the rightmost one. Anchoring to the right inside the component covers every instance, so the override props are gone and this can't be reintroduced per call site.

**A second bug found while testing: titles with no space to wrap at.**

A title that is a single unbroken word wider than its column — a pasted URL, a long hashtag, a compound word, or any language that doesn't break on spaces — pushed both the Latest post and Top posts cards off-screen, with the title running under the metrics. Titles containing spaces were never affected.

The fix is `wrap-anywhere` rather than `break-words`. Both break inside a word, but only `overflow-wrap: anywhere` also reduces the intrinsic width the layout reserves. With `break-word` the text wraps while every ancestor still reserves the whole word's width — and the analytics views sit inside a grid whose items are sized by their content, so the page kept overflowing with the text visibly wrapped.

**Two things fixed while in here**, neither of which caused the reported scrolling:

- *Latest post* applied a negative left margin and 40px of left padding at every width, though the `lg:border-l` beside them shows they belong to the wide layout where a divider separates the columns. On a phone that pulled the block out of alignment and spent 40px on padding for a divider that isn't drawn.
- *Top newsletters* bounded itself with viewport arithmetic, subtracting a hardcoded gutter and sidebar width from `100vw`. That measurement includes the scrollbar and goes wrong silently whenever either width changes. The card sits in a container that already knows its own width and scrolls its table internally, so it can simply not exceed its parent.

### Why is this something Ghost users or developers need?

Analytics is one of the most-visited screens in admin and a large share of that traffic is mobile. A page that pans sideways for no visible reason reads as broken rather than imperfect — which is how it was reported.

### Notes for review

The commits are split so the two genuine bugs stand apart from the two tidy-ups.

There is a closed earlier attempt at this issue, [#28641](https://github.com/TryGhost/Ghost/pull/28641), which landed on the same root cause for the tooltip. This PR is deliberately narrower: that one also added `min-w-0` across 19 files in all five analytics views, and changed `MetricValue` in Shade. None of the containment turned out to be needed — the one case that genuinely needed help was the unbroken-word case, and `min-w-0` doesn't fix it, since it addresses boxes that refuse to shrink rather than words wider than any box. The `MetricValue` change alters a shared component used beyond analytics and is a design decision, so it's left out.

### Testing

Verified by hand on a phone-width viewport across all five analytics views, before and after. The unbroken-word case was reproduced by setting an 81-character single-word title on the seeded posts, then reverted.

Worth flagging for a follow-up: the acceptance suite runs at a fixed 1280×800, so it is structurally blind to this class of bug. A test asserting `scrollWidth <= clientWidth` at phone width would cover all of the above.

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works — see the note above; the suite can't currently render a mobile viewport
