### PR TITLE
Added the Code injection pane to the React editor's settings sidebar

### DIFF
--- a/apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx
@@ -149,6 +149,9 @@ async function typeInto(editor: ReturnType<typeof headEditor>, code: string) {
   await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}');
   await userEvent.keyboard('{Backspace}');
   await expect.poll(() => editor.element().textContent).toBe('');
+  if (!code) {
+    return;
+  }
   await editor.fill(code);
   await expect.poll(() => (editor.element() as HTMLElement).innerText).toBe(code);
 }
@@ -326,6 +329,49 @@ describe('Post settings code injection', () => {
         codeinjection_head: '<script>staged();</script>',
         status: 'published',
       });
+    },
+    SLOW,
+  );
+
+  it(
+    'persists the focused editor when the writer closes the pane',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      await typeInto(headEditor(), '<script>onClose();</script>');
+      await expect.element(headEditor()).toHaveFocus();
+      await editorScreen.settingsSubviewBack(BACK_LABEL).click();
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi).codeinjection_head).toBe('<script>onClose();</script>');
+
+      await editorScreen.settingsSubviewRow(ROW_LABEL).click();
+      await expect.element(headEditor()).toHaveTextContent('<script>onClose();</script>');
+    },
+    SLOW,
+  );
+
+  it.each(['codeinjection_head', 'codeinjection_foot'] as const)(
+    'clears saved %s code to null on blur',
+    async (field) => {
+      const saveApi = fakeSavablePost({
+        codeinjection_head: '<script>head();</script>',
+        codeinjection_foot: '<script>foot();</script>',
+      });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      const editor = field === 'codeinjection_head' ? headEditor() : footEditor();
+      const otherEditor = field === 'codeinjection_head' ? footEditor() : headEditor();
+      await typeInto(editor, '');
+      await otherEditor.click();
+
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)[field]).toBeNull();
+      await expect.poll(() => editor.element().textContent).toBe('');
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+import {
+  codeInjectionFootLabel,
+  codeInjectionHeadLabel,
+  codeInjectionPageFootLabel,
+  codeInjectionPageHeadLabel,
+} from '@tryghost/test-data/selectors/editor';
+
+import {
+  currentUserResponse,
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePages,
+  fakePosts,
+  fakeSnippets,
+  fakeTiers,
+  post,
+  renderAdminApp,
+  staffRole,
+  unsavedChangesGuarded,
+  type EndpointCapture,
+  type StaffRoleName,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const CURRENT_USER_ID = '1';
+const FLAG_ON = { labs: { editorReact: true } };
+const LOADED_AT = '2026-01-01T00:00:00.000Z';
+const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
+const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+const PAGE_ROUTE = new RegExp(`^/pages/${POST_ID}/\\?`);
+// The panel's own width, and the width the wide pane widens it to.
+const PANEL_WIDTH = 350;
+const WIDE_PANEL_WIDTH = 500;
+const BACK_LABEL = 'Close code injection panel';
+const ROW_LABEL = 'Code injection';
+
+// A settings save waits on the engine's queue, so these journeys outlast the default timeout.
+const SLOW = 20_000;
+const POLL = { timeout: 10_000 };
+// Under the 3s autosave debounce, so only an undebounced field save can satisfy it.
+const FIELD_POLL = { timeout: 2_000 };
+
+type SavedPost = ReturnType<typeof post>;
+
+function submittedPost(capture: EndpointCapture): Record<string, unknown> {
+  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}
+
+function asRole(name: StaffRoleName) {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+function editorChrome() {
+  fakeSnippets([]);
+  fakePosts([]);
+  // The header's publish inputs and preview read these beyond the boot table.
+  fakeMembers([]);
+  fakeNewsletters([]);
+  fakeTiers([]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+}
+
+/** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
+function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
+  editorChrome();
+  let current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    codeinjection_head: null,
+    codeinjection_foot: null,
+    tags: [],
+    ...overrides,
+  });
+  let saves = 0;
+
+  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
+
+  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
+    saves += 1;
+    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
+    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    return { posts: [current] };
+  });
+}
+
+/** The same post fixture served on the pages collection the page editor reads. */
+function fakeSavablePage() {
+  editorChrome();
+  fakePages([]);
+  const current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: LOADED_AT,
+    published_at: null,
+    codeinjection_head: null,
+    codeinjection_foot: null,
+    tags: [],
+  });
+
+  fakeAdminEndpoint('GET', PAGE_ROUTE, () => ({ pages: [current] }));
+  fakeAdminEndpoint('PUT', PAGE_ROUTE, () => ({ pages: [current] }));
+}
+
+function sidebarWidthPx(): number {
+  return editorScreen.settingsSidebar().element().getBoundingClientRect().width;
+}
+
+function headEditor() {
+  return editorScreen.settingsCodeInjection(codeInjectionHeadLabel);
+}
+
+function footEditor() {
+  return editorScreen.settingsCodeInjection(codeInjectionFootLabel);
+}
+
+async function openCodeInjection() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await editorScreen.settingsSubviewRow(ROW_LABEL).click();
+  await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+  await expect.element(headEditor()).toBeVisible();
+  await expect.element(footEditor()).toBeVisible();
+}
+
+/**
+ * Playwright clears a contenteditable by writing to the DOM, which races
+ * CodeMirror's reconciliation. Clear through its own keymap first.
+ */
+async function typeInto(editor: ReturnType<typeof headEditor>, code: string) {
+  await editor.click();
+  await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}');
+  await userEvent.keyboard('{Backspace}');
+  await expect.poll(() => editor.element().textContent).toBe('');
+  await editor.fill(code);
+  await expect.poll(() => (editor.element() as HTMLElement).innerText).toBe(code);
+}
+
+/**
+ * The sidebar's Code injection pane: the header and footer code this post adds
+ * to the page it renders on.
+ */
+describe('Post settings code injection', () => {
+  it(
+    'opens the pane over the section list and comes back from it',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      // The pane replaces the list it was opened from, in a widened panel.
+      await expect(editorScreen.settingsExcerpt()).toHaveCount(0);
+      expect(sidebarWidthPx()).toBe(WIDE_PANEL_WIDTH);
+
+      await editorScreen.settingsSubviewBack(BACK_LABEL).click();
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsExcerpt()).toBeVisible();
+      await expect.element(editorScreen.settingsSubviewRow(ROW_LABEL)).toBeVisible();
+      // The panel goes back to the width the section list is shown at.
+      await expect.poll(sidebarWidthPx).toBe(PANEL_WIDTH);
+    },
+    SLOW,
+  );
+
+  it(
+    'closes the pane on Escape from outside the editors',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      // Opening a pane leaves the writer on its back button.
+      await expect.element(editorScreen.settingsSubviewBack(BACK_LABEL)).toHaveFocus();
+      await userEvent.keyboard('{Escape}');
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewRow(ROW_LABEL)).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'keeps the pane open on Escape inside an editor',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      await headEditor().click();
+      await userEvent.keyboard('{Escape}');
+
+      await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+      await expect.element(headEditor()).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'moves between the editors on the Tab that follows Escape',
+    async () => {
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      await headEditor().click();
+      await expect.element(headEditor()).toHaveFocus();
+
+      // Without Escape first, Tab indents the code rather than leaving.
+      await userEvent.keyboard('{Escape}');
+      await userEvent.tab();
+      await expect.element(footEditor()).toHaveFocus();
+
+      await userEvent.keyboard('{Escape}');
+      await userEvent.tab({ shift: true });
+      await expect.element(headEditor()).toHaveFocus();
+      await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'names a page’s editors for a page',
+    async () => {
+      fakeSavablePage();
+      await renderAdminApp(`/editor/page/${POST_ID}`, FLAG_ON);
+      await editorScreen.settingsToggle().click();
+      await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+      await editorScreen.settingsSubviewRow(ROW_LABEL).click();
+
+      await expect
+        .element(editorScreen.settingsCodeInjection(codeInjectionPageHeadLabel))
+        .toBeVisible();
+      await expect
+        .element(editorScreen.settingsCodeInjection(codeInjectionPageFootLabel))
+        .toBeVisible();
+      await expect(editorScreen.settingsCodeInjection(codeInjectionHeadLabel)).toHaveCount(0);
+    },
+    SLOW,
+  );
+
+  it(
+    'shows the code the post was saved with',
+    async () => {
+      const head = '<script>\n    head();\n</script>';
+      const foot = '<style>\n    .footer { display: block; }\n</style>';
+      fakeSavablePost({ codeinjection_head: head, codeinjection_foot: foot });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      await expect.poll(() => (headEditor().element() as HTMLElement).innerText).toBe(head);
+      await expect.poll(() => (footEditor().element() as HTMLElement).innerText).toBe(foot);
+    },
+    SLOW,
+  );
+
+  it(
+    'persists a draft’s header and footer code on the blur that ends each edit',
+    async () => {
+      const saveApi = fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      await typeInto(headEditor(), '<script>head();</script>');
+      await footEditor().click();
+
+      // A field save has no debounce, so it lands well inside the autosave's 3s.
+      await expect.poll(() => saveApi.requests.length, FIELD_POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        codeinjection_head: '<script>head();</script>',
+      });
+
+      await typeInto(footEditor(), '<script>foot();</script>');
+      await headEditor().click();
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(2);
+      expect(submittedPost(saveApi)).toMatchObject({
+        codeinjection_foot: '<script>foot();</script>',
+      });
+      // The editors keep what the writer typed once the save is answered.
+      await expect
+        .poll(() => (headEditor().element() as HTMLElement).innerText)
+        .toBe('<script>head();</script>');
+      await expect
+        .poll(() => (footEditor().element() as HTMLElement).innerText)
+        .toBe('<script>foot();</script>');
+    },
+    SLOW,
+  );
+
+  it(
+    'stages a published post’s header code until Update',
+    async () => {
+      const saveApi = fakeSavablePost({ status: 'published', published_at: PUBLISHED_AT });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openCodeInjection();
+
+      await typeInto(headEditor(), '<script>staged();</script>');
+      await footEditor().click();
+
+      await expect.element(editorScreen.updateButton()).toBeEnabled();
+      await expect.poll(unsavedChangesGuarded).toBe(true);
+      expect(saveApi.requests).toHaveLength(0);
+
+      await userEvent.keyboard('{Meta>}s{/Meta}');
+
+      await expect.poll(() => saveApi.requests.length, POLL).toBe(1);
+      expect(submittedPost(saveApi)).toMatchObject({
+        codeinjection_head: '<script>staged();</script>',
+        status: 'published',
+      });
+    },
+    SLOW,
+  );
+
+  it(
+    'gives a contributor the pane their role can write',
+    async () => {
+      // A contributor may only open a draft they authored.
+      const saveApi = fakeSavablePost({ authors: [{ id: CURRENT_USER_ID }] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, asRole('Contributor'));
+      await openCodeInjection();
+
+      await typeInto(headEditor(), '<script>contributor();</script>');
+      await footEditor().click();
+
+      await expect
+        .poll(() => submittedPost(saveApi).codeinjection_head, POLL)
+        .toBe('<script>contributor();</script>');
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -215,6 +215,9 @@ export const editorScreen = {
   settingsMetaTitle: () => page.getByTestId(settingsMetaTitleInput),
   settingsMetaDescription: () => page.getByTestId(settingsMetaDescriptionInput),
   settingsSerpPreview: () => page.getByTestId(settingsSerpPreview),
+  /** CodeMirror exposes its content as a textbox named by the editor's label. */
+  settingsCodeInjection: (label: string) =>
+    page.getByRole('textbox', { name: new RegExp(`^${label}`) }),
 
   settingsPostHistory: () => page.getByTestId(settingsPostHistoryButton),
   postHistoryModal: () => page.getByTestId(postHistoryModal),

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -392,6 +392,26 @@ left holding the save engine's slug wait. The restore's save carries the slug
 the post already holds, and the URL section accepts the next manual edit
 normally.
 
+## Code injection
+
+The row opens a pane holding the header and footer code this post injects into
+the page it renders on, each an HTML editor labelled with the theme helper it
+lands in. Every role that can open the panel can write both fields. A page's
+editors are named for a page rather than a post.
+
+The two fields are settings fields like any other: staged as the writer types,
+committed on the blur that ends the edit, and persisted or held back by the
+panel's save policy. Closing the pane commits the editor the writer was in, and
+a field cleared back to empty is stored as no value, as the excerpt is. A post
+saved before that convention holds an empty string rather than no value, so
+clearing such a field back to empty counts as a change until the next save.
+
+Escape inside either editor leaves the pane open. An open completion list or a
+selection wider than the cursor takes it first; otherwise it frees the editor's
+Tab, so the next Tab moves on to the footer editor and out of the pane rather
+than indenting. The back button, or Escape from anywhere else in the pane,
+still closes the pane.
+
 ## Open and closed
 
 The toggle sits in the editor header, and the panel starts closed on every

--- a/apps/admin/src/editor/settings/code-injection-section.tsx
+++ b/apps/admin/src/editor/settings/code-injection-section.tsx
@@ -1,0 +1,80 @@
+import { CodeEditor } from '@tryghost/shade/components';
+import { LucideIcon } from '@tryghost/shade/utils';
+import type { PostType } from '@/editor/card-config';
+import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
+import { SettingsSubview } from './settings-subview';
+
+// An Escape no other binding answers leaves the event unprevented, closing the
+// pane. Arm tab-focus mode for the 2s @codemirror/view does, so Tab leaves.
+const TAB_FOCUS_ESCAPE = () =>
+  import('@uiw/react-codemirror').then(({ Prec, keymap }) =>
+    Prec.lowest(
+      keymap.of([
+        {
+          key: 'Escape',
+          run: (view) => {
+            view.setTabFocusMode(2_000);
+            return true;
+          },
+        },
+      ]),
+    ),
+  );
+
+// Loaded on demand so CodeMirror stays out of the editor's main bundle.
+const EDITOR_EXTENSIONS = [
+  () => import('@codemirror/lang-html').then((module) => module.html()),
+  TAB_FOCUS_ESCAPE,
+];
+
+const EDITOR_HEIGHT = '240px';
+
+function EditorLabel({ text, helper }: { text: string; helper: string }) {
+  return (
+    <>
+      {text} <code className="ml-1 font-normal">{helper}</code>
+    </>
+  );
+}
+
+export interface CodeInjectionSectionProps {
+  session: EditorSessionHandle;
+  postType: PostType;
+}
+
+/**
+ * The header and footer code this post injects into the page it renders on,
+ * beside whatever the site already injects.
+ */
+export function CodeInjectionSection({ session, postType }: CodeInjectionSectionProps) {
+  const name = postType === 'page' ? 'Page' : 'Post';
+
+  return (
+    <SettingsSubview
+      closeLabel="Close code injection panel"
+      icon={<LucideIcon.Code />}
+      id="code-injection"
+      label="Code injection"
+      title="Code injection"
+      wide
+    >
+      <CodeEditor
+        extensions={EDITOR_EXTENSIONS}
+        height={EDITOR_HEIGHT}
+        title={<EditorLabel helper="{{ghost_head}}" text={`${name} header`} />}
+        value={session.settings.codeinjection_head ?? ''}
+        onBlur={session.commitSettings}
+        // A field cleared back to empty is stored as no value, as the excerpt is.
+        onChange={(value) => session.stageSettings({ codeinjection_head: value || null })}
+      />
+      <CodeEditor
+        extensions={EDITOR_EXTENSIONS}
+        height={EDITOR_HEIGHT}
+        title={<EditorLabel helper="{{ghost_foot}}" text={`${name} footer`} />}
+        value={session.settings.codeinjection_foot ?? ''}
+        onBlur={session.commitSettings}
+        onChange={(value) => session.stageSettings({ codeinjection_foot: value || null })}
+      />
+    </SettingsSubview>
+  );
+}

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -18,6 +18,7 @@ import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
 import { AccessSection } from './access-section';
 import { PublishDateSection } from './publish-date-section';
 import { AuthorsSection } from './authors-section';
+import { CodeInjectionSection } from './code-injection-section';
 import { DeleteSection } from './delete-section';
 import { MetaDataSection } from './meta-data-section';
 import { PostHistorySection } from './post-history-section';
@@ -116,6 +117,7 @@ export function PostSettingsSidebar({
       postType === 'page' ? <ShowTitleSection currentUser={currentUser} session={session} /> : null,
     template: <TemplateSection postType={postType} session={session} />,
     delete: <DeleteSection postType={postType} session={session} />,
+    'code-injection': <CodeInjectionSection postType={postType} session={session} />,
     'meta-data': <MetaDataSection session={session} siteUrl={siteUrl} />,
     'post-history': (
       <PostHistorySection

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -164,3 +164,7 @@ export const postHistoryLatestText = 'Latest';
 export const postHistoryPublishedText = 'Published';
 export const postHistoryUnpublishedText = 'Unpublished';
 export const restoreRevisionButton = 'Restore';
+export const codeInjectionHeadLabel = 'Post header';
+export const codeInjectionFootLabel = 'Post footer';
+export const codeInjectionPageHeadLabel = 'Page header';
+export const codeInjectionPageFootLabel = 'Page footer';


### PR DESCRIPTION
The React post editor's settings sidebar was missing the header and footer code a single post injects into the page it renders on, so a writer had to go back to the Ember editor to set it.

## What this adds

- A `Code injection` row in the settings sidebar that opens a wide pane with two HTML editors, `Post header {{ghost_head}}` and `Post footer {{ghost_foot}}`, named for a page in the page editor.
- The pane reuses Shade's `CodeEditor` with the same lazily-imported `@codemirror/lang-html` grammar the rest of Admin loads for code injection, so it behaves the way Settings and tag detail already do.
- Both fields are ordinary settings fields: staged as the writer types, committed on the blur that ends the edit, so the sidebar's save policy decides whether a draft persists them or a published post holds them until Update. Closing the pane blurs the focused editor first, so the back button commits like a blur does.
- Every role that can open the panel gets the pane, including Contributors.

## Escape inside an editor

The pane closes on an Escape that reaches the window unprevented. CodeMirror binds Escape to collapsing the selection, which declines a plain cursor and leaves the event unprevented, so typing in an editor and pressing Escape closed the pane out from under the writer, which also took away the Escape-then-Tab route CodeMirror offers between the two editors.

These two editors get a lowest-precedence Escape binding that arms CodeMirror's own tab-focus mode for the 2 seconds `@codemirror/view` uses and consumes the event. Lowest precedence leaves the bindings that already answer Escape — an open completion list, a selection wider than the cursor — in front, so they still win; only the Escape nothing else wanted reaches the new binding. The pane then stays open, and the next Tab moves to the footer editor and on out of the pane rather than indenting. The back button, or Escape from anywhere else in the pane, still closes the pane. The change is confined to this section: Shade's `CodeEditor` and its other consumers are untouched.

## Empty means no value

A field cleared back to empty is stored as `null`, matching the excerpt and meta fields. A post the Ember editor saved with `''` in one of these fields therefore reads as changed after a type-then-delete, until the next save that touches the field rewrites it to `null`. That is a one-off transition per post, not an ongoing difference.

## Testing

`apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx` covers opening the pane and coming back from it, closing it on Escape from the back button, keeping it open on Escape inside an editor, Tab and Shift-Tab moving between the two editors after Escape, the page editor's naming, the code a saved post comes back with, a draft persisting each editor on blur, a published post staging until Cmd-S, and a Contributor writing the field. The pane's width is asserted as the measured panel width at the suite's 1280px viewport rather than as a class name.

Verified locally: `vitest run src/editor` (1106 passed), browser-mode acceptance for `src/editor src/layout` (358 passed across 24 files; 337 without `editor-conflict.acceptance.test.tsx`'s 21), `eslint src`, `tsc -b`, `format:check`, `lint:boundaries`, `lint:markdown`.

Each test was checked against a revert of the hunk it pins:

| Reverted | Acceptance tests that fail |
| --- | --- |
| Section registration in the sidebar | 9 — all of them |
| `wide` on the subview | 1 — opens the pane |
| Header editor's `value` hard-coded | 1 — shows the saved code |
| Header editor's `onBlur` | 1 — draft blur save |
| Header editor's `onChange` | 3 — draft blur save, published staging, Contributor |
| The Escape tab-focus extension | 2 — Escape inside an editor, Tab between editors |
| Page naming forced to `Post` | 1 — page editor naming |

