### PR TITLE
Moved both chip pickers onto one shared shell

### DIFF
--- a/apps/admin/src/editor/editor-settings-tags.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-tags.acceptance.test.tsx
@@ -141,8 +141,9 @@ describe('Post settings tags', () => {
       await openSidebar();
       await openTagList();
 
-      // No row shows a post count, so the read does not ask for the join.
-      await expect.poll(() => tagsApi.lastRequest?.url, POLL).not.toContain('count.posts');
+      await expect.poll(() => tagsApi.lastRequest?.url, POLL).toBeDefined();
+      // Ghost rejects an explicitly empty include instead of treating it as absent.
+      expect(new URL(tagsApi.lastRequest!.url).searchParams.get('include')).not.toBe('');
 
       await editorScreen.settingsTagOption('Sport').click();
 

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -251,7 +251,7 @@ ignoring case and accents, and it leaves out anyone already credited. Arrow keys
 move the highlight, Enter takes the highlighted row and so does Tab once
 something has been typed, Escape closes the list and keeps the term, and both
 clicking away and moving focus out of the field close it and discard the term. A
-chip goes with its own remove button, and Backspace in an empty field drops the
+chip is removed by clicking it, and Backspace in an empty field drops the
 last one and opens the list on the staff it can offer again. A pick that empties
 the row under the highlight moves it to the last row rather than losing it.
 

--- a/apps/admin/src/editor/settings/authors-options.test.ts
+++ b/apps/admin/src/editor/settings/authors-options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { User } from '@tryghost/admin-x-framework/api/users';
-import { authorSuggestions, matchesAuthor, selectedAuthors } from './authors-options';
+import { matchesAuthor, selectedAuthors, toAuthorOption } from './authors-options';
 
 function user(overrides: Partial<User>): User {
   return {
@@ -36,29 +36,17 @@ describe('matchesAuthor', () => {
   });
 });
 
-describe('authorSuggestions', () => {
-  it('offers everyone who is not already an author', () => {
-    const suggestions = authorSuggestions(
-      [JANE, JOSE],
-      [{ id: '1', name: 'Jane Doe', email: '' }],
-      '',
-    );
-
-    expect(suggestions.map(({ id }) => id)).toEqual(['2']);
-  });
-
-  it('narrows the offer by the typed term', () => {
-    expect(authorSuggestions([JANE, JOSE], [], 'jane').map(({ id }) => id)).toEqual(['1']);
+describe('toAuthorOption', () => {
+  it('keeps the staff member’s own name', () => {
+    expect(toAuthorOption(JANE)).toEqual({ id: '1', name: 'Jane Doe', email: 'jane@example.com' });
   });
 
   it('falls back to the email when a staff member has no name', () => {
-    expect(authorSuggestions([NAMELESS], [], '')).toEqual([
-      { id: '3', name: 'ghost@example.com', email: 'ghost@example.com' },
-    ]);
-  });
-
-  it('answers with nothing before the staff browse has loaded', () => {
-    expect(authorSuggestions(undefined, [], '')).toEqual([]);
+    expect(toAuthorOption(NAMELESS)).toEqual({
+      id: '3',
+      name: 'ghost@example.com',
+      email: 'ghost@example.com',
+    });
   });
 });
 

--- a/apps/admin/src/editor/settings/authors-options.ts
+++ b/apps/admin/src/editor/settings/authors-options.ts
@@ -22,8 +22,13 @@ function fold(value: string): string {
     .toLowerCase();
 }
 
-function toOption(user: Pick<User, 'id' | 'name' | 'email'>): AuthorOption {
-  return { id: user.id, name: user.name || user.email, email: user.email };
+/** What a staff member reads as: their name, or their email when they have none. */
+export function authorName(person: Pick<User, 'name' | 'email'>): string {
+  return person.name || person.email;
+}
+
+export function toAuthorOption(user: Pick<User, 'id' | 'name' | 'email'>): AuthorOption {
+  return { id: user.id, name: authorName(user), email: user.email };
 }
 
 /**
@@ -33,19 +38,6 @@ function toOption(user: Pick<User, 'id' | 'name' | 'email'>): AuthorOption {
 export function matchesAuthor(user: Pick<User, 'name' | 'slug' | 'email'>, term: string): boolean {
   const needle = fold(term);
   return [user.name, user.slug, user.email].some((field) => fold(field ?? '').includes(needle));
-}
-
-/** The rows the list offers: everyone not already an author, narrowed by the term. */
-export function authorSuggestions(
-  users: User[] | undefined,
-  selected: ReadonlyArray<AuthorOption>,
-  term: string,
-): AuthorOption[] {
-  const chosen = new Set(selected.map(({ id }) => id));
-  const trimmed = term.trim();
-  return (users ?? [])
-    .filter((user) => !chosen.has(user.id) && (!trimmed || matchesAuthor(user, trimmed)))
-    .map(toOption);
 }
 
 /**
@@ -65,7 +57,7 @@ export function selectedAuthors(
     const user = known.get(author.id);
     options.push(
       user
-        ? toOption(user)
+        ? toAuthorOption(user)
         : {
             id: author.id,
             name: author.name || author.email || author.id,

--- a/apps/admin/src/editor/settings/authors-picker.tsx
+++ b/apps/admin/src/editor/settings/authors-picker.tsx
@@ -1,14 +1,14 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import type { KeyboardEvent } from 'react';
-import { Badge, Button, inputSurface } from '@tryghost/shade/components';
+import { useCallback, useRef } from 'react';
+import { Button } from '@tryghost/shade/components';
 import { Stack, Text } from '@tryghost/shade/primitives';
-import { cn, LucideIcon } from '@tryghost/shade/utils';
+import type { User } from '@tryghost/admin-x-framework/api/users';
 import {
   settingsAuthorChip,
   settingsAuthorsList,
   settingsAuthorsPicker,
 } from '@tryghost/test-data/selectors/editor';
-import type { AuthorOption } from './authors-options';
+import { ChipPicker } from '@/shared/pickers/chip-picker';
+import { authorName, matchesAuthor, toAuthorOption, type AuthorOption } from './authors-options';
 
 export interface AuthorsPickerProps {
   inputId: string;
@@ -16,16 +16,14 @@ export interface AuthorsPickerProps {
   invalid: boolean;
   /** The post's authors, in order. */
   selected: AuthorOption[];
-  /** Everyone else, already narrowed by the typed term. */
-  suggestions: AuthorOption[];
+  /** The site's staff, whoever the browse has answered with so far. */
+  staff: User[];
   loading: boolean;
   loadError: boolean;
   onRetry: () => void;
   onChange: (next: AuthorOption[]) => void;
   /** The first open; the staff browse starts here rather than on every editor entry. */
   onOpen: () => void;
-  onSearch: (term: string) => void;
-  term: string;
 }
 
 /**
@@ -38,246 +36,76 @@ export function AuthorsPicker({
   describedBy,
   invalid,
   selected,
-  suggestions,
+  staff,
   loading,
   loadError,
   onRetry,
   onChange,
   onOpen,
-  onSearch,
-  term,
 }: AuthorsPickerProps) {
-  const listId = useId();
-  const optionId = (index: number) => `${listId}-${index}`;
-  const [open, setOpen] = useState(false);
-  const [highlighted, setHighlighted] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
   const showLoadError = loadError && !loading;
 
-  // The term goes with the list when the writer leaves the field: left behind,
-  // it reads as an edit that nothing will ever commit.
-  const closeAndDiscard = useCallback(() => {
-    setOpen(false);
-    onSearch('');
-  }, [onSearch]);
-
-  // Dismissal on `pointerdown` without preventing the default, so the click
-  // that follows still reaches whatever the writer aimed at.
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        closeAndDiscard();
+  // Stable: a new handler each render would re-register the shell's document
+  // listeners for as long as the list is open.
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        onOpen();
       }
-    };
-
-    document.addEventListener('pointerdown', handlePointerDown);
-
-    return () => document.removeEventListener('pointerdown', handlePointerDown);
-  }, [closeAndDiscard, open]);
-
-  // Back to the first row whenever the list narrows, so the highlight never
-  // points past the end of what is on screen.
-  useEffect(() => {
-    setHighlighted(0);
-  }, [term]);
-
-  // A pick can shrink the list under the highlight, which leaves the stored
-  // index past the end until the next arrow key moves it.
-  const highlightedIndex = Math.min(highlighted, Math.max(suggestions.length - 1, 0));
-
-  useEffect(() => {
-    listRef.current
-      ?.querySelector('[data-highlighted="true"]')
-      ?.scrollIntoView({ block: 'nearest' });
-  }, [highlightedIndex, open]);
-
-  const reveal = () => {
-    setOpen(true);
-    onOpen();
-  };
-
-  const choose = (option: AuthorOption) => {
-    onChange([...selected, option]);
-    // Cleared either way: leaving the term in the field means the next thing
-    // typed appends to a search already acted on.
-    onSearch('');
-  };
-
-  const remove = (option: AuthorOption) => {
-    onChange(selected.filter((author) => author.id !== option.id));
-  };
-
-  const handleKeyDown = (event: KeyboardEvent) => {
-    // IME confirmation and candidate navigation belong to the input method.
-    // Safari can end composition before its confirmation keydown, reporting 229.
-    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
-      return;
-    }
-
-    if (event.key === 'Backspace' && !term && selected.length > 0) {
-      remove(selected[selected.length - 1]);
-      // The list comes back with the removed author in it (gh-token-input.js).
-      reveal();
-      return;
-    }
-
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-
-      if (!open) {
-        reveal();
-        return;
-      }
-
-      if (suggestions.length > 0) {
-        const step = event.key === 'ArrowDown' ? 1 : -1;
-
-        setHighlighted((highlightedIndex + step + suggestions.length) % suggestions.length);
-      }
-
-      return;
-    }
-
-    // Escape keeps the term: the writer closed the list, not the search.
-    if (event.key === 'Escape' && open) {
-      event.preventDefault();
-      event.stopPropagation();
-      setOpen(false);
-      return;
-    }
-
-    const commits = event.key === 'Enter' || (event.key === 'Tab' && term.trim().length > 0);
-    if (commits && open && !showLoadError && suggestions[highlightedIndex]) {
-      event.preventDefault();
-      choose(suggestions[highlightedIndex]);
-    }
-  };
+    },
+    [onOpen],
+  );
 
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          closeAndDiscard();
-        }
-      }}
-    >
-      <div
-        className={cn(
-          inputSurface('within'),
-          'flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 px-3 py-1 text-control',
-        )}
-        data-testid={settingsAuthorsPicker}
-        onClick={() => {
-          inputRef.current?.focus();
-          reveal();
-        }}
-      >
-        {selected.map((author) => (
-          <Badge key={author.id} className="gap-1 pr-1" data-testid={settingsAuthorChip}>
-            {author.name}
-            <button
-              aria-label={`Remove ${author.name}`}
-              className="rounded-full hover:opacity-70"
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                remove(author);
+    <ChipPicker<User, AuthorOption>
+      describedBy={describedBy}
+      emptyMessage={loading ? 'Loading authors...' : 'No authors found'}
+      getKey={(person) => person.id}
+      getLabel={authorName}
+      inputId={inputId}
+      inputLabel="Authors"
+      inputRef={inputRef}
+      invalid={invalid}
+      matches={matchesAuthor}
+      notice={
+        showLoadError ? (
+          <Stack align="start" className="p-2" gap="sm">
+            <Text role="alert" size="sm">
+              Couldn’t load authors.
+            </Text>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                inputRef.current?.focus();
+                onRetry();
               }}
             >
-              <LucideIcon.X className="size-3" />
-            </button>
-          </Badge>
-        ))}
-        <input
-          ref={inputRef}
-          aria-activedescendant={
-            open && !showLoadError && suggestions[highlightedIndex]
-              ? optionId(highlightedIndex)
-              : undefined
-          }
-          aria-autocomplete="list"
-          aria-controls={listId}
-          aria-describedby={describedBy}
-          aria-expanded={open}
-          aria-invalid={invalid}
-          className="min-w-20 flex-1 bg-transparent text-control outline-hidden placeholder:text-muted-foreground"
-          id={inputId}
-          placeholder={selected.length === 0 ? 'Select authors...' : ''}
-          role="combobox"
-          value={term}
-          onChange={(event) => {
-            onSearch(event.target.value);
-            reveal();
-          }}
-          onKeyDown={handleKeyDown}
-        />
-        <LucideIcon.ChevronDown className="size-4 shrink-0 text-muted-foreground" />
-      </div>
-      {open && (
-        <div className="absolute top-full left-0 z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-border/60 bg-surface-elevated-2 p-1 text-popover-foreground shadow-md dark:border-border/30">
-          {showLoadError && (
-            <Stack align="start" className="p-2" gap="sm">
-              <Text role="alert" size="sm">
-                Couldn’t load authors.
-              </Text>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => {
-                  inputRef.current?.focus();
-                  onRetry();
-                }}
-              >
-                Retry
-              </Button>
-            </Stack>
-          )}
-          <div ref={listRef} data-testid={settingsAuthorsList} id={listId} role="listbox">
-            {!showLoadError && suggestions.length === 0 && (
-              <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                {loading ? 'Loading authors...' : 'No authors found'}
-              </div>
-            )}
-            {!showLoadError &&
-              suggestions.map((option, index) => {
-                const isHighlighted = index === highlightedIndex;
-
-                return (
-                  <div
-                    key={option.id}
-                    // Never true: the list leaves out everyone the post already credits.
-                    aria-selected={false}
-                    className={cn(
-                      'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
-                      isHighlighted && 'bg-accent text-accent-foreground',
-                    )}
-                    data-highlighted={isHighlighted}
-                    id={optionId(index)}
-                    role="option"
-                    onClick={() => choose(option)}
-                    // Keeps focus in the input, which clicking a plain div would
-                    // otherwise drop, so the writer can keep typing after picking.
-                    onMouseDown={(event) => event.preventDefault()}
-                    onMouseEnter={() => setHighlighted(index)}
-                  >
-                    <span className="truncate">{option.name}</span>
-                    <span className="ms-auto truncate text-xs text-muted-foreground">
-                      {option.email}
-                    </span>
-                  </div>
-                );
-              })}
-          </div>
-        </div>
+              Retry
+            </Button>
+          </Stack>
+        ) : null
+      }
+      options={staff}
+      placeholder="Select authors..."
+      renderOption={(person) => (
+        <>
+          <span className="truncate">{authorName(person)}</span>
+          <span className="ms-auto truncate text-xs text-muted-foreground">{person.email}</span>
+        </>
       )}
-    </div>
+      selected={selected}
+      testIds={{
+        field: settingsAuthorsPicker,
+        list: settingsAuthorsList,
+        chip: settingsAuthorChip,
+      }}
+      hideSelected
+      reopenOnRemove
+      onAdd={(person) => onChange([...selected, toAuthorOption(person)])}
+      onOpenChange={handleOpenChange}
+      onRemove={(key) => onChange(selected.filter((author) => author.id !== key))}
+    />
   );
 }

--- a/apps/admin/src/editor/settings/authors-section.tsx
+++ b/apps/admin/src/editor/settings/authors-section.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useCallback, useId, useState } from 'react';
 import { Label } from '@tryghost/shade/components';
 import { Text } from '@tryghost/shade/primitives';
 import { useBrowseUsers, type User } from '@tryghost/admin-x-framework/api/users';
@@ -9,12 +9,7 @@ import { AUTHORS_REQUIRED } from '@/editor/session/settings-fields';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
 import { SettingsSection } from './settings-section';
 import { AuthorsPicker } from './authors-picker';
-import {
-  AUTHORS_SEARCH_PARAMS,
-  authorSuggestions,
-  selectedAuthors,
-  type AuthorOption,
-} from './authors-options';
+import { AUTHORS_SEARCH_PARAMS, selectedAuthors, type AuthorOption } from './authors-options';
 
 export interface AuthorsSectionProps {
   session: EditorSessionHandle;
@@ -30,7 +25,7 @@ export function AuthorsSection({ session, currentUser }: AuthorsSectionProps) {
   const inputId = useId();
   const errorId = useId();
   const [browsing, setBrowsing] = useState(false);
-  const [term, setTerm] = useState('');
+  const startBrowsing = useCallback(() => setBrowsing(true), []);
 
   const { data, isFetching, isError, refetch } = useBrowseUsers({
     defaultErrorHandler: false,
@@ -60,12 +55,10 @@ export function AuthorsSection({ session, currentUser }: AuthorsSectionProps) {
         loadError={isError}
         loading={isFetching}
         selected={selected}
-        suggestions={authorSuggestions(data?.users, selected, term)}
-        term={term}
+        staff={data?.users ?? []}
         onChange={change}
-        onOpen={() => setBrowsing(true)}
+        onOpen={startBrowsing}
         onRetry={() => void refetch()}
-        onSearch={setTerm}
       />
       {invalid ? (
         <Text

--- a/apps/admin/src/editor/settings/tags-section.tsx
+++ b/apps/admin/src/editor/settings/tags-section.tsx
@@ -43,7 +43,7 @@ export function TagsSection({ session }: { session: EditorSessionHandle }) {
           field: settingsTagsField,
           input: settingsTagsInput,
           list: settingsTagsList,
-          token: settingsTagsToken,
+          chip: settingsTagsToken,
         }}
         deferSearch
         hideSelected

--- a/apps/admin/src/posts/list/posts-list-bulk-actions.acceptance.test.tsx
+++ b/apps/admin/src/posts/list/posts-list-bulk-actions.acceptance.test.tsx
@@ -419,7 +419,8 @@ describe('Posts list bulk actions', () => {
       await postsListScreen.contextMenuItem('Add a tag').click();
       await postsListScreen.tagPickerField().click();
 
-      // First closes the list, second reaches the dialog.
+      // With nothing typed one Escape does both: the dialog's guard stands
+      // aside and the list closes under it. The second has nothing left to do.
       await userEvent.keyboard('{Escape}');
       await userEvent.keyboard('{Escape}');
 

--- a/apps/admin/src/posts/list/posts-list-bulk-actions.acceptance.test.tsx
+++ b/apps/admin/src/posts/list/posts-list-bulk-actions.acceptance.test.tsx
@@ -290,6 +290,8 @@ describe('Posts list bulk actions', () => {
       await postsListScreen.tagSearchInput().fill('C++');
 
       await expect.poll(() => tags.lastRequest?.filter).toContain("tags.name:~'C++'");
+      // An empty include makes the real API refuse the search with withRelated.
+      expect(new URL(tags.lastRequest!.url).searchParams.get('include')).not.toBe('');
       await expect.element(postsListScreen.tagOption('C++')).toBeVisible();
       await expect(postsListScreen.tagOption(/Create/)).toHaveCount(0);
     });

--- a/apps/admin/src/shared/pickers/chip-picker.test.tsx
+++ b/apps/admin/src/shared/pickers/chip-picker.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChipPicker } from './chip-picker';
+
+interface Option {
+  id: string;
+  name: string;
+}
+
+const scrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
+
+beforeEach(() => {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  if (scrollIntoView) {
+    Object.defineProperty(Element.prototype, 'scrollIntoView', scrollIntoView);
+  } else {
+    Reflect.deleteProperty(Element.prototype, 'scrollIntoView');
+  }
+});
+
+/** The settings sidebar's pane, reduced to the Escape listener it dismisses on. */
+function Pane() {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !event.defaultPrevented) {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  if (!open) {
+    return <p>Pane closed</p>;
+  }
+
+  return (
+    <ChipPicker<Option, Option>
+      emptyMessage="No options found"
+      getKey={(option) => option.id}
+      getLabel={(option) => option.name}
+      inputLabel="Options"
+      options={[{ id: 'alpha', name: 'Alpha' }]}
+      placeholder="Select options..."
+      selected={[]}
+      onAdd={vi.fn()}
+      onRemove={vi.fn()}
+    />
+  );
+}
+
+describe('ChipPicker Escape', () => {
+  it('closes the list without dismissing the pane around it', () => {
+    render(<Pane />);
+    fireEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('listbox')).toBeVisible();
+
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pane closed')).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/shared/pickers/chip-picker.tsx
+++ b/apps/admin/src/shared/pickers/chip-picker.tsx
@@ -1,0 +1,406 @@
+import { badgeVariants, inputSurface } from '@tryghost/shade/components';
+import { cn, LucideIcon } from '@tryghost/shade/utils';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { KeyboardEvent, ReactNode, RefObject } from 'react';
+
+/** Trailing and leading space is never part of what is picked. */
+const trimTerm = (search: string) => search.trim();
+
+/** The offer to commit what was typed as something the list does not hold yet. */
+export interface ChipPickerCreateRow<TOption> {
+  /** Whether the term is worth offering, given the rows already on screen. */
+  offer: (term: string, offered: readonly TOption[]) => boolean;
+  render: (term: string) => ReactNode;
+  onSelect: (term: string) => void;
+}
+
+export interface ChipPickerTestIds {
+  field?: string;
+  input?: string;
+  list?: string;
+  chip?: string;
+}
+
+export interface ChipPickerProps<TOption, TChip> {
+  /** Everything the list can offer, in the order it should read. */
+  options: ReadonlyArray<TOption>;
+  /** What the field already carries, in the order it should read. */
+  selected: ReadonlyArray<TChip>;
+  getKey: (item: TOption | TChip) => string;
+  getLabel: (item: TOption | TChip) => string;
+  /** Whether a row is a chip the field already carries. Keys are the default test. */
+  isChosen?: (option: TOption, chip: TChip) => boolean;
+  renderOption?: (option: TOption, state: { chosen: boolean }) => ReactNode;
+  chipVariant?: (chip: TChip) => 'default' | 'secondary';
+  onAdd: (option: TOption) => void;
+  onRemove: (key: string) => void;
+  /** Leaves the chosen rows out of the list rather than listing them ticked. */
+  hideSelected?: boolean;
+  /** Narrows the rows by the typed term, for a list the server has not narrowed. */
+  matches?: (option: TOption, term: string) => boolean;
+  /** Reduces what is typed to the term the rows and the create offer read against. */
+  normalizeTerm?: (search: string) => string;
+  createRow?: ChipPickerCreateRow<TOption>;
+  /** Reports what is typed, for a caller that must know there is work to lose. */
+  onSearchChange?: (search: string) => void;
+  onOpenChange?: (open: boolean) => void;
+  /** Opens the list again on the row a Backspace removal handed back. */
+  reopenOnRemove?: boolean;
+  /** Stands in for the rows, for a list with nothing it can offer. */
+  notice?: ReactNode;
+  /** Hands the caller the search input, for a notice that puts focus back on it. */
+  inputRef?: RefObject<HTMLInputElement>;
+  emptyMessage: string;
+  placeholder: string;
+  /** The accessible name of the field and of the list it opens. */
+  inputLabel: string;
+  /** Ties the input to a visible label the caller renders. */
+  inputId?: string;
+  describedBy?: string;
+  invalid?: boolean;
+  maxLength?: number;
+  testIds?: ChipPickerTestIds;
+}
+
+type Row<TOption> =
+  | { kind: 'option'; key: string; option: TOption; chosen: boolean }
+  | { kind: 'create'; key: string };
+
+/**
+ * The chips-in-a-field picker: what the field carries drawn as removable chips,
+ * and a list of what else it could carry under a search input.
+ *
+ * The list is built by hand rather than with `cmdk`: cmdk only drives the
+ * keyboard for an input inside its own tree, and this input sits in the chip
+ * field above the list.
+ */
+export function ChipPicker<TOption, TChip>({
+  options,
+  selected,
+  getKey,
+  getLabel,
+  isChosen,
+  renderOption,
+  chipVariant,
+  onAdd,
+  onRemove,
+  hideSelected = false,
+  matches,
+  normalizeTerm = trimTerm,
+  createRow,
+  onSearchChange,
+  onOpenChange,
+  reopenOnRemove = false,
+  notice,
+  inputRef,
+  emptyMessage,
+  placeholder,
+  inputLabel,
+  inputId,
+  describedBy,
+  invalid,
+  maxLength,
+  testIds,
+}: ChipPickerProps<TOption, TChip>) {
+  const listId = useId();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [highlighted, setHighlighted] = useState(0);
+  const ownInputRef = useRef<HTMLInputElement>(null);
+  const input = inputRef ?? ownInputRef;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // One term behind the rows and the create offer, and behind whatever the
+  // caller queries with: a caller that normalises differently hands its own in.
+  const term = normalizeTerm(search);
+
+  const updateSearch = (value: string) => {
+    setSearch(value);
+    onSearchChange?.(value);
+  };
+
+  const reveal = () => {
+    setOpen(true);
+    onOpenChange?.(true);
+  };
+
+  // Backs out of the list only: the term stays for the caller that reads it.
+  const close = useCallback(() => {
+    setOpen(false);
+    onOpenChange?.(false);
+  }, [onOpenChange]);
+
+  // The term goes with the list when the writer leaves the field: left behind,
+  // it reads as an edit that nothing will ever commit.
+  const closeAndDiscard = useCallback(() => {
+    setOpen(false);
+    onOpenChange?.(false);
+    setSearch('');
+    onSearchChange?.('');
+  }, [onOpenChange, onSearchChange]);
+
+  // Not a Radix Popover: portalled, it would sit outside a Dialog's subtree
+  // where the scroll-lock blocks it. Closing on `pointerdown` without
+  // preventing the default lets the `click` that follows reach what is under it.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        closeAndDiscard();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [closeAndDiscard, open]);
+
+  // On the document, not the input: clicking a row with the mouse moves focus
+  // off the input, and an Escape after that never reached a handler bound there.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.isComposing || event.keyCode === 229) {
+        return;
+      }
+      // Capture runs after any Radix layer and before an enclosing pane's bubble
+      // listener; claiming the key keeps the pane from closing with the list.
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [close, open]);
+
+  // Back to the top whenever the list narrows, so the highlight never points
+  // past the end of what is on screen.
+  useEffect(() => {
+    setHighlighted(0);
+  }, [term]);
+
+  const chipFor = (option: TOption) =>
+    selected.find((chip) => (isChosen ? isChosen(option, chip) : getKey(option) === getKey(chip)));
+
+  const narrowed =
+    matches && term !== '' ? options.filter((option) => matches(option, term)) : options;
+  const offered = hideSelected ? narrowed.filter((option) => !chipFor(option)) : narrowed;
+  const rows: Row<TOption>[] = notice
+    ? []
+    : [
+        ...offered.map((option) => ({
+          kind: 'option' as const,
+          key: getKey(option),
+          option,
+          chosen: Boolean(chipFor(option)),
+        })),
+        ...(createRow?.offer(term, offered) ? [{ kind: 'create' as const, key: 'create' }] : []),
+      ];
+
+  // A pick can shrink the list under the highlight, which leaves the stored
+  // index past the end until the next arrow key moves it.
+  const highlightedIndex = Math.min(highlighted, Math.max(rows.length - 1, 0));
+
+  // Keeps the highlighted row in view while arrowing through a long list.
+  useEffect(() => {
+    listRef.current
+      ?.querySelector('[data-highlighted="true"]')
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex, open]);
+
+  const choose = (row: Row<TOption>) => {
+    if (row.kind === 'create') {
+      createRow?.onSelect(term);
+    } else {
+      const chip = chipFor(row.option);
+
+      if (chip) {
+        onRemove(getKey(chip));
+      } else {
+        onAdd(row.option);
+      }
+    }
+    // Cleared either way: leaving the term in the field means the next thing
+    // typed appends to a search already acted on.
+    updateSearch('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    // IME confirmation and candidate navigation belong to the input method.
+    // Safari can end composition before its confirmation keydown, reporting 229.
+    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+      return;
+    }
+
+    // Backspace on an empty field removes the last chip — the chips are
+    // otherwise only removable by mouse.
+    if (event.key === 'Backspace' && search === '' && selected.length > 0) {
+      onRemove(getKey(selected[selected.length - 1]));
+
+      if (reopenOnRemove) {
+        reveal();
+      }
+
+      return;
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+
+      if (!open) {
+        reveal();
+        return;
+      }
+
+      if (rows.length > 0) {
+        const step = event.key === 'ArrowDown' ? 1 : -1;
+
+        setHighlighted((highlightedIndex + step + rows.length) % rows.length);
+      }
+
+      return;
+    }
+
+    // Tab commits the highlighted row rather than moving on and dropping what
+    // was typed. With nothing typed there is nothing to lose, so it keeps its
+    // own job and moves focus out of the field.
+    const commits = event.key === 'Enter' || (event.key === 'Tab' && term !== '');
+
+    if (commits && open && rows[highlightedIndex]) {
+      event.preventDefault();
+      choose(rows[highlightedIndex]);
+    }
+  };
+
+  const optionId = (index: number) => `${listId}-option-${index}`;
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          closeAndDiscard();
+        }
+      }}
+    >
+      <div
+        className={cn(
+          inputSurface('within'),
+          'flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 px-3 py-1 text-control',
+        )}
+        data-testid={testIds?.field}
+        onClick={() => {
+          input.current?.focus();
+          reveal();
+        }}
+      >
+        {/* The whole chip removes, so it is the button rather than carrying one. */}
+        {selected.map((chip) => (
+          <button
+            key={getKey(chip)}
+            aria-label={`Remove ${getLabel(chip)}`}
+            className={cn(
+              badgeVariants({ variant: chipVariant?.(chip) ?? 'default' }),
+              'cursor-pointer gap-1 pr-1',
+            )}
+            data-testid={testIds?.chip}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onRemove(getKey(chip));
+            }}
+          >
+            {getLabel(chip)}
+            <LucideIcon.X className="size-3" />
+          </button>
+        ))}
+        <input
+          ref={input}
+          aria-activedescendant={
+            open && rows[highlightedIndex] ? optionId(highlightedIndex) : undefined
+          }
+          aria-autocomplete="list"
+          // Named only while the list it names is on screen.
+          aria-controls={open ? listId : undefined}
+          aria-describedby={describedBy}
+          aria-expanded={open}
+          aria-invalid={invalid}
+          // A visible label the caller renders is the accessible name; a second
+          // one here would shadow it.
+          aria-label={inputId ? undefined : inputLabel}
+          className="min-w-20 flex-1 bg-transparent text-control outline-hidden placeholder:text-muted-foreground"
+          data-testid={testIds?.input}
+          id={inputId}
+          maxLength={maxLength}
+          placeholder={selected.length === 0 ? placeholder : ''}
+          role="combobox"
+          value={search}
+          onChange={(event) => {
+            updateSearch(event.target.value);
+            reveal();
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        {/* Says the field opens a list; without it a bordered box with a
+            placeholder reads as a plain text input. */}
+        <LucideIcon.ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+      </div>
+      {open && (
+        <div className="absolute top-full left-0 z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-border/60 bg-surface-elevated-2 p-1 text-popover-foreground shadow-md dark:border-border/30">
+          {notice}
+          <div
+            ref={listRef}
+            aria-label={inputLabel}
+            data-testid={testIds?.list}
+            id={listId}
+            role="listbox"
+          >
+            {!notice && rows.length === 0 && (
+              <div className="px-2 py-1.5 text-sm text-muted-foreground">{emptyMessage}</div>
+            )}
+            {rows.map((row, index) => {
+              const isHighlighted = index === highlightedIndex;
+              const chosen = row.kind === 'option' && row.chosen;
+
+              return (
+                <div
+                  key={row.key}
+                  aria-selected={chosen}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
+                    isHighlighted && 'bg-accent text-accent-foreground',
+                  )}
+                  data-highlighted={isHighlighted}
+                  id={optionId(index)}
+                  role="option"
+                  onClick={() => choose(row)}
+                  // Keeps focus in the input, which clicking a plain div would
+                  // otherwise drop, so typing and Escape both still work after a pick.
+                  onMouseDown={(event) => event.preventDefault()}
+                  onMouseEnter={() => setHighlighted(index)}
+                >
+                  {row.kind === 'create'
+                    ? createRow?.render(term)
+                    : (renderOption?.(row.option, { chosen }) ?? (
+                        <span className="truncate">{getLabel(row.option)}</span>
+                      ))}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/shared/tags/tag-picker.tsx
+++ b/apps/admin/src/shared/tags/tag-picker.tsx
@@ -1,17 +1,15 @@
-import { badgeVariants, inputSurface } from '@tryghost/shade/components';
 import { cn, LucideIcon } from '@tryghost/shade/utils';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import type { KeyboardEvent } from 'react';
+import { useCallback, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { escapeNqlString } from '@tryghost/nql-string';
 import { useBrowseTags, type Tag } from '@tryghost/admin-x-framework/api/tags';
+import { ChipPicker } from '@/shared/pickers/chip-picker';
 import {
-  availableTags,
   canCreateTag,
   isInternalTag,
-  matchingTags,
   normalizeTagName,
   sameTag,
+  sortTagsByName,
   tagKey,
   tagName,
   type PickedTag,
@@ -38,19 +36,13 @@ interface TagPickerProps {
   /** Reports what is typed, for a caller that must know there is work to lose. */
   onSearchChange?: (search: string) => void;
   maxLength?: number;
-  testIds?: { field?: string; input?: string; list?: string; token?: string };
+  testIds?: { field?: string; input?: string; list?: string; chip?: string };
 }
 
-/** A row in the list: an existing tag, or the offer to create what was typed. */
-type PickerOption = { kind: 'tag'; tag: Tag } | { kind: 'create'; name: string };
-
 /**
- * The chips-in-a-field tag picker, shared by the editor's settings sidebar and
- * the posts list's bulk "Add tags".
- *
- * The list is built by hand rather than with `cmdk`: cmdk only drives the
- * keyboard for an input inside its own tree, and this input sits in the chip
- * field above the list.
+ * The tag picker, shared by the editor's settings sidebar and the posts list's
+ * bulk "Add tags": the site's tags read from the server as the writer types,
+ * with what is typed offered as a new tag when nothing already carries it.
  */
 export function TagPicker({
   selected,
@@ -66,13 +58,8 @@ export function TagPicker({
   maxLength,
   testIds,
 }: TagPickerProps) {
-  const listId = useId();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const [highlighted, setHighlighted] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
 
   const term = normalizeTagName(search);
   const [debouncedTerm] = useDebounce(term, SEARCH_DEBOUNCE_MS);
@@ -91,280 +78,65 @@ export function TagPicker({
     },
   });
   const tags = data?.tags ?? [];
-
-  const updateSearch = (value: string) => {
-    setSearch(value);
-    onSearchChange?.(value);
-  };
-
-  const close = useCallback(() => {
-    setOpen(false);
-  }, []);
-
-  // The term goes with the list when the writer leaves the field: left behind,
-  // it reads as an edit that nothing will ever commit.
-  const closeAndDiscard = useCallback(() => {
-    setOpen(false);
-    setSearch('');
-    onSearchChange?.('');
-  }, [onSearchChange]);
-
-  // Not a Radix Popover: portalled, it would sit outside a Dialog's subtree
-  // where the scroll-lock blocks it. Closing on `pointerdown` without
-  // preventing the default lets the `click` that follows reach what is under
-  // the list, which is how one click on the bulk dialog's Add both works.
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        closeAndDiscard();
-      }
-    };
-
-    document.addEventListener('pointerdown', handlePointerDown);
-
-    return () => document.removeEventListener('pointerdown', handlePointerDown);
-  }, [closeAndDiscard, open]);
-
-  // On the document, not the input: clicking a row with the mouse moves focus
-  // off the input, and an Escape after that never reached a handler bound there.
-  // Escape backs out of the list only; the term stays for the caller that reads
-  // it to decide whether the writer has work to lose.
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.isComposing || event.keyCode === 229) {
-        return;
-      }
-      if (event.key === 'Escape') {
-        close();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown, true);
-
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
-  }, [close, open]);
-
-  // Back to the top whenever the list narrows, so the highlight never points
-  // past the end of what is on screen.
-  useEffect(() => {
-    setHighlighted(0);
-  }, [term]);
-
-  const matches = hideSelected ? availableTags(tags, selected, term) : matchingTags(tags, term);
   // Held back until the server has answered for what is typed, or a term still
   // being searched would offer to create a tag that already exists.
   const searchSettled = !isFetching && term === debouncedTerm;
-  const options: PickerOption[] = [
-    ...matches.map((tag) => ({ kind: 'tag' as const, tag })),
-    ...(searchSettled && canCreateTag(term, matches, selected)
-      ? [{ kind: 'create' as const, name: term }]
-      : []),
-  ];
-  // A pick can shrink the list under the highlight, which leaves the stored
-  // index past the end until the next arrow key moves it.
-  const highlightedIndex = Math.min(highlighted, Math.max(options.length - 1, 0));
 
-  // Keeps the highlighted row in view while arrowing through a long list.
-  useEffect(() => {
-    listRef.current
-      ?.querySelector('[data-highlighted="true"]')
-      ?.scrollIntoView({ block: 'nearest' });
-  }, [highlightedIndex, open]);
-
-  const choose = (option: PickerOption) => {
-    if (option.kind === 'tag') {
-      const chosen = selected.find((tag) => sameTag(tag, option.tag));
-
-      if (chosen) {
-        onRemove(tagKey(chosen));
-      } else {
-        onAdd({ id: option.tag.id, name: option.tag.name, slug: option.tag.slug });
-      }
-    } else {
-      onAdd({ name: option.name });
-    }
-    // Cleared either way: leaving the term in the field means the next thing
-    // typed appends to a search already acted on.
-    updateSearch('');
-  };
-
-  const handleKeyDown = (event: KeyboardEvent) => {
-    // IME confirmation and candidate navigation belong to the input method.
-    // Safari can end composition before its confirmation keydown, reporting 229.
-    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
-      return;
-    }
-
-    // Backspace on an empty field removes the last chip, as the members picker
-    // does — the chips are otherwise only removable by mouse.
-    if (event.key === 'Backspace' && search === '' && selected.length > 0) {
-      onRemove(tagKey(selected[selected.length - 1]));
-      return;
-    }
-
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-
-      if (!open) {
-        setOpen(true);
-        return;
-      }
-
-      if (options.length > 0) {
-        const step = event.key === 'ArrowDown' ? 1 : -1;
-
-        setHighlighted((highlightedIndex + step + options.length) % options.length);
-      }
-
-      return;
-    }
-
-    // Tab commits the highlighted row rather than moving on and dropping what
-    // was typed. With nothing typed there is nothing to lose, so it keeps its
-    // own job and moves focus out of the field.
-    const commits = event.key === 'Enter' || (event.key === 'Tab' && term !== '');
-
-    if (commits && open && options[highlightedIndex]) {
-      event.preventDefault();
-      choose(options[highlightedIndex]);
-    }
-  };
-
-  const optionId = (index: number) => `${listId}-option-${index}`;
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearch(value);
+      onSearchChange?.(value);
+    },
+    [onSearchChange],
+  );
 
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          closeAndDiscard();
-        }
+    <ChipPicker<Tag, TagLike>
+      chipVariant={(tag) => (isInternalTag(tag) ? 'default' : 'secondary')}
+      createRow={{
+        offer: (typed, offered) => searchSettled && canCreateTag(typed, offered, selected),
+        render: (typed) => (
+          <>
+            <LucideIcon.Plus className="size-4 shrink-0" />
+            <span className="truncate">Create “{typed}”</span>
+          </>
+        ),
+        onSelect: (typed) => onAdd({ name: typed }),
       }}
-    >
-      <div
-        className={cn(
-          inputSurface('within'),
-          'flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 px-3 py-1 text-control',
-        )}
-        data-testid={testIds?.field ?? 'tag-picker'}
-        onClick={() => {
-          inputRef.current?.focus();
-          setOpen(true);
-        }}
-      >
-        {/* The whole chip removes, so it is the button rather than carrying one. */}
-        {selected.map((tag) => (
-          <button
-            key={tagKey(tag)}
-            aria-label={`Remove ${tagName(tag)}`}
-            className={cn(
-              badgeVariants({ variant: isInternalTag(tag) ? 'default' : 'secondary' }),
-              'cursor-pointer gap-1 pr-1',
-            )}
-            data-testid={testIds?.token}
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              onRemove(tagKey(tag));
-            }}
-          >
-            {tagName(tag)}
-            <LucideIcon.X className="size-3" />
-          </button>
-        ))}
-        <input
-          ref={inputRef}
-          aria-activedescendant={
-            open && options[highlightedIndex] ? optionId(highlightedIndex) : undefined
-          }
-          aria-autocomplete="list"
-          aria-controls={listId}
-          aria-expanded={open}
-          // A visible label the caller renders is the accessible name; a second
-          // one here would shadow it.
-          aria-label={inputId ? undefined : inputLabel}
-          className="min-w-20 flex-1 bg-transparent text-control outline-hidden placeholder:text-muted-foreground"
-          data-testid={testIds?.input}
-          id={inputId}
-          maxLength={maxLength}
-          placeholder={selected.length === 0 ? 'Select or enter tags...' : ''}
-          role="combobox"
-          value={search}
-          onChange={(event) => {
-            updateSearch(event.target.value);
-            setOpen(true);
-          }}
-          onKeyDown={handleKeyDown}
-        />
-        {/* Says the field opens a list; without it a bordered box with a
-            placeholder reads as a plain text input. */}
-        <LucideIcon.ChevronDown className="size-4 shrink-0 text-muted-foreground" />
-      </div>
-      {open && (
-        <div
-          ref={listRef}
-          aria-label={inputLabel}
-          className="absolute top-full left-0 z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-border/60 bg-surface-elevated-2 p-1 text-popover-foreground shadow-md dark:border-border/30"
-          data-testid={testIds?.list}
-          id={listId}
-          role="listbox"
-        >
-          {options.length === 0 && (
-            <div className="px-2 py-1.5 text-sm text-muted-foreground">No tags found</div>
-          )}
-          {options.map((option, index) => {
-            const isHighlighted = index === highlightedIndex;
-            const isChosen =
-              option.kind === 'tag' && selected.some((tag) => sameTag(tag, option.tag));
-
-            return (
-              <div
-                key={option.kind === 'tag' ? option.tag.id : 'create'}
-                aria-selected={isChosen}
-                className={cn(
-                  'flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
-                  isHighlighted && 'bg-accent text-accent-foreground',
-                )}
-                data-highlighted={isHighlighted}
-                id={optionId(index)}
-                role="option"
-                onClick={() => choose(option)}
-                // Keeps focus in the input, which clicking a plain div would
-                // otherwise drop, so typing and Escape both still work after a pick.
-                onMouseDown={(event) => event.preventDefault()}
-                onMouseEnter={() => setHighlighted(index)}
-              >
-                {option.kind === 'create' ? (
-                  <>
-                    <LucideIcon.Plus className="size-4 shrink-0" />
-                    <span className="truncate">Create “{option.name}”</span>
-                  </>
-                ) : (
-                  <>
-                    <span className={cn('truncate', isInternalTag(option.tag) && 'font-medium')}>
-                      {option.tag.name}
-                    </span>
-                    {/* Names are not unique; the slug is what tells two of them apart. */}
-                    <span className="ms-auto truncate font-mono text-xs text-muted-foreground">
-                      {option.tag.slug}
-                    </span>
-                    {isChosen && <LucideIcon.Check className="size-4 shrink-0 text-primary" />}
-                  </>
-                )}
-              </div>
-            );
-          })}
-        </div>
+      emptyMessage="No tags found"
+      getKey={tagKey}
+      getLabel={tagName}
+      hideSelected={hideSelected}
+      inputId={inputId}
+      inputLabel={inputLabel}
+      // Names are not unique, so what makes a row a chip is the id when both carry one.
+      isChosen={(tag, chip) => sameTag(chip, tag)}
+      matches={(tag, typed) => tagName(tag).toLowerCase().includes(typed.toLowerCase())}
+      maxLength={maxLength}
+      normalizeTerm={normalizeTagName}
+      options={sortTagsByName(tags)}
+      placeholder="Select or enter tags..."
+      renderOption={(tag, { chosen }) => (
+        <>
+          <span className={cn('truncate', isInternalTag(tag) && 'font-medium')}>{tag.name}</span>
+          {/* Names are not unique; the slug is what tells two of them apart. */}
+          <span className="ms-auto truncate font-mono text-xs text-muted-foreground">
+            {tag.slug}
+          </span>
+          {chosen && <LucideIcon.Check className="size-4 shrink-0 text-primary" />}
+        </>
       )}
-    </div>
+      selected={selected}
+      testIds={{
+        field: testIds?.field ?? 'tag-picker',
+        input: testIds?.input,
+        list: testIds?.list,
+        chip: testIds?.chip,
+      }}
+      onAdd={(tag) => onAdd({ id: tag.id, name: tag.name, slug: tag.slug })}
+      onOpenChange={setOpen}
+      onRemove={onRemove}
+      onSearchChange={handleSearchChange}
+    />
   );
 }

--- a/apps/admin/src/shared/tags/tag-picker.tsx
+++ b/apps/admin/src/shared/tags/tag-picker.tsx
@@ -72,8 +72,6 @@ export function TagPicker({
     searchParams: {
       limit: TAG_PAGE_LIMIT,
       order: 'name asc',
-      // No row shows a post count, so the join behind one is wasted per keystroke.
-      include: '',
       ...(debouncedTerm ? { filter: `tags.name:~${escapeNqlString(debouncedTerm)}` } : {}),
     },
   });

--- a/apps/admin/src/shared/tags/tag-selection.test.ts
+++ b/apps/admin/src/shared/tags/tag-selection.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   addTag,
-  availableTags,
   canCreateTag,
   isInternalTag,
-  matchingTags,
   normalizeTagName,
   removeTag,
   sameTag,
@@ -97,37 +95,6 @@ describe('sortTagsByName', () => {
     const sorted = sortTagsByName([{ name: 'Apple' }, { name: '#Bees' }, { name: 'Cider' }]);
 
     expect(sorted.map((tag) => tag.name)).toEqual(['Apple', '#Bees', 'Cider']);
-  });
-});
-
-describe('matchingTags', () => {
-  it('narrows by the term, case-insensitively, and keeps what is selected', () => {
-    const site = [
-      { id: 't1', name: 'News' },
-      { id: 't2', name: 'Newsletter' },
-      { id: 't3', name: 'Sport' },
-    ];
-
-    expect(matchingTags(site, 'news').map((tag) => tag.name)).toEqual(['News', 'Newsletter']);
-  });
-});
-
-describe('availableTags', () => {
-  const site = [
-    { id: 't1', name: 'News', slug: 'news' },
-    { id: 't2', name: 'News', slug: 'news-2' },
-    { id: 't3', name: 'Sport' },
-  ];
-
-  it('leaves out the tag the post carries, not every tag sharing its name', () => {
-    expect(availableTags(site, [{ id: 't1', name: 'News' }], '').map((tag) => tag.slug)).toEqual([
-      'news-2',
-      undefined,
-    ]);
-  });
-
-  it('narrows by the term', () => {
-    expect(availableTags(site, [], 'sport').map((tag) => tag.name)).toEqual(['Sport']);
   });
 });
 

--- a/apps/admin/src/shared/tags/tag-selection.ts
+++ b/apps/admin/src/shared/tags/tag-selection.ts
@@ -82,24 +82,6 @@ export function sortTagsByName<T extends TagLike>(tags: ReadonlyArray<T>): T[] {
   );
 }
 
-/** The tags a search term matches, in name order. */
-export function matchingTags<T extends TagLike>(tags: ReadonlyArray<T>, term: string): T[] {
-  const needle = term.toLowerCase();
-
-  return sortTagsByName(tags).filter(
-    (tag) => needle === '' || tagName(tag).toLowerCase().includes(needle),
-  );
-}
-
-/** Those a selection does not already carry. */
-export function availableTags<T extends TagLike>(
-  tags: ReadonlyArray<T>,
-  selected: ReadonlyArray<TagLike>,
-  term: string,
-): T[] {
-  return matchingTags(tags, term).filter((tag) => !selected.some((chosen) => sameTag(chosen, tag)));
-}
-
 /**
  * Whether the term is worth offering as a new tag. Anything already carrying
  * that name — offered a row below, or selected already — would be a duplicate.


### PR DESCRIPTION
The React admin had two chips-in-a-field pickers — the tag picker used by the
editor's Tags section and the posts list's bulk "Add tags", and the editor's
authors picker. They were near-copies of the same control and had drifted.

A new presentational `apps/admin/src/shared/pickers/chip-picker.tsx` owns
everything both were doing twice: open and highlight state with its clamp,
pointerdown dismissal, Escape, the container blur that closes and discards the
term, the IME guard, Backspace-on-empty removal, the Arrow/Enter/Tab keyboard,
the `inputSurface('within')` field, the dropdown surface, the combobox and
listbox ARIA, and the chip.

`TagPicker` keeps what is its own: the tag browse, its debounce, and the offer
to create what was typed. `AuthorsPicker` keeps the staff rows, the name-slug-email
match and the load-error notice. `matchingTags`, `availableTags` and
`authorSuggestions` had no callers left and are gone.

The shell trims what is typed to reach the term its rows and its create offer
read against, and takes a `normalizeTerm` for a caller that normalises
differently — `TagPicker` hands it `normalizeTagName`, so the offer to create a
tag and the query that decides whether one already exists can never disagree.

## Drift resolved

- Escape is answered on the document in both, and the shell claims the key while
  the list is open. A Radix layer registers its own capture listener at mount, so
  it still answers first and an enclosing dialog's `onEscapeKeyDown` guard keeps
  working; what the prevented default buys is a settings pane, which listens on
  the window bubble and bails on it rather than closing along with the list. The
  authors field used to answer on the input and stop the key.
- A chip is a single button named `Remove <name>` in both. The authors field used
  to draw a badge wrapping a smaller remove button.
- `aria-controls` is written only while the list is on screen, with
  `aria-expanded` carrying the state either way. Both fields used to name a
  listbox that was not rendered.

## Verification

- `vitest run src/editor src/posts src/shared`: 1907 passed, including a new
  `chip-picker.test.tsx` case that puts the shell inside a pane listening for
  Escape the way `useSubviewController` does: one Escape closes the list and
  leaves the pane open. Dropping the `preventDefault` fails it.
- Acceptance `src/editor src/layout src/posts`: 486 passed, including every
  existing case in the tags, authors and bulk-actions specs unchanged.
- `eslint src`, `tsc -b`, `pnpm format:check`, `pnpm lint:boundaries`,
  `pnpm lint:markdown`.
