### PR TITLE
Added the Keyboard shortcuts pane to the React editor's settings sidebar

### DIFF
--- a/apps/admin/src/editor/editor-settings-keyboard-shortcuts.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-keyboard-shortcuts.acceptance.test.tsx
@@ -1,0 +1,210 @@
+import { describe, expect, it, onTestFinished } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { buildLexicalParagraph } from '@tryghost/test-data';
+
+import {
+  currentUserResponse,
+  fakeAdminEndpoint,
+  fakeMembers,
+  fakeNewsletters,
+  fakePosts,
+  fakeSnippets,
+  fakeTiers,
+  post,
+  renderAdminApp,
+  staffRole,
+  type StaffRoleName,
+} from '@test-utils/acceptance';
+import { editorScreen } from '@/editor/editor.screen';
+
+const POST_ID = 'abc123';
+const CURRENT_USER_ID = '1';
+const FLAG_ON = { labs: { editorReact: true } };
+const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
+const BACK_LABEL = 'Close keyboard shortcuts panel';
+const ROW_LABEL = 'Keyboard shortcuts';
+const MAC_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+const WINDOWS_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+// A full-app render outlasts the default timeout.
+const SLOW = 20_000;
+
+/** The pane reads the platform as it renders, so the agent has to be in place first. */
+function onPlatform(userAgent: string) {
+  Object.defineProperty(navigator, 'userAgent', { configurable: true, get: () => userAgent });
+  onTestFinished(() => {
+    Reflect.deleteProperty(navigator, 'userAgent');
+  });
+}
+
+function asRole(name: StaffRoleName) {
+  const me = currentUserResponse();
+  me.users[0].roles = [staffRole({ name })];
+  return { ...FLAG_ON, boot: { browseMe: { response: me } } };
+}
+
+function fakeEditablePost(overrides: Partial<ReturnType<typeof post>> = {}) {
+  fakeSnippets([]);
+  fakePosts([]);
+  // The header's publish inputs and preview read these beyond the boot table.
+  fakeMembers([]);
+  fakeNewsletters([]);
+  fakeTiers([]);
+  fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
+    slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
+  }));
+
+  const current = post({
+    id: POST_ID,
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    tags: [],
+    ...overrides,
+  });
+
+  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
+  fakeAdminEndpoint('PUT', ROUTE, () => ({ posts: [current] }));
+}
+
+async function openShortcuts() {
+  await editorScreen.settingsToggle().click();
+  await expect.element(editorScreen.settingsSidebar()).toBeVisible();
+  await editorScreen.settingsSubviewRow(ROW_LABEL).click();
+  await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+}
+
+/**
+ * The sidebar's Keyboard shortcuts pane: the reference list of every chord and
+ * slash command the editor answers to, in the writer's own platform glyphs.
+ */
+describe('Post settings keyboard shortcuts', () => {
+  it(
+    'opens the pane over the section list and comes back from it',
+    async () => {
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openShortcuts();
+
+      // The pane replaces the list it was opened from.
+      await expect(editorScreen.settingsExcerpt()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSidebar()).toHaveAttribute('aria-label', ROW_LABEL);
+      await expect.element(page.getByRole('heading', { level: 2, name: ROW_LABEL })).toBeVisible();
+
+      await editorScreen.settingsSubviewBack(BACK_LABEL).click();
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsExcerpt()).toBeVisible();
+      await expect.element(editorScreen.settingsSubviewRow(ROW_LABEL)).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'lists every shortcut under the group it belongs to, without widening the panel',
+    async () => {
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openShortcuts();
+
+      const pane = editorScreen.settingsSubviewPane();
+      await expect.element(pane).toHaveTextContent('Formatting');
+      await expect.element(pane).toHaveTextContent('Editing');
+      await expect.element(pane).toHaveTextContent('Application');
+      await expect.element(pane).toHaveTextContent('Inserting');
+
+      expect(editorScreen.settingsShortcutRows()).toHaveLength(50);
+      expect(editorScreen.settingsSidebar().element().getBoundingClientRect().width).toBe(350);
+    },
+    SLOW,
+  );
+
+  it(
+    'shows a Mac writer the Mac glyphs',
+    async () => {
+      onPlatform(MAC_AGENT);
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openShortcuts();
+
+      const rows = editorScreen.settingsShortcutRows();
+      expect(rows).toContain('Bold⌘B');
+      expect(rows).toContain('Strike through⌃⌥U');
+      expect(rows).toContain('Inline code⌃⇧K');
+      expect(rows).toContain('Toggle card edit mode⌘↩');
+      expect(rows).toContain('Publish⌘⇧P');
+      expect(rows).toContain('Image/image');
+      expect(rows).toContain('Divider---or/hr');
+    },
+    SLOW,
+  );
+
+  it(
+    'names the modifier a glyph stands for when the writer hovers it',
+    async () => {
+      onPlatform(MAC_AGENT);
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openShortcuts();
+
+      await userEvent.hover(page.getByText('⌘').first());
+
+      // The tooltip opens after Radix's hover delay.
+      await expect.element(page.getByText('Command'), { timeout: SLOW }).toBeVisible();
+    },
+    SLOW,
+  );
+
+  it(
+    'shows everyone else the key names instead',
+    async () => {
+      onPlatform(WINDOWS_AGENT);
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openShortcuts();
+
+      const rows = editorScreen.settingsShortcutRows();
+      expect(rows).toContain('BoldCtrlB');
+      expect(rows).toContain('Strike throughCtrlAltU');
+      expect(rows).toContain('Inline codeCtrl⇧K');
+      expect(rows).toContain('Toggle card edit modeCtrl↩');
+      expect(rows).toContain('PublishCtrl⇧P');
+      // A slash command is the same text whatever the writer is typing it on.
+      expect(rows).toContain('Image/image');
+    },
+    SLOW,
+  );
+
+  it(
+    'closes the pane on Escape and returns focus to the row',
+    async () => {
+      fakeEditablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openShortcuts();
+
+      await userEvent.keyboard('{Escape}');
+
+      await expect(editorScreen.settingsSubviewPane()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewRow(ROW_LABEL)).toHaveFocus();
+    },
+    SLOW,
+  );
+
+  it(
+    'gives a contributor the same reference list',
+    async () => {
+      onPlatform(MAC_AGENT);
+      // A contributor may only open a draft they authored.
+      fakeEditablePost({ authors: [{ id: CURRENT_USER_ID }] });
+      await renderAdminApp(`/editor/post/${POST_ID}`, asRole('Contributor'));
+      await openShortcuts();
+
+      expect(editorScreen.settingsShortcutRows()).toHaveLength(50);
+      expect(editorScreen.settingsShortcutRows()).toContain('Bold⌘B');
+    },
+    SLOW,
+  );
+});

--- a/apps/admin/src/editor/editor-settings-keyboard-shortcuts.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-keyboard-shortcuts.acceptance.test.tsx
@@ -150,7 +150,7 @@ describe('Post settings keyboard shortcuts', () => {
       await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
       await openShortcuts();
 
-      await userEvent.hover(page.getByText('⌘').first());
+      await userEvent.hover(page.getByRole('img', { name: 'Command', exact: true }).first());
 
       // The tooltip opens after Radix's hover delay.
       await expect.element(page.getByText('Command'), { timeout: SLOW }).toBeVisible();
@@ -169,9 +169,9 @@ describe('Post settings keyboard shortcuts', () => {
       const rows = editorScreen.settingsShortcutRows();
       expect(rows).toContain('BoldCtrlB');
       expect(rows).toContain('Strike throughCtrlAltU');
-      expect(rows).toContain('Inline codeCtrl⇧K');
-      expect(rows).toContain('Toggle card edit modeCtrl↩');
-      expect(rows).toContain('PublishCtrl⇧P');
+      expect(rows).toContain('Inline codeCtrlShiftK');
+      expect(rows).toContain('Toggle card edit modeCtrlEnter');
+      expect(rows).toContain('PublishCtrlShiftP');
       // A slash command is the same text whatever the writer is typing it on.
       expect(rows).toContain('Image/image');
     },

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -64,6 +64,7 @@ import {
   settingsMetaDescriptionInput,
   settingsMetaTitleInput,
   settingsSerpPreview,
+  settingsShortcutRow,
   restoreRevisionButton,
   settingsPostHistoryButton,
   settingsShowTitleToggle,
@@ -218,6 +219,12 @@ export const editorScreen = {
   /** CodeMirror exposes its content as a textbox named by the editor's label. */
   settingsCodeInjection: (label: string) =>
     page.getByRole('textbox', { name: new RegExp(`^${label}`) }),
+  /** Each keyboard-shortcut row as its label followed by the keys shown against it. */
+  settingsShortcutRows: (): string[] =>
+    page
+      .getByTestId(settingsShortcutRow)
+      .elements()
+      .map((row) => row.textContent ?? ''),
 
   settingsPostHistory: () => page.getByTestId(settingsPostHistoryButton),
   postHistoryModal: () => page.getByTestId(postHistoryModal),

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -412,6 +412,17 @@ Tab, so the next Tab moves on to the footer editor and out of the pane rather
 than indenting. The back button, or Escape from anywhere else in the pane,
 still closes the pane.
 
+## Keyboard shortcuts
+
+A pane every role that can open the panel can open, and the one thing in the
+sidebar that edits nothing: the chords and slash commands the editor answers to,
+grouped as Formatting, Editing, Application and Inserting, with the keys shown
+against each. The modifiers are drawn as the writer's own platform draws them —
+the Mac glyphs for a Mac writer, the key names for everyone else — read from the
+user agent as the pane renders. Hovering a glyph names the key it stands for;
+a key already shown as its name carries no tooltip. A slash command reads the
+same wherever it is typed.
+
 ## Open and closed
 
 The toggle sits in the editor header, and the panel starts closed on every

--- a/apps/admin/src/editor/settings/keyboard-shortcuts-section.tsx
+++ b/apps/admin/src/editor/settings/keyboard-shortcuts-section.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from 'react';
+import { Kbd, KbdGroup, Tooltip, TooltipContent, TooltipTrigger } from '@tryghost/shade/components';
+import { Inline, Stack, Text } from '@tryghost/shade/primitives';
+import { LucideIcon, cn } from '@tryghost/shade/utils';
+import { settingsShortcutRow } from '@tryghost/test-data/selectors/editor';
+import { isMacPlatform } from '@/utils/is-mac-platform';
+import {
+  keyboardShortcutGroups,
+  type Shortcut,
+  type ShortcutKey,
+  type ShortcutStyle,
+} from './keyboard-shortcuts';
+import { SettingsSubview } from './settings-subview';
+
+const LABEL_CLASSES: Record<ShortcutStyle, string> = {
+  bold: 'font-semibold',
+  italic: 'italic',
+  underline: 'underline',
+  strikethrough: 'line-through',
+  // A sample of the highlight the editor applies, not themed chrome, so the
+  // pair stays the same in either theme.
+  highlight: 'bg-yellow-200 text-black',
+  link: 'text-ghostaccent',
+  code: 'font-mono',
+};
+
+function KeyCap({ token }: { token: ShortcutKey }) {
+  const cap = (
+    <Kbd
+      aria-label={token.tooltip}
+      className={cn(
+        token.mono && 'font-mono',
+        token.plain && 'bg-transparent',
+        // Kbd takes no pointer events by default; the cap opts back in so the
+        // glyph reads as the tooltip's target.
+        token.tooltip && 'pointer-events-auto',
+      )}
+      role={token.tooltip ? 'img' : undefined}
+    >
+      {token.text}
+    </Kbd>
+  );
+
+  if (!token.tooltip) {
+    return cap;
+  }
+
+  // Kbd forwards no ref, so the tooltip anchors on a wrapper instead.
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">{cap}</span>
+      </TooltipTrigger>
+      <TooltipContent>{token.tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function ShortcutRow({ shortcut }: { shortcut: Shortcut }) {
+  return (
+    <Inline data-testid={settingsShortcutRow} gap="sm" justify="between">
+      <dt>
+        <Text as="span" className={shortcut.style && LABEL_CLASSES[shortcut.style]} size="sm">
+          {shortcut.label}
+        </Text>
+      </dt>
+      <dd>
+        <KbdGroup>
+          {shortcut.keys.map((token) => (
+            <KeyCap key={token.text} token={token} />
+          ))}
+        </KbdGroup>
+      </dd>
+    </Inline>
+  );
+}
+
+/** The editor's keyboard shortcuts, as a reference the writer reads rather than edits. */
+export function KeyboardShortcutsSection() {
+  const groups = useMemo(() => keyboardShortcutGroups(isMacPlatform()), []);
+
+  return (
+    <SettingsSubview
+      closeLabel="Close keyboard shortcuts panel"
+      icon={<LucideIcon.Keyboard />}
+      id="keyboard-shortcuts"
+      label="Keyboard shortcuts"
+      title="Keyboard shortcuts"
+    >
+      {groups.map((group) => (
+        <Stack key={group.title} gap="sm">
+          <Text as="h3" size="sm" weight="medium">
+            {group.title}
+          </Text>
+          <dl className="flex flex-col gap-2">
+            {group.shortcuts.map((shortcut) => (
+              <ShortcutRow key={shortcut.label} shortcut={shortcut} />
+            ))}
+          </dl>
+        </Stack>
+      ))}
+    </SettingsSubview>
+  );
+}

--- a/apps/admin/src/editor/settings/keyboard-shortcuts.test.ts
+++ b/apps/admin/src/editor/settings/keyboard-shortcuts.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { keyboardShortcutGroups, type Shortcut, type ShortcutGroup } from './keyboard-shortcuts';
+
+function find(groups: ShortcutGroup[], label: string): Shortcut {
+  const shortcut = groups.flatMap((group) => group.shortcuts).find((row) => row.label === label);
+  if (!shortcut) {
+    throw new Error(`No shortcut labelled ${label}`);
+  }
+  return shortcut;
+}
+
+function keys(groups: ShortcutGroup[], label: string): string[] {
+  return find(groups, label).keys.map((token) => token.text);
+}
+
+describe('keyboardShortcutGroups', () => {
+  const mac = keyboardShortcutGroups(true);
+  const windows = keyboardShortcutGroups(false);
+
+  it('lists every group in order', () => {
+    expect(mac.map((group) => group.title)).toEqual([
+      'Formatting',
+      'Editing',
+      'Application',
+      'Inserting',
+    ]);
+    expect(mac.map((group) => group.shortcuts.length)).toEqual([12, 7, 3, 28]);
+  });
+
+  it('shows Mac writers the Mac glyphs', () => {
+    expect(keys(mac, 'Bold')).toEqual(['⌘', 'B']);
+    expect(keys(mac, 'Strike through')).toEqual(['⌃', '⌥', 'U']);
+    expect(keys(mac, 'Highlight')).toEqual(['⌘', '⌥', 'H']);
+    expect(keys(mac, 'Inline code')).toEqual(['⌃', '⇧', 'K']);
+    expect(keys(mac, 'Toggle card edit mode')).toEqual(['⌘', '↩']);
+    expect(keys(mac, 'Publish')).toEqual(['⌘', '⇧', 'P']);
+  });
+
+  it('shows everyone else the key names', () => {
+    expect(keys(windows, 'Bold')).toEqual(['Ctrl', 'B']);
+    expect(keys(windows, 'Strike through')).toEqual(['Ctrl', 'Alt', 'U']);
+    expect(keys(windows, 'Highlight')).toEqual(['Ctrl', 'Alt', 'H']);
+    expect(keys(windows, 'Inline code')).toEqual(['Ctrl', '⇧', 'K']);
+    expect(keys(windows, 'Toggle card edit mode')).toEqual(['Ctrl', '↩']);
+    expect(keys(windows, 'Publish')).toEqual(['Ctrl', '⇧', 'P']);
+  });
+
+  it('names the modifier a glyph stands for, and only where it is a glyph', () => {
+    const macCommand = find(mac, 'Bold').keys[0];
+    expect(macCommand).toEqual({ text: '⌘', tooltip: 'Command' });
+    expect(find(mac, 'Strike through').keys[0].tooltip).toBe('Control');
+    expect(find(mac, 'Strike through').keys[1].tooltip).toBe('Option');
+    expect(find(mac, 'Inline code').keys[1].tooltip).toBe('Shift');
+    expect(find(mac, 'Toggle card edit mode').keys[1].tooltip).toBe('Return');
+
+    expect(find(windows, 'Bold').keys[0]).toEqual({ text: 'Ctrl', mono: true });
+  });
+
+  it('carries the slash commands unchanged on either platform', () => {
+    expect(keys(mac, 'Image')).toEqual(['/image']);
+    expect(keys(windows, 'Image')).toEqual(['/image']);
+    expect(keys(mac, 'YouTube')).toEqual(['/youtube [url]']);
+    expect(keys(mac, 'Code block')).toEqual(['```', '↩']);
+  });
+
+  it('joins the divider alternatives with a word that is not a key', () => {
+    expect(find(mac, 'Divider').keys).toEqual([
+      { text: '---', mono: true },
+      { text: 'or', mono: true, plain: true },
+      { text: '/hr', mono: true },
+    ]);
+  });
+
+  it('shows the formatting labels as the formatting they produce', () => {
+    expect(find(mac, 'Bold').style).toBe('bold');
+    expect(find(mac, 'Emphasize').style).toBe('italic');
+    expect(find(mac, 'Underline').style).toBe('underline');
+    expect(find(mac, 'Strike through').style).toBe('strikethrough');
+    expect(find(mac, 'Highlight').style).toBe('highlight');
+    expect(find(mac, 'Link').style).toBe('link');
+    expect(find(mac, 'Inline code').style).toBe('code');
+    expect(find(mac, 'List').style).toBeUndefined();
+  });
+});

--- a/apps/admin/src/editor/settings/keyboard-shortcuts.test.ts
+++ b/apps/admin/src/editor/settings/keyboard-shortcuts.test.ts
@@ -40,9 +40,11 @@ describe('keyboardShortcutGroups', () => {
     expect(keys(windows, 'Bold')).toEqual(['Ctrl', 'B']);
     expect(keys(windows, 'Strike through')).toEqual(['Ctrl', 'Alt', 'U']);
     expect(keys(windows, 'Highlight')).toEqual(['Ctrl', 'Alt', 'H']);
-    expect(keys(windows, 'Inline code')).toEqual(['Ctrl', '⇧', 'K']);
-    expect(keys(windows, 'Toggle card edit mode')).toEqual(['Ctrl', '↩']);
-    expect(keys(windows, 'Publish')).toEqual(['Ctrl', '⇧', 'P']);
+    expect(keys(windows, 'Inline code')).toEqual(['Ctrl', 'Shift', 'K']);
+    expect(keys(windows, 'Toggle card edit mode')).toEqual(['Ctrl', 'Enter']);
+    expect(keys(windows, 'Publish')).toEqual(['Ctrl', 'Shift', 'P']);
+    expect(keys(windows, 'Line break')).toEqual(['Shift', 'Enter']);
+    expect(keys(windows, 'Code block')).toEqual(['```', 'Enter']);
   });
 
   it('names the modifier a glyph stands for, and only where it is a glyph', () => {

--- a/apps/admin/src/editor/settings/keyboard-shortcuts.ts
+++ b/apps/admin/src/editor/settings/keyboard-shortcuts.ts
@@ -30,9 +30,6 @@ export interface ShortcutGroup {
   shortcuts: Shortcut[];
 }
 
-const SHIFT: ShortcutKey = { text: '⇧', tooltip: 'Shift' };
-const RETURN: ShortcutKey = { text: '↩', tooltip: 'Return' };
-
 function typed(text: string): ShortcutKey {
   return { text, mono: true };
 }
@@ -45,6 +42,9 @@ export function keyboardShortcutGroups(isMac: boolean): ShortcutGroup[] {
     : { text: 'Ctrl', mono: true };
   const alt: ShortcutKey = isMac ? { text: '⌥', tooltip: 'Option' } : { text: 'Alt', mono: true };
 
+  const shift: ShortcutKey = isMac ? { text: '⇧', tooltip: 'Shift' } : typed('Shift');
+  const enter: ShortcutKey = isMac ? { text: '↩', tooltip: 'Return' } : typed('Enter');
+
   return [
     {
       title: 'Formatting',
@@ -55,7 +55,7 @@ export function keyboardShortcutGroups(isMac: boolean): ShortcutGroup[] {
         { label: 'Strike through', style: 'strikethrough', keys: [ctrl, alt, typed('U')] },
         { label: 'Highlight', style: 'highlight', keys: [cmd, alt, typed('H')] },
         { label: 'Link', style: 'link', keys: [cmd, typed('K')] },
-        { label: 'Inline code', style: 'code', keys: [ctrl, SHIFT, typed('K')] },
+        { label: 'Inline code', style: 'code', keys: [ctrl, shift, typed('K')] },
         { label: 'List', keys: [ctrl, typed('L')] },
         { label: 'Ordered list', keys: [ctrl, alt, typed('L')] },
         { label: 'Quote', keys: [ctrl, typed('Q')] },
@@ -66,13 +66,13 @@ export function keyboardShortcutGroups(isMac: boolean): ShortcutGroup[] {
     {
       title: 'Editing',
       shortcuts: [
-        { label: 'Toggle card edit mode', keys: [cmd, RETURN] },
-        { label: 'Paste without formatting', keys: [cmd, SHIFT, typed('V')] },
+        { label: 'Toggle card edit mode', keys: [cmd, enter] },
+        { label: 'Paste without formatting', keys: [cmd, shift, typed('V')] },
         { label: 'Indent', keys: [typed('tab')] },
-        { label: 'Unindent', keys: [SHIFT, typed('tab')] },
-        { label: 'Line break', keys: [SHIFT, RETURN] },
+        { label: 'Unindent', keys: [shift, typed('tab')] },
+        { label: 'Line break', keys: [shift, enter] },
         { label: 'Undo', keys: [cmd, typed('Z')] },
-        { label: 'Redo', keys: [cmd, SHIFT, typed('Z')] },
+        { label: 'Redo', keys: [cmd, shift, typed('Z')] },
       ],
     },
     {
@@ -80,14 +80,14 @@ export function keyboardShortcutGroups(isMac: boolean): ShortcutGroup[] {
       shortcuts: [
         { label: 'Save', keys: [cmd, typed('S')] },
         { label: 'Preview', keys: [cmd, typed('P')] },
-        { label: 'Publish', keys: [cmd, SHIFT, typed('P')] },
+        { label: 'Publish', keys: [cmd, shift, typed('P')] },
       ],
     },
     {
       title: 'Inserting',
       shortcuts: [
-        { label: 'Code block', keys: [typed('```'), RETURN] },
-        { label: 'Language code block', keys: [typed('```html'), RETURN] },
+        { label: 'Code block', keys: [typed('```'), enter] },
+        { label: 'Language code block', keys: [typed('```html'), enter] },
         { label: 'Emoji', keys: [typed(':emoji_name:')] },
         { label: 'Image', keys: [typed('/image')] },
         { label: 'Markdown', keys: [typed('/md')] },

--- a/apps/admin/src/editor/settings/keyboard-shortcuts.ts
+++ b/apps/admin/src/editor/settings/keyboard-shortcuts.ts
@@ -1,0 +1,123 @@
+/** One token in a shortcut: a modifier glyph, a key cap, or text the writer types. */
+export interface ShortcutKey {
+  text: string;
+  /** What a glyph stands for, where the glyph alone does not say. */
+  tooltip?: string;
+  /** Typed text or a letter key rather than a symbol. */
+  mono?: boolean;
+  /** A word joining two alternatives rather than a key of its own. */
+  plain?: boolean;
+}
+
+/** The formatting a shortcut produces, which its label is shown in. */
+export type ShortcutStyle =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'strikethrough'
+  | 'highlight'
+  | 'link'
+  | 'code';
+
+export interface Shortcut {
+  label: string;
+  style?: ShortcutStyle;
+  keys: ShortcutKey[];
+}
+
+export interface ShortcutGroup {
+  title: string;
+  shortcuts: Shortcut[];
+}
+
+const SHIFT: ShortcutKey = { text: '⇧', tooltip: 'Shift' };
+const RETURN: ShortcutKey = { text: '↩', tooltip: 'Return' };
+
+function typed(text: string): ShortcutKey {
+  return { text, mono: true };
+}
+
+/** Every shortcut the editor offers, in the order they are shown. */
+export function keyboardShortcutGroups(isMac: boolean): ShortcutGroup[] {
+  const cmd: ShortcutKey = isMac ? { text: '⌘', tooltip: 'Command' } : { text: 'Ctrl', mono: true };
+  const ctrl: ShortcutKey = isMac
+    ? { text: '⌃', tooltip: 'Control' }
+    : { text: 'Ctrl', mono: true };
+  const alt: ShortcutKey = isMac ? { text: '⌥', tooltip: 'Option' } : { text: 'Alt', mono: true };
+
+  return [
+    {
+      title: 'Formatting',
+      shortcuts: [
+        { label: 'Bold', style: 'bold', keys: [cmd, typed('B')] },
+        { label: 'Emphasize', style: 'italic', keys: [cmd, typed('I')] },
+        { label: 'Underline', style: 'underline', keys: [cmd, typed('U')] },
+        { label: 'Strike through', style: 'strikethrough', keys: [ctrl, alt, typed('U')] },
+        { label: 'Highlight', style: 'highlight', keys: [cmd, alt, typed('H')] },
+        { label: 'Link', style: 'link', keys: [cmd, typed('K')] },
+        { label: 'Inline code', style: 'code', keys: [ctrl, SHIFT, typed('K')] },
+        { label: 'List', keys: [ctrl, typed('L')] },
+        { label: 'Ordered list', keys: [ctrl, alt, typed('L')] },
+        { label: 'Quote', keys: [ctrl, typed('Q')] },
+        { label: 'H2', keys: [ctrl, alt, typed('2')] },
+        { label: 'H3', keys: [ctrl, alt, typed('3')] },
+      ],
+    },
+    {
+      title: 'Editing',
+      shortcuts: [
+        { label: 'Toggle card edit mode', keys: [cmd, RETURN] },
+        { label: 'Paste without formatting', keys: [cmd, SHIFT, typed('V')] },
+        { label: 'Indent', keys: [typed('tab')] },
+        { label: 'Unindent', keys: [SHIFT, typed('tab')] },
+        { label: 'Line break', keys: [SHIFT, RETURN] },
+        { label: 'Undo', keys: [cmd, typed('Z')] },
+        { label: 'Redo', keys: [cmd, SHIFT, typed('Z')] },
+      ],
+    },
+    {
+      title: 'Application',
+      shortcuts: [
+        { label: 'Save', keys: [cmd, typed('S')] },
+        { label: 'Preview', keys: [cmd, typed('P')] },
+        { label: 'Publish', keys: [cmd, SHIFT, typed('P')] },
+      ],
+    },
+    {
+      title: 'Inserting',
+      shortcuts: [
+        { label: 'Code block', keys: [typed('```'), RETURN] },
+        { label: 'Language code block', keys: [typed('```html'), RETURN] },
+        { label: 'Emoji', keys: [typed(':emoji_name:')] },
+        { label: 'Image', keys: [typed('/image')] },
+        { label: 'Markdown', keys: [typed('/md')] },
+        { label: 'HTML', keys: [typed('/html')] },
+        { label: 'Gallery', keys: [typed('/gallery')] },
+        {
+          label: 'Divider',
+          keys: [typed('---'), { text: 'or', mono: true, plain: true }, typed('/hr')],
+        },
+        { label: 'Bookmark', keys: [typed('/bookmark [url]')] },
+        { label: 'Public preview', keys: [typed('/paywall')] },
+        { label: 'Button', keys: [typed('/button')] },
+        { label: 'Callout', keys: [typed('/callout')] },
+        { label: 'Toggle', keys: [typed('/toggle')] },
+        { label: 'Video', keys: [typed('/video')] },
+        { label: 'Audio', keys: [typed('/audio')] },
+        { label: 'File', keys: [typed('/file')] },
+        { label: 'Product', keys: [typed('/product')] },
+        { label: 'Header', keys: [typed('/header')] },
+        { label: 'GIF', keys: [typed('/gif')] },
+        { label: 'Signup', keys: [typed('/signup')] },
+        { label: 'YouTube', keys: [typed('/youtube [url]')] },
+        { label: 'X (Twitter)', keys: [typed('/twitter [url]')] },
+        { label: 'Unsplash', keys: [typed('/unsplash')] },
+        { label: 'Vimeo', keys: [typed('/vimeo [url]')] },
+        { label: 'CodePen', keys: [typed('/codepen [url]')] },
+        { label: 'Spotify', keys: [typed('/spotify [url]')] },
+        { label: 'SoundCloud', keys: [typed('/soundcloud [url]')] },
+        { label: 'Other embed', keys: [typed('/embed [url]')] },
+      ],
+    },
+  ];
+}

--- a/apps/admin/src/editor/settings/post-settings-sidebar.tsx
+++ b/apps/admin/src/editor/settings/post-settings-sidebar.tsx
@@ -20,6 +20,7 @@ import { PublishDateSection } from './publish-date-section';
 import { AuthorsSection } from './authors-section';
 import { CodeInjectionSection } from './code-injection-section';
 import { DeleteSection } from './delete-section';
+import { KeyboardShortcutsSection } from './keyboard-shortcuts-section';
 import { MetaDataSection } from './meta-data-section';
 import { PostHistorySection } from './post-history-section';
 import { SETTINGS_SECTION_ORDER, type SettingsSectionId } from './sections';
@@ -119,6 +120,7 @@ export function PostSettingsSidebar({
     delete: <DeleteSection postType={postType} session={session} />,
     'code-injection': <CodeInjectionSection postType={postType} session={session} />,
     'meta-data': <MetaDataSection session={session} siteUrl={siteUrl} />,
+    'keyboard-shortcuts': <KeyboardShortcutsSection />,
     'post-history': (
       <PostHistorySection
         cardConfig={cardConfig}

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
@@ -5,8 +5,9 @@ import { getSettingValue, useBrowseSettings } from '@tryghost/admin-x-framework/
 import { useBrowseSite } from '@tryghost/admin-x-framework/api/site';
 import { useCurrentUser } from '@tryghost/admin-x-framework/api/current-user';
 import { isContributorUser } from '@tryghost/admin-x-framework/api/users';
+import { isMacPlatform } from '@/utils/is-mac-platform';
 
-const ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
+const ctrlOrCmd = isMacPlatform() ? 'command' : 'ctrl';
 const searchShortcut = ctrlOrCmd === 'command' ? '⌘K' : 'Ctrl+K';
 
 // Search is currently handled by the Ember app, firing a keyboard event avoids needing to sync state

--- a/apps/admin/src/utils/is-mac-platform.test.ts
+++ b/apps/admin/src/utils/is-mac-platform.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isMacPlatform } from './is-mac-platform';
+
+const MAC_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+const WINDOWS_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+describe('isMacPlatform', () => {
+  it('reads the platform off the user agent', () => {
+    expect(isMacPlatform(MAC_AGENT)).toBe(true);
+    expect(isMacPlatform(WINDOWS_AGENT)).toBe(false);
+    expect(isMacPlatform('Mozilla/5.0 (X11; Linux x86_64)')).toBe(false);
+  });
+
+  it('reads the live user agent when none is given', () => {
+    expect(isMacPlatform()).toBe(navigator.userAgent.includes('Mac'));
+  });
+});

--- a/apps/admin/src/utils/is-mac-platform.ts
+++ b/apps/admin/src/utils/is-mac-platform.ts
@@ -1,0 +1,4 @@
+/** Whether the writer is on a Mac, which decides the modifier keys shown to them. */
+export function isMacPlatform(userAgent: string = navigator.userAgent): boolean {
+  return userAgent.indexOf('Mac') !== -1;
+}

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -71,6 +71,7 @@ export const settingsMetaTitleInput = 'settings-meta-title-input';
 export const settingsMetaDescriptionInput = 'settings-meta-description-input';
 export const settingsSerpPreview = 'settings-serp-preview';
 export const settingsPostHistoryButton = 'settings-post-history-button';
+export const settingsShortcutRow = 'settings-shortcut-row';
 
 // post history testids
 export const postHistoryModal = 'post-history-modal';


### PR DESCRIPTION
The React post editor's settings sidebar had no reference list of the chords and slash commands the editor answers to, so a writer had to leave the editor to look one up. This adds the Keyboard shortcuts pane: 50 rows across Formatting, Editing, Application and Inserting, in the order they are shown.

The rows are a pure data module rather than markup, so the platform glyphs are decided in one place and unit tested. Mac writers get the Mac symbols and everyone else the key names, read from the user agent through a shared `isMacPlatform` helper that the app sidebar's search hint now reads too. The pane is the sidebar's existing subview shell, so it opens, closes and returns focus like the panes beside it, and every role that can open the panel can open it.

A glyph standing in for a key name carries the name two ways: a tooltip on hover, and an accessible name on the cap itself for keyboard and screen-reader users. The tooltip is a real one rather than a `title` attribute, since a key cap takes no pointer events of its own and a native tooltip would never open. A key already shown as its name gets neither. Groups are headings and rows are term/definition pairs, so the pane reads as a list rather than a run of rows.

## Verification

- `pnpm --filter @tryghost/admin exec vitest run src/editor src/layout src/utils` — 1162 passed
- `pnpm --filter @tryghost/admin exec vitest run -c vitest.acceptance.config.ts src/editor src/layout` — 356 passed
- `eslint src` (0 errors), `tsc -b`, `pnpm format:check`, `pnpm lint:boundaries`, `pnpm run lint:markdown`

Every new assertion was checked against a deliberate break: unregistering the section, pinning the platform to Mac and to non-Mac, marking the pane wide, dropping a row, dropping a modifier tooltip, and swapping a modifier all fail the tests that cover them. Putting the modifier name back on a `title` attribute fails the hover assertion.

