### PR TITLE
Fixed internal package destination validation

### DIFF
--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -68,6 +68,14 @@ Before changing either repository, record the source repository, its default
 branch, the package path within it, the destination path in Ghost, and whether
 the package has been published to npm. Then:
 
+All packages moved by this workflow belong in Ghost's root `packages/`
+workspace. Derive the destination as `packages/<package-directory>` from the
+source package directory and report that exact path to the user before creating
+the subtree. Never place an imported package under `ghost/`, even when Ghost
+Core is its only consumer. If the derived path conflicts with an existing path
+or the request appears to require another workspace, stop and resolve the
+destination explicitly before manipulating history.
+
 1. Find every Ghost and source-repository reference to the package name and
    directory.
 2. Inspect its npm metadata, README, documentation, release configuration and

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -54,6 +54,11 @@ excluding unrelated source-repository paths.
 
 ## Attach the history to Ghost
 
+The destination is always `packages/<package-directory>` at the Ghost
+repository root. A Core consumer does not make `ghost/<package-directory>` a
+valid package location. Record the derived destination in the work log and PR
+body before running `git subtree add`.
+
 Before creating the worktree, inspect collisions rather than discovering them
 halfway through the import:
 
@@ -96,6 +101,11 @@ git-subtree-dir: packages/<ghost-directory>
 git-subtree-mainline: <ghost-parent>
 git-subtree-split: <source-split-tip>
 ```
+
+The guarded merge script reads this metadata from the PR commits and rejects
+the import unless `git-subtree-dir` is exactly one direct child of `packages/`
+with a `package.json` at the reviewed PR head. Treat that check as a backstop,
+not a substitute for reviewing the destination before importing.
 
 Verify the topology before adding integration commits:
 

--- a/.agents/skills/migrate-internal-package/scripts/merge-history-pr
+++ b/.agents/skills/migrate-internal-package/scripts/merge-history-pr
@@ -85,6 +85,17 @@ history_status=$(gh api "repos/$repo/compare/$split_tip...$head_sha" --jq '.stat
 [[ $history_status == ahead || $history_status == identical ]] ||
     fail "source split tip is not an ancestor of the PR head (compare status: $history_status)"
 
+subtree_dir=$(gh api --paginate "repos/$repo/pulls/$pr_number/commits" \
+    --jq '.[].commit.message' | sed -n 's/^git-subtree-dir: //p' | sort -u)
+[[ -n $subtree_dir ]] ||
+    fail "PR commits do not contain git-subtree-dir metadata"
+[[ $subtree_dir != *$'\n'* ]] ||
+    fail "PR contains more than one git-subtree-dir: $subtree_dir"
+[[ $subtree_dir =~ ^packages/[A-Za-z0-9._-]+$ ]] ||
+    fail "subtree destination must be one direct child of packages/ (found: $subtree_dir)"
+gh api "repos/$repo/contents/$subtree_dir/package.json?ref=$head_sha" >/dev/null ||
+    fail "reviewed PR head does not contain $subtree_dir/package.json"
+
 original_setting=$(gh api "repos/$repo" --jq '.allow_merge_commit')
 [[ $original_setting == true || $original_setting == false ]] ||
     fail "could not read the repository merge-commit setting"
@@ -94,6 +105,7 @@ printf '  repository: %s\n' "$repo"
 printf '  PR:         %s\n' "$pr_number"
 printf '  head:       %s\n' "$head_sha"
 printf '  split tip:  %s\n' "$split_tip"
+printf '  destination:%s\n' " $subtree_dir"
 printf '  merge state:%s\n' " $merge_state"
 printf '  setting:    allow_merge_commit=%s\n' "$original_setting"
 

--- a/docs/contributing/internal-package-migrations.md
+++ b/docs/contributing/internal-package-migrations.md
@@ -20,6 +20,12 @@ into Ghost as an internal-only package.
 The skill audits current consumers, prepares and tests the Ghost import, and
 opens a PR. It stops when the PR is ready for its exceptional merge.
 
+Internal packages imported through this workflow always live at
+`packages/<package>` in the Ghost repository root. They do not live under
+`ghost/`, even when Ghost Core is their only consumer. The skill reports the
+derived destination before it manipulates history, and the guarded merge
+preflight verifies it from the subtree metadata.
+
 Expect the handoff to include:
 
 - a green, unstacked PR titled `[Don't merge] ...`;


### PR DESCRIPTION
## Summary

- makes `packages/<package>` an explicit invariant for internal package imports, including packages consumed only by Ghost Core
- requires agents to derive and report the destination before manipulating history
- makes the guarded merge preflight read `git-subtree-dir` from PR commits, reject destinations outside a direct child of `packages/`, and verify the imported package manifest at the pinned head
- documents the invariant in the contributor workflow

## Context

PR #30607 incorrectly imported `api-framework` into `ghost/api-framework`. The detailed migration reference already showed `packages/<ghost-directory>`, but the rule was not prominent in the top-level workflow and the guarded merge script did not enforce it. A stale prior attempt at the same wrong location was incorrectly treated as precedent.

## Testing

- [x] `bash -n .agents/skills/migrate-internal-package/scripts/merge-history-pr`
- [x] Regression check against #30607: extracted `git-subtree-dir: ghost/api-framework` and verified the new invariant rejects it
- [x] `pnpm lint:agent-skills`
- [x] Targeted Markdown lint and link validation via the pre-commit hook
- [x] `git diff --check`
- [ ] `pnpm lint:docs` — blocked by the pre-existing unchanged `e2e/README.md` link to the missing `#stripe-webhooks` heading