### PR TITLE
Removed stale api-framework release automation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -356,7 +356,6 @@
     {
       groupName: 'TryGhost runtime packages',
       matchPackageNames: [
-        '@tryghost/api-framework',
         '@tryghost/bookshelf-plugins',
         '@tryghost/database-info',
         '@tryghost/debug',

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,7 +79,6 @@ catalog:
   '@tanstack/react-virtual': 3.14.9
   '@testing-library/jest-dom': 6.9.1
   '@testing-library/react': 14.3.1
-  '@tryghost/api-framework': 3.3.12
   '@tryghost/brute-knex': 3.2.2
   '@tryghost/color-utils': 0.2.20
   '@tryghost/custom-fonts': 1.0.11


### PR DESCRIPTION
## Summary

- Removes `@tryghost/api-framework` from the shared npm dependency catalog now that Ghost Core resolves the internal workspace package.
- Removes it from Renovate's public TryGhost runtime-package update group.
- Keeps the temporary `api-framework-migration` catalog and scoped override because they preserve the imported runtime dependency graph until the separate TypeScript/ESM modernization.

This follows the history-preserving import in [#30618](https://github.com/TryGhost/Ghost/pull/30618). Source-repository removal is tracked separately in [TryGhost/framework#974](https://github.com/TryGhost/framework/pull/974).

## Testing

- [x] `pnpm install`
- [x] `pnpm format:check`
- [x] `pnpm lint:packages`
- [ ] Renovate config validator — not installed in the workspace; this only removes one existing array entry.
