### PR TITLE
Updated newsletter sending status copy in post analytics

### DIFF
--- a/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
+++ b/apps/admin/src/posts/analytics/newsletter/newsletter.tsx
@@ -438,7 +438,7 @@ const Newsletter: React.FC = () => {
                 </div>
                 <PendingSendEmpty
                   description="Sends, opens and clicks will appear once every email has been sent"
-                  title="This newsletter is still sending"
+                  title="Your newsletter is being sent"
                 >
                   <div
                     className={`mx-auto grid grid-cols-1 items-center justify-center gap-4 transition-all md:gap-0 ${chartHeaderClass === 'grid-cols-2' && 'md:grid-cols-2'} ${chartHeaderClass === 'grid-cols-3' && 'md:grid-cols-3'}`}

--- a/apps/admin/src/posts/analytics/overview/components/newsletter-overview.tsx
+++ b/apps/admin/src/posts/analytics/overview/components/newsletter-overview.tsx
@@ -135,7 +135,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({
           <PendingSendEmpty
             className={cn(fullWidth && 'grid gap-6 md:grid-cols-2 md:gap-0')}
             description="Opens and clicks will appear once every email has been sent"
-            title="This newsletter is still sending"
+            title="Your newsletter is being sent"
           >
             <div className={cn(fullWidth && 'md:border-r md:pr-6')}>
               <div className="grid grid-cols-2 gap-6">

--- a/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
+++ b/apps/admin/src/posts/analytics/post-analytics.acceptance.test.tsx
@@ -238,7 +238,7 @@ describe('Post analytics overview', () => {
 
     await expect.element(page.getByText('Sending emails')).toBeVisible();
     await expect.element(page.getByText(/500 of 1,000/)).toBeVisible();
-    await expect.element(page.getByText('This newsletter is still sending')).toBeVisible();
+    await expect.element(page.getByText('Your newsletter is being sent')).toBeVisible();
     await expect.element(postAnalyticsScreen.uniqueVisitors()).toHaveTextContent('250');
 
     await postAnalyticsScreen.newsletterTab().click();
@@ -495,9 +495,7 @@ describe('Post analytics overview', () => {
     });
 
     await expect.element(page.getByText('Newsletter performance')).toBeVisible();
-    await expect
-      .element(page.getByText('This newsletter is still sending'))
-      .not.toBeInTheDocument();
+    await expect.element(page.getByText('Your newsletter is being sent')).not.toBeInTheDocument();
     await expect.element(postAnalyticsScreen.emailSendingStatusBanner()).not.toBeInTheDocument();
     await expect.poll(() => statusApi.requests.length).toBe(1);
     await app.unmount();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3946/update-newsletter-sending-status-copy

## Why

While a newsletter is going out, the post analytics Overview and Newsletter tabs show a pending-send card in place of the email figures. Its title read "This newsletter is still sending". The "still" gives a normal in-progress state a negative tone, as if something were taking too long.

## What changes

The card title is now "Your newsletter is being sent" on both tabs. This matches the tone of the sending banner above it and the post-publish success modal, which already say "being sent". The description lines under the title are unchanged. No other copy or behaviour changes.

This state is behind the `improveSendingUI` labs flag.

## How it was tested

- The post analytics acceptance suite (`post-analytics.acceptance.test.tsx`) covers both tabs in the sending state and was updated for the new string. It passes.
- Lint passes on the changed files.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
