### PR TITLE
Fixed gift email analytics site filtering

### DIFF
--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -97,10 +97,12 @@ export const init = ({
 
   const newsletterMailgunTags = ['bulk-email'];
   const automationMailgunTags = [AUTOMATION_EMAIL_TAG];
+  const giftMailgunTags = [GIFT_DELIVERY_EMAIL_TAG];
   const mailgunTagFromConfig = config.get('bulkEmail:mailgun:tag');
   if (mailgunTagFromConfig) {
     newsletterMailgunTags.push(mailgunTagFromConfig);
     automationMailgunTags.push(mailgunTagFromConfig);
+    giftMailgunTags.push(mailgunTagFromConfig);
   }
 
   prometheusClient?.registerCounter({
@@ -171,7 +173,7 @@ export const init = ({
     domainEvents,
     event: StartGiftEmailAnalyticsJobEvent,
     queries,
-    mailgunTags: [GIFT_DELIVERY_EMAIL_TAG],
+    mailgunTags: giftMailgunTags,
     jobNames: {
       latestNonOpened: 'email-analytics-gifts-latest-others',
       missing: 'email-analytics-gifts-missing',

--- a/ghost/core/core/server/services/gifts/gift-email-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-email-service.ts
@@ -5,6 +5,7 @@ import { Color } from '@tryghost/color-utils';
 import errors from '@tryghost/errors';
 import { getMailgunMessageId } from '../lib/mailgun-message-id';
 import { GIFT_DELIVERY_EMAIL_TAG } from './constants';
+import type { ConfigInstance } from '../../../shared/config/loader';
 import { formatGiftDate } from './gift-date';
 
 const DEFAULT_ACCENT_COLOR = '#15212A';
@@ -99,6 +100,7 @@ type GiftSentConfirmationData = GiftDeliveryNoticeData;
 
 export class GiftEmailService {
   private readonly transactionalMailer: TransactionalMailer;
+  private readonly config: Pick<ConfigInstance, 'get'>;
   private readonly bulkMailer: BulkMailer;
   private readonly settingsCache: SettingsCache;
   private readonly urlUtils: UrlUtils;
@@ -109,6 +111,7 @@ export class GiftEmailService {
   private readonly t: Translate;
 
   constructor({
+    config,
     transactionalMailer,
     bulkMailer,
     settingsCache,
@@ -118,6 +121,7 @@ export class GiftEmailService {
     blogIcon,
     t,
   }: {
+    config: Pick<ConfigInstance, 'get'>;
     transactionalMailer: TransactionalMailer;
     bulkMailer: BulkMailer;
     settingsCache: SettingsCache;
@@ -127,6 +131,7 @@ export class GiftEmailService {
     blogIcon: BlogIcon;
     t: Translate;
   }) {
+    this.config = config;
     this.transactionalMailer = transactionalMailer;
     this.bulkMailer = bulkMailer;
     this.settingsCache = settingsCache;
@@ -363,6 +368,12 @@ export class GiftEmailService {
       interpolation: { escapeValue: false },
     });
 
+    const tags = [GIFT_DELIVERY_EMAIL_TAG];
+    const mailgunTagFromConfig = this.config.get('bulkEmail:mailgun:tag');
+    if (typeof mailgunTagFromConfig === 'string' && mailgunTagFromConfig.length > 0) {
+      tags.push(mailgunTagFromConfig);
+    }
+
     if (!this.bulkMailer.isConfigured()) {
       await this.transactionalMailer.send({
         to: recipientEmail,
@@ -372,7 +383,7 @@ export class GiftEmailService {
         from: this.getFromAddress(),
         replyTo: this.getReplyToAddress(),
         forceTextContent: true,
-        tags: [GIFT_DELIVERY_EMAIL_TAG],
+        tags,
         disableTracking: true,
       });
 
@@ -386,7 +397,7 @@ export class GiftEmailService {
         plaintext: text,
         from: this.getFromAddress(),
         replyTo: this.getReplyToAddress(),
-        tags: [GIFT_DELIVERY_EMAIL_TAG],
+        tags,
         disable_tracking: true,
       },
       { [recipientEmail]: {} },

--- a/ghost/core/core/server/services/gifts/index.ts
+++ b/ghost/core/core/server/services/gifts/index.ts
@@ -75,6 +75,7 @@ export function init(options: GiftServiceInitOptions): void {
   });
 
   const giftEmailService = new GiftEmailService({
+    config,
     transactionalMailer: new GhostMailer(),
     bulkMailer: new MailgunClient({ config, settings: settingsCache }),
     settingsCache,

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -139,7 +139,7 @@ describe('email analytics service', function () {
         event: {
           name: 'StartGiftEmailAnalyticsJobEvent',
         },
-        mailgunTags: [GIFT_DELIVERY_EMAIL_TAG],
+        mailgunTags: [GIFT_DELIVERY_EMAIL_TAG, 'custom-mailgun-tag'],
         jobNames: {
           latestNonOpened: 'email-analytics-gifts-latest-others',
           missing: 'email-analytics-gifts-missing',
@@ -172,6 +172,20 @@ describe('email analytics service', function () {
       }),
     );
   });
+
+  it.each([undefined, ''])(
+    'does not add a gift analytics site tag when configured as %s',
+    function (siteTag) {
+      config.get.withArgs('bulkEmail:mailgun:tag').returns(siteTag);
+
+      init(dependencies);
+
+      sinon.assert.calledOnceWithExactly(
+        giftsInit,
+        sinon.match({ mailgunTags: [GIFT_DELIVERY_EMAIL_TAG] }),
+      );
+    },
+  );
 
   it('registers Prometheus metrics for member stat aggregation', function () {
     const registerCounter = sinon.stub();

--- a/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
+++ b/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
@@ -8,6 +8,7 @@ describe('GiftEmailService', function () {
   let transactionalMailer;
   let bulkMailer;
   let service;
+  let config;
 
   const settingsCache = {
     get: (key) => {
@@ -70,12 +71,14 @@ describe('GiftEmailService', function () {
   };
 
   beforeEach(function () {
+    config = { get: sinon.stub() };
     transactionalMailer = { send: sinon.stub().resolves() };
     bulkMailer = {
       isConfigured: sinon.stub().returns(true),
       send: sinon.stub().resolves({ id: '<provider-123>' }),
     };
     service = new GiftEmailService({
+      config,
       transactionalMailer,
       bulkMailer,
       settingsCache,
@@ -226,6 +229,7 @@ describe('GiftEmailService', function () {
       },
     };
     const localizedService = new GiftEmailService({
+      config,
       transactionalMailer,
       bulkMailer,
       settingsCache: localizedSettingsCache,
@@ -265,6 +269,7 @@ describe('GiftEmailService', function () {
     };
 
     const noTitleService = new GiftEmailService({
+      config,
       transactionalMailer,
       bulkMailer,
       settingsCache: noTitleSettingsCache,
@@ -296,6 +301,7 @@ describe('GiftEmailService', function () {
     };
 
     const hostileService = new GiftEmailService({
+      config,
       transactionalMailer,
       bulkMailer,
       settingsCache: hostileSettingsCache,
@@ -333,74 +339,79 @@ describe('GiftEmailService', function () {
   });
 
   describe('sendGiftDelivery', function () {
-    it('sends the prototype delivery content through bulk Mailgun without open or click tracking', async function () {
-      const result = await service.sendGiftDelivery({
-        recipientEmail: 'recipient@example.com',
-        recipientName: 'Recipient',
-        buyerEmail: 'buyer@example.com',
-        buyerName: 'Buyer',
-        personalMessage: 'Enjoy this gift',
-        token: 'abc-123',
-        tierName: 'Gold',
-        benefits: ['All stories'],
-        cadence: 'year',
-        duration: 1,
-        expiresAt: new Date('2027-04-07'),
-      });
+    it.each([undefined, '', 'blog-123'])(
+      'sends gift delivery with site tag %s and without open or click tracking',
+      async function (siteTag) {
+        config.get.withArgs('bulkEmail:mailgun:tag').returns(siteTag);
+        const result = await service.sendGiftDelivery({
+          recipientEmail: 'recipient@example.com',
+          recipientName: 'Recipient',
+          buyerEmail: 'buyer@example.com',
+          buyerName: 'Buyer',
+          personalMessage: 'Enjoy this gift',
+          token: 'abc-123',
+          tierName: 'Gold',
+          benefits: ['All stories'],
+          cadence: 'year',
+          duration: 1,
+          expiresAt: new Date('2027-04-07'),
+        });
 
-      assert.deepEqual(result, { providerMessageId: 'provider-123' });
-      sinon.assert.notCalled(transactionalMailer.send);
-      const message = bulkMailer.send.firstCall.firstArg;
-      sinon.assert.match(message, {
-        subject: 'Buyer sent you a gift',
-        replyTo: 'support@example.com',
-        tags: ['gift-delivery'],
-        disable_tracking: true,
-      });
-      assert.deepEqual(bulkMailer.send.firstCall.args[1], { 'recipient@example.com': {} });
-      for (const field of ['html', 'plaintext']) {
-        sinon.assert.match(message[field], sinon.match('Recipient'));
-        sinon.assert.match(message[field], sinon.match('Enjoy this gift'));
-        sinon.assert.match(message[field], sinon.match('All stories'));
-        sinon.assert.match(message[field], sinon.match('https://example.com/gift/abc-123'));
-      }
-      sinon.assert.match(
-        message.plaintext,
-        sinon.match('Buyer has gifted you a 1-year Gold membership to Test Site'),
-      );
-      sinon.assert.match(
-        message.plaintext,
-        sinon.match('Redeem your gift:\nhttps://example.com/gift/abc-123'),
-      );
-      sinon.assert.match(
-        message.plaintext,
-        sinon.match(
-          'This message was sent from example.com to recipient@example.com on behalf of Buyer (buyer@example.com).',
-        ),
-      );
-      sinon.assert.match(message.html, sinon.match('Redeem your gift</a>'));
-      sinon.assert.match(
-        message.html,
-        sinon.match((value) => !value.includes('Redeem your gift:')),
-      );
-      sinon.assert.match(
-        message.html,
-        sinon.match(
-          '<strong>Buyer</strong> has gifted you a <strong>1-year</strong> <strong>Gold</strong> membership to Test Site',
-        ),
-      );
-      sinon.assert.match(
-        message.html,
-        sinon.match(
-          'This message was sent from example.com to recipient@example.com on behalf of Buyer (buyer@example.com).',
-        ),
-      );
-      sinon.assert.match(message.html, sinon.match('background:#fff3ed'));
-      sinon.assert.match(message.html, sinon.match('color:#bd460c'));
-    });
+        assert.deepEqual(result, { providerMessageId: 'provider-123' });
+        sinon.assert.notCalled(transactionalMailer.send);
+        const message = bulkMailer.send.firstCall.firstArg;
+        sinon.assert.match(message, {
+          subject: 'Buyer sent you a gift',
+          replyTo: 'support@example.com',
+          tags: ['gift-delivery', ...(siteTag ? [siteTag] : [])],
+          disable_tracking: true,
+        });
+        assert.deepEqual(bulkMailer.send.firstCall.args[1], { 'recipient@example.com': {} });
+        for (const field of ['html', 'plaintext']) {
+          sinon.assert.match(message[field], sinon.match('Recipient'));
+          sinon.assert.match(message[field], sinon.match('Enjoy this gift'));
+          sinon.assert.match(message[field], sinon.match('All stories'));
+          sinon.assert.match(message[field], sinon.match('https://example.com/gift/abc-123'));
+        }
+        sinon.assert.match(
+          message.plaintext,
+          sinon.match('Buyer has gifted you a 1-year Gold membership to Test Site'),
+        );
+        sinon.assert.match(
+          message.plaintext,
+          sinon.match('Redeem your gift:\nhttps://example.com/gift/abc-123'),
+        );
+        sinon.assert.match(
+          message.plaintext,
+          sinon.match(
+            'This message was sent from example.com to recipient@example.com on behalf of Buyer (buyer@example.com).',
+          ),
+        );
+        sinon.assert.match(message.html, sinon.match('Redeem your gift</a>'));
+        sinon.assert.match(
+          message.html,
+          sinon.match((value) => !value.includes('Redeem your gift:')),
+        );
+        sinon.assert.match(
+          message.html,
+          sinon.match(
+            '<strong>Buyer</strong> has gifted you a <strong>1-year</strong> <strong>Gold</strong> membership to Test Site',
+          ),
+        );
+        sinon.assert.match(
+          message.html,
+          sinon.match(
+            'This message was sent from example.com to recipient@example.com on behalf of Buyer (buyer@example.com).',
+          ),
+        );
+        sinon.assert.match(message.html, sinon.match('background:#fff3ed'));
+        sinon.assert.match(message.html, sinon.match('color:#bd460c'));
+      },
+    );
 
     it('shows the publication title when the publication has no icon', async function () {
       const iconlessService = new GiftEmailService({
+        config,
         transactionalMailer,
         bulkMailer,
         settingsCache,
@@ -449,6 +460,7 @@ describe('GiftEmailService', function () {
         },
       };
       const siteDateService = new GiftEmailService({
+        config,
         transactionalMailer,
         bulkMailer,
         settingsCache: siteSettingsCache,
@@ -491,6 +503,7 @@ describe('GiftEmailService', function () {
         },
       };
       const invalidLocaleService = new GiftEmailService({
+        config,
         transactionalMailer,
         bulkMailer,
         settingsCache: invalidLocaleSettingsCache,
@@ -525,6 +538,7 @@ describe('GiftEmailService', function () {
         get: (key) => (key === 'accent_color' ? 'invalid' : settingsCache.get(key)),
       };
       const invalidColorService = new GiftEmailService({
+        config,
         transactionalMailer,
         bulkMailer,
         settingsCache: invalidColorSettingsCache,
@@ -652,6 +666,7 @@ describe('GiftEmailService', function () {
         },
       };
       const literalService = new GiftEmailService({
+        config,
         transactionalMailer,
         bulkMailer,
         settingsCache: literalSettingsCache,
@@ -819,6 +834,7 @@ describe('GiftEmailService', function () {
         },
       };
       const localizedService = new GiftEmailService({
+        config,
         transactionalMailer,
         bulkMailer,
         settingsCache: localizedSettingsCache,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3951/

Gift delivery analytics queried all events on shared Mailgun domains because the filter only included `gift-delivery`. Gift delivery sends now include `bulkEmail:mailgun:tag`, and analytics require both tags. Missing or empty site tags remain supported.

Automation analytics were already fixed in [#30430](https://github.com/TryGhost/Ghost/pull/30430); this change completes site scoping for gift delivery emails.
