### PR TITLE
Fixed bot open event filtering in email analytics

### DIFF
--- a/ghost/core/core/server/services/email-analytics/automation-email-analytics-batch-processor.ts
+++ b/ghost/core/core/server/services/email-analytics/automation-email-analytics-batch-processor.ts
@@ -16,6 +16,7 @@ type EmailAnalyticsEvent = {
   type: string;
   providerId: string;
   timestamp: Date;
+  bot?: string | null;
 };
 
 const getMailgunMessageIds = (events: Iterable<EmailAnalyticsEvent>): Set<string> => {
@@ -113,7 +114,7 @@ export class AutomationEmailAnalyticsBatchProcessor implements BatchEventProcess
         }
         case 'opened': {
           const recipient = getRecipient();
-          if (recipient) {
+          if (recipient && !event.bot) {
             trackEarliest(
               eventsByAutomatedEmailRecipientId,
               recipient,

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -115,14 +115,18 @@ class NewsletterEmailAnalyticsBatchProcessor {
   }
 
   /**
-   * @param {{id: string, type: any; severity: any; recipientEmail: any; emailId?: string; providerId: string; timestamp: Date; error: {code: number; message: string; enhandedCode: string|number} | null}} event
+   * @param {{id: string, type: any; severity: any; recipientEmail: any; emailId?: string; providerId: string; timestamp: Date; bot?: string | null; error: {code: number; message: string; enhandedCode: string|number} | null}} event
    * @param {Map<string, any>} [recipientCache] Optional cache for batched processing
    * @returns {Promise<EventProcessingResult>}
    */
   async #processEvent(event, recipientCache) {
     if (event.type === 'delivered') {
       const recipient = await this.#emailEventProcessor.handleDelivered(
-        { emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail },
+        {
+          emailId: event.emailId,
+          providerId: event.providerId,
+          email: event.recipientEmail,
+        },
         event.timestamp,
         recipientCache,
       );
@@ -139,8 +143,15 @@ class NewsletterEmailAnalyticsBatchProcessor {
     }
 
     if (event.type === 'opened') {
+      if (event.bot) {
+        return new EventProcessingResult({ unprocessable: 1 });
+      }
       const recipient = await this.#emailEventProcessor.handleOpened(
-        { emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail },
+        {
+          emailId: event.emailId,
+          providerId: event.providerId,
+          email: event.recipientEmail,
+        },
         event.timestamp,
         recipientCache,
       );
@@ -159,7 +170,11 @@ class NewsletterEmailAnalyticsBatchProcessor {
     if (event.type === 'failed') {
       if (event.severity === 'permanent') {
         const recipient = await this.#emailEventProcessor.handlePermanentFailed(
-          { emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail },
+          {
+            emailId: event.emailId,
+            providerId: event.providerId,
+            email: event.recipientEmail,
+          },
           { id: event.id, timestamp: event.timestamp, error: event.error },
           recipientCache,
         );
@@ -175,7 +190,11 @@ class NewsletterEmailAnalyticsBatchProcessor {
         return new EventProcessingResult({ unprocessable: 1 });
       } else {
         const recipient = await this.#emailEventProcessor.handleTemporaryFailed(
-          { emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail },
+          {
+            emailId: event.emailId,
+            providerId: event.providerId,
+            email: event.recipientEmail,
+          },
           { id: event.id, timestamp: event.timestamp, error: event.error },
           recipientCache,
         );
@@ -194,7 +213,11 @@ class NewsletterEmailAnalyticsBatchProcessor {
 
     if (event.type === 'unsubscribed') {
       const recipient = await this.#emailEventProcessor.handleUnsubscribed(
-        { emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail },
+        {
+          emailId: event.emailId,
+          providerId: event.providerId,
+          email: event.recipientEmail,
+        },
         event.timestamp,
         recipientCache,
       );
@@ -212,7 +235,11 @@ class NewsletterEmailAnalyticsBatchProcessor {
 
     if (event.type === 'complained') {
       const recipient = await this.#emailEventProcessor.handleComplained(
-        { emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail },
+        {
+          emailId: event.emailId,
+          providerId: event.providerId,
+          email: event.recipientEmail,
+        },
         event.timestamp,
         recipientCache,
       );

--- a/ghost/core/core/server/services/lib/mailgun-client.js
+++ b/ghost/core/core/server/services/lib/mailgun-client.js
@@ -386,7 +386,12 @@ module.exports = class MailgunClient {
       emailId: event['user-variables'] && event['user-variables']['email-id'],
       providerId: providerId,
       timestamp: new Date(event.timestamp * 1000),
-
+      bot:
+        event['client-info'] &&
+        typeof event['client-info'].bot === 'string' &&
+        event['client-info'].bot.trim()
+          ? event['client-info'].bot.trim()
+          : null,
       error:
         event['delivery-status'] &&
         typeof (event['delivery-status'].message || event['delivery-status'].description) ===

--- a/ghost/core/test/unit/server/services/email-analytics/automation-email-analytics-batch-processor.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/automation-email-analytics-batch-processor.test.ts
@@ -91,6 +91,31 @@ describe('AutomationEmailAnalyticsBatchProcessor', function () {
       );
     });
 
+    it('ignores opened events with bot flag', async function () {
+      const automationsApi = buildAutomationsApi([buildRecipient()]);
+      const processor = new AutomationEmailAnalyticsBatchProcessor({ automationsApi });
+
+      const result = new EventProcessingResult();
+      const fetchData: { lastEventTimestamp?: Date } = {};
+      await processor.processBatch(
+        [
+          {
+            type: 'opened',
+            providerId: 'message-1',
+            timestamp: new Date(1),
+            bot: 'generic',
+          },
+        ],
+        result,
+        fetchData,
+      );
+
+      assert.deepEqual(result, new EventProcessingResult({ unprocessable: 1 }));
+      assert.deepEqual(fetchData, { lastEventTimestamp: new Date(1) });
+
+      sinon.assert.calledOnceWithExactly(automationsApi.trackEmailDeliveredAndOpened, new Map());
+    });
+
     it('handles a mix of events for several recipients', async function () {
       const automationsApi = buildAutomationsApi([
         buildRecipient({ id: 'recipient-1', mailgun_message_id: 'message-1' }),

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
@@ -184,6 +184,45 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
             });
           });
 
+          it('ignores opened events with bot flag', async function () {
+            const processor = new NewsletterEmailAnalyticsBatchProcessor({
+              config: createMockConfig(),
+              emailEventProcessor,
+            });
+            const result = new EventProcessingResult();
+            const fetchData = {};
+
+            await processor.processBatch(
+              [
+                {
+                  type: 'opened',
+                  emailId: 1,
+                  timestamp: new Date(1),
+                  bot: 'generic',
+                },
+              ],
+              result,
+              fetchData,
+            );
+
+            sinon.assert.notCalled(emailEventProcessor.handleOpened);
+
+            assert.deepEqual(
+              result,
+              new EventProcessingResult({
+                delivered: 0,
+                opened: 0,
+                unprocessable: 1,
+                emailIds: [],
+                memberIds: [],
+              }),
+            );
+
+            assert.deepEqual(fetchData, {
+              lastEventTimestamp: new Date(1),
+            });
+          });
+
           it('handles delivered', async function () {
             const processor = new NewsletterEmailAnalyticsBatchProcessor({
               config: createMockConfig(),
@@ -753,9 +792,11 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
         const processor = new NewsletterEmailAnalyticsBatchProcessor({
           config: createMockConfig(),
           emailEventProcessor: {
-            handleDelivered: sinon
-              .stub()
-              .resolves({ emailId: 'e-1', emailRecipientId: 'r-1', memberId: 'm-1' }),
+            handleDelivered: sinon.stub().resolves({
+              emailId: 'e-1',
+              emailRecipientId: 'r-1',
+              memberId: 'm-1',
+            }),
           },
           queries,
         });

--- a/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
+++ b/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
@@ -798,7 +798,9 @@ describe('MailgunClient', function () {
 
       const mailgunClient = new MailgunClient({ config, settings });
 
-      await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler, { maxEvents });
+      await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler, {
+        maxEvents,
+      });
       assert.equal(counter.batches, 2);
       assert.equal(counter.events, 6);
       assert.equal(firstPageMock.isDone(), true);
@@ -844,7 +846,9 @@ describe('MailgunClient', function () {
 
       const mailgunClient = new MailgunClient({ config, settings });
 
-      await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler, { maxEvents });
+      await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler, {
+        maxEvents,
+      });
       assert.equal(counter.batches, 1);
       assert.equal(counter.events, 4);
       assert.equal(firstPageMock.isDone(), true);
@@ -972,6 +976,7 @@ describe('MailgunClient', function () {
         emailId: 'testEmailId',
         providerId: 'testProviderId',
         timestamp: new Date('2021-02-25T17:54:22.000Z'),
+        bot: null,
         error: null,
         id: 'pl271FzxTTmGRW8Uj3dUWw',
       });
@@ -1034,6 +1039,7 @@ describe('MailgunClient', function () {
         emailId: undefined,
         providerId: 'testProviderId',
         timestamp: new Date('2021-02-25T17:54:22.000Z'),
+        bot: null,
         error: {
           code: 605,
           enhancedCode: null,
@@ -1107,6 +1113,7 @@ describe('MailgunClient', function () {
         emailId: undefined,
         providerId: 'testProviderId',
         timestamp: new Date('2021-02-25T17:54:22.000Z'),
+        bot: null,
         error: {
           code: 451,
           enhancedCode: '4.7.652',
@@ -1115,6 +1122,51 @@ describe('MailgunClient', function () {
         },
         id: 'pl271FzxTTmGRW8Uj3dUWw',
       });
+    });
+
+    it('normalizes bot flag when present', function () {
+      const mailgunClient = new MailgunClient({ config, settings });
+
+      for (const botType of ['generic', 'apple', 'gmail']) {
+        const event = {
+          id: 'test-id',
+          event: 'opened',
+          recipient: 'test-recipient@example.com',
+          timestamp: 1614275662,
+          message: {
+            headers: {
+              'message-id': 'testProviderId',
+            },
+          },
+          'client-info': {
+            bot: botType,
+          },
+        };
+        const result = mailgunClient.normalizeEvent(event);
+        assert.equal(result.bot, botType);
+      }
+    });
+
+    it('sets bot to null when client-info.bot is missing or empty', function () {
+      const mailgunClient = new MailgunClient({ config, settings });
+
+      const eventWithoutBot = {
+        id: 'test-id',
+        event: 'opened',
+        recipient: 'test-recipient@example.com',
+        timestamp: 1614275662,
+        message: {
+          headers: {
+            'message-id': 'testProviderId',
+          },
+        },
+        'client-info': {
+          bot: '   ',
+        },
+      };
+      const result = mailgunClient.normalizeEvent(eventWithoutBot);
+
+      assert.equal(result.bot, null);
     });
   });
 


### PR DESCRIPTION
Fixes #30388

### Issue Summary

Mailgun flags automated interactions - from security scanners and pre-fetching proxies - via a `client-info.bot` field (`apple`, `gmail`, `generic`). Ghost previously ignored this field, so bot-triggered opens were counted as genuine member engagement, inflating open rates.

This PR filters out bot-flagged open events so newsletter and automation email analytics reflect real human engagement.

### Changes Made

- **Mailgun Client**: Extracted and normalized `client-info.bot` in `mailgun-client.js` as `bot: string | null`.
- **Newsletter Batch Processor**: In `newsletter-email-analytics-batch-processor.js`, skipped `opened` events when `event.bot` is present, returning `unprocessable: 1` without calling `emailEventProcessor.handleOpened`.
- **Automation Batch Processor**: In `automation-email-analytics-batch-processor.ts`, updated the `EmailAnalyticsEvent` type and skipped recording `openedAt` when `event.bot` is present.
- **Unit Tests**: Added coverage in `mailgun-client.test.js`, `newsletter-email-analytics-batch-processor.test.js`, and `automation-email-analytics-batch-processor.test.ts` to verify bot detection and exclusion.

### How was this tested?

- `test/unit/server/services/lib/mailgun-client.test.js` - 42 tests passed
- `test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js` - 46 tests passed
- `test/unit/server/services/email-analytics/automation-email-analytics-batch-processor.test.ts` - 14 tests passed
- ESLint and Prettier checks passed with 0 errors
