### PR TITLE
Changed the React editor's save gates to validate the same fields

### DIFF
--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -8,6 +8,7 @@ import {
   type EditorSessionOptions,
   type EditorWritePayload,
 } from './editor-session';
+import { META_TITLE_MAX, META_TITLE_TOO_LONG } from './settings-fields';
 import type { EditorRecord } from './projection';
 
 type SaveEngineModule = typeof import('@/editor/engine/save-engine');
@@ -1207,6 +1208,23 @@ describe('createEditorSession', () => {
 
       expect(state.updates).toHaveLength(persists ? 1 : 0);
       expect(session.isDirty()).toBe(!persists);
+    });
+
+    it('refuses a field save and an explicit save on the same over-long value', async () => {
+      const { session, state } = harness({ record: record() });
+
+      session.patchFields({ meta_title: 'a'.repeat(META_TITLE_MAX + 1) });
+      session.commitField();
+      await settle();
+
+      expect(engineSpy.dispatched).toEqual([]);
+      expect(state.updates).toHaveLength(0);
+
+      expect(await session.dispatchExplicit()).toMatchObject({
+        kind: 'failed',
+        error: { kind: 'validation', message: META_TITLE_TOO_LONG },
+      });
+      expect(state.updates).toHaveLength(0);
     });
 
     it('stages a field on a published post until an explicit save', async () => {

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -544,7 +544,7 @@ export function createEditorSession({
     // Invalid settings stay staged rather than dispatching a field save.
     if (
       status !== 'draft' ||
-      settingsFieldError(live) ||
+      settingsFieldError(validatedFieldsOf(live)) ||
       authorsEmptied() ||
       publishedAtInFuture(status, livePublishedAt())
     ) {

--- a/apps/admin/src/editor/session/settings-fields.test.ts
+++ b/apps/admin/src/editor/session/settings-fields.test.ts
@@ -13,6 +13,7 @@ import {
   overLength,
   settingsFieldError,
   validatedFieldsOf,
+  type ValidatedSettingsFields,
 } from './settings-fields';
 
 const VALID = {
@@ -41,6 +42,17 @@ describe('validatedFieldsOf', () => {
 
     expect(validatedFieldsOf(live)).toEqual({ ...VALID, meta_title: 'Meta' });
     expect(Object.keys(validatedFieldsOf(live))).toEqual([...VALIDATED_SETTINGS_FIELD_KEYS]);
+  });
+
+  it('is the whole of what the validator reads, so a removed key stops being checked', () => {
+    const live = { ...VALID, meta_title: 'a'.repeat(META_TITLE_MAX + 1) };
+    const validated = validatedFieldsOf(live);
+    // The same projection, built as the list without that key would build it.
+    const withoutMetaTitle = { ...validated };
+    delete (withoutMetaTitle as Partial<ValidatedSettingsFields>).meta_title;
+
+    expect(settingsFieldError(validated)).toBe(META_TITLE_TOO_LONG);
+    expect(settingsFieldError(withoutMetaTitle)).toBeNull();
   });
 });
 

--- a/apps/admin/src/editor/session/settings-fields.ts
+++ b/apps/admin/src/editor/session/settings-fields.ts
@@ -105,10 +105,10 @@ export const VALIDATED_SETTINGS_FIELD_KEYS = [
   'og_description',
 ] as const;
 
-export type ValidatedSettingsFields = Pick<
-  EditorSettingsFields,
-  (typeof VALIDATED_SETTINGS_FIELD_KEYS)[number]
->;
+export type ValidatedSettingsFieldKey = (typeof VALIDATED_SETTINGS_FIELD_KEYS)[number];
+
+/** The validator's whole input, so reading an unlisted key does not compile. */
+export type ValidatedSettingsFields = Pick<EditorSettingsFields, ValidatedSettingsFieldKey>;
 
 /** The validator's own view of the live document. */
 export function validatedFieldsOf(fields: ValidatedSettingsFields): ValidatedSettingsFields {


### PR DESCRIPTION
The post editor's settings sidebar has two save gates, and they were not
validating the same thing. `commitField` ran `settingsFieldError` over the whole
live document; an explicit save ran it over `prepare`'s snapshot, which
`validatedFieldsOf` builds from `VALIDATED_SETTINGS_FIELD_KEYS`. A key the
validator reads but the list does not carry therefore stopped guarding the
explicit save while the field save kept refusing the same value, and nothing
reported the split.

Both gates now read `validatedFieldsOf(live)`, so the key list is the only thing
deciding what either of them checks. The validator's parameter is named after
that list (`Pick<EditorSettingsFields, ValidatedSettingsFieldKey>`), so reading a
key the list does not carry fails `tsc` rather than silently passing at runtime.

No behaviour changes for any listed key: every field the validator checks today
is in the list, so both gates refuse exactly what they refused before.

## Verification

- `settings-fields.test.ts` gains a case pinning the list as the single source:
  an over-long value is refused through `validatedFieldsOf`, and the same
  projection with that key taken out of the list is not checked at all — which
  is now true of both gates at once rather than one of them.
- `editor-session.test.ts` gains a session case where a draft's field save and an
  explicit save refuse the same over-length meta title, the field save holding
  the value staged and the explicit save failing with the same message.
- Removing a key from the list locally fails both new tests and `tsc`.
- `vitest run src/editor` 1129 passing, acceptance `src/editor` 347 passing with
  the access, meta data and Facebook card specs unedited; `eslint src` clean,
  `tsc -b` clean, root `format:check`, `lint:boundaries` and `lint:markdown` clean.