### PR TITLE
Fixed the CI typecheck job never running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
           AFFECTED_PROJECTS_STR=$(pnpm nx show projects ${AFFECTED_ARG} --sep=, | tr -d '\n')
           echo "affected_projects_str=$AFFECTED_PROJECTS_STR" >> "$GITHUB_OUTPUT"
 
-          TYPECHECK_PROJECTS_STR=$(pnpm -s nx show projects ${AFFECTED_ARG} --withTarget test:types --sep=, | tr -d '\n')
+          TYPECHECK_PROJECTS_STR=$(pnpm nx show projects ${AFFECTED_ARG} --withTarget test:types --sep=, | tr -d '\n')
           echo "typecheck_projects_str=$TYPECHECK_PROJECTS_STR" >> "$GITHUB_OUTPUT"
 
           UNIT_TEST_AFFECTED_ARG="$AFFECTED_ARG"

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -70,6 +70,9 @@ const field = (overrides: Partial<MemberCustomField>): MemberCustomField => ({
   name: 'Nickname',
   type: 'short_text',
   status: 'active',
+  // The server reads a field with no access set as closed to members, so a case that says
+  // nothing about access gets the field the API would return for one.
+  access: { member: 'none' },
   created_at: '2026-07-01T00:00:00.000Z',
   updated_at: null,
   ...overrides,


### PR DESCRIPTION
## Problem

Ghost's CI has a job that type-checks the code. It has not actually run for a long time. On every recent commit on main it is recorded as "skipped", and a skipped job is easy to mistake for a passing one, so nothing drew attention to it.

The job works out whether it has anything to do by asking the build tool to list the projects that have a type-checking step. That question is asked with a command-line option the current version of our package manager no longer accepts. The command exits with an error and prints nothing usable.

The failure is invisible for two reasons. The error goes to the error stream rather than the output stream, and the output is piped into a second command, so the step reports the success of that second command instead. The list of projects comes back empty, the job reads that as "nothing to type-check", and skips itself.

## What this changes

The first commit removes the option. The lines either side of it ask the build tool the same kind of question and never carried it.

Switching type-checking back on immediately surfaces a real error that had been sitting on main unnoticed. A recent change made a member field's access setting a required part of that field's shape, but the helper that builds those fields in a test still leaves it out, and the overrides it accepts cannot supply it either. The compiler rejects the result.

The second commit gives that helper a default, so a test that does not care about access gets one and a test that does can still override it.

## Why it is in this order

The first commit is pushed on its own so CI can run against it and show the type-check failing. That is the evidence the job is genuinely working again rather than passing because it still has nothing to do. The second commit then takes it green.

That run is here, and fails exactly as described: https://github.com/TryGhost/Ghost/actions/runs/34372927232/job/102538811310

## How it got this way

The option was correct when the type-checking job was written: every similar call in the file carried it. Between that work being opened and it being merged, a separate change upgraded the package manager to a major version that no longer accepts the option, and removed it from all the calls that existed at the time. The two changes never touched the same line, so nothing conflicted, and the new job arrived the next day still carrying it. The job has therefore never run since it landed.
