### PR TITLE
Moved publish option actions into the React publish hook

### DIFF
--- a/apps/admin/src/editor/editor-conflict.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-conflict.acceptance.test.tsx
@@ -5,10 +5,7 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 import {
   currentRoute,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
   post,
   renderAdminApp,
   unsavedChangesGuarded,
@@ -90,11 +87,7 @@ const theirs = (overrides: Partial<ReturnType<typeof mine>> = {}) => ({
  * refusal the read serves their version instead.
  */
 function fakeCollidingPost() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));

--- a/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
@@ -1,16 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   post,
   renderAdminApp,
-  type EndpointCapture,
+  submittedPost,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 
@@ -25,40 +22,14 @@ const SAVE_POLL = { timeout: 10_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] };
-  return body.posts[0];
-}
-
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  fakeEditorChrome();
+  return fakeEditorPost({
     tags: [],
     feature_image: null,
     feature_image_alt: null,
     feature_image_caption: null,
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-header.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-header.acceptance.test.tsx
@@ -15,7 +15,7 @@ import {
   renderAdminApp,
   settingsResponse,
   staffRole,
-  type EndpointCapture,
+  submittedPost,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -52,12 +52,6 @@ const MAILGUN_ON = {
 };
 
 type SavedPost = ReturnType<typeof post>;
-
-function submittedPost(capture: EndpointCapture, index = -1): Record<string, unknown> {
-  const request = capture.requests.at(index);
-  const body = request?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
 
 /** The error body Ghost answers a failed save with, by status. */
 function failureBody(status: number) {

--- a/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-leave-guard.acceptance.test.tsx
@@ -5,10 +5,7 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 import {
   currentRoute,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
   post,
   renderAdminApp,
   unsavedChangesGuarded,
@@ -31,16 +28,8 @@ const SAVE_POLL = { timeout: 10_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
-}
-
 function fakeEditablePost(overrides: Partial<SavedPost> = {}, { failSaves = false } = {}) {
-  editorChrome();
+  fakeEditorChrome();
   let current = post({
     id: POST_ID,
     title: 'Hello from React',
@@ -78,7 +67,7 @@ function fakeEditablePost(overrides: Partial<SavedPost> = {}, { failSaves = fals
 }
 
 function fakeNewPost({ failUpdates = false } = {}) {
-  editorChrome();
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
   let created = post({
     id: NEW_POST_ID,
@@ -118,7 +107,7 @@ function fakeNewPost({ failUpdates = false } = {}) {
 }
 
 function fakeDeferredCleanSave() {
-  editorChrome();
+  fakeEditorChrome();
   let current = post({
     id: POST_ID,
     title: 'Hello from React',

--- a/apps/admin/src/editor/editor-save.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-save.acceptance.test.tsx
@@ -6,13 +6,12 @@ import {
   currentRoute,
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   tag,
   type CapturedEndpointRequest,
   type EndpointCapture,
@@ -40,21 +39,9 @@ function postIn(request: CapturedEndpointRequest | undefined): Record<string, un
   return body?.posts[0] ?? {};
 }
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  return postIn(capture.lastRequest);
-}
-
 function submittedBody(capture: EndpointCapture): string {
   const lexical = submittedPost(capture).lexical;
   return typeof lexical === 'string' ? lexical : '';
-}
-
-function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
 }
 
 /**
@@ -63,39 +50,19 @@ function editorChrome() {
  * serves whatever was saved last.
  */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
-  editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
-    tags: [],
-    ...overrides,
-  });
-  let saves = 0;
-
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));
-
-  fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), () => ({ posts: [current] }));
-
-  const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/posts/${POST_ID}/\\?`), ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
+  return fakeEditorPost({
+    tags: [],
+    ...overrides,
   });
-
-  return saveApi;
 }
 
 /** A post that does not exist yet, with the create and the follow-up writes answered. */
 function fakeCreatablePost() {
-  editorChrome();
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
   let created = post({
     id: NEW_POST_ID,
@@ -204,7 +171,7 @@ describe('Post editor saving', () => {
   it(
     'creates a new post on the first edit and swaps the URL without remounting',
     async () => {
-      editorChrome();
+      fakeEditorChrome();
       fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
       let created = post({
         id: NEW_POST_ID,
@@ -265,7 +232,7 @@ describe('Post editor saving', () => {
   it(
     'keeps typing that lands while the create is in flight and updates the new post',
     async () => {
-      editorChrome();
+      fakeEditorChrome();
       fakeAdminEndpoint('GET', /^\/slugs\/post\/untitled\//, { slugs: [{ slug: 'untitled' }] });
       let created = post({
         id: NEW_POST_ID,
@@ -435,7 +402,7 @@ describe('Post editor saving', () => {
   it(
     'halts on a collision and keeps the content',
     async () => {
-      editorChrome();
+      fakeEditorChrome();
       fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
         posts: [
           post({
@@ -484,7 +451,7 @@ describe('Post editor saving', () => {
   it(
     'offers a retry in place when the session expired',
     async () => {
-      editorChrome();
+      fakeEditorChrome();
       fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
         posts: [
           post({
@@ -523,7 +490,7 @@ describe('Post editor saving', () => {
   it(
     'still says saving stopped after the session banner is dismissed',
     async () => {
-      editorChrome();
+      fakeEditorChrome();
       fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
         posts: [
           post({
@@ -560,7 +527,7 @@ describe('Post editor saving', () => {
   it(
     'does not leave the editor when the slug request finds no session',
     async () => {
-      editorChrome();
+      fakeEditorChrome();
       fakeAdminEndpoint('GET', new RegExp(`^/posts/${POST_ID}/\\?`), {
         posts: [
           post({

--- a/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-access.acceptance.test.tsx
@@ -1,22 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeTiers,
   post,
   renderAdminApp,
   settingsResponse,
   staffRole,
+  submittedPost,
   tier,
   unsavedChangesGuarded,
-  type EndpointCapture,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 
@@ -25,7 +22,6 @@ const NEW_POST_ID = 'new123';
 const FLAG_ON = { labs: { editorReact: true } };
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 
 // A settings save waits on the engine's queue, so these journeys outlast the default timeout.
 const SLOW = 20_000;
@@ -44,11 +40,6 @@ const SITE_TIERS = [GOLD, SILVER, BRONZE, FREE];
 const MANY_TIERS = Array.from({ length: 18 }, (_, index) =>
   tier({ name: `Tier ${String(index + 1).padStart(2, '0')}`, type: 'paid', active: true }),
 );
-
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
 
 function asContributor() {
   const me = currentUserResponse();
@@ -69,12 +60,8 @@ function withDefaultVisibility(visibility: string) {
 }
 
 function editorChrome(tiers = SITE_TIERS) {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
-  // After fakeMembers, which serves its filter bar an empty tier list of its own.
+  fakeEditorChrome();
+  // The shared editor reads install an empty tier list for the member filter bar.
   fakeTiers(tiers);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -84,28 +71,11 @@ function editorChrome(tiers = SITE_TIERS) {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}, tiers = SITE_TIERS) {
   editorChrome(tiers);
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     visibility: 'public',
     tiers: [],
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-authors.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-authors.acceptance.test.tsx
@@ -1,21 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeUsers,
   post,
   renderAdminApp,
   staffRole,
   staffUser,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type StaffRoleName,
   type StaffUser,
 } from '@test-utils/acceptance';
@@ -28,7 +25,6 @@ const OWNER_ID = '1';
 const FLAG_ON = { labs: { editorReact: true } };
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 
 // A settings save waits on the engine's queue, so these journeys outlast the default timeout.
 const SLOW = 20_000;
@@ -55,11 +51,6 @@ function hydrateAuthors(authors: unknown): unknown[] {
   );
 }
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function asRole(name: StaffRoleName) {
   const me = currentUserResponse();
   me.users[0].roles = [staffRole({ name })];
@@ -67,11 +58,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function editorChrome(staff: StaffUser[] = [NADIA, JOSE]) {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeUsers([...(currentUserResponse().users as unknown as StaffUser[]), ...staff]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -81,33 +68,14 @@ function editorChrome(staff: StaffUser[] = [NADIA, JOSE]) {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}, staff?: StaffUser[]) {
   editorChrome(staff);
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
-    authors: [OWNER],
-    tags: [],
-    ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = {
-      ...current,
-      ...submitted,
-      authors: hydrateAuthors(submitted.authors ?? current.authors),
-      updated_at: `2026-01-01T00:00:0${saves}.000Z`,
-    };
-    return { posts: [current] };
-  });
+  return fakeEditorPost(
+    {
+      authors: [OWNER],
+      tags: [],
+      ...overrides,
+    },
+    (saved) => ({ ...saved, authors: hydrateAuthors(saved.authors) }),
+  );
 }
 
 async function openAuthors() {

--- a/apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-code-injection.acceptance.test.tsx
@@ -11,17 +11,15 @@ import {
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakePages,
-  fakePosts,
-  fakeSnippets,
   fakeTiers,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -31,7 +29,6 @@ const CURRENT_USER_ID = '1';
 const FLAG_ON = { labs: { editorReact: true } };
 const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 const PAGE_ROUTE = new RegExp(`^/pages/${POST_ID}/\\?`);
 // The panel's own width, and the width the wide pane widens it to.
 const PANEL_WIDTH = 350;
@@ -47,11 +44,6 @@ const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function asRole(name: StaffRoleName) {
   const me = currentUserResponse();
   me.users[0].roles = [staffRole({ name })];
@@ -59,11 +51,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs and preview read these beyond the boot table.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -73,28 +61,11 @@ function editorChrome() {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     codeinjection_head: null,
     codeinjection_foot: null,
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-delete.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-delete.acceptance.test.tsx
@@ -6,11 +6,9 @@ import {
   currentRoute,
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
+  fakeEditorChrome,
   fakePosts,
   fakePostsListScreen,
-  fakeSnippets,
   post,
   renderAdminApp,
   staffRole,
@@ -38,11 +36,7 @@ function asContributor() {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));

--- a/apps/admin/src/editor/editor-settings-facebook-card.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-facebook-card.acceptance.test.tsx
@@ -1,20 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeTiers,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -22,9 +19,7 @@ import { editorScreen } from '@/editor/editor.screen';
 const POST_ID = 'abc123';
 const CURRENT_USER_ID = '1';
 const FLAG_ON = { labs: { editorReact: true } };
-const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 const BACK_LABEL = 'Close Facebook card panel';
 const UPLOADED = 'https://example.com/content/images/2026/09/hills.png';
 const FEATURE = 'https://example.com/content/images/2026/09/coast.png';
@@ -39,11 +34,6 @@ const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function asRole(name: StaffRoleName) {
   const me = currentUserResponse();
   me.users[0].roles = [staffRole({ name })];
@@ -51,11 +41,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs and preview read these beyond the boot table.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -65,14 +51,7 @@ function editorChrome() {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     custom_excerpt: null,
     excerpt: null,
     meta_title: null,
@@ -83,16 +62,6 @@ function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
     feature_image: null,
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-keyboard-shortcuts.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-keyboard-shortcuts.acceptance.test.tsx
@@ -5,10 +5,7 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
   fakeTiers,
   post,
   renderAdminApp,
@@ -46,11 +43,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function fakeEditablePost(overrides: Partial<ReturnType<typeof post>> = {}) {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs and preview read these beyond the boot table.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],

--- a/apps/admin/src/editor/editor-settings-meta-data.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-meta-data.acceptance.test.tsx
@@ -1,20 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeTiers,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -23,9 +20,7 @@ import { previewScreen } from '@/editor/preview/preview.screen';
 const POST_ID = 'abc123';
 const CURRENT_USER_ID = '1';
 const FLAG_ON = { labs: { editorReact: true } };
-const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 const BACK_LABEL = 'Close meta data panel';
 const PLACEHOLDER =
   'Search engines will automatically show a custom preview of content related to the search term here if no custom meta description is set.';
@@ -38,11 +33,6 @@ const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function asRole(name: StaffRoleName) {
   const me = currentUserResponse();
   me.users[0].roles = [staffRole({ name })];
@@ -50,11 +40,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs and preview read these beyond the boot table.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -64,29 +50,12 @@ function editorChrome() {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     custom_excerpt: null,
     meta_title: null,
     meta_description: null,
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-post-history.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-post-history.acceptance.test.tsx
@@ -9,17 +9,15 @@ import {
 
 import {
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeTiers,
   post,
   postRevision,
   renderAdminApp,
   settingsResponse,
   staffUser,
-  type EndpointCapture,
+  submittedPost,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 import { deferred } from '@/utils/deferred';
@@ -82,17 +80,8 @@ const BARE = postRevision({
 // Deliberately out of order: the list is the component's to sort.
 const REVISIONS = [MIDDLE, NEWEST, OLDEST];
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  return (
-    (capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined)?.posts[0] ?? {}
-  );
-}
-
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -119,17 +108,7 @@ function savedPost(overrides: Partial<SavedPost> = {}): SavedPost {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = savedPost(overrides);
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
-  });
+  return fakeEditorPost(savedPost(overrides));
 }
 
 /** The same post, but every save is refused. */

--- a/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-publish-date.acceptance.test.tsx
@@ -1,45 +1,35 @@
 import moment from 'moment-timezone';
 import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeTiers,
   post,
   renderAdminApp,
   settingsResponse,
   staffRole,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 
 const POST_ID = 'abc123';
 const FLAG_ON = { labs: { editorReact: true } };
-const LOADED_AT = '2026-01-01T00:00:00.000Z';
 // 2025-12-01 10:00 UTC is 2025-12-01 21:00 in Sydney: a date the offset moves.
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
 // What a real publish stamps: seconds the minute-granular fields cannot show.
 const STAMPED_AT = '2025-12-01T10:00:37.000Z';
 const SYDNEY = 'Australia/Sydney';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 
 const SLOW = 20_000;
 const POLL = { timeout: 10_000 };
 const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
-
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
 
 /**
  * A fixed-offset zone in which the current instant is around midday, so a later
@@ -66,10 +56,7 @@ function asContributor() {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -78,28 +65,11 @@ function editorChrome() {
 
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     visibility: 'public',
     tiers: [],
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-sidebar.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-sidebar.acceptance.test.tsx
@@ -5,15 +5,13 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -35,11 +33,6 @@ const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function asRole(name: StaffRoleName) {
   const me = currentUserResponse();
   me.users[0].roles = [staffRole({ name })];
@@ -47,11 +40,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));
@@ -60,28 +49,11 @@ function editorChrome() {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     featured: false,
     custom_excerpt: null,
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-tags.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-tags.acceptance.test.tsx
@@ -5,14 +5,12 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
   fakeTags,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   tag,
   unsavedChangesGuarded,
   type EndpointCapture,
@@ -43,20 +41,12 @@ const NOTICE = tag({ id: 'tag3', name: 'Notice', slug: 'notice', visibility: 'pu
 const NEWS_2 = tag({ id: 'tag4', name: 'News', slug: 'news-2', visibility: 'public' });
 const SITE_TAGS = [NEWS, SPORT, NOTICE, NEWS_2];
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function submittedTags(capture: EndpointCapture): Array<Record<string, unknown>> {
   return (submittedPost(capture).tags ?? []) as Array<Record<string, unknown>>;
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));

--- a/apps/admin/src/editor/editor-settings-template.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-template.acceptance.test.tsx
@@ -1,28 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeThemes,
   post,
   renderAdminApp,
+  submittedPost,
   theme,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type ThemeTemplate,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 
 const POST_ID = 'abc123';
 const FLAG_ON = { labs: { editorReact: true } };
-const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const POST_ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 
 // A settings save waits on the engine's queue, so these journeys outlast the default timeout.
 const SLOW = 20_000;
@@ -52,11 +47,6 @@ const SLUG_TEMPLATE = {
   slug: 'hello-from-react',
 };
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 /** The active theme's templates, alongside an installed theme whose templates never count. */
 function fakeSiteThemes(templates: ThemeTemplate[]) {
   fakeThemes([
@@ -66,11 +56,7 @@ function fakeSiteThemes(templates: ThemeTemplate[]) {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
   }));
@@ -79,27 +65,10 @@ function editorChrome() {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     custom_template: null,
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', POST_ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', POST_ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/editor-settings-url.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-url.acceptance.test.tsx
@@ -1,27 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentRoute,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   post,
   renderAdminApp,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 import { deferred } from '@/utils/deferred';
 
 const POST_ID = 'abc123';
 const FLAG_ON = { labs: { editorReact: true } };
-const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 
 // A slug edit waits on the generator and then on the save queue.
 const SLOW = 20_000;
@@ -30,11 +25,6 @@ const POLL = { timeout: 10_000 };
 const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
-
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
 
 /** The slugs endpoint, answering with the requested name unless it is taken. */
 function fakeSlugs(taken: Record<string, string> = {}) {
@@ -46,32 +36,9 @@ function fakeSlugs(taken: Record<string, string> = {}) {
 
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
 
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
-    ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
-  });
+  return fakeEditorPost(overrides);
 }
 
 async function openSidebar() {

--- a/apps/admin/src/editor/editor-settings-x-card.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-x-card.acceptance.test.tsx
@@ -1,20 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import { buildLexicalParagraph } from '@tryghost/test-data';
 
 import {
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
+  fakeEditorChrome,
+  fakeEditorPost,
   fakeTiers,
   post,
   renderAdminApp,
   staffRole,
+  submittedPost,
   unsavedChangesGuarded,
-  type EndpointCapture,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -22,9 +19,7 @@ import { editorScreen } from '@/editor/editor.screen';
 const POST_ID = 'abc123';
 const CURRENT_USER_ID = '1';
 const FLAG_ON = { labs: { editorReact: true } };
-const LOADED_AT = '2026-01-01T00:00:00.000Z';
 const PUBLISHED_AT = '2025-12-01T10:00:00.000Z';
-const ROUTE = new RegExp(`^/posts/${POST_ID}/\\?`);
 const BACK_LABEL = 'Close X card panel';
 const UPLOADED = 'https://example.com/content/images/2026/09/hills.png';
 const FEATURE = 'https://example.com/content/images/2026/09/coast.png';
@@ -39,11 +34,6 @@ const FIELD_POLL = { timeout: 2_000 };
 
 type SavedPost = ReturnType<typeof post>;
 
-function submittedPost(capture: EndpointCapture): Record<string, unknown> {
-  const body = capture.lastRequest?.body as { posts: Record<string, unknown>[] } | undefined;
-  return body?.posts[0] ?? {};
-}
-
 function asRole(name: StaffRoleName) {
   const me = currentUserResponse();
   me.users[0].roles = [staffRole({ name })];
@@ -51,11 +41,7 @@ function asRole(name: StaffRoleName) {
 }
 
 function editorChrome() {
-  fakeSnippets([]);
-  fakePosts([]);
-  // The header's publish inputs and preview read these beyond the boot table.
-  fakeMembers([]);
-  fakeNewsletters([]);
+  fakeEditorChrome();
   fakeTiers([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],
@@ -65,14 +51,7 @@ function editorChrome() {
 /** A post that answers saves the way Ghost does: submitted fields back, fresh token. */
 function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
   editorChrome();
-  let current = post({
-    id: POST_ID,
-    title: 'Hello from React',
-    slug: 'hello-from-react',
-    status: 'draft',
-    lexical: buildLexicalParagraph('Hello from React'),
-    updated_at: LOADED_AT,
-    published_at: null,
+  return fakeEditorPost({
     custom_excerpt: null,
     excerpt: null,
     meta_title: null,
@@ -83,16 +62,6 @@ function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
     feature_image: null,
     tags: [],
     ...overrides,
-  });
-  let saves = 0;
-
-  fakeAdminEndpoint('GET', ROUTE, () => ({ posts: [current] }));
-
-  return fakeAdminEndpoint('PUT', ROUTE, ({ body }) => {
-    saves += 1;
-    const submitted = (body as { posts: Partial<SavedPost>[] }).posts[0];
-    current = { ...current, ...submitted, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
-    return { posts: [current] };
   });
 }
 

--- a/apps/admin/src/editor/publish/publish-flow-modal.tsx
+++ b/apps/admin/src/editor/publish/publish-flow-modal.tsx
@@ -148,18 +148,11 @@ function PublishFlowDialog({
     onBeforePublish,
     onCompleted,
   });
-  const { machine, state, step } = flow;
+  const { state, step } = flow;
   const close = () => {
     flow.cancel();
     onClose();
   };
-
-  const transition =
-    <T,>(apply: (value: T) => void) =>
-    (value: T) => {
-      apply(value);
-      flow.refresh();
-    };
 
   return (
     <Dialog modal={false} open onOpenChange={(open) => !open && close()}>
@@ -232,11 +225,11 @@ function PublishFlowDialog({
               timezone={timezone}
               onContinue={flow.toConfirm}
               onRetryLimits={flow.retryLimits}
-              onSetNewsletter={transition((value) => machine.setNewsletter(value))}
-              onSetPublishType={transition((value) => machine.setPublishType(value))}
-              onSetRecipientFilter={transition((value) => machine.setRecipientFilter(value))}
-              onSetScheduledAt={transition((value) => machine.setScheduledAt(value))}
-              onToggleScheduled={transition((value) => machine.setIsScheduled(value))}
+              onSetNewsletter={flow.setNewsletter}
+              onSetPublishType={flow.setPublishType}
+              onSetRecipientFilter={flow.setRecipientFilter}
+              onSetScheduledAt={flow.setScheduledAt}
+              onToggleScheduled={flow.setIsScheduled}
             />
           )}
         </Stack>

--- a/apps/admin/src/editor/publish/use-publish-flow.test.ts
+++ b/apps/admin/src/editor/publish/use-publish-flow.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePublishFlow, type PublishFlowOptions } from './use-publish-flow';
+import type { NewsletterInput } from './publish-options';
+
+const transport = vi.hoisted(() => ({ fetchApi: vi.fn(), retryEmail: vi.fn() }));
+vi.mock('@tryghost/admin-x-framework/hooks', () => ({ useFetchApi: () => transport.fetchApi }));
+vi.mock('@tryghost/admin-x-framework/api/emails', () => ({
+  useRetryEmail: () => ({ mutateAsync: transport.retryEmail }),
+}));
+
+const NOW = new Date('2026-09-02T10:00:00.000Z');
+const SCHEDULED_AT = '2026-09-03T10:00:00.000Z';
+const WEEKLY: NewsletterInput = { slug: 'weekly', name: 'Weekly', status: 'active', sortOrder: 0 };
+const DAILY: NewsletterInput = { slug: 'daily', name: 'Daily', status: 'active', sortOrder: 1 };
+
+function options(): PublishFlowOptions {
+  return {
+    post: {
+      id: 'post-1',
+      displayName: 'post',
+      status: 'draft',
+      title: 'Hello',
+      visibility: 'public',
+    },
+    site: {
+      membersEnabled: true,
+      mailgunConfigured: true,
+      memberCount: 100,
+      newsletters: [WEEKLY, DAILY],
+      editorDefaultEmailRecipients: 'visibility',
+      editorDefaultEmailRecipientsFilter: null,
+    },
+    user: { isAdmin: true, isAuthorOrContributor: false },
+    now: () => NOW,
+    dispatch: vi.fn().mockResolvedValue({
+      kind: 'saved',
+      executedAs: 'schedule',
+      result: { id: 'post-1', status: 'scheduled', updatedAt: NOW.toISOString() },
+    }),
+  };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('publish option actions', () => {
+  it('renders changed options and confirms the same command without a caller refresh', async () => {
+    const inputs = options();
+    const { result } = renderHook(() => usePublishFlow(inputs));
+    await waitFor(() => expect(result.current.limitsChecked).toBe(true));
+
+    act(() => result.current.setPublishType('send'));
+    expect(result.current.state.willOnlyEmail).toBe(true);
+
+    act(() => result.current.setNewsletter(DAILY));
+    expect(result.current.state.newsletter?.slug).toBe('daily');
+
+    act(() => result.current.setRecipientFilter('label:vip'));
+    expect(result.current.state.recipientFilter).toBe('label:vip');
+
+    act(() => result.current.setIsScheduled(true));
+    expect(result.current.state.isScheduled).toBe(true);
+
+    act(() => result.current.setScheduledAt(new Date(SCHEDULED_AT)));
+    expect(result.current.state.scheduledAt).toBe(SCHEDULED_AT);
+
+    act(() => result.current.toConfirm());
+    expect(result.current.step).toBe('confirm');
+    expect(result.current.captured).toMatchObject({ isScheduled: true, willOnlyEmail: true });
+    await act(() => result.current.confirmPublish());
+    expect(inputs.dispatch).toHaveBeenCalledWith({
+      kind: 'schedule',
+      options: {
+        publishedAt: SCHEDULED_AT,
+        emailOnly: true,
+        newsletter: 'daily',
+        emailSegment: 'label:vip',
+      },
+    });
+    expect(result.current.step).toBe('complete');
+  });
+
+  it('keeps actions and selections through caller rerenders', async () => {
+    const inputs = options();
+    const { result, rerender } = renderHook((props) => usePublishFlow(props), {
+      initialProps: inputs,
+    });
+    await waitFor(() => expect(result.current.limitsChecked).toBe(true));
+    const setNewsletter = result.current.setNewsletter;
+    act(() => setNewsletter(DAILY));
+    rerender({ ...inputs, site: { ...inputs.site } });
+    expect(result.current.setNewsletter).toBe(setNewsletter);
+    expect(result.current.state.newsletter?.slug).toBe('daily');
+
+    act(() => setNewsletter(WEEKLY));
+    expect(result.current.state.newsletter?.slug).toBe('weekly');
+    expect(inputs.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/editor/publish/use-publish-flow.ts
+++ b/apps/admin/src/editor/publish/use-publish-flow.ts
@@ -42,8 +42,12 @@ export interface PublishFlowOptions {
   onCompleted?: (info: { postId: string; isScheduled: boolean; hasEmail: boolean }) => void;
 }
 
-export interface PublishFlow {
-  machine: PublishOptionsMachine;
+type PublishOptionActions = Pick<
+  PublishOptionsMachine,
+  'setPublishType' | 'setNewsletter' | 'setRecipientFilter' | 'setScheduledAt' | 'setIsScheduled'
+>;
+
+export interface PublishFlow extends PublishOptionActions {
   state: PublishOptionsState;
   step: PublishStep;
   confirmStatus: ConfirmStatus;
@@ -66,8 +70,6 @@ export interface PublishFlow {
     willOnlyEmail: boolean;
     isScheduled: boolean;
   };
-  /** Re-renders after a machine transition; the machine has no subscription. */
-  refresh: () => void;
   retryLimits: () => void;
   toConfirm: () => void;
   toOptions: () => void;
@@ -123,6 +125,33 @@ export function usePublishFlow({
       now: current.now,
     });
   }, [post.id]);
+
+  // Keep model changes and React updates together; callers only receive actions.
+  const optionActions = useMemo<PublishOptionActions>(
+    () => ({
+      setPublishType: (value) => {
+        machine.setPublishType(value);
+        refresh();
+      },
+      setNewsletter: (value) => {
+        machine.setNewsletter(value);
+        refresh();
+      },
+      setRecipientFilter: (value) => {
+        machine.setRecipientFilter(value);
+        refresh();
+      },
+      setScheduledAt: (value) => {
+        machine.setScheduledAt(value);
+        refresh();
+      },
+      setIsScheduled: (value) => {
+        machine.setIsScheduled(value);
+        refresh();
+      },
+    }),
+    [machine],
+  );
 
   // The email is created by the save, so its id is only knowable from a reload.
   const emailIdRef = useRef<string | null>(post.email?.id ?? null);
@@ -499,7 +528,7 @@ export function usePublishFlow({
   }, [complete, confirmation, post.id]);
 
   return {
-    machine,
+    ...optionActions,
     state,
     step,
     confirmStatus,
@@ -511,7 +540,6 @@ export function usePublishFlow({
     limitsFailure,
     emailNote,
     captured,
-    refresh,
     retryLimits: () => void checkLimits(),
     toConfirm,
     toOptions,

--- a/apps/admin/test-utils/acceptance/editor.ts
+++ b/apps/admin/test-utils/acceptance/editor.ts
@@ -1,0 +1,46 @@
+import { buildLexicalParagraph, post, type Post } from '@tryghost/test-data';
+import { fakeMembers, fakeNewsletters, fakePosts, fakeSnippets } from './resources';
+import { fakeAdminEndpoint, type EndpointCapture } from './worker';
+
+/** Supporting reads shared by the editor's header and card configuration. */
+export function fakeEditorChrome(): void {
+  fakeSnippets([]);
+  fakePosts([]);
+  fakeMembers([]);
+  fakeNewsletters([]);
+}
+
+/** Saved fields are returned by later reads; each save advances the collision token. */
+export function fakeEditorPost(
+  overrides: Partial<Post> = {},
+  normalize: (saved: Post) => Post = (saved) => saved,
+): EndpointCapture {
+  let current = post({
+    id: 'abc123',
+    title: 'Hello from React',
+    slug: 'hello-from-react',
+    status: 'draft',
+    lexical: buildLexicalParagraph('Hello from React'),
+    updated_at: '2026-01-01T00:00:00.000Z',
+    published_at: null,
+    ...overrides,
+  });
+  const route = new RegExp(`^/posts/${current.id}/\\?`);
+
+  fakeAdminEndpoint('GET', route, () => ({ posts: [current] }));
+  return fakeAdminEndpoint('PUT', route, ({ body }) => {
+    const submitted = (body as { posts: Partial<Post>[] }).posts[0];
+    current = normalize({
+      ...current,
+      ...submitted,
+      updated_at: new Date(Date.parse(current.updated_at) + 1000).toISOString(),
+    });
+    return { posts: [current] };
+  });
+}
+
+/** The submitted fields from a captured save, defaulting to the most recent request. */
+export function submittedPost(capture: EndpointCapture, index = -1): Record<string, unknown> {
+  const body = capture.requests.at(index)?.body as { posts: Record<string, unknown>[] } | undefined;
+  return body?.posts[0] ?? {};
+}

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,5 +1,6 @@
 /** Acceptance-harness public surface — see README.md for the spec anatomy. */
 export { fakeAnalyticsOverview } from './analytics';
+export { fakeEditorChrome, fakeEditorPost, submittedPost } from './editor';
 export { currentRoute, renderAdminApp } from './render-admin-app';
 export type { RenderAdminAppOptions } from './render-admin-app';
 export {


### PR DESCRIPTION
The publish modal previously mutated the options model and manually refreshed React after each change. The hook now exposes stable actions that perform both operations, and keeps the mutable model and refresh mechanism private. The modal consumes state and passes the actions to its controls directly.

Hook tests verify that changing delivery mode, newsletter, recipients and schedule immediately changes the rendered state and produces the same command at confirmation. They also cover retained selections across caller rerenders.

Stacked on #30633; merge the preceding PRs first and retarget this PR to main.

Validation: 250 publishing unit tests and 103 publish/header/preview Chromium acceptance tests passed, plus Admin typechecking and commit-hook lint/boundary checks. The existing unrelated documentation-link failure still limits full `pnpm check`.

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written an automated test to prove my change works