### PR TITLE
Added Tinybird automation stats with MySQL fallback

### DIFF
--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -1,16 +1,22 @@
 import errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
 import tpl from '@tryghost/tpl';
 import ObjectId from 'bson-objectid';
 import { z } from 'zod';
 import { createDatabaseAutomationsRepository } from './database-automations-repository';
 import { parseFakeWaitHoursMultiplier } from './fake-wait-hours-multiplier';
 import type { AutomationsRepository, EditAutomationData } from './automations-repository';
+import { EMPTY_AUTOMATION_STATS, fetchAutomationStats } from './tinybird-automation-stats';
 import { StartAutomationsPollEvent } from './events/start-automations-poll-event';
 
 const { knex } = require('../../data/db');
 const domainEvents = require('@tryghost/domain-events');
 const labs = require('../../../shared/labs');
 const config = require('../../../shared/config');
+const settingsCache = require('../../../shared/settings-cache');
+const requestExternal = require('../../lib/request-external');
+const TinybirdServiceWrapper = require('../tinybird');
+const { create: createTinybirdClient } = require('../stats/utils/tinybird');
 const lexicalLib = require('../../lib/lexical');
 
 const MAX_AUTOMATION_ACTIONS = 20;
@@ -72,8 +78,49 @@ const repository = createDatabaseAutomationsRepository({
   ),
 });
 
+function getTinybirdClient() {
+  if (!labs.isSet('automationsTinybirdSync') || !config.get('tinybird:stats')) {
+    return null;
+  }
+  try {
+    const tinybirdService = TinybirdServiceWrapper.instance;
+    if (!tinybirdService?.getToken()?.token) {
+      return null;
+    }
+    return createTinybirdClient({
+      config,
+      // Fall back to MySQL after the first failed attempt.
+      request: requestExternal.extend({ retry: { limit: 0 } }),
+      settingsCache,
+      tinybirdService,
+    });
+  } catch (error) {
+    logging.error('Error preparing Tinybird automation stats client:', error);
+    return null;
+  }
+}
+
 export async function browse() {
-  return await repository.browse({ includeStats: true });
+  const tinybirdClient = getTinybirdClient();
+  if (!tinybirdClient) {
+    return await repository.browse({ includeStats: true });
+  }
+
+  const [browseResult, stats] = await Promise.all([
+    repository.browse({ includeStats: false }),
+    fetchAutomationStats(tinybirdClient),
+  ]);
+  if (stats === null) {
+    return await repository.browse({ includeStats: true });
+  }
+
+  return {
+    ...browseResult,
+    data: browseResult.data.map((automation) => ({
+      ...automation,
+      stats: stats.get(automation.id) ?? { ...EMPTY_AUTOMATION_STATS },
+    })),
+  };
 }
 
 export async function read(automationId: string) {

--- a/ghost/core/core/server/services/automations/tinybird-automation-stats.ts
+++ b/ghost/core/core/server/services/automations/tinybird-automation-stats.ts
@@ -1,0 +1,68 @@
+import logging from '@tryghost/logging';
+import { z } from 'zod';
+import type { AutomationBrowseResult } from './automations-repository';
+
+export type TinybirdClient = {
+  fetch(pipeName: string, options: { version: string }): Promise<unknown>;
+};
+
+export type AutomationStats = NonNullable<AutomationBrowseResult['stats']>;
+
+export const EMPTY_AUTOMATION_STATS: AutomationStats = {
+  last_run_created_at: null,
+  total_run_count: 0,
+  in_progress_run_count: 0,
+};
+
+const runCountSchema = z
+  .union([z.number(), z.string().regex(/^\d+$/)])
+  .pipe(z.coerce.number<string | number>().int().nonnegative());
+
+const statsRowSchema = z.object({
+  automation_id: z.string(),
+  last_run_created_at: z.iso
+    .datetime()
+    .transform((value) => new Date(value))
+    .nullable(),
+  total_run_count: runCountSchema,
+  in_progress_run_count: runCountSchema,
+});
+
+export async function fetchAutomationStats(
+  client: TinybirdClient,
+): Promise<Map<string, AutomationStats> | null> {
+  let rows: unknown;
+  try {
+    // Override the traffic analytics version: this pipe has no version suffix.
+    rows = await client.fetch('api_automation_browse_stats', { version: '' });
+  } catch (error) {
+    logging.error('Error fetching Tinybird automation stats:', error);
+    return null;
+  }
+  if (rows === null) {
+    return null;
+  }
+
+  const parsed = z.array(statsRowSchema).safeParse(rows);
+  if (!parsed.success) {
+    logging.error(
+      {
+        system: { event: 'automations.stats.invalid_tinybird_response' },
+        issues: parsed.error.issues,
+      },
+      'Unexpected response from the Tinybird automation stats pipe',
+    );
+    return null;
+  }
+
+  return new Map(
+    parsed.data.map((row) => [
+      row.automation_id,
+      {
+        last_run_created_at: row.last_run_created_at,
+        total_run_count: row.total_run_count,
+        in_progress_run_count: row.in_progress_run_count,
+      },
+    ]),
+  );
+}

--- a/ghost/core/core/server/services/stats/stats-service.js
+++ b/ghost/core/core/server/services/stats/stats-service.js
@@ -246,10 +246,19 @@ class StatsService {
     const request = deps.request || require('../../lib/request-external');
     const settingsCache = deps.settingsCache || require('../../../shared/settings-cache');
 
-    if (settingsCache.get('web_analytics_enabled')) {
-      // TODO: move the tinybird client to the tinybird service
-      const TinybirdServiceWrapper = require('../tinybird');
+    const labs = deps.labs || require('../../../shared/labs');
+    const webAnalyticsEnabled = settingsCache.get('web_analytics_enabled');
+    const TinybirdServiceWrapper = require('../tinybird');
+
+    if (
+      webAnalyticsEnabled ||
+      (labs.isSet('automationsTinybirdSync') && config.get('tinybird:stats'))
+    ) {
       TinybirdServiceWrapper.init();
+    }
+
+    if (webAnalyticsEnabled) {
+      // TODO: move the tinybird client to the tinybird service
       tinybirdClient = require('./utils/tinybird').create({
         config,
         request,

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -1,6 +1,9 @@
 const assert = require('node:assert/strict');
 const { createHash } = require('node:crypto');
 const sinon = require('sinon');
+const nock = require('nock');
+const TinybirdServiceWrapper = require('../../../core/server/services/tinybird');
+const configUtils = require('../../utils/config-utils');
 const domainEvents = require('@tryghost/domain-events');
 const ObjectId = require('bson-objectid').default;
 const models = require('../../../core/server/models');
@@ -12,6 +15,7 @@ const {
 const {
   agentProvider,
   fixtureManager,
+  mockManager,
   matchers,
   assertions,
 } = require('../../utils/e2e-framework');
@@ -318,6 +322,242 @@ describe('Automations API', function () {
       const automation = body.automations.find((candidate) => candidate.id === automationId);
 
       assert.equal(automation.stats.in_progress_run_count, 1);
+    });
+
+    describe('with Tinybird configured', function () {
+      const TINYBIRD_ENDPOINT = 'https://api.tinybird.co';
+
+      let previousTinybirdInstance;
+
+      beforeEach(function () {
+        previousTinybirdInstance = TinybirdServiceWrapper.instance;
+        mockManager.mockLabsEnabled('automationsTinybirdSync');
+        mockManager.mockLabsDisabled('automationRunAnalytics');
+        mockManager.mockSetting('web_analytics_enabled', false);
+        configUtils.set('tinybird', {
+          workspaceId: 'test-workspace-id',
+          adminToken: 'test-admin-token',
+          stats: { endpoint: TINYBIRD_ENDPOINT, version: 'v2' },
+        });
+        TinybirdServiceWrapper.init();
+      });
+
+      afterEach(async function () {
+        await configUtils.restore();
+        mockManager.restore();
+        TinybirdServiceWrapper.instance = previousTinybirdInstance;
+      });
+
+      it('initializes automation stats through StatsService with web analytics disabled', async function () {
+        TinybirdServiceWrapper.reset();
+        require('../../../core/server/services/stats/stats-service').create({
+          knex: models.Base.knex,
+          models,
+        });
+        const beforeBody = {
+          automations: await models.Base.knex('automations').select('id').orderBy('name'),
+        };
+        const [automationId, otherAutomationId] = beforeBody.automations.map(
+          (automation) => automation.id,
+        );
+        await createAutomationRun(automationId, new Date('2026-01-01T00:00:00.000Z'));
+
+        const siteUuid = (await models.Settings.findOne({ key: 'site_uuid' })).get('value');
+        const tinybird = nock(TINYBIRD_ENDPOINT)
+          .get('/v0/pipes/api_automation_browse_stats.json')
+          .query({ site_uuid: siteUuid })
+          .reply(200, {
+            data: [
+              {
+                automation_id: automationId,
+                last_run_created_at: '2026-02-01T01:00:00.000Z',
+                total_run_count: 5,
+                in_progress_run_count: 2,
+              },
+            ],
+          });
+
+        const queries = [];
+        const captureQuery = (query) => queries.push(query.sql);
+        models.Base.knex.on('query', captureQuery);
+        let body;
+        try {
+          ({ body } = await agent.get('automations').expectStatus(200));
+        } finally {
+          models.Base.knex.removeListener('query', captureQuery);
+        }
+
+        assert.equal(
+          queries.some((sql) => /\bautomation_runs\b|\bautomation_run_steps\b/.test(sql)),
+          false,
+        );
+        assert.ok(tinybird.isDone());
+        const automation = body.automations.find((candidate) => candidate.id === automationId);
+        assert.deepEqual(automation.stats, {
+          last_run_created_at: '2026-02-01T01:00:00.000Z',
+          total_run_count: 5,
+          in_progress_run_count: 2,
+        });
+        const otherAutomation = body.automations.find(
+          (candidate) => candidate.id === otherAutomationId,
+        );
+        assert.deepEqual(otherAutomation.stats, {
+          last_run_created_at: null,
+          total_run_count: 0,
+          in_progress_run_count: 0,
+        });
+      });
+
+      it('uses database stats when the flag is disabled', async function () {
+        mockManager.mockLabsDisabled('automationsTinybirdSync');
+        const [automation] = await models.Base.knex('automations').select('id');
+        await createAutomationRun(automation.id, new Date('2026-01-01T00:00:00.000Z'));
+
+        const { body } = await agent.get('automations').expectStatus(200);
+
+        assert.equal(
+          body.automations.find((item) => item.id === automation.id).stats.total_run_count,
+          1,
+        );
+      });
+
+      it('uses database stats when no Tinybird token is available', async function () {
+        sinon.stub(TinybirdServiceWrapper.instance, 'getToken').returns(null);
+        const [automation] = await models.Base.knex('automations').select('id');
+        await createAutomationRun(automation.id, new Date('2026-01-01T00:00:00.000Z'));
+
+        const { body } = await agent.get('automations').expectStatus(200);
+
+        assert.equal(
+          body.automations.find((item) => item.id === automation.id).stats.total_run_count,
+          1,
+        );
+      });
+
+      it.each([undefined, ''])(
+        'uses MySQL without requesting Tinybird when the local token is %j',
+        async function (token) {
+          configUtils.set('tinybird', {
+            stats: { local: { enabled: true, endpoint: TINYBIRD_ENDPOINT, token } },
+          });
+          TinybirdServiceWrapper.init();
+          const [automation] = await models.Base.knex('automations').select('id');
+          await createAutomationRun(automation.id, new Date('2026-01-01T00:00:00.000Z'));
+          const siteUuid = (await models.Settings.findOne({ key: 'site_uuid' })).get('value');
+          const tinybird = nock(TINYBIRD_ENDPOINT)
+            .get('/v0/pipes/api_automation_browse_stats.json')
+            .query({ site_uuid: siteUuid })
+            .reply(200, { data: [] });
+
+          const { body } = await agent.get('automations').expectStatus(200);
+
+          assert.equal(tinybird.isDone(), false);
+          assert.equal(
+            body.automations.find((item) => item.id === automation.id).stats.total_run_count,
+            1,
+          );
+        },
+      );
+
+      it.each(['client preparation', 'request construction'])(
+        'uses MySQL when token generation throws during %s',
+        async function (stage) {
+          const error = sinon.stub(require('@tryghost/logging'), 'error');
+          const getToken = sinon.stub(TinybirdServiceWrapper.instance, 'getToken');
+          if (stage === 'request construction') {
+            getToken.onFirstCall().returns({ token: 'test-token' });
+            getToken.onSecondCall().throws(new Error('Token signing failed'));
+          } else {
+            getToken.throws(new Error('Token signing failed'));
+          }
+          const [automation] = await models.Base.knex('automations').select('id');
+          await createAutomationRun(automation.id, new Date('2026-01-01T00:00:00.000Z'));
+
+          const { body } = await agent.get('automations').expectStatus(200);
+
+          assert.equal(
+            body.automations.find((item) => item.id === automation.id).stats.total_run_count,
+            1,
+          );
+          assert.ok(error.calledOnce);
+        },
+      );
+
+      it.each([
+        { reason: 'unavailable', status: 500, response: 'nope' },
+        { reason: 'malformed', status: 200, response: { data: [{ automation_id: 42 }] } },
+      ])('uses database stats when Tinybird is $reason', async function ({ status, response }) {
+        sinon.stub(require('@tryghost/logging'), 'error');
+        const [automation] = await models.Base.knex('automations').select('id');
+        const createdAt = new Date('2026-01-01T00:00:00.000Z');
+        const runId = await createAutomationRun(automation.id, createdAt);
+        await createAutomationRunStep(automation.id, runId, 'pending');
+        const siteUuid = (await models.Settings.findOne({ key: 'site_uuid' })).get('value');
+        const tinybird = nock(TINYBIRD_ENDPOINT)
+          .get('/v0/pipes/api_automation_browse_stats.json')
+          .query({ site_uuid: siteUuid })
+          .reply(status, response);
+
+        const { body } = await agent.get('automations').expectStatus(200);
+
+        assert.ok(tinybird.isDone());
+        assert.equal(body.automations.length, 2);
+        assert.deepEqual(body.automations.find((item) => item.id === automation.id).stats, {
+          last_run_created_at: createdAt.toISOString(),
+          total_run_count: 1,
+          in_progress_run_count: 1,
+        });
+      });
+
+      it('falls back after one retryable response without the test-only retry override', async function () {
+        const got = require('got').default;
+        const requestExternal = require('../../../core/server/lib/request-external');
+        // Use Got's normal retry policy, without request-external's test-only hook.
+        const extend = sinon
+          .stub(requestExternal, 'extend')
+          .callsFake((options) => got.extend(options));
+        sinon.stub(require('@tryghost/logging'), 'error');
+        const [automation] = await models.Base.knex('automations').select('id');
+        await createAutomationRun(automation.id, new Date('2026-01-01T00:00:00.000Z'));
+        const siteUuid = (await models.Settings.findOne({ key: 'site_uuid' })).get('value');
+        const firstAttempt = nock(TINYBIRD_ENDPOINT)
+          .get('/v0/pipes/api_automation_browse_stats.json')
+          .query({ site_uuid: siteUuid })
+          .reply(503, 'unavailable');
+        const retry = nock(TINYBIRD_ENDPOINT)
+          .get('/v0/pipes/api_automation_browse_stats.json')
+          .query({ site_uuid: siteUuid })
+          .reply(200, { data: [] });
+
+        const { body } = await agent.get('automations').expectStatus(200);
+
+        assert.ok(extend.calledOnce);
+        assert.ok(firstAttempt.isDone());
+        assert.equal(retry.isDone(), false);
+        assert.equal(
+          body.automations.find((item) => item.id === automation.id).stats.total_run_count,
+          1,
+        );
+      });
+
+      it('keeps zero stats for a successful empty Tinybird response', async function () {
+        const [automation] = await models.Base.knex('automations').select('id');
+        await createAutomationRun(automation.id, new Date('2026-01-01T00:00:00.000Z'));
+        const siteUuid = (await models.Settings.findOne({ key: 'site_uuid' })).get('value');
+        const tinybird = nock(TINYBIRD_ENDPOINT)
+          .get('/v0/pipes/api_automation_browse_stats.json')
+          .query({ site_uuid: siteUuid })
+          .reply(200, { data: [] });
+
+        const { body } = await agent.get('automations').expectStatus(200);
+
+        assert.ok(tinybird.isDone());
+        assert.deepEqual(body.automations.find((item) => item.id === automation.id).stats, {
+          last_run_created_at: null,
+          total_run_count: 0,
+          in_progress_run_count: 0,
+        });
+      });
     });
 
     it('upserts the default free and paid automations', async function () {

--- a/ghost/core/test/unit/server/services/automations/tinybird-automation-stats.test.ts
+++ b/ghost/core/test/unit/server/services/automations/tinybird-automation-stats.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { afterEach, describe, it } from 'vitest';
+import logging from '@tryghost/logging';
+import { fetchAutomationStats } from '../../../../../core/server/services/automations/tinybird-automation-stats';
+
+const clientReturning = (value: unknown) => ({ fetch: sinon.stub().resolves(value) });
+
+describe('fetchAutomationStats', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('reads the automation browse stats pipe', async function () {
+    const client = clientReturning([]);
+
+    await fetchAutomationStats(client);
+
+    assert.ok(client.fetch.calledOnceWithExactly('api_automation_browse_stats', { version: '' }));
+  });
+
+  it('maps rows by automation id, parsing UTC dates and numeric strings', async function () {
+    const client = clientReturning([
+      {
+        automation_id: 'automation-1',
+        last_run_created_at: '2026-02-01T01:00:00.000Z',
+        total_run_count: '4',
+        in_progress_run_count: 2,
+      },
+      {
+        automation_id: 'automation-2',
+        last_run_created_at: null,
+        total_run_count: 0,
+        in_progress_run_count: 0,
+      },
+    ]);
+
+    const stats = await fetchAutomationStats(client);
+
+    assert.ok(stats);
+    assert.deepEqual(stats.get('automation-1'), {
+      last_run_created_at: new Date('2026-02-01T01:00:00.000Z'),
+      total_run_count: 4,
+      in_progress_run_count: 2,
+    });
+    assert.deepEqual(stats.get('automation-2'), {
+      last_run_created_at: null,
+      total_run_count: 0,
+      in_progress_run_count: 0,
+    });
+  });
+
+  it('returns null when the client could not fetch', async function () {
+    assert.equal(await fetchAutomationStats(clientReturning(null)), null);
+  });
+
+  it('returns null and logs when the response has an unexpected shape', async function () {
+    const error = sinon.stub(logging, 'error');
+
+    const stats = await fetchAutomationStats(clientReturning([{ automation_id: 42 }]));
+
+    assert.equal(stats, null);
+    assert.ok(error.calledOnce);
+  });
+  it.each([
+    { last_run_created_at: 'invalid' },
+    { last_run_created_at: '2026-02-01 01:00:00' },
+    { last_run_created_at: '2026-02-30T01:00:00.000Z' },
+    { total_run_count: null },
+    { total_run_count: -1 },
+    { in_progress_run_count: 1.5 },
+  ])('omits invalid stats: %j', async function (overrides) {
+    sinon.stub(logging, 'error');
+    const stats = await fetchAutomationStats(
+      clientReturning([
+        {
+          automation_id: 'automation-1',
+          last_run_created_at: '2026-02-01T01:00:00.000Z',
+          total_run_count: 4,
+          in_progress_run_count: 2,
+          ...overrides,
+        },
+      ]),
+    );
+    assert.equal(stats, null);
+  });
+});

--- a/ghost/core/test/unit/server/services/stats/stats.test.ts
+++ b/ghost/core/test/unit/server/services/stats/stats.test.ts
@@ -1,9 +1,45 @@
 import assert from 'node:assert/strict';
 import knex from 'knex';
+import sinon from 'sinon';
+const TinybirdServiceWrapper = require('../../../../../core/server/services/tinybird');
 // @ts-expect-error This module lacks type definitions.
 import StatsService from '../../../../../core/server/services/stats/stats-service';
 
 describe('StatsService', function () {
+  afterEach(() => sinon.restore());
+
+  it.each([
+    { webAnalytics: false, sync: true, configured: true, initialized: true },
+    { webAnalytics: false, sync: false, configured: true, initialized: false },
+    { webAnalytics: false, sync: true, configured: false, initialized: false },
+    { webAnalytics: true, sync: false, configured: true, initialized: true },
+  ])(
+    'initializes Tinybird for the enabled analytics source: %j',
+    function ({ webAnalytics, sync, configured, initialized }) {
+      const init = sinon.stub(TinybirdServiceWrapper, 'init');
+      const isSet = sinon.stub();
+      isSet.withArgs('automationsTinybirdSync').returns(sync);
+      const getSetting = sinon.stub();
+      getSetting.withArgs('web_analytics_enabled').returns(webAnalytics);
+      const getConfig = sinon.stub();
+      getConfig
+        .withArgs('tinybird:stats')
+        .returns(configured ? { endpoint: 'https://api.tinybird.co' } : null);
+      const service = StatsService.create({
+        knex: knex({
+          client: 'better-sqlite3',
+          useNullAsDefault: true,
+          connection: { filename: ':memory:' },
+        }),
+        settingsCache: { get: getSetting },
+        config: { get: getConfig },
+        labs: { isSet },
+      });
+      assert.equal(init.calledOnce, initialized);
+      assert.equal(Boolean(service.posts.tinybirdClient), webAnalytics);
+      assert.equal(Boolean(service.content.tinybirdClient), webAnalytics);
+    },
+  );
   it('Exposes a create factory', function () {
     const service = StatsService.create({
       knex: knex({


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1560

Read automation browse stats from Tinybird behind automationsTinybirdSync, skipping MySQL aggregation on success. Validate responses and fall back to MySQL on missing credentials or failure, without retrying Tinybird requests.

Initialize Tinybird independently of web analytics while keeping traffic queries gated. Cover source selection, fallback, initialization, and retries.
