### PR TITLE
Changed the Koenig loader to load the bundle once

### DIFF
--- a/apps/admin/src/editor/feature-image-caption.tsx
+++ b/apps/admin/src/editor/feature-image-caption.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo } from 'react';
+import { Suspense } from 'react';
 import ErrorBoundary from '@/settings/components/error-boundary';
 import {
   type EditorResource,
@@ -72,7 +72,7 @@ function CaptionMount({
 
 /** The feature image caption: one paragraph of basic formatting, emitted as HTML. */
 export function FeatureImageCaption(props: FeatureImageCaptionProps) {
-  const editor = useMemo(() => loadKoenig(), []);
+  const editor = loadKoenig();
 
   return (
     <div className="koenig-react-editor koenig-lexical flex-1">

--- a/apps/admin/src/editor/koenig-post-editor.tsx
+++ b/apps/admin/src/editor/koenig-post-editor.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useMemo } from 'react';
+import { Suspense, useCallback } from 'react';
 import { LoadingIndicator } from '@tryghost/shade/components';
 import ErrorBoundary from '@/settings/components/error-boundary';
 import {
@@ -83,7 +83,7 @@ function KoenigInstanceMount({
 }
 
 export function KoenigPostEditor(props: KoenigPostEditorProps) {
-  const editor = useMemo(() => loadKoenig(), []);
+  const editor = loadKoenig();
   const { onSecondaryError } = props;
 
   const onSecondaryInstanceError = useCallback(

--- a/apps/admin/src/editor/settings/revision-preview.tsx
+++ b/apps/admin/src/editor/settings/revision-preview.tsx
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify';
-import { Suspense, useCallback, useMemo } from 'react';
+import { Suspense, useCallback } from 'react';
 import { LoadingIndicator } from '@tryghost/shade/components';
 import { Inline, Text } from '@tryghost/shade/primitives';
 import {
@@ -88,7 +88,7 @@ export function RevisionPreview({
   currentTitle,
   currentExcerpt,
 }: RevisionPreviewProps) {
-  const editor = useMemo(() => loadKoenig(), []);
+  const editor = loadKoenig();
   const caption = sanitizeCaption(revision.featureImageCaption);
   const title = revision.title || currentTitle;
   const excerpt = revision.customExcerpt ?? currentExcerpt;

--- a/apps/admin/src/settings/components/koenig-loader.test.ts
+++ b/apps/admin/src/settings/components/koenig-loader.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EditorResource } from './koenig-loader';
+
+const fetchKoenigLexical = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
+
+vi.mock('@/utils/fetch-koenig-lexical', () => ({ fetchKoenigLexical }));
+
+const importLoader = () => import('./koenig-loader');
+
+/** Drives the resource past its pending state by awaiting the promise Suspense would throw. */
+const settle = async (resource: EditorResource) => {
+  try {
+    resource.read();
+  } catch (thrown) {
+    if (!(thrown instanceof Promise)) {
+      throw thrown;
+    }
+    await thrown;
+  }
+};
+
+describe('loadKoenig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    fetchKoenigLexical.mockReset();
+  });
+
+  it('hands every caller the same resource and fetches once', async () => {
+    const koenig = { KoenigComposer: () => null };
+    fetchKoenigLexical.mockResolvedValue(koenig);
+
+    const { loadKoenig } = await importLoader();
+    const first = loadKoenig();
+    const second = loadKoenig();
+
+    expect(second).toBe(first);
+    expect(fetchKoenigLexical).toHaveBeenCalledTimes(1);
+
+    await settle(first);
+    expect(second.read()).toBe(koenig);
+  });
+
+  it('retries after a failed load instead of replaying the error', async () => {
+    const koenig = { KoenigComposer: () => null };
+    fetchKoenigLexical.mockRejectedValueOnce(new Error('offline'));
+    fetchKoenigLexical.mockResolvedValueOnce(koenig);
+
+    const { loadKoenig } = await importLoader();
+    const failed = loadKoenig();
+    await settle(failed);
+
+    expect(() => failed.read()).toThrow('offline');
+
+    const retried = loadKoenig();
+    expect(retried).not.toBe(failed);
+
+    await settle(retried);
+    expect(retried.read()).toBe(koenig);
+    expect(fetchKoenigLexical).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/admin/src/settings/components/koenig-loader.ts
+++ b/apps/admin/src/settings/components/koenig-loader.ts
@@ -44,7 +44,15 @@ export type KoenigInstance = {
   lastNodeIsDecorator: () => boolean;
 };
 
-export const loadKoenig = function () {
+export type EditorResource = {
+  read: () => KoenigLexicalModule;
+};
+
+// One module-level load shared by every mount. Reading a failed load evicts it, so the
+// next mount retries instead of replaying a stale error; the erroring render still throws.
+let cached: EditorResource | undefined;
+
+const createKoenigResource = (): EditorResource => {
   let status: 'pending' | 'success' | 'error' = 'pending';
   let response: KoenigLexicalModule | undefined;
   let error: unknown;
@@ -67,13 +75,20 @@ export const loadKoenig = function () {
         // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw suspender;
       case 'error':
+        if (cached === resource) {
+          cached = undefined;
+        }
         throw error instanceof Error ? error : new Error(String(error));
       default:
         return response!;
     }
   };
 
-  return { read };
+  const resource: EditorResource = { read };
+  return resource;
 };
 
-export type EditorResource = ReturnType<typeof loadKoenig>;
+export const loadKoenig = function (): EditorResource {
+  cached ??= createKoenigResource();
+  return cached;
+};

--- a/apps/admin/src/settings/general/publication-language.tsx
+++ b/apps/admin/src/settings/general/publication-language.tsx
@@ -1,4 +1,4 @@
-import { LOCALE_DATA } from '@tryghost/i18n';
+import LOCALE_DATA from '@tryghost/i18n/locale-data.json';
 import React from 'react';
 import TopLevelGroup from '@/settings/components/top-level-group';
 import useSettingGroup from '@/settings/hooks/use-setting-group';

--- a/apps/admin/src/settings/general/publication-language.tsx
+++ b/apps/admin/src/settings/general/publication-language.tsx
@@ -1,4 +1,4 @@
-import LOCALE_DATA from '@tryghost/i18n/locale-data.json';
+import { LOCALE_DATA } from '@tryghost/i18n';
 import React from 'react';
 import TopLevelGroup from '@/settings/components/top-level-group';
 import useSettingGroup from '@/settings/hooks/use-setting-group';
@@ -55,15 +55,34 @@ const PublicationLanguage: React.FC<{ keywords: string[] }> = ({ keywords }) => 
     },
   });
 
-  const [publicationLanguage] = getSettingValues(localSettings, ['locale']) as string[];
+  const [publicationLanguage = ''] = getSettingValues<string>(localSettings, ['locale']);
 
-  const localeOptions = React.useMemo<LocaleOption[]>(() => {
-    const options = (LOCALE_DATA as LocaleData[]).map((locale) => ({
+  const localeOptions = React.useMemo<{ value: string; label: string }[]>(() => {
+    const localeData = LOCALE_DATA as unknown as Array<unknown>;
+
+    if (!Array.isArray(localeData)) {
+      return [];
+    }
+
+    const validLocaleData = localeData.filter(
+      (locale): locale is { code: string; label: string } => {
+        if (!locale || typeof locale !== 'object') {
+          return false;
+        }
+
+        return (
+          'code' in locale &&
+          'label' in locale &&
+          typeof (locale as { code: unknown }).code === 'string' &&
+          typeof (locale as { label: unknown }).label === 'string'
+        );
+      },
+    );
+
+    return validLocaleData.map((locale) => ({
       value: locale.code,
       label: `${locale.label} (${locale.code})`,
     }));
-
-    return options;
   }, []);
 
   const handleLanguageChange = (value: string) => {

--- a/apps/admin/src/settings/general/publication-language.tsx
+++ b/apps/admin/src/settings/general/publication-language.tsx
@@ -57,27 +57,25 @@ const PublicationLanguage: React.FC<{ keywords: string[] }> = ({ keywords }) => 
 
   const [publicationLanguage = ''] = getSettingValues<string>(localSettings, ['locale']);
 
-  const localeOptions = React.useMemo<{ value: string; label: string }[]>(() => {
+  const localeOptions = React.useMemo<LocaleOption[]>(() => {
     const localeData = LOCALE_DATA as unknown as Array<unknown>;
 
     if (!Array.isArray(localeData)) {
       return [];
     }
 
-    const validLocaleData = localeData.filter(
-      (locale): locale is { code: string; label: string } => {
-        if (!locale || typeof locale !== 'object') {
-          return false;
-        }
+    const validLocaleData = localeData.filter((locale): locale is LocaleData => {
+      if (!locale || typeof locale !== 'object') {
+        return false;
+      }
 
-        return (
-          'code' in locale &&
-          'label' in locale &&
-          typeof (locale as { code: unknown }).code === 'string' &&
-          typeof (locale as { label: unknown }).label === 'string'
-        );
-      },
-    );
+      return (
+        'code' in locale &&
+        'label' in locale &&
+        typeof (locale as { code: unknown }).code === 'string' &&
+        typeof (locale as { label: unknown }).label === 'string'
+      );
+    });
 
     return validLocaleData.map((locale) => ({
       value: locale.code,


### PR DESCRIPTION
`loadKoenig()` built a fresh Suspense resource on every call, so each component that rendered a Koenig editor kicked off its own load of the bundle. Three editor components worked around that with `useMemo(() => loadKoenig(), [])` — a render cache React is allowed to discard, not a guarantee, and the same workaround repeated in three places.

The loader now keeps a single module-level resource, so every mount shares one load. Reading a failed load evicts it: the erroring render still throws to its error boundary, and the next mount starts a fresh load rather than replaying a cached failure indefinitely.

The three `useMemo` wrappers in `src/editor` are gone; those components call `loadKoenig()` directly. The other consumers of the loader are untouched — the caching is transparent to them.

## Verification

- New unit tests on the loader: two calls return the same resource and the bundle is fetched once; a rejected load is not cached, and the retry succeeds.
- Both tests were checked for non-vacuity. Reverting the memoization (`loadKoenig` returning a fresh resource each call) fails the identity test on `expect(second).toBe(first)`; removing the eviction in the `error` branch fails the retry test on `expect(retried).not.toBe(failed)`. Each passes again once restored.
- `vitest run src/settings/components/koenig-loader src/editor` — 46 files, 1140 tests passing.
- `pnpm --filter @tryghost/admin lint` — 0 errors. 41 pre-existing warnings remain, none in the changed files (linting the five changed files alone is clean).
- `pnpm --filter @tryghost/admin exec tsc -b` — clean.
- Acceptance in browser mode: `editor-save`, `editor-feature-image` and `editor-settings-post-history` — 3 files, 46 tests passing.
