### PR TITLE
Changed limit-service from CommonJS to ESM

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -49,11 +49,7 @@ export default defineConfig(({ command }) => ({
     // forwardConsole: { logLevels: ['warn', 'error'] }
   },
   optimizeDeps: {
-    // limit-service is CommonJS, and Vite only converts CommonJS while pre-bundling. A
-    // workspace package is treated as source and served raw, where `module` does not exist,
-    // so the import fails and the limiter silently falls back to reporting every host limit
-    // as absent. Force it through the pre-bundler until the package itself is converted.
-    include: ['@tryghost/koenig-lexical', '@tryghost/limit-service'],
+    include: ['@tryghost/koenig-lexical'],
   },
   resolve: sharedResolve,
   test: {

--- a/apps/admin/vitest.acceptance.config.ts
+++ b/apps/admin/vitest.acceptance.config.ts
@@ -34,11 +34,6 @@ export default defineConfig({
     // suite. Test files and screen helpers import test-lane modules the
     // browser bundler can't process; vitest serves those itself.
     entries: ['src/**/*.{ts,tsx}', '!src/**/*.test.*', '!src/**/*.screen.ts'],
-    // limit-service is CommonJS, and Vite only converts CommonJS while pre-bundling. A
-    // workspace package is treated as source and served raw, where `module` does not exist,
-    // so the import fails and the limiter silently falls back to reporting every host limit
-    // as absent. Force it through the pre-bundler until the package itself is converted.
-    include: ['@tryghost/limit-service'],
   },
   resolve: sharedResolve,
   test: {

--- a/ghost/core/core/server/services/limits.js
+++ b/ghost/core/core/server/services/limits.js
@@ -2,7 +2,8 @@ const errors = require('@tryghost/errors');
 const config = require('../../shared/config');
 const db = require('../data/db');
 const logging = require('@tryghost/logging');
-const LimitService = require('@tryghost/limit-service');
+// @tryghost/limit-service is ESM, so require() hands back its namespace
+const LimitService = require('@tryghost/limit-service').default;
 let limitService = new LimitService();
 
 const init = () => {

--- a/ghost/core/test/e2e-api/admin/host-limits.test.ts
+++ b/ghost/core/test/e2e-api/admin/host-limits.test.ts
@@ -436,7 +436,7 @@ describe('Host limits', function () {
     it('exports something a caller can construct directly', function () {
       // Two places construct the service themselves rather than using Ghost's, so the shape
       // of the export is part of what a change to this package must not break.
-      const exported = require('@tryghost/limit-service');
+      const exported = require('@tryghost/limit-service').default;
 
       assert.equal(typeof exported, 'function');
       assert.doesNotThrow(() => new exported());

--- a/ghost/core/test/integration/services/webhook-request.test.js
+++ b/ghost/core/test/integration/services/webhook-request.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const nock = require('nock');
-const LimitService = require('@tryghost/limit-service');
+const LimitService = require('@tryghost/limit-service').default;
 
 const WebhookTrigger = require('../../../core/server/services/webhooks/webhook-trigger');
 const configUtils = require('../../utils/config-utils');

--- a/ghost/core/test/unit/server/services/webhooks/trigger.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/trigger.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const crypto = require('crypto');
 const sinon = require('sinon');
 const logging = require('@tryghost/logging');
-const LimitService = require('@tryghost/limit-service');
+const LimitService = require('@tryghost/limit-service').default;
 
 const WebhookTrigger = require('../../../../../core/server/services/webhooks/webhook-trigger');
 const configUtils = require('../../../../utils/config-utils');

--- a/packages/limit-service/.eslintrc.js
+++ b/packages/limit-service/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-    plugins: ['ghost'],
-    extends: [
-        'plugin:ghost/node'
-    ]
-};

--- a/packages/limit-service/README.md
+++ b/packages/limit-service/README.md
@@ -17,9 +17,10 @@ or
 Below is a sample code to wire up limit service and perform few common limit checks:
 
 ```js
-const knex = require('knex');
-const errors = require('@tryghost/errors');
-const LimitService = require('@tryghost/limit-service');
+import knex from 'knex';
+import errors from '@tryghost/errors';
+import LimitService from '@tryghost/limit-service';
+// CommonJS callers get the namespace: const LimitService = require('@tryghost/limit-service').default;
 
 // create a LimitService instance
 const limitService = new LimitService();

--- a/packages/limit-service/eslint.config.mjs
+++ b/packages/limit-service/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { nodeLibConfig } from '@internal/cfg-eslint';
+
+export default nodeLibConfig({
+  typescript: false,
+  extraTestRules: {
+    // The spec for the PascalCase service class is PascalCase too.
+    'ghost/filenames/match-regex': 'off',
+    // Tests throw native errors as unreachable-path guards.
+    'ghost/ghost-custom/no-native-error': 'off',
+  },
+  extraBlocks: [
+    {
+      // The service class file is PascalCase, matching the exported class.
+      files: ['lib/LimitService.js'],
+      rules: { 'ghost/filenames/match-regex': 'off' },
+    },
+  ],
+});

--- a/packages/limit-service/index.js
+++ b/packages/limit-service/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/LimitService');
+export {default} from './lib/LimitService.js';

--- a/packages/limit-service/lib/LimitService.js
+++ b/packages/limit-service/lib/LimitService.js
@@ -1,9 +1,13 @@
-const camelCase = require('lodash/camelCase');
-const has = require('lodash/has');
-const {IncorrectUsageError} = require('@tryghost/errors');
+import camelCase from 'lodash/camelCase.js';
+import has from 'lodash/has.js';
+// Node's loader offers no named exports for @tryghost/errors, so its classes
+// come off the default export
+import ghostErrors from '@tryghost/errors';
 
-const {MaxLimit, MaxPeriodicLimit, FlagLimit, AllowlistLimit} = require('./limit');
-const config = require('./config');
+import {MaxLimit, MaxPeriodicLimit, FlagLimit, AllowlistLimit} from './limit.js';
+import config from './config.js';
+
+const {IncorrectUsageError} = ghostErrors;
 
 const messages = {
     missingErrorsConfig: `Config Missing: 'errors' is required.`,
@@ -186,7 +190,7 @@ class LimitService {
     }
 }
 
-module.exports = LimitService;
+export default LimitService;
 
 /**
  * @typedef {Object} LimitConfig

--- a/packages/limit-service/lib/config.js
+++ b/packages/limit-service/lib/config.js
@@ -2,7 +2,7 @@
 // Each type of limit has it's own structure:
 // 1. FlagLimit and AllowlistLimit types are empty objects paired with a key, e.g.: `customThemes: {}`
 // 2. MaxLimit should contain a `currentCountQuery` function which would count the resources under limit
-module.exports = {
+export default {
     members: {
         currentCountQuery: async (knex) => {
             let result = await knex('members').count('id', {as: 'count'}).first();

--- a/packages/limit-service/lib/date-utils.js
+++ b/packages/limit-service/lib/date-utils.js
@@ -1,5 +1,9 @@
-const {DateTime} = require('luxon');
-const {IncorrectUsageError} = require('@tryghost/errors');
+import {DateTime} from 'luxon';
+// Node's loader offers no named exports for @tryghost/errors, so its classes
+// come off the default export
+import ghostErrors from '@tryghost/errors';
+
+const {IncorrectUsageError} = ghostErrors;
 
 const messages = {
     invalidInterval: 'Invalid interval specified. Only "month" value is accepted.'
@@ -31,7 +35,7 @@ const lastPeriodStart = (startDate, interval) => {
     });
 };
 
-module.exports = {
+export {
     lastPeriodStart,
     SUPPORTED_INTERVALS
 };

--- a/packages/limit-service/lib/limit.js
+++ b/packages/limit-service/lib/limit.js
@@ -1,6 +1,6 @@
-const lowerCase = require('lodash/lowerCase');
-const template = require('lodash/template');
-const {lastPeriodStart, SUPPORTED_INTERVALS} = require('./date-utils');
+import lowerCase from 'lodash/lowerCase.js';
+import template from 'lodash/template.js';
+import {lastPeriodStart, SUPPORTED_INTERVALS} from './date-utils.js';
 
 const interpolate = /{{([\s\S]+?)}}/g;
 
@@ -366,7 +366,7 @@ class AllowlistLimit extends Limit {
     }
 }
 
-module.exports = {
+export {
     MaxLimit,
     MaxPeriodicLimit,
     FlagLimit,

--- a/packages/limit-service/package.json
+++ b/packages/limit-service/package.json
@@ -8,12 +8,13 @@
     },
     "author": "Ghost Foundation",
     "license": "MIT",
+    "type": "module",
     "main": "index.js",
     "exports": "./index.js",
     "scripts": {
         "dev": "echo \"Implement me!\"",
         "test": "NODE_ENV=testing c8 --reporter text --reporter cobertura mocha './test/**/*.test.js'",
-        "lint": "eslint . --ext .js --cache",
+        "lint": "eslint . --cache",
         "posttest": "pnpm run lint"
     },
     "files": [
@@ -21,7 +22,9 @@
         "lib"
     ],
     "devDependencies": {
+        "@internal/cfg-eslint": "workspace:*",
         "c8": "12.0.0",
+        "eslint": "catalog:",
         "mocha": "12.0.0",
         "should": "13.2.3",
         "sinon": "22.1.0"
@@ -34,6 +37,6 @@
     "private": true,
     "ghostPackage": {
         "goldenPath": "migration",
-        "reason": "Imported from TryGhost/SDK with its history. Still CommonJS with mocha tests, and still contains Ghost's database queries. Modernised in the change that follows this one."
+        "reason": "Imported from TryGhost/SDK with its history. Now ESM, but still plain JavaScript with mocha tests, and still contains Ghost's database queries."
     }
 }

--- a/packages/limit-service/test/.eslintrc.js
+++ b/packages/limit-service/test/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-    plugins: ['ghost'],
-    extends: [
-        'plugin:ghost/test'
-    ]
-};

--- a/packages/limit-service/test/LimitService.test.js
+++ b/packages/limit-service/test/LimitService.test.js
@@ -1,25 +1,23 @@
 // Switch these lines once there are useful utils
-// const testUtils = require('./utils');
-require('./utils');
-const should = require('should');
-const assert = require('node:assert').strict;
-const LimitService = require('../lib/LimitService');
-const {MaxLimit, MaxPeriodicLimit, FlagLimit} = require('../lib/limit');
-const sinon = require('sinon');
+// import * as testUtils from './utils/index.js';
+import './utils/index.js';
+import should from 'should';
+import {strict as assert} from 'node:assert';
+import LimitService from '../lib/LimitService.js';
+import LimitServiceFromIndex from '../index.js';
+import {MaxLimit, MaxPeriodicLimit, FlagLimit} from '../lib/limit.js';
+import sinon from 'sinon';
+import _ from 'lodash';
 
-const errors = require('./fixtures/errors');
+import errors from './fixtures/errors.js';
 
 describe('Limit Service', function () {
     it('is exported via the package index', function () {
-        const LimitServiceFromIndex = require('../index');
         assert.equal(LimitServiceFromIndex, LimitService);
     });
 
     describe('Lodash Template', function () {
         it('Does not get clobbered by this lib', function () {
-            require('../lib/limit');
-            let _ = require('lodash');
-
             _.templateSettings.interpolate.should.eql(/<%=([\s\S]+?)%>/g);
         });
     });

--- a/packages/limit-service/test/config.test.js
+++ b/packages/limit-service/test/config.test.js
@@ -1,7 +1,7 @@
-require('./utils');
-const assert = require('node:assert').strict;
-const sinon = require('sinon');
-const config = require('../lib/config');
+import './utils/index.js';
+import {strict as assert} from 'node:assert';
+import sinon from 'sinon';
+import config from '../lib/config.js';
 
 describe('Config', function () {
     afterEach(function () {

--- a/packages/limit-service/test/date-utils.test.js
+++ b/packages/limit-service/test/date-utils.test.js
@@ -1,11 +1,11 @@
 // Switch these lines once there are useful utils
-// const testUtils = require('./utils');
-require('./utils');
+// import * as testUtils from './utils/index.js';
+import './utils/index.js';
 
-const {DateTime} = require('luxon');
-const sinon = require('sinon');
-const assert = require('node:assert').strict;
-const {lastPeriodStart} = require('../lib/date-utils');
+import {DateTime} from 'luxon';
+import sinon from 'sinon';
+import {strict as assert} from 'node:assert';
+import {lastPeriodStart} from '../lib/date-utils.js';
 
 describe('Date Utils', function () {
     describe('fn: lastPeriodStart', function () {

--- a/packages/limit-service/test/fixtures/errors.js
+++ b/packages/limit-service/test/fixtures/errors.js
@@ -19,7 +19,7 @@ class HostLimitError extends Error {
 }
 
 // NOTE: this module is here to serve as a dummy fixture for GhostError errors (@tryghost/errors)
-module.exports = {
+export default {
     IncorrectUsageError,
     HostLimitError
 };

--- a/packages/limit-service/test/limit.test.js
+++ b/packages/limit-service/test/limit.test.js
@@ -1,12 +1,12 @@
 // Switch these lines once there are useful utils
-// const testUtils = require('./utils');
-require('./utils');
-const should = require('should');
-const sinon = require('sinon');
-const assert = require('node:assert').strict;
+// import * as testUtils from './utils/index.js';
+import './utils/index.js';
+import should from 'should';
+import sinon from 'sinon';
+import {strict as assert} from 'node:assert';
 
-const errors = require('./fixtures/errors');
-const {MaxLimit, AllowlistLimit, FlagLimit, MaxPeriodicLimit} = require('../lib/limit');
+import errors from './fixtures/errors.js';
+import {MaxLimit, AllowlistLimit, FlagLimit, MaxPeriodicLimit} from '../lib/limit.js';
 
 describe('Limit', function () {
     describe('Flag Limit', function () {

--- a/packages/limit-service/test/utils/index.js
+++ b/packages/limit-service/test/utils/index.js
@@ -4,8 +4,8 @@
  * Shared utils for writing tests
  */
 
-// Require overrides - these add globals for tests
-require('./overrides');
+// Import overrides - these add globals for tests
+import './overrides.js';
 
-// Require assertions - adds custom should assertions
-require('./assertions');
+// Import assertions - adds custom should assertions
+import './assertions.js';

--- a/packages/limit-service/test/utils/overrides.js
+++ b/packages/limit-service/test/utils/overrides.js
@@ -1,10 +1,7 @@
-// This file is required before any test is run
+// This file is imported before any test is run
 
-// Taken from the should wiki, this is how to make should global
-// Should is a global in our eslint test config
-global.should = require('should').noConflict();
-should.extend();
+import shouldModule from 'should';
 
-// Sinon is a simple case
-// Sinon is a global in our eslint test config
-global.sinon = require('sinon');
+// `should` installs itself as a non-writable global on import, so it can only be
+// re-pointed through its own noConflict()/extend() pair
+shouldModule.noConflict().extend();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4370,9 +4370,15 @@ importers:
         specifier: 3.7.2
         version: 3.7.2
     devDependencies:
+      '@internal/cfg-eslint':
+        specifier: workspace:*
+        version: link:../../configs/eslint
       c8:
         specifier: 12.0.0
         version: 12.0.0
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
       mocha:
         specifier: 12.0.0
         version: 12.0.0


### PR DESCRIPTION
`@tryghost/limit-service` was the last workspace package still written in CommonJS. It is now `"type": "module"` with `import`/`export` throughout, including its mocha suite.

## Why

Admin loads the package through a module-level dynamic import in the limiter hook, and Vite serves a workspace package as source rather than pre-bundling it. Both admin Vite configs therefore carried an `optimizeDeps.include` entry to force the CommonJS source through the pre-bundler. Vite could not resolve that entry from `apps/admin` in any case — the package is a dependency of `admin-x-framework`, not of `apps/admin` — so every acceptance run logged:

```
Failed to resolve dependency: @tryghost/limit-service, present in client 'optimizeDeps.include'
```

With the package as ESM there is nothing to pre-bundle around: Vite serves it as-is, Node loads it directly, and both `optimizeDeps.include` entries and their comments are gone, along with that warning.

## Changes

- `packages/limit-service` is `"type": "module"`; `index.js`, `lib/` and `test/` use `import`/`export`.
- `ghost/core` and the two suites that construct the service directly keep `require()` and read the class off `.default`. Node 22.12+ supports `require()` of an ESM graph with no top-level await, and the package has none.
- `should` installs itself as a non-writable global, so the test overrides go through its own `noConflict()`/`extend()` pair. The old assignment to `global.should` was a silent no-op under sloppy-mode CommonJS and throws under ESM. The unused `global.sinon` alias is dropped — every spec imports sinon directly.
- Lint moves to the shared `nodeLibConfig()` flat config. The package only had the two legacy `.eslintrc.js` files, which ESLint 9 ignores and which would not parse in a module package, so `pnpm lint` was matching the repo root's flat config and linting nothing (`ESLintEmptyConfigWarning`). The new config disables the filename rule for the PascalCase service class file and its spec, and the native-error rule for the specs that throw guard errors; the `lint` script drops the now pointless `--ext` flag.
- The README usage sample uses the ESM import and notes the `.default` form CommonJS callers need.

## Verification

- `pnpm --filter @tryghost/limit-service test` — 83 passing, 100% statement coverage; `posttest` lint clean.
- `pnpm --filter @tryghost/limit-service lint` — exit 0, now actually linting 14 files.
- `pnpm nx run @tryghost/admin-x-framework:build` — exit 0.
- Admin acceptance, scoped to `src/editor/editor.acceptance.test.tsx src/tags` at 2 workers — 3 files, 43 tests, exit 0, and the `optimizeDeps` resolve warning no longer appears.
- Admin acceptance, `src/settings/general/staff-invitations.acceptance.test.tsx` (renders the invite modal, which calls `useLimiter`) — 6 tests, exit 0.

