### PR TITLE
Fixed the acceptance boot table missing a member-count request shape

### DIFF
--- a/apps/admin/src/editor/editor-settings-show-title.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-show-title.acceptance.test.tsx
@@ -6,7 +6,6 @@ import {
   activeThemeResponse,
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
   fakeNewsletters,
   fakePages,
   fakePosts,
@@ -94,8 +93,7 @@ function editorChrome() {
   fakeSnippets([]);
   fakePosts([]);
   fakePages([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
+  // The header's publish inputs read the newsletter list.
   fakeNewsletters([]);
   fakeAdminEndpoint('GET', /^\/slugs\/post\//, ({ url }) => ({
     slugs: [{ slug: decodeURIComponent(url.split('/slugs/post/')[1].split('/')[0]) }],

--- a/apps/admin/src/editor/editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor.acceptance.test.tsx
@@ -1,18 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  fakeAdminEndpoint,
-  fakeMembers,
-  fakeNewsletters,
-  fakePosts,
-  fakeSnippets,
-  post,
-  renderAdminApp,
-} from '@test-utils/acceptance';
+import { fakeAdminEndpoint, fakeEditorChrome, post, renderAdminApp } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
 
 const FLAG_ON = { labs: { editorReact: true } };
 const FLAG_OFF = { labs: { editorReact: false } };
+
+/**
+ * `EmberRoot` reparents the `#ember-app` stand-in out of `body` into its own
+ * wrapper and leaves that wrapper `hidden` until a route registers an Ember
+ * fallback, so both conditions have to hold — the stand-in is still parented to
+ * `body` on a React route.
+ */
+function emberShellShown(): boolean {
+  const app = document.getElementById('ember-app');
+  const emberRoot = app?.parentElement;
+  if (!app || !emberRoot || emberRoot === document.body) {
+    return false;
+  }
+  return !emberRoot.hidden && app.checkVisibility();
+}
 
 /**
  * The editor route mounts only when its feature flag is enabled. Disabled and
@@ -20,11 +27,7 @@ const FLAG_OFF = { labs: { editorReact: false } };
  */
 describe('Editor flag', () => {
   function fakeEditorWorld() {
-    fakeSnippets([]);
-    fakePosts([]);
-    // The header's publish inputs read the site's member total and newsletter list.
-    fakeMembers([]);
-    fakeNewsletters([]);
+    fakeEditorChrome();
     fakeAdminEndpoint('GET', /^\/posts\/abc123\/\?/, { posts: [post({ id: 'abc123' })] });
     fakeAdminEndpoint('GET', /^\/pages\/abc123\/\?/, { pages: [post({ id: 'abc123' })] });
   }
@@ -52,15 +55,19 @@ describe('Editor flag', () => {
     await expect.element(editorScreen.backLink('page')).toHaveAttribute('href', '#/pages');
   });
 
-  it('does not mount the editor when the flag is off', async () => {
+  it('leaves the editor route to Ember when the flag is off', async () => {
+    fakeEditorChrome();
     await renderAdminApp('/editor/post/abc123', FLAG_OFF);
 
+    await expect.poll(emberShellShown).toBe(true);
     await expect(editorScreen.root()).toHaveCount(0);
   });
 
-  it('does not mount the editor when the flag is absent', async () => {
+  it('leaves the editor route to Ember when the flag is absent', async () => {
+    fakeEditorChrome();
     await renderAdminApp('/editor/post/abc123');
 
+    await expect.poll(emberShellShown).toBe(true);
     await expect(editorScreen.root()).toHaveCount(0);
   });
 });

--- a/apps/admin/src/editor/post-editor.acceptance.test.tsx
+++ b/apps/admin/src/editor/post-editor.acceptance.test.tsx
@@ -6,7 +6,6 @@ import {
   currentRoute,
   currentUserResponse,
   fakeAdminEndpoint,
-  fakeMembers,
   fakeNewsletters,
   fakePosts,
   fakeSnippets,
@@ -28,8 +27,7 @@ const MOBILEDOC =
 // link toolbar preload, the five latest published posts.
 function fakeEditorChrome() {
   fakeSnippets([]);
-  // The header's publish inputs read the site's member total and newsletter list.
-  fakeMembers([]);
+  // The header's publish inputs read the newsletter list.
   fakeNewsletters([]);
   return fakePosts([]);
 }

--- a/apps/admin/src/layout/editor-sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/editor-sidebar.acceptance.test.tsx
@@ -3,7 +3,6 @@ import { page } from 'vitest/browser';
 
 import {
   fakeAdminEndpoint,
-  fakeMembers,
   fakeNewsletters,
   fakePosts,
   fakeSnippets,
@@ -53,8 +52,7 @@ describe('Editor chrome', () => {
   it('hides it with editorReact on', async () => {
     fakeSnippets([]);
     fakePosts([]);
-    // The header's publish inputs read the site's member total and newsletter list.
-    fakeMembers([]);
+    // The header's publish inputs read the newsletter list.
     fakeNewsletters([]);
     fakeAdminEndpoint('GET', /^\/posts\/abc123\/\?/, { posts: [post({ id: 'abc123' })] });
     await renderAdminApp('/editor/post/abc123', { labs: { editorReact: true } });

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -26,6 +26,15 @@ export interface BootRequestConfig {
   responseStatus?: number;
 }
 
+/**
+ * The site-wide member total, asked for in two shapes: `useMemberCount` sends
+ * only `limit`, `useMembersCount` pins order/page around an empty filter. Both
+ * are shell chrome; the members resource fake skips them so they never land in
+ * a spec's `lastRequest`.
+ */
+export const MEMBER_COUNT_PROBE_PATH =
+  /^\/members\/\?(?:limit=1|filter=&order=id&limit=1&page=1)$/;
+
 // A function so every lookup serves freshly-minted responses — mutations
 // can't leak between tests.
 export function defaultBootRequests() {
@@ -52,7 +61,7 @@ export function defaultBootRequests() {
     },
     browseMembersCount: {
       method: 'GET',
-      path: '/members/?limit=1',
+      path: MEMBER_COUNT_PROBE_PATH,
       response: browseResponse('members', [], { limit: 1 }),
     },
     browseMemberCustomFieldDefinitions: {

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -32,8 +32,7 @@ export interface BootRequestConfig {
  * are shell chrome; the members resource fake skips them so they never land in
  * a spec's `lastRequest`.
  */
-export const MEMBER_COUNT_PROBE_PATH =
-  /^\/members\/\?(?:limit=1|filter=&order=id&limit=1&page=1)$/;
+export const MEMBER_COUNT_PROBE_PATH = /^\/members\/\?(?:limit=1|filter=&order=id&limit=1&page=1)$/;
 
 // A function so every lookup serves freshly-minted responses — mutations
 // can't leak between tests.

--- a/apps/admin/test-utils/acceptance/editor.ts
+++ b/apps/admin/test-utils/acceptance/editor.ts
@@ -1,13 +1,12 @@
 import { buildLexicalParagraph, post, settingsResponse, type Post } from '@tryghost/test-data';
 import type { RenderAdminAppOptions } from './render-admin-app';
-import { fakeMembers, fakeNewsletters, fakePosts, fakeSnippets } from './resources';
+import { fakeNewsletters, fakePosts, fakeSnippets } from './resources';
 import { fakeAdminEndpoint, fakeEndpoint, type EndpointCapture } from './worker';
 
 /** Supporting reads shared by the editor's header and card configuration. */
 export function fakeEditorChrome(): void {
   fakeSnippets([]);
   fakePosts([]);
-  fakeMembers([]);
   fakeNewsletters([]);
 }
 

--- a/apps/admin/test-utils/acceptance/resources.ts
+++ b/apps/admin/test-utils/acceptance/resources.ts
@@ -24,6 +24,7 @@ import {
   type Tier,
 } from '@tryghost/test-data';
 
+import { MEMBER_COUNT_PROBE_PATH } from './boot';
 import {
   fakeAdminEndpoint,
   record418,
@@ -240,15 +241,12 @@ export const fakeComments = defineResource<Comment>({
   semantics: { kind: 'passthrough' },
 });
 
-/** The sidebar's global member-count probe — shell chrome, served by the boot table. */
-const MEMBER_COUNT_PROBE_PATH = '/members/?limit=1';
-
 const membersResource = defineResource<Member>({
   resource: 'members',
   semantics: { kind: 'passthrough' },
-  // Leave the sidebar count probe to the boot table so it never pollutes
+  // Leave the site-wide count probe to the boot table so it never pollutes
   // `lastRequest` assertions.
-  skip: (apiPath) => apiPath === MEMBER_COUNT_PROBE_PATH,
+  skip: (apiPath) => MEMBER_COUNT_PROBE_PATH.test(apiPath),
 });
 
 /**


### PR DESCRIPTION
The admin acceptance shell answers the site-wide member count for every spec, but only in one of the two shapes the app asks for it. The boot table's `browseMembersCount` entry declared the exact path `/members/?limit=1`, which is what `useMemberCount` sends; `useMembersCount` asks for the same total as `/members/?filter=&order=id&limit=1&page=1`. Nothing in the shell handled that second shape, so it hit the 418 catch-all and every editor spec had to declare `fakeMembers([])` to cover the publish header.

## What changed

**The boot table matches both count shapes.** The entry now matches `/members/?limit=1` and `/members/?filter=&order=id&limit=1&page=1`, and only those, so a filtered recipient count still 418s when a spec forgets it. Resource fakes are registered at runtime and keep winning over the boot table, so a spec that serves a count with data — or overrides `browseMembersCount` with one — is unaffected.

The members resource fake already skipped the count probe so it could not pollute a spec's `lastRequest`, and it only knew the one shape. It now skips on the same exported pattern the boot table matches on, rather than a second copy of it, so neither shape can be captured by a spec asserting on the members browse it actually made.

**The editor specs drop their member fakes.** `fakeEditorChrome()` and the three editor specs that carried their own `fakeMembers([])` no longer need it. `fakeMembers` declares more than the count — it also stubs labels, tiers, offers, newsletters and member custom-field definitions — and all of that goes with it. Nothing these specs render loses a fake: the boot table serves the custom-field definitions, each of them declares its own `fakeNewsletters([])`, and the editor asks for no labels, tiers or offers.

**The flag-off editor tests assert something.** They checked only that the React editor was absent, which an empty page also satisfies. They now assert the Ember shell is actually shown: `EmberRoot` reparents the `#ember-app` stand-in out of `body` into its own wrapper and leaves that wrapper `hidden` until a route registers an Ember fallback, so the assertion requires both — and is false on a plain React route, where the stand-in never moves. They also declare the editor world so a straggler from a neighbouring test is served rather than blamed on them.

## Verification

- `src/editor` and `src/layout/editor-sidebar` at 2 workers (CI's shape): 376 passed, zero 418s.
- The four specs most exposed to the change — `src/editor/editor`, `src/editor/editor-header`, `src/editor/editor-save`, `src/posts/analytics/post-analytics` — 60 passed, zero 418s. `post-analytics` asserts on the members browse it makes; the count probe stays out of that capture.
- The new Ember-shell predicate was probed both ways: stubbing out `registerFallback()` fails both flag-off tests, and a throwaway render of `/tags` evaluates it to `false`.
- `pnpm --filter @tryghost/admin lint` (0 errors) and `tsc -b` clean.
