### PR TITLE
Added a shared fullscreen dialog to the React editor

### DIFF
--- a/apps/admin/src/editor/editor-header.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-header.acceptance.test.tsx
@@ -625,4 +625,59 @@ describe('Editor header actions', () => {
     },
     SLOW,
   );
+
+  it(
+    'returns focus to the Preview button when the preview closes',
+    async () => {
+      publishChrome();
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await editorScreen.previewButton().click();
+      await expect.element(previewScreen.modal()).toBeVisible();
+
+      await userEvent.keyboard('{Escape}');
+
+      await expect(previewScreen.modal()).toHaveCount(0);
+      await expect.element(editorScreen.previewButton()).toHaveFocus();
+    },
+    SLOW,
+  );
+
+  it(
+    'returns focus to the Publish button when the publish flow closes',
+    async () => {
+      publishChrome();
+      fakeSavablePost();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.publishButton()).toBeEnabled();
+      await editorScreen.publishButton().click();
+      await expect.element(publishScreen.options()).toBeVisible();
+
+      await userEvent.keyboard('{Escape}');
+
+      await expect(publishScreen.root()).toHaveCount(0);
+      await expect.element(editorScreen.publishButton()).toHaveFocus();
+    },
+    SLOW,
+  );
+
+  it(
+    'returns focus to the Unpublish button when the update flow closes',
+    async () => {
+      publishChrome();
+      fakeSavablePost({ status: 'published', published_at: '2026-02-01T10:00:00.000Z' });
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await editorScreen.unpublishButton().click();
+      await expect.element(publishScreen.updateFlow()).toBeVisible();
+
+      await userEvent.keyboard('{Escape}');
+
+      await expect(publishScreen.updateFlow()).toHaveCount(0);
+      await expect.element(editorScreen.unpublishButton()).toHaveFocus();
+    },
+    SLOW,
+  );
 });

--- a/apps/admin/src/editor/fullscreen-dialog.tsx
+++ b/apps/admin/src/editor/fullscreen-dialog.tsx
@@ -1,0 +1,93 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@tryghost/shade/components';
+import { cn } from '@tryghost/shade/utils';
+import { useLayoutEffect, useRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+
+// Overrides Shade's centred, sized dialog surface with a full-viewport one.
+const FRAME =
+  'top-0 left-0 h-dvh w-full max-w-none translate-0 gap-0 rounded-none border-0 p-0 shadow-none sm:rounded-none';
+
+const LAYOUTS = {
+  /** A fixed header row above a body that owns its own scrolling. */
+  header: 'grid-rows-[auto_1fr]',
+  /** One scrolling region, with the title exposed to screen readers only. */
+  plain: 'grid-rows-[1fr] overflow-y-auto',
+} as const;
+
+type DialogContentProps = ComponentPropsWithoutRef<typeof DialogContent>;
+
+export interface FullscreenDialogProps extends Omit<DialogContentProps, 'title'> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Non-modal leaves the page behind interactive; the frame still covers it. */
+  modal?: boolean;
+  title: ReactNode;
+  layout?: keyof typeof LAYOUTS;
+  /** Controls rendered in the header row beside the title. */
+  headerActions?: ReactNode;
+}
+
+/**
+ * The editor's fullscreen dialog frame. Closing it restores focus to the opener,
+ * unless the caller's own `onCloseAutoFocus` claims the event first.
+ */
+export function FullscreenDialog({
+  open,
+  onOpenChange,
+  modal = true,
+  title,
+  layout = 'plain',
+  headerActions,
+  className,
+  children,
+  onCloseAutoFocus,
+  ...props
+}: FullscreenDialogProps) {
+  const openerRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
+
+  // Radix restores focus to a DialogTrigger; these dialogs open from state instead,
+  // so the element focused as they opened is the opener.
+  useLayoutEffect(() => {
+    // Radix fires onCloseAutoFocus a tick after `open` flips, so only capture here.
+    if (open && !wasOpenRef.current) {
+      const active = document.activeElement;
+      openerRef.current = active instanceof HTMLElement && active !== document.body ? active : null;
+    }
+    wasOpenRef.current = open;
+  }, [open]);
+
+  const returnFocus = (event: Event) => {
+    onCloseAutoFocus?.(event);
+
+    const opener = openerRef.current;
+    openerRef.current = null;
+
+    if (event.defaultPrevented || !opener?.isConnected) {
+      return;
+    }
+    event.preventDefault();
+    opener.focus();
+  };
+
+  return (
+    <Dialog modal={modal} open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(FRAME, LAYOUTS[layout], className)}
+        onCloseAutoFocus={returnFocus}
+        // The frame covers the viewport, so an outside interaction is never a dismissal.
+        onInteractOutside={(event) => event.preventDefault()}
+        {...props}
+      >
+        {layout === 'header' ? (
+          <DialogHeader className="flex-row items-center justify-between gap-4 border-b border-border-default p-4">
+            <DialogTitle className="text-lg">{title}</DialogTitle>
+            {headerActions}
+          </DialogHeader>
+        ) : (
+          <DialogTitle className="sr-only">{title}</DialogTitle>
+        )}
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/editor/preview/post-preview-modal.tsx
+++ b/apps/admin/src/editor/preview/post-preview-modal.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
   EmptyIndicator,
   LoadingIndicator,
   Select,
@@ -41,6 +37,7 @@ import {
 } from '@tryghost/admin-x-framework/api/users';
 
 import { EDITOR_REQUEST_OPTIONS } from '@/editor/request-options';
+import { FullscreenDialog } from '@/editor/fullscreen-dialog';
 import { BrowserPreview } from './browser-preview';
 import { EmailPreview } from './email-preview';
 import {
@@ -278,14 +275,11 @@ export function PostPreviewModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        aria-describedby={undefined}
-        className="top-0 left-0 grid h-dvh w-dvw max-w-none translate-x-0 grid-rows-[auto_1fr] gap-0 rounded-none p-0"
-        data-testid="post-preview-modal"
-      >
-        <DialogHeader className="flex-row items-center justify-between gap-4 border-b border-border-default p-4">
-          <DialogTitle className="text-lg">Preview</DialogTitle>
+    <FullscreenDialog
+      aria-describedby={undefined}
+      data-testid="post-preview-modal"
+      headerActions={
+        <>
           <Inline gap="md">
             {emailAvailable && (
               <Tabs
@@ -392,52 +386,57 @@ export function PostPreviewModal({
             </Button>
             {onReturnToPublish ? <Button onClick={onReturnToPublish}>Publish</Button> : null}
           </Inline>
-        </DialogHeader>
-        <Inline className="min-h-0 overflow-auto bg-surface-panel p-6" gap="none" justify="center">
-          {prepareState === 'preparing' ? (
-            <Inline align="center" className="grow" gap="none" justify="center">
-              <LoadingIndicator size="lg" />
-            </Inline>
-          ) : prepareState === 'failed' ? (
-            <EmptyIndicator
-              actions={
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    preparePromise.current = null;
-                    setPrepareState('preparing');
-                  }}
-                >
-                  Retry
-                </Button>
-              }
-              className="grow justify-center"
-              data-testid="post-preview-save-failed"
-              description="Saving the post failed, so there is nothing new to preview."
-              title="Couldn’t preview this post"
-            >
-              <LucideIcon.TriangleAlert />
-            </EmptyIndicator>
-          ) : showEmail ? (
-            <EmailPreview
-              audience={audience}
-              canSendTestEmail={testEmailAvailable}
-              device={device}
-              newsletterLookupError={newsletterLookupError}
-              newsletterLookupPending={newsletterLookupPending}
-              newsletterMissing={postNewsletterDeleted && selectedNewsletterSlug === newsletterSlug}
-              newsletters={newsletters}
-              newsletterSlug={selectedNewsletterSlug}
-              postId={postId}
-              tierName={selectedTier?.name}
-              onNewsletterChange={setPickedNewsletterSlug}
-              onRetryNewsletterLookup={retryNewsletterLookup}
-            />
-          ) : (
-            <BrowserPreview audience={audience} device={device} previewUrl={previewUrl} />
-          )}
-        </Inline>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+      layout="header"
+      open={open}
+      title="Preview"
+      onOpenChange={onOpenChange}
+    >
+      <Inline className="min-h-0 overflow-auto bg-surface-panel p-6" gap="none" justify="center">
+        {prepareState === 'preparing' ? (
+          <Inline align="center" className="grow" gap="none" justify="center">
+            <LoadingIndicator size="lg" />
+          </Inline>
+        ) : prepareState === 'failed' ? (
+          <EmptyIndicator
+            actions={
+              <Button
+                variant="outline"
+                onClick={() => {
+                  preparePromise.current = null;
+                  setPrepareState('preparing');
+                }}
+              >
+                Retry
+              </Button>
+            }
+            className="grow justify-center"
+            data-testid="post-preview-save-failed"
+            description="Saving the post failed, so there is nothing new to preview."
+            title="Couldn’t preview this post"
+          >
+            <LucideIcon.TriangleAlert />
+          </EmptyIndicator>
+        ) : showEmail ? (
+          <EmailPreview
+            audience={audience}
+            canSendTestEmail={testEmailAvailable}
+            device={device}
+            newsletterLookupError={newsletterLookupError}
+            newsletterLookupPending={newsletterLookupPending}
+            newsletterMissing={postNewsletterDeleted && selectedNewsletterSlug === newsletterSlug}
+            newsletters={newsletters}
+            newsletterSlug={selectedNewsletterSlug}
+            postId={postId}
+            tierName={selectedTier?.name}
+            onNewsletterChange={setPickedNewsletterSlug}
+            onRetryNewsletterLookup={retryNewsletterLookup}
+          />
+        ) : (
+          <BrowserPreview audience={audience} device={device} previewUrl={previewUrl} />
+        )}
+      </Inline>
+    </FullscreenDialog>
   );
 }

--- a/apps/admin/src/editor/publish/publish-flow-modal.tsx
+++ b/apps/admin/src/editor/publish/publish-flow-modal.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogContent, DialogTitle } from '@tryghost/shade/components';
+import { Button } from '@tryghost/shade/components';
 import { Inline, Stack } from '@tryghost/shade/primitives';
 import { formatNumber } from '@tryghost/shade/utils';
 import { useState } from 'react';
@@ -8,6 +8,7 @@ import {
   publishFlowPreviewButton,
   tkReminderDialog,
 } from '@tryghost/test-data/selectors/editor';
+import { FullscreenDialog } from '@/editor/fullscreen-dialog';
 import { CompleteStep } from './components/complete-step';
 import { CompleteWithEmailErrorStep } from './components/complete-with-email-error-step';
 import { ConfirmStep } from './components/confirm-step';
@@ -18,10 +19,6 @@ import { usePublishFlow } from './use-publish-flow';
 import type { PublishDispatcher } from './publish-options';
 import type { PublishFlowPost } from './flow-post';
 import type { PublishLimitPorts, PublishSiteInput, PublishUserInput } from './publish-options';
-
-// A fullscreen surface: the flow owns the screen, like Ember's total overlay.
-const FULLSCREEN =
-  'top-0 left-0 h-[100dvh] w-full max-w-full translate-0 grid-rows-[1fr] gap-0 overflow-y-auto rounded-none border-0 p-0 shadow-none sm:rounded-none';
 
 export interface PublishFlowModalProps {
   post: PublishFlowPost;
@@ -155,85 +152,84 @@ function PublishFlowDialog({
   };
 
   return (
-    <Dialog modal={false} open onOpenChange={(open) => !open && close()}>
-      <DialogContent
-        className={FULLSCREEN}
-        data-testid={publishFlowModal}
-        onInteractOutside={(event) => event.preventDefault()}
-      >
-        <DialogTitle className="sr-only">Publish</DialogTitle>
-        <Stack className="mx-auto w-full max-w-2xl px-6 pb-16" gap="xl">
-          <Inline className="py-4" justify="end">
-            {step === 'complete' ? null : (
-              <>
-                <Button variant="outline" onClick={close}>
-                  Close
+    <FullscreenDialog
+      data-testid={publishFlowModal}
+      modal={false}
+      title="Publish"
+      open
+      onOpenChange={(open) => !open && close()}
+    >
+      <Stack className="mx-auto w-full max-w-2xl px-6 pb-16" gap="xl">
+        <Inline className="py-4" justify="end">
+          {step === 'complete' ? null : (
+            <>
+              <Button variant="outline" onClick={close}>
+                Close
+              </Button>
+              {flow.emailErrorMessage || !onPreview ? null : (
+                <Button
+                  data-testid={publishFlowPreviewButton}
+                  variant="outline"
+                  onClick={onPreview}
+                >
+                  Preview
                 </Button>
-                {flow.emailErrorMessage || !onPreview ? null : (
-                  <Button
-                    data-testid={publishFlowPreviewButton}
-                    variant="outline"
-                    onClick={onPreview}
-                  >
-                    Preview
-                  </Button>
-                )}
-              </>
-            )}
-          </Inline>
-
-          {step === 'email-error' && flow.emailErrorMessage ? (
-            <CompleteWithEmailErrorStep
-              emailErrorMessage={flow.emailErrorMessage}
-              mailgunConfigured={site.mailgunConfigured}
-              post={post}
-              retryFailure={flow.retryFailure}
-              status={flow.retryStatus}
-              willOnlyEmail={state.willOnlyEmail}
-              onRetry={() => void flow.retryEmail()}
-            />
-          ) : step === 'complete' ? (
-            <CompleteStep
-              captured={flow.captured}
-              completedAt={flow.completedAt}
-              note={flow.emailNote}
-              post={post}
-              postCount={flow.postCount}
-              siteTitle={siteTitle}
-              state={state}
-              timezone={timezone}
-              onRevertToDraft={onRevertToDraft}
-            />
-          ) : step === 'confirm' ? (
-            <ConfirmStep
-              captured={flow.captured}
-              failure={flow.failure}
-              post={post}
-              state={state}
-              status={flow.confirmStatus}
-              timezone={timezone}
-              onBack={flow.toOptions}
-              onConfirm={() => void flow.confirmPublish()}
-            />
-          ) : (
-            <OptionsStep
-              emailDisabledInSettings={site.editorDefaultEmailRecipients === 'disabled'}
-              limitsChecked={flow.limitsChecked}
-              limitsFailure={flow.limitsFailure}
-              post={post}
-              state={state}
-              timezone={timezone}
-              onContinue={flow.toConfirm}
-              onRetryLimits={flow.retryLimits}
-              onSetNewsletter={flow.setNewsletter}
-              onSetPublishType={flow.setPublishType}
-              onSetRecipientFilter={flow.setRecipientFilter}
-              onSetScheduledAt={flow.setScheduledAt}
-              onToggleScheduled={flow.setIsScheduled}
-            />
+              )}
+            </>
           )}
-        </Stack>
-      </DialogContent>
-    </Dialog>
+        </Inline>
+
+        {step === 'email-error' && flow.emailErrorMessage ? (
+          <CompleteWithEmailErrorStep
+            emailErrorMessage={flow.emailErrorMessage}
+            mailgunConfigured={site.mailgunConfigured}
+            post={post}
+            retryFailure={flow.retryFailure}
+            status={flow.retryStatus}
+            willOnlyEmail={state.willOnlyEmail}
+            onRetry={() => void flow.retryEmail()}
+          />
+        ) : step === 'complete' ? (
+          <CompleteStep
+            captured={flow.captured}
+            completedAt={flow.completedAt}
+            note={flow.emailNote}
+            post={post}
+            postCount={flow.postCount}
+            siteTitle={siteTitle}
+            state={state}
+            timezone={timezone}
+            onRevertToDraft={onRevertToDraft}
+          />
+        ) : step === 'confirm' ? (
+          <ConfirmStep
+            captured={flow.captured}
+            failure={flow.failure}
+            post={post}
+            state={state}
+            status={flow.confirmStatus}
+            timezone={timezone}
+            onBack={flow.toOptions}
+            onConfirm={() => void flow.confirmPublish()}
+          />
+        ) : (
+          <OptionsStep
+            emailDisabledInSettings={site.editorDefaultEmailRecipients === 'disabled'}
+            limitsChecked={flow.limitsChecked}
+            limitsFailure={flow.limitsFailure}
+            post={post}
+            state={state}
+            timezone={timezone}
+            onContinue={flow.toConfirm}
+            onRetryLimits={flow.retryLimits}
+            onSetNewsletter={flow.setNewsletter}
+            onSetPublishType={flow.setPublishType}
+            onSetRecipientFilter={flow.setRecipientFilter}
+            onSetScheduledAt={flow.setScheduledAt}
+            onToggleScheduled={flow.setIsScheduled}
+          />
+        )}
+      </Stack>
+    </FullscreenDialog>
   );
 }

--- a/apps/admin/src/editor/publish/update-flow-modal.tsx
+++ b/apps/admin/src/editor/publish/update-flow-modal.tsx
@@ -1,4 +1,4 @@
-import { Banner, Button, Dialog, DialogContent, DialogTitle } from '@tryghost/shade/components';
+import { Banner, Button } from '@tryghost/shade/components';
 import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { formatNumber } from '@tryghost/shade/utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -16,6 +16,7 @@ import {
   updateFlowPreviousEmail,
   updateFlowTitle,
 } from '@tryghost/test-data/selectors/editor';
+import { FullscreenDialog } from '@/editor/fullscreen-dialog';
 import { createPublishOptions } from './publish-options';
 import {
   describeCompletionFailure,
@@ -27,9 +28,6 @@ import type { PublishDispatcher } from './publish-options';
 import type { PublishFlowPost } from './flow-post';
 import type { PublishSiteInput, PublishUserInput } from './publish-options';
 import type { SaveCompletion } from '@/editor/engine/save-engine';
-
-const FULLSCREEN =
-  'top-0 left-0 h-[100dvh] w-full max-w-full translate-0 grid-rows-[1fr] gap-0 overflow-y-auto rounded-none border-0 p-0 shadow-none sm:rounded-none';
 
 export interface UpdateFlowModalProps {
   post: PublishFlowPost;
@@ -165,94 +163,93 @@ function KeyedUpdateFlowModal({
   const publishedAt = post.publishedAt;
 
   return (
-    <Dialog modal={false} open onOpenChange={(open) => !open && close()}>
-      <DialogContent
-        className={FULLSCREEN}
-        data-testid={updateFlowModal}
-        onInteractOutside={(event) => event.preventDefault()}
-      >
-        <DialogTitle className="sr-only">{isScheduled ? 'Unschedule' : 'Unpublish'}</DialogTitle>
-        <Stack className="mx-auto w-full max-w-2xl px-6 pb-16" gap="xl">
-          <Inline className="py-4" justify="end">
-            {isSent ? null : (
-              <Button variant="outline" onClick={close}>
-                Close
-              </Button>
-            )}
-          </Inline>
+    <FullscreenDialog
+      data-testid={updateFlowModal}
+      modal={false}
+      title={isScheduled ? 'Unschedule' : 'Unpublish'}
+      open
+      onOpenChange={(open) => !open && close()}
+    >
+      <Stack className="mx-auto w-full max-w-2xl px-6 pb-16" gap="xl">
+        <Inline className="py-4" justify="end">
+          {isSent ? null : (
+            <Button variant="outline" onClick={close}>
+              Close
+            </Button>
+          )}
+        </Inline>
 
-          <Text as="h2" data-testid={updateFlowTitle} size="3xl" weight="bold">
-            This {post.displayName} {isSent ? 'was' : 'has been'}{' '}
-            <span className="text-state-success">
-              {post.status}
-              {isSent ? ' by email' : ''}
-            </span>
-          </Text>
+        <Text as="h2" data-testid={updateFlowTitle} size="3xl" weight="bold">
+          This {post.displayName} {isSent ? 'was' : 'has been'}{' '}
+          <span className="text-state-success">
+            {post.status}
+            {isSent ? ' by email' : ''}
+          </span>
+        </Text>
 
-          <Text data-testid={updateFlowConfirmation}>
-            Your {post.displayName} {isScheduled ? 'will be' : 'was'}{' '}
-            {hasBeenEmailed || willEmail ? (
-              <>
-                {emailOnly ? 'sent to' : 'published and sent to'}{' '}
-                <strong>
-                  {isScheduled
-                    ? pluralSubscribers(count)
-                    : pluralSubscribers(post.email?.email_count ?? null)}
-                </strong>
-                {showNewsletterName && post.newsletterName ? (
-                  <>
-                    {' '}
-                    of <strong>{post.newsletterName}</strong>
-                  </>
-                ) : null}
-              </>
-            ) : (
-              'published on your site'
-            )}
-            {publishedAt ? <> on {formatSiteDateTime(publishedAt, timezone)}.</> : '.'}
-          </Text>
-
-          {isScheduled && post.email ? (
-            <Text data-testid={updateFlowPreviousEmail}>
-              This post was previously emailed to{' '}
-              <strong>{pluralSubscribers(post.email.email_count ?? null)}</strong>
+        <Text data-testid={updateFlowConfirmation}>
+          Your {post.displayName} {isScheduled ? 'will be' : 'was'}{' '}
+          {hasBeenEmailed || willEmail ? (
+            <>
+              {emailOnly ? 'sent to' : 'published and sent to'}{' '}
+              <strong>
+                {isScheduled
+                  ? pluralSubscribers(count)
+                  : pluralSubscribers(post.email?.email_count ?? null)}
+              </strong>
               {showNewsletterName && post.newsletterName ? (
                 <>
                   {' '}
                   of <strong>{post.newsletterName}</strong>
                 </>
               ) : null}
-              {post.emailCreatedAt ? (
-                <> on {formatSiteDateTime(post.emailCreatedAt, timezone)}.</>
-              ) : (
-                '.'
-              )}
-            </Text>
-          ) : null}
+            </>
+          ) : (
+            'published on your site'
+          )}
+          {publishedAt ? <> on {formatSiteDateTime(publishedAt, timezone)}.</> : '.'}
+        </Text>
 
-          {failure ? (
-            <Banner role="alert" variant="destructive">
-              {failure.message}
-            </Banner>
-          ) : null}
+        {isScheduled && post.email ? (
+          <Text data-testid={updateFlowPreviousEmail}>
+            This post was previously emailed to{' '}
+            <strong>{pluralSubscribers(post.email.email_count ?? null)}</strong>
+            {showNewsletterName && post.newsletterName ? (
+              <>
+                {' '}
+                of <strong>{post.newsletterName}</strong>
+              </>
+            ) : null}
+            {post.emailCreatedAt ? (
+              <> on {formatSiteDateTime(post.emailCreatedAt, timezone)}.</>
+            ) : (
+              '.'
+            )}
+          </Text>
+        ) : null}
 
-          {isScheduled || !emailOnly ? (
-            <div>
-              <Button
-                data-testid={publishRevertToDraft}
-                disabled={running}
-                size="lg"
-                variant="outline"
-                onClick={() => void revert()}
-              >
-                {isScheduled
-                  ? 'Unschedule and revert to draft →'
-                  : 'Unpublish and revert to private draft →'}
-              </Button>
-            </div>
-          ) : null}
-        </Stack>
-      </DialogContent>
-    </Dialog>
+        {failure ? (
+          <Banner role="alert" variant="destructive">
+            {failure.message}
+          </Banner>
+        ) : null}
+
+        {isScheduled || !emailOnly ? (
+          <div>
+            <Button
+              data-testid={publishRevertToDraft}
+              disabled={running}
+              size="lg"
+              variant="outline"
+              onClick={() => void revert()}
+            >
+              {isScheduled
+                ? 'Unschedule and revert to draft →'
+                : 'Unpublish and revert to private draft →'}
+            </Button>
+          </div>
+        ) : null}
+      </Stack>
+    </FullscreenDialog>
   );
 }

--- a/apps/admin/src/editor/settings/post-history-modal.tsx
+++ b/apps/admin/src/editor/settings/post-history-modal.tsx
@@ -11,10 +11,6 @@ import {
   AlertDialogTitle,
   Avatar,
   Button,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
 } from '@tryghost/shade/components';
 import { Inline, Stack, Text } from '@tryghost/shade/primitives';
 import { cn } from '@tryghost/shade/utils';
@@ -26,6 +22,7 @@ import {
   postHistoryRevisionList,
 } from '@tryghost/test-data/selectors/editor';
 import type { PostCardConfig, PostType } from '@/editor/card-config';
+import { FullscreenDialog } from '@/editor/fullscreen-dialog';
 import { memberAvatarProps } from '@/members/api';
 import { revisionDate, type RevisionEntry, type RevisionTag } from './post-history';
 import { RevisionPreview } from './revision-preview';
@@ -158,17 +155,15 @@ export function PostHistoryModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(next) => !restoring && onOpenChange(next)}>
-      <DialogContent
-        className="top-0 left-0 grid h-dvh w-dvw max-w-none translate-x-0 grid-rows-[auto_1fr] gap-0 rounded-none p-0"
+    <>
+      <FullscreenDialog
         data-testid={postHistoryModal}
+        layout="header"
+        open={open}
+        title={`${postType === 'page' ? 'Page' : 'Post'} history`}
         onCloseAutoFocus={onCloseAutoFocus}
+        onOpenChange={(next) => !restoring && onOpenChange(next)}
       >
-        <DialogHeader className="flex-row items-center gap-4 border-b border-border-default p-4">
-          <DialogTitle className="text-lg">
-            {postType === 'page' ? 'Page' : 'Post'} history
-          </DialogTitle>
-        </DialogHeader>
         <Inline align="stretch" className="min-h-0" gap="none">
           <div className="min-w-0 flex-1 overflow-y-auto bg-surface-panel p-8">
             {selected ? (
@@ -210,7 +205,7 @@ export function PostHistoryModal({
             </ul>
           </Stack>
         </Inline>
-      </DialogContent>
+      </FullscreenDialog>
 
       <AlertDialog
         open={!!confirming}
@@ -245,6 +240,6 @@ export function PostHistoryModal({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
The React editor's publish flow, update flow, post history and post preview modals each configured their own Radix dialog to cover the screen. The publish and update copies of the frame class string were byte-identical, as were the preview and post history header rows.

All four of them also inherited Radix's default focus restore, which targets a `DialogTrigger`. These dialogs open from state rather than a trigger, so on close Radix had nothing to focus and dropped focus to the document body — keyboard and screen reader users closing the preview or a publish flow landed back at the top of the editor instead of at the control they came from. (A dialog opened by shortcut while nothing had focus still lands on the body, as before; opened from the title or the body, focus returns there.)

## What changed

- Added `apps/admin/src/editor/fullscreen-dialog.tsx`. `FullscreenDialog` owns the fullscreen frame classes, the portal, modal mode, the "an outside interaction is not a dismissal" rule, and the close-focus contract. Two layouts cover the four callers: `header` (a fixed header row above a scrolling body) and `plain` (one scrolling region with a screen-reader-only title).
- It records the element that was focused as the dialog opened and focuses it again from `onCloseAutoFocus`. A caller that wants to restore focus itself prevents the event first — post history does this, so it still returns focus to the sidebar's Post history button.
- Adopted it in `publish/publish-flow-modal.tsx`, `publish/update-flow-modal.tsx`, `settings/post-history-modal.tsx` and `preview/post-preview-modal.tsx`. Both pairs of duplicated class strings are gone. The shared frame is the union of the two originals; two of the differences render: the preview and post history surfaces are now square-cornered at wide viewports (Shade's `sm:rounded-lg` used to show the overlay through the four viewport corners), and both now ignore outside interactions, as the publish flows already did. The remaining differences (`border-0`, `shadow-none`, `w-full` for `w-dvw`) measure identical on a full-viewport surface.

Modal content, steps and copy are unchanged, and nothing in Shade was touched.

## Verification

- Three acceptance cases added to `editor-header.acceptance.test.tsx`: closing the preview, the publish flow and the update flow each return focus to the header button that opened them. They live in the header spec because the preview and publish specs render those modals in isolation, with no opener on screen.
- Non-vacuity check: with `onCloseAutoFocus` removed from the shared shell, all three fail on `toHaveFocus()`; restored, they pass.
- `pnpm --filter @tryghost/admin lint` — 0 errors (41 pre-existing warnings in unrelated files).
- `pnpm --filter @tryghost/admin exec tsc -b` — clean.
- Acceptance: `src/editor/publish src/editor/preview src/editor/editor-header.acceptance.test.tsx src/editor/editor-settings-post-history.acceptance.test.tsx` — 5 files, 129 tests passing.
