### PR TITLE
Updated local dev image to bookworm

### DIFF
--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -4,7 +4,7 @@
 
 ARG NODE_VERSION=22.23.1
 
-FROM node:$NODE_VERSION-bullseye-slim
+FROM node:$NODE_VERSION-bookworm-slim
 
 # Install system dependencies needed for building native modules.
 # watchman: ember-cli (ghost/admin's dev server) auto-detects and prefers it


### PR DESCRIPTION
no ref
- bullseye is EOL, and all other node bases use bookworm, this was the only remaining bullseye reference