### PR TITLE
Changed the editor's Unsplash search to answer only its own Escape

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -25,6 +25,8 @@
     "@codemirror/state": "catalog:",
     "@codemirror/theme-one-dark": "catalog:",
     "@dnd-kit/sortable": "catalog:",
+    "@radix-ui/react-focus-guards": "catalog:",
+    "@radix-ui/react-focus-scope": "catalog:",
     "@sentry/react": "catalog:",
     "@svg-maps/world": "2.0.0",
     "@tanstack/react-query": "catalog:",

--- a/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-feature-image.acceptance.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
+  UNSPLASH_PICKED,
   currentRoute,
   fakeAdminEndpoint,
   fakeEditorChrome,
   fakeEditorPost,
+  fakeUnsplashPhotos,
   post,
   renderAdminApp,
   submittedPost,
@@ -197,6 +199,27 @@ describe('Post editor feature image', () => {
         feature_image: UPLOADED,
         feature_image_alt: 'Rolling hills',
       });
+    },
+    SLOW,
+  );
+
+  it(
+    'saves an image picked from Unsplash with the credit it carries',
+    async () => {
+      const saveApi = fakeSavablePost();
+      fakeUnsplashPhotos();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+
+      await expect.element(editorScreen.featureImageUnsplashButton()).toBeVisible();
+      await editorScreen.featureImageUnsplashButton().click();
+      await editorScreen.unsplashInsertImage().click();
+
+      await expect.poll(() => saveApi.requests.length, SAVE_POLL).toBe(1);
+      const saved = submittedPost(saveApi);
+      expect(saved.feature_image).toBe(UNSPLASH_PICKED);
+      // The photographer credit the picker hands over, as the caption stores it.
+      expect(String(saved.feature_image_caption)).toContain('A Photographer');
+      await expect.element(editorScreen.removeFeatureImage()).toBeVisible();
     },
     SLOW,
   );

--- a/apps/admin/src/editor/editor-settings-facebook-card.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-facebook-card.acceptance.test.tsx
@@ -2,18 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
 import {
+  UNSPLASH_PICKED,
   currentUserResponse,
   fakeAdminEndpoint,
   fakeEditorChrome,
   fakeEditorPost,
-  fakeEndpoint,
   fakeTiers,
+  fakeUnsplashPhotos,
   post,
   renderAdminApp,
-  settingsResponse,
   staffRole,
   submittedPost,
   unsavedChangesGuarded,
+  withoutUnsplash,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -65,44 +66,6 @@ function fakeSavablePost(overrides: Partial<SavedPost> = {}) {
     tags: [],
     ...overrides,
   });
-}
-
-const UNSPLASH_REGULAR = 'https://images.unsplash.com/photo-1?ixid=1&w=1080';
-// The picker asks Unsplash for a wider rendition of the image it inserts.
-const UNSPLASH_PICKED = 'https://images.unsplash.com/photo-1?ixid=1&w=2000';
-
-/** One Unsplash photo, in the shape the search modal lays out and inserts. */
-function fakeUnsplashPhotos() {
-  fakeEndpoint('GET', 'https://api.unsplash.com/photos', [
-    {
-      id: 'photo-1',
-      color: '#123456',
-      alt_description: 'A hillside',
-      height: 800,
-      width: 1200,
-      likes: 12,
-      urls: { regular: UNSPLASH_REGULAR },
-      links: {
-        html: 'https://unsplash.com/photos/photo-1',
-        download: 'https://unsplash.com/photos/photo-1/download',
-        download_location: 'https://api.unsplash.com/photos/photo-1/download',
-      },
-      user: {
-        name: 'A Photographer',
-        links: { html: 'https://unsplash.com/@photographer' },
-        profile_image: { medium: 'https://images.unsplash.com/profile-1' },
-      },
-    },
-  ]);
-  fakeEndpoint('GET', 'https://api.unsplash.com/photos/photo-1/download', {});
-}
-
-/** The site fixture turns Unsplash on, so only the off case needs an override. */
-function withoutUnsplash() {
-  return {
-    ...FLAG_ON,
-    boot: { browseSettings: { response: settingsResponse({ settings: { unsplash: false } }) } },
-  };
 }
 
 async function openFacebookCard() {
@@ -378,7 +341,7 @@ describe('Post settings Facebook card', () => {
     'leaves Unsplash out while the site’s integration is off',
     async () => {
       fakeSavablePost();
-      await renderAdminApp(`/editor/post/${POST_ID}`, withoutUnsplash());
+      await renderAdminApp(`/editor/post/${POST_ID}`, { ...FLAG_ON, ...withoutUnsplash() });
       await openFacebookCard();
 
       await expect.element(editorScreen.settingsFacebookImageInput()).toBeInTheDocument();

--- a/apps/admin/src/editor/editor-settings-x-card.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-x-card.acceptance.test.tsx
@@ -510,6 +510,38 @@ describe('Post settings X card', () => {
   );
 
   it(
+    'keeps keyboard navigation inside Unsplash and restores focus after Escape',
+    async () => {
+      fakeSavablePost();
+      fakeUnsplashPhotos();
+      await renderAdminApp(`/editor/post/${POST_ID}`, FLAG_ON);
+      await openXCard();
+
+      await editorScreen.settingsXImageUnsplashButton().click();
+      await expect.element(editorScreen.unsplashSearchInput()).toHaveFocus();
+      await expect.element(editorScreen.unsplashInsertImage()).toBeVisible();
+
+      // Back past the close button: focus must wrap inside the search rather
+      // than reaching the picker button in the pane behind it.
+      await userEvent.keyboard('{Shift>}{Tab}{Tab}{/Shift}');
+      expect(editorScreen.unsplashSearch().element().contains(document.activeElement)).toBe(true);
+
+      // Traverse past the close button, search field and one photo's links.
+      // Every stop stays inside, including the forward wrap.
+      for (let i = 0; i < 6; i++) {
+        await userEvent.keyboard('{Tab}');
+        expect(editorScreen.unsplashSearch().element().contains(document.activeElement)).toBe(true);
+      }
+      await userEvent.keyboard('{Escape}');
+
+      await expect(editorScreen.unsplashModal()).toHaveCount(0);
+      await expect.element(editorScreen.settingsSubviewPane()).toBeVisible();
+      await expect.element(editorScreen.settingsXImageUnsplashButton()).toHaveFocus();
+    },
+    SLOW,
+  );
+
+  it(
     'keeps the pane open when Escape dismisses the Unsplash search',
     async () => {
       fakeSavablePost();

--- a/apps/admin/src/editor/editor-settings-x-card.acceptance.test.tsx
+++ b/apps/admin/src/editor/editor-settings-x-card.acceptance.test.tsx
@@ -2,18 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 import {
+  UNSPLASH_PICKED,
   currentUserResponse,
   fakeAdminEndpoint,
   fakeEditorChrome,
   fakeEditorPost,
-  fakeEndpoint,
   fakeTiers,
+  fakeUnsplashPhotos,
   post,
   renderAdminApp,
-  settingsResponse,
   staffRole,
   submittedPost,
   unsavedChangesGuarded,
+  withoutUnsplash,
   type StaffRoleName,
 } from '@test-utils/acceptance';
 import { editorScreen } from '@/editor/editor.screen';
@@ -71,44 +72,6 @@ function fakeImageUpload() {
   return fakeAdminEndpoint('POST', '/images/upload/', {
     images: [{ url: UPLOADED, ref: null }],
   });
-}
-
-const UNSPLASH_REGULAR = 'https://images.unsplash.com/photo-1?ixid=1&w=1080';
-// The picker asks Unsplash for a wider rendition of the image it inserts.
-const UNSPLASH_PICKED = 'https://images.unsplash.com/photo-1?ixid=1&w=2000';
-
-/** One Unsplash photo, in the shape the search modal lays out and inserts. */
-function fakeUnsplashPhotos() {
-  fakeEndpoint('GET', 'https://api.unsplash.com/photos', [
-    {
-      id: 'photo-1',
-      color: '#123456',
-      alt_description: 'A hillside',
-      height: 800,
-      width: 1200,
-      likes: 12,
-      urls: { regular: UNSPLASH_REGULAR },
-      links: {
-        html: 'https://unsplash.com/photos/photo-1',
-        download: 'https://unsplash.com/photos/photo-1/download',
-        download_location: 'https://api.unsplash.com/photos/photo-1/download',
-      },
-      user: {
-        name: 'A Photographer',
-        links: { html: 'https://unsplash.com/@photographer' },
-        profile_image: { medium: 'https://images.unsplash.com/profile-1' },
-      },
-    },
-  ]);
-  fakeEndpoint('GET', 'https://api.unsplash.com/photos/photo-1/download', {});
-}
-
-/** The site fixture turns Unsplash on, so only the off case needs an override. */
-function withoutUnsplash() {
-  return {
-    ...FLAG_ON,
-    boot: { browseSettings: { response: settingsResponse({ settings: { unsplash: false } }) } },
-  };
 }
 
 async function openXCard() {
@@ -517,7 +480,7 @@ describe('Post settings X card', () => {
     'leaves Unsplash out while the site’s integration is off',
     async () => {
       fakeSavablePost();
-      await renderAdminApp(`/editor/post/${POST_ID}`, withoutUnsplash());
+      await renderAdminApp(`/editor/post/${POST_ID}`, { ...FLAG_ON, ...withoutUnsplash() });
       await openXCard();
 
       await expect.element(editorScreen.settingsXImageInput()).toBeInTheDocument();

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -101,6 +101,7 @@ import {
   stayInEditorButton,
   tkIndicator,
   toggleFeatureImageAltButton,
+  unsplashSearchModal,
 } from '@tryghost/test-data/selectors/editor';
 
 /** Editor screen locators and gestures for acceptance specs; no assertions. */
@@ -285,7 +286,7 @@ export const editorScreen = {
   featureImageUnsplashButton: () => page.getByRole('button', { name: featureImageUnsplashButton }),
   /** The Unsplash search modal, wherever the picker that opened it sits. */
   unsplashModal: () => page.getByRole('heading', { name: 'Unsplash' }),
-  unsplashInsertImage: () => page.getByText('Insert image'),
+  unsplashInsertImage: () => page.getByTestId(unsplashSearchModal).getByText('Insert image'),
   removeFeatureImage: () => page.getByRole('button', { name: removeFeatureImageButton }),
   featureImageAltToggle: () => page.getByRole('button', { name: toggleFeatureImageAltButton }),
   featureImageAltInput: () => page.getByLabelText(featureImageAltLabel),

--- a/apps/admin/src/editor/editor.screen.ts
+++ b/apps/admin/src/editor/editor.screen.ts
@@ -286,6 +286,8 @@ export const editorScreen = {
   featureImageUnsplashButton: () => page.getByRole('button', { name: featureImageUnsplashButton }),
   /** The Unsplash search modal, wherever the picker that opened it sits. */
   unsplashModal: () => page.getByRole('heading', { name: 'Unsplash' }),
+  unsplashSearch: () => page.getByTestId(unsplashSearchModal),
+  unsplashSearchInput: () => page.getByPlaceholder('Search free high-resolution photos'),
   unsplashInsertImage: () => page.getByTestId(unsplashSearchModal).getByText('Insert image'),
   removeFeatureImage: () => page.getByRole('button', { name: removeFeatureImageButton }),
   featureImageAltToggle: () => page.getByRole('button', { name: toggleFeatureImageAltButton }),

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -205,6 +205,9 @@ uploader it closes that control. In the Unsplash search it closes the search and
 leaves the field it was opened from. With none of those open it closes the pane,
 and with no pane open the sidebar answers Escape with nothing.
 
+The Unsplash search traps focus and loops Tab navigation in both directions.
+Closing it returns focus to the picker button when that field is still present.
+
 ## Access
 
 Access is two coupled fields, `visibility` and `tiers`, and only an Owner,

--- a/apps/admin/src/editor/settings/README.md
+++ b/apps/admin/src/editor/settings/README.md
@@ -196,6 +196,15 @@ that cannot write it, falls back to the section list rather than an empty panel.
 The panel owns which pane is open, so closing the panel or leaving the editor
 drops it and the panel is next opened on the section list.
 
+## Escape
+
+Escape closes one layer, the innermost the writer is in. In a tag or author list
+it closes the list and keeps the term that was typed. In a code injection editor
+it frees the editor's Tab and closes nothing. In a dialog, a select or an
+uploader it closes that control. In the Unsplash search it closes the search and
+leaves the field it was opened from. With none of those open it closes the pane,
+and with no pane open the sidebar answers Escape with nothing.
+
 ## Access
 
 Access is two coupled fields, `visibility` and `tiers`, and only an Owner,

--- a/apps/admin/src/editor/settings/code-injection-section.tsx
+++ b/apps/admin/src/editor/settings/code-injection-section.tsx
@@ -4,8 +4,8 @@ import type { PostType } from '@/editor/card-config';
 import type { EditorSessionHandle } from '@/editor/session/use-editor-session';
 import { SettingsSubview } from './settings-subview';
 
-// An Escape no other binding answers leaves the event unprevented, closing the
-// pane. Arm tab-focus mode for the 2s @codemirror/view does, so Tab leaves.
+// A binding that returns true prevents the event's default, which the pane
+// reads as answered. Arm tab-focus mode for the 2s @codemirror/view does.
 const TAB_FOCUS_ESCAPE = () =>
   import('@uiw/react-codemirror').then(({ Prec, keymap }) =>
     Prec.lowest(

--- a/apps/admin/src/editor/unsplash-picker.test.tsx
+++ b/apps/admin/src/editor/unsplash-picker.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { UnsplashPicker } from './unsplash-picker';
+
+vi.mock('@tryghost/kg-unsplash-selector', () => ({
+  UnsplashSearchModal: () => <div>Unsplash search</div>,
+}));
+
+vi.mock('@tryghost/admin-x-framework', () => ({
+  useFramework: () => ({ unsplashConfig: null }),
+}));
+
+const LABEL = 'Select an image from Unsplash';
+
+/** Whether an Escape raised from `from` is marked as already answered. */
+function escapeMarked(from: EventTarget): boolean {
+  const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+  from.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+function picker(enabled: boolean) {
+  return <UnsplashPicker enabled={enabled} label={LABEL} onSelect={vi.fn()} />;
+}
+
+function openSearch() {
+  fireEvent.click(screen.getByRole('button', { name: LABEL }));
+  return screen.getByText('Unsplash search');
+}
+
+/**
+ * The Unsplash affordance on an image field. Only the search itself answers
+ * Escape, so the pane it opened over keeps its own.
+ */
+describe('UnsplashPicker', () => {
+  it('marks only the Escape raised inside the open search', () => {
+    render(picker(true));
+
+    const search = openSearch();
+
+    expect(escapeMarked(search)).toBe(true);
+    // Anything the search does not contain still reaches the pane behind it.
+    expect(escapeMarked(window)).toBe(false);
+    expect(escapeMarked(document.body)).toBe(false);
+  });
+
+  it('closes the search and gives Escape back when the integration goes off', () => {
+    const { rerender } = render(picker(true));
+
+    const search = openSearch();
+
+    expect(search).toBeInTheDocument();
+    expect(escapeMarked(search)).toBe(true);
+
+    rerender(picker(false));
+
+    expect(screen.queryByText('Unsplash search')).not.toBeInTheDocument();
+    expect(escapeMarked(search)).toBe(false);
+
+    rerender(picker(true));
+
+    // The affordance comes back closed rather than reopening what was dismissed.
+    expect(screen.queryByText('Unsplash search')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: LABEL })).toBeVisible();
+  });
+});

--- a/apps/admin/src/editor/unsplash-picker.test.tsx
+++ b/apps/admin/src/editor/unsplash-picker.test.tsx
@@ -1,9 +1,16 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { UnsplashPicker } from './unsplash-picker';
 
 vi.mock('@tryghost/kg-unsplash-selector', () => ({
-  UnsplashSearchModal: () => <div>Unsplash search</div>,
+  UnsplashSearchModal: ({ onClose }: { onClose: () => void }) => (
+    <div>
+      Unsplash search
+      <button type="button" onClick={onClose}>
+        Close search
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@tryghost/admin-x-framework', () => ({
@@ -33,6 +40,19 @@ function openSearch() {
  * Escape, so the pane it opened over keeps its own.
  */
 describe('UnsplashPicker', () => {
+  it('returns focus to the picker when the search closes', async () => {
+    render(picker(true));
+    const trigger = screen.getByRole('button', { name: LABEL });
+    trigger.focus();
+    openSearch();
+
+    const close = screen.getByRole('button', { name: 'Close search' });
+    expect(close).toHaveFocus();
+    fireEvent.click(close);
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
   it('marks only the Escape raised inside the open search', () => {
     render(picker(true));
 

--- a/apps/admin/src/editor/unsplash-picker.tsx
+++ b/apps/admin/src/editor/unsplash-picker.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { FocusGuards } from '@radix-ui/react-focus-guards';
+import { FocusScope } from '@radix-ui/react-focus-scope';
 import { UnsplashSearchModal } from '@tryghost/kg-unsplash-selector';
 import { Button } from '@tryghost/shade/components';
 import { ImageUploadActions } from '@tryghost/shade/patterns';
@@ -37,6 +39,7 @@ export function UnsplashPicker({
   onSelect,
 }: UnsplashPickerProps) {
   const { unsplashConfig } = useFramework();
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
 
@@ -73,6 +76,7 @@ export function UnsplashPicker({
     <>
       <ImageUploadActions className={cn('top-1 right-1 opacity-100', className)}>
         <Button
+          ref={triggerRef}
           aria-label={label}
           className="group/unsplash hover:bg-button-hover"
           disabled={disabled}
@@ -89,20 +93,32 @@ export function UnsplashPicker({
       </ImageUploadActions>
       {isOpen &&
         createPortal(
-          // The root the Escape listener is bound to: no layout of its own, and
-          // focusable so a click on the gallery keeps focus inside it.
-          <div ref={setModalRoot} data-testid={unsplashSearchModal} tabIndex={-1}>
-            <UnsplashSearchModal
-              unsplashProviderConfig={unsplashConfig}
-              onClose={() => setIsOpen(false)}
-              onImageInsert={(inserted) => {
-                if (inserted.src) {
-                  onSelect({ src: inserted.src, caption: inserted.caption ?? '' });
-                }
-                setIsOpen(false);
+          // Keep keyboard navigation and gallery clicks inside the root that
+          // marks Escape, so the settings pane behind it never answers too.
+          <FocusGuards>
+            <FocusScope
+              asChild
+              loop
+              trapped
+              onUnmountAutoFocus={(event) => {
+                event.preventDefault();
+                triggerRef.current?.focus();
               }}
-            />
-          </div>,
+            >
+              <div ref={setModalRoot} data-testid={unsplashSearchModal} tabIndex={-1}>
+                <UnsplashSearchModal
+                  unsplashProviderConfig={unsplashConfig}
+                  onClose={() => setIsOpen(false)}
+                  onImageInsert={(inserted) => {
+                    if (inserted.src) {
+                      onSelect({ src: inserted.src, caption: inserted.caption ?? '' });
+                    }
+                    setIsOpen(false);
+                  }}
+                />
+              </div>
+            </FocusScope>
+          </FocusGuards>,
           document.body,
         )}
     </>

--- a/apps/admin/src/editor/unsplash-picker.tsx
+++ b/apps/admin/src/editor/unsplash-picker.tsx
@@ -5,6 +5,7 @@ import { Button } from '@tryghost/shade/components';
 import { ImageUploadActions } from '@tryghost/shade/patterns';
 import { cn } from '@tryghost/shade/utils';
 import { useFramework } from '@tryghost/admin-x-framework';
+import { unsplashSearchModal } from '@tryghost/test-data/selectors/editor';
 import BrandIcon from '@/shared/brand-icon/brand-icon';
 
 export interface UnsplashSelection {
@@ -37,11 +38,20 @@ export function UnsplashPicker({
 }: UnsplashPickerProps) {
   const { unsplashConfig } = useFramework();
   const [isOpen, setIsOpen] = useState(false);
+  const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
+
+  // A gate that goes off while the search is open closes it, so nothing is left
+  // listening for a field the writer can no longer see.
+  useEffect(() => {
+    if (!enabled) {
+      setIsOpen(false);
+    }
+  }, [enabled]);
 
   // The modal answers Escape itself but does not mark it, so a settings pane
   // behind it would read the same Escape as its own and close too.
   useEffect(() => {
-    if (!isOpen) {
+    if (!modalRoot) {
       return;
     }
 
@@ -51,9 +61,9 @@ export function UnsplashPicker({
       }
     };
 
-    window.addEventListener('keydown', markHandled, true);
-    return () => window.removeEventListener('keydown', markHandled, true);
-  }, [isOpen]);
+    modalRoot.addEventListener('keydown', markHandled, true);
+    return () => modalRoot.removeEventListener('keydown', markHandled, true);
+  }, [modalRoot]);
 
   if (!enabled) {
     return null;
@@ -79,16 +89,20 @@ export function UnsplashPicker({
       </ImageUploadActions>
       {isOpen &&
         createPortal(
-          <UnsplashSearchModal
-            unsplashProviderConfig={unsplashConfig}
-            onClose={() => setIsOpen(false)}
-            onImageInsert={(inserted) => {
-              if (inserted.src) {
-                onSelect({ src: inserted.src, caption: inserted.caption ?? '' });
-              }
-              setIsOpen(false);
-            }}
-          />,
+          // The root the Escape listener is bound to: no layout of its own, and
+          // focusable so a click on the gallery keeps focus inside it.
+          <div ref={setModalRoot} data-testid={unsplashSearchModal} tabIndex={-1}>
+            <UnsplashSearchModal
+              unsplashProviderConfig={unsplashConfig}
+              onClose={() => setIsOpen(false)}
+              onImageInsert={(inserted) => {
+                if (inserted.src) {
+                  onSelect({ src: inserted.src, caption: inserted.caption ?? '' });
+                }
+                setIsOpen(false);
+              }}
+            />
+          </div>,
           document.body,
         )}
     </>

--- a/apps/admin/src/shared/images/image-upload.ts
+++ b/apps/admin/src/shared/images/image-upload.ts
@@ -11,7 +11,7 @@ export const ACCEPTED_IMAGE_TYPES = {
   'image/png': ['.png'],
   'image/svg+xml': ['.svg', '.svgz'],
   'image/webp': ['.webp'],
-};
+} as const;
 
 export const UNSUPPORTED_IMAGE_MESSAGE =
   'The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP';

--- a/apps/admin/test-utils/acceptance/editor.ts
+++ b/apps/admin/test-utils/acceptance/editor.ts
@@ -1,6 +1,7 @@
-import { buildLexicalParagraph, post, type Post } from '@tryghost/test-data';
+import { buildLexicalParagraph, post, settingsResponse, type Post } from '@tryghost/test-data';
+import type { RenderAdminAppOptions } from './render-admin-app';
 import { fakeMembers, fakeNewsletters, fakePosts, fakeSnippets } from './resources';
-import { fakeAdminEndpoint, type EndpointCapture } from './worker';
+import { fakeAdminEndpoint, fakeEndpoint, type EndpointCapture } from './worker';
 
 /** Supporting reads shared by the editor's header and card configuration. */
 export function fakeEditorChrome(): void {
@@ -43,4 +44,41 @@ export function fakeEditorPost(
 export function submittedPost(capture: EndpointCapture, index = -1): Record<string, unknown> {
   const body = capture.requests.at(index)?.body as { posts: Record<string, unknown>[] } | undefined;
   return body?.posts[0] ?? {};
+}
+
+const UNSPLASH_REGULAR = 'https://images.unsplash.com/photo-1?ixid=1&w=1080';
+// The picker asks Unsplash for a wider rendition of the image it inserts.
+export const UNSPLASH_PICKED = 'https://images.unsplash.com/photo-1?ixid=1&w=2000';
+
+/** One Unsplash photo, in the shape the search modal lays out and inserts. */
+export function fakeUnsplashPhotos(): void {
+  fakeEndpoint('GET', 'https://api.unsplash.com/photos', [
+    {
+      id: 'photo-1',
+      color: '#123456',
+      alt_description: 'A hillside',
+      height: 800,
+      width: 1200,
+      likes: 12,
+      urls: { regular: UNSPLASH_REGULAR },
+      links: {
+        html: 'https://unsplash.com/photos/photo-1',
+        download: 'https://unsplash.com/photos/photo-1/download',
+        download_location: 'https://api.unsplash.com/photos/photo-1/download',
+      },
+      user: {
+        name: 'A Photographer',
+        links: { html: 'https://unsplash.com/@photographer' },
+        profile_image: { medium: 'https://images.unsplash.com/profile-1' },
+      },
+    },
+  ]);
+  fakeEndpoint('GET', 'https://api.unsplash.com/photos/photo-1/download', {});
+}
+
+/** The site fixture turns Unsplash on, so only the off case needs an override. */
+export function withoutUnsplash(): RenderAdminAppOptions {
+  return {
+    boot: { browseSettings: { response: settingsResponse({ settings: { unsplash: false } }) } },
+  };
 }

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,6 +1,13 @@
 /** Acceptance-harness public surface — see README.md for the spec anatomy. */
 export { fakeAnalyticsOverview } from './analytics';
-export { fakeEditorChrome, fakeEditorPost, submittedPost } from './editor';
+export {
+  UNSPLASH_PICKED,
+  fakeEditorChrome,
+  fakeEditorPost,
+  fakeUnsplashPhotos,
+  submittedPost,
+  withoutUnsplash,
+} from './editor';
 export { currentRoute, renderAdminApp } from './render-admin-app';
 export type { RenderAdminAppOptions } from './render-admin-app';
 export {

--- a/packages/testing/test-data/src/selectors/editor.ts
+++ b/packages/testing/test-data/src/selectors/editor.ts
@@ -35,6 +35,7 @@ export const featureImageTkIndicator = 'feature-image-tk-indicator';
 export const editorLeaveDialog = 'editor-leave-dialog';
 export const editorHeaderActions = 'editor-header-actions';
 export const editorPublishInputsError = 'editor-publish-inputs-error';
+export const unsplashSearchModal = 'unsplash-search-modal';
 
 // settings sidebar testids
 export const postSettingsSidebar = 'post-settings-sidebar';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,12 @@ catalogs:
     '@radix-ui/react-context-menu':
       specifier: 2.3.2
       version: 2.3.2
+    '@radix-ui/react-focus-guards':
+      specifier: 1.1.4
+      version: 1.1.4
+    '@radix-ui/react-focus-scope':
+      specifier: 1.1.11
+      version: 1.1.11
     '@radix-ui/react-form':
       specifier: 0.1.11
       version: 0.1.11
@@ -938,6 +944,12 @@ importers:
       '@dnd-kit/sortable':
         specifier: 'catalog:'
         version: 7.0.2(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards':
+        specifier: 'catalog:'
+        version: 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-focus-scope':
+        specifier: 'catalog:'
+        version: 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/react':
         specifier: 'catalog:'
         version: 7.120.4(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,6 +62,8 @@ catalog:
   '@radix-ui/react-avatar': 1.2.1
   '@radix-ui/react-checkbox': 1.3.6
   '@radix-ui/react-context-menu': 2.3.2
+  '@radix-ui/react-focus-guards': 1.1.4
+  '@radix-ui/react-focus-scope': 1.1.11
   '@radix-ui/react-form': 0.1.11
   '@radix-ui/react-popover': 1.1.18
   '@radix-ui/react-radio-group': 1.4.2


### PR DESCRIPTION
While the Unsplash search modal was open, the picker held a capture-phase
`keydown` listener on `window` that called `preventDefault()` on every Escape,
whoever it was meant for. The settings panel reads a prevented Escape as "some
inner layer already answered this", so for as long as the search was open the
key was claimed on behalf of layers that had nothing to do with it.

The picker now portals the search into a root element of its own and binds the
marking to that element, so only an Escape the search actually contains is
marked. That root is focusable (`tabIndex={-1}`) so a click on a gallery photo —
a plain element the browser will not focus — keeps focus inside the search
rather than dropping it to the body, which would otherwise hand the next Escape
to the pane behind it. Escape in the Unsplash search still closes only the
search and leaves the pane it was opened from.

Two related fixes ride along:

- A gate that goes off while the search is open now closes it, so the picker
  never leaves a listener bound for a field the writer can no longer see.
- The comment above the code injection editors' Escape binding described the
  behaviour from before that marking existed and contradicted the settings
  README. It is corrected, and the README gains a short "Escape" section that
  writes down the whole order in one place: which surface answers Escape when a
  chip list, a code editor, a Radix control, the Unsplash search, or the pane
  itself has focus.

Polish on the picker and its specs:

- The Unsplash fixtures the three image fields each needed were three copies of
  the same photo; they move to `test-utils/acceptance/editor.ts` beside the
  other editor fixtures, alongside the `withoutUnsplash()` boot override.
- The "Insert image" locator is scoped to the search modal's own testid rather
  than matching the text anywhere on the page.
- The feature image gains the Unsplash acceptance case the two card panes
  already had, covering the photographer credit landing in the caption.
- `ACCEPTED_IMAGE_TYPES` is `as const`.

## Verification

- `pnpm --filter @tryghost/admin lint` — 0 errors (41 pre-existing warnings).
- `pnpm --filter @tryghost/admin exec tsc -b` — clean.
- New unit spec `src/editor/unsplash-picker.test.tsx` — 2 passed. It asserts an
  Escape raised inside the open search is marked and one raised on `window` or
  `document.body` is not. Reverting the scoping to the old window listener fails
  that assertion (`expected true to be false`), so it is not vacuous.
- Editor acceptance at 2 workers — 77 passed across the feature image, X card,
  Facebook card, code injection, tags and sidebar specs, including the existing
  "keeps the pane open when Escape dismisses the Unsplash search" cases.
