### PR TITLE
Changed the React editor's write payload to a checked type

### DIFF
--- a/apps/admin/src/editor/engine/change-tracker.ts
+++ b/apps/admin/src/editor/engine/change-tracker.ts
@@ -5,6 +5,7 @@ import {
   type HumanizedDiffEntry,
   type LexicalInput,
 } from '@/editor/engine/lexical-compare';
+import { pick } from '@/editor/engine/pick';
 import { sameTag, type TagLike } from '@/shared/tags/tag-selection';
 
 // Codes are reported to Sentry when the leave modal opens; keep them stable.
@@ -34,8 +35,9 @@ export interface ChangeVerdict {
 /** null until the create request has been acknowledged. */
 export type PostId = string | null;
 
+/** An editor read always carries the relation's id (content-types.ts). */
 export interface PostRelationLike {
-  id?: string;
+  id: string;
 }
 
 // Client-owned editable fields only; other server metadata lives with the save engine.
@@ -181,21 +183,12 @@ function clonePlain<T>(value: T): T {
 }
 
 function pickProjection(post: EditablePostProjection): EditablePostProjection {
-  const out: Record<string, unknown> = {};
-  for (const key of PROJECTION_KEYS) {
-    out[key] = clonePlain(post[key]);
-  }
-  return out as unknown as EditablePostProjection;
+  return clonePlain(pick(post, PROJECTION_KEYS));
 }
 
 function pickPatch(patch: EditablePostPatch): EditablePostPatch {
-  const out: Record<string, unknown> = {};
-  for (const key of PROJECTION_KEYS) {
-    if (key in patch && patch[key] !== undefined) {
-      out[key] = clonePlain(patch[key]);
-    }
-  }
-  return out;
+  const keys = PROJECTION_KEYS.filter((key) => key in patch && patch[key] !== undefined);
+  return clonePlain(pick(patch, keys));
 }
 
 function errorMessage(error: unknown): string {
@@ -429,11 +422,11 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
         return;
       }
       const next = pickProjection(acknowledged);
-      const rebased: Record<string, unknown> = { ...live };
+      const rebasedKeys: ProjectionKey[] = [];
       for (const key of PROJECTION_KEYS) {
         const base = submitted[key] !== undefined ? submitted[key] : saved[key];
         if (key === 'updated_at' || sameField(key, live[key], base)) {
-          rebased[key] = next[key];
+          rebasedKeys.push(key);
         }
       }
       if (postId === null && id !== null) {
@@ -447,7 +440,7 @@ export function createChangeTracker(options: ChangeTrackerOptions = {}): ChangeT
         baseline = { status: 'ready', lexical: next.lexical };
       }
       saved = next;
-      live = rebased as unknown as EditablePostProjection;
+      live = { ...live, ...pick(next, rebasedKeys) };
       saveError = null;
     },
 

--- a/apps/admin/src/editor/engine/pick.test.ts
+++ b/apps/admin/src/editor/engine/pick.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { pick } from './pick';
+
+describe('pick', () => {
+  it('copies only the keys it is given', () => {
+    const source = { id: 'abc', title: 'Hello', slug: 'hello', featured: false };
+
+    expect(pick(source, ['title', 'featured'])).toEqual({ title: 'Hello', featured: false });
+  });
+
+  it('keeps a key whose value is undefined', () => {
+    const source: { title: string; slug?: string } = { title: 'Hello', slug: undefined };
+    const picked = pick(source, ['slug']);
+
+    expect('slug' in picked).toBe(true);
+    expect(picked.slug).toBeUndefined();
+  });
+
+  it('materialises a key the source does not carry', () => {
+    const source: { title: string; slug?: string } = { title: 'Hello' };
+    const picked = pick(source, ['slug']);
+
+    expect('slug' in picked).toBe(true);
+    expect(picked.slug).toBeUndefined();
+  });
+
+  it('copies values by reference rather than cloning them', () => {
+    const tags = [{ id: 'tag-1' }];
+    const picked = pick({ tags, title: 'Hello' }, ['tags']);
+
+    expect(picked.tags).toBe(tags);
+  });
+
+  it('answers with an empty object for no keys', () => {
+    expect(pick({ title: 'Hello' }, [])).toEqual({});
+  });
+});

--- a/apps/admin/src/editor/engine/pick.ts
+++ b/apps/admin/src/editor/engine/pick.ts
@@ -1,0 +1,14 @@
+/**
+ * A shallow copy of `source` holding only `keys`, in the order they are given.
+ * The copy is only as complete as `source`: a key it lacks lands as undefined.
+ */
+export function pick<T extends object, K extends keyof T>(
+  source: T,
+  keys: readonly K[],
+): Pick<T, K> {
+  const picked = {} as Pick<T, K>;
+  for (const key of keys) {
+    picked[key] = source[key];
+  }
+  return picked;
+}

--- a/apps/admin/src/editor/session/access-save.test.ts
+++ b/apps/admin/src/editor/session/access-save.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { serializePostPayload } from '@tryghost/admin-x-framework/api/post-contract';
-import { createEditorSession, type EditorWritePayload } from './editor-session';
+import { createEditorSession, type EditorCreatePayload } from './editor-session';
 import type { EditorRecord } from './projection';
 
 const TIERS = [{ id: 'gold' }, { id: 'silver' }];
@@ -21,7 +21,7 @@ function accessSession(visibility: string | null, tiers = TIERS) {
     tags: [],
   };
   let saves = 0;
-  const persist = (payload: EditorWritePayload) => {
+  const persist = (payload: EditorCreatePayload) => {
     // Exercise the same serialization as the post/page transports: an unpaired
     // tier visibility disappears before the API sees it.
     const serialized = serializePostPayload(payload);

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -1885,4 +1885,21 @@ describe('write payload', () => {
 
     expect(payload).toMatchObject({ id: 'abc123', updated_at: LOADED_AT });
   });
+
+  it('requires both the id and collision token for an update', () => {
+    // @ts-expect-error an update must identify the post
+    const withoutId: EditorEditPayload = { title: 'Hello', updated_at: LOADED_AT };
+    // @ts-expect-error an update must carry its collision token
+    const withoutToken: EditorEditPayload = { title: 'Hello', id: 'abc123' };
+    const nullToken: EditorEditPayload = {
+      title: 'Hello',
+      id: 'abc123',
+      // @ts-expect-error null would bypass the server's collision check
+      updated_at: null,
+    };
+
+    expect(withoutId.id).toBeUndefined();
+    expect(withoutToken.updated_at).toBeUndefined();
+    expect(nullToken.updated_at).toBeNull();
+  });
 });

--- a/apps/admin/src/editor/session/editor-session.test.ts
+++ b/apps/admin/src/editor/session/editor-session.test.ts
@@ -5,8 +5,9 @@ import { buildLexicalParagraph } from '@tryghost/test-data';
 import { deferred } from '@/utils/deferred';
 import {
   createEditorSession,
+  type EditorCreatePayload,
+  type EditorEditPayload,
   type EditorSessionOptions,
-  type EditorWritePayload,
 } from './editor-session';
 import { META_TITLE_MAX, META_TITLE_TOO_LONG } from './settings-fields';
 import type { EditorRecord } from './projection';
@@ -76,8 +77,8 @@ function updateCollision(): JSONError {
 }
 
 interface Harness {
-  updates: Array<{ payload: EditorWritePayload; saveRevision?: boolean }>;
-  creates: EditorWritePayload[];
+  updates: Array<{ payload: EditorEditPayload; saveRevision?: boolean }>;
+  creates: EditorCreatePayload[];
   acquiredIds: string[];
   /** The record every acknowledgement answers with; tests advance it. */
   acknowledged: EditorRecord;
@@ -115,9 +116,9 @@ function harness(options: Partial<EditorSessionOptions> = {}, hooks: HarnessHook
         const next = record({
           ...state.acknowledged,
           id: 'created-id',
-          title: payload.title as string,
-          slug: payload.slug as string,
-          lexical: payload.lexical as string,
+          title: payload.title,
+          slug: payload.slug,
+          lexical: payload.lexical,
           updated_at: `2026-01-01T00:00:0${saveCount}.000Z`,
         });
         state.acknowledged = hooks.acknowledge?.(next, saveCount) ?? next;
@@ -135,9 +136,9 @@ function harness(options: Partial<EditorSessionOptions> = {}, hooks: HarnessHook
         }
         const next = record({
           ...state.acknowledged,
-          title: payload.title as string,
-          slug: payload.slug as string,
-          lexical: payload.lexical as string,
+          title: payload.title,
+          slug: payload.slug,
+          lexical: payload.lexical,
           custom_excerpt: ('custom_excerpt' in payload
             ? payload.custom_excerpt
             : (state.acknowledged.custom_excerpt ?? null)) as string | null,
@@ -1851,5 +1852,37 @@ describe('createEditorSession', () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect(session.isDirty()).toBe(false);
+  });
+});
+
+describe('write payload', () => {
+  it('refuses a key the write contract does not carry', () => {
+    const payload: EditorCreatePayload = {
+      title: 'Hello',
+      // @ts-expect-error a misspelled field is not part of the write contract
+      custom_excerptt: 'A summary',
+    };
+
+    expect(payload.title).toBe('Hello');
+  });
+
+  it('refuses a value the field does not hold', () => {
+    const payload: EditorCreatePayload = {
+      title: 'Hello',
+      // @ts-expect-error `featured` is a boolean
+      featured: 'yes',
+    };
+
+    expect(payload.title).toBe('Hello');
+  });
+
+  it('carries the identity an update needs', () => {
+    const payload: EditorEditPayload = {
+      title: 'Hello',
+      id: 'abc123',
+      updated_at: LOADED_AT,
+    };
+
+    expect(payload).toMatchObject({ id: 'abc123', updated_at: LOADED_AT });
   });
 });

--- a/apps/admin/src/editor/session/editor-session.ts
+++ b/apps/admin/src/editor/session/editor-session.ts
@@ -23,6 +23,7 @@ import type {
   RevisionProjection,
 } from '@/editor/engine/change-tracker';
 import type { LexicalInput } from '@/editor/engine/lexical-compare';
+import { pick } from '@/editor/engine/pick';
 import type { PostWriteOptions } from '@tryghost/admin-x-framework/api/post-contract';
 import { toSaveError } from './error-mapping';
 import { createSlugPort } from './slug-port';
@@ -41,8 +42,9 @@ import {
   type SettingsFieldKey,
   type ValidatedSettingsFields,
 } from './settings-fields';
+import type { EditorCreatePayload, EditorEditPayload } from './write-payload';
 
-export type EditorWritePayload = Record<string, unknown>;
+export type { EditorCreatePayload, EditorEditPayload } from './write-payload';
 
 /** What a manual slug edit did, so the input can revert and report a failure. */
 type SlugEditOutcome = 'applied' | 'unchanged' | 'failed';
@@ -57,7 +59,7 @@ const AUTHORED_KEYS = ['title', 'slug'] as const;
 
 type AuthoredFields = Pick<EditablePostProjection, (typeof AUTHORED_KEYS)[number]>;
 
-export interface PreparedSave extends SaveRequest<EditorSaveSnapshot> {
+interface PreparedWrite extends SaveRequest<EditorSaveSnapshot> {
   /** What the request submits, for the tracker's three-way rebase. */
   projection: EditablePostPatch;
   /** What the live post held for the authored fields when the request was built. */
@@ -66,15 +68,18 @@ export interface PreparedSave extends SaveRequest<EditorSaveSnapshot> {
   validated: ValidatedSettingsFields;
   /** The edit version the request was built at, for the settings adoption guard. */
   builtAtVersion: number;
-  payload: EditorWritePayload;
   options: PostWriteOptions;
-  isCreate: boolean;
 }
 
+/** `isCreate` picks the transport call, and with it the payload's identity. */
+export type PreparedSave =
+  | (PreparedWrite & { isCreate: true; payload: EditorCreatePayload })
+  | (PreparedWrite & { isCreate: false; payload: EditorEditPayload });
+
 export interface EditorSessionTransport {
-  create: (payload: EditorWritePayload) => Promise<EditorRecord | undefined>;
+  create: (payload: EditorCreatePayload) => Promise<EditorRecord | undefined>;
   update: (
-    payload: EditorWritePayload,
+    payload: EditorEditPayload,
     options: PostWriteOptions,
   ) => Promise<EditorRecord | undefined>;
   generateSlug: (text: string, postId: string | null) => Promise<string>;
@@ -155,6 +160,17 @@ export interface EditorSession {
   reauthAbandoned: () => void;
   leaveRequested: () => Promise<LeaveDecision>;
   dispose: () => void;
+}
+
+/** Stages one dirty settings field into both the submitted projection and the payload. */
+function stageSettingsField<Key extends SettingsFieldKey>(
+  key: Key,
+  fields: EditorSettingsFields,
+  projection: EditablePostPatch,
+  payload: EditorCreatePayload,
+): void {
+  projection[key] = fields[key];
+  payload[key] = identityFor(key, fields);
 }
 
 /**
@@ -253,9 +269,7 @@ export function createEditorSession({
     const settings =
       view && SETTINGS_FIELD_KEYS.every((key) => view.settings[key] === live[key])
         ? view.settings
-        : (Object.fromEntries(
-            SETTINGS_FIELD_KEYS.map((key) => [key, live[key]]),
-          ) as EditorSettingsFields);
+        : pick(live, SETTINGS_FIELD_KEYS);
     const publishTime =
       view &&
       view.publishTime.status === status &&
@@ -372,7 +386,7 @@ export function createEditorSession({
   const stopSlugNotifications = machine.subscribe(notifyChanged);
 
   function prepare(request: SaveRequest<EditorSaveSnapshot>): Promise<PreparedSave> {
-    const isCreate = request.snapshot.id === null;
+    const id = request.snapshot.id;
     const projection: EditablePostPatch = {
       title: request.title,
       slug: request.slug,
@@ -383,9 +397,9 @@ export function createEditorSession({
       updated_at: request.snapshot.updatedAt,
     };
 
-    const payload: EditorWritePayload = {
-      title: projection.title,
-      slug: projection.slug,
+    const payload: EditorCreatePayload = {
+      title: request.title,
+      slug: request.slug,
       lexical: projection.lexical,
       feature_image: projection.feature_image,
       feature_image_alt: projection.feature_image_alt,
@@ -395,15 +409,13 @@ export function createEditorSession({
     };
     // An Author's or Contributor's create is refused unless `authors` names them
     // (core/server/models/relations/authors.js). Updates never resend it.
-    if (isCreate && currentUserId) {
+    if (id === null && currentUserId) {
       payload.authors = [{ id: currentUserId }];
     }
 
-    const staged = projection as Record<string, unknown>;
     for (const key of SETTINGS_FIELD_KEYS) {
       if (tracker.isFieldDirty(key)) {
-        staged[key] = live[key];
-        payload[key] = identityFor(key, live[key]);
+        stageSettingsField(key, live, projection, payload);
       }
     }
     // The write contract requires the pair even when only one field changed.
@@ -413,36 +425,37 @@ export function createEditorSession({
       projection.visibility = live.visibility;
       payload.visibility = live.visibility;
       projection.tiers = live.tiers;
-      payload.tiers = live.tiers;
-    }
-    if (!isCreate) {
-      if (!projection.updated_at) {
-        // Without the token the server skips its collision check entirely and the
-        // save would overwrite whatever landed in the meantime.
-        return Promise.reject(
-          new Error('Cannot save without the version this post was loaded at.'),
-        );
-      }
-      payload.id = request.snapshot.id;
-      payload.updated_at = projection.updated_at;
+      payload.tiers = identityFor('tiers', live);
     }
     if (request.target.emailOnly !== undefined) {
       payload.email_only = request.target.emailOnly;
     }
 
-    return Promise.resolve({
+    const prepared: PreparedWrite = {
       ...request,
       projection,
       authoredFrom: { title: live.title, slug: live.slug },
       validated: validatedFieldsOf(live),
       builtAtVersion: version,
-      payload,
       options: {
         saveRevision: request.saveRevision,
         newsletter: request.target.newsletter,
         emailSegment: request.target.emailSegment,
       },
-      isCreate,
+    };
+
+    if (id === null) {
+      return Promise.resolve({ ...prepared, isCreate: true, payload });
+    }
+    if (!projection.updated_at) {
+      // Without the token the server skips its collision check entirely and the
+      // save would overwrite whatever landed in the meantime.
+      return Promise.reject(new Error('Cannot save without the version this post was loaded at.'));
+    }
+    return Promise.resolve({
+      ...prepared,
+      isCreate: false,
+      payload: { ...payload, id, updated_at: projection.updated_at },
     });
   }
 

--- a/apps/admin/src/editor/session/publish-time-save.test.ts
+++ b/apps/admin/src/editor/session/publish-time-save.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createEditorSession, type EditorWritePayload } from './editor-session';
+import { serializePostPayload } from '@tryghost/admin-x-framework/api/post-contract';
+import { createEditorSession, type EditorCreatePayload } from './editor-session';
 import type { EditorRecord } from './projection';
 import { PUBLISHED_AT_MUST_BE_PAST, publishedAtInFuture } from './settings-fields';
 import { deferred } from '@/utils/deferred';
@@ -33,9 +34,12 @@ function publishTimeSession(status: EditorRecord['status'], publishedAt: string 
     tags: [],
   };
   let saves = 0;
-  const persist = (payload: EditorWritePayload) => {
+  const persist = (payload: EditorCreatePayload) => {
     saves += 1;
-    saved = { ...saved, ...payload, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
+    // The payload is not a record, so the post serializer stands in for the
+    // transport to resolve it into the fields a saved record carries.
+    const serialized = serializePostPayload(payload);
+    saved = { ...saved, ...serialized, updated_at: `2026-01-01T00:00:0${saves}.000Z` };
     return Promise.resolve(saved);
   };
   const create = vi.fn(persist);

--- a/apps/admin/src/editor/session/settings-fields.ts
+++ b/apps/admin/src/editor/session/settings-fields.ts
@@ -1,6 +1,8 @@
-import type { EditablePostProjection, PostRelationLike } from '@/editor/engine/change-tracker';
+import type { EditablePostProjection } from '@/editor/engine/change-tracker';
+import { pick } from '@/editor/engine/pick';
 import type { PostStatus } from '@/editor/engine/save-engine';
-import { tagIdentities, type TagLike } from '@/shared/tags/tag-selection';
+import { tagIdentities } from '@/shared/tags/tag-selection';
+import type { EditorCreatePayload } from './write-payload';
 
 /**
  * The projection keys the settings sidebar may write. Slug, status and publish
@@ -33,7 +35,11 @@ export type SettingsFieldKey = (typeof SETTINGS_FIELD_KEYS)[number];
 
 export type EditorSettingsFields = Pick<EditablePostProjection, SettingsFieldKey>;
 
-export type EditorSettingsPatch = Partial<EditorSettingsFields>;
+export type EditorSettingsPatch = Partial<
+  Omit<EditorSettingsFields, 'show_title_and_feature_image'>
+> & {
+  show_title_and_feature_image?: boolean;
+};
 
 export const TIERS_REQUIRED = 'Please select at least one tier';
 
@@ -41,19 +47,34 @@ export const TIERS_REQUIRED = 'Please select at least one tier';
 export const AUTHORS_REQUIRED = 'At least one author is required.';
 
 /**
- * What a settings field writes. A relation travels as identity alone, so the
- * field can hold the whole record and still send nothing but order.
+ * What a settings field writes. Tags and authors travel as identity alone; a
+ * tier relation travels as the record the field holds, and the API reads its id.
  */
-export function identityFor(key: SettingsFieldKey, value: unknown): unknown {
+export function identityFor<Key extends SettingsFieldKey>(
+  key: Key,
+  fields: EditorSettingsFields,
+): EditorCreatePayload[Key];
+export function identityFor(
+  key: SettingsFieldKey,
+  fields: EditorSettingsFields,
+): EditorCreatePayload[SettingsFieldKey] {
   if (key === 'authors') {
-    return (value as ReadonlyArray<PostRelationLike>).map(({ id }) => ({ id }));
+    return fields.authors.map(({ id }) => ({ id }));
   }
   // The field holds the tag records the field displays; the relation is
   // written by identity alone.
   if (key === 'tags') {
-    return tagIdentities(value as ReadonlyArray<TagLike>);
+    return tagIdentities(fields.tags);
   }
-  return value;
+  if (key === 'tiers') {
+    return [...fields.tiers];
+  }
+  // The flag is a page's; a null is a record that carries none, never a write —
+  // the patch type admits only a boolean for it.
+  if (key === 'show_title_and_feature_image') {
+    return fields.show_title_and_feature_image ?? undefined;
+  }
+  return fields[key];
 }
 
 /** The column widths the schema gives these fields. */
@@ -118,9 +139,7 @@ export type ValidatedSettingsFields = Pick<EditorSettingsFields, ValidatedSettin
 
 /** The validator's own view of the live document. */
 export function validatedFieldsOf(fields: ValidatedSettingsFields): ValidatedSettingsFields {
-  return Object.fromEntries(
-    VALIDATED_SETTINGS_FIELD_KEYS.map((key) => [key, fields[key]]),
-  ) as ValidatedSettingsFields;
+  return pick(fields, VALIDATED_SETTINGS_FIELD_KEYS);
 }
 
 /** The first rule the settings fields break, in the post validator's order. */

--- a/apps/admin/src/editor/session/use-editor-session.ts
+++ b/apps/admin/src/editor/session/use-editor-session.ts
@@ -11,19 +11,15 @@ import {
   useEditPage,
   useEditorPage,
   pagesDataType,
-  type PageEditableData,
+  type PageStatus,
 } from '@tryghost/admin-x-framework/api/pages';
 import {
   useAddPost,
   useEditPost,
   useEditorPost,
   postsDataType,
-  type PostEditableData,
+  type PostStatus,
 } from '@tryghost/admin-x-framework/api/posts';
-import type {
-  CreateContentData,
-  EditContentData,
-} from '@tryghost/admin-x-framework/api/content-types';
 import {
   buildPostEditorReadParams,
   type PostWriteOptions,
@@ -41,9 +37,10 @@ import type { PostType } from '@/editor/card-config';
 import { contentToText } from './content-text';
 import {
   createEditorSession,
+  type EditorCreatePayload,
+  type EditorEditPayload,
   type EditorSession,
   type EditorSessionView,
-  type EditorWritePayload,
 } from './editor-session';
 import { createPublishDispatcher } from './publish-dispatch';
 import type { PublishDispatcher } from '@/editor/publish/publish-options';
@@ -149,6 +146,11 @@ export interface UseEditorSessionOptions {
   currentUserId?: string;
 }
 
+/** A page is never sent, so the page write contract has no such status. */
+function pageStatus(status: PostStatus | undefined): PageStatus | undefined {
+  return status === 'sent' ? undefined : status;
+}
+
 function reportError(error: unknown): void {
   // eslint-disable-next-line no-console
   console.error(error);
@@ -191,33 +193,33 @@ export function useEditorSession({
       onIdAcquired: setPersistedId,
       onError: reportError,
       transport: {
-        create: async (payload: EditorWritePayload) => {
+        create: async (payload: EditorCreatePayload) => {
           const current = transport.current;
           if (current.postType === 'page') {
             const { pages } = await current.addPage({
-              page: payload as CreateContentData<PageEditableData>,
+              page: { ...payload, status: pageStatus(payload.status) },
               sessionExpiryRedirect: false,
             });
             return pages[0];
           }
           const { posts } = await current.addPost({
-            post: payload as CreateContentData<PostEditableData>,
+            post: payload,
             sessionExpiryRedirect: false,
           });
           return posts[0];
         },
-        update: async (payload: EditorWritePayload, options: PostWriteOptions) => {
+        update: async (payload: EditorEditPayload, options: PostWriteOptions) => {
           const current = transport.current;
           if (current.postType === 'page') {
             const { pages } = await current.editPage({
-              page: payload as EditContentData<PageEditableData>,
+              page: { ...payload, status: pageStatus(payload.status) },
               options,
               sessionExpiryRedirect: false,
             });
             return pages[0];
           }
           const { posts } = await current.editPost({
-            post: payload as EditContentData<PostEditableData>,
+            post: payload,
             options,
             sessionExpiryRedirect: false,
           });

--- a/apps/admin/src/editor/session/write-payload.ts
+++ b/apps/admin/src/editor/session/write-payload.ts
@@ -1,0 +1,28 @@
+import type {
+  CreateContentData,
+  PageEditableData,
+  PostEditableData,
+  PostTier,
+} from '@tryghost/admin-x-framework/api/content-types';
+
+/**
+ * The fields the editor writes. `show_title_and_feature_image` is a page field;
+ * the write contract strips it from post payloads (post-contract.ts).
+ */
+type EditorWritableData = Omit<
+  PostEditableData & Pick<PageEditableData, 'show_title_and_feature_image'>,
+  'tiers'
+> & {
+  // A tier relation travels as the record the settings field holds; the API
+  // reads its id and ignores the rest.
+  tiers?: PostTier[];
+};
+
+/** A create carries no identity: the server assigns the id and the first token. */
+export type EditorCreatePayload = CreateContentData<EditorWritableData>;
+
+/** An update carries the id and the collision token the save was built at. */
+export type EditorEditPayload = EditorCreatePayload & {
+  id: string;
+  updated_at: string | null;
+};

--- a/apps/admin/src/editor/session/write-payload.ts
+++ b/apps/admin/src/editor/session/write-payload.ts
@@ -24,5 +24,5 @@ export type EditorCreatePayload = CreateContentData<EditorWritableData>;
 /** An update carries the id and the collision token the save was built at. */
 export type EditorEditPayload = EditorCreatePayload & {
   id: string;
-  updated_at: string | null;
+  updated_at: string;
 };

--- a/apps/admin/src/editor/settings/access-options.ts
+++ b/apps/admin/src/editor/settings/access-options.ts
@@ -43,7 +43,7 @@ export function tierOptions(tiers: Tier[] | undefined): TierOption[] {
   }));
 }
 
-type PostTier = PostRelationLike & { type?: string };
+type PostTier = { id?: string; type?: string };
 
 /** Public/member reads include the free tier, which cannot grant specific-tier access. */
 export function selectedTierIds(tiers: ReadonlyArray<PostTier>): string[] {

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -366,7 +366,7 @@ renderings: at Stripe's current default the shipping address moves to
 The same difference applies to `stripe listen`, which `pnpm dev:stripe --listen` uses:
 it renders events at the account default too. The default `pnpm dev:stripe` lets Ghost
 register its own pinned endpoint, so it receives the payloads production receives (see
-[Development setup](../docs/contributing/development-setup.md#stripe-webhooks)).
+[Stripe testing](../docs/contributing/testing-stripe.md#receive-production-shaped-webhooks)).
 
 ## Resolving issues
 


### PR DESCRIPTION
The React editor's save payload was declared `EditorWritePayload = Record<string, unknown>`. A misspelled key compiled and shipped to the API as an unknown field, and because the payload carried no type, the transport asserted it back to `CreateContentData<PostEditableData>` / `EditContentData<PageEditableData>` and friends at four call sites.

## What changed

**A real payload type.** `session/write-payload.ts` derives the payload from the framework's editable-data types: `PostEditableData` plus the page-only `show_title_and_feature_image`, split into `EditorCreatePayload` and `EditorEditPayload` (the latter adds the `id` and the collision token an update must carry). `PreparedSave` is now a union discriminated on `isCreate`, so `execute` picks the transport call and the payload shape together and all four transport assertions fall away.

**`identityFor` is typed per key.** It took `(key, value: unknown): unknown`, which fed `unknown` straight into the payload. It now takes the settings fields and returns the payload's own type for the key it is given, so a wrong value type for a field stops compiling. Its relation rules are unchanged: authors and tags travel as identity alone, and a tier relation travels as the record the field holds — the payload type says `tiers?: PostTier[]` so the declared type matches what is sent.

**One shared `pick`.** `engine/pick.ts` provides `pick<T, K extends keyof T>(source, keys): Pick<T, K>`, replacing the five build-an-object-over-a-key-tuple-then-assert sites — including both `as unknown as` casts in the change tracker (`pickProjection` and the `saveAcknowledged` rebase), `pickPatch`, `validatedFieldsOf`, and the session view's settings snapshot.

**Relations require their id.** `PostRelationLike.id` is now `string` rather than `string | undefined`. An editor read always carries the id (the framework's `EditorRelations` says so), and the write contract's `PostAuthorInput` / `PostTierInput` demand it — without this the relation writes could not be typed.

Lines carrying an ` as ` assertion under `apps/admin/src/editor` (excluding ` as const`): **198 before, 185 after**, a net −13, including both `as unknown as` in the engine. The one added is the standard `{} as Pick<T, K>` accumulator inside `pick` itself. Counted with:

```
git grep -h " as " <rev> -- 'apps/admin/src/editor/**/*.ts' 'apps/admin/src/editor/**/*.tsx' | grep -cv " as const"
```

run at `origin/main` and at this branch's head.

## Where the types and the resource disagree

- **`status` on a page.** The session is resource-blind, so its status domain is the post's `PostStatus`, which includes `sent`; `PageEditableData` correctly excludes it. The page branch of the transport — the one place that knows the resource — narrows it with a three-line `pageStatus` helper instead of an assertion. A page is never `sent`, so no request changes.
- **`show_title_and_feature_image`.** The projection holds `boolean | null`, null standing for a record with no page-builder flag, while the page write contract accepts `boolean`. `EditorSettingsPatch` now types that one key as `boolean`, so a null can never be staged as a write: the toggle is the only writer and it always commits a boolean.

No framework types were modified.

## One cosmetic wire change

A publish or revert builds `email_only` onto the payload before the edit branch attaches `id` and `updated_at`, where it used to be the other way round. The JSON keys are the same keys with the same values; only their order in the serialised body differs.

## Tests

- `engine/pick.test.ts` covers `pick`: selected keys only, a key whose value is `undefined`, a key the source does not carry at all (materialised as `undefined`), copy-by-reference, and the empty-key case.
- `session/editor-session.test.ts` gains a compile-time block: `@ts-expect-error` on a misspelled payload key and on a wrong value type, plus a case asserting the edit payload carries its identity. Both directives are load-bearing — an unused `@ts-expect-error` fails `tsc`.
- The session, settings-fields and change-tracker suites keep passing unchanged, apart from the harnesses adopting the new types (which let six `payload.x as string` assertions go).

## Review follow-up

Rebased onto `main` at `75f2239d91`, which contains the publication-language type fix for the original CI lint failure. The edit payload now requires a non-null `updated_at`, matching the existing save guard; compile-time tests reject a missing ID and missing or null collision tokens. Fixed the stale Stripe documentation link found by the full repository check.

## Verification

- `pnpm check` — passed formatting, repository lint/documentation checks, and tests across 39 projects. The first full run hit a five-second timeout in the unchanged RSS suite; all 13 RSS tests passed in isolation, and the full check passed on rerun using completed-task caches.
- `pnpm --filter @tryghost/admin exec tsc -b` — passed, including payload compile-time tests.
- Admin lint — zero errors, 41 existing warnings.
- Editor engine/session unit tests — 19 files, 707 tests passed.
- Chromium acceptance at two workers: `editor-settings-show-title`, `editor-settings-access`, and `editor-save` — 40 tests passed.
- GitHub CI is running on the pushed branch.
