### PR TITLE
Removed unused welcome email service barrel

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/index.js
+++ b/ghost/core/core/server/services/member-welcome-emails/index.js
@@ -1,7 +1,0 @@
-const service = require('./service');
-const constants = require('./constants');
-
-module.exports = {
-  service,
-  ...constants,
-};


### PR DESCRIPTION
no refs

## Summary

- Removed the unreferenced `member-welcome-emails/index.js` CommonJS barrel.
- Kept the live service, constants, and their direct consumers unchanged.

## Evidence and history

Ghost Core-scoped Knip reported the barrel as unused, and a repository-wide search found no import or require of the directory entry point. Every live consumer imports either `/service` or `/constants` directly.

The historical facts show why the barrel existed and why it is now obsolete:

- [8e34ad1793a3c03d288a03c362f5481cda46294d](https://github.com/TryGhost/Ghost/commit/8e34ad1793a3c03d288a03c362f5481cda46294d) introduced the wrapper to initialize the first welcome-email outbox job.
- [019cba2a1c9faf74c66e9751b238559431ef668d](https://github.com/TryGhost/Ghost/commit/019cba2a1c9faf74c66e9751b238559431ef668d) made the barrel reusable while decoupling outbox processing in [#25610](https://github.com/TryGhost/Ghost/pull/25610). At that point the member-created outbox handler was the sole directory-level consumer.
- [295cfd0973d97b2cd48188a86dc520ba95791a2a](https://github.com/TryGhost/Ghost/commit/295cfd0973d97b2cd48188a86dc520ba95791a2a) deliberately moved that final consumer to `/service` in [#25626](https://github.com/TryGhost/Ghost/pull/25626), whose stated goal included cleaning up the boundary so the outbox no longer owned welcome-email configuration.

From those facts, the inference is that retaining the updated but unreferenced barrel was incomplete cleanup from that boundary change. No compatibility or boot-time boundary remains at this path.

## Verification

- Repository-wide reference search: no directory-level consumers.
- Ghost Core-scoped Knip: the deleted barrel is no longer reported.
- Focused member welcome email integration and snapshot tests: 29 passed.
- `pnpm check`: formatting, linting, documentation checks, and 38 of 39 test projects passed. Ghost Core completed 8,614 tests successfully, with four unrelated gift-preview PNG tests timing out alongside the environment's recurring `Fontconfig error: Cannot load default config file: File not found`.

No changeset is needed because this removes an internal Ghost Core file without changing a published package API.
