### PR TITLE
Changed email analytics result merging to linear time

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -504,8 +504,9 @@ export class EmailAnalyticsService {
         unhandled: processingResult.unhandled,
         unprocessable: processingResult.unprocessable,
       };
-      const beforeEmailIds = new Set(processingResult.emailIds);
-      const beforeMemberIds = new Set(processingResult.memberIds);
+      // IDs are appended in first-seen order, so everything past these offsets is new to this batch
+      const beforeEmailIdCount = processingResult.emailIds.length;
+      const beforeMemberIdCount = processingResult.memberIds.length;
 
       await eventProcessor.processBatch(events, processingResult, fetchData);
       processingTimeMs += Date.now() - processingStart;
@@ -521,8 +522,8 @@ export class EmailAnalyticsService {
         complained: processingResult.complained - beforeCounts.complained,
         unhandled: processingResult.unhandled - beforeCounts.unhandled,
         unprocessable: processingResult.unprocessable - beforeCounts.unprocessable,
-        emailIds: processingResult.emailIds.filter((id) => !beforeEmailIds.has(id)),
-        memberIds: processingResult.memberIds.filter((id) => !beforeMemberIds.has(id)),
+        emailIds: processingResult.emailIds.slice(beforeEmailIdCount),
+        memberIds: processingResult.memberIds.slice(beforeMemberIdCount),
       });
       cumulativeResult.merge(batchDelta);
 

--- a/ghost/core/core/server/services/email-analytics/event-processing-result.ts
+++ b/ghost/core/core/server/services/email-analytics/event-processing-result.ts
@@ -1,9 +1,6 @@
-type EventProcessingResultInput = Partial<Omit<EventProcessingResult, 'merge'>>;
+type EventProcessingResultInput = Partial<Omit<EventProcessingResult, 'merge' | 'reset'>>;
 
 export class EventProcessingResult {
-  #emailIdSet = new Set<string>();
-  #memberIdSet = new Set<string>();
-
   // counts
   delivered: number = 0;
   opened: number = 0;
@@ -17,12 +14,26 @@ export class EventProcessingResult {
   // processing failures are counted separately in addition to event type counts
   processingFailures: number = 0;
 
-  // ids seen whilst processing ready for passing to stats aggregator
-  emailIds: string[] = [];
-  memberIds: string[] = [];
+  // ids seen whilst processing ready for passing to stats aggregator.
+  // The arrays are append-only in first-seen order; merge() is the only write path,
+  // so the membership sets can never drift from them. The getters return the
+  // backing arrays (not copies) so hot-path `.length` reads stay O(1); `readonly`
+  // is the only guard, so never mutate them from untyped callers.
+  #emailIds: string[] = [];
+  #memberIds: string[] = [];
+  #emailIdSet = new Set<string>();
+  #memberIdSet = new Set<string>();
 
   constructor(result: EventProcessingResultInput = {}) {
     this.merge(result);
+  }
+
+  get emailIds(): readonly string[] {
+    return this.#emailIds;
+  }
+
+  get memberIds(): readonly string[] {
+    return this.#memberIds;
   }
 
   reset(): void {
@@ -35,8 +46,10 @@ export class EventProcessingResult {
     this.unhandled = 0;
     this.unprocessable = 0;
     this.processingFailures = 0;
-    this.emailIds = [];
-    this.memberIds = [];
+    // Reassign rather than clear in place: an aggregation may still be iterating
+    // the previous arrays across awaits when the result is reset.
+    this.#emailIds = [];
+    this.#memberIds = [];
     this.#emailIdSet.clear();
     this.#memberIdSet.clear();
   }
@@ -53,17 +66,16 @@ export class EventProcessingResult {
 
     this.processingFailures += other.processingFailures || 0;
 
-    // Only visit incoming IDs; rebuilding the accumulated arrays per event is quadratic.
-    for (const emailId of other.emailIds || []) {
-      if (emailId && !this.#emailIdSet.has(emailId)) {
-        this.#emailIdSet.add(emailId);
-        this.emailIds.push(emailId);
-      }
-    }
-    for (const memberId of other.memberIds || []) {
-      if (memberId && !this.#memberIdSet.has(memberId)) {
-        this.#memberIdSet.add(memberId);
-        this.memberIds.push(memberId);
+    EventProcessingResult.#collect(this.#emailIdSet, this.#emailIds, other.emailIds);
+    EventProcessingResult.#collect(this.#memberIdSet, this.#memberIds, other.memberIds);
+  }
+
+  // Only visit incoming IDs; rebuilding the accumulated arrays per event is quadratic.
+  static #collect(seen: Set<string>, ordered: string[], ids?: readonly string[] | null): void {
+    for (const id of ids ?? []) {
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        ordered.push(id);
       }
     }
   }

--- a/ghost/core/core/server/services/email-analytics/event-processing-result.ts
+++ b/ghost/core/core/server/services/email-analytics/event-processing-result.ts
@@ -1,6 +1,9 @@
 type EventProcessingResultInput = Partial<Omit<EventProcessingResult, 'merge'>>;
 
 export class EventProcessingResult {
+  #emailIdSet = new Set<string>();
+  #memberIdSet = new Set<string>();
+
   // counts
   delivered: number = 0;
   opened: number = 0;
@@ -34,6 +37,8 @@ export class EventProcessingResult {
     this.processingFailures = 0;
     this.emailIds = [];
     this.memberIds = [];
+    this.#emailIdSet.clear();
+    this.#memberIdSet.clear();
   }
 
   merge(other: EventProcessingResultInput = {}): void {
@@ -48,12 +53,18 @@ export class EventProcessingResult {
 
     this.processingFailures += other.processingFailures || 0;
 
-    // TODO: come up with a cleaner way to merge these without churning through Array and Set
-    this.emailIds = Array.from(new Set([...this.emailIds, ...(other.emailIds || [])])).filter(
-      Boolean,
-    );
-    this.memberIds = Array.from(new Set([...this.memberIds, ...(other.memberIds || [])])).filter(
-      Boolean,
-    );
+    // Only visit incoming IDs; rebuilding the accumulated arrays per event is quadratic.
+    for (const emailId of other.emailIds || []) {
+      if (emailId && !this.#emailIdSet.has(emailId)) {
+        this.#emailIdSet.add(emailId);
+        this.emailIds.push(emailId);
+      }
+    }
+    for (const memberId of other.memberIds || []) {
+      if (memberId && !this.#memberIdSet.has(memberId)) {
+        this.#memberIdSet.add(memberId);
+        this.memberIds.push(memberId);
+      }
+    }
   }
 }

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -697,8 +697,7 @@ describe('EmailAnalyticsService', function () {
       it('preserves new email and member IDs in the cumulative result', async function () {
         const eventProcessor = createStubEventProcessor();
         eventProcessor.processBatch.callsFake(async (_events, result) => {
-          result.emailIds.push('email-id');
-          result.memberIds.push('member-id');
+          result.merge({ emailIds: ['email-id'], memberIds: ['member-id'] });
         });
         const service = createServiceWithEventProcessor(eventProcessor);
 
@@ -706,6 +705,49 @@ describe('EmailAnalyticsService', function () {
 
         assert.deepEqual(result.result.emailIds, ['email-id']);
         assert.deepEqual(result.result.memberIds, ['member-id']);
+      });
+
+      it('accumulates only the IDs first seen in each batch across intermediate resets', async function () {
+        const eventProcessor = createStubEventProcessor();
+        const batches = [
+          { emailIds: ['email-1'], memberIds: ['member-1', 'member-2'] },
+          { emailIds: ['email-1', 'email-2'], memberIds: ['member-2', 'member-3'] },
+          { emailIds: ['email-2'], memberIds: ['member-3'] },
+        ];
+        eventProcessor.processBatch.callsFake(async (_events, result) => {
+          result.merge(batches.shift());
+        });
+        // A processor resets the shared result after some intermediate aggregations,
+        // so batch deltas start from both zero and non-zero offsets
+        let intermediateAggregations = 0;
+        eventProcessor.aggregate.callsFake(async ({ processingResult, isFinal }) => {
+          if (!isFinal) {
+            intermediateAggregations += 1;
+            if (intermediateAggregations === 2) {
+              processingResult.reset();
+            }
+          }
+          return { emailAggregationTimeMs: 0, memberAggregationTimeMs: 0 };
+        });
+        const service = createService({
+          queries: {
+            getLastEventTimestamp: sinon.stub().resolves(),
+            setJobTimestamp: sinon.stub().resolves(),
+            setJobStatus: sinon.stub().resolves(),
+          },
+          fetchEvents: async ({ batchHandler }: { batchHandler: BatchHandler }) => {
+            for (let i = 0; i < 3; i++) {
+              await batchHandler([{ type: 'delivered', timestamp: new Date(i + 1) }]);
+            }
+          },
+          createEventProcessor: () => eventProcessor,
+        });
+
+        const result = await service.fetchLatestOpenedEvents();
+
+        assert.equal(result.eventCount, 3);
+        assert.deepEqual(result.result.emailIds, ['email-1', 'email-2']);
+        assert.deepEqual(result.result.memberIds, ['member-1', 'member-2', 'member-3']);
       });
 
       it('rejects when fetching events fails', async function () {

--- a/ghost/core/test/unit/server/services/email-analytics/event-processing-result.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/event-processing-result.test.ts
@@ -69,6 +69,8 @@ describe('EventProcessingResult', function () {
     result.reset();
 
     assert.deepEqual(result, new EventProcessingResult());
+    assert.deepEqual(result.emailIds, []);
+    assert.deepEqual(result.memberIds, []);
   });
 
   describe('merge()', function () {
@@ -89,6 +91,17 @@ describe('EventProcessingResult', function () {
       assert.equal(result.opened, 3);
       assert.deepEqual(result.emailIds, ['email-2', 'email-1', 'email-3']);
       assert.deepEqual(result.memberIds, ['member-2', 'member-1', 'member-3']);
+    });
+
+    it('exposes accumulated IDs as read-only views that reflect later merges', function () {
+      const result = new EventProcessingResult({ emailIds: ['email-1'], memberIds: ['member-1'] });
+      const emailIds = result.emailIds;
+      const memberIds = result.memberIds;
+
+      result.merge({ emailIds: ['email-1', 'email-2'], memberIds: ['member-2', 'member-1'] });
+
+      assert.deepEqual(emailIds, ['email-1', 'email-2']);
+      assert.deepEqual(memberIds, ['member-1', 'member-2']);
     });
 
     it('can collect the same IDs again after reset', function () {

--- a/ghost/core/test/unit/server/services/email-analytics/event-processing-result.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/event-processing-result.test.ts
@@ -72,6 +72,68 @@ describe('EventProcessingResult', function () {
   });
 
   describe('merge()', function () {
+    it('ignores empty IDs and preserves first-seen order across repeated merges', function () {
+      const result = new EventProcessingResult({
+        emailIds: ['', 'email-2', 'email-2', 'email-1'],
+        memberIds: ['member-2', '', 'member-1', 'member-2'],
+      });
+
+      for (let i = 0; i < 3; i++) {
+        result.merge({
+          opened: 1,
+          emailIds: ['email-1', '', 'email-3', 'email-2'],
+          memberIds: ['', 'member-3', 'member-1', 'member-2'],
+        });
+      }
+
+      assert.equal(result.opened, 3);
+      assert.deepEqual(result.emailIds, ['email-2', 'email-1', 'email-3']);
+      assert.deepEqual(result.memberIds, ['member-2', 'member-1', 'member-3']);
+    });
+
+    it('can collect the same IDs again after reset', function () {
+      const result = new EventProcessingResult({
+        opened: 2,
+        emailIds: ['email-1', 'email-2'],
+        memberIds: ['member-1', 'member-2'],
+      });
+
+      result.reset();
+      result.merge({
+        opened: 1,
+        emailIds: ['email-2', 'email-2', 'email-1'],
+        memberIds: ['member-2', 'member-2', 'member-1'],
+      });
+
+      assert.equal(result.opened, 1);
+      assert.deepEqual(result.emailIds, ['email-2', 'email-1']);
+      assert.deepEqual(result.memberIds, ['member-2', 'member-1']);
+    });
+
+    it('keeps merged results independent when the source resets and is reused', function () {
+      const page = new EventProcessingResult({
+        opened: 2,
+        emailIds: ['email-1'],
+        memberIds: ['member-1', 'member-2'],
+      });
+      const total = new EventProcessingResult(page);
+
+      page.reset();
+      page.merge({
+        opened: 2,
+        emailIds: ['email-1', 'email-2'],
+        memberIds: ['member-2', 'member-3'],
+      });
+      total.merge(page);
+      page.reset();
+
+      assert.equal(total.opened, 4);
+      assert.deepEqual(total.emailIds, ['email-1', 'email-2']);
+      assert.deepEqual(total.memberIds, ['member-1', 'member-2', 'member-3']);
+      assert.deepEqual(page.emailIds, []);
+      assert.deepEqual(page.memberIds, []);
+    });
+
     it('adds counts and merges id arrays', function () {
       const result = new EventProcessingResult({
         delivered: 1,


### PR DESCRIPTION
After a newsletter is sent, Ghost fetches events from Mailgun telling us which messages were delivered, opened, or failed. Ghost uses these events to update newsletter and member statistics. Large sends generate a lot of events, so the work we repeat for each event affects how quickly analytics can catch up.

While processing events, Ghost keeps lists of the emails and members whose statistics need updating. Each email or member should appear only once in its list, even if several events refer to it. These lists let Ghost group the later statistics updates together.

Currently, Ghost recreates both lists after every event: it copies all the IDs collected so far, adds the incoming IDs, and removes duplicates. Once a list contains thousands of members, adding one member means checking thousands of earlier entries again. We also repeat this work when the incoming member is already on the list.

This PR keeps a record of the IDs already seen. For each incoming ID, Ghost checks that record and adds the ID only if it is new. The lists still contain the same emails and members in the same order, but building them no longer requires repeatedly copying and checking earlier entries.

The comparison below shows what happens for each email or member ID:

```mermaid
flowchart LR
    subgraph before["Before: rebuild the list"]
        direction TB
        B0(["An event supplies an ID"]) --> B1["Copy the existing list and add the ID"]
        B1 --> B2["Check the whole list for duplicates and empty IDs"]
        B2 --> B3["Keep the resulting list for statistics updates"]
    end

    subgraph after["After: check the incoming ID"]
        direction TB
        A0(["An event supplies an ID"]) --> A1{"Is the ID nonempty and new?"}
        A1 -->|Yes| A2["Remember the ID and append it to the list"]
        A2 --> A3["Keep the list for statistics updates"]
        A1 -->|No: nothing to add| A3
    end

    before ~~~ after
```

The implementation uses a persistent `Set` alongside each existing ID array. `merge()` checks only incoming IDs; `reset()` clears both the arrays and the sets so the next group of events starts fresh. Event counts still accumulate on every merge, including when an ID has already been seen. Keeping the sets uses additional memory proportional to the number of unique IDs.

Automation and gift email analytics share this result type too. They use it to accumulate event counts while persisting outcomes through their own APIs. The focused validation covers these consumers as well as both newsletter processing modes.

ref https://linear.app/ghost/issue/BER-3932/make-email-analytics-event-result-merging-linear-time

A local benchmark measured the time spent collecting these IDs across repeated merges. It included 31% repeated member IDs and produced identical results before and after. Median of three runs:

| Events | Before | After |
| --- | ---: | ---: |
| 5,000 | 252 ms | 1.2 ms |
| 10,000 | 1,116 ms | 2.6 ms |

Doubling the events roughly doubles the time with the new implementation. This measures one part of event processing; Mailgun requests, database writes, and statistics updates still contribute to overall ingestion time.

Validation:

- All 8 focused tests pass, covering event counts, deduplication, ordering, empty IDs, reset/reuse, and independence from a source result that is later reset. Run from `ghost/core`: `pnpm test:single test/unit/server/services/email-analytics/event-processing-result.test.ts`.
- Shared-consumer validation: all 69 tests pass across the result suite (8), newsletter processor (44, covering batched and sequential modes), automation processor (13), and gift processor (4). Existing consumer tests cover count accumulation and calls to their respective storage APIs.
- Scoped ESLint, Oxfmt, TypeScript checks, and `git diff --check` pass.
- Related analytics suite: 293 passed, with the same 14 baseline failures before and after. The changed module's stale generated JavaScript was refreshed before the final run; generated output is excluded from the PR.
- Full `pnpm check` stops on existing formatting failures; full Core typechecking reports missing/stale workspace dependency types.

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written automated tests for the preserved behavior
