### PR TITLE
Changed batched newsletter events to use exact transactional transitions

### DIFF
--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -46,22 +46,31 @@ class NewsletterEmailAnalyticsBatchProcessor {
         await this.#emailEventProcessor.batchGetRecipients(emailIdentifications);
       let lastEventTimestamp = fetchData.lastEventTimestamp;
 
-      for (const event of events) {
-        const batchResult = await this.#processEvent(event, recipientCache);
+      try {
+        for (const event of events) {
+          const batchResult = await this.#processEvent(event, recipientCache);
 
-        // Save last event timestamp
-        if (!lastEventTimestamp || (event.timestamp && event.timestamp > lastEventTimestamp)) {
-          lastEventTimestamp = event.timestamp;
+          // Save last event timestamp
+          if (!lastEventTimestamp || (event.timestamp && event.timestamp > lastEventTimestamp)) {
+            lastEventTimestamp = event.timestamp;
+          }
+
+          // batchResult lists every matched member, not only those whose row will
+          // transition in the flush. Keep replayed members eligible for recount
+          // until counters are written atomically with recipient transitions: a
+          // prior run may have committed the recipient update but failed before
+          // refreshing member statistics.
+          result.merge(batchResult);
         }
 
-        // Keep replayed members eligible for recount until counters are written
-        // atomically with recipient transitions. A prior run may have committed
-        // the recipient update but failed before refreshing member statistics.
-        result.merge(batchResult);
+        // Flush all batched updates to the database
+        await this.#emailEventProcessor.flushBatchedUpdates();
+      } finally {
+        // The storage is shared across fetch jobs. Nothing queued for this page
+        // may outlive it: a failure anywhere above leaves the cursor behind, and
+        // the caller replays the page rather than letting a later job flush it.
+        this.#emailEventProcessor.discardBatchedUpdates();
       }
-
-      // Flush all batched updates to the database
-      await this.#emailEventProcessor.flushBatchedUpdates();
       // Advance only after every email has committed. The caller can replay
       // this page after a failure while still recounting earlier committed sets.
       fetchData.lastEventTimestamp = lastEventTimestamp;

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -44,23 +44,27 @@ class NewsletterEmailAnalyticsBatchProcessor {
 
       const recipientCache =
         await this.#emailEventProcessor.batchGetRecipients(emailIdentifications);
+      let lastEventTimestamp = fetchData.lastEventTimestamp;
 
       for (const event of events) {
         const batchResult = await this.#processEvent(event, recipientCache);
 
         // Save last event timestamp
-        if (
-          !fetchData.lastEventTimestamp ||
-          (event.timestamp && event.timestamp > fetchData.lastEventTimestamp)
-        ) {
-          fetchData.lastEventTimestamp = event.timestamp;
+        if (!lastEventTimestamp || (event.timestamp && event.timestamp > lastEventTimestamp)) {
+          lastEventTimestamp = event.timestamp;
         }
 
+        // Keep replayed members eligible for recount until counters are written
+        // atomically with recipient transitions. A prior run may have committed
+        // the recipient update but failed before refreshing member statistics.
         result.merge(batchResult);
       }
 
       // Flush all batched updates to the database
       await this.#emailEventProcessor.flushBatchedUpdates();
+      // Advance only after every email has committed. The caller can replay
+      // this page after a failure while still recounting earlier committed sets.
+      fetchData.lastEventTimestamp = lastEventTimestamp;
     } else {
       // Sequential mode: process events one by one (original behavior)
       for (const event of events) {

--- a/ghost/core/core/server/services/email-service/email-event-processor.js
+++ b/ghost/core/core/server/services/email-service/email-event-processor.js
@@ -35,7 +35,8 @@ async function waitForEvent() {
  * @property {(event: EmailTemporaryBouncedEvent) => Promise<void>} handleTemporaryFailed
  * @property {(event: EmailUnsubscribedEvent) => Promise<void>} handleUnsubscribed
  * @property {(event: SpamComplaintEvent) => Promise<void>} handleComplained
- * @property {import('./newsletter-email-event-storage')['flushBatchedUpdates']} flushBatchedUpdates
+ * @property {InstanceType<typeof import('./newsletter-email-event-storage')>['flushBatchedUpdates']} flushBatchedUpdates
+ * @property {InstanceType<typeof import('./newsletter-email-event-storage')>['discardBatchedUpdates']} discardBatchedUpdates
  */
 
 /**
@@ -365,10 +366,18 @@ class EmailEventProcessor {
 
   /**
    * Flush any batched updates to the database
-   * @returns {ReturnType<import('./newsletter-email-event-storage')['flushBatchedUpdates']>}
+   * @returns {ReturnType<InstanceType<typeof import('./newsletter-email-event-storage')>['flushBatchedUpdates']>}
    */
   async flushBatchedUpdates() {
     return await this.#eventStorage.flushBatchedUpdates();
+  }
+
+  /**
+   * Drop any batched updates that were queued but not flushed
+   * @returns {void}
+   */
+  discardBatchedUpdates() {
+    this.#eventStorage.discardBatchedUpdates();
   }
 }
 

--- a/ghost/core/core/server/services/email-service/email-event-processor.js
+++ b/ghost/core/core/server/services/email-service/email-event-processor.js
@@ -35,6 +35,7 @@ async function waitForEvent() {
  * @property {(event: EmailTemporaryBouncedEvent) => Promise<void>} handleTemporaryFailed
  * @property {(event: EmailUnsubscribedEvent) => Promise<void>} handleUnsubscribed
  * @property {(event: SpamComplaintEvent) => Promise<void>} handleComplained
+ * @property {import('./newsletter-email-event-storage')['flushBatchedUpdates']} flushBatchedUpdates
  */
 
 /**
@@ -364,7 +365,7 @@ class EmailEventProcessor {
 
   /**
    * Flush any batched updates to the database
-   * @returns {Promise<void>}
+   * @returns {ReturnType<import('./newsletter-email-event-storage')['flushBatchedUpdates']>}
    */
   async flushBatchedUpdates() {
     return await this.#eventStorage.flushBatchedUpdates();

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -1,7 +1,12 @@
 const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 const { setTimeout: delay } = require('node:timers/promises');
+
+// Lock waits are expected while batch creation inserts recipients for the same
+// email; both errors leave the transaction rolled back and safe to retry.
+const RETRYABLE_LOCK_ERRORS = new Set(['ER_LOCK_DEADLOCK', 'ER_LOCK_WAIT_TIMEOUT']);
 
 class NewsletterEmailEventStorage {
   #config;
@@ -40,18 +45,7 @@ class NewsletterEmailEventStorage {
     const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
     if (useBatchProcessing) {
-      // Accumulate update for batch processing
-      const timestamp = moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss');
-      const existing = this.#pendingUpdates.delivered.get(event.emailRecipientId);
-
-      // Keep the earliest timestamp (out-of-order protection)
-      if (!existing || timestamp < existing.timestamp) {
-        this.#pendingUpdates.delivered.set(event.emailRecipientId, {
-          timestamp,
-          emailId: event.emailId,
-          memberId: event.memberId,
-        });
-      }
+      this.#queueUpdate('delivered', event);
     } else {
       // Sequential mode: immediate update
       // To properly handle events that are received out of order (this happens because of polling)
@@ -71,18 +65,7 @@ class NewsletterEmailEventStorage {
     const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
     if (useBatchProcessing) {
-      // Accumulate update for batch processing
-      const timestamp = moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss');
-      const existing = this.#pendingUpdates.opened.get(event.emailRecipientId);
-
-      // Keep the earliest timestamp (out-of-order protection)
-      if (!existing || timestamp < existing.timestamp) {
-        this.#pendingUpdates.opened.set(event.emailRecipientId, {
-          timestamp,
-          emailId: event.emailId,
-          memberId: event.memberId,
-        });
-      }
+      this.#queueUpdate('opened', event);
     } else {
       // Sequential mode: immediate update
       // To properly handle events that are received out of order (this happens because of polling)
@@ -102,18 +85,7 @@ class NewsletterEmailEventStorage {
     const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
     if (useBatchProcessing) {
-      // Accumulate update for batch processing
-      const timestamp = moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss');
-      const existing = this.#pendingUpdates.failed.get(event.emailRecipientId);
-
-      // Keep the earliest timestamp (out-of-order protection)
-      if (!existing || timestamp < existing.timestamp) {
-        this.#pendingUpdates.failed.set(event.emailRecipientId, {
-          timestamp,
-          emailId: event.emailId,
-          memberId: event.memberId,
-        });
-      }
+      this.#queueUpdate('failed', event);
     } else {
       // Sequential mode: immediate update
       // To properly handle events that are received out of order (this happens because of polling)
@@ -307,10 +279,54 @@ class NewsletterEmailEventStorage {
   }
 
   /**
-   * Flush all batched updates to the database
+   * Accumulate an update for batch processing, keeping the earliest timestamp
+   * per recipient (out-of-order protection).
+   * @param {'delivered' | 'opened' | 'failed'} type
+   * @param {{emailRecipientId: string, emailId: string, memberId: string, timestamp: Date}} event
+   */
+  #queueUpdate(type, event) {
+    const timestamp = moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss');
+    const existing = this.#pendingUpdates[type].get(event.emailRecipientId);
+
+    if (!existing || timestamp < existing.timestamp) {
+      this.#pendingUpdates[type].set(event.emailRecipientId, {
+        timestamp,
+        emailId: event.emailId,
+        memberId: event.memberId,
+      });
+    }
+  }
+
+  /**
+   * Flush all batched updates to the database, one transaction per email.
+   *
+   * Pending updates are always cleared, even when a later email fails after
+   * earlier ones committed: the caller keeps its cursor behind the page and
+   * replays it, and the guarded updates make that replay a no-op for
+   * committed rows. Retaining failed entries instead would let the next
+   * fetch job flush and report transitions that belong to another page.
    * @returns {Promise<Array<{emailId: string, delivered: Array<{recipientId: string, memberId: string}>, opened: Array<{recipientId: string, memberId: string}>, failed: Array<{recipientId: string, memberId: string}>}>>}
    */
   async flushBatchedUpdates() {
+    try {
+      return await this.#flushPendingUpdates();
+    } finally {
+      this.discardBatchedUpdates();
+    }
+  }
+
+  /**
+   * Drop queued updates without writing them. The batch processor calls this
+   * when a page fails before its flush, so entries never leak into the next
+   * page or fetch job that shares this storage.
+   */
+  discardBatchedUpdates() {
+    for (const pending of Object.values(this.#pendingUpdates)) {
+      pending.clear();
+    }
+  }
+
+  async #flushPendingUpdates() {
     const groups = new Map();
     for (const [type, pending] of Object.entries(this.#pendingUpdates)) {
       for (const [recipientId, update] of pending) {
@@ -330,7 +346,7 @@ class NewsletterEmailEventStorage {
       const updates = groups.get(emailId);
       const transitioned = await this.#transactionWithRetry(async (trx) => {
         const query = trx('email_recipients');
-        if (['mysql', 'mysql2'].includes(trx.client.config.client)) {
+        if (DatabaseInfo.isMySQL(trx)) {
           // Lock in primary-key order, rather than whichever secondary index
           // the optimizer chooses. Sorting the IN list alone is insufficient.
           query.fromRaw('?? FORCE INDEX (PRIMARY)', ['email_recipients']);
@@ -361,7 +377,7 @@ class NewsletterEmailEventStorage {
             continue;
           }
           const bindings = eligible.flatMap(({ id }) => [id, pending.get(id).timestamp]);
-          await trx('email_recipients')
+          const affected = await trx('email_recipients')
             .whereIn(
               'id',
               eligible.map(({ id }) => id),
@@ -373,6 +389,15 @@ class NewsletterEmailEventStorage {
                 bindings,
               ),
             });
+          if (affected !== eligible.length) {
+            // Only possible without row locks (e.g. SQLite): another writer
+            // changed a locked-set row between the read and the guarded update.
+            // Fail loudly rather than report a transition that did not happen.
+            throw new errors.InternalServerError({
+              message: `Email recipient ${type} transitions changed during flush`,
+              context: `email ${emailId}: expected ${eligible.length}, updated ${affected}`,
+            });
+          }
           result[type] = eligible.map(({ id, member_id: memberId }) => ({
             recipientId: id,
             memberId,
@@ -385,14 +410,13 @@ class NewsletterEmailEventStorage {
         transitioned.opened.length ||
         transitioned.failed.length
       ) {
-        this.recordEventStored('delivered', transitioned.delivered.length);
-        this.recordEventStored('opened', transitioned.opened.length);
+        for (const type of ['delivered', 'opened']) {
+          if (transitioned[type].length) {
+            this.recordEventStored(type, transitioned[type].length);
+          }
+        }
         transitions.push(transitioned);
       }
-    }
-
-    for (const pending of Object.values(this.#pendingUpdates)) {
-      pending.clear();
     }
     return transitions;
   }
@@ -404,10 +428,10 @@ class NewsletterEmailEventStorage {
       } catch (error) {
         // Retry the whole rolled-back transaction, never an individual write.
         // Connection/commit errors can have an unknown outcome and must escape.
-        if (error.code !== 'ER_LOCK_DEADLOCK' || attempt >= 2) {
+        if (!RETRYABLE_LOCK_ERRORS.has(error.code) || attempt >= 2) {
           throw error;
         }
-        await delay(10 * 2 ** attempt);
+        await delay(10 * 2 ** attempt + Math.random() * 10);
       }
     }
   }

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -1,6 +1,7 @@
 const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const { setTimeout: delay } = require('node:timers/promises');
 
 class NewsletterEmailEventStorage {
   #config;
@@ -21,9 +22,9 @@ class NewsletterEmailEventStorage {
 
     // Initialize pending updates for batched processing
     this.#pendingUpdates = {
-      delivered: new Map(), // recipientId -> timestamp
+      delivered: new Map(), // recipientId -> {timestamp, emailId, memberId}
       opened: new Map(), // recipientId -> {timestamp, emailId, memberId}
-      failed: new Map(), // recipientId -> timestamp
+      failed: new Map(), // recipientId -> {timestamp, emailId, memberId}
     };
 
     if (this.#prometheusClient) {
@@ -44,8 +45,12 @@ class NewsletterEmailEventStorage {
       const existing = this.#pendingUpdates.delivered.get(event.emailRecipientId);
 
       // Keep the earliest timestamp (out-of-order protection)
-      if (!existing || timestamp < existing) {
-        this.#pendingUpdates.delivered.set(event.emailRecipientId, timestamp);
+      if (!existing || timestamp < existing.timestamp) {
+        this.#pendingUpdates.delivered.set(event.emailRecipientId, {
+          timestamp,
+          emailId: event.emailId,
+          memberId: event.memberId,
+        });
       }
     } else {
       // Sequential mode: immediate update
@@ -102,8 +107,12 @@ class NewsletterEmailEventStorage {
       const existing = this.#pendingUpdates.failed.get(event.emailRecipientId);
 
       // Keep the earliest timestamp (out-of-order protection)
-      if (!existing || timestamp < existing) {
-        this.#pendingUpdates.failed.set(event.emailRecipientId, timestamp);
+      if (!existing || timestamp < existing.timestamp) {
+        this.#pendingUpdates.failed.set(event.emailRecipientId, {
+          timestamp,
+          emailId: event.emailId,
+          memberId: event.memberId,
+        });
       }
     } else {
       // Sequential mode: immediate update
@@ -302,82 +311,24 @@ class NewsletterEmailEventStorage {
    * @returns {Promise<Array<{emailId: string, delivered: Array<{recipientId: string, memberId: string}>, opened: Array<{recipientId: string, memberId: string}>, failed: Array<{recipientId: string, memberId: string}>}>>}
    */
   async flushBatchedUpdates() {
-    const deliveredCount = this.#pendingUpdates.delivered.size;
-    const openedCount = this.#pendingUpdates.opened.size;
-    const failedCount = this.#pendingUpdates.failed.size;
-
-    if (deliveredCount === 0 && openedCount === 0 && failedCount === 0) {
-      return []; // Nothing to flush
-    }
-    const transitions = [];
-
-    // Flush delivered events
-    if (deliveredCount > 0) {
-      await this.#flushDeliveredUpdates();
-    }
-
-    // Flush opened events
-    if (openedCount > 0) {
-      transitions.push(...(await this.#flushOpenedUpdates()));
-    }
-
-    // Flush failed events
-    if (failedCount > 0) {
-      await this.#flushFailedUpdates();
-    }
-
-    // Clear the pending updates
-    this.#pendingUpdates.delivered.clear();
-    this.#pendingUpdates.opened.clear();
-    this.#pendingUpdates.failed.clear();
-    return transitions;
-  }
-
-  /**
-   * @private
-   */
-  async #flushDeliveredUpdates() {
-    const updates = Array.from(this.#pendingUpdates.delivered.entries());
-    if (updates.length === 0) {
-      return;
-    }
-
-    // Build CASE statement for batched update
-    const recipientIds = updates.map(([id]) => id);
-    const caseClauses = updates
-      .map(([id, timestamp]) => {
-        return `WHEN '${id}' THEN '${timestamp}'`;
-      })
-      .join(' ');
-
-    const sql = `
-            UPDATE email_recipients
-            SET delivered_at = CASE id ${caseClauses} END
-            WHERE id IN (${recipientIds.map(() => '?').join(',')})
-            AND delivered_at IS NULL
-        `;
-
-    const rowCount = await this.#db.knex.raw(sql, recipientIds);
-    this.recordEventStored('delivered', updates.length);
-    return rowCount;
-  }
-
-  /**
-   * @private
-   */
-  async #flushOpenedUpdates() {
     const groups = new Map();
-    for (const [recipientId, update] of this.#pendingUpdates.opened) {
-      if (!groups.has(update.emailId)) {
-        groups.set(update.emailId, new Map());
+    for (const [type, pending] of Object.entries(this.#pendingUpdates)) {
+      for (const [recipientId, update] of pending) {
+        if (!groups.has(update.emailId)) {
+          groups.set(update.emailId, {
+            delivered: new Map(),
+            opened: new Map(),
+            failed: new Map(),
+          });
+        }
+        groups.get(update.emailId)[type].set(recipientId, update);
       }
-      groups.get(update.emailId).set(recipientId, update);
     }
 
     const transitions = [];
     for (const emailId of Array.from(groups.keys()).sort()) {
       const updates = groups.get(emailId);
-      const opened = await this.#db.knex.transaction(async (trx) => {
+      const transitioned = await this.#transactionWithRetry(async (trx) => {
         const query = trx('email_recipients');
         if (['mysql', 'mysql2'].includes(trx.client.config.client)) {
           // Lock in primary-key order, rather than whichever secondary index
@@ -385,66 +336,80 @@ class NewsletterEmailEventStorage {
           query.fromRaw('?? FORCE INDEX (PRIMARY)', ['email_recipients']);
         }
         const recipients = await query
-          .select('id', 'member_id')
+          .select('id', 'member_id', 'delivered_at', 'opened_at', 'failed_at')
           .where('email_id', emailId)
-          .whereIn('id', Array.from(updates.keys()).sort())
-          .whereNull('opened_at')
+          .where(function () {
+            for (const [type, pending] of Object.entries(updates)) {
+              if (pending.size) {
+                this.orWhere(function () {
+                  this.whereIn('id', Array.from(pending.keys()).sort()).whereNull(`${type}_at`);
+                });
+              }
+            }
+          })
           .orderBy('id')
           .forUpdate();
-        if (!recipients.length) {
-          return [];
+
+        const result = { emailId, delivered: [], opened: [], failed: [] };
+        // The locked set, not an affected-row count, determines which members
+        // transitioned. Dependent counter writes must use this same transaction.
+        for (const [type, pending] of Object.entries(updates)) {
+          const eligible = recipients.filter(
+            (row) => pending.has(row.id) && row[`${type}_at`] === null,
+          );
+          if (!eligible.length) {
+            continue;
+          }
+          const bindings = eligible.flatMap(({ id }) => [id, pending.get(id).timestamp]);
+          await trx('email_recipients')
+            .whereIn(
+              'id',
+              eligible.map(({ id }) => id),
+            )
+            .whereNull(`${type}_at`)
+            .update({
+              [`${type}_at`]: trx.raw(
+                `CASE id ${eligible.map(() => 'WHEN ? THEN ?').join(' ')} END`,
+                bindings,
+              ),
+            });
+          result[type] = eligible.map(({ id, member_id: memberId }) => ({
+            recipientId: id,
+            memberId,
+          }));
         }
-
-        const bindings = recipients.flatMap(({ id }) => [id, updates.get(id).timestamp]);
-        await trx('email_recipients')
-          .whereIn(
-            'id',
-            recipients.map(({ id }) => id),
-          )
-          .whereNull('opened_at')
-          .update({
-            opened_at: trx.raw(
-              `CASE id ${recipients.map(() => 'WHEN ? THEN ?').join(' ')} END`,
-              bindings,
-            ),
-          });
-
-        return recipients.map(({ id, member_id: memberId }) => ({ recipientId: id, memberId }));
+        return result;
       });
-      if (opened.length) {
-        this.recordEventStored('opened', opened.length);
-        transitions.push({ emailId, delivered: [], opened, failed: [] });
+      if (
+        transitioned.delivered.length ||
+        transitioned.opened.length ||
+        transitioned.failed.length
+      ) {
+        this.recordEventStored('delivered', transitioned.delivered.length);
+        this.recordEventStored('opened', transitioned.opened.length);
+        transitions.push(transitioned);
       }
+    }
+
+    for (const pending of Object.values(this.#pendingUpdates)) {
+      pending.clear();
     }
     return transitions;
   }
 
-  /**
-   * @private
-   */
-  async #flushFailedUpdates() {
-    const updates = Array.from(this.#pendingUpdates.failed.entries());
-    if (updates.length === 0) {
-      return;
+  async #transactionWithRetry(callback) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await this.#db.knex.transaction(callback);
+      } catch (error) {
+        // Retry the whole rolled-back transaction, never an individual write.
+        // Connection/commit errors can have an unknown outcome and must escape.
+        if (error.code !== 'ER_LOCK_DEADLOCK' || attempt >= 2) {
+          throw error;
+        }
+        await delay(10 * 2 ** attempt);
+      }
     }
-
-    // Build CASE statement for batched update
-    const recipientIds = updates.map(([id]) => id);
-    const caseClauses = updates
-      .map(([id, timestamp]) => {
-        return `WHEN '${id}' THEN '${timestamp}'`;
-      })
-      .join(' ');
-
-    const sql = `
-            UPDATE email_recipients
-            SET failed_at = CASE id ${caseClauses} END
-            WHERE id IN (${recipientIds.map(() => '?').join(',')})
-            AND failed_at IS NULL
-        `;
-
-    const rowCount = await this.#db.knex.raw(sql, recipientIds);
-    return rowCount;
   }
 }
 

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -22,7 +22,7 @@ class NewsletterEmailEventStorage {
     // Initialize pending updates for batched processing
     this.#pendingUpdates = {
       delivered: new Map(), // recipientId -> timestamp
-      opened: new Map(), // recipientId -> timestamp
+      opened: new Map(), // recipientId -> {timestamp, emailId, memberId}
       failed: new Map(), // recipientId -> timestamp
     };
 
@@ -71,8 +71,12 @@ class NewsletterEmailEventStorage {
       const existing = this.#pendingUpdates.opened.get(event.emailRecipientId);
 
       // Keep the earliest timestamp (out-of-order protection)
-      if (!existing || timestamp < existing) {
-        this.#pendingUpdates.opened.set(event.emailRecipientId, timestamp);
+      if (!existing || timestamp < existing.timestamp) {
+        this.#pendingUpdates.opened.set(event.emailRecipientId, {
+          timestamp,
+          emailId: event.emailId,
+          memberId: event.memberId,
+        });
       }
     } else {
       // Sequential mode: immediate update
@@ -295,7 +299,7 @@ class NewsletterEmailEventStorage {
 
   /**
    * Flush all batched updates to the database
-   * @returns {Promise<void>}
+   * @returns {Promise<Array<{emailId: string, delivered: Array<{recipientId: string, memberId: string}>, opened: Array<{recipientId: string, memberId: string}>, failed: Array<{recipientId: string, memberId: string}>}>>}
    */
   async flushBatchedUpdates() {
     const deliveredCount = this.#pendingUpdates.delivered.size;
@@ -303,8 +307,9 @@ class NewsletterEmailEventStorage {
     const failedCount = this.#pendingUpdates.failed.size;
 
     if (deliveredCount === 0 && openedCount === 0 && failedCount === 0) {
-      return; // Nothing to flush
+      return []; // Nothing to flush
     }
+    const transitions = [];
 
     // Flush delivered events
     if (deliveredCount > 0) {
@@ -313,7 +318,7 @@ class NewsletterEmailEventStorage {
 
     // Flush opened events
     if (openedCount > 0) {
-      await this.#flushOpenedUpdates();
+      transitions.push(...(await this.#flushOpenedUpdates()));
     }
 
     // Flush failed events
@@ -325,6 +330,7 @@ class NewsletterEmailEventStorage {
     this.#pendingUpdates.delivered.clear();
     this.#pendingUpdates.opened.clear();
     this.#pendingUpdates.failed.clear();
+    return transitions;
   }
 
   /**
@@ -360,29 +366,57 @@ class NewsletterEmailEventStorage {
    * @private
    */
   async #flushOpenedUpdates() {
-    const updates = Array.from(this.#pendingUpdates.opened.entries());
-    if (updates.length === 0) {
-      return;
+    const groups = new Map();
+    for (const [recipientId, update] of this.#pendingUpdates.opened) {
+      if (!groups.has(update.emailId)) {
+        groups.set(update.emailId, new Map());
+      }
+      groups.get(update.emailId).set(recipientId, update);
     }
 
-    // Build CASE statement for batched update
-    const recipientIds = updates.map(([id]) => id);
-    const caseClauses = updates
-      .map(([id, timestamp]) => {
-        return `WHEN '${id}' THEN '${timestamp}'`;
-      })
-      .join(' ');
+    const transitions = [];
+    for (const emailId of Array.from(groups.keys()).sort()) {
+      const updates = groups.get(emailId);
+      const opened = await this.#db.knex.transaction(async (trx) => {
+        const query = trx('email_recipients');
+        if (['mysql', 'mysql2'].includes(trx.client.config.client)) {
+          // Lock in primary-key order, rather than whichever secondary index
+          // the optimizer chooses. Sorting the IN list alone is insufficient.
+          query.fromRaw('?? FORCE INDEX (PRIMARY)', ['email_recipients']);
+        }
+        const recipients = await query
+          .select('id', 'member_id')
+          .where('email_id', emailId)
+          .whereIn('id', Array.from(updates.keys()).sort())
+          .whereNull('opened_at')
+          .orderBy('id')
+          .forUpdate();
+        if (!recipients.length) {
+          return [];
+        }
 
-    const sql = `
-            UPDATE email_recipients
-            SET opened_at = CASE id ${caseClauses} END
-            WHERE id IN (${recipientIds.map(() => '?').join(',')})
-            AND opened_at IS NULL
-        `;
+        const bindings = recipients.flatMap(({ id }) => [id, updates.get(id).timestamp]);
+        await trx('email_recipients')
+          .whereIn(
+            'id',
+            recipients.map(({ id }) => id),
+          )
+          .whereNull('opened_at')
+          .update({
+            opened_at: trx.raw(
+              `CASE id ${recipients.map(() => 'WHEN ? THEN ?').join(' ')} END`,
+              bindings,
+            ),
+          });
 
-    const rowCount = await this.#db.knex.raw(sql, recipientIds);
-    this.recordEventStored('opened', updates.length);
-    return rowCount;
+        return recipients.map(({ id, member_id: memberId }) => ({ recipientId: id, memberId }));
+      });
+      if (opened.length) {
+        this.recordEventStored('opened', opened.length);
+        transitions.push({ emailId, delivered: [], opened, failed: [] });
+      }
+    }
+    return transitions;
   }
 
   /**

--- a/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
@@ -23,19 +23,23 @@ const {
 
 describe('Newsletter event flush', function () {
   let recipient;
+  let otherRecipient;
   let storage;
 
   beforeAll(async function () {
     await agentProvider.getAdminAPIAgent();
     await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
     recipient = fixtureManager.get('email_recipients', 0);
+    otherRecipient = fixtureManager.get('email_recipients', 1);
   });
 
   beforeEach(async function () {
-    await models.EmailRecipient.edit(
-      { opened_at: null, delivered_at: null, failed_at: null },
-      { id: recipient.id },
-    );
+    for (const row of [recipient, otherRecipient]) {
+      await models.EmailRecipient.edit(
+        { opened_at: null, delivered_at: null, failed_at: null },
+        { id: row.id },
+      );
+    }
     storage = new NewsletterEmailEventStorage({
       config: { get: () => true },
       db,
@@ -185,6 +189,42 @@ describe('Newsletter event flush', function () {
     assert.deepEqual(replay.memberIds, [recipient.member_id]);
   });
 
+  it('discards a page queued before a failure so a later flush cannot write it', async function () {
+    const failingProcessor = new EmailEventProcessor({
+      db,
+      eventStorage: storage,
+      domainEvents: { dispatch() {} },
+    });
+    failingProcessor.handleDelivered = async () => {
+      throw new Error('event handling failed');
+    };
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config: { get: () => true },
+      emailEventProcessor: failingProcessor,
+    });
+    const opened = {
+      type: 'opened',
+      emailId: recipient.email_id,
+      recipientEmail: recipient.member_email,
+      timestamp: new Date('2026-09-01T12:00:00.000Z'),
+    };
+    // A later event in the same page fails before the flush runs
+    const cursor = { lastEventTimestamp: new Date('2026-09-01T11:00:00.000Z') };
+    await assert.rejects(
+      processor.processBatch(
+        [opened, { ...opened, type: 'delivered' }],
+        new EventProcessingResult(),
+        cursor,
+      ),
+      /event handling failed/,
+    );
+    assert.equal(cursor.lastEventTimestamp.toISOString(), '2026-09-01T11:00:00.000Z');
+    // A later page from another job must not carry the stranded open
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+    const saved = await models.EmailRecipient.findOne({ id: recipient.id }, { require: true });
+    assert.equal(saved.get('opened_at'), null);
+  });
+
   it('returns only the first open transition when events are duplicated and replayed', async function () {
     const firstOpen = new Date('2026-09-01T12:00:00.000Z');
     const event = (timestamp) =>
@@ -215,7 +255,7 @@ describe('Newsletter event flush', function () {
     assert.deepEqual(await storage.flushBatchedUpdates(), []);
   });
 
-  it('rolls back every transition for an email and can retry the failed flush', async function () {
+  it('rolls back every transition for an email and applies them when the page is replayed', async function () {
     const data = {
       email: recipient.member_email,
       emailRecipientId: recipient.id,
@@ -223,9 +263,12 @@ describe('Newsletter event flush', function () {
       memberId: recipient.member_id,
       timestamp: new Date('2026-09-01T12:00:00.000Z'),
     };
-    await storage.handleDelivered(EmailDeliveredEvent.create(data));
-    await storage.handleOpened(EmailOpenedEvent.create(data));
-    await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
+    const queueAll = async () => {
+      await storage.handleDelivered(EmailDeliveredEvent.create(data));
+      await storage.handleOpened(EmailOpenedEvent.create(data));
+      await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
+    };
+    await queueAll();
 
     // A real database error on the final write must roll back earlier writes.
     await db.knex.raw(`CREATE TRIGGER reject_recipient_failure BEFORE UPDATE ON email_recipients
@@ -244,6 +287,11 @@ describe('Newsletter event flush', function () {
       await db.knex.raw('DROP TRIGGER reject_recipient_failure');
     }
 
+    // The failed page's entries are dropped so another fetch job cannot flush
+    // them as its own; the caller replays the page instead.
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+
+    await queueAll();
     const transitioned = [{ recipientId: recipient.id, memberId: recipient.member_id }];
     assert.deepEqual(await storage.flushBatchedUpdates(), [
       {
@@ -255,50 +303,87 @@ describe('Newsletter event flush', function () {
     ]);
   });
 
-  it('retries a rolled-back deadlock without losing or duplicating transitions', async function () {
-    let attempts = 0;
-    storage = new NewsletterEmailEventStorage({
-      config: { get: () => true },
-      models,
-      db: {
-        knex: {
-          transaction: (callback) =>
-            db.knex.transaction(async (trx) => {
-              const result = await callback(trx);
-              attempts += 1;
-              if (attempts === 1) {
-                // Inject the database failure after real writes; Knex rolls them back.
-                throw Object.assign(new Error('simulated deadlock'), { code: 'ER_LOCK_DEADLOCK' });
-              }
-              return result;
-            }),
+  for (const code of ['ER_LOCK_DEADLOCK', 'ER_LOCK_WAIT_TIMEOUT']) {
+    it(`retries a rolled-back ${code} without losing or duplicating transitions`, async function () {
+      let attempts = 0;
+      storage = new NewsletterEmailEventStorage({
+        config: { get: () => true },
+        models,
+        db: {
+          knex: {
+            transaction: (callback) =>
+              db.knex.transaction(async (trx) => {
+                const result = await callback(trx);
+                attempts += 1;
+                if (attempts === 1) {
+                  // Inject the database failure after real writes; Knex rolls them back.
+                  throw Object.assign(new Error(`simulated ${code}`), { code });
+                }
+                return result;
+              }),
+          },
         },
-      },
+      });
+      await storage.handleOpened(
+        EmailOpenedEvent.create({
+          email: recipient.member_email,
+          emailRecipientId: recipient.id,
+          emailId: recipient.email_id,
+          memberId: recipient.member_id,
+          timestamp: new Date('2026-09-01T12:00:00.000Z'),
+        }),
+      );
+      assert.deepEqual(await storage.flushBatchedUpdates(), [
+        {
+          emailId: recipient.email_id,
+          delivered: [],
+          opened: [{ recipientId: recipient.id, memberId: recipient.member_id }],
+          failed: [],
+        },
+      ]);
+      assert.equal(attempts, 2);
+      assert.deepEqual(await storage.flushBatchedUpdates(), []);
     });
-    await storage.handleOpened(
-      EmailOpenedEvent.create({
-        email: recipient.member_email,
-        emailRecipientId: recipient.id,
-        emailId: recipient.email_id,
-        memberId: recipient.member_id,
+  }
+
+  it('locks a multi-type page through a primary-key range without a filesort', async function () {
+    for (const row of [recipient, otherRecipient]) {
+      const data = {
+        email: row.member_email,
+        emailRecipientId: row.id,
+        emailId: row.email_id,
+        memberId: row.member_id,
         timestamp: new Date('2026-09-01T12:00:00.000Z'),
-      }),
+      };
+      await storage.handleOpened(EmailOpenedEvent.create(data));
+      await storage.handleDelivered(EmailDeliveredEvent.create(data));
+      await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
+    }
+    const lockingQueries = [];
+    const observe = (query) => {
+      if (/select.*email_recipients.*for update/i.test(query.sql)) {
+        lockingQueries.push(query);
+      }
+    };
+    db.knex.on('query', observe);
+    try {
+      await storage.flushBatchedUpdates();
+    } finally {
+      db.knex.off('query', observe);
+    }
+    assert.equal(lockingQueries.length, 1);
+    // One OR branch per event type in the locking predicate
+    assert.equal(lockingQueries[0].sql.match(/is null/g).length, 3);
+    const [plan] = await db.knex.raw(
+      `EXPLAIN ${lockingQueries[0].sql}`,
+      lockingQueries[0].bindings,
     );
-    assert.deepEqual(await storage.flushBatchedUpdates(), [
-      {
-        emailId: recipient.email_id,
-        delivered: [],
-        opened: [{ recipientId: recipient.id, memberId: recipient.member_id }],
-        failed: [],
-      },
-    ]);
-    assert.equal(attempts, 2);
-    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+    assert.equal(plan[0].key, 'PRIMARY');
+    assert.equal(plan[0].type, 'range');
+    assert(!plan[0].Extra?.includes('filesort'));
   });
 
   it('counts contended opens once while batch creation inserts recipients', async function () {
-    const otherRecipient = fixtureManager.get('email_recipients', 1);
-    await models.EmailRecipient.edit({ opened_at: null }, { id: otherRecipient.id });
     const otherStorage = new NewsletterEmailEventStorage({
       config: { get: () => true },
       db,
@@ -367,6 +452,7 @@ describe('Newsletter event flush', function () {
         lockingQueries[0].bindings,
       );
       assert.equal(plan[0].key, 'PRIMARY');
+      assert.equal(plan[0].type, 'range');
       assert(!plan[0].Extra?.includes('filesort'));
     } finally {
       await models.EmailRecipient.destroy({ destroyBy: { batch_id: batch.id } });

--- a/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
@@ -4,6 +4,13 @@ const db = require('../../../../core/server/data/db');
 const models = require('../../../../core/server/models');
 const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
 const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
+const EmailEventProcessor = require('../../../../core/server/services/email-service/email-event-processor');
+const {
+  NewsletterEmailAnalyticsBatchProcessor,
+} = require('../../../../core/server/services/email-analytics/newsletter-email-analytics-batch-processor');
+const {
+  EventProcessingResult,
+} = require('../../../../core/server/services/email-analytics/event-processing-result');
 const {
   EmailDeliveredEvent,
 } = require('../../../../core/server/services/email-service/events/email-delivered-event');
@@ -34,6 +41,148 @@ describe('Newsletter event flush', function () {
       db,
       models,
     });
+  });
+
+  it('keeps replayed members available for recount until counter updates are atomic', async function () {
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config: { get: () => true },
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: storage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const event = {
+      type: 'opened',
+      emailId: recipient.email_id,
+      recipientEmail: recipient.member_email,
+      timestamp: new Date('2026-09-01T12:00:00.000Z'),
+    };
+    const first = new EventProcessingResult();
+    await processor.processBatch([event, event], first, {});
+    assert.equal(first.opened, 2);
+    assert.deepEqual(first.memberIds, [recipient.member_id]);
+    const replay = new EventProcessingResult();
+    const cursor = {};
+    await processor.processBatch([event], replay, cursor);
+    assert.equal(replay.opened, 1);
+    assert.deepEqual(replay.memberIds, [recipient.member_id]);
+    assert.deepEqual(cursor, { lastEventTimestamp: event.timestamp });
+  });
+
+  it('retains committed members and the old cursor when a later email fails, then replays safely', async function () {
+    const secondEmail = fixtureManager.get('emails', 1);
+    const batch = await models.EmailBatch.add({ email_id: secondEmail.id, status: 'pending' });
+    const second = await models.EmailRecipient.add({
+      ...fixtureManager.get('email_recipients', 1),
+      id: undefined,
+      email_id: secondEmail.id,
+      batch_id: batch.id,
+      opened_at: null,
+    });
+    const rows = [recipient, second.toJSON()].sort((a, b) => a.email_id.localeCompare(b.email_id));
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config: { get: () => true },
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: storage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const events = rows.toReversed().map((row) => ({
+      type: 'opened',
+      emailId: row.email_id,
+      recipientEmail: row.member_email,
+      timestamp: new Date('2026-09-01T12:00:00.000Z'),
+    }));
+    const result = new EventProcessingResult();
+    const previous = new Date('2026-09-01T11:00:00.000Z');
+    const cursor = { lastEventTimestamp: previous };
+    try {
+      await db.knex.raw(
+        `CREATE TRIGGER reject_later_email BEFORE UPDATE ON email_recipients
+        FOR EACH ROW BEGIN
+          IF NEW.email_id = ? AND NEW.opened_at IS NOT NULL THEN
+            SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'later email failed';
+          END IF;
+        END`,
+        [rows[1].email_id],
+      );
+      try {
+        await assert.rejects(processor.processBatch(events, result, cursor), /later email failed/);
+        assert.deepEqual(
+          result.memberIds,
+          rows.toReversed().map((row) => row.member_id),
+        );
+        assert.equal(cursor.lastEventTimestamp, previous);
+        const committed = await models.EmailRecipient.findOne(
+          { id: rows[0].id },
+          { require: true },
+        );
+        assert.equal(committed.get('opened_at').toISOString(), events[0].timestamp.toISOString());
+      } finally {
+        await db.knex.raw('DROP TRIGGER reject_later_email');
+      }
+      const replay = new EventProcessingResult();
+      await processor.processBatch(events, replay, cursor);
+      assert.equal(replay.opened, 2);
+      assert.deepEqual(
+        replay.memberIds,
+        rows.toReversed().map((row) => row.member_id),
+      );
+      assert.equal(cursor.lastEventTimestamp, events[0].timestamp);
+    } finally {
+      await models.EmailRecipient.destroy({ id: second.id });
+      await models.EmailBatch.destroy({ id: batch.id });
+    }
+  });
+
+  it('keeps recount candidates when a commit succeeds but its acknowledgement is lost', async function () {
+    const lostAckStorage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      models,
+      db: {
+        knex: {
+          transaction: async (callback) => {
+            await db.knex.transaction(callback);
+            throw Object.assign(new Error('commit acknowledgement lost'), { code: 'ECONNRESET' });
+          },
+        },
+      },
+    });
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config: { get: () => true },
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: lostAckStorage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const event = {
+      type: 'opened',
+      emailId: recipient.email_id,
+      recipientEmail: recipient.member_email,
+      timestamp: new Date('2026-09-01T12:00:00.000Z'),
+    };
+    const result = new EventProcessingResult();
+    const cursor = {};
+    await assert.rejects(processor.processBatch([event], result, cursor), /acknowledgement lost/);
+    assert.deepEqual(result.memberIds, [recipient.member_id]);
+    assert.deepEqual(cursor, {});
+    const committed = await models.EmailRecipient.findOne({ id: recipient.id }, { require: true });
+    assert.equal(committed.get('opened_at').toISOString(), event.timestamp.toISOString());
+
+    const restarted = new NewsletterEmailAnalyticsBatchProcessor({
+      config: { get: () => true },
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: storage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const replay = new EventProcessingResult();
+    await restarted.processBatch([event], replay, {});
+    assert.deepEqual(replay.memberIds, [recipient.member_id]);
   });
 
   it('returns only the first open transition when events are duplicated and replayed', async function () {

--- a/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
@@ -3,6 +3,13 @@ const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework'
 const db = require('../../../../core/server/data/db');
 const models = require('../../../../core/server/models');
 const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
+const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
+const {
+  EmailDeliveredEvent,
+} = require('../../../../core/server/services/email-service/events/email-delivered-event');
+const {
+  EmailBouncedEvent,
+} = require('../../../../core/server/services/email-service/events/email-bounced-event');
 const {
   EmailOpenedEvent,
 } = require('../../../../core/server/services/email-service/events/email-opened-event');
@@ -18,7 +25,10 @@ describe('Newsletter event flush', function () {
   });
 
   beforeEach(async function () {
-    await models.EmailRecipient.edit({ opened_at: null }, { id: recipient.id });
+    await models.EmailRecipient.edit(
+      { opened_at: null, delivered_at: null, failed_at: null },
+      { id: recipient.id },
+    );
     storage = new NewsletterEmailEventStorage({
       config: { get: () => true },
       db,
@@ -53,6 +63,192 @@ describe('Newsletter event flush', function () {
 
     await storage.handleOpened(event(firstOpen));
     assert.deepEqual(await storage.flushBatchedUpdates(), []);
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+  });
+
+  it('rolls back every transition for an email and can retry the failed flush', async function () {
+    const data = {
+      email: recipient.member_email,
+      emailRecipientId: recipient.id,
+      emailId: recipient.email_id,
+      memberId: recipient.member_id,
+      timestamp: new Date('2026-09-01T12:00:00.000Z'),
+    };
+    await storage.handleDelivered(EmailDeliveredEvent.create(data));
+    await storage.handleOpened(EmailOpenedEvent.create(data));
+    await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
+
+    // A real database error on the final write must roll back earlier writes.
+    await db.knex.raw(`CREATE TRIGGER reject_recipient_failure BEFORE UPDATE ON email_recipients
+      FOR EACH ROW BEGIN
+        IF NEW.failed_at IS NOT NULL THEN
+          SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'simulated flush failure';
+        END IF;
+      END`);
+    try {
+      await assert.rejects(storage.flushBatchedUpdates(), /simulated flush failure/);
+      const saved = await models.EmailRecipient.findOne({ id: recipient.id }, { require: true });
+      assert.equal(saved.get('delivered_at'), null);
+      assert.equal(saved.get('opened_at'), null);
+      assert.equal(saved.get('failed_at'), null);
+    } finally {
+      await db.knex.raw('DROP TRIGGER reject_recipient_failure');
+    }
+
+    const transitioned = [{ recipientId: recipient.id, memberId: recipient.member_id }];
+    assert.deepEqual(await storage.flushBatchedUpdates(), [
+      {
+        emailId: recipient.email_id,
+        delivered: transitioned,
+        opened: transitioned,
+        failed: transitioned,
+      },
+    ]);
+  });
+
+  it('retries a rolled-back deadlock without losing or duplicating transitions', async function () {
+    let attempts = 0;
+    storage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      models,
+      db: {
+        knex: {
+          transaction: (callback) =>
+            db.knex.transaction(async (trx) => {
+              const result = await callback(trx);
+              attempts += 1;
+              if (attempts === 1) {
+                // Inject the database failure after real writes; Knex rolls them back.
+                throw Object.assign(new Error('simulated deadlock'), { code: 'ER_LOCK_DEADLOCK' });
+              }
+              return result;
+            }),
+        },
+      },
+    });
+    await storage.handleOpened(
+      EmailOpenedEvent.create({
+        email: recipient.member_email,
+        emailRecipientId: recipient.id,
+        emailId: recipient.email_id,
+        memberId: recipient.member_id,
+        timestamp: new Date('2026-09-01T12:00:00.000Z'),
+      }),
+    );
+    assert.deepEqual(await storage.flushBatchedUpdates(), [
+      {
+        emailId: recipient.email_id,
+        delivered: [],
+        opened: [{ recipientId: recipient.id, memberId: recipient.member_id }],
+        failed: [],
+      },
+    ]);
+    assert.equal(attempts, 2);
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+  });
+
+  it('counts contended opens once while batch creation inserts recipients', async function () {
+    const otherRecipient = fixtureManager.get('email_recipients', 1);
+    await models.EmailRecipient.edit({ opened_at: null }, { id: otherRecipient.id });
+    const otherStorage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db,
+      models,
+    });
+    const email = await models.Email.findOne({ id: recipient.email_id }, { require: true });
+    const member = await models.Member.findOne({ id: recipient.member_id }, { require: true });
+    const batchService = new BatchSendingService({ db, models });
+    for (const target of [storage, otherStorage]) {
+      // Feed opposite input orders to exercise the shared database lock order.
+      const rows = target === storage ? [recipient, otherRecipient] : [otherRecipient, recipient];
+      for (const row of rows) {
+        await target.handleOpened(
+          EmailOpenedEvent.create({
+            email: row.member_email,
+            emailRecipientId: row.id,
+            emailId: row.email_id,
+            memberId: row.member_id,
+            timestamp: new Date('2026-09-01T12:00:00.000Z'),
+          }),
+        );
+      }
+    }
+
+    const blocker = await db.knex.transaction();
+    await blocker('email_recipients').where({ id: recipient.id }).forUpdate();
+    const waiting = Promise.withResolvers();
+    const lockingQueries = [];
+    const observe = (query) => {
+      if (/select.*email_recipients.*for update/i.test(query.sql)) {
+        lockingQueries.push(query);
+        if (lockingQueries.length === 2) {
+          waiting.resolve();
+        }
+      }
+    };
+    db.knex.on('query', observe);
+    const completed = Promise.all([
+      storage.flushBatchedUpdates(),
+      otherStorage.flushBatchedUpdates(),
+      batchService.createBatch(email, null, [member.toJSON()], {}),
+    ]);
+    try {
+      await Promise.race([waiting.promise, completed]);
+    } finally {
+      db.knex.off('query', observe);
+      await blocker.commit();
+    }
+    const [first, second, batch] = await completed;
+    try {
+      assert.deepEqual(
+        [...first, ...second]
+          .flatMap((group) => group.opened)
+          .sort((a, b) => a.recipientId.localeCompare(b.recipientId)),
+        [recipient, otherRecipient]
+          .map((row) => ({ recipientId: row.id, memberId: row.member_id }))
+          .sort((a, b) => a.recipientId.localeCompare(b.recipientId)),
+      );
+      const inserted = await models.EmailRecipient.findAll({ filter: `batch_id:${batch.id}` });
+      assert.equal(inserted.length, 1);
+
+      // Check the actual MySQL access path: sorting an IN list is not proof of
+      // lock order, and a filesort would happen after locks were acquired.
+      const [plan] = await db.knex.raw(
+        `EXPLAIN ${lockingQueries[0].sql}`,
+        lockingQueries[0].bindings,
+      );
+      assert.equal(plan[0].key, 'PRIMARY');
+      assert(!plan[0].Extra?.includes('filesort'));
+    } finally {
+      await models.EmailRecipient.destroy({ destroyBy: { batch_id: batch.id } });
+      await models.EmailBatch.destroy({ id: batch.id });
+    }
+  });
+
+  it('returns independent delivery, open and failure transitions for the same recipient', async function () {
+    const data = {
+      email: recipient.member_email,
+      emailRecipientId: recipient.id,
+      emailId: recipient.email_id,
+      memberId: recipient.member_id,
+      timestamp: new Date('2026-09-01T12:00:00.000Z'),
+    };
+    await storage.handleOpened(EmailOpenedEvent.create(data));
+    await storage.handleDelivered(EmailDeliveredEvent.create(data));
+    await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
+    const transitioned = [{ recipientId: recipient.id, memberId: recipient.member_id }];
+    assert.deepEqual(await storage.flushBatchedUpdates(), [
+      {
+        emailId: recipient.email_id,
+        delivered: transitioned,
+        opened: transitioned,
+        failed: transitioned,
+      },
+    ]);
+
+    await storage.handleOpened(EmailOpenedEvent.create(data));
+    await storage.handleDelivered(EmailDeliveredEvent.create(data));
+    await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
     assert.deepEqual(await storage.flushBatchedUpdates(), []);
   });
 });

--- a/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.js
@@ -1,0 +1,58 @@
+const assert = require('node:assert/strict');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const db = require('../../../../core/server/data/db');
+const models = require('../../../../core/server/models');
+const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
+const {
+  EmailOpenedEvent,
+} = require('../../../../core/server/services/email-service/events/email-opened-event');
+
+describe('Newsletter event flush', function () {
+  let recipient;
+  let storage;
+
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
+    recipient = fixtureManager.get('email_recipients', 0);
+  });
+
+  beforeEach(async function () {
+    await models.EmailRecipient.edit({ opened_at: null }, { id: recipient.id });
+    storage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db,
+      models,
+    });
+  });
+
+  it('returns only the first open transition when events are duplicated and replayed', async function () {
+    const firstOpen = new Date('2026-09-01T12:00:00.000Z');
+    const event = (timestamp) =>
+      EmailOpenedEvent.create({
+        email: recipient.member_email,
+        emailRecipientId: recipient.id,
+        emailId: recipient.email_id,
+        memberId: recipient.member_id,
+        timestamp,
+      });
+
+    await storage.handleOpened(event(new Date('2026-09-01T12:01:00.000Z')));
+    await storage.handleOpened(event(firstOpen));
+
+    assert.deepEqual(await storage.flushBatchedUpdates(), [
+      {
+        emailId: recipient.email_id,
+        delivered: [],
+        opened: [{ recipientId: recipient.id, memberId: recipient.member_id }],
+        failed: [],
+      },
+    ]);
+    const saved = await models.EmailRecipient.findOne({ id: recipient.id }, { require: true });
+    assert.equal(saved.get('opened_at').toISOString(), firstOpen.toISOString());
+
+    await storage.handleOpened(event(firstOpen));
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+  });
+});

--- a/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-event-flush.test.ts
@@ -1,6 +1,8 @@
-const assert = require('node:assert/strict');
+import assert from 'node:assert/strict';
+import type { Knex } from 'knex';
+
 const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
-const db = require('../../../../core/server/data/db');
+const db: { knex: Knex } = require('../../../../core/server/data/db');
 const models = require('../../../../core/server/models');
 const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
 const BatchSendingService = require('../../../../core/server/services/email-service/batch-sending-service');
@@ -21,10 +23,33 @@ const {
   EmailOpenedEvent,
 } = require('../../../../core/server/services/email-service/events/email-opened-event');
 
+// The legacy Bookshelf models and fixtures are untyped; describe only what this test reads.
+type RecipientRow = {
+  id: string;
+  email_id: string;
+  member_id: string;
+  member_email: string;
+};
+type Transition = { recipientId: string; memberId: string };
+type FlushedPage = {
+  emailId: string;
+  delivered: Transition[];
+  opened: Transition[];
+  failed: Transition[];
+};
+type EventStorage = {
+  handleDelivered: (event: unknown) => Promise<void>;
+  handleOpened: (event: unknown) => Promise<void>;
+  handlePermanentFailed: (event: unknown) => Promise<void>;
+  flushBatchedUpdates: () => Promise<FlushedPage[]>;
+};
+type TransactionCallback = (trx: Knex.Transaction) => Promise<unknown>;
+type ObservedQuery = { sql: string; bindings: unknown[] };
+
 describe('Newsletter event flush', function () {
-  let recipient;
-  let otherRecipient;
-  let storage;
+  let recipient: RecipientRow;
+  let otherRecipient: RecipientRow;
+  let storage: EventStorage;
 
   beforeAll(async function () {
     await agentProvider.getAdminAPIAgent();
@@ -67,7 +92,7 @@ describe('Newsletter event flush', function () {
     assert.equal(first.opened, 2);
     assert.deepEqual(first.memberIds, [recipient.member_id]);
     const replay = new EventProcessingResult();
-    const cursor = {};
+    const cursor: { lastEventTimestamp?: Date } = {};
     await processor.processBatch([event], replay, cursor);
     assert.equal(replay.opened, 1);
     assert.deepEqual(replay.memberIds, [recipient.member_id]);
@@ -84,7 +109,9 @@ describe('Newsletter event flush', function () {
       batch_id: batch.id,
       opened_at: null,
     });
-    const rows = [recipient, second.toJSON()].sort((a, b) => a.email_id.localeCompare(b.email_id));
+    const rows: RecipientRow[] = [recipient, second.toJSON()].sort(
+      (a: RecipientRow, b: RecipientRow) => a.email_id.localeCompare(b.email_id),
+    );
     const processor = new NewsletterEmailAnalyticsBatchProcessor({
       config: { get: () => true },
       emailEventProcessor: new EmailEventProcessor({
@@ -93,7 +120,7 @@ describe('Newsletter event flush', function () {
         domainEvents: { dispatch() {} },
       }),
     });
-    const events = rows.toReversed().map((row) => ({
+    const events = [...rows].reverse().map((row) => ({
       type: 'opened',
       emailId: row.email_id,
       recipientEmail: row.member_email,
@@ -116,7 +143,7 @@ describe('Newsletter event flush', function () {
         await assert.rejects(processor.processBatch(events, result, cursor), /later email failed/);
         assert.deepEqual(
           result.memberIds,
-          rows.toReversed().map((row) => row.member_id),
+          [...rows].reverse().map((row) => row.member_id),
         );
         assert.equal(cursor.lastEventTimestamp, previous);
         const committed = await models.EmailRecipient.findOne(
@@ -132,7 +159,7 @@ describe('Newsletter event flush', function () {
       assert.equal(replay.opened, 2);
       assert.deepEqual(
         replay.memberIds,
-        rows.toReversed().map((row) => row.member_id),
+        [...rows].reverse().map((row) => row.member_id),
       );
       assert.equal(cursor.lastEventTimestamp, events[0].timestamp);
     } finally {
@@ -147,7 +174,7 @@ describe('Newsletter event flush', function () {
       models,
       db: {
         knex: {
-          transaction: async (callback) => {
+          transaction: async (callback: TransactionCallback) => {
             await db.knex.transaction(callback);
             throw Object.assign(new Error('commit acknowledgement lost'), { code: 'ECONNRESET' });
           },
@@ -169,7 +196,7 @@ describe('Newsletter event flush', function () {
       timestamp: new Date('2026-09-01T12:00:00.000Z'),
     };
     const result = new EventProcessingResult();
-    const cursor = {};
+    const cursor: { lastEventTimestamp?: Date } = {};
     await assert.rejects(processor.processBatch([event], result, cursor), /acknowledgement lost/);
     assert.deepEqual(result.memberIds, [recipient.member_id]);
     assert.deepEqual(cursor, {});
@@ -227,7 +254,7 @@ describe('Newsletter event flush', function () {
 
   it('returns only the first open transition when events are duplicated and replayed', async function () {
     const firstOpen = new Date('2026-09-01T12:00:00.000Z');
-    const event = (timestamp) =>
+    const event = (timestamp: Date) =>
       EmailOpenedEvent.create({
         email: recipient.member_email,
         emailRecipientId: recipient.id,
@@ -311,7 +338,7 @@ describe('Newsletter event flush', function () {
         models,
         db: {
           knex: {
-            transaction: (callback) =>
+            transaction: (callback: TransactionCallback) =>
               db.knex.transaction(async (trx) => {
                 const result = await callback(trx);
                 attempts += 1;
@@ -359,8 +386,8 @@ describe('Newsletter event flush', function () {
       await storage.handleDelivered(EmailDeliveredEvent.create(data));
       await storage.handlePermanentFailed(EmailBouncedEvent.create({ ...data, error: null }));
     }
-    const lockingQueries = [];
-    const observe = (query) => {
+    const lockingQueries: ObservedQuery[] = [];
+    const observe = (query: ObservedQuery) => {
       if (/select.*email_recipients.*for update/i.test(query.sql)) {
         lockingQueries.push(query);
       }
@@ -373,7 +400,7 @@ describe('Newsletter event flush', function () {
     }
     assert.equal(lockingQueries.length, 1);
     // One OR branch per event type in the locking predicate
-    assert.equal(lockingQueries[0].sql.match(/is null/g).length, 3);
+    assert.equal(lockingQueries[0].sql.match(/is null/g)?.length, 3);
     const [plan] = await db.knex.raw(
       `EXPLAIN ${lockingQueries[0].sql}`,
       lockingQueries[0].bindings,
@@ -410,9 +437,16 @@ describe('Newsletter event flush', function () {
 
     const blocker = await db.knex.transaction();
     await blocker('email_recipients').where({ id: recipient.id }).forUpdate();
-    const waiting = Promise.withResolvers();
-    const lockingQueries = [];
-    const observe = (query) => {
+    // Promise.withResolvers() is ES2024; this test compiles against the es2022 lib.
+    let resolveWaiting!: () => void;
+    const waiting = {
+      promise: new Promise<void>((resolve) => {
+        resolveWaiting = resolve;
+      }),
+      resolve: () => resolveWaiting(),
+    };
+    const lockingQueries: ObservedQuery[] = [];
+    const observe = (query: ObservedQuery) => {
       if (/select.*email_recipients.*for update/i.test(query.sql)) {
         lockingQueries.push(query);
         if (lockingQueries.length === 2) {

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
@@ -52,6 +52,7 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
             emailEventProcessor = {};
             emailEventProcessor.batchGetRecipients = sinon.stub().resolves(new Map());
             emailEventProcessor.flushBatchedUpdates = sinon.stub().resolves();
+            emailEventProcessor.discardBatchedUpdates = sinon.stub();
             emailEventProcessor.handleDelivered = sinon.stub().callsFake(({ emailId }) => {
               return {
                 emailId,
@@ -420,6 +421,7 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
             emailEventProcessor = {};
             emailEventProcessor.batchGetRecipients = sinon.stub().resolves(new Map());
             emailEventProcessor.flushBatchedUpdates = sinon.stub().resolves();
+            emailEventProcessor.discardBatchedUpdates = sinon.stub();
             emailEventProcessor.handleDelivered = sinon.stub().returns(null);
             emailEventProcessor.handleOpened = sinon.stub().returns(null);
             emailEventProcessor.handlePermanentFailed = sinon.stub().returns(null);
@@ -609,6 +611,7 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
           const emailEventProcessor = {
             batchGetRecipients: sinon.stub().resolves(new Map()),
             flushBatchedUpdates: sinon.stub().resolves(),
+            discardBatchedUpdates: sinon.stub(),
             handleDelivered: sinon
               .stub()
               .resolves({ emailId: 1, emailRecipientId: 1, memberId: 1 }),


### PR DESCRIPTION
Batched newsletter ingestion currently writes delivery, open and failure timestamps separately. To replace repeated analytics recounts with counters, we first need to know exactly which recipients changed, and keep those changes inside a transaction that future counter updates can share.

This PR groups pending events by email and returns the exact recipient/member sets whose timestamps changed from NULL. Duplicate events return zero transitions. Delivery, open and failure remain independent facts, and the earliest timestamp within a pending batch wins.

```text
for each email, in ID order
  begin transaction
    lock eligible recipients in primary-key order
    apply guarded delivery / open / failure updates
    collect the exact transitioned recipient and member sets
  commit

advance the page cursor after every email has committed
```

The locking read matters because an affected-row count cannot tell us which members changed. It uses `FORCE INDEX (PRIMARY)` and `ORDER BY id`; sorting an `IN` list alone would not establish lock order. The MySQL test checks the actual query plan and races competing flushes alongside batch-creation inserts. Deadlocks retry the whole transaction, up to three attempts. Other errors propagate so the page can be replayed.

Existing recounts remain responsible for counters. We also retain replayed members in the recount queue: a previous run may have committed recipient facts and failed before updating statistics. Skipping duplicate-driven member recounts is deferred until member counters commit atomically with recipient transitions. Sequential processing and automation/gift storage keep their existing behavior.

Validation:

- 102 email-service MySQL integration tests and 180 analytics unit tests passed; 27 storage unit tests passed.
- Regression coverage includes duplicate replay, out-of-order timestamps, independent event types, transaction rollback/retry, contention, multiple emails, partial progress and a lost commit acknowledgement.
- Core and test TypeScript checks, focused ESLint and commit hooks passed. Full `pnpm check` stopped at existing formatting issues in 452 unrelated files; no changed file appears in that list.
- Five independent review passes covered each slice and the combined PR 1–2 stack. The recovery finding led to retaining replay recounts; re-review found no remaining high-confidence issues.

A local synthetic comparison used 5,000 members, 500 historical emails and 2,009,528 recipient rows, with 300-event pages and unchanged recounts. Median handler reads over three measured cycles were:

| Duplicate opens | Previous | This PR |
| --- | ---: | ---: |
| 0% | 4,000,418 | 4,005,418 |
| 50% | 4,000,418 | 4,002,918 |
| 100% | 4,000,418 | 4,000,418 |

Recounts still dominate; this step establishes correctness for the later counter change. The harness uses `innodb_flush_log_at_trx_commit=0` and no binary log. Local timing varied, so these results make no production write-latency or throughput claim.

Stacked on #30667. Future counter updates belong inside the recipient transaction.

ref https://linear.app/ghost/issue/BER-3933/make-batched-email-event-writes-transactional-with-exact-per-email
