### PR TITLE
Fixed Admin locale data type resolution

### DIFF
--- a/apps/admin/tsconfig.app.json
+++ b/apps/admin/tsconfig.app.json
@@ -10,6 +10,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -44,6 +44,7 @@
     },
     "./locale-data.json": {
       "source": "./src/locale-data.json",
+      "types": "./src/locale-data.json",
       "default": "./build/locale-data.json"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Admin lint and typecheck fail in `publication-language.tsx` because the locale JSON export cannot be resolved after #30635. Type-aware lint reports 20 cascading unsafe-value errors, including on unrelated Admin PRs such as #30588.

Enable JSON module typing in Admin and give the locale JSON export a `types` condition pointing to the checked-in source. Type resolution then works without generated i18n output; runtime export resolution is unchanged.

Validation:
- `pnpm --filter @tryghost/admin typecheck`
- `pnpm --filter @tryghost/admin lint` (existing warnings only)
- `pnpm lint:packages`
- Formatting checks

Validated with `packages/i18n/build/locale-data.json` absent.
