### PR TITLE
Added atomic newsletter email counters with drift comparison

### DIFF
--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -1,0 +1,44 @@
+# Email analytics
+
+Newsletter events update recipient facts before refreshing email and member
+statistics. Automation and gift events use their own outcome APIs.
+
+## Newsletter email counter comparison
+
+`emailAnalytics.emailCounterMode` defaults to `off`. Setting it to `compare`
+also requires `emailAnalytics.batchProcessing: true`. This enables atomic
+delivered, opened and failed email counters and changes email aggregation to
+comparison without repair. Member statistics still use recomputation, including
+replayed members needed to recover an interrupted recount.
+
+The mode is selected at analytics boot. Stop and drain existing analytics
+workers before changing modes, then restart them with the same configuration.
+Legacy recipient writers and recomputations do not acquire the counter lock;
+running them alongside counter writers is not supported. Returning to `off`
+restores legacy recomputation. A later counter startup establishes a fresh
+baseline before applying increments.
+
+There is no historical email backfill. Each worker corrects existing counters
+once for each email it touches after startup. Usually those are active sends
+and emails still inside the fetch trust window; scheduled recovery can also
+touch an older email. That recount always includes opens, then hands off to
+increments within the same transaction. Restart repeats this bounded-by-touched-
+emails work, rather than remembering readiness durably or scanning history.
+
+Counter transactions lock the email row first, then eligible recipients in
+primary-key order. Both the startup recount and shadow comparison acquire the
+email lock before their first consistent read. All three event types remain
+independent; delivery is not a prerequisite for an open. Recipient timestamps
+and exact counter increments commit together. Readiness is remembered only
+after the commit is acknowledged, so retrying an uncertain commit is safe.
+
+Comparisons always recount opens regardless of the fetch lane. Once the startup
+baseline exists, comparison never overwrites counters. Drift logs include the
+email ID and signed differences. The Prometheus counters
+`email_analytics_email_counter_comparisons` and
+`email_analytics_email_counter_drift` record comparisons and the sum of absolute
+differences by event type. Repeated observations of the same drift contribute
+again; a worker restart rebaselines, so monitor drift before restarting.
+
+Comparison retains the recount query load. Removing mid-cycle email recounts
+is a separate rollout step after comparison has established correctness.

--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -24,6 +24,17 @@ and emails still inside the fetch trust window; scheduled recovery can also
 touch an older email. That recount always includes opens, then hands off to
 increments within the same transaction. Restart repeats this bounded-by-touched-
 emails work, rather than remembering readiness durably or scanning history.
+The correction a baseline applies is logged with `phase: "baseline"` and summed
+into `email_analytics_email_counter_baseline_corrections`, so a counter left
+wrong by an earlier process remains observable even though the comparison that
+follows starts from corrected values. A missing email row takes no baseline and
+is not remembered as initialized.
+
+The recount issues one covering-index count per outcome, matching the legacy
+recount. It runs while the email row is locked, so keep it short: recipient
+inserts for the same email take a shared lock on that row through their foreign
+key and wait for the counter transaction to finish. Comparison transactions
+retry lock waits and deadlocks the same way event flushes do.
 
 Counter transactions lock the email row first, then eligible recipients in
 primary-key order. Both the startup recount and shadow comparison acquire the

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -21,6 +21,7 @@ import type { EmailRecipientFailure, EmailSpamComplaintEvent, Email } from '../.
 // @ts-expect-error This module lacks type definitions.
 import type DomainEvents from '@tryghost/domain-events';
 import { Queries } from './lib/queries';
+import { NewsletterEmailCounters } from './newsletter-email-counters';
 import { StartEmailAnalyticsJobEvent } from './events/start-email-analytics-job-event';
 import { StartAutomationEmailAnalyticsJobEvent } from './events/start-automation-email-analytics-job-event';
 import { AUTOMATION_EMAIL_TAG } from '../member-welcome-emails/constants';
@@ -76,11 +77,19 @@ export const init = ({
   settingsCache: Pick<typeof SettingsCache, 'get'>;
 }) => {
   const queries = new Queries(db.knex);
+  // Mode changes take effect at boot. Drain old analytics workers before changing
+  // modes: sequential and legacy recount writers do not use the counter lock.
+  const emailCounters =
+    config.get('emailAnalytics:batchProcessing') &&
+    config.get('emailAnalytics:emailCounterMode') === 'compare'
+      ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient })
+      : null;
 
   const newsletterEmailEventProcessor = new EmailEventProcessor({
     domainEvents,
     db,
     eventStorage: new NewsletterEmailEventStorage({
+      emailCounters,
       config,
       db,
       membersRepository,
@@ -134,6 +143,7 @@ export const init = ({
     settingsCache,
     createEventProcessor: () =>
       new NewsletterEmailAnalyticsBatchProcessor({
+        emailCounters,
         config,
         emailEventProcessor: newsletterEmailEventProcessor,
         prometheusClient,

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -1,4 +1,6 @@
 import type { Knex } from 'knex';
+import logging from '@tryghost/logging';
+import { z } from 'zod';
 import type { PrometheusClient } from '@tryghost/prometheus-metrics';
 import type { ConfigInstance } from '../../../shared/config/loader';
 import type { GhostMetrics } from '@tryghost/metrics';
@@ -44,6 +46,38 @@ export const gifts = new EmailAnalyticsServiceWrapper({
   logName: 'gifts',
 });
 
+const EmailCounterMode = z.enum(['off', 'compare']);
+type EmailCounterMode = z.infer<typeof EmailCounterMode>;
+
+/**
+ * Config is boundary data: an unrecognised or unsupported mode must be visible
+ * in the logs rather than silently behaving like `off`.
+ */
+export function resolveEmailCounterMode(
+  config: Pick<ConfigInstance, 'get'>,
+): Exclude<EmailCounterMode, 'off'> | null {
+  const configured: unknown = config.get('emailAnalytics:emailCounterMode') ?? 'off';
+  const parsed = EmailCounterMode.safeParse(configured);
+  if (!parsed.success) {
+    logging.warn(
+      `[EmailAnalytics] Ignoring unknown emailAnalytics.emailCounterMode ${JSON.stringify(configured)}; email counters are off`,
+    );
+    return null;
+  }
+  const mode = parsed.data;
+  if (mode === 'off') {
+    return null;
+  }
+  if (!config.get('emailAnalytics:batchProcessing')) {
+    logging.warn(
+      `[EmailAnalytics] emailAnalytics.emailCounterMode ${mode} requires emailAnalytics.batchProcessing; email counters are off`,
+    );
+    return null;
+  }
+  logging.info(`[EmailAnalytics] Newsletter email counter mode: ${mode}`);
+  return mode;
+}
+
 export const init = ({
   automationsApi,
   config,
@@ -79,11 +113,9 @@ export const init = ({
   const queries = new Queries(db.knex);
   // Mode changes take effect at boot. Drain old analytics workers before changing
   // modes: sequential and legacy recount writers do not use the counter lock.
-  const emailCounters =
-    config.get('emailAnalytics:batchProcessing') &&
-    config.get('emailAnalytics:emailCounterMode') === 'compare'
-      ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient })
-      : null;
+  const emailCounters = resolveEmailCounterMode(config)
+    ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient })
+    : null;
 
   const newsletterEmailEventProcessor = new EmailEventProcessor({
     domainEvents,

--- a/ghost/core/core/server/services/email-analytics/lib/transaction-with-retry.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/transaction-with-retry.ts
@@ -1,0 +1,34 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import type { Knex } from 'knex';
+
+// Lock waits are expected while batch creation inserts recipients for the same
+// email; both errors leave the transaction rolled back and safe to retry.
+const RETRYABLE_LOCK_ERRORS = new Set(['ER_LOCK_DEADLOCK', 'ER_LOCK_WAIT_TIMEOUT']);
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Run a transaction, retrying the whole rolled-back transaction after a lock
+ * error. Never retries an individual write, and lets connection or commit
+ * errors escape because their outcome is unknown.
+ */
+export async function transactionWithRetry<T>(
+  knex: Pick<Knex, 'transaction'>,
+  callback: (trx: Knex.Transaction) => Promise<T>,
+): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await knex.transaction(callback);
+    } catch (error) {
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined;
+      if (
+        typeof code !== 'string' ||
+        !RETRYABLE_LOCK_ERRORS.has(code) ||
+        attempt >= MAX_ATTEMPTS - 1
+      ) {
+        throw error;
+      }
+      await delay(10 * 2 ** attempt + Math.random() * 10);
+    }
+  }
+}

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -14,14 +14,16 @@ class NewsletterEmailAnalyticsBatchProcessor {
   #emailEventProcessor;
   #prometheusClient;
   #queries;
+  #emailCounters;
 
   #lastAggregation = Date.now();
 
-  constructor({ config, emailEventProcessor, prometheusClient, queries }) {
+  constructor({ config, emailEventProcessor, prometheusClient, queries, emailCounters = null }) {
     this.#config = config;
     this.#emailEventProcessor = emailEventProcessor;
     this.#prometheusClient = prometheusClient;
     this.#queries = queries;
+    this.#emailCounters = emailCounters;
   }
 
   /**
@@ -294,6 +296,10 @@ class NewsletterEmailAnalyticsBatchProcessor {
    * @returns {Promise<void>}
    */
   async #aggregateEmailStats(emailId, includeOpenedEvents) {
+    if (this.#emailCounters) {
+      await this.#emailCounters.compare(emailId);
+      return;
+    }
     return this.#queries.aggregateEmailStats(emailId, includeOpenedEvents);
   }
 

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
@@ -1,0 +1,129 @@
+import type { Knex } from 'knex';
+import logging from '@tryghost/logging';
+import type { PrometheusClient } from '@tryghost/prometheus-metrics';
+
+const events = ['delivered', 'opened', 'failed'] as const;
+type Transitions = Record<(typeof events)[number], readonly unknown[]>;
+
+/** Newsletter-only counter maintenance. Constructed once at analytics boot. */
+export class NewsletterEmailCounters {
+  #initialized = new Set<string>();
+  #knex: Knex;
+  #prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
+
+  constructor({
+    knex,
+    prometheusClient = null,
+  }: {
+    knex: Knex;
+    prometheusClient?: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
+  }) {
+    this.#knex = knex;
+    this.#prometheusClient = prometheusClient;
+    prometheusClient?.registerCounter({
+      name: 'email_analytics_email_counter_comparisons',
+      help: 'Number of newsletter email counter comparisons',
+      labelNames: ['event'],
+    });
+    prometheusClient?.registerCounter({
+      name: 'email_analytics_email_counter_drift',
+      help: 'Sum of absolute newsletter email counter differences observed at comparison',
+      labelNames: ['event'],
+    });
+  }
+
+  /** Must precede recipient locks, within a fresh per-email transaction. */
+  async prepare(trx: Knex.Transaction, emailId: string): Promise<void> {
+    const email = await trx('emails').where('id', emailId).forUpdate().first('id');
+    if (!email || this.#initialized.has(emailId)) {
+      return;
+    }
+
+    // Existing counters already have a baseline from recomputation. Correct it
+    // once per touched email after startup, including opens from missing lanes.
+    // The email lock serializes this handoff with other counter writers. The
+    // first consistent read happens AFTER that lock, avoiding a stale snapshot.
+    const truth = await this.#recount(trx, emailId);
+    await trx('emails').where('id', emailId).update(truth);
+  }
+
+  async #recount(trx: Knex.Transaction, emailId: string) {
+    // Lane flags must never suppress opened counting in the source of truth.
+    const row = await trx('email_recipients')
+      .where('email_id', emailId)
+      .count({
+        delivered_count: 'delivered_at',
+        opened_count: 'opened_at',
+        failed_count: 'failed_at',
+      })
+      .first();
+    return {
+      delivered_count: Number(row?.delivered_count ?? 0),
+      opened_count: Number(row?.opened_count ?? 0),
+      failed_count: Number(row?.failed_count ?? 0),
+    };
+  }
+
+  async increment(trx: Knex.Transaction, emailId: string, transitions: Transitions): Promise<void> {
+    const increments = Object.fromEntries(
+      events
+        .filter((event) => transitions[event].length)
+        .map((event) => [
+          `${event}_count`,
+          trx.raw('?? + ?', [`${event}_count`, transitions[event].length]),
+        ]),
+    );
+    if (Object.keys(increments).length) {
+      await trx('emails').where('id', emailId).update(increments);
+    }
+  }
+
+  /** Only call after COMMIT is acknowledged; retries may safely rebaseline. */
+  committed(emailId: string): void {
+    this.#initialized.add(emailId);
+  }
+
+  async compare(emailId: string): Promise<Record<(typeof events)[number], number> | null> {
+    const drift = await this.#knex.transaction(async (trx) => {
+      await this.prepare(trx, emailId);
+      const email = await trx('emails').where('id', emailId).first();
+      if (!email) {
+        return null;
+      }
+      const truth = await this.#recount(trx, emailId);
+      return {
+        delivered: Number(email.delivered_count) - truth.delivered_count,
+        opened: Number(email.opened_count) - truth.opened_count,
+        failed: Number(email.failed_count) - truth.failed_count,
+      };
+    });
+    this.committed(emailId);
+    if (drift) {
+      // Comparison observes drift; it must not hide a bad counter by repairing it.
+      if (events.some((event) => drift[event] !== 0)) {
+        logging.warn(
+          `[EmailAnalytics] Newsletter email counter drift: ${JSON.stringify({ emailId, drift })}`,
+        );
+      }
+      try {
+        for (const event of events) {
+          const comparisons = this.#prometheusClient?.getMetric(
+            'email_analytics_email_counter_comparisons',
+          );
+          const differences = this.#prometheusClient?.getMetric(
+            'email_analytics_email_counter_drift',
+          );
+          if (comparisons && 'inc' in comparisons) {
+            comparisons.inc({ event });
+          }
+          if (differences && 'inc' in differences) {
+            differences.inc({ event }, Math.abs(drift[event]));
+          }
+        }
+      } catch (error) {
+        logging.error('Error recording newsletter email counter comparison', error);
+      }
+    }
+    return drift;
+  }
+}

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
@@ -1,78 +1,135 @@
 import type { Knex } from 'knex';
 import logging from '@tryghost/logging';
 import type { PrometheusClient } from '@tryghost/prometheus-metrics';
+import { z } from 'zod';
+import { DbCount } from '../../lib/db-types/count';
+import { transactionWithRetry } from './lib/transaction-with-retry';
 
 const events = ['delivered', 'opened', 'failed'] as const;
-type Transitions = Record<(typeof events)[number], readonly unknown[]>;
+type Event = (typeof events)[number];
+type Drift = Record<Event, number>;
+type Transitions = Record<Event, readonly unknown[]>;
+
+// Projection of the `emails` counter columns; the Bookshelf model owns the row.
+const DbEmailCounters = z.object({
+  delivered_count: DbCount,
+  opened_count: DbCount,
+  failed_count: DbCount,
+});
+type Counts = z.output<typeof DbEmailCounters>;
+const DbCountRow = z.object({ count: DbCount });
+
+const COMPARISONS_METRIC = 'email_analytics_email_counter_comparisons';
+const DRIFT_METRIC = 'email_analytics_email_counter_drift';
+const BASELINE_METRIC = 'email_analytics_email_counter_baseline_corrections';
 
 /** Newsletter-only counter maintenance. Constructed once at analytics boot. */
 export class NewsletterEmailCounters {
+  // Emails whose baseline this process has committed. Grows with the distinct
+  // emails touched during the process lifetime; a restart rebaselines.
   #initialized = new Set<string>();
-  #knex: Knex;
+  // Corrections written by a baseline in a transaction that has not yet been
+  // acknowledged as committed; reported once the commit is acknowledged.
+  #prepared = new Map<string, Drift>();
+  #knex: Pick<Knex, 'transaction'>;
   #prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
 
   constructor({
     knex,
     prometheusClient = null,
   }: {
-    knex: Knex;
+    knex: Pick<Knex, 'transaction'>;
     prometheusClient?: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
   }) {
     this.#knex = knex;
     this.#prometheusClient = prometheusClient;
     prometheusClient?.registerCounter({
-      name: 'email_analytics_email_counter_comparisons',
+      name: COMPARISONS_METRIC,
       help: 'Number of newsletter email counter comparisons',
       labelNames: ['event'],
     });
     prometheusClient?.registerCounter({
-      name: 'email_analytics_email_counter_drift',
+      name: DRIFT_METRIC,
       help: 'Sum of absolute newsletter email counter differences observed at comparison',
+      labelNames: ['event'],
+    });
+    prometheusClient?.registerCounter({
+      name: BASELINE_METRIC,
+      help: 'Sum of absolute newsletter email counter differences corrected when a baseline was established',
       labelNames: ['event'],
     });
   }
 
-  /** Must precede recipient locks, within a fresh per-email transaction. */
-  async prepare(trx: Knex.Transaction, emailId: string): Promise<void> {
-    const email = await trx('emails').where('id', emailId).forUpdate().first('id');
-    if (!email || this.#initialized.has(emailId)) {
-      return;
+  /**
+   * Lock the email row and, on the first touch per process, replace its
+   * counters with recounted truth. Must precede recipient locks, within a
+   * fresh per-email transaction.
+   * @returns the locked counters as read, and the truth written over them
+   * when a baseline was taken; null when the email row does not exist
+   */
+  async prepare(
+    trx: Knex.Transaction,
+    emailId: string,
+  ): Promise<{ current: Counts; baseline: Counts | null } | null> {
+    const email = await trx('emails')
+      .where('id', emailId)
+      .forUpdate()
+      .first('delivered_count', 'opened_count', 'failed_count');
+    if (!email) {
+      // No baseline can be taken; forget any correction a rolled-back attempt
+      // recorded so committed() cannot mark this ID initialized.
+      this.#prepared.delete(emailId);
+      return null;
+    }
+    const current = DbEmailCounters.parse(email);
+    if (this.#initialized.has(emailId)) {
+      return { current, baseline: null };
     }
 
     // Existing counters already have a baseline from recomputation. Correct it
     // once per touched email after startup, including opens from missing lanes.
     // The email lock serializes this handoff with other counter writers. The
     // first consistent read happens AFTER that lock, avoiding a stale snapshot.
-    const truth = await this.#recount(trx, emailId);
-    await trx('emails').where('id', emailId).update(truth);
+    const baseline = await this.#recount(trx, emailId);
+    await trx('emails').where('id', emailId).update(baseline);
+    // Remember what the baseline changed so a wrong counter left by an earlier
+    // process is still observable, even though comparisons start from the
+    // corrected values. Reported by committed(), so a rolled-back attempt
+    // does not count and a retry reports once.
+    this.#prepared.set(emailId, this.#diff(current, baseline));
+    return { current, baseline };
   }
 
-  async #recount(trx: Knex.Transaction, emailId: string) {
-    // Lane flags must never suppress opened counting in the source of truth.
-    const row = await trx('email_recipients')
-      .where('email_id', emailId)
-      .count({
-        delivered_count: 'delivered_at',
-        opened_count: 'opened_at',
-        failed_count: 'failed_at',
-      })
-      .first();
+  async #recount(trx: Knex.Transaction, emailId: string): Promise<Counts> {
+    // One covering-index count per outcome, as the legacy recount did. Lane
+    // flags must never suppress opened counting in the source of truth.
+    const counts = await Promise.all(
+      events.map(async (event) => {
+        const row = await trx('email_recipients')
+          .where('email_id', emailId)
+          .whereNotNull(`${event}_at`)
+          .count({ count: '*' })
+          .first();
+        return DbCountRow.parse(row).count;
+      }),
+    );
     return {
-      delivered_count: Number(row?.delivered_count ?? 0),
-      opened_count: Number(row?.opened_count ?? 0),
-      failed_count: Number(row?.failed_count ?? 0),
+      delivered_count: counts[0],
+      opened_count: counts[1],
+      failed_count: counts[2],
     };
   }
 
   async increment(trx: Knex.Transaction, emailId: string, transitions: Transitions): Promise<void> {
-    const increments = Object.fromEntries(
-      events
-        .filter((event) => transitions[event].length)
-        .map((event) => [
+    const increments: Record<string, Knex.Raw> = {};
+    for (const event of events) {
+      if (transitions[event].length) {
+        increments[`${event}_count`] = trx.raw('?? + ?', [
           `${event}_count`,
-          trx.raw('?? + ?', [`${event}_count`, transitions[event].length]),
-        ]),
-    );
+          transitions[event].length,
+        ]);
+      }
+    }
     if (Object.keys(increments).length) {
       await trx('emails').where('id', emailId).update(increments);
     }
@@ -80,50 +137,68 @@ export class NewsletterEmailCounters {
 
   /** Only call after COMMIT is acknowledged; retries may safely rebaseline. */
   committed(emailId: string): void {
-    this.#initialized.add(emailId);
+    // A missing email row takes no baseline, so it must not be remembered as
+    // initialized: a later row with that ID would receive raw increments.
+    const correction = this.#prepared.get(emailId);
+    if (correction) {
+      this.#prepared.delete(emailId);
+      this.#initialized.add(emailId);
+      this.#report(emailId, correction, 'baseline');
+    }
   }
 
-  async compare(emailId: string): Promise<Record<(typeof events)[number], number> | null> {
-    const drift = await this.#knex.transaction(async (trx) => {
-      await this.prepare(trx, emailId);
-      const email = await trx('emails').where('id', emailId).first();
-      if (!email) {
+  async compare(emailId: string): Promise<Drift | null> {
+    const drift = await transactionWithRetry(this.#knex, async (trx) => {
+      const state = await this.prepare(trx, emailId);
+      if (!state) {
         return null;
       }
-      const truth = await this.#recount(trx, emailId);
-      return {
-        delivered: Number(email.delivered_count) - truth.delivered_count,
-        opened: Number(email.opened_count) - truth.opened_count,
-        failed: Number(email.failed_count) - truth.failed_count,
-      };
+      // A baseline just replaced the counters with truth; do not recount twice.
+      if (state.baseline) {
+        return { delivered: 0, opened: 0, failed: 0 };
+      }
+      return this.#diff(state.current, await this.#recount(trx, emailId));
     });
     this.committed(emailId);
     if (drift) {
       // Comparison observes drift; it must not hide a bad counter by repairing it.
-      if (events.some((event) => drift[event] !== 0)) {
-        logging.warn(
-          `[EmailAnalytics] Newsletter email counter drift: ${JSON.stringify({ emailId, drift })}`,
-        );
-      }
-      try {
-        for (const event of events) {
-          const comparisons = this.#prometheusClient?.getMetric(
-            'email_analytics_email_counter_comparisons',
-          );
-          const differences = this.#prometheusClient?.getMetric(
-            'email_analytics_email_counter_drift',
-          );
-          if (comparisons && 'inc' in comparisons) {
-            comparisons.inc({ event });
-          }
-          if (differences && 'inc' in differences) {
-            differences.inc({ event }, Math.abs(drift[event]));
-          }
-        }
-      } catch (error) {
-        logging.error('Error recording newsletter email counter comparison', error);
-      }
+      this.#report(emailId, drift, 'comparison');
     }
     return drift;
+  }
+
+  #diff(current: Counts, truth: Counts): Drift {
+    return {
+      delivered: current.delivered_count - truth.delivered_count,
+      opened: current.opened_count - truth.opened_count,
+      failed: current.failed_count - truth.failed_count,
+    };
+  }
+
+  #report(emailId: string, drift: Drift, phase: 'baseline' | 'comparison'): void {
+    if (events.some((event) => drift[event] !== 0)) {
+      logging.warn(
+        `[EmailAnalytics] Newsletter email counter drift: ${JSON.stringify({ emailId, drift, phase })}`,
+      );
+    }
+    try {
+      for (const event of events) {
+        if (phase === 'comparison') {
+          this.#inc(COMPARISONS_METRIC, event, 1);
+          this.#inc(DRIFT_METRIC, event, Math.abs(drift[event]));
+        } else {
+          this.#inc(BASELINE_METRIC, event, Math.abs(drift[event]));
+        }
+      }
+    } catch (error) {
+      logging.error('[EmailAnalytics] Error recording newsletter email counter drift', error);
+    }
+  }
+
+  #inc(name: string, event: Event, value: number): void {
+    const metric = this.#prometheusClient?.getMetric(name);
+    if (metric && 'inc' in metric) {
+      metric.inc({ event }, value);
+    }
   }
 }

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -16,14 +16,24 @@ class NewsletterEmailEventStorage {
   #emailSuppressionList;
   #prometheusClient;
   #pendingUpdates;
+  #emailCounters;
 
-  constructor({ config, db, models, membersRepository, emailSuppressionList, prometheusClient }) {
+  constructor({
+    config,
+    db,
+    models,
+    membersRepository,
+    emailSuppressionList,
+    prometheusClient,
+    emailCounters = null,
+  }) {
     this.#config = config;
     this.#db = db;
     this.#models = models;
     this.#membersRepository = membersRepository;
     this.#emailSuppressionList = emailSuppressionList;
     this.#prometheusClient = prometheusClient;
+    this.#emailCounters = emailCounters;
 
     // Initialize pending updates for batched processing
     this.#pendingUpdates = {
@@ -345,6 +355,7 @@ class NewsletterEmailEventStorage {
     for (const emailId of Array.from(groups.keys()).sort()) {
       const updates = groups.get(emailId);
       const transitioned = await this.#transactionWithRetry(async (trx) => {
+        await this.#emailCounters?.prepare(trx, emailId);
         const query = trx('email_recipients');
         if (DatabaseInfo.isMySQL(trx)) {
           // Lock in primary-key order, rather than whichever secondary index
@@ -403,8 +414,10 @@ class NewsletterEmailEventStorage {
             memberId,
           }));
         }
+        await this.#emailCounters?.increment(trx, emailId, result);
         return result;
       });
+      this.#emailCounters?.committed(emailId);
       if (
         transitioned.delivered.length ||
         transitioned.opened.length ||

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -2,11 +2,7 @@ const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const DatabaseInfo = require('@tryghost/database-info');
-const { setTimeout: delay } = require('node:timers/promises');
-
-// Lock waits are expected while batch creation inserts recipients for the same
-// email; both errors leave the transaction rolled back and safe to retry.
-const RETRYABLE_LOCK_ERRORS = new Set(['ER_LOCK_DEADLOCK', 'ER_LOCK_WAIT_TIMEOUT']);
+const { transactionWithRetry } = require('../email-analytics/lib/transaction-with-retry');
 
 class NewsletterEmailEventStorage {
   #config;
@@ -354,7 +350,7 @@ class NewsletterEmailEventStorage {
     const transitions = [];
     for (const emailId of Array.from(groups.keys()).sort()) {
       const updates = groups.get(emailId);
-      const transitioned = await this.#transactionWithRetry(async (trx) => {
+      const transitioned = await transactionWithRetry(this.#db.knex, async (trx) => {
         await this.#emailCounters?.prepare(trx, emailId);
         const query = trx('email_recipients');
         if (DatabaseInfo.isMySQL(trx)) {
@@ -432,21 +428,6 @@ class NewsletterEmailEventStorage {
       }
     }
     return transitions;
-  }
-
-  async #transactionWithRetry(callback) {
-    for (let attempt = 0; ; attempt++) {
-      try {
-        return await this.#db.knex.transaction(callback);
-      } catch (error) {
-        // Retry the whole rolled-back transaction, never an individual write.
-        // Connection/commit errors can have an unknown outcome and must escape.
-        if (!RETRYABLE_LOCK_ERRORS.has(error.code) || attempt >= 2) {
-          throw error;
-        }
-        await delay(10 * 2 ** attempt + Math.random() * 10);
-      }
-    }
   }
 }
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -298,6 +298,7 @@
   "enableStripePromoCodes": false,
   "enableTipsAndDonations": true,
   "emailAnalytics": {
+    "emailCounterMode": "off",
     "enabled": true,
     "batchProcessing": false,
     "metrics": {

--- a/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.js
@@ -139,6 +139,115 @@ describe('Newsletter email counters', function () {
     });
   }
 
+  it('reports the correction a baseline applies to counters left by another process', async function () {
+    await resetFacts();
+    await db.knex('email_recipients').where('id', recipient.id).update({
+      delivered_at: '2026-09-01 11:00:00',
+    });
+    const metrics = {
+      email_analytics_email_counter_comparisons: { inc: sinon.stub() },
+      email_analytics_email_counter_drift: { inc: sinon.stub() },
+      email_analytics_email_counter_baseline_corrections: { inc: sinon.stub() },
+    };
+    const counters = new NewsletterEmailCounters({
+      knex: db.knex,
+      prometheusClient: { registerCounter: sinon.stub(), getMetric: (name) => metrics[name] },
+    });
+    const warn = sinon.stub(require('@tryghost/logging'), 'warn');
+    try {
+      assert.deepEqual(await counters.compare(recipient.email_id), {
+        delivered: 0,
+        opened: 0,
+        failed: 0,
+      });
+    } finally {
+      warn.restore();
+    }
+    // 99/99/99 counters were corrected to 1/0/0 before the zero-drift comparison
+    sinon.assert.calledOnce(warn);
+    sinon.assert.calledWithMatch(warn, /"phase":"baseline"/);
+    sinon.assert.calledWithMatch(warn, /"drift":\{"delivered":98,"opened":99,"failed":99\}/);
+    const corrections = metrics.email_analytics_email_counter_baseline_corrections.inc;
+    sinon.assert.calledWithExactly(corrections, { event: 'delivered' }, 98);
+    sinon.assert.calledWithExactly(corrections, { event: 'opened' }, 99);
+    sinon.assert.calledWithExactly(corrections, { event: 'failed' }, 99);
+    for (const event of ['delivered', 'opened', 'failed']) {
+      sinon.assert.calledWithExactly(metrics.email_analytics_email_counter_drift.inc, { event }, 0);
+      sinon.assert.calledWithExactly(
+        metrics.email_analytics_email_counter_comparisons.inc,
+        { event },
+        1,
+      );
+    }
+  });
+
+  it('retries a comparison that loses a lock wait and reports its baseline correction once', async function () {
+    await resetFacts();
+    let attempts = 0;
+    const warn = sinon.stub(require('@tryghost/logging'), 'warn');
+    try {
+      const counters = new NewsletterEmailCounters({
+        knex: {
+          transaction: (callback) =>
+            db.knex.transaction(async (trx) => {
+              const result = await callback(trx);
+              attempts += 1;
+              if (attempts === 1) {
+                throw Object.assign(new Error('lock wait'), { code: 'ER_LOCK_WAIT_TIMEOUT' });
+              }
+              return result;
+            }),
+        },
+      });
+      assert.deepEqual(await counters.compare(recipient.email_id), {
+        delivered: 0,
+        opened: 0,
+        failed: 0,
+      });
+    } finally {
+      warn.restore();
+    }
+    assert.equal(attempts, 2);
+    sinon.assert.calledOnce(warn);
+    sinon.assert.calledWithMatch(warn, /"phase":"baseline"/);
+    const row = await db.knex('emails').where('id', recipient.email_id).first();
+    assert.equal(row.delivered_count, 0);
+  });
+
+  it('does not treat a missing email as initialized, even after a rolled-back baseline', async function () {
+    const email = await models.Email.add({
+      post_id: '000000000000000000000001',
+      submitted_at: new Date(),
+      email_count: 0,
+      recipient_filter: 'all',
+      delivered_count: 5,
+    });
+    const counters = new NewsletterEmailCounters({ knex: db.knex });
+    try {
+      // A baseline is written, then the transaction fails for a non-retryable reason
+      await assert.rejects(
+        db.knex.transaction(async (trx) => {
+          await counters.prepare(trx, email.id);
+          throw new Error('lost before commit');
+        }),
+        /lost before commit/,
+      );
+      assert.equal((await db.knex('emails').where('id', email.id).first()).delivered_count, 5);
+      // The row disappears before the next touch, so no baseline can be taken
+      await db.knex('emails').where('id', email.id).del();
+      assert.equal(await counters.compare(email.id), null);
+      const storage = createStorage(counters);
+      await storage.handleOpened({ ...makeEvent(), emailId: email.id });
+      assert.deepEqual(await storage.flushBatchedUpdates(), []);
+      // A row that exists again under that ID still receives a baseline on first touch
+      await db.knex('emails').insert({ ...email.toJSON(), delivered_count: 5 });
+      assert.deepEqual(await counters.compare(email.id), { delivered: 0, opened: 0, failed: 0 });
+      assert.equal((await db.knex('emails').where('id', email.id).first()).delivered_count, 0);
+    } finally {
+      await db.knex('emails').where('id', email.id).del();
+    }
+  });
+
   it('detects deliberately incorrect counters without overwriting them', async function () {
     await resetFacts();
     const counters = new NewsletterEmailCounters({ knex: db.knex });
@@ -188,6 +297,9 @@ describe('Newsletter email counters', function () {
     } finally {
       await db.knex.raw('DROP TRIGGER reject_email_counter');
     }
+    // The failed page was discarded; the caller replays it
+    await storage.handleDelivered(makeEvent());
+    await storage.handleOpened(makeEvent());
     await storage.flushBatchedUpdates();
     assert.deepEqual(await counters.compare(recipient.email_id), {
       delivered: 0,

--- a/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.js
@@ -1,0 +1,303 @@
+const assert = require('node:assert/strict');
+const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
+const db = require('../../../../core/server/data/db');
+const models = require('../../../../core/server/models');
+const sinon = require('sinon');
+const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
+const {
+  NewsletterEmailCounters,
+} = require('../../../../core/server/services/email-analytics/newsletter-email-counters');
+const EmailEventProcessor = require('../../../../core/server/services/email-service/email-event-processor');
+const {
+  NewsletterEmailAnalyticsBatchProcessor,
+} = require('../../../../core/server/services/email-analytics/newsletter-email-analytics-batch-processor');
+const {
+  EventProcessingResult,
+} = require('../../../../core/server/services/email-analytics/event-processing-result');
+
+describe('Newsletter email counters', function () {
+  let recipient;
+
+  beforeAll(async function () {
+    await agentProvider.getAdminAPIAgent();
+    await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
+    recipient = fixtureManager.get('email_recipients', 0);
+  });
+
+  it('baselines existing facts including opens and counts each new transition once', async function () {
+    await db.knex('email_recipients').where('email_id', recipient.email_id).update({
+      opened_at: null,
+      delivered_at: null,
+      failed_at: null,
+    });
+    await db.knex('emails').where('id', recipient.email_id).update({
+      delivered_count: 99,
+      opened_count: 99,
+      failed_count: 99,
+    });
+    await db.knex('email_recipients').where('id', recipient.id).update({
+      opened_at: '2026-09-01 11:00:00',
+    });
+    const emailCounters = new NewsletterEmailCounters({ knex: db.knex });
+    const storage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db,
+      models,
+      emailCounters,
+    });
+    const event = {
+      emailId: recipient.email_id,
+      emailRecipientId: recipient.id,
+      memberId: recipient.member_id,
+      timestamp: new Date('2026-09-01T12:00:00Z'),
+    };
+    await storage.handleOpened(event);
+    await storage.handleDelivered(event);
+    await storage.flushBatchedUpdates();
+    await storage.handleDelivered(event);
+    await storage.flushBatchedUpdates();
+    const row = await db.knex('emails').where('id', recipient.email_id).first();
+    assert.equal(row.delivered_count, 1);
+    assert.equal(row.opened_count, 1);
+    assert.equal(row.failed_count, 0);
+  });
+
+  it('compares a missing-lane-only open with opens-inclusive truth while retaining member recounts', async function () {
+    await db.knex('email_recipients').where('email_id', recipient.email_id).update({
+      opened_at: null,
+      delivered_at: null,
+      failed_at: null,
+    });
+    const emailCounters = new NewsletterEmailCounters({ knex: db.knex });
+    const config = { get: () => true };
+    const storage = new NewsletterEmailEventStorage({ config, db, models, emailCounters });
+    const queries = { aggregateEmailStats: sinon.stub(), aggregateMemberStatsBatch: sinon.stub() };
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config,
+      emailCounters,
+      queries,
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: storage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const result = new EventProcessingResult();
+    await processor.processBatch(
+      [
+        {
+          type: 'opened',
+          emailId: recipient.email_id,
+          recipientEmail: recipient.member_email,
+          timestamp: new Date('2026-09-01T12:00:00Z'),
+        },
+      ],
+      result,
+      {},
+    );
+    await processor.aggregate({
+      processingResult: result,
+      includeOpenedEvents: false,
+      isFinal: true,
+    });
+    sinon.assert.notCalled(queries.aggregateEmailStats);
+    sinon.assert.calledOnceWithExactly(queries.aggregateMemberStatsBatch, [recipient.member_id]);
+    const comparison = await emailCounters.compare(recipient.email_id);
+    assert.deepEqual(comparison, { delivered: 0, opened: 0, failed: 0 });
+    const email = await db.knex('emails').where('id', recipient.email_id).first();
+    assert.equal(email.opened_count, 1);
+  });
+
+  function createStorage(emailCounters, database = db) {
+    return new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db: database,
+      models,
+      emailCounters,
+    });
+  }
+
+  function makeEvent() {
+    return {
+      emailId: recipient.email_id,
+      emailRecipientId: recipient.id,
+      memberId: recipient.member_id,
+      timestamp: new Date('2026-09-01T12:00:00Z'),
+    };
+  }
+
+  async function resetFacts() {
+    await db.knex('email_recipients').where('email_id', recipient.email_id).update({
+      delivered_at: null,
+      opened_at: null,
+      failed_at: null,
+    });
+    await db.knex('emails').where('id', recipient.email_id).update({
+      delivered_count: 99,
+      opened_count: 99,
+      failed_count: 99,
+    });
+  }
+
+  it('detects deliberately incorrect counters without overwriting them', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex });
+    const storage = createStorage(counters);
+    await storage.handleOpened(makeEvent());
+    await storage.flushBatchedUpdates();
+    await db
+      .knex('emails')
+      .where('id', recipient.email_id)
+      .update({ delivered_count: 7, opened_count: 0, failed_count: 9 });
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 7,
+      opened: -1,
+      failed: 9,
+    });
+    await storage.handleOpened(makeEvent());
+    await storage.flushBatchedUpdates();
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 7,
+      opened: -1,
+      failed: 9,
+    });
+  });
+
+  it('rolls back recipient transitions and the baseline when the counter write fails', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex });
+    const storage = createStorage(counters);
+    await storage.handleDelivered(makeEvent());
+    await storage.handleOpened(makeEvent());
+    await db.knex.raw(
+      `CREATE TRIGGER reject_email_counter BEFORE UPDATE ON emails
+      FOR EACH ROW BEGIN
+        IF NEW.id = ? AND NEW.delivered_count = 1 THEN
+          SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'counter write failed';
+        END IF;
+      END`,
+      [recipient.email_id],
+    );
+    try {
+      await assert.rejects(storage.flushBatchedUpdates(), /counter write failed/);
+      const row = await db.knex('email_recipients').where('id', recipient.id).first();
+      assert.equal(row.opened_at, null);
+      assert.equal(row.delivered_at, null);
+      const email = await db.knex('emails').where('id', recipient.email_id).first();
+      assert.equal(email.delivered_count, 99);
+    } finally {
+      await db.knex.raw('DROP TRIGGER reject_email_counter');
+    }
+    await storage.flushBatchedUpdates();
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 0,
+      opened: 0,
+      failed: 0,
+    });
+  });
+
+  it('recovers a lost commit acknowledgement and restart without double counting', async function () {
+    await resetFacts();
+    const storage = createStorage(new NewsletterEmailCounters({ knex: db.knex }), {
+      knex: {
+        transaction: async (callback) => {
+          await db.knex.transaction(callback);
+          throw Object.assign(new Error('Lost commit acknowledgement'), { code: 'ECONNRESET' });
+        },
+      },
+    });
+    await storage.handleDelivered(makeEvent());
+    await storage.handleOpened(makeEvent());
+    await assert.rejects(storage.flushBatchedUpdates(), /Lost commit acknowledgement/);
+    const counters = new NewsletterEmailCounters({ knex: db.knex });
+    const restarted = createStorage(counters);
+    await restarted.handleDelivered(makeEvent());
+    await restarted.handleOpened(makeEvent());
+    assert.deepEqual(await restarted.flushBatchedUpdates(), []);
+    const row = await db.knex('emails').where('id', recipient.email_id).first();
+    assert.equal(row.delivered_count, 1);
+    assert.equal(row.opened_count, 1);
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 0,
+      opened: 0,
+      failed: 0,
+    });
+  });
+
+  it('serializes concurrent worker baselines, increments and comparisons', async function () {
+    await resetFacts();
+    const counters = [
+      new NewsletterEmailCounters({ knex: db.knex }),
+      new NewsletterEmailCounters({ knex: db.knex }),
+    ];
+    const workers = counters.map((counter) => createStorage(counter));
+    for (const storage of workers) {
+      await storage.handleOpened(makeEvent());
+      await storage.handleDelivered(makeEvent());
+      await storage.handlePermanentFailed(makeEvent());
+    }
+    const results = await Promise.all(workers.map((storage) => storage.flushBatchedUpdates()));
+    assert.equal(results.flat().length, 1);
+    assert.deepEqual(
+      await Promise.all(counters.map((counter) => counter.compare(recipient.email_id))),
+      [
+        { delivered: 0, opened: 0, failed: 0 },
+        { delivered: 0, opened: 0, failed: 0 },
+      ],
+    );
+    const row = await db.knex('emails').where('id', recipient.email_id).first();
+    assert.equal(row.delivered_count, 1);
+    assert.equal(row.opened_count, 1);
+    assert.equal(row.failed_count, 1);
+  });
+
+  it('compares against the committed view when an event transaction is still in flight', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex });
+    const initial = createStorage(counters);
+    await initial.handleDelivered(makeEvent());
+    await initial.flushBatchedUpdates();
+
+    let allowCommit;
+    let writesCompleted;
+    const hold = new Promise((resolve) => {
+      allowCommit = resolve;
+    });
+    const ready = new Promise((resolve) => {
+      writesCompleted = resolve;
+    });
+    const writer = createStorage(counters, {
+      knex: {
+        transaction: (callback) =>
+          db.knex.transaction(async (trx) => {
+            const result = await callback(trx);
+            writesCompleted();
+            await hold;
+            return result;
+          }),
+      },
+    });
+    await writer.handleOpened(makeEvent());
+    const flush = writer.flushBatchedUpdates();
+    await ready;
+    let comparisonIssued;
+    const issued = new Promise((resolve) => {
+      comparisonIssued = resolve;
+    });
+    const onQuery = (query) => {
+      if (query.sql.includes('emails') && query.sql.includes('for update')) {
+        comparisonIssued();
+      }
+    };
+    db.knex.on('query', onQuery);
+    const comparison = counters.compare(recipient.email_id);
+    try {
+      await issued;
+    } finally {
+      db.knex.removeListener('query', onQuery);
+      allowCommit();
+    }
+    await flush;
+    assert.deepEqual(await comparison, { delivered: 0, opened: 0, failed: 0 });
+  });
+});

--- a/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.ts
@@ -1,12 +1,14 @@
-const assert = require('node:assert/strict');
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import type { Knex } from 'knex';
+import type { PrometheusClient } from '@tryghost/prometheus-metrics';
+import { NewsletterEmailCounters } from '../../../../core/server/services/email-analytics/newsletter-email-counters';
+
 const { agentProvider, fixtureManager } = require('../../../utils/e2e-framework');
-const db = require('../../../../core/server/data/db');
+const logging = require('@tryghost/logging');
+const db: { knex: Knex } = require('../../../../core/server/data/db');
 const models = require('../../../../core/server/models');
-const sinon = require('sinon');
 const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
-const {
-  NewsletterEmailCounters,
-} = require('../../../../core/server/services/email-analytics/newsletter-email-counters');
 const EmailEventProcessor = require('../../../../core/server/services/email-service/email-event-processor');
 const {
   NewsletterEmailAnalyticsBatchProcessor,
@@ -15,8 +17,16 @@ const {
   EventProcessingResult,
 } = require('../../../../core/server/services/email-analytics/event-processing-result');
 
+// The legacy Bookshelf models and fixtures are untyped; describe only what this test reads.
+type RecipientRow = {
+  id: string;
+  email_id: string;
+  member_id: string;
+  member_email: string;
+};
+
 describe('Newsletter email counters', function () {
-  let recipient;
+  let recipient: RecipientRow;
 
   beforeAll(async function () {
     await agentProvider.getAdminAPIAgent();
@@ -108,7 +118,7 @@ describe('Newsletter email counters', function () {
     assert.equal(email.opened_count, 1);
   });
 
-  function createStorage(emailCounters, database = db) {
+  function createStorage(emailCounters: NewsletterEmailCounters, database: { knex: unknown } = db) {
     return new NewsletterEmailEventStorage({
       config: { get: () => true },
       db: database,
@@ -151,9 +161,12 @@ describe('Newsletter email counters', function () {
     };
     const counters = new NewsletterEmailCounters({
       knex: db.knex,
-      prometheusClient: { registerCounter: sinon.stub(), getMetric: (name) => metrics[name] },
+      prometheusClient: {
+        registerCounter: sinon.stub(),
+        getMetric: (name: string) => metrics[name as keyof typeof metrics],
+      } as unknown as Pick<PrometheusClient, 'registerCounter' | 'getMetric'>,
     });
-    const warn = sinon.stub(require('@tryghost/logging'), 'warn');
+    const warn = sinon.stub(logging, 'warn');
     try {
       assert.deepEqual(await counters.compare(recipient.email_id), {
         delivered: 0,
@@ -184,11 +197,11 @@ describe('Newsletter email counters', function () {
   it('retries a comparison that loses a lock wait and reports its baseline correction once', async function () {
     await resetFacts();
     let attempts = 0;
-    const warn = sinon.stub(require('@tryghost/logging'), 'warn');
+    const warn = sinon.stub(logging, 'warn');
     try {
       const counters = new NewsletterEmailCounters({
         knex: {
-          transaction: (callback) =>
+          transaction: (callback: (trx: Knex.Transaction) => Promise<unknown>) =>
             db.knex.transaction(async (trx) => {
               const result = await callback(trx);
               attempts += 1;
@@ -197,7 +210,7 @@ describe('Newsletter email counters', function () {
               }
               return result;
             }),
-        },
+        } as unknown as Pick<Knex, 'transaction'>,
       });
       assert.deepEqual(await counters.compare(recipient.email_id), {
         delivered: 0,
@@ -312,7 +325,7 @@ describe('Newsletter email counters', function () {
     await resetFacts();
     const storage = createStorage(new NewsletterEmailCounters({ knex: db.knex }), {
       knex: {
-        transaction: async (callback) => {
+        transaction: async (callback: (trx: Knex.Transaction) => Promise<unknown>) => {
           await db.knex.transaction(callback);
           throw Object.assign(new Error('Lost commit acknowledgement'), { code: 'ECONNRESET' });
         },
@@ -370,17 +383,17 @@ describe('Newsletter email counters', function () {
     await initial.handleDelivered(makeEvent());
     await initial.flushBatchedUpdates();
 
-    let allowCommit;
-    let writesCompleted;
-    const hold = new Promise((resolve) => {
+    let allowCommit!: () => void;
+    let writesCompleted!: () => void;
+    const hold = new Promise<void>((resolve) => {
       allowCommit = resolve;
     });
-    const ready = new Promise((resolve) => {
+    const ready = new Promise<void>((resolve) => {
       writesCompleted = resolve;
     });
     const writer = createStorage(counters, {
       knex: {
-        transaction: (callback) =>
+        transaction: (callback: (trx: Knex.Transaction) => Promise<unknown>) =>
           db.knex.transaction(async (trx) => {
             const result = await callback(trx);
             writesCompleted();
@@ -392,11 +405,11 @@ describe('Newsletter email counters', function () {
     await writer.handleOpened(makeEvent());
     const flush = writer.flushBatchedUpdates();
     await ready;
-    let comparisonIssued;
-    const issued = new Promise((resolve) => {
+    let comparisonIssued!: () => void;
+    const issued = new Promise<void>((resolve) => {
       comparisonIssued = resolve;
     });
-    const onQuery = (query) => {
+    const onQuery = (query: { sql: string }) => {
       if (query.sql.includes('emails') && query.sql.includes('for update')) {
         comparisonIssued();
       }

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -71,6 +71,25 @@ describe('email analytics service', function () {
     sinon.restore();
   });
 
+  it.each([
+    [false, 'compare', false],
+    [true, 'off', false],
+    [true, undefined, false],
+    [true, 'compare', true],
+  ])(
+    'gates newsletter counter comparison with batchProcessing=%s and mode=%s',
+    function (batchProcessing, mode, enabled) {
+      config.get.withArgs('emailAnalytics:batchProcessing').returns(batchProcessing);
+      config.get.withArgs('emailAnalytics:emailCounterMode').returns(mode);
+      const registerCounter = sinon.stub();
+      dependencies.prometheusClient = { registerCounter, getMetric: sinon.stub() };
+      init(dependencies);
+      const names = registerCounter.args.map(([definition]) => definition.name);
+      expect(names.includes('email_analytics_email_counter_comparisons')).toBe(enabled);
+      expect(names.includes('email_analytics_email_counter_drift')).toBe(enabled);
+    },
+  );
+
   it('initializes newsletter, automation, and gift analytics with configured Mailgun tags', function () {
     init(dependencies);
 

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -75,6 +75,7 @@ describe('email analytics service', function () {
     [false, 'compare', false],
     [true, 'off', false],
     [true, undefined, false],
+    [true, 'Compare', false],
     [true, 'compare', true],
   ])(
     'gates newsletter counter comparison with batchProcessing=%s and mode=%s',


### PR DESCRIPTION
Newsletter analytics currently recount recipient history to refresh email statistics. The transactional flush in #30668 now tells us exactly which recipients changed, so we can maintain delivered, opened and failed counts in that same transaction. Replaying a delivery then leaves its count at one, even after a lost commit acknowledgement.

This is the email-only counter step. It lets us validate counters independently of the member preparation work in #30671 and its dependencies. Existing email counter columns are sufficient; there is no migration or historical email backfill.

```text
flush one newsletter email
  begin transaction
    lock email row
    first touch after startup → recount existing facts, including opens
    lock eligible recipient rows in primary-key order
    write timestamps + increment counters from exact transitions
  commit
  remember that this worker established the baseline

aggregate
  lock email row → recount all three outcomes → report differences
  recount member statistics, including replayed members
```

The startup recount corrects existing counters once per touched email per worker lifetime. It normally covers active sends and the fetch trust window; scheduled recovery can also touch an older email. Baseline and increments share the email lock, so concurrent workers and retries can safely repeat initialization. Subsequent comparisons observe drift without repairing it. They always include opens, even when the fetch lane passes `includeOpenedEvents: false`.

The new `emailAnalytics.emailCounterMode` defaults to `off`. `compare` requires `batchProcessing: true`; mode changes require draining existing analytics workers and restarting with consistent configuration. Legacy writers do not take the counter lock. Member recomputation and its replay recovery remain in place. Automation/gift persistence and opens-first scheduling are unchanged.

Comparison logs signed differences and records comparison counts plus absolute observed drift by event type. See the email analytics README for startup, rollback and metric semantics. A restart rebaselines touched emails, so operators should inspect drift before restarting.

Validation:

- 108 MySQL email-service integration tests and 184 analytics unit tests passed.
- The final focused counter suite passed all 7 tests: existing opens at cutover, missing-lane comparison, deliberately wrong counters surviving comparison/replay, transaction rollback, lost commit acknowledgement plus restart, concurrent baselines, and comparison overlapping an uncommitted event transaction.
- Core/test TypeScript checks, focused lint and commit hooks passed. `pnpm check` stops on the same 452 pre-existing formatting files; none is changed here.
- Five independent slice reviews and five accumulated-stack review passes found no high-confidence issues.
- Synthetic benchmark: 5,000 members, 500 historical emails, 2,009,528 recipient rows, 5,000 events per cycle, 0/50/100% duplicate opens. All email/member truth assertions passed. Median handler reads increased 0.0023–0.0028% relative to #30668, including startup baselining. Comparison retains recount load; this does not claim the later read reduction. The harness uses `innodb_flush_log_at_trx_commit=0` and no binlog, so absolute write timings are not production estimates.

Based on #30668; independent of the schema-only #30671. Removing mid-cycle email recounts follows after comparison has established correctness.

ref https://linear.app/ghost/issue/BER-3934
ref https://linear.app/ghost/issue/BER-3937
