### PR TITLE
Added final newsletter email reconciliation mode

### DIFF
--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -15,8 +15,9 @@ email counters atomically with recipient transitions:
 | `incremental` | Defer recounts                          | Recount all outcomes and repair drift   |
 
 Enable `incremental` only after a comparison soak has established correctness.
-This removes email recounts from intermediate aggregation. Member statistics still use recomputation, including
-replayed members needed to recover an interrupted recount.
+This removes email recounts from intermediate aggregation. Member statistics
+still use recomputation, including replayed members needed to recover an
+interrupted recount.
 
 The mode is selected at analytics boot. Stop and drain existing analytics
 workers before changing modes, then restart them with the same configuration.
@@ -59,12 +60,26 @@ differences by event type. Repeated observations of the same drift contribute
 again; a worker restart rebaselines, so monitor drift before restarting.
 
 In incremental mode, the counter service retains pending email IDs across fetch
-processors. A failed final repair is retried by the next final aggregation,
-even when it fetched no new events. Drains are serialized and process a snapshot
-of queued emails. Only successful repairs clear entries; an email requeued
-during repair remains pending. Each repair uses the same email lock as event
-increments. Repair logs carry `phase: "repair"` with the differences observed
-before correction; comparison mode continues to report drift without repair.
+processors. A failed repair is logged, left queued and retried by the next final
+aggregation, even one that fetched no new events; it never fails the fetch,
+because the fetch's recipient facts and increments are already committed and a
+failure would discard its cursor and member statistics. Every queued email is
+attempted in each drain, so one contended email cannot block the others. Drains
+are serialized and process a snapshot of queued emails; an email requeued during
+its repair remains pending. Each repair uses the same email lock as event
+increments. Repair logs and the comparison metrics carry `phase: "repair"` with
+the differences observed before correction, separate from `phase: "comparison"`,
+so a drift alert calibrated during the comparison soak is not fired by drift that
+was corrected. Each failed repair increments
+`email_analytics_email_counter_repair_failures`, so an email stuck behind
+persistent contention is visible without reading logs. Comparison mode never
+repairs; `reconcile` refuses to run in it.
+
+The pending queue is in memory. A process that stops between the last flush and
+the final aggregation loses it, and an email that is never touched again keeps
+the counters its atomic increments produced. Those increments are exact by
+construction; final repair is a safety net for drift introduced outside the
+counter lock, not the source of correctness.
 
 This email-only mode does not remove member history queries. Removing those
 requires initialized member counters and scheduled member reconciliation.

--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -3,12 +3,19 @@
 Newsletter events update recipient facts before refreshing email and member
 statistics. Automation and gift events use their own outcome APIs.
 
-## Newsletter email counter comparison
+## Newsletter email counters
 
-`emailAnalytics.emailCounterMode` defaults to `off`. Setting it to `compare`
-also requires `emailAnalytics.batchProcessing: true`. This enables atomic
-delivered, opened and failed email counters and changes email aggregation to
-comparison without repair. Member statistics still use recomputation, including
+`emailAnalytics.emailCounterMode` defaults to `off`. Both opt-in modes require
+`emailAnalytics.batchProcessing: true` and maintain delivered, opened and failed
+email counters atomically with recipient transitions:
+
+| Mode          | Mid-fetch email aggregation             | Final email aggregation                 |
+| ------------- | --------------------------------------- | --------------------------------------- |
+| `compare`     | Recount and report drift without repair | Recount and report drift without repair |
+| `incremental` | Defer recounts                          | Recount all outcomes and repair drift   |
+
+Enable `incremental` only after a comparison soak has established correctness.
+This removes email recounts from intermediate aggregation. Member statistics still use recomputation, including
 replayed members needed to recover an interrupted recount.
 
 The mode is selected at analytics boot. Stop and drain existing analytics
@@ -51,5 +58,14 @@ email ID and signed differences. The Prometheus counters
 differences by event type. Repeated observations of the same drift contribute
 again; a worker restart rebaselines, so monitor drift before restarting.
 
-Comparison retains the recount query load. Removing mid-cycle email recounts
-is a separate rollout step after comparison has established correctness.
+In incremental mode, the counter service retains pending email IDs across fetch
+processors. A failed final repair is retried by the next final aggregation,
+even when it fetched no new events. Drains are serialized and process a snapshot
+of queued emails. Only successful repairs clear entries; an email requeued
+during repair remains pending. Each repair uses the same email lock as event
+increments. Repair logs carry `phase: "repair"` with the differences observed
+before correction; comparison mode continues to report drift without repair.
+
+This email-only mode does not remove member history queries. Removing those
+requires initialized member counters and scheduled member reconciliation.
+Comparison retains email recount load until the incremental mode is enabled.

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -46,7 +46,7 @@ export const gifts = new EmailAnalyticsServiceWrapper({
   logName: 'gifts',
 });
 
-const EmailCounterMode = z.enum(['off', 'compare']);
+const EmailCounterMode = z.enum(['off', 'compare', 'incremental']);
 type EmailCounterMode = z.infer<typeof EmailCounterMode>;
 
 /**
@@ -113,8 +113,9 @@ export const init = ({
   const queries = new Queries(db.knex);
   // Mode changes take effect at boot. Drain old analytics workers before changing
   // modes: sequential and legacy recount writers do not use the counter lock.
-  const emailCounters = resolveEmailCounterMode(config)
-    ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient })
+  const emailCounterMode = resolveEmailCounterMode(config);
+  const emailCounters = emailCounterMode
+    ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient, mode: emailCounterMode })
     : null;
 
   const newsletterEmailEventProcessor = new EmailEventProcessor({

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -108,7 +108,9 @@ class NewsletterEmailAnalyticsBatchProcessor {
     /** @type {boolean} */ let shouldAggregate;
     if (isFinal) {
       shouldAggregate = Boolean(
-        processingResult.emailIds.length || processingResult.memberIds.length,
+        processingResult.emailIds.length ||
+        processingResult.memberIds.length ||
+        this.#emailCounters?.hasPendingReconciliation,
       );
     } else {
       // Every 5 minutes or 5000 members we do an aggregation and clear the processingResult
@@ -121,7 +123,14 @@ class NewsletterEmailAnalyticsBatchProcessor {
       return null;
     }
 
-    const result = await this.#aggregateStats(processingResult, includeOpenedEvents);
+    const incrementalEmails = this.#emailCounters?.mode === 'incremental';
+    if (incrementalEmails) {
+      // Member aggregation resets the result mid-fetch. Retain every touched
+      // email in the boot-lifetime queue until repair succeeds, even if the
+      // next fetch creates a new processor after a failed final aggregation.
+      this.#emailCounters.deferReconciliation(processingResult.emailIds);
+    }
+    const result = await this.#aggregateStats(processingResult, includeOpenedEvents, isFinal);
 
     processingResult.reset();
     this.#lastAggregation = Date.now();
@@ -249,14 +258,25 @@ class NewsletterEmailAnalyticsBatchProcessor {
   /**
    * @param {{emailIds?: string[], memberIds?: string[]}} stats
    * @param {boolean} includeOpenedEvents
+   * @param {boolean} isFinal
    * @returns {Promise<{emailAggregationTimeMs: number, memberAggregationTimeMs: number}>}
    */
-  async #aggregateStats({ emailIds = [], memberIds = [] }, includeOpenedEvents = true) {
+  async #aggregateStats(
+    { emailIds = [], memberIds = [] },
+    includeOpenedEvents = true,
+    isFinal = false,
+  ) {
     const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
     const emailAggregationStart = Date.now();
-    for (const emailId of emailIds) {
-      await this.#aggregateEmailStats(emailId, includeOpenedEvents);
+    if (this.#emailCounters?.mode === 'incremental') {
+      if (isFinal) {
+        await this.#emailCounters.reconcilePending();
+      }
+    } else {
+      for (const emailId of emailIds) {
+        await this.#aggregateEmailStats(emailId, includeOpenedEvents);
+      }
     }
     const emailAggregationTimeMs = Date.now() - emailAggregationStart;
 

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -123,8 +123,7 @@ class NewsletterEmailAnalyticsBatchProcessor {
       return null;
     }
 
-    const incrementalEmails = this.#emailCounters?.mode === 'incremental';
-    if (incrementalEmails) {
+    if (this.#emailCounters?.incremental) {
       // Member aggregation resets the result mid-fetch. Retain every touched
       // email in the boot-lifetime queue until repair succeeds, even if the
       // next fetch creates a new processor after a failed final aggregation.
@@ -269,8 +268,9 @@ class NewsletterEmailAnalyticsBatchProcessor {
     const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
     const emailAggregationStart = Date.now();
-    if (this.#emailCounters?.mode === 'incremental') {
+    if (this.#emailCounters?.incremental) {
       if (isFinal) {
+        // Failed repairs stay queued and are logged; they must not fail the fetch.
         await this.#emailCounters.reconcilePending();
       }
     } else {

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
@@ -1,4 +1,5 @@
 import type { Knex } from 'knex';
+import { IncorrectUsageError } from '@tryghost/errors';
 import logging from '@tryghost/logging';
 import type { PrometheusClient } from '@tryghost/prometheus-metrics';
 import { z } from 'zod';
@@ -10,6 +11,7 @@ type Event = (typeof events)[number];
 type Drift = Record<Event, number>;
 type Transitions = Record<Event, readonly unknown[]>;
 type Phase = 'baseline' | 'comparison' | 'repair';
+type ReconciliationSummary = { repaired: number; failed: number };
 
 // Projection of the `emails` counter columns; the Bookshelf model owns the row.
 const DbEmailCounters = z.object({
@@ -23,6 +25,7 @@ const DbCountRow = z.object({ count: DbCount });
 const COMPARISONS_METRIC = 'email_analytics_email_counter_comparisons';
 const DRIFT_METRIC = 'email_analytics_email_counter_drift';
 const BASELINE_METRIC = 'email_analytics_email_counter_baseline_corrections';
+const REPAIR_FAILURES_METRIC = 'email_analytics_email_counter_repair_failures';
 
 /** Newsletter-only counter maintenance. Constructed once at analytics boot. */
 export class NewsletterEmailCounters {
@@ -33,8 +36,10 @@ export class NewsletterEmailCounters {
   // Corrections written by a baseline in a transaction that has not yet been
   // acknowledged as committed; reported once the commit is acknowledged.
   #prepared = new Map<string, Drift>();
-  #pendingReconciliation = new Map<string, symbol>();
-  #draining: Promise<void> | null = null;
+  // Emails touched since their last successful final repair. Boot-lifetime and
+  // shared by every fetch lane, so a failed repair is retried by a later drain.
+  #pendingReconciliation = new Set<string>();
+  #draining: Promise<ReconciliationSummary> | null = null;
   #knex: Pick<Knex, 'transaction'>;
   #prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
 
@@ -50,20 +55,27 @@ export class NewsletterEmailCounters {
     this.#knex = knex;
     this.mode = mode;
     this.#prometheusClient = prometheusClient;
+    // `phase` separates observe-only comparison from final repair, so a drift
+    // alert calibrated during a comparison soak is not fired by corrected drift.
     prometheusClient?.registerCounter({
       name: COMPARISONS_METRIC,
-      help: 'Number of newsletter email counter comparisons',
-      labelNames: ['event'],
+      help: 'Number of newsletter email counter comparisons and repairs',
+      labelNames: ['event', 'phase'],
     });
     prometheusClient?.registerCounter({
       name: DRIFT_METRIC,
-      help: 'Sum of absolute newsletter email counter differences observed at comparison',
-      labelNames: ['event'],
+      help: 'Sum of absolute newsletter email counter differences observed at comparison or repair',
+      labelNames: ['event', 'phase'],
     });
     prometheusClient?.registerCounter({
       name: BASELINE_METRIC,
       help: 'Sum of absolute newsletter email counter differences corrected when a baseline was established',
       labelNames: ['event'],
+    });
+    prometheusClient?.registerCounter({
+      name: REPAIR_FAILURES_METRIC,
+      help: 'Number of newsletter email counter repairs that failed and were left queued',
+      labelNames: [],
     });
   }
 
@@ -154,39 +166,65 @@ export class NewsletterEmailCounters {
     }
   }
 
+  /** Whether email recounts are deferred to a final repair instead of compared mid-fetch. */
+  get incremental(): boolean {
+    return this.mode === 'incremental';
+  }
+
   get hasPendingReconciliation(): boolean {
     return this.#pendingReconciliation.size > 0;
   }
 
   deferReconciliation(emailIds: readonly string[]): void {
     for (const emailId of emailIds) {
-      this.#pendingReconciliation.set(emailId, Symbol());
+      this.#pendingReconciliation.add(emailId);
     }
   }
 
-  async reconcilePending(): Promise<void> {
-    // Different fetch processors share this boot-lifetime queue. Serialize
-    // drains, but let each drain finish a bounded snapshot of pending work.
-    while (this.#draining) {
-      // A failed drain is reported to its own caller; waiters only need it over.
-      await this.#draining.catch(() => {});
-    }
-    this.#draining = this.#drain();
+  /**
+   * Repair every queued email. Different fetch processors share this
+   * boot-lifetime queue, so drains run one at a time, each over a snapshot.
+   * A failed repair is logged and left queued for the next drain rather than
+   * failing the fetch: its recipient facts and increments are already
+   * committed, and failing here would discard the fetch cursor and the member
+   * statistics that follow.
+   */
+  async reconcilePending(): Promise<ReconciliationSummary> {
+    this.#requireIncremental('Newsletter email counter repair');
+    const drain = (this.#draining ?? Promise.resolve()).then(
+      () => this.#drain(),
+      () => this.#drain(),
+    );
+    this.#draining = drain;
     try {
-      await this.#draining;
+      return await drain;
     } finally {
-      this.#draining = null;
-    }
-  }
-
-  async #drain(): Promise<void> {
-    for (const [emailId, generation] of [...this.#pendingReconciliation]) {
-      await this.reconcile(emailId);
-      // An event arriving during repair must retain its newly queued work.
-      if (this.#pendingReconciliation.get(emailId) === generation) {
-        this.#pendingReconciliation.delete(emailId);
+      if (this.#draining === drain) {
+        this.#draining = null;
       }
     }
+  }
+
+  async #drain(): Promise<ReconciliationSummary> {
+    const summary: ReconciliationSummary = { repaired: 0, failed: 0 };
+    for (const emailId of [...this.#pendingReconciliation]) {
+      // Remove before repairing: an event arriving during the repair queues the
+      // email again, and that newer work must survive this drain.
+      this.#pendingReconciliation.delete(emailId);
+      try {
+        await this.reconcile(emailId);
+        summary.repaired += 1;
+      } catch (error) {
+        this.#pendingReconciliation.add(emailId);
+        summary.failed += 1;
+        logging.error(
+          `[EmailAnalytics] Newsletter email counter repair failed for ${emailId}; retrying at the next final aggregation`,
+          error,
+        );
+        this.#inc(REPAIR_FAILURES_METRIC, {}, 1);
+      }
+    }
+    return summary;
   }
 
   async compare(emailId: string): Promise<Drift | null> {
@@ -194,7 +232,17 @@ export class NewsletterEmailCounters {
   }
 
   async reconcile(emailId: string): Promise<Drift | null> {
+    this.#requireIncremental(`Newsletter email counter repair for ${emailId}`);
     return this.#observe(emailId, true);
+  }
+
+  #requireIncremental(action: string): void {
+    if (!this.incremental) {
+      // Comparison must never hide a bad counter by repairing it.
+      throw new IncorrectUsageError({
+        message: `${action} requires the incremental email counter mode`,
+      });
+    }
   }
 
   async #observe(emailId: string, repair: boolean): Promise<Drift | null> {
@@ -239,24 +287,24 @@ export class NewsletterEmailCounters {
         `[EmailAnalytics] Newsletter email counter drift: ${JSON.stringify({ emailId, drift, phase })}`,
       );
     }
-    try {
-      for (const event of events) {
-        if (phase === 'baseline') {
-          this.#inc(BASELINE_METRIC, event, Math.abs(drift[event]));
-        } else {
-          this.#inc(COMPARISONS_METRIC, event, 1);
-          this.#inc(DRIFT_METRIC, event, Math.abs(drift[event]));
-        }
+    for (const event of events) {
+      if (phase === 'baseline') {
+        this.#inc(BASELINE_METRIC, { event }, Math.abs(drift[event]));
+      } else {
+        this.#inc(COMPARISONS_METRIC, { event, phase }, 1);
+        this.#inc(DRIFT_METRIC, { event, phase }, Math.abs(drift[event]));
       }
-    } catch (error) {
-      logging.error('[EmailAnalytics] Error recording newsletter email counter drift', error);
     }
   }
 
-  #inc(name: string, event: Event, value: number): void {
-    const metric = this.#prometheusClient?.getMetric(name);
-    if (metric && 'inc' in metric) {
-      metric.inc({ event }, value);
+  #inc(name: string, labels: Record<string, string>, value: number): void {
+    try {
+      const metric = this.#prometheusClient?.getMetric(name);
+      if (metric && 'inc' in metric) {
+        metric.inc(labels, value);
+      }
+    } catch (error) {
+      logging.error(`[EmailAnalytics] Error recording ${name}`, error);
     }
   }
 }

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
@@ -9,6 +9,7 @@ const events = ['delivered', 'opened', 'failed'] as const;
 type Event = (typeof events)[number];
 type Drift = Record<Event, number>;
 type Transitions = Record<Event, readonly unknown[]>;
+type Phase = 'baseline' | 'comparison' | 'repair';
 
 // Projection of the `emails` counter columns; the Bookshelf model owns the row.
 const DbEmailCounters = z.object({
@@ -25,23 +26,29 @@ const BASELINE_METRIC = 'email_analytics_email_counter_baseline_corrections';
 
 /** Newsletter-only counter maintenance. Constructed once at analytics boot. */
 export class NewsletterEmailCounters {
+  readonly mode: 'compare' | 'incremental';
   // Emails whose baseline this process has committed. Grows with the distinct
   // emails touched during the process lifetime; a restart rebaselines.
   #initialized = new Set<string>();
   // Corrections written by a baseline in a transaction that has not yet been
   // acknowledged as committed; reported once the commit is acknowledged.
   #prepared = new Map<string, Drift>();
+  #pendingReconciliation = new Map<string, symbol>();
+  #draining: Promise<void> | null = null;
   #knex: Pick<Knex, 'transaction'>;
   #prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
 
   constructor({
     knex,
+    mode = 'compare',
     prometheusClient = null,
   }: {
     knex: Pick<Knex, 'transaction'>;
+    mode?: 'compare' | 'incremental';
     prometheusClient?: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
   }) {
     this.#knex = knex;
+    this.mode = mode;
     this.#prometheusClient = prometheusClient;
     prometheusClient?.registerCounter({
       name: COMPARISONS_METRIC,
@@ -147,22 +154,73 @@ export class NewsletterEmailCounters {
     }
   }
 
+  get hasPendingReconciliation(): boolean {
+    return this.#pendingReconciliation.size > 0;
+  }
+
+  deferReconciliation(emailIds: readonly string[]): void {
+    for (const emailId of emailIds) {
+      this.#pendingReconciliation.set(emailId, Symbol());
+    }
+  }
+
+  async reconcilePending(): Promise<void> {
+    // Different fetch processors share this boot-lifetime queue. Serialize
+    // drains, but let each drain finish a bounded snapshot of pending work.
+    while (this.#draining) {
+      // A failed drain is reported to its own caller; waiters only need it over.
+      await this.#draining.catch(() => {});
+    }
+    this.#draining = this.#drain();
+    try {
+      await this.#draining;
+    } finally {
+      this.#draining = null;
+    }
+  }
+
+  async #drain(): Promise<void> {
+    for (const [emailId, generation] of [...this.#pendingReconciliation]) {
+      await this.reconcile(emailId);
+      // An event arriving during repair must retain its newly queued work.
+      if (this.#pendingReconciliation.get(emailId) === generation) {
+        this.#pendingReconciliation.delete(emailId);
+      }
+    }
+  }
+
   async compare(emailId: string): Promise<Drift | null> {
+    return this.#observe(emailId, false);
+  }
+
+  async reconcile(emailId: string): Promise<Drift | null> {
+    return this.#observe(emailId, true);
+  }
+
+  async #observe(emailId: string, repair: boolean): Promise<Drift | null> {
     const drift = await transactionWithRetry(this.#knex, async (trx) => {
       const state = await this.prepare(trx, emailId);
       if (!state) {
         return null;
       }
-      // A baseline just replaced the counters with truth; do not recount twice.
+      // A baseline just replaced the counters with truth; there is nothing
+      // left to compare or repair, and recounting again would be wasted.
       if (state.baseline) {
         return { delivered: 0, opened: 0, failed: 0 };
       }
-      return this.#diff(state.current, await this.#recount(trx, emailId));
+      const truth = await this.#recount(trx, emailId);
+      if (repair) {
+        // Keep the email lock through repair so a concurrent event increment
+        // cannot be overwritten with counts from an earlier snapshot.
+        await trx('emails').where('id', emailId).update(truth);
+      }
+      return this.#diff(state.current, truth);
     });
     this.committed(emailId);
     if (drift) {
-      // Comparison observes drift; it must not hide a bad counter by repairing it.
-      this.#report(emailId, drift, 'comparison');
+      // Comparison stays observe-only. Final reconciliation reports the drift
+      // observed before repair so operators can distinguish repair from parity.
+      this.#report(emailId, drift, repair ? 'repair' : 'comparison');
     }
     return drift;
   }
@@ -175,7 +233,7 @@ export class NewsletterEmailCounters {
     };
   }
 
-  #report(emailId: string, drift: Drift, phase: 'baseline' | 'comparison'): void {
+  #report(emailId: string, drift: Drift, phase: Phase): void {
     if (events.some((event) => drift[event] !== 0)) {
       logging.warn(
         `[EmailAnalytics] Newsletter email counter drift: ${JSON.stringify({ emailId, drift, phase })}`,
@@ -183,11 +241,11 @@ export class NewsletterEmailCounters {
     }
     try {
       for (const event of events) {
-        if (phase === 'comparison') {
+        if (phase === 'baseline') {
+          this.#inc(BASELINE_METRIC, event, Math.abs(drift[event]));
+        } else {
           this.#inc(COMPARISONS_METRIC, event, 1);
           this.#inc(DRIFT_METRIC, event, Math.abs(drift[event]));
-        } else {
-          this.#inc(BASELINE_METRIC, event, Math.abs(drift[event]));
         }
       }
     } catch (error) {

--- a/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.ts
@@ -261,6 +261,113 @@ describe('Newsletter email counters', function () {
     }
   });
 
+  it('repairs all email counters from opens-inclusive truth at final reconciliation', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex, mode: 'incremental' });
+    const storage = createStorage(counters);
+    await storage.handleOpened(makeEvent());
+    await storage.flushBatchedUpdates();
+    await db
+      .knex('emails')
+      .where('id', recipient.email_id)
+      .update({ delivered_count: 7, opened_count: 0, failed_count: 9 });
+    assert.deepEqual(await counters.reconcile(recipient.email_id), {
+      delivered: 7,
+      opened: -1,
+      failed: 9,
+    });
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 0,
+      opened: 0,
+      failed: 0,
+    });
+    const row = await db.knex('emails').where('id', recipient.email_id).first();
+    assert.equal(row.opened_count, 1);
+  });
+
+  it('retries failed final repair after recreating the processor, even without new events', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex, mode: 'incremental' });
+    const storage = createStorage(counters);
+    await storage.handleOpened(makeEvent());
+    await storage.flushBatchedUpdates();
+    await db.knex('emails').where('id', recipient.email_id).update({ opened_count: 0 });
+    const reconcile = counters.reconcile.bind(counters);
+    const repair = sinon.stub(counters, 'reconcile').callsFake(reconcile);
+    repair.onFirstCall().rejects(new Error('repair unavailable'));
+    const createProcessor = () =>
+      new NewsletterEmailAnalyticsBatchProcessor({
+        config: { get: () => true },
+        emailCounters: counters,
+        queries: { aggregateMemberStatsBatch: sinon.stub() },
+      });
+    await assert.rejects(
+      createProcessor().aggregate({
+        includeOpenedEvents: false,
+        isFinal: true,
+        processingResult: new EventProcessingResult({ emailIds: [recipient.email_id] }),
+      }),
+      /repair unavailable/,
+    );
+    await createProcessor().aggregate({
+      includeOpenedEvents: false,
+      isFinal: true,
+      processingResult: new EventProcessingResult(),
+    });
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 0,
+      opened: 0,
+      failed: 0,
+    });
+    sinon.assert.calledTwice(repair);
+  });
+
+  it('serializes repair drains and retains an email requeued while an earlier repair finishes', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex, mode: 'incremental' });
+    const storage = createStorage(counters);
+    await storage.handleOpened(makeEvent());
+    await storage.flushBatchedUpdates();
+    let finishRepair;
+    let firstRepairCompleted;
+    const hold = new Promise((resolve) => {
+      finishRepair = resolve;
+    });
+    const ready = new Promise((resolve) => {
+      firstRepairCompleted = resolve;
+    });
+    const reconcile = counters.reconcile.bind(counters);
+    const repair = sinon.stub(counters, 'reconcile').callsFake(reconcile);
+    repair.onFirstCall().callsFake(async (emailId) => {
+      const drift = await reconcile(emailId);
+      firstRepairCompleted();
+      await hold;
+      return drift;
+    });
+    counters.deferReconciliation([recipient.email_id]);
+    const first = counters.reconcilePending();
+    await ready;
+    let second;
+    let callsBeforeRelease;
+    try {
+      await db.knex('emails').where('id', recipient.email_id).update({ opened_count: 7 });
+      counters.deferReconciliation([recipient.email_id]);
+      second = counters.reconcilePending();
+      callsBeforeRelease = repair.callCount;
+    } finally {
+      finishRepair();
+    }
+    await Promise.all([first, second]);
+    assert.equal(callsBeforeRelease, 1);
+    sinon.assert.calledTwice(repair);
+    assert.equal(counters.hasPendingReconciliation, false);
+    assert.deepEqual(await counters.compare(recipient.email_id), {
+      delivered: 0,
+      opened: 0,
+      failed: 0,
+    });
+  });
+
   it('detects deliberately incorrect counters without overwriting them', async function () {
     await resetFacts();
     const counters = new NewsletterEmailCounters({ knex: db.knex });
@@ -376,53 +483,69 @@ describe('Newsletter email counters', function () {
     assert.equal(row.failed_count, 1);
   });
 
-  it('compares against the committed view when an event transaction is still in flight', async function () {
-    await resetFacts();
-    const counters = new NewsletterEmailCounters({ knex: db.knex });
-    const initial = createStorage(counters);
-    await initial.handleDelivered(makeEvent());
-    await initial.flushBatchedUpdates();
+  it.each(['compare', 'reconcile'] as const)(
+    '%s uses the committed view when an event transaction is still in flight',
+    async function (operation) {
+      await resetFacts();
+      const counters = new NewsletterEmailCounters({ knex: db.knex });
+      const initial = createStorage(counters);
+      await initial.handleDelivered(makeEvent());
+      await initial.flushBatchedUpdates();
 
-    let allowCommit!: () => void;
-    let writesCompleted!: () => void;
-    const hold = new Promise<void>((resolve) => {
-      allowCommit = resolve;
-    });
-    const ready = new Promise<void>((resolve) => {
-      writesCompleted = resolve;
-    });
-    const writer = createStorage(counters, {
-      knex: {
-        transaction: (callback: (trx: Knex.Transaction) => Promise<unknown>) =>
-          db.knex.transaction(async (trx) => {
-            const result = await callback(trx);
-            writesCompleted();
-            await hold;
-            return result;
-          }),
-      },
-    });
-    await writer.handleOpened(makeEvent());
-    const flush = writer.flushBatchedUpdates();
-    await ready;
-    let comparisonIssued!: () => void;
-    const issued = new Promise<void>((resolve) => {
-      comparisonIssued = resolve;
-    });
-    const onQuery = (query: { sql: string }) => {
-      if (query.sql.includes('emails') && query.sql.includes('for update')) {
-        comparisonIssued();
+      if (operation === 'reconcile') {
+        await db.knex('emails').where('id', recipient.email_id).update({ opened_count: 7 });
       }
-    };
-    db.knex.on('query', onQuery);
-    const comparison = counters.compare(recipient.email_id);
-    try {
-      await issued;
-    } finally {
-      db.knex.removeListener('query', onQuery);
-      allowCommit();
-    }
-    await flush;
-    assert.deepEqual(await comparison, { delivered: 0, opened: 0, failed: 0 });
-  });
+
+      let allowCommit!: () => void;
+      let writesCompleted!: () => void;
+      const hold = new Promise<void>((resolve) => {
+        allowCommit = resolve;
+      });
+      const ready = new Promise<void>((resolve) => {
+        writesCompleted = resolve;
+      });
+      const writer = createStorage(counters, {
+        knex: {
+          transaction: (callback: (trx: Knex.Transaction) => Promise<unknown>) =>
+            db.knex.transaction(async (trx) => {
+              const result = await callback(trx);
+              writesCompleted();
+              await hold;
+              return result;
+            }),
+        },
+      });
+      await writer.handleOpened(makeEvent());
+      const flush = writer.flushBatchedUpdates();
+      await ready;
+      let comparisonIssued!: () => void;
+      const issued = new Promise<void>((resolve) => {
+        comparisonIssued = resolve;
+      });
+      const onQuery = (query: { sql: string }) => {
+        if (query.sql.includes('emails') && query.sql.includes('for update')) {
+          comparisonIssued();
+        }
+      };
+      db.knex.on('query', onQuery);
+      const comparison = counters[operation](recipient.email_id);
+      try {
+        await issued;
+      } finally {
+        db.knex.removeListener('query', onQuery);
+        allowCommit();
+      }
+      await flush;
+      assert.deepEqual(await comparison, {
+        delivered: 0,
+        opened: operation === 'reconcile' ? 7 : 0,
+        failed: 0,
+      });
+      assert.deepEqual(await counters.compare(recipient.email_id), {
+        delivered: 0,
+        opened: 0,
+        failed: 0,
+      });
+    },
+  );
 });

--- a/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-counters.test.ts
@@ -185,10 +185,14 @@ describe('Newsletter email counters', function () {
     sinon.assert.calledWithExactly(corrections, { event: 'opened' }, 99);
     sinon.assert.calledWithExactly(corrections, { event: 'failed' }, 99);
     for (const event of ['delivered', 'opened', 'failed']) {
-      sinon.assert.calledWithExactly(metrics.email_analytics_email_counter_drift.inc, { event }, 0);
+      sinon.assert.calledWithExactly(
+        metrics.email_analytics_email_counter_drift.inc,
+        { event, phase: 'comparison' },
+        0,
+      );
       sinon.assert.calledWithExactly(
         metrics.email_analytics_email_counter_comparisons.inc,
-        { event },
+        { event, phase: 'comparison' },
         1,
       );
     }
@@ -263,7 +267,15 @@ describe('Newsletter email counters', function () {
 
   it('repairs all email counters from opens-inclusive truth at final reconciliation', async function () {
     await resetFacts();
-    const counters = new NewsletterEmailCounters({ knex: db.knex, mode: 'incremental' });
+    const inc = sinon.stub();
+    const counters = new NewsletterEmailCounters({
+      knex: db.knex,
+      mode: 'incremental',
+      prometheusClient: {
+        registerCounter: sinon.stub(),
+        getMetric: () => ({ inc }),
+      } as unknown as Pick<PrometheusClient, 'registerCounter' | 'getMetric'>,
+    });
     const storage = createStorage(counters);
     await storage.handleOpened(makeEvent());
     await storage.flushBatchedUpdates();
@@ -276,11 +288,16 @@ describe('Newsletter email counters', function () {
       opened: -1,
       failed: 9,
     });
+    // Repaired drift is labelled separately from observe-only comparison
+    sinon.assert.calledWithExactly(inc, { event: 'delivered', phase: 'repair' }, 7);
+    sinon.assert.calledWithExactly(inc, { event: 'opened', phase: 'repair' }, 1);
+    sinon.assert.calledWithExactly(inc, { event: 'failed', phase: 'repair' }, 9);
     assert.deepEqual(await counters.compare(recipient.email_id), {
       delivered: 0,
       opened: 0,
       failed: 0,
     });
+    sinon.assert.calledWithExactly(inc, { event: 'delivered', phase: 'comparison' }, 0);
     const row = await db.knex('emails').where('id', recipient.email_id).first();
     assert.equal(row.opened_count, 1);
   });
@@ -301,14 +318,14 @@ describe('Newsletter email counters', function () {
         emailCounters: counters,
         queries: { aggregateMemberStatsBatch: sinon.stub() },
       });
-    await assert.rejects(
-      createProcessor().aggregate({
-        includeOpenedEvents: false,
-        isFinal: true,
-        processingResult: new EventProcessingResult({ emailIds: [recipient.email_id] }),
-      }),
-      /repair unavailable/,
-    );
+    // A failed repair is logged and retried later; it must not fail the fetch
+    await createProcessor().aggregate({
+      includeOpenedEvents: false,
+      isFinal: true,
+      processingResult: new EventProcessingResult({ emailIds: [recipient.email_id] }),
+    });
+    assert.equal(counters.hasPendingReconciliation, true);
+    assert.equal((await db.knex('emails').where('id', recipient.email_id).first()).opened_count, 0);
     await createProcessor().aggregate({
       includeOpenedEvents: false,
       isFinal: true,
@@ -328,12 +345,12 @@ describe('Newsletter email counters', function () {
     const storage = createStorage(counters);
     await storage.handleOpened(makeEvent());
     await storage.flushBatchedUpdates();
-    let finishRepair;
-    let firstRepairCompleted;
-    const hold = new Promise((resolve) => {
+    let finishRepair!: () => void;
+    let firstRepairCompleted!: () => void;
+    const hold = new Promise<void>((resolve) => {
       finishRepair = resolve;
     });
-    const ready = new Promise((resolve) => {
+    const ready = new Promise<void>((resolve) => {
       firstRepairCompleted = resolve;
     });
     const reconcile = counters.reconcile.bind(counters);
@@ -483,11 +500,23 @@ describe('Newsletter email counters', function () {
     assert.equal(row.failed_count, 1);
   });
 
+  it('refuses to repair counters outside the incremental mode', async function () {
+    await resetFacts();
+    const counters = new NewsletterEmailCounters({ knex: db.knex, mode: 'compare' });
+    await db.knex('emails').where('id', recipient.email_id).update({ opened_count: 7 });
+    await assert.rejects(counters.reconcile(recipient.email_id), /incremental email counter mode/);
+    await assert.rejects(counters.reconcilePending(), /incremental email counter mode/);
+    assert.equal((await db.knex('emails').where('id', recipient.email_id).first()).opened_count, 7);
+  });
+
   it.each(['compare', 'reconcile'] as const)(
     '%s uses the committed view when an event transaction is still in flight',
     async function (operation) {
       await resetFacts();
-      const counters = new NewsletterEmailCounters({ knex: db.knex });
+      const counters = new NewsletterEmailCounters({
+        knex: db.knex,
+        mode: operation === 'reconcile' ? 'incremental' : 'compare',
+      });
       const initial = createStorage(counters);
       await initial.handleDelivered(makeEvent());
       await initial.flushBatchedUpdates();

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -77,6 +77,8 @@ describe('email analytics service', function () {
     [true, undefined, false],
     [true, 'Compare', false],
     [true, 'compare', true],
+    [true, 'incremental', true],
+    [false, 'incremental', false],
   ])(
     'gates newsletter counter comparison with batchProcessing=%s and mode=%s',
     function (batchProcessing, mode, enabled) {

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
@@ -706,7 +706,7 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
       );
     });
 
-    it('retains every deferred email when final repair fails, including those from earlier pages', async function () {
+    it('retains a failed repair for the next drain without failing the fetch or blocking later emails', async function () {
       configUtils.set('emailAnalytics:batchProcessing', true);
       const emailCounters = createIncrementalCounters();
       const processor = new NewsletterEmailAnalyticsBatchProcessor({
@@ -718,14 +718,18 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
       clock.tick(5 * 60 * 1000 + 1);
       await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: false });
       processingResult.merge({ emailIds: ['e-2'], memberIds: ['m-2'] });
-      emailCounters.reconcile.withArgs('e-2').onFirstCall().rejects(new Error('repair failed'));
-      await assert.rejects(
-        processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true }),
-        /repair failed/,
-      );
+      emailCounters.reconcile.withArgs('e-1').onFirstCall().rejects(new Error('repair failed'));
+      // The failed email stays queued without failing the fetch or blocking
+      // the emails queued behind it
       await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true });
       sinon.assert.calledOnce(emailCounters.reconcile.withArgs('e-1'));
-      sinon.assert.calledTwice(emailCounters.reconcile.withArgs('e-2'));
+      sinon.assert.calledOnce(emailCounters.reconcile.withArgs('e-2'));
+      sinon.assert.calledOnce(queries.aggregateMemberStatsBatch.withArgs(['m-2']));
+      assert.equal(emailCounters.hasPendingReconciliation, true);
+      await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true });
+      sinon.assert.calledTwice(emailCounters.reconcile.withArgs('e-1'));
+      sinon.assert.calledOnce(emailCounters.reconcile.withArgs('e-2'));
+      assert.equal(emailCounters.hasPendingReconciliation, false);
       assert.equal(
         await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true }),
         null,

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
@@ -2,6 +2,9 @@ const assert = require('node:assert/strict');
 
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
+const {
+  NewsletterEmailCounters,
+} = require('../../../../../core/server/services/email-analytics/newsletter-email-counters');
 
 const {
   NewsletterEmailAnalyticsBatchProcessor,
@@ -671,6 +674,63 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
         queries,
       });
     }
+
+    function createIncrementalCounters() {
+      const counters = new NewsletterEmailCounters({ knex: sinon.stub(), mode: 'incremental' });
+      sinon.stub(counters, 'compare').resolves();
+      sinon.stub(counters, 'reconcile').resolves();
+      return counters;
+    }
+
+    it('defers email reconciliation until final aggregation while preserving drained email IDs', async function () {
+      configUtils.set('emailAnalytics:batchProcessing', true);
+      const emailCounters = createIncrementalCounters();
+      const processor = new NewsletterEmailAnalyticsBatchProcessor({
+        config: createMockConfig(),
+        queries,
+        emailCounters,
+      });
+      const processingResult = new EventProcessingResult({ emailIds: ['e-1'], memberIds: ['m-1'] });
+      clock.tick(5 * 60 * 1000 + 1);
+      await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: false });
+      sinon.assert.notCalled(emailCounters.compare);
+      sinon.assert.notCalled(emailCounters.reconcile);
+      sinon.assert.notCalled(queries.aggregateEmailStats);
+      sinon.assert.calledOnceWithExactly(queries.aggregateMemberStatsBatch, ['m-1']);
+      assert.deepEqual(processingResult.emailIds, []);
+      await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true });
+      sinon.assert.calledOnceWithExactly(emailCounters.reconcile, 'e-1');
+      assert.equal(
+        await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true }),
+        null,
+      );
+    });
+
+    it('retains every deferred email when final repair fails, including those from earlier pages', async function () {
+      configUtils.set('emailAnalytics:batchProcessing', true);
+      const emailCounters = createIncrementalCounters();
+      const processor = new NewsletterEmailAnalyticsBatchProcessor({
+        config: createMockConfig(),
+        queries,
+        emailCounters,
+      });
+      const processingResult = new EventProcessingResult({ emailIds: ['e-1'], memberIds: ['m-1'] });
+      clock.tick(5 * 60 * 1000 + 1);
+      await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: false });
+      processingResult.merge({ emailIds: ['e-2'], memberIds: ['m-2'] });
+      emailCounters.reconcile.withArgs('e-2').onFirstCall().rejects(new Error('repair failed'));
+      await assert.rejects(
+        processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true }),
+        /repair failed/,
+      );
+      await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true });
+      sinon.assert.calledOnce(emailCounters.reconcile.withArgs('e-1'));
+      sinon.assert.calledTwice(emailCounters.reconcile.withArgs('e-2'));
+      assert.equal(
+        await processor.aggregate({ includeOpenedEvents: false, processingResult, isFinal: true }),
+        null,
+      );
+    });
 
     describe('final aggregation', function () {
       it('aggregates stats from the processing result', async function () {


### PR DESCRIPTION
The email counters in #30674 keep newsletter totals current as recipient events commit. Once comparison has established correctness, intermediate email recounts repeat work those counters already provide. This adds an opt-in `incremental` mode that skips those recounts and repairs delivered, opened and failed counts at fetch completion.

```text
process page → commit recipient facts and exact email increments

intermediate aggregation
  recount members
  remember touched emails for final repair

final aggregation
  lock each pending email → recount all outcomes → repair counts
  keep unsuccessful work for the next fetch, even if it has no events
```

Pending emails belong to the existing counter service, which survives across fetch processors. This matters when an earlier email's repair fails after later events have advanced the in-memory cursor: recreating the processor must not discard the earlier repair. Drains process a bounded snapshot, serialize with other drains, clear only successful entries, and preserve emails requeued during an in-flight repair.

Final repair uses the same email-row lock as event increments, and its source of truth always includes opens regardless of lane. Logs identify repaired drift separately from observe-only comparison. `compare` retains its existing behavior; `emailCounterMode` still defaults to `off`, and both opt-in modes require batched processing. Member recounts and replay recovery remain in place. Automation/gift paths and opens-first scheduling are unchanged.

Validation:

- 113 MySQL email-service integration tests and 188 analytics unit tests passed, along with Core/test types, focused lint and commit hooks.
- Regression coverage includes deferred IDs after intermediate resets, failed repair across processor recreation and an empty fetch, positive/negative drift repair, concurrent recipient writes, overlapping drains and work requeued during repair.
- Five independent slice reviews and five accumulated-stack review passes found no remaining high-confidence issues. Review exposed the processor-lifetime recovery gap above; the added regression failed before the queue moved to the counter service and passed afterward.
- `pnpm check` stops on the same 452 pre-existing formatting files; none is changed here.
- Controlled synthetic benchmark: 5,000 events, five intermediate aggregation checkpoints, 0/50/100% duplicate opens, 2,009,528 recipient rows. All email/member truth assertions passed. Five intermediate comparisons become one final repair, saving 20,011 handler reads per cycle, about 0.5% overall. Member history queries still dominate. The harness uses `innodb_flush_log_at_trx_commit=0` and no binlog; absolute write timings are not production estimates.

This is the email-only fallback portion of reconciliation, based on #30674. Member counter initialization and the scheduled member sweep remain separate work. Production enablement requires the comparison soak; the planned fleet defaults and rollback lifetime must be decided before this PR merges. This PR does not enable the mode anywhere.

ref https://linear.app/ghost/issue/BER-3935/replace-per-cycle-analytics-recompute-with-bounded-reconciliation
