### PR TITLE
Added resumable member counters and frozen preparation handoff

### DIFF
--- a/ghost/core/core/server/services/email-analytics/lib/open-rate.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/open-rate.ts
@@ -1,0 +1,14 @@
+/** Members need this many tracked emails before an open rate is meaningful. */
+export const MIN_EMAIL_COUNT_FOR_OPEN_RATE = 5;
+
+/**
+ * Percentage open rate rounded to a whole number, or null below the tracked
+ * email threshold. Shared by every writer of members.email_open_rate so the
+ * rounding and threshold cannot drift between recount and counter paths.
+ */
+export function deriveOpenRate(openedCount: number, trackedCount: number): number | null {
+  if (trackedCount < MIN_EMAIL_COUNT_FOR_OPEN_RATE) {
+    return null;
+  }
+  return Math.round((openedCount / trackedCount) * 100);
+}

--- a/ghost/core/core/server/services/email-analytics/lib/open-rate.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/open-rate.ts
@@ -3,8 +3,10 @@ export const MIN_EMAIL_COUNT_FOR_OPEN_RATE = 5;
 
 /**
  * Percentage open rate rounded to a whole number, or null below the tracked
- * email threshold. Shared by every writer of members.email_open_rate so the
- * rounding and threshold cannot drift between recount and counter paths.
+ * email threshold. Shared by the batched recount and the counter writers so
+ * the rounding and threshold cannot drift between them. The sequential
+ * recount keeps its own form because it leaves the column untouched below
+ * the threshold instead of writing null.
  */
 export function deriveOpenRate(openedCount: number, trackedCount: number): number | null {
   if (trackedCount < MIN_EMAIL_COUNT_FOR_OPEN_RATE) {

--- a/ghost/core/core/server/services/email-analytics/lib/queries.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.ts
@@ -7,7 +7,7 @@ import type { JsonObject } from 'type-fest';
 
 const debug = debugFactory('services:email-analytics');
 
-const MIN_EMAIL_COUNT_FOR_OPEN_RATE = 5;
+import { MIN_EMAIL_COUNT_FOR_OPEN_RATE, deriveOpenRate } from './open-rate';
 
 type EmailAnalyticsJobName = string;
 type EmailAnalyticsEvent = 'delivered' | 'opened' | 'failed';
@@ -360,10 +360,7 @@ export class Queries {
       { email_count: number; email_opened_count: number; email_open_rate: number | null }
     >();
     for (const stat of stats) {
-      const emailOpenRate =
-        stat.tracked_count >= MIN_EMAIL_COUNT_FOR_OPEN_RATE
-          ? Math.round((stat.email_opened_count / stat.tracked_count) * 100)
-          : null;
+      const emailOpenRate = deriveOpenRate(stat.email_opened_count, stat.tracked_count);
 
       memberStatsMap.set(stat.member_id, {
         email_count: stat.email_count,

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -44,6 +44,120 @@ export class NewsletterMemberCounters {
     this.#knex = knex;
   }
 
+  /** Apply only explicitly enrolled, frozen batches, atomically with their marker. */
+  async applyPreparedBatch(batchId: string): Promise<boolean> {
+    const owner = await this.#knex('email_batches').where('id', batchId).first('email_id');
+    if (!owner) {
+      throw this.#preparationError(batchId, 'Batch does not exist');
+    }
+    return this.#knex.transaction(async (trx) => {
+      // Match ingestion's email-before-recipient-before-member lock order. All
+      // reads before the member locks are locking reads, never an old snapshot.
+      const email = await trx('emails').where('id', owner.email_id).forUpdate().first();
+      const batch = await trx('email_batches').where('id', batchId).forUpdate().first();
+      if (!batch || batch.email_id !== owner.email_id) {
+        throw this.#preparationError(batchId, 'Batch ownership changed');
+      }
+      if (!batch.member_counters_enabled || batch.member_counters_applied_at !== null) {
+        return false;
+      }
+      if (!email || email.preflight_email_count === null || email.prepared_at === null) {
+        throw this.#preparationError(batchId, 'Member counters require frozen preparation');
+      }
+      if (batch.status !== 'pending') {
+        throw this.#preparationError(batchId, 'Unapplied member counters must precede submission');
+      }
+      const recipients: {
+        email_id: string;
+        member_id: string;
+        opened_at: Date | null;
+        delivered_at: Date | null;
+        failed_at: Date | null;
+      }[] = await trx('email_recipients')
+        .where('batch_id', batchId)
+        .select('email_id', 'member_id', 'opened_at', 'delivered_at', 'failed_at')
+        .limit(MAX_SWEEP_PAGE_SIZE + 1)
+        .forShare();
+      if (
+        recipients.length > MAX_SWEEP_PAGE_SIZE ||
+        recipients.length !== batch.recipient_count ||
+        recipients.some((row) => row.email_id !== email.id)
+      ) {
+        throw this.#preparationError(
+          batchId,
+          'Prepared recipient membership does not match the batch',
+        );
+      }
+      if (
+        recipients.some(
+          (row) => row.opened_at !== null || row.delivered_at !== null || row.failed_at !== null,
+        )
+      ) {
+        throw this.#preparationError(
+          batchId,
+          'Recipient events preceded member counter application',
+        );
+      }
+      const deltas = new Map<string, number>();
+      for (const row of recipients) {
+        deltas.set(row.member_id, (deltas.get(row.member_id) ?? 0) + 1);
+      }
+      const members: ({ id: string } & Omit<MemberCounts, 'email_tracked_count'> & {
+          email_tracked_count: number | null;
+        })[] = await this.#members(trx)
+        .whereIn('id', [...deltas.keys()])
+        .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
+        .orderBy('id')
+        .forUpdate();
+      const uninitialized = members
+        .filter((row) => row.email_tracked_count === null)
+        .map((row) => row.id);
+      const baseline =
+        uninitialized.length > 0
+          ? await this.#derive(trx, uninitialized)
+          : new Map<string, MemberCounts>();
+      const totals = new Map<string, MemberCounts>();
+      for (const member of members) {
+        const current =
+          member.email_tracked_count === null
+            ? (baseline.get(member.id) ?? {
+                email_count: 0,
+                email_tracked_count: 0,
+                email_opened_count: 0,
+                email_open_rate: null,
+              })
+            : member;
+        const delta = deltas.get(member.id)!;
+        const tracked = Number(current.email_tracked_count) + (email.track_opens ? delta : 0);
+        const opened = Number(current.email_opened_count);
+        totals.set(member.id, {
+          email_count: Number(current.email_count) + delta,
+          email_tracked_count: tracked,
+          email_opened_count: opened,
+          email_open_rate:
+            tracked >= MIN_EMAIL_COUNT_FOR_OPEN_RATE ? Math.round((opened / tracked) * 100) : null,
+        });
+      }
+      if (members.length > 0) {
+        await this.#setCounts(
+          trx,
+          members.map((row) => row.id),
+          totals,
+        );
+      }
+      await trx('email_batches')
+        .where('id', batchId)
+        .update({ member_counters_applied_at: trx.fn.now() });
+      return true;
+    }, this.#transactionConfig());
+  }
+
+  #preparationError(batchId: string, message: string) {
+    return Object.assign(new IncorrectUsageError({ message, context: `Email batch ${batchId}` }), {
+      retryable: false,
+    });
+  }
+
   /** Resume the persisted sweep, or explicitly start another completed sweep. */
   async runSweepPage({
     limit = MAX_SWEEP_PAGE_SIZE,

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -253,7 +253,7 @@ export class NewsletterMemberCounters {
       // Another writer, a restored database or a newer checkpoint format owns
       // this row. Never overwrite it silently; an operator can pass restart.
       throw this.#nonRetryable(
-        'Member counter sweep checkpoint is missing or unreadable; rerun with restart to begin a new sweep',
+        'Member counter sweep checkpoint is missing or unreadable; rerun with --restart to begin a new sweep',
         `Jobs row ${SWEEP_JOB_NAME}`,
       );
     }
@@ -326,6 +326,13 @@ export class NewsletterMemberCounters {
     // lists would grow each statement with the site's history; joining every
     // historical recipient to its email would be far more expensive.
     const untrackedEmails = trx('emails').select('id').where('track_opens', false);
+    // Legacy preparation with only pending batches is also rebuilt on resume.
+    // Preserve the entire recipient set once any batch has started submission
+    // or been applied, including an accounted email whose prepared_at was never
+    // saved (a rollback to older send code can submit that way): the send path
+    // refuses to discard such a set, so its recipients are frozen facts.
+    // Treating them as truth keeps live ingestion and comparison running rather
+    // than stopping every newsletter's counters on one anomalous email.
     const discardableEmails = trx('emails')
       .select('id')
       .whereNull('prepared_at')
@@ -338,23 +345,15 @@ export class NewsletterMemberCounters {
               .whereRaw('?? = ??', ['email_batches.email_id', 'emails.id'])
               .whereNot('status', 'pending'),
           ),
-      );
-    // Legacy preparation with only pending batches is also rebuilt on resume.
-    // Preserve the entire legacy set once any batch has started submission.
-    const ambiguous = await trx('email_batches')
-      .whereIn('email_id', discardableEmails.clone())
-      .where((builder) =>
-        builder.whereNot('status', 'pending').orWhereNotNull('member_counters_applied_at'),
       )
-      .first('email_id');
-    if (ambiguous) {
-      // Rollback to older send code can submit without saving prepared_at.
-      // Those recipients cannot be discarded or silently removed from truth.
-      throw this.#nonRetryable(
-        'Cannot reconcile member counters for batches submitted or applied without frozen preparation.',
-        `Email ${ambiguous.email_id} requires preparation reconciliation.`,
+      .whereNotExists(
+        trx('email_batches')
+          .select('id')
+          .whereRaw('?? = ??', ['email_batches.email_id', 'emails.id'])
+          .where((builder) =>
+            builder.whereNot('status', 'pending').orWhereNotNull('member_counters_applied_at'),
+          ),
       );
-    }
     const pendingBatches = trx('email_batches')
       .select('id')
       .where('member_counters_enabled', true)

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -291,9 +291,20 @@ export class NewsletterMemberCounters {
     // recipient facts. Avoid joining every historical recipient to its email.
     const untrackedEmailIds: string[] = await trx('emails').where('track_opens', false).pluck('id');
     const discardableEmailIds: string[] = await trx('emails')
-      .whereNotNull('preflight_email_count')
       .whereNull('prepared_at')
+      .where((builder) =>
+        builder
+          .whereNotNull('preflight_email_count')
+          .orWhereNotExists(
+            trx('email_batches')
+              .select('id')
+              .whereRaw('?? = ??', ['email_batches.email_id', 'emails.id'])
+              .whereNot('status', 'pending'),
+          ),
+      )
       .pluck('id');
+    // Legacy preparation with only pending batches is also rebuilt on resume.
+    // Preserve the entire legacy set once any batch has started submission.
     if (discardableEmailIds.length > 0) {
       const ambiguous = await trx('email_batches')
         .whereIn('email_id', discardableEmailIds)

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -1,0 +1,262 @@
+import type { Knex } from 'knex';
+import { IncorrectUsageError } from '@tryghost/errors';
+import ObjectID from 'bson-objectid';
+import { z } from 'zod';
+
+export type MemberSweepPage = { afterId?: string; throughId?: string; limit?: number };
+export type MemberSweepResult = { afterId: string | undefined; processed: number };
+
+type MemberCounts = {
+  email_count: number;
+  email_tracked_count: number;
+  email_opened_count: number;
+  email_open_rate: number | null;
+};
+type DerivedRow = {
+  member_id: string;
+  email_count: number | string;
+  email_tracked_count: number | string;
+  email_opened_count: number | string;
+};
+const MIN_EMAIL_COUNT_FOR_OPEN_RATE = 5;
+const MAX_SWEEP_PAGE_SIZE = 5000;
+const SWEEP_JOB_NAME = 'email-analytics-member-reconciliation';
+const checkpointSchema = z.object({
+  version: z.literal(1),
+  afterId: z
+    .string()
+    .regex(/^[a-f0-9]{24}$/)
+    .nullable(),
+  throughId: z
+    .string()
+    .regex(/^[a-f0-9]{24}$/)
+    .nullable(),
+  processed: z.number().int().nonnegative(),
+  complete: z.boolean(),
+});
+export type MemberSweepCheckpoint = z.infer<typeof checkpointSchema>;
+
+/** Shared derived truth for initialization, repair and rollback re-baselining. */
+export class NewsletterMemberCounters {
+  readonly #knex: Knex;
+
+  constructor(knex: Knex) {
+    this.#knex = knex;
+  }
+
+  /** Resume the persisted sweep, or explicitly start another completed sweep. */
+  async runSweepPage({
+    limit = MAX_SWEEP_PAGE_SIZE,
+    restart = false,
+  }: {
+    limit?: number;
+    restart?: boolean;
+  } = {}): Promise<MemberSweepCheckpoint> {
+    this.#validateLimit(limit);
+    // Outside the page transaction: this range lookup must not establish its
+    // recipient snapshot before the member locks. New members are initialized
+    // by preparation; a later full sweep will also visit them.
+    const upper = await this.#knex('members').max('id as id').first();
+    const throughId: string | null = upper?.id ?? null;
+    const initial: MemberSweepCheckpoint = {
+      version: 1,
+      afterId: null,
+      throughId,
+      processed: 0,
+      complete: throughId === null,
+    };
+    await this.#knex('jobs')
+      .insert({
+        id: ObjectID().toHexString(),
+        name: SWEEP_JOB_NAME,
+        created_at: new Date(),
+        started_at: new Date(),
+        status: initial.complete ? 'finished' : 'started',
+        finished_at: initial.complete ? new Date() : null,
+        metadata: JSON.stringify(initial),
+      })
+      .onConflict('name')
+      .ignore();
+    return this.#knex.transaction(async (trx) => {
+      const job = await trx('jobs').where('name', SWEEP_JOB_NAME).forUpdate().first();
+      let state = checkpointSchema.parse(JSON.parse(job.metadata));
+      if (state.complete && !restart) {
+        return state;
+      }
+      const starting = state.complete && restart;
+      if (starting) {
+        state = initial;
+      }
+      if (state.throughId !== null) {
+        const page = await this.#sweepPage(trx, {
+          afterId: state.afterId ?? undefined,
+          throughId: state.throughId,
+          limit,
+        });
+        state.afterId = page.afterId ?? null;
+        state.processed += page.processed;
+        state.complete = page.processed === 0 || state.afterId === state.throughId;
+      }
+      await trx('jobs')
+        .where('id', job.id)
+        .update({
+          metadata: JSON.stringify(state),
+          updated_at: new Date(),
+          status: state.complete ? 'finished' : 'started',
+          finished_at: state.complete ? new Date() : null,
+          ...(starting ? { started_at: new Date() } : {}),
+        });
+      return state;
+    }, this.#transactionConfig());
+  }
+
+  /**
+   * The caller persists afterId only after this promise succeeds. Repeating a
+   * committed page is safe, including after a lost COMMIT acknowledgement.
+   * A page returning zero members ends the sweep; throughId can freeze its range.
+   */
+  async sweepPage({
+    afterId,
+    throughId,
+    limit = MAX_SWEEP_PAGE_SIZE,
+  }: MemberSweepPage = {}): Promise<MemberSweepResult> {
+    this.#validateLimit(limit);
+    return this.#knex.transaction(
+      (trx) => this.#sweepPage(trx, { afterId, throughId, limit }),
+      this.#transactionConfig(),
+    );
+  }
+
+  #validateLimit(limit: number): void {
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_SWEEP_PAGE_SIZE) {
+      throw new IncorrectUsageError({
+        message: `Member sweep limit must be an integer between 1 and ${MAX_SWEEP_PAGE_SIZE}`,
+      });
+    }
+  }
+
+  #transactionConfig(): Knex.TransactionConfig | undefined {
+    return this.#knex.client.config.client === 'mysql2'
+      ? { isolationLevel: 'repeatable read' }
+      : undefined;
+  }
+
+  async #sweepPage(
+    trx: Knex.Transaction,
+    { afterId, throughId, limit }: MemberSweepPage & { limit: number },
+  ): Promise<MemberSweepResult> {
+    // Lock before the first consistent read. Event and preparation increments
+    // must take the same member locks before changing recipient-derived totals.
+    // An IN-list's input order alone would not establish InnoDB lock order.
+    const members = this.#members(trx).select('id').orderBy('id').limit(limit).forUpdate();
+    if (afterId !== undefined) {
+      members.where('id', '>', afterId);
+    }
+    if (throughId !== undefined) {
+      members.where('id', '<=', throughId);
+    }
+    const rows: { id: string }[] = await members;
+    if (rows.length === 0) {
+      return { afterId, processed: 0 };
+    }
+    const memberIds = rows.map((row) => row.id);
+    await this.#setCounts(trx, memberIds, await this.#derive(trx, memberIds));
+    return { afterId: memberIds.at(-1), processed: rows.length };
+  }
+
+  #members(trx: Knex.Transaction) {
+    const query = trx('members');
+    if (trx.client.config.client === 'mysql2') {
+      query.from(trx.raw('?? FORCE INDEX (PRIMARY)', ['members']));
+    }
+    return query;
+  }
+
+  async #derive(trx: Knex.Transaction, memberIds: string[]): Promise<Map<string, MemberCounts>> {
+    // Read these small metadata sets from the same transaction snapshot as the
+    // recipient facts. Avoid joining every historical recipient to its email.
+    const untrackedEmailIds: string[] = await trx('emails').where('track_opens', false).pluck('id');
+    const discardableEmailIds: string[] = await trx('emails')
+      .whereNotNull('preflight_email_count')
+      .whereNull('prepared_at')
+      .pluck('id');
+    if (discardableEmailIds.length > 0) {
+      const ambiguous = await trx('email_batches')
+        .whereIn('email_id', discardableEmailIds)
+        .where((builder) =>
+          builder.whereNot('status', 'pending').orWhereNotNull('member_counters_applied_at'),
+        )
+        .first('email_id');
+      if (ambiguous) {
+        // Rollback to older send code can submit without saving prepared_at.
+        // Those recipients cannot be discarded or silently removed from truth.
+        throw new IncorrectUsageError({
+          message:
+            'Cannot reconcile member counters for batches submitted or applied without frozen preparation.',
+          context: `Email ${ambiguous.email_id} requires preparation reconciliation.`,
+        });
+      }
+    }
+    const pendingBatchIds: string[] = await trx('email_batches')
+      .where('member_counters_enabled', true)
+      .whereNull('member_counters_applied_at')
+      .pluck('id');
+    const trackedCount =
+      untrackedEmailIds.length === 0
+        ? trx.raw('COUNT(*) AS email_tracked_count')
+        : trx.raw(
+            `SUM(CASE WHEN email_id IN (${untrackedEmailIds.map(() => '?').join(',')}) THEN 0 ELSE 1 END) AS email_tracked_count`,
+            untrackedEmailIds,
+          );
+    const rows: DerivedRow[] = await trx('email_recipients')
+      .select(
+        'member_id',
+        trx.raw('COUNT(*) AS email_count'),
+        trackedCount,
+        trx.raw('SUM(CASE WHEN opened_at IS NOT NULL THEN 1 ELSE 0 END) AS email_opened_count'),
+      )
+      .whereIn('member_id', memberIds)
+      .whereNotIn('email_id', discardableEmailIds)
+      .whereNotIn('batch_id', pendingBatchIds)
+      .groupBy('member_id');
+    const counts = new Map<string, MemberCounts>();
+    for (const row of rows) {
+      const tracked = Number(row.email_tracked_count);
+      const opened = Number(row.email_opened_count);
+      counts.set(row.member_id, {
+        email_count: Number(row.email_count),
+        email_tracked_count: tracked,
+        email_opened_count: opened,
+        email_open_rate:
+          tracked >= MIN_EMAIL_COUNT_FOR_OPEN_RATE ? Math.round((opened / tracked) * 100) : null,
+      });
+    }
+    return counts;
+  }
+
+  async #setCounts(
+    trx: Knex.Transaction,
+    memberIds: string[],
+    counts: Map<string, MemberCounts>,
+  ): Promise<void> {
+    const columns = [
+      'email_count',
+      'email_tracked_count',
+      'email_opened_count',
+      'email_open_rate',
+    ] as const;
+    const updates: Record<string, Knex.Raw> = {};
+    for (const column of columns) {
+      const bindings: (string | number | null)[] = [];
+      const cases = memberIds.map((memberId) => {
+        bindings.push(
+          memberId,
+          counts.get(memberId)?.[column] ?? (column === 'email_open_rate' ? null : 0),
+        );
+        return 'WHEN ? THEN ?';
+      });
+      updates[column] = trx.raw(`CASE id ${cases.join(' ')} END`, bindings);
+    }
+    await trx('members').whereIn('id', memberIds).update(updates);
+  }
+}

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -1,7 +1,10 @@
 import type { Knex } from 'knex';
 import { IncorrectUsageError } from '@tryghost/errors';
+import DatabaseInfo from '@tryghost/database-info';
 import ObjectID from 'bson-objectid';
 import { z } from 'zod';
+import { DbCount } from '../../lib/db-types/count';
+import { deriveOpenRate } from './lib/open-rate';
 
 export type MemberSweepPage = { afterId?: string; throughId?: string; limit?: number };
 export type MemberSweepResult = { afterId: string | undefined; processed: number };
@@ -12,14 +15,15 @@ type MemberCounts = {
   email_opened_count: number;
   email_open_rate: number | null;
 };
-type DerivedRow = {
-  member_id: string;
-  email_count: number | string;
-  email_tracked_count: number | string;
-  email_opened_count: number | string;
-};
-const MIN_EMAIL_COUNT_FOR_OPEN_RATE = 5;
+// Aggregates over email_recipients; COUNT/SUM arrive as strings from MySQL.
+const DerivedRow = z.object({
+  member_id: z.string(),
+  email_count: DbCount,
+  email_tracked_count: DbCount,
+  email_opened_count: DbCount,
+});
 const MAX_SWEEP_PAGE_SIZE = 5000;
+const UPDATE_CHUNK_SIZE = 1000;
 const SWEEP_JOB_NAME = 'email-analytics-member-reconciliation';
 const checkpointSchema = z.object({
   version: z.literal(1),
@@ -78,8 +82,13 @@ export class NewsletterMemberCounters {
         .select('email_id', 'member_id', 'opened_at', 'delivered_at', 'failed_at')
         .limit(MAX_SWEEP_PAGE_SIZE + 1)
         .forShare();
+      if (recipients.length > MAX_SWEEP_PAGE_SIZE) {
+        throw this.#preparationError(
+          batchId,
+          `Member counters support at most ${MAX_SWEEP_PAGE_SIZE} recipients per batch; lower bulkEmail.batchSize`,
+        );
+      }
       if (
-        recipients.length > MAX_SWEEP_PAGE_SIZE ||
         recipients.length !== batch.recipient_count ||
         recipients.some((row) => row.email_id !== email.id)
       ) {
@@ -134,8 +143,7 @@ export class NewsletterMemberCounters {
           email_count: Number(current.email_count) + delta,
           email_tracked_count: tracked,
           email_opened_count: opened,
-          email_open_rate:
-            tracked >= MIN_EMAIL_COUNT_FOR_OPEN_RATE ? Math.round((opened / tracked) * 100) : null,
+          email_open_rate: deriveOpenRate(opened, tracked),
         });
       }
       if (members.length > 0) {
@@ -153,12 +161,18 @@ export class NewsletterMemberCounters {
   }
 
   #preparationError(batchId: string, message: string) {
-    return Object.assign(new IncorrectUsageError({ message, context: `Email batch ${batchId}` }), {
-      retryable: false,
-    });
+    return this.#nonRetryable(message, `Email batch ${batchId}`);
   }
 
-  /** Resume the persisted sweep, or explicitly start another completed sweep. */
+  /** A deterministic failure: callers with retry budgets must not spend them on it. */
+  #nonRetryable(message: string, context: string) {
+    return Object.assign(new IncorrectUsageError({ message, context }), { retryable: false });
+  }
+
+  /**
+   * Resume the persisted sweep. `restart` abandons whatever checkpoint exists,
+   * complete or not, and begins a fresh sweep over the current member range.
+   */
   async runSweepPage({
     limit = MAX_SWEEP_PAGE_SIZE,
     restart = false,
@@ -193,14 +207,17 @@ export class NewsletterMemberCounters {
       .ignore();
     return this.#knex.transaction(async (trx) => {
       const job = await trx('jobs').where('name', SWEEP_JOB_NAME).forUpdate().first();
-      let state = checkpointSchema.parse(JSON.parse(job.metadata));
+      if (!job) {
+        throw this.#nonRetryable(
+          'Member counter sweep checkpoint disappeared while starting a page',
+          `Jobs row ${SWEEP_JOB_NAME}`,
+        );
+      }
+      const state = restart ? initial : this.#parseCheckpoint(job.metadata);
       if (state.complete && !restart) {
         return state;
       }
-      const starting = state.complete && restart;
-      if (starting) {
-        state = initial;
-      }
+      const starting = restart;
       if (state.throughId !== null) {
         const page = await this.#sweepPage(trx, {
           afterId: state.afterId ?? undefined,
@@ -222,6 +239,25 @@ export class NewsletterMemberCounters {
         });
       return state;
     }, this.#transactionConfig());
+  }
+
+  #parseCheckpoint(metadata: unknown): MemberSweepCheckpoint {
+    let parsed: unknown;
+    try {
+      parsed = typeof metadata === 'string' ? JSON.parse(metadata) : metadata;
+    } catch {
+      parsed = undefined;
+    }
+    const checkpoint = checkpointSchema.safeParse(parsed);
+    if (!checkpoint.success) {
+      // Another writer, a restored database or a newer checkpoint format owns
+      // this row. Never overwrite it silently; an operator can pass restart.
+      throw this.#nonRetryable(
+        'Member counter sweep checkpoint is missing or unreadable; rerun with restart to begin a new sweep',
+        `Jobs row ${SWEEP_JOB_NAME}`,
+      );
+    }
+    return checkpoint.data;
   }
 
   /**
@@ -250,9 +286,7 @@ export class NewsletterMemberCounters {
   }
 
   #transactionConfig(): Knex.TransactionConfig | undefined {
-    return this.#knex.client.config.client === 'mysql2'
-      ? { isolationLevel: 'repeatable read' }
-      : undefined;
+    return DatabaseInfo.isMySQL(this.#knex) ? { isolationLevel: 'repeatable read' } : undefined;
   }
 
   async #sweepPage(
@@ -280,17 +314,20 @@ export class NewsletterMemberCounters {
 
   #members(trx: Knex.Transaction) {
     const query = trx('members');
-    if (trx.client.config.client === 'mysql2') {
+    if (DatabaseInfo.isMySQL(trx)) {
       query.from(trx.raw('?? FORCE INDEX (PRIMARY)', ['members']));
     }
     return query;
   }
 
   async #derive(trx: Knex.Transaction, memberIds: string[]): Promise<Map<string, MemberCounts>> {
-    // Read these small metadata sets from the same transaction snapshot as the
-    // recipient facts. Avoid joining every historical recipient to its email.
-    const untrackedEmailIds: string[] = await trx('emails').where('track_opens', false).pluck('id');
-    const discardableEmailIds: string[] = await trx('emails')
+    // Express the small metadata sets as subqueries evaluated inside the same
+    // transaction snapshot as the recipient facts. Inlining them as bound ID
+    // lists would grow each statement with the site's history; joining every
+    // historical recipient to its email would be far more expensive.
+    const untrackedEmails = trx('emails').select('id').where('track_opens', false);
+    const discardableEmails = trx('emails')
+      .select('id')
       .whereNull('prepared_at')
       .where((builder) =>
         builder
@@ -301,59 +338,48 @@ export class NewsletterMemberCounters {
               .whereRaw('?? = ??', ['email_batches.email_id', 'emails.id'])
               .whereNot('status', 'pending'),
           ),
-      )
-      .pluck('id');
+      );
     // Legacy preparation with only pending batches is also rebuilt on resume.
     // Preserve the entire legacy set once any batch has started submission.
-    if (discardableEmailIds.length > 0) {
-      const ambiguous = await trx('email_batches')
-        .whereIn('email_id', discardableEmailIds)
-        .where((builder) =>
-          builder.whereNot('status', 'pending').orWhereNotNull('member_counters_applied_at'),
-        )
-        .first('email_id');
-      if (ambiguous) {
-        // Rollback to older send code can submit without saving prepared_at.
-        // Those recipients cannot be discarded or silently removed from truth.
-        throw new IncorrectUsageError({
-          message:
-            'Cannot reconcile member counters for batches submitted or applied without frozen preparation.',
-          context: `Email ${ambiguous.email_id} requires preparation reconciliation.`,
-        });
-      }
+    const ambiguous = await trx('email_batches')
+      .whereIn('email_id', discardableEmails.clone())
+      .where((builder) =>
+        builder.whereNot('status', 'pending').orWhereNotNull('member_counters_applied_at'),
+      )
+      .first('email_id');
+    if (ambiguous) {
+      // Rollback to older send code can submit without saving prepared_at.
+      // Those recipients cannot be discarded or silently removed from truth.
+      throw this.#nonRetryable(
+        'Cannot reconcile member counters for batches submitted or applied without frozen preparation.',
+        `Email ${ambiguous.email_id} requires preparation reconciliation.`,
+      );
     }
-    const pendingBatchIds: string[] = await trx('email_batches')
+    const pendingBatches = trx('email_batches')
+      .select('id')
       .where('member_counters_enabled', true)
-      .whereNull('member_counters_applied_at')
-      .pluck('id');
-    const trackedCount =
-      untrackedEmailIds.length === 0
-        ? trx.raw('COUNT(*) AS email_tracked_count')
-        : trx.raw(
-            `SUM(CASE WHEN email_id IN (${untrackedEmailIds.map(() => '?').join(',')}) THEN 0 ELSE 1 END) AS email_tracked_count`,
-            untrackedEmailIds,
-          );
-    const rows: DerivedRow[] = await trx('email_recipients')
+      .whereNull('member_counters_applied_at');
+    const rows = await trx('email_recipients')
       .select(
         'member_id',
         trx.raw('COUNT(*) AS email_count'),
-        trackedCount,
+        trx.raw('SUM(CASE WHEN email_id IN (?) THEN 0 ELSE 1 END) AS email_tracked_count', [
+          untrackedEmails,
+        ]),
         trx.raw('SUM(CASE WHEN opened_at IS NOT NULL THEN 1 ELSE 0 END) AS email_opened_count'),
       )
       .whereIn('member_id', memberIds)
-      .whereNotIn('email_id', discardableEmailIds)
-      .whereNotIn('batch_id', pendingBatchIds)
+      .whereNotIn('email_id', discardableEmails)
+      .whereNotIn('batch_id', pendingBatches)
       .groupBy('member_id');
     const counts = new Map<string, MemberCounts>();
-    for (const row of rows) {
-      const tracked = Number(row.email_tracked_count);
-      const opened = Number(row.email_opened_count);
+    for (const raw of rows) {
+      const row = DerivedRow.parse(raw);
       counts.set(row.member_id, {
-        email_count: Number(row.email_count),
-        email_tracked_count: tracked,
-        email_opened_count: opened,
-        email_open_rate:
-          tracked >= MIN_EMAIL_COUNT_FOR_OPEN_RATE ? Math.round((opened / tracked) * 100) : null,
+        email_count: row.email_count,
+        email_tracked_count: row.email_tracked_count,
+        email_opened_count: row.email_opened_count,
+        email_open_rate: deriveOpenRate(row.email_opened_count, row.email_tracked_count),
       });
     }
     return counts;
@@ -370,18 +396,22 @@ export class NewsletterMemberCounters {
       'email_opened_count',
       'email_open_rate',
     ] as const;
-    const updates: Record<string, Knex.Raw> = {};
-    for (const column of columns) {
-      const bindings: (string | number | null)[] = [];
-      const cases = memberIds.map((memberId) => {
-        bindings.push(
-          memberId,
-          counts.get(memberId)?.[column] ?? (column === 'email_open_rate' ? null : 0),
-        );
-        return 'WHEN ? THEN ?';
-      });
-      updates[column] = trx.raw(`CASE id ${cases.join(' ')} END`, bindings);
+    // Bound the statement size: a full page carries four CASE ladders.
+    for (let start = 0; start < memberIds.length; start += UPDATE_CHUNK_SIZE) {
+      const chunk = memberIds.slice(start, start + UPDATE_CHUNK_SIZE);
+      const updates: Record<string, Knex.Raw> = {};
+      for (const column of columns) {
+        const bindings: (string | number | null)[] = [];
+        const cases = chunk.map((memberId) => {
+          bindings.push(
+            memberId,
+            counts.get(memberId)?.[column] ?? (column === 'email_open_rate' ? null : 0),
+          );
+          return 'WHEN ? THEN ?';
+        });
+        updates[column] = trx.raw(`CASE id ${cases.join(' ')} END`, bindings);
+      }
+      await trx('members').whereIn('id', chunk).update(updates);
     }
-    await trx('members').whereIn('id', memberIds).update(updates);
   }
 }

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -363,10 +363,14 @@ NODE_ENV=production node --import tsx scripts/reconcile-member-email-counters.ts
 ```
 
 The script uses the configured database and prints the durable checkpoint after
-each page. Repeat to resume; `--restart` explicitly begins another completed
-sweep. A sweep fixes its upper member-ID boundary when it starts. New members are
-handled by preparation or a later sweep. The script neither schedules work nor
-enables incremental ingestion.
+each page. Repeat to resume; `--restart` abandons the existing checkpoint,
+complete or not, and begins a new sweep; `--pause-ms` waits between pages so
+member-facing writes that queued behind a page's locks can proceed. A sweep
+fixes its upper member-ID boundary when it starts. New members are handled by
+preparation or a later sweep. The script neither schedules work nor enables
+incremental ingestion. An unreadable checkpoint row (for example after a
+database restore, or written by a newer version) stops the sweep with an
+explicit error rather than being overwritten; pass `--restart` to replace it.
 
 Drain legacy analytics and preparation writers before manually initializing or
 re-baselining. The sweep's live concurrency guarantee requires every counter
@@ -377,7 +381,8 @@ periodic repair alongside live ingestion. MySQL pages explicitly use repeatable
 read; multiple metadata and recipient reads share the same snapshot.
 
 `emailAnalytics.memberCounterPreparation` defaults to false and requires batched
-analytics. When enabled, new preparation operations persist batch enrollment with
+analytics; without `emailAnalytics.batchProcessing` it logs a warning at boot and
+stays off. When enabled, new preparation operations persist batch enrollment with
 their recipient rows. Creation and discard/rebuild never increment member counters.
 After frozen preparation verifies, submission applies each enrolled batch's member
 totals and marker atomically. A resumed send honors existing enrollment even if
@@ -396,5 +401,10 @@ this batch is added exactly once. Deleted members are skipped. Application rejec
 unfrozen, already-submitting or inconsistent batches before changing counters.
 All batch applications finish before the first provider submission. An uncertain
 commit is retried through the persisted marker, so it cannot increment twice.
-A transaction handles at most 5,000 recipient rows; larger batches require an
-explicit implementation change before enabling this mode.
+A transaction handles at most 5,000 recipient rows; a larger `bulkEmail.batchSize`
+fails application with an explicit message before enabling this mode. An email
+whose batches were submitted or applied without frozen preparation, which only a
+rollback to older send code can produce, stops both the sweep and every enrolled
+application with a non-retryable error until its preparation is reconciled; the
+send path reports it as a verification failure instead of spending its retry
+budget on it.

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -347,8 +347,11 @@ preparation replaces their recipient set. Once any legacy batch has started
 submission, the entire set remains part of derived truth, including its pending
 batches. A frozen legacy set also remains part of derived truth.
 An accounted email without frozen preparation but with non-pending or already
-counter-applied batches stops the sweep for explicit preparation reconciliation;
-its recipient facts must not be silently removed during rollback re-baselining.
+counter-applied batches, which only a rollback to older send code can produce,
+is treated as frozen: its recipient facts stay in derived truth, because the
+send path refuses to discard such a set. This keeps live ingestion and
+comparison running on one anomalous email rather than stopping every
+newsletter's counters; the send itself still needs preparation reconciliation.
 Opted-in batches contribute only after `member_counters_applied_at` is persisted.
 Preparation increments and that marker must commit together under the same member
 locks, after the preparation boundary freezes the recipient membership. This keeps
@@ -402,9 +405,4 @@ unfrozen, already-submitting or inconsistent batches before changing counters.
 All batch applications finish before the first provider submission. An uncertain
 commit is retried through the persisted marker, so it cannot increment twice.
 A transaction handles at most 5,000 recipient rows; a larger `bulkEmail.batchSize`
-fails application with an explicit message before enabling this mode. An email
-whose batches were submitted or applied without frozen preparation, which only a
-rollback to older send code can produce, stops both the sweep and every enrolled
-application with a non-retryable error until its preparation is reconciled; the
-send path reports it as a verification failure instead of spending its retry
-budget on it.
+fails application with an explicit message before enabling this mode.

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -328,3 +328,46 @@ saves it when re-queuing the email. Batches completed before that timestamp
 belong to an earlier attempt and are left out of the rate window. The proxy
 only holds while nothing saves the Email model, or sets `emails.updated_at`
 through a raw update, while batches are being submitted.
+
+## Member counter reconciliation
+
+`NewsletterMemberCounters` provides one bounded sweep for member counter
+initialization, repair and rollback re-baselining. Its checkpoint lives in the
+`email-analytics-member-reconciliation` jobs row. A page locks members in primary-key
+order before reading recipient facts, then writes all four member statistics and
+the checkpoint in one transaction. An interrupted or uncertain commit resumes
+from persisted state. NULL `email_tracked_count` means uninitialized; zero is a
+valid initialized denominator. Open rates remain null below five tracked emails.
+
+Historical batches have `member_counters_enabled = false` and are never enrolled
+by an absent application marker. The derived baseline includes their recipients,
+except discardable incomplete preparation under the recipient-accounting protocol.
+An accounted email without frozen preparation but with non-pending or already
+counter-applied batches stops the sweep for explicit preparation reconciliation;
+its recipient facts must not be silently removed during rollback re-baselining.
+Opted-in batches contribute only after `member_counters_applied_at` is persisted.
+Preparation increments and that marker must commit together under the same member
+locks, after the preparation boundary freezes the recipient membership. This keeps
+pending preparation recipients out of the baseline that precedes their increments.
+
+Run the manual sweep from a bootstrapped source checkout configured for the target
+blog database. The blog must already have its jobs table initialized. This operator
+script uses source-checkout dependencies and is not included in the published release:
+
+```sh
+NODE_ENV=production node --import tsx scripts/reconcile-member-email-counters.ts --limit 5000 --pages 1
+```
+
+The script uses the configured database and prints the durable checkpoint after
+each page. Repeat to resume; `--restart` explicitly begins another completed
+sweep. A sweep fixes its upper member-ID boundary when it starts. New members are
+handled by preparation or a later sweep. The script neither schedules work nor
+enables incremental ingestion.
+
+Drain legacy analytics and preparation writers before manually initializing or
+re-baselining. The sweep's live concurrency guarantee requires every counter
+writer to acquire member locks before establishing its recipient snapshot.
+Legacy recounts and recipient creation do not follow this protocol. The later
+incremental-ingestion integration must establish that boundary before allowing
+periodic repair alongside live ingestion. MySQL pages explicitly use repeatable
+read; multiple metadata and recipient reads share the same snapshot.

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -342,6 +342,10 @@ valid initialized denominator. Open rates remain null below five tracked emails.
 Historical batches have `member_counters_enabled = false` and are never enrolled
 by an absent application marker. The derived baseline includes their recipients,
 except discardable incomplete preparation under the recipient-accounting protocol.
+Unfrozen legacy emails whose batches are all pending are also discardable: resumed
+preparation replaces their recipient set. Once any legacy batch has started
+submission, the entire set remains part of derived truth, including its pending
+batches. A frozen legacy set also remains part of derived truth.
 An accounted email without frozen preparation but with non-pending or already
 counter-applied batches stops the sweep for explicit preparation reconciliation;
 its recipient facts must not be silently removed during rollback re-baselining.

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -371,3 +371,26 @@ Legacy recounts and recipient creation do not follow this protocol. The later
 incremental-ingestion integration must establish that boundary before allowing
 periodic repair alongside live ingestion. MySQL pages explicitly use repeatable
 read; multiple metadata and recipient reads share the same snapshot.
+
+`emailAnalytics.memberCounterPreparation` defaults to false and requires batched
+analytics. When enabled, new preparation operations persist batch enrollment with
+their recipient rows. Creation and discard/rebuild never increment member counters.
+After frozen preparation verifies, submission applies each enrolled batch's member
+totals and marker atomically. A resumed send honors existing enrollment even if
+new enrollment has been disabled. Historical batches remain opted out.
+
+Keep this flag off with legacy analytics workers. For isolated preparation testing,
+stop analytics jobs first: legacy recounts include pending recipient rows and do
+not coordinate with these increments. Enabling preparation with live analytics
+requires the subsequent member-event counter integration and a drained-worker
+cutover. The flag does not itself enable that integration.
+
+Application locks the email, batch, persisted recipient rows and then members in
+primary-key order, before its first consistent read. Uninitialized members use the
+same derived baseline as the sweep; pending enrolled recipients are excluded, then
+this batch is added exactly once. Deleted members are skipped. Application rejects
+unfrozen, already-submitting or inconsistent batches before changing counters.
+All batch applications finish before the first provider submission. An uncertain
+commit is retried through the persisted marker, so it cannot increment twice.
+A transaction handles at most 5,000 recipient rows; larger batches require an
+explicit implementation change before enabling this mode.

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -53,6 +53,8 @@ class BatchSendingService {
   #sentry;
   #getRequiredUrlRelations;
   #batchCreationConcurrency;
+  #memberCounterPreparation;
+  #memberCounters;
   #shuttingDown = false;
   #inFlight = new Set();
 
@@ -84,6 +86,8 @@ class BatchSendingService {
    * @param {() => string[]} [dependencies.getRequiredUrlRelations] Post relations the live routes need loaded to generate URLs (lazy routing); defaults to none
    * @param {object} [dependencies.sentry]
    * @param {number} [dependencies.batchCreationConcurrency] Maximum active preparation pages
+   * @param {boolean} [dependencies.memberCounterPreparation] Enroll newly prepared batches
+   * @param {import('../email-analytics/newsletter-member-counters').NewsletterMemberCounters} [dependencies.memberCounters]
    * @param {object} [dependencies.BEFORE_RETRY_CONFIG]
    * @param {object} [dependencies.AFTER_RETRY_CONFIG]
    * @param {object} [dependencies.MAILGUN_API_RETRY_CONFIG]
@@ -99,6 +103,8 @@ class BatchSendingService {
     sentry,
     getRequiredUrlRelations = () => [],
     batchCreationConcurrency = 2,
+    memberCounterPreparation = false,
+    memberCounters,
     BEFORE_RETRY_CONFIG,
     AFTER_RETRY_CONFIG,
     MAILGUN_API_RETRY_CONFIG,
@@ -116,6 +122,17 @@ class BatchSendingService {
       batchCreationConcurrency,
       'bulkEmail:batchCreationConcurrency',
     );
+    if (
+      typeof memberCounterPreparation !== 'boolean' ||
+      (memberCounterPreparation && !memberCounters)
+    ) {
+      throw new errors.IncorrectUsageError({
+        message:
+          'Member counter preparation requires a boolean flag and a counter service when enabled',
+      });
+    }
+    this.#memberCounterPreparation = memberCounterPreparation;
+    this.#memberCounters = memberCounters;
 
     if (BEFORE_RETRY_CONFIG) {
       this.#BEFORE_RETRY_CONFIG = BEFORE_RETRY_CONFIG;
@@ -961,6 +978,7 @@ class BatchSendingService {
       useFallbackDomain,
       batchId: ObjectID().toHexString(),
       attemptId,
+      memberCountersEnabled: this.#memberCounterPreparation,
     };
     const batch = await this.retryDb(() => this.#createOrRecoverBatch(operation), {
       ...this.#getBeforeRetryConfig(email),
@@ -1004,12 +1022,14 @@ class BatchSendingService {
   }
 
   async #createOrRecoverBatch(operation) {
-    const { email, segment, members, useFallbackDomain, batchId } = operation;
+    const { email, segment, members, useFallbackDomain, batchId, memberCountersEnabled } =
+      operation;
     try {
       return await this.createBatch(email, segment, members, {
         useFallbackDomain,
         batchId,
         recipientCount: members.length,
+        memberCountersEnabled,
       });
     } catch (error) {
       return this.#recoverCommittedBatch(operation, error);
@@ -1049,7 +1069,7 @@ class BatchSendingService {
   }
 
   #verifyRecoveredBatch(
-    { email, batchId, segment, members, useFallbackDomain },
+    { email, batchId, segment, members, useFallbackDomain, memberCountersEnabled },
     committed,
     recipients,
   ) {
@@ -1074,6 +1094,7 @@ class BatchSendingService {
       (committed.get('member_segment') ?? null) !== (segment ?? null) ||
       Boolean(committed.get('fallback_sending_domain')) !== Boolean(useFallbackDomain) ||
       committed.get('recipient_count') !== members.length ||
+      Boolean(committed.get('member_counters_enabled')) !== memberCountersEnabled ||
       JSON.stringify(identities) !== JSON.stringify(intended)
     ) {
       throw this.#verificationFailure(
@@ -1098,6 +1119,7 @@ class BatchSendingService {
    * @param {boolean} options.useFallbackDomain
    * @param {string} [options.batchId] Stable operation identity for accounted preparation
    * @param {number} [options.recipientCount] Expected size of the accounted recipient snapshot
+   * @param {boolean} [options.memberCountersEnabled] Enrollment captured for this preparation operation
    * @param {import('knex').Knex} [options.transacting]
    * @returns {Promise<EmailBatch>}
    */
@@ -1141,6 +1163,7 @@ class BatchSendingService {
         member_segment: segment,
         status: 'pending',
         fallback_sending_domain: Boolean(options.useFallbackDomain),
+        member_counters_enabled: Boolean(options.memberCountersEnabled),
         ...(options.recipientCount !== undefined
           ? { recipient_count: options.recipientCount }
           : {}),
@@ -1166,6 +1189,40 @@ class BatchSendingService {
   }
 
   async sendBatches({ email, batches, post, newsletter }) {
+    // Finish persisted enrollment even if new opt-in has since been disabled.
+    // All batches must be accounted before any provider submission can start.
+    for (const batch of batches) {
+      if (this.#shuttingDown) {
+        break;
+      }
+      if (!batch.get('member_counters_enabled')) {
+        continue;
+      }
+      if (!this.#memberCounters) {
+        throw this.#verificationFailure(email, 'member_counter_service_unavailable', {
+          batch_id: batch.id,
+        });
+      }
+      await this.retryDb(
+        async () => {
+          try {
+            await this.#memberCounters.applyPreparedBatch(batch.id);
+          } catch (error) {
+            if (error.retryable === false) {
+              throw this.#verificationFailure(email, 'member_counter_application', {
+                batch_id: batch.id,
+                error: error.message,
+              });
+            }
+            throw error;
+          }
+        },
+        {
+          ...this.#getBeforeRetryConfig(email),
+          description: `apply member counters for batch ${batch.id}`,
+        },
+      );
+    }
     logging.info(`Sending ${batches.length} batches for email ${email.id}`);
     const deadline = this.getDeliveryDeadline(email);
 

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -2,6 +2,8 @@ const debug = require('@tryghost/debug')('i18n');
 const url = require('../../api/endpoints/utils/serializers/output/utils/url');
 const events = require('../../lib/common/events');
 
+const logging = require('@tryghost/logging');
+
 class EmailServiceWrapper {
   getPostUrl(post) {
     const jsonModel = post.toJSON();
@@ -36,13 +38,15 @@ class EmailServiceWrapper {
     const MailgunClient = require('../lib/mailgun-client');
     const configService = require('../../../shared/config');
     const batchCreationConcurrency = configService.get('bulkEmail:batchCreationConcurrency');
-    const memberCounterPreparation =
-      configService.get('emailAnalytics:memberCounterPreparation') ?? false;
+    let memberCounterPreparation =
+      configService.get('emailAnalytics:memberCounterPreparation') === true;
     if (memberCounterPreparation && configService.get('emailAnalytics:batchProcessing') !== true) {
-      const errors = require('@tryghost/errors');
-      throw new errors.IncorrectUsageError({
-        message: 'Member counter preparation requires emailAnalytics.batchProcessing',
-      });
+      // Config is boundary data: a mismatch must be visible, but a newsletter
+      // counter flag must not stop the whole site from booting.
+      logging.warn(
+        '[EmailService] emailAnalytics.memberCounterPreparation requires emailAnalytics.batchProcessing; member counter preparation is off',
+      );
+      memberCounterPreparation = false;
     }
     const settingsCache = require('../../../shared/settings-cache');
     const settingsHelpers = require('../settings-helpers');

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -24,6 +24,7 @@ class EmailServiceWrapper {
     const EmailRenderer = require('./email-renderer');
     const SendingService = require('./sending-service');
     const BatchSendingService = require('./batch-sending-service');
+    const { NewsletterMemberCounters } = require('../email-analytics/newsletter-member-counters');
     const { SendingStatusService } = require('./sending-status-service');
     const EmailSegmenter = require('./email-segmenter');
     const MailgunEmailProvider = require('./mailgun-email-provider');
@@ -35,6 +36,14 @@ class EmailServiceWrapper {
     const MailgunClient = require('../lib/mailgun-client');
     const configService = require('../../../shared/config');
     const batchCreationConcurrency = configService.get('bulkEmail:batchCreationConcurrency');
+    const memberCounterPreparation =
+      configService.get('emailAnalytics:memberCounterPreparation') ?? false;
+    if (memberCounterPreparation && configService.get('emailAnalytics:batchProcessing') !== true) {
+      const errors = require('@tryghost/errors');
+      throw new errors.IncorrectUsageError({
+        message: 'Member counter preparation requires emailAnalytics.batchProcessing',
+      });
+    }
     const settingsCache = require('../../../shared/settings-cache');
     const settingsHelpers = require('../settings-helpers');
     const jobsService = require('../jobs');
@@ -130,6 +139,8 @@ class EmailServiceWrapper {
       sentry,
       getRequiredUrlRelations,
       batchCreationConcurrency,
+      memberCounterPreparation,
+      memberCounters: new NewsletterMemberCounters(db.knex),
     });
     const sendingStatusService = new SendingStatusService({ knex: db.knex });
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -300,6 +300,7 @@
   "emailAnalytics": {
     "enabled": true,
     "batchProcessing": false,
+    "memberCounterPreparation": false,
     "metrics": {
       "openThroughput": {
         "enabled": false,

--- a/ghost/core/scripts/reconcile-member-email-counters.ts
+++ b/ghost/core/scripts/reconcile-member-email-counters.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from 'node:util';
+import { setTimeout as delay } from 'node:timers/promises';
 import { IncorrectUsageError } from '@tryghost/errors';
 import type { Knex } from 'knex';
 import { NewsletterMemberCounters } from '../core/server/services/email-analytics/newsletter-member-counters';
@@ -8,21 +9,25 @@ async function main(): Promise<void> {
     options: {
       limit: { type: 'string', default: '5000' },
       pages: { type: 'string', default: '1' },
+      'pause-ms': { type: 'string', default: '0' },
       restart: { type: 'boolean', default: false },
     },
   });
   const limit = Number(values.limit);
   const pages = Number(values.pages);
+  const pauseMs = Number(values['pause-ms']);
   if (
     !Number.isInteger(limit) ||
     limit < 1 ||
     limit > 5000 ||
     !Number.isSafeInteger(pages) ||
-    pages < 1
+    pages < 1 ||
+    !Number.isSafeInteger(pauseMs) ||
+    pauseMs < 0
   ) {
     throw new IncorrectUsageError({
       message:
-        'Use --limit 1..5000 and a positive integer --pages; --restart starts a new completed sweep.',
+        'Use --limit 1..5000, a positive integer --pages and a non-negative --pause-ms between pages; --restart abandons any existing checkpoint and starts a new sweep.',
     });
   }
   const db: { knex: Knex } = require('../core/server/data/db');
@@ -33,6 +38,10 @@ async function main(): Promise<void> {
       process.stdout.write(`${JSON.stringify(state)}\n`);
       if (state.complete) {
         break;
+      }
+      if (pauseMs > 0 && page + 1 < pages) {
+        // Let member-facing writes that waited behind the page's locks proceed.
+        await delay(pauseMs);
       }
     }
   } finally {

--- a/ghost/core/scripts/reconcile-member-email-counters.ts
+++ b/ghost/core/scripts/reconcile-member-email-counters.ts
@@ -1,0 +1,48 @@
+import { parseArgs } from 'node:util';
+import { IncorrectUsageError } from '@tryghost/errors';
+import type { Knex } from 'knex';
+import { NewsletterMemberCounters } from '../core/server/services/email-analytics/newsletter-member-counters';
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      limit: { type: 'string', default: '5000' },
+      pages: { type: 'string', default: '1' },
+      restart: { type: 'boolean', default: false },
+    },
+  });
+  const limit = Number(values.limit);
+  const pages = Number(values.pages);
+  if (
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    limit > 5000 ||
+    !Number.isSafeInteger(pages) ||
+    pages < 1
+  ) {
+    throw new IncorrectUsageError({
+      message:
+        'Use --limit 1..5000 and a positive integer --pages; --restart starts a new completed sweep.',
+    });
+  }
+  const db: { knex: Knex } = require('../core/server/data/db');
+  try {
+    const counters = new NewsletterMemberCounters(db.knex);
+    for (let page = 0; page < pages; page++) {
+      const state = await counters.runSweepPage({ limit, restart: page === 0 && values.restart });
+      process.stdout.write(`${JSON.stringify(state)}\n`);
+      if (state.complete) {
+        break;
+      }
+    }
+  } finally {
+    await db.knex.destroy();
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : 'Member reconciliation failed'}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -12,6 +12,13 @@ const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
 const dbUtils = require('../../../utils/db-utils');
 const id = (n: number) => n.toString(16).padStart(24, '0');
+const nonRetryable = (pattern: RegExp) => (error: unknown) => {
+  const failure = error as { message?: string; retryable?: boolean };
+  // A deterministic failure: a caller with a retry budget must not spend it here.
+  assert.equal(failure.retryable, false);
+  assert.match(String(failure.message), pattern);
+  return true;
+};
 function sqlOf(query: unknown): string {
   if (typeof query === 'string') {
     return query;
@@ -216,14 +223,16 @@ describe('Newsletter member counter baselines through MySQL', () => {
     }
   });
 
-  it('keeps frozen legacy preparation and rejects counter-applied unfrozen legacy state', async () => {
+  it('keeps frozen legacy preparation and counter-applied unfrozen legacy state as truth', async () => {
     await recipient({ accounted: false, prepared: true });
     await recipient({ accounted: false, prepared: false });
     await counters.sweepPage({ throughId: id(3) });
     assert.equal((await stats()).email_count, 1);
+    // An applied batch can only exist through a rollback that never saved
+    // prepared_at; its recipients are frozen facts, not discardable preparation
     await recipient({ accounted: false, prepared: false, enrolled: true, applied: true });
-    await assert.rejects(counters.sweepPage({ throughId: id(3) }), /without frozen preparation/);
-    assert.equal((await stats()).email_count, 1);
+    await counters.sweepPage({ throughId: id(3) });
+    assert.equal((await stats()).email_count, 2);
   });
 
   it('commits its checkpoint with the page and resumes it after recreation', async () => {
@@ -301,6 +310,61 @@ describe('Newsletter member counter baselines through MySQL', () => {
     assert.equal(restarted.processed, 1);
     assert.equal(restarted.complete, true);
     assert.equal((await stats()).email_tracked_count, 0);
+  });
+
+  it('restart abandons an incomplete sweep and starts over from the current member range', async () => {
+    const first = await counters.runSweepPage({ limit: 2 });
+    assert.equal(first.afterId, id(2));
+    assert.equal(first.complete, false);
+    const job = () =>
+      db.knex('jobs').where('name', 'email-analytics-member-reconciliation').first();
+    const stale = new Date('2020-01-01T00:00:00Z');
+    await db
+      .knex('jobs')
+      .where('name', 'email-analytics-member-reconciliation')
+      .update({ started_at: stale });
+    // A restart is a new sweep, not a resume: it re-reads the member range from
+    // the beginning, so its first page covers members the abandoned one already had.
+    const restarted = await counters.runSweepPage({ limit: 2, restart: true });
+    assert.deepEqual(restarted, {
+      version: 1,
+      afterId: id(2),
+      throughId: id(3),
+      processed: 2,
+      complete: false,
+    });
+    const started = await job();
+    assert.equal(started.status, 'started');
+    assert.ok(started.started_at > stale);
+    await db
+      .knex('jobs')
+      .where('name', 'email-analytics-member-reconciliation')
+      .update({ started_at: stale });
+    const resumed = await counters.runSweepPage({ limit: 2 });
+    assert.equal(resumed.afterId, id(3));
+    assert.equal(resumed.processed, 3);
+    assert.deepEqual((await job()).started_at, stale);
+  });
+
+  it('stops with a non-retryable error when the checkpoint row is unreadable', async () => {
+    await recipient();
+    await counters.runSweepPage({ limit: 2 });
+    // Another writer, a restored database or a newer checkpoint format owns the
+    // row: never overwrite it silently, and never burn a retry budget on it.
+    for (const metadata of [
+      null,
+      JSON.stringify({ version: 2, afterId: null, throughId: null, processed: 0, complete: false }),
+    ]) {
+      await db
+        .knex('jobs')
+        .where('name', 'email-analytics-member-reconciliation')
+        .update({ metadata });
+      await assert.rejects(counters.runSweepPage({ limit: 2 }), nonRetryable(/--restart/));
+    }
+    const restarted = await counters.runSweepPage({ limit: 2, restart: true });
+    assert.equal(restarted.afterId, id(2));
+    assert.equal(restarted.processed, 2);
+    assert.equal((await stats()).email_count, 1);
   });
 
   it('uses a primary-key ordered locking access path on MySQL', async () => {
@@ -424,17 +488,13 @@ describe('Newsletter member counter baselines through MySQL', () => {
     assert.equal(resumed.complete, true);
   });
 
-  it('rejects rollback states that may have submitted without freezing preparation', async () => {
+  it('keeps rollback states that submitted without freezing preparation as truth', async () => {
     const { batchId } = await recipient({ prepared: false, opened: true });
     await db.knex('email_batches').where('id', batchId).update({ status: 'submitted' });
-    await assert.rejects(counters.runSweepPage({ limit: 2 }), /without frozen preparation/);
-    assert.equal((await stats()).email_tracked_count, null);
-    assert.equal((await stats()).email_opened_count, 99);
-    const job = await db
-      .knex('jobs')
-      .where('name', 'email-analytics-member-reconciliation')
-      .first();
-    assert.equal(JSON.parse(job.metadata).afterId, null);
+    const state = await counters.runSweepPage({ limit: 3 });
+    assert.equal(state.complete, true);
+    assert.equal((await stats()).email_tracked_count, 1);
+    assert.equal((await stats()).email_opened_count, 1);
   });
 
   it('resumes the source-checkout command across separate processes', async () => {
@@ -504,8 +564,27 @@ describe('Newsletter member counter baselines through MySQL', () => {
     const legacy = await recipient();
     assert.equal(await counters.applyPreparedBatch(legacy.batchId), false);
     const pending = await recipient({ enrolled: true, prepared: false });
-    await assert.rejects(counters.applyPreparedBatch(pending.batchId), /frozen preparation/);
+    await assert.rejects(
+      counters.applyPreparedBatch(pending.batchId),
+      nonRetryable(/frozen preparation/),
+    );
     assert.equal((await stats()).email_tracked_count, null);
+  });
+
+  it('reports a recipient count beyond the cap as a membership mismatch', async () => {
+    const { batchId } = await recipient({ enrolled: true });
+    await db.knex('email_batches').where('id', batchId).update({ recipient_count: 5001 });
+    // The cap guards the rows actually read, not the batch's own claim about
+    // them, so a claimed count beyond it is still only a membership mismatch.
+    await assert.rejects(
+      counters.applyPreparedBatch(batchId),
+      nonRetryable(/Prepared recipient membership does not match the batch/),
+    );
+    assert.equal(
+      (await db.knex('email_batches').where('id', batchId).first()).member_counters_applied_at,
+      null,
+    );
+    assert.equal((await stats()).email_count, 99);
   });
 
   it('rolls member initialization and increments back when the batch marker fails', async () => {

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -113,7 +113,8 @@ describe('Newsletter member counter baselines through MySQL', () => {
     await recipient({ enrolled: true });
     await recipient({ prepared: false });
     // A pre-accounting send has no preparation boundary, but remains historical truth.
-    await recipient({ accounted: false, prepared: false, tracked: false });
+    const legacy = await recipient({ accounted: false, prepared: false, tracked: false });
+    await db.knex('email_batches').where('id', legacy.batchId).update({ status: 'submitted' });
     const page = await counters.sweepPage({ throughId: id(3), limit: 2 });
     assert.deepEqual(page, { afterId: id(2), processed: 2 });
     assert.deepEqual(await stats(), {
@@ -213,6 +214,16 @@ describe('Newsletter member counter baselines through MySQL', () => {
     for (const limit of [0, -1, 5001, 1.5, NaN]) {
       await assert.rejects(counters.sweepPage({ throughId: id(3), limit }), /limit/);
     }
+  });
+
+  it('keeps frozen legacy preparation and rejects counter-applied unfrozen legacy state', async () => {
+    await recipient({ accounted: false, prepared: true });
+    await recipient({ accounted: false, prepared: false });
+    await counters.sweepPage({ throughId: id(3) });
+    assert.equal((await stats()).email_count, 1);
+    await recipient({ accounted: false, prepared: false, enrolled: true, applied: true });
+    await assert.rejects(counters.sweepPage({ throughId: id(3) }), /without frozen preparation/);
+    assert.equal((await stats()).email_count, 1);
   });
 
   it('commits its checkpoint with the page and resumes it after recreation', async () => {

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -453,4 +453,135 @@ describe('Newsletter member counter baselines through MySQL', () => {
     assert.equal(second.afterId, id(3));
     assert.equal(second.complete, true);
   });
+
+  it('hands a baseline over to preparation without adding its recipients twice', async () => {
+    await recipient({ opened: true });
+    const { batchId } = await recipient({ enrolled: true });
+    await counters.sweepPage({ throughId: id(3), limit: 3 });
+    assert.equal((await stats()).email_count, 1);
+    assert.equal(await counters.applyPreparedBatch(batchId), true);
+    assert.deepEqual(await stats(), {
+      email_count: 2,
+      email_tracked_count: 2,
+      email_opened_count: 1,
+      email_open_rate: null,
+    });
+    assert.ok(
+      (await db.knex('email_batches').where('id', batchId).first()).member_counters_applied_at,
+    );
+    assert.equal(await new NewsletterMemberCounters(db.knex).applyPreparedBatch(batchId), false);
+    await counters.sweepPage({ throughId: id(3), limit: 3 });
+    assert.equal((await stats()).email_count, 2);
+  });
+
+  it('initializes an unseen member from the same historical truth before applying preparation', async () => {
+    await recipient({ opened: true });
+    const { batchId } = await recipient({ enrolled: true, tracked: false });
+    const pending = await recipient({ enrolled: true });
+    assert.equal(await counters.applyPreparedBatch(batchId), true);
+    assert.deepEqual(await stats(), {
+      email_count: 2,
+      email_tracked_count: 1,
+      email_opened_count: 1,
+      email_open_rate: null,
+    });
+    assert.equal(await counters.applyPreparedBatch(pending.batchId), true);
+    assert.equal((await stats()).email_tracked_count, 2);
+  });
+
+  it('does not enroll historical batches or apply unfrozen preparation', async () => {
+    const legacy = await recipient();
+    assert.equal(await counters.applyPreparedBatch(legacy.batchId), false);
+    const pending = await recipient({ enrolled: true, prepared: false });
+    await assert.rejects(counters.applyPreparedBatch(pending.batchId), /frozen preparation/);
+    assert.equal((await stats()).email_tracked_count, null);
+  });
+
+  it('rolls member initialization and increments back when the batch marker fails', async () => {
+    const { batchId } = await recipient({ enrolled: true });
+    await db.knex.raw(
+      "CREATE TRIGGER member_counter_application_failure BEFORE UPDATE ON email_batches FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected application failure'",
+    );
+    try {
+      await assert.rejects(counters.applyPreparedBatch(batchId), /injected application failure/);
+      assert.equal((await stats()).email_tracked_count, null);
+      assert.equal((await stats()).email_count, 99);
+      assert.equal(
+        (await db.knex('email_batches').where('id', batchId).first()).member_counters_applied_at,
+        null,
+      );
+    } finally {
+      await db.knex.raw('DROP TRIGGER member_counter_application_failure');
+    }
+    assert.equal(await counters.applyPreparedBatch(batchId), true);
+    assert.equal((await stats()).email_count, 1);
+  });
+
+  it('applies a batch once across a lost commit acknowledgement and concurrent retries', async () => {
+    const { batchId } = await recipient({ enrolled: true });
+    const lostAckCounters = new NewsletterMemberCounters(
+      new Proxy(db.knex, {
+        get(target, property) {
+          if (property === 'transaction') {
+            return async (
+              callback: (trx: Knex.Transaction) => Promise<unknown>,
+              config?: Knex.TransactionConfig,
+            ) => {
+              await db.knex.transaction(callback, config);
+              throw Object.assign(new Error('Lost application acknowledgement'), {
+                code: 'ECONNRESET',
+              });
+            };
+          }
+          return Reflect.get(target, property);
+        },
+      }),
+    );
+    await assert.rejects(
+      lostAckCounters.applyPreparedBatch(batchId),
+      /Lost application acknowledgement/,
+    );
+    const restarted = new NewsletterMemberCounters(db.knex);
+    assert.deepEqual(
+      await Promise.all([
+        counters.applyPreparedBatch(batchId),
+        restarted.applyPreparedBatch(batchId),
+      ]),
+      [false, false],
+    );
+    assert.equal((await stats()).email_count, 1);
+    assert.equal((await stats()).email_tracked_count, 1);
+  });
+
+  it('keeps prepared totals consistent while application races the shared sweep', async () => {
+    await recipient({ opened: true });
+    const { batchId } = await recipient({ enrolled: true });
+    await Promise.all([
+      counters.applyPreparedBatch(batchId),
+      new NewsletterMemberCounters(db.knex).runSweepPage({ limit: 3 }),
+    ]);
+    assert.deepEqual(await stats(), {
+      email_count: 2,
+      email_tracked_count: 2,
+      email_opened_count: 1,
+      email_open_rate: null,
+    });
+  });
+
+  it('counts persisted recipient rows per member and updates the rate as the denominator grows', async () => {
+    for (let n = 0; n < 4; n++) {
+      await recipient({ opened: n < 2 });
+    }
+    const { batchId, recipientId } = await recipient({ enrolled: true });
+    const row = await db.knex('email_recipients').where('id', recipientId).first();
+    await db.knex('email_recipients').insert({ ...row, id: ObjectID().toHexString() });
+    await db.knex('email_batches').where('id', batchId).update({ recipient_count: 2 });
+    await counters.applyPreparedBatch(batchId);
+    assert.deepEqual(await stats(), {
+      email_count: 6,
+      email_tracked_count: 6,
+      email_opened_count: 2,
+      email_open_rate: 33,
+    });
+  });
 });

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -1,0 +1,456 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import ObjectID from 'bson-objectid';
+import type { Knex } from 'knex';
+import sinon from 'sinon';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { NewsletterMemberCounters } from '../../../../core/server/services/email-analytics/newsletter-member-counters';
+
+const models = require('../../../../core/server/models');
+const db: { knex: Knex } = require('../../../../core/server/data/db');
+const dbUtils = require('../../../utils/db-utils');
+const id = (n: number) => n.toString(16).padStart(24, '0');
+function sqlOf(query: unknown): string {
+  if (typeof query === 'string') {
+    return query;
+  }
+  assert.ok(query && typeof query === 'object' && 'sql' in query && typeof query.sql === 'string');
+  return query.sql;
+}
+
+describe('Newsletter member counter baselines through MySQL', () => {
+  let emailIds: string[];
+  let counters: NewsletterMemberCounters;
+
+  beforeAll(async () => dbUtils.reset());
+  beforeEach(async () => {
+    await db.knex('jobs').where('name', 'email-analytics-member-reconciliation').del();
+    emailIds = [];
+    counters = new NewsletterMemberCounters(db.knex);
+    await db.knex('members').insert(
+      [1, 2, 3].map((n) => ({
+        id: id(n),
+        uuid: crypto.randomUUID(),
+        transient_id: crypto.randomUUID(),
+        email: `member-counter-${n}@example.com`,
+        status: 'free',
+        email_count: 99,
+        email_opened_count: 99,
+        email_open_rate: 99,
+        created_at: new Date(),
+        updated_at: new Date(),
+      })),
+    );
+  });
+  afterEach(async () => {
+    sinon.restore();
+    await db.knex('jobs').where('name', 'email-analytics-member-reconciliation').del();
+    await db.knex('email_recipients').whereIn('email_id', emailIds).del();
+    await db.knex('email_batches').whereIn('email_id', emailIds).del();
+    await db.knex('emails').whereIn('id', emailIds).del();
+    await db
+      .knex('members')
+      .whereIn('id', [id(1), id(2), id(3)])
+      .del();
+  });
+
+  async function recipient({
+    member = 1,
+    tracked = true,
+    opened = false,
+    enrolled = false,
+    applied = false,
+    prepared = true,
+    accounted = true,
+  } = {}) {
+    const email = await models.Email.add({
+      post_id: ObjectID().toHexString(),
+      submitted_at: new Date(),
+      email_count: 1,
+      recipient_filter: 'all',
+      track_opens: tracked,
+      preflight_email_count: accounted ? 1 : null,
+      prepared_at: prepared ? new Date() : null,
+    });
+    emailIds.push(email.id);
+    const batchId = ObjectID().toHexString();
+    await db.knex('email_batches').insert({
+      id: batchId,
+      email_id: email.id,
+      status: 'pending',
+      recipient_count: 1,
+      member_counters_enabled: enrolled,
+      member_counters_applied_at: applied ? new Date() : null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    const recipientId = ObjectID().toHexString();
+    await db.knex('email_recipients').insert({
+      id: recipientId,
+      email_id: email.id,
+      batch_id: batchId,
+      member_id: id(member),
+      member_uuid: crypto.randomUUID(),
+      member_email: `member-counter-${member}@example.com`,
+      opened_at: opened ? new Date() : null,
+    });
+    return { emailId: email.id as string, batchId, recipientId };
+  }
+  const stats = (member = 1) =>
+    db
+      .knex('members')
+      .where('id', id(member))
+      .first('email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate');
+
+  it('derives legacy and applied facts, excluding pending enrollment and discardable preparation', async () => {
+    for (let n = 0; n < 4; n++) {
+      await recipient({ opened: n === 0 });
+    }
+    await recipient({ enrolled: true, applied: true });
+    await recipient({ tracked: false });
+    await recipient({ enrolled: true });
+    await recipient({ prepared: false });
+    // A pre-accounting send has no preparation boundary, but remains historical truth.
+    await recipient({ accounted: false, prepared: false, tracked: false });
+    const page = await counters.sweepPage({ throughId: id(3), limit: 2 });
+    assert.deepEqual(page, { afterId: id(2), processed: 2 });
+    assert.deepEqual(await stats(), {
+      email_count: 7,
+      email_tracked_count: 5,
+      email_opened_count: 1,
+      email_open_rate: 20,
+    });
+    assert.deepEqual(await stats(2), {
+      email_count: 0,
+      email_tracked_count: 0,
+      email_opened_count: 0,
+      email_open_rate: null,
+    });
+    assert.equal((await stats(3)).email_count, 99);
+  });
+
+  it('resumes bounded pages after recreation and safely repeats an acknowledged page', async () => {
+    await recipient({ member: 3 });
+    const first = await counters.sweepPage({ throughId: id(3), limit: 2 });
+    assert.deepEqual(await counters.sweepPage({ throughId: id(3), limit: 2 }), first);
+    const restarted = new NewsletterMemberCounters(db.knex);
+    assert.deepEqual(
+      await restarted.sweepPage({ afterId: first.afterId, throughId: id(3), limit: 2 }),
+      { afterId: id(3), processed: 1 },
+    );
+    assert.deepEqual(await restarted.sweepPage({ afterId: id(3), throughId: id(3), limit: 2 }), {
+      afterId: id(3),
+      processed: 0,
+    });
+    assert.deepEqual(await stats(3), {
+      email_count: 1,
+      email_tracked_count: 1,
+      email_opened_count: 0,
+      email_open_rate: null,
+    });
+  });
+
+  it('rolls back a failed page without publishing partial member baselines', async () => {
+    await recipient();
+    await db.knex.raw(
+      `CREATE TRIGGER member_counter_sweep_failure BEFORE UPDATE ON members FOR EACH ROW BEGIN IF NEW.id = '${id(2)}' THEN SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected sweep failure'; END IF; END`,
+    );
+    try {
+      await assert.rejects(
+        counters.sweepPage({ throughId: id(3), limit: 2 }),
+        /injected sweep failure/,
+      );
+      assert.deepEqual(await stats(), {
+        email_count: 99,
+        email_tracked_count: null,
+        email_opened_count: 99,
+        email_open_rate: 99,
+      });
+    } finally {
+      await db.knex.raw('DROP TRIGGER member_counter_sweep_failure');
+    }
+    await counters.sweepPage({ throughId: id(3), limit: 2 });
+    assert.equal((await stats()).email_count, 1);
+  });
+
+  it('reads truth after waiting for a concurrent member-locked event commit', async () => {
+    const { recipientId } = await recipient();
+    await counters.sweepPage({ throughId: id(3), limit: 3 });
+    const writer = await db.knex.transaction();
+    try {
+      await writer('members').where('id', id(1)).forUpdate().first();
+      await writer('email_recipients').where('id', recipientId).update({ opened_at: new Date() });
+      await writer('members').where('id', id(1)).update({ email_opened_count: 1 });
+      let reachedLock!: () => void;
+      const lockDispatched = new Promise<void>((resolve) => {
+        reachedLock = resolve;
+      });
+      const listener = (query: Knex.Sql) => {
+        if (query.sql.includes('members') && query.sql.includes('for update')) {
+          reachedLock();
+        }
+      };
+      db.knex.on('query', listener);
+      const sweep = counters.sweepPage({ throughId: id(3), limit: 3 });
+      try {
+        await lockDispatched;
+        await writer.commit();
+        await sweep;
+      } finally {
+        db.knex.removeListener('query', listener);
+      }
+      assert.equal((await stats()).email_opened_count, 1);
+    } finally {
+      if (!writer.isCompleted()) {
+        await writer.rollback();
+      }
+    }
+  });
+
+  it('rejects an unbounded or invalid page before querying', async () => {
+    for (const limit of [0, -1, 5001, 1.5, NaN]) {
+      await assert.rejects(counters.sweepPage({ throughId: id(3), limit }), /limit/);
+    }
+  });
+
+  it('commits its checkpoint with the page and resumes it after recreation', async () => {
+    await recipient();
+    const first = await counters.runSweepPage({ limit: 2 });
+    assert.equal(first.afterId, id(2));
+    assert.equal(first.processed, 2);
+    assert.equal(first.complete, false);
+    const job = await db
+      .knex('jobs')
+      .where('name', 'email-analytics-member-reconciliation')
+      .first();
+    assert.deepEqual(JSON.parse(job.metadata), first);
+    const restarted = new NewsletterMemberCounters(db.knex);
+    const next = await restarted.runSweepPage({ limit: 2 });
+    assert.notEqual(next.afterId, first.afterId);
+    assert.equal(next.processed, 3);
+    let final = next;
+    while (!final.complete) {
+      final = await restarted.runSweepPage({ limit: 2 });
+    }
+    assert.deepEqual(await restarted.runSweepPage({ limit: 2 }), final);
+    assert.equal((await db.knex('jobs').where('id', job.id).first()).status, 'finished');
+  });
+
+  it('rolls member updates back when persisting the checkpoint fails', async () => {
+    await recipient();
+    await db.knex.raw(
+      "CREATE TRIGGER member_counter_checkpoint_failure BEFORE UPDATE ON jobs FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected checkpoint failure'",
+    );
+    try {
+      await assert.rejects(counters.runSweepPage({ limit: 2 }), /injected checkpoint failure/);
+      assert.equal((await stats()).email_count, 99);
+      const job = await db
+        .knex('jobs')
+        .where('name', 'email-analytics-member-reconciliation')
+        .first();
+      assert.equal(JSON.parse(job.metadata).afterId, null);
+    } finally {
+      await db.knex.raw('DROP TRIGGER member_counter_checkpoint_failure');
+    }
+    assert.equal((await counters.runSweepPage({ limit: 2 })).afterId, id(2));
+    assert.equal((await stats()).email_count, 1);
+  });
+
+  it('finishes an empty range and starts another sweep only when explicitly requested', async () => {
+    await db
+      .knex('members')
+      .whereIn('id', [id(1), id(2), id(3)])
+      .del();
+    const empty = await counters.runSweepPage({ limit: 2 });
+    assert.deepEqual(empty, {
+      version: 1,
+      afterId: null,
+      throughId: null,
+      processed: 0,
+      complete: true,
+    });
+    const job = await db
+      .knex('jobs')
+      .where('name', 'email-analytics-member-reconciliation')
+      .first();
+    assert.equal(job.status, 'finished');
+    await db.knex('members').insert({
+      id: id(1),
+      uuid: crypto.randomUUID(),
+      transient_id: crypto.randomUUID(),
+      email: 'member-counter-1@example.com',
+      status: 'free',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    assert.deepEqual(await counters.runSweepPage(), empty);
+    const restarted = await counters.runSweepPage({ restart: true });
+    assert.equal(restarted.processed, 1);
+    assert.equal(restarted.complete, true);
+    assert.equal((await stats()).email_tracked_count, 0);
+  });
+
+  it('uses a primary-key ordered locking access path on MySQL', async () => {
+    const queries: Knex.Sql[] = [];
+    const listener = (query: Knex.Sql) => queries.push(query);
+    db.knex.on('query', listener);
+    try {
+      await counters.sweepPage({ throughId: id(3), limit: 2 });
+    } finally {
+      db.knex.removeListener('query', listener);
+    }
+    const locking = queries.find((query) => query.sql.includes('for update'))!;
+    assert.match(locking.sql, /FORCE INDEX \(PRIMARY\)/);
+    const [plan] = await db.knex.raw(`EXPLAIN ${locking.sql}`, locking.bindings);
+    assert.equal(plan[0].key, 'PRIMARY');
+    assert.doesNotMatch(plan[0].Extra, /filesort/i);
+  });
+
+  it('preserves an event increment that waits behind the sweep', async () => {
+    const { recipientId } = await recipient();
+    let release!: () => void;
+    const paused = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let reached!: () => void;
+    const atFacts = new Promise<void>((resolve) => {
+      reached = resolve;
+    });
+    const pausedCounters = new NewsletterMemberCounters(
+      new Proxy(db.knex, {
+        get(target, property) {
+          if (property === 'transaction') {
+            return (
+              callback: (trx: Knex.Transaction) => Promise<unknown>,
+              config?: Knex.TransactionConfig,
+            ) =>
+              db.knex.transaction(async (trx) => {
+                const original = trx.client.query.bind(trx.client);
+                const stub = sinon
+                  .stub(trx.client, 'query')
+                  .callsFake(async (connection, query) => {
+                    const sql = sqlOf(query);
+                    if (sql.startsWith('select') && sql.includes('from `email_recipients`')) {
+                      reached();
+                      await paused;
+                    }
+                    return original(connection, query);
+                  });
+                try {
+                  return await callback(trx);
+                } finally {
+                  stub.restore();
+                }
+              }, config);
+          }
+          return Reflect.get(target, property);
+        },
+      }),
+    );
+    const sweep = pausedCounters.sweepPage({ throughId: id(3), limit: 3 });
+    await atFacts;
+    const writer = await db.knex.transaction();
+    let waiting!: () => void;
+    const atLock = new Promise<void>((resolve) => {
+      waiting = resolve;
+    });
+    const listener = (query: Knex.Sql) => {
+      if (query.sql.includes('members') && query.sql.includes('for update')) {
+        waiting();
+      }
+    };
+    db.knex.on('query', listener);
+    const increment = (async () => {
+      await writer('members').where('id', id(1)).forUpdate().first();
+      await writer('email_recipients').where('id', recipientId).update({ opened_at: new Date() });
+      await writer('members').where('id', id(1)).increment('email_opened_count', 1);
+      await writer.commit();
+    })();
+    try {
+      await atLock;
+      release();
+      await sweep;
+      await increment;
+      assert.equal((await stats()).email_opened_count, 1);
+    } finally {
+      release();
+      db.knex.removeListener('query', listener);
+      if (!writer.isCompleted()) {
+        await writer.rollback();
+      }
+    }
+  });
+
+  it('resumes beyond a page whose COMMIT succeeded but acknowledgement was lost', async () => {
+    await recipient();
+    const lostAckCounters = new NewsletterMemberCounters(
+      new Proxy(db.knex, {
+        get(target, property) {
+          if (property === 'transaction') {
+            return async (
+              callback: (trx: Knex.Transaction) => Promise<unknown>,
+              config?: Knex.TransactionConfig,
+            ) => {
+              await db.knex.transaction(callback, config);
+              throw Object.assign(new Error('Lost sweep commit acknowledgement'), {
+                code: 'ECONNRESET',
+              });
+            };
+          }
+          return Reflect.get(target, property);
+        },
+      }),
+    );
+    await assert.rejects(
+      lostAckCounters.runSweepPage({ limit: 2 }),
+      /Lost sweep commit acknowledgement/,
+    );
+    assert.equal((await stats()).email_count, 1);
+    const resumed = await new NewsletterMemberCounters(db.knex).runSweepPage({ limit: 2 });
+    assert.equal(resumed.processed, 3);
+    assert.equal(resumed.complete, true);
+  });
+
+  it('rejects rollback states that may have submitted without freezing preparation', async () => {
+    const { batchId } = await recipient({ prepared: false, opened: true });
+    await db.knex('email_batches').where('id', batchId).update({ status: 'submitted' });
+    await assert.rejects(counters.runSweepPage({ limit: 2 }), /without frozen preparation/);
+    assert.equal((await stats()).email_tracked_count, null);
+    assert.equal((await stats()).email_opened_count, 99);
+    const job = await db
+      .knex('jobs')
+      .where('name', 'email-analytics-member-reconciliation')
+      .first();
+    assert.equal(JSON.parse(job.metadata).afterId, null);
+  });
+
+  it('resumes the source-checkout command across separate processes', async () => {
+    await recipient();
+    const execute = promisify(execFile);
+    const run = () =>
+      execute(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          'scripts/reconcile-member-email-counters.ts',
+          '--limit',
+          '2',
+          '--pages',
+          '1',
+        ],
+        {
+          cwd: path.resolve(__dirname, '../../../..'),
+          env: { ...process.env, NODE_OPTIONS: '--conditions=source' },
+        },
+      );
+    const first = JSON.parse((await run()).stdout.trim());
+    assert.equal(first.afterId, id(2));
+    assert.equal(first.complete, false);
+    const second = JSON.parse((await run()).stdout.trim());
+    assert.equal(second.afterId, id(3));
+    assert.equal(second.complete, true);
+  });
+});

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -1028,6 +1028,15 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     return batches;
   }
 
+  async function rememberMemberCounters() {
+    const before = await db
+      .knex('members')
+      .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate');
+    for (const { id, ...attributes } of before) {
+      memberRestorations.push({ id, attributes });
+    }
+  }
+
   for (const pendingCount of [0, 2, 4]) {
     it(`rebuilds unsent legacy preparation against current eligibility (${pendingCount} pending batches)`, async function () {
       const old = await createLegacyBatches(Array(pendingCount).fill('pending'));
@@ -1059,9 +1068,39 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
   }
 
+  it('does not baseline legacy recipients that resumed preparation will discard and replace', async function () {
+    await rememberMemberCounters();
+    await email.save({ track_opens: true }, { patch: true });
+    await createLegacyBatches(['pending', 'pending', 'pending', 'pending']);
+    const memberCounters = new NewsletterMemberCounters(db.knex);
+    await memberCounters.sweepPage();
+    await corruptMember('000000000000000000000004', { status: 'paid' });
+    service = createService({ memberCounterPreparation: true, memberCounters });
+    const batches = await service.createBatches(data);
+    for (const batch of batches) {
+      await memberCounters.applyPreparedBatch(batch.id);
+    }
+    const totals = await db
+      .knex('members')
+      .orderBy('id')
+      .select('id', 'email_count', 'email_tracked_count');
+    assert.deepEqual(
+      totals.map((row) => [row.email_count, row.email_tracked_count]),
+      [
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 0],
+      ],
+    );
+  });
+
   for (const status of ['submitting', 'submitted', 'failed']) {
     it(`preserves all legacy batches when one has started submission (${status})`, async function () {
+      await rememberMemberCounters();
       await createLegacyBatches([status, 'pending']);
+      await new NewsletterMemberCounters(db.knex).sweepPage();
+      assert.deepEqual(await db.knex('members').orderBy('id').pluck('email_count'), [0, 0, 1, 1]);
       const before = await db.knex('email_batches').where({ email_id: email.id }).orderBy('id');
       const recipients = await db
         .knex('email_recipients')

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -2232,16 +2232,30 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     assert.ok(batches.every((batch) => !abandoned.some((old) => old.id === batch.id)));
     // Enrollment is durable: disabling new opt-in must still finish these batches.
     service = createService({ memberCounters, memberCounterPreparation: false });
+    // Record state during the provider call and assert afterwards: sendBatch
+    // catches provider errors, so an assertion inside the fake would be swallowed.
+    const duringSend: { members: unknown[]; batches: unknown[] }[] = [];
     sender.send.callsFake(async () => {
-      const saved = await db.knex('members').whereIn('id', memberIds);
-      assert.ok(
-        saved.every((member) => member.email_count === 1 && member.email_tracked_count === 1),
-      );
-      const prepared = await db.knex('email_batches').where('email_id', email.id);
-      assert.ok(prepared.every((batch) => batch.member_counters_applied_at !== null));
+      duringSend.push({
+        members: await db.knex('members').whereIn('id', memberIds),
+        batches: await db.knex('email_batches').where('email_id', email.id),
+      });
       return { id: 'accepted' };
     });
     await service.sendBatches({ ...data, batches });
+    assert.equal(duringSend.length, batches.length);
+    for (const snapshot of duringSend) {
+      assert.ok(
+        (snapshot.members as { email_count: number; email_tracked_count: number }[]).every(
+          (member) => member.email_count === 1 && member.email_tracked_count === 1,
+        ),
+      );
+      assert.ok(
+        (snapshot.batches as { member_counters_applied_at: unknown }[]).every(
+          (batch) => batch.member_counters_applied_at !== null,
+        ),
+      );
+    }
     const first = await db
       .knex('members')
       .whereIn('id', memberIds)

--- a/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
+++ b/ghost/core/test/integration/services/email-service/recipient-accounting.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import type { Knex } from 'knex';
 import { recipientVerificationError } from '../../../../core/server/services/email-service/recipient-accounting';
 import { SendingStatusService } from '../../../../core/server/services/email-service/sending-status-service';
+import { NewsletterMemberCounters } from '../../../../core/server/services/email-analytics/newsletter-member-counters';
 
 const mapBatch = require('../../../../core/server/api/endpoints/utils/serializers/output/mappers/email-batches');
 const logging = require('@tryghost/logging');
@@ -139,7 +140,12 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     await db.knex('members').whereIn('id', addedMemberIds).del();
   });
 
-  function createService(): typeof service {
+  function createService(
+    counterOptions: {
+      memberCounterPreparation?: boolean;
+      memberCounters?: NewsletterMemberCounters;
+    } = {},
+  ): typeof service {
     return new BatchSendingService({
       db,
       models,
@@ -162,6 +168,7 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
       // These transaction fault injections target one operation at a time.
       // Concurrent scheduling is covered in recipient-preparation.test.ts.
       batchCreationConcurrency: 1,
+      ...counterOptions,
     });
   }
 
@@ -2141,5 +2148,78 @@ describe('Recipient accounting through MySQL and Bookshelf', function () {
     });
     // An equal-sized omission could mask the duplicate: count equations alone
     // do not establish global recipient identity uniqueness.
+  });
+  it('counts only frozen rebuilt preparation before provider submission and resumes persisted enrollment', async () => {
+    const memberCounters = new NewsletterMemberCounters(db.knex);
+    const memberIds = [1, 2, 3, 4].map((n) => n.toString(16).padStart(24, '0'));
+    const before = await db
+      .knex('members')
+      .whereIn('id', memberIds)
+      .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate');
+    for (const { id, ...attributes } of before) {
+      memberRestorations.push({ id, attributes });
+    }
+    await email.save({ track_opens: true }, { patch: true });
+    service = createService({ memberCounters, memberCounterPreparation: true });
+    const interrupted = Object.assign(new Error('interrupted preparation'), { retryable: false });
+    const create = sinon.stub(models.EmailBatch, 'add').callThrough();
+    create.onSecondCall().rejects(interrupted);
+    await assert.rejects(service.createBatches(data), /interrupted preparation/);
+    create.restore();
+    const abandoned = await db.knex('email_batches').where('email_id', email.id);
+    assert.ok(abandoned.length > 0);
+    assert.ok(
+      abandoned.every(
+        (batch) => batch.member_counters_enabled === 1 && batch.member_counters_applied_at === null,
+      ),
+    );
+    assert.equal(email.get('prepared_at'), null);
+    assert.deepEqual(
+      await db
+        .knex('members')
+        .whereIn('id', memberIds)
+        .select(
+          'id',
+          'email_count',
+          'email_tracked_count',
+          'email_opened_count',
+          'email_open_rate',
+        ),
+      before,
+    );
+
+    const batches = await service.createBatches(data);
+    assert.ok(email.get('prepared_at'));
+    assert.ok(batches.every((batch) => !abandoned.some((old) => old.id === batch.id)));
+    // Enrollment is durable: disabling new opt-in must still finish these batches.
+    service = createService({ memberCounters, memberCounterPreparation: false });
+    sender.send.callsFake(async () => {
+      const saved = await db.knex('members').whereIn('id', memberIds);
+      assert.ok(
+        saved.every((member) => member.email_count === 1 && member.email_tracked_count === 1),
+      );
+      const prepared = await db.knex('email_batches').where('email_id', email.id);
+      assert.ok(prepared.every((batch) => batch.member_counters_applied_at !== null));
+      return { id: 'accepted' };
+    });
+    await service.sendBatches({ ...data, batches });
+    const first = await db
+      .knex('members')
+      .whereIn('id', memberIds)
+      .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate');
+    await service.sendBatches({ ...data, batches: await service.getBatches(email) });
+    assert.deepEqual(
+      await db
+        .knex('members')
+        .whereIn('id', memberIds)
+        .select(
+          'id',
+          'email_count',
+          'email_tracked_count',
+          'email_opened_count',
+          'email_open_rate',
+        ),
+      first,
+    );
   });
 });

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -25,6 +25,21 @@ describe('Batch Sending Service', function () {
   });
 
   describe('constructor', function () {
+    it('rejects invalid or incomplete preparation counter configuration', function () {
+      for (const memberCounterPreparation of ['true', 1, null, true]) {
+        assert.throws(
+          () => new BatchSendingService({ memberCounterPreparation }),
+          /Member counter preparation/,
+        );
+      }
+      assert.doesNotThrow(
+        () =>
+          new BatchSendingService({
+            memberCounterPreparation: true,
+            memberCounters: { applyPreparedBatch: async () => true },
+          }),
+      );
+    });
     it('works in development mode', async function () {
       const env = process.env.NODE_ENV;
       process.env.NODE_ENV = 'development';

--- a/ghost/core/test/unit/server/services/email-service/email-service-wrapper.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service-wrapper.test.js
@@ -1,7 +1,10 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const url = require('../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
+const logging = require('@tryghost/logging');
 const EmailServiceWrapper = require('../../../../../core/server/services/email-service/email-service-wrapper');
+const membersService = require('../../../../../core/server/services/members');
+const configUtils = require('../../../../utils/config-utils');
 
 describe('EmailServiceWrapper getPostUrl', function () {
   afterEach(function () {
@@ -31,5 +34,66 @@ describe('EmailServiceWrapper getPostUrl', function () {
     new EmailServiceWrapper().getPostUrl(fakePost('post'));
 
     assert.equal(forPost.getCall(0).args[3], 'posts');
+  });
+});
+
+describe('EmailServiceWrapper member counter preparation config', function () {
+  const batchSendingPath =
+    require.resolve('../../../../../core/server/services/email-service/batch-sending-service');
+  const originalBatchSending = require.cache[batchSendingPath];
+  let captured;
+
+  beforeEach(function () {
+    captured = undefined;
+    // The unit suite shares one module registry, so the fake is swapped in for
+    // the duration of the test and put back exactly as it was found.
+    require.cache[batchSendingPath] = {
+      id: batchSendingPath,
+      filename: batchSendingPath,
+      loaded: true,
+      exports: class FakeBatchSendingService {
+        constructor(options) {
+          captured = options;
+        }
+      },
+    };
+    sinon.stub(membersService, 'api').get(() => ({ members: {} }));
+  });
+
+  afterEach(async function () {
+    if (originalBatchSending) {
+      require.cache[batchSendingPath] = originalBatchSending;
+    } else {
+      delete require.cache[batchSendingPath];
+    }
+    sinon.restore();
+    await configUtils.restore();
+  });
+
+  it('boots with preparation off and a warning when batch processing is not enabled', function () {
+    // Config is boundary data: the mismatch has to be visible without taking
+    // the whole site down over a newsletter counter flag.
+    const warn = sinon.stub(logging, 'warn');
+    configUtils.set({
+      emailAnalytics: { memberCounterPreparation: true, batchProcessing: false },
+    });
+
+    new EmailServiceWrapper().init();
+
+    assert.equal(captured.memberCounterPreparation, false);
+    assert.equal(warn.callCount, 1);
+    assert.match(warn.getCall(0).args[0], /memberCounterPreparation requires .*batchProcessing/);
+  });
+
+  it('hands preparation to batch sending when both flags are enabled', function () {
+    const warn = sinon.stub(logging, 'warn');
+    configUtils.set({
+      emailAnalytics: { memberCounterPreparation: true, batchProcessing: true },
+    });
+
+    new EmailServiceWrapper().init();
+
+    assert.equal(captured.memberCounterPreparation, true);
+    assert.equal(warn.callCount, 0);
   });
 });

--- a/ghost/core/types/tryghost__database-info.d.ts
+++ b/ghost/core/types/tryghost__database-info.d.ts
@@ -1,0 +1,18 @@
+declare module '@tryghost/database-info' {
+  import type { Knex } from 'knex';
+
+  type KnexLike = Pick<Knex, 'client'> | Knex.Transaction;
+
+  export default class DatabaseInfo {
+    constructor(knex: Knex);
+    init(): Promise<{ driver: string; database: string; engine: string; version: string }>;
+    getDriver(): string;
+    getDatabase(): string;
+    getEngine(): string;
+    getVersion(): string;
+    static isSQLite(knex: KnexLike): boolean;
+    static isSQLiteConfig(config: unknown): boolean;
+    static isMySQL(knex: KnexLike): boolean;
+    static isMySQLConfig(config: unknown): boolean;
+  }
+}


### PR DESCRIPTION
Member event counters need an initialized denominator and a reliable handoff from email preparation. If a baseline includes recipients that preparation later adds again, member totals drift before we process the first open.

This adds one bounded, resumable member sweep for initialization, future drift repair and rollback re-baselining. Preparation uses the same derived truth for uninitialized members, then applies each explicitly enrolled batch once after its recipient membership is frozen.

```text
prepare recipients → freeze membership
  for each enrolled batch, in one transaction
    lock email → batch → recipients → members
    initialize members from shared derived truth when needed
    add this batch's recipient totals
    save the application marker
  submit to the provider after every batch is accounted

shared member sweep
  lock a bounded member page
  derive truth, excluding pending enrolled batches
  commit member totals + resumable checkpoint together
```

Historical batches stay outside preparation increments. Pending enrolled batches are excluded from the baseline, and become part of derived truth in the same commit that adds their counters. Unfinished accounted preparation and unfrozen legacy sends with only pending batches are excluded because they can discard and rebuild their recipients. Frozen legacy sends, and the entire legacy set once any batch starts submission, remain historical truth. Discarded preparation does not increment anything. Retries after a lost commit acknowledgement see the persisted marker and cannot add a batch twice. Existing enrollment is honored even after new enrollment is disabled.

The sweep locks members in primary-key order before its first consistent read. Its checkpoint lives in the existing jobs table; the same mechanism can serve initialization, repair and re-baselining. An explicit source-checkout CLI runs a bounded number of pages and resumes across processes. Ambiguous preparation left by older send code is rejected for reconciliation rather than silently removed from derived truth.

`emailAnalytics.memberCounterPreparation` defaults to false and requires batched analytics. **Keep it off for live ingestion until member event integration lands in PR 5b and legacy writers have been drained.** Legacy recounts include pending recipient rows and do not follow the new member locking contract. This PR provides the preparation and initialization boundary; the later reconciliation PR owns cadence.

Validation:

- 234 MySQL newsletter/preparation tests passed across 11 files; 507 email-service unit tests passed in UTC. Core/test types, focused lint and commit hooks passed.
- Regressions cover discard/rebuild, frozen membership, persisted enrollment after flag changes, provider gating, real transaction rollback, lost commit acknowledgements, concurrent retries, sweep/application races, duplicate recipients per member, and CLI resumption across processes.
- Five independent reviews of each slice and the accumulated PR found no remaining high-confidence issues.
- Full `pnpm check` stops at the existing 452 unrelated formatting files.

An isolated synthetic benchmark uses 5,000 members and about 1.99 million historical recipient rows. The shared sweep performs 2,005,265 handler reads versus 3,985,996 for the existing joined recount, about 50% fewer. With members already initialized, preparing and accounting for 5,000 new recipients adds 15,030 reads over preparation alone (65,600 versus 50,570); first-use initialization also scans the relevant history. The measured transactional implementation does not support the earlier 34 ms sizing extrapolation. The harness disables commit flushing and binary logging, so these results support read-cost comparisons, not production write-latency or rollout-duration claims.

Stacked on the member schema in #30671, which is based on the in-review preparation stack #30592. Email-only counters remain independently reviewable in #30674 and #30675. Member event increments and periodic sweep scheduling follow separately.

ref https://linear.app/ghost/issue/BER-3934/add-incremental-email-and-member-analytics-counters

The updated base includes the schema PR's serialization correction: the internal tracked-email denominator stays out of comment reaction/report responses. The rebase changes only that two-file fix; counter and reconciliation behavior is unchanged.
