### PR TITLE
Added a shared convention for Admin 7 milestone flags

### DIFF
--- a/.agents/skills/add-private-feature-flag/SKILL.md
+++ b/.agents/skills/add-private-feature-flag/SKILL.md
@@ -13,6 +13,10 @@ Read and follow the canonical [feature flag guide](../../../docs/practices/featu
 before adding a flag. The guide covers when a Labs flag is appropriate, safe
 gating across server and Admin, testing, and the cleanup lifecycle.
 
+For Admin 7 milestone flags, also use the
+[Admin 7 feature flags skill](../admin7-feature-flags/SKILL.md) for shared resolution
+and the Shade integration contract.
+
 ## Steps
 
 1. **Add the flag to `ghost/core/core/shared/labs.js`**

--- a/.agents/skills/admin7-feature-flags/SKILL.md
+++ b/.agents/skills/admin7-feature-flags/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: admin7-feature-flags
+description: Add, consume, review, or remove Admin 7 milestone flags using the shared Admin resolver and Shade feature contract.
+---
+
+# Admin 7 milestone flags
+
+Read the canonical [Admin 7 milestone convention](../../../docs/practices/feature-flags.md#admin-7-milestones)
+before changing a milestone's gating or introducing another Admin 7 flag.
+
+1. Inspect the [Admin 7 module](../../../apps/admin/src/admin7/) and the existing
+   milestone. Identify whether the change belongs to flag resolution, shared
+   Shade presentation, or page structure before adding a check.
+2. Follow the guide's resolution and removal contract. For a new Labs key, also
+   use [Add private feature flag](../add-private-feature-flag/SKILL.md) for its
+   registration and settings integration.
+3. Verify the affected rollout boundaries using the guide's focused testing
+   policy, and report which off/on states were checked. Update the canonical
+   guide if the convention changes; keep design-specific rules in Storybook.

--- a/.claude/skills/admin7-feature-flags
+++ b/.claude/skills/admin7-feature-flags
@@ -1,0 +1,1 @@
+../../.agents/skills/admin7-feature-flags

--- a/apps/activitypub/src/app.tsx
+++ b/apps/activitypub/src/app.tsx
@@ -22,7 +22,7 @@ const App: React.FC<AppProps> = ({ framework, activityPubEnabled }) => {
     <FrameworkProvider {...framework}>
       <RouterProvider prefix={'/'} routes={routes}>
         <FeatureFlagsProvider>
-          <ShadeApp className="shade-activitypub" darkMode={false}>
+          <ShadeApp admin7={{ pill: false }} className="shade-activitypub" darkMode={false}>
             <Outlet />
           </ShadeApp>
         </FeatureFlagsProvider>

--- a/apps/admin-x-framework/src/hooks.ts
+++ b/apps/admin-x-framework/src/hooks.ts
@@ -10,7 +10,7 @@ export type {
   SaveState,
 } from './hooks/use-form';
 export { default as useHandleError } from './hooks/use-handle-error';
-export { useFeatureFlag } from './hooks/use-feature-flag';
+export { useFeatureFlag, useFeatureFlags } from './hooks/use-feature-flag';
 export { useHostLimits } from './hooks/use-host-limits';
 export type { HostLimits } from './hooks/use-host-limits';
 export { useLimiter } from './hooks/use-limiter';

--- a/apps/admin-x-framework/src/hooks/use-feature-flag.ts
+++ b/apps/admin-x-framework/src/hooks/use-feature-flag.ts
@@ -9,14 +9,14 @@ export interface FeatureFlagOptions {
 }
 
 /**
- * Returns whether a Labs flag is explicitly enabled by config or the current
- * session's URL overrides. Only boolean `true` config values count. Avoids
+ * Returns whether each requested Labs flag is explicitly enabled by config or
+ * the current session's URL overrides. Only boolean `true` config values count. Avoids
  * refetching stale config when a feature-gated component mounts.
  */
-export const useFeatureFlag = (
-  flag: string,
+export const useFeatureFlags = (
+  flags: readonly string[],
   { requestOptions, defaultErrorHandler }: FeatureFlagOptions = {},
-): boolean => {
+): Record<string, boolean> => {
   const { data: config } = useBrowseConfig({
     defaultErrorHandler,
     refetchOnMount: false,
@@ -24,5 +24,13 @@ export const useFeatureFlag = (
   });
   const { enabledFlags } = useFeatureFlagOverrides();
 
-  return config?.config.labs?.[flag] === true || enabledFlags.includes(flag);
+  return Object.fromEntries(
+    flags.map((flag) => [
+      flag,
+      config?.config.labs?.[flag] === true || enabledFlags.includes(flag),
+    ]),
+  );
 };
+
+export const useFeatureFlag = (flag: string, options?: FeatureFlagOptions): boolean =>
+  useFeatureFlags([flag], options)[flag] ?? false;

--- a/apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { useFeatureFlag } from '../../../src/hooks/use-feature-flag';
+import { useFeatureFlag, useFeatureFlags } from '../../../src/hooks/use-feature-flag';
 
 vi.mock('../../../src/api/config', () => ({
   useBrowseConfig: vi.fn(),
@@ -104,5 +104,23 @@ describe('useFeatureFlag', () => {
     const { result } = renderHook(() => useFeatureFlag('myFlag'));
 
     expect(result.current).toBe(false);
+  });
+
+  it('resolves a requested group with the same config and session override rules', () => {
+    mockUseBrowseConfig.mockReturnValue(
+      withLabs({ fromConfig: true, fromSession: false, truthy: 'true', unrelated: true }),
+    );
+    mockUseFeatureFlagOverrides.mockReturnValue({ enabledFlags: ['fromSession'] });
+
+    const { result } = renderHook(() =>
+      useFeatureFlags(['fromConfig', 'fromSession', 'truthy', 'absent']),
+    );
+
+    expect(result.current).toEqual({
+      fromConfig: true,
+      fromSession: true,
+      truthy: false,
+      absent: false,
+    });
   });
 });

--- a/apps/admin/src/admin7/features.ts
+++ b/apps/admin/src/admin7/features.ts
@@ -1,0 +1,30 @@
+import type { Admin7Features } from '@tryghost/shade/app';
+
+export type Admin7Route = {
+  pathname: string;
+  surface: 'react' | 'ember';
+};
+
+export type Admin7FeatureDefinition<Feature extends string> = {
+  flag: string;
+  title: string;
+  description: string;
+  surfaces: readonly Admin7Route['surface'][];
+  excludedRoutes: readonly RegExp[];
+  requires: readonly Feature[];
+};
+
+export const admin7Features: Record<
+  keyof Admin7Features,
+  Admin7FeatureDefinition<keyof Admin7Features>
+> = {
+  pill: {
+    flag: 'admin7Pill',
+    title: 'Admin 7 · Milestone 2 · Pill controls',
+    description:
+      'Preview Admin 7 controls and page headers on React pages. The editor is excluded.',
+    surfaces: ['react'],
+    excludedRoutes: [/^\/editor(?:\/|$)/],
+    requires: [],
+  },
+};

--- a/apps/admin/src/admin7/resolve-admin7.test.ts
+++ b/apps/admin/src/admin7/resolve-admin7.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from 'vitest';
+import type { Admin7FeatureDefinition } from './features';
+import { resolveAdmin7 } from './resolve-admin7';
+
+// Test-only milestones exercise dependencies without registering speculative flags.
+type Feature = 'foundation' | 'dependent';
+const definitions: Record<Feature, Admin7FeatureDefinition<Feature>> = {
+  foundation: {
+    flag: 'foundationFlag',
+    title: 'Foundation',
+    description: '',
+    surfaces: ['react'],
+    excludedRoutes: [/^\/editor(?:\/|$)/],
+    requires: [],
+  },
+  dependent: {
+    flag: 'dependentFlag',
+    title: 'Dependent',
+    description: '',
+    surfaces: ['react'],
+    excludedRoutes: [],
+    requires: ['foundation'],
+  },
+};
+const route = { pathname: '/members', surface: 'react' } as const;
+
+it('requires both milestone flags and never enables a prerequisite implicitly', () => {
+  expect(resolveAdmin7(definitions, { dependentFlag: true }, route)).toEqual({
+    foundation: false,
+    dependent: false,
+  });
+  expect(resolveAdmin7(definitions, { foundationFlag: true, dependentFlag: false }, route)).toEqual(
+    { foundation: true, dependent: false },
+  );
+  expect(resolveAdmin7(definitions, { foundationFlag: true, dependentFlag: true }, route)).toEqual({
+    foundation: true,
+    dependent: true,
+  });
+});
+
+it('disables dependents when their prerequisite is excluded on the current route', () => {
+  expect(
+    resolveAdmin7(
+      definitions,
+      { foundationFlag: true, dependentFlag: true },
+      { pathname: '/editor/post/new', surface: 'react' },
+    ),
+  ).toEqual({ foundation: false, dependent: false });
+});
+
+it('fails closed for circular prerequisites', () => {
+  const circular = {
+    ...definitions,
+    foundation: { ...definitions.foundation, requires: ['dependent'] satisfies Feature[] },
+  };
+  expect(resolveAdmin7(circular, { foundationFlag: true, dependentFlag: true }, route)).toEqual({
+    foundation: false,
+    dependent: false,
+  });
+});

--- a/apps/admin/src/admin7/resolve-admin7.ts
+++ b/apps/admin/src/admin7/resolve-admin7.ts
@@ -1,0 +1,37 @@
+import type { Admin7FeatureDefinition, Admin7Route } from './features';
+
+/** Resolve prerequisites on this route, not just their raw Labs values. */
+export function resolveAdmin7<Feature extends string>(
+  definitions: Record<Feature, Admin7FeatureDefinition<Feature>>,
+  flags: Readonly<Record<string, boolean | undefined>>,
+  route: Admin7Route,
+): Record<Feature, boolean> {
+  const resolved: Partial<Record<Feature, boolean>> = {};
+  const resolving = new Set<Feature>();
+
+  function isEnabled(feature: Feature): boolean {
+    if (resolved[feature] !== undefined) {
+      return resolved[feature];
+    }
+    // A mistaken dependency cycle must never expose an unfinished milestone.
+    if (resolving.has(feature)) {
+      return false;
+    }
+    resolving.add(feature);
+    const definition = definitions[feature];
+    const enabled = Boolean(
+      definition &&
+      flags[definition.flag] === true &&
+      definition.surfaces.includes(route.surface) &&
+      !definition.excludedRoutes.some((pattern) => pattern.test(route.pathname)) &&
+      definition.requires.every(isEnabled),
+    );
+    resolving.delete(feature);
+    resolved[feature] = enabled;
+    return enabled;
+  }
+
+  return Object.fromEntries(
+    (Object.keys(definitions) as Feature[]).map((feature) => [feature, isEnabled(feature)]),
+  ) as Record<Feature, boolean>;
+}

--- a/apps/admin/src/admin7/use-resolved-admin7.ts
+++ b/apps/admin/src/admin7/use-resolved-admin7.ts
@@ -1,0 +1,12 @@
+import { useFeatureFlags } from '@tryghost/admin-x-framework/hooks';
+import type { Admin7Features } from '@tryghost/shade/app';
+import { admin7Features, type Admin7Route } from './features';
+import { resolveAdmin7 } from './resolve-admin7';
+
+const flagNames = Object.values(admin7Features).map((feature) => feature.flag);
+
+/** Only the Admin root reads Labs; consumers read the resolved Shade context. */
+export function useResolvedAdmin7(route: Admin7Route): Admin7Features {
+  const flags = useFeatureFlags(flagNames);
+  return resolveAdmin7(admin7Features, flags, route);
+}

--- a/apps/admin/src/app-root.tsx
+++ b/apps/admin/src/app-root.tsx
@@ -3,19 +3,29 @@ import {
   FrameworkProvider,
   RouterProvider,
   type TopLevelFrameworkProps,
+  useLocation,
 } from '@tryghost/admin-x-framework';
 import { ShadeApp } from '@tryghost/shade/app';
 
 import App from './app.tsx';
-import { routes } from './routes.tsx';
+import { routes, useIsEmberOwnedRoute } from './routes.tsx';
+import { useResolvedAdmin7 } from './admin7/use-resolved-admin7';
 import { useThemeContext } from './providers/theme-context';
 import { ThemeProvider } from './providers/theme-provider';
 
 function ThemedAdminApp() {
   const { resolvedTheme } = useThemeContext();
+  const { pathname } = useLocation();
+  const isEmberOwnedRoute = useIsEmberOwnedRoute(pathname);
+  const admin7 = useResolvedAdmin7({ pathname, surface: isEmberOwnedRoute ? 'ember' : 'react' });
 
   return (
-    <ShadeApp className="shade-admin" darkMode={resolvedTheme === 'dark'} data-react-admin-mounted>
+    <ShadeApp
+      admin7={admin7}
+      className="shade-admin"
+      darkMode={resolvedTheme === 'dark'}
+      data-react-admin-mounted
+    >
       <App />
     </ShadeApp>
   );

--- a/apps/admin/src/layout/admin7-design.acceptance.test.tsx
+++ b/apps/admin/src/layout/admin7-design.acceptance.test.tsx
@@ -1,0 +1,30 @@
+import { expect, it } from 'vitest';
+import { fakeMembers, renderAdminApp } from '@test-utils/acceptance';
+
+// Protect the rollout boundary without prescribing the experimental appearance.
+it.each<{
+  name: string;
+  route: string;
+  labs: Record<string, boolean>;
+  enabled: boolean;
+}>([
+  { name: 'flag absent', route: '/members', labs: {}, enabled: false },
+  { name: 'flag disabled', route: '/members', labs: { admin7Pill: false }, enabled: false },
+  { name: 'flag enabled', route: '/members', labs: { admin7Pill: true }, enabled: true },
+  { name: 'Ember route excluded', route: '/site', labs: { admin7Pill: true }, enabled: false },
+  {
+    name: 'editor excluded',
+    route: '/editor/post/new',
+    labs: { admin7Pill: true },
+    enabled: false,
+  },
+])('selects the Admin 7 design only when allowed: $name', async ({ route, labs, enabled }) => {
+  fakeMembers([]);
+  await renderAdminApp(route, { labs });
+
+  await expect
+    .poll(() =>
+      document.querySelector('[data-react-admin-mounted]')?.getAttribute('data-admin7-pill'),
+    )
+    .toBe(String(enabled));
+});

--- a/apps/admin/src/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/advanced/labs/private-features.tsx
@@ -1,4 +1,5 @@
 import FeatureToggle from './feature-toggle';
+import { admin7Features } from '@/admin7/features';
 import LabItem from './lab-item';
 import React, { useEffect, useState } from 'react';
 import { ActionList } from '@tryghost/shade/components';
@@ -49,6 +50,13 @@ const features: Feature[] = [
     description: 'Enable Admin UI refresh (exploration)',
     flag: 'adminUIRefresh',
   },
+  ...Object.values(admin7Features).map(({ title, description, flag, requires }) => ({
+    title,
+    flag,
+    description: requires.length
+      ? `${description} Requires ${requires.map((feature) => admin7Features[feature].title).join(', ')} to be enabled and available on the current page.`
+      : description,
+  })),
   {
     title: 'Tags X',
     description: 'Enables the new Tags UI',

--- a/apps/shade/src/app.ts
+++ b/apps/shade/src/app.ts
@@ -2,3 +2,6 @@
 export { default as ShadeApp } from '@/shade-app';
 export type { ShadeAppProps } from '@/shade-app';
 export { useFocusContext } from '@/providers/shade-provider';
+
+export { useAdmin7 } from '@/providers/admin7-provider';
+export type { Admin7Features } from '@/providers/admin7-provider';

--- a/apps/shade/src/components/ui/alert-dialog.tsx
+++ b/apps/shade/src/components/ui/alert-dialog.tsx
@@ -3,7 +3,7 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
 import { cn } from '@/lib/utils';
 import { buttonVariants } from '@/components/ui/button';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -37,7 +37,7 @@ const AlertDialogContent = React.forwardRef<
   AlertDialogContentProps
 >(({ className, overlayClassName, ...props }, ref) => (
   <AlertDialogPortal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <AlertDialogOverlay className={overlayClassName} onClick={(e) => e.stopPropagation()} />
       <AlertDialogPrimitive.Content
         ref={ref}
@@ -47,7 +47,7 @@ const AlertDialogContent = React.forwardRef<
         )}
         {...props}
       />
-    </div>
+    </ShadeScope>
   </AlertDialogPortal>
 ));
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/context-menu.tsx
+++ b/apps/shade/src/components/ui/context-menu.tsx
@@ -3,7 +3,7 @@ import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 const ContextMenu = ContextMenuPrimitive.Root;
 
@@ -42,7 +42,7 @@ const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <div className={SHADE_APP_NAMESPACES}>
+  <ShadeScope>
     <ContextMenuPrimitive.SubContent
       ref={ref}
       className={cn(
@@ -51,7 +51,7 @@ const ContextMenuSubContent = React.forwardRef<
       )}
       {...props}
     />
-  </div>
+  </ShadeScope>
 ));
 ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 
@@ -60,7 +60,7 @@ const ContextMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <ContextMenuPrimitive.Content
         ref={ref}
         className={cn(
@@ -70,7 +70,7 @@ const ContextMenuContent = React.forwardRef<
         )}
         {...props}
       />
-    </div>
+    </ShadeScope>
   </ContextMenuPrimitive.Portal>
 ));
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/dialog.tsx
+++ b/apps/shade/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 
 import { cn } from '@/lib/utils';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -32,7 +32,7 @@ const DialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <DialogOverlay />
       <DialogPrimitive.Content
         ref={ref}
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       >
         {children}
       </DialogPrimitive.Content>
-    </div>
+    </ShadeScope>
   </DialogPortal>
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/dropdown-menu.tsx
+++ b/apps/shade/src/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import { Check, ChevronRight, Circle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { consumeOverlayEscape } from '@/lib/overlay-escape';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
@@ -42,7 +42,7 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, onEscapeKeyDown, ...props }, ref) => (
-  <div className={SHADE_APP_NAMESPACES}>
+  <ShadeScope>
     <DropdownMenuPrimitive.SubContent
       ref={ref}
       className={cn(
@@ -52,7 +52,7 @@ const DropdownMenuSubContent = React.forwardRef<
       onEscapeKeyDown={(event) => consumeOverlayEscape(event, onEscapeKeyDown)}
       {...props}
     />
-  </div>
+  </ShadeScope>
 ));
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
@@ -61,7 +61,7 @@ const DropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, onEscapeKeyDown, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <DropdownMenuPrimitive.Content
         ref={ref}
         className={cn(
@@ -73,7 +73,7 @@ const DropdownMenuContent = React.forwardRef<
         onEscapeKeyDown={(event) => consumeOverlayEscape(event, onEscapeKeyDown)}
         {...props}
       />
-    </div>
+    </ShadeScope>
   </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/hover-card.tsx
+++ b/apps/shade/src/components/ui/hover-card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 import { cn } from '@/lib/utils';
 
@@ -13,7 +13,7 @@ const HoverCardContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
   <HoverCardPrimitive.Portal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <HoverCardPrimitive.Content
         ref={ref}
         align={align}
@@ -24,7 +24,7 @@ const HoverCardContent = React.forwardRef<
         sideOffset={sideOffset}
         {...props}
       />
-    </div>
+    </ShadeScope>
   </HoverCardPrimitive.Portal>
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/popover.tsx
+++ b/apps/shade/src/components/ui/popover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 import { cn } from '@/lib/utils';
 import { consumeOverlayEscape } from '@/lib/overlay-escape';
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', onEscapeKeyDown, sideOffset = 4, ...props }, ref) => (
   <PopoverPrimitive.Portal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <PopoverPrimitive.Content
         ref={ref}
         align={align}
@@ -29,7 +29,7 @@ const PopoverContent = React.forwardRef<
         onEscapeKeyDown={(event) => consumeOverlayEscape(event, onEscapeKeyDown)}
         {...props}
       />
-    </div>
+    </ShadeScope>
   </PopoverPrimitive.Portal>
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/select.tsx
+++ b/apps/shade/src/components/ui/select.tsx
@@ -3,7 +3,7 @@ import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 import { inputSurface, inputSurfaceClasses } from '@/components/ui/input-surface';
 import { consumeOverlayEscape } from '@/lib/overlay-escape';
 const Select = SelectPrimitive.Root;
@@ -67,7 +67,7 @@ const SelectContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, onEscapeKeyDown, position = 'popper', ...props }, ref) => (
   <SelectPrimitive.Portal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <SelectPrimitive.Content
         ref={ref}
         className={cn(
@@ -92,7 +92,7 @@ const SelectContent = React.forwardRef<
         </SelectPrimitive.Viewport>
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
-    </div>
+    </ShadeScope>
   </SelectPrimitive.Portal>
 ));
 SelectContent.displayName = SelectPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/sheet.tsx
+++ b/apps/shade/src/components/ui/sheet.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 const Sheet = SheetPrimitive.Root;
 
@@ -61,7 +61,7 @@ const SheetContent = React.forwardRef<
   SheetContentProps
 >(({ side = 'right', className, children, ...props }, ref) => (
   <SheetPortal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <SheetOverlay />
       <SheetPrimitive.Content
         ref={ref}
@@ -74,7 +74,7 @@ const SheetContent = React.forwardRef<
         </SheetPrimitive.Close>
         {children}
       </SheetPrimitive.Content>
-    </div>
+    </ShadeScope>
   </SheetPortal>
 ));
 SheetContent.displayName = SheetPrimitive.Content.displayName;

--- a/apps/shade/src/components/ui/tooltip.tsx
+++ b/apps/shade/src/components/ui/tooltip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
 import { cn } from '@/lib/utils';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
@@ -15,7 +15,7 @@ const TooltipContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <TooltipPrimitive.Portal>
-    <div className={SHADE_APP_NAMESPACES}>
+    <ShadeScope>
       <TooltipPrimitive.Content
         ref={ref}
         className={cn(
@@ -25,7 +25,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         {...props}
       />
-    </div>
+    </ShadeScope>
   </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/apps/shade/src/providers/admin7-provider.tsx
+++ b/apps/shade/src/providers/admin7-provider.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext } from 'react';
+
+/** Resolved milestone availability. Hosts own Labs, route and capability checks. */
+export interface Admin7Features {
+  readonly pill: boolean;
+}
+
+// Shade previews show the intended defaults. Admin must supply resolved features.
+export const ADMIN7_PREVIEW_FEATURES: Admin7Features = { pill: true };
+
+const Admin7Context = createContext<Admin7Features>(ADMIN7_PREVIEW_FEATURES);
+
+export const useAdmin7 = () => useContext(Admin7Context);
+
+export function Admin7Provider({
+  features,
+  children,
+}: {
+  features: Admin7Features;
+  children: React.ReactNode;
+}) {
+  return <Admin7Context.Provider value={features}>{children}</Admin7Context.Provider>;
+}
+
+/** Use on the app scope and every portal scope, never on document.body. */
+export function getAdmin7ScopeAttributes(features: Admin7Features) {
+  return { 'data-admin7-pill': features.pill } satisfies {
+    [Feature in keyof Admin7Features as `data-admin7-${Feature}`]: boolean;
+  };
+}

--- a/apps/shade/src/providers/shade-provider.tsx
+++ b/apps/shade/src/providers/shade-provider.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import { GlobalDirtyStateProvider } from '../hooks/use-global-dirty-state';
 import Icon from '../components/ui/icon';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { SHADE_APP_NAMESPACES } from '@/shade-app';
+import { ShadeScope } from '@/shade-scope';
 
 interface ShadeContextType {
   isAnyTextFieldFocused: boolean;
@@ -38,7 +38,7 @@ const ToasterPortal = () => {
 
   return mounted
     ? createPortal(
-        <div className={SHADE_APP_NAMESPACES} style={{ width: 'unset', height: 'unset' }}>
+        <ShadeScope style={{ width: 'unset', height: 'unset' }}>
           <Toaster
             duration={5000}
             icons={{
@@ -60,7 +60,7 @@ const ToasterPortal = () => {
             }}
             closeButton
           />
-        </div>,
+        </ShadeScope>,
         document.body,
       )
     : null;

--- a/apps/shade/src/shade-app.tsx
+++ b/apps/shade/src/shade-app.tsx
@@ -1,6 +1,12 @@
 import clsx from 'clsx';
 import React from 'react';
-import ShadeProvider from './providers/shade-provider';
+import ShadeProvider from '@/providers/shade-provider';
+import {
+  ADMIN7_PREVIEW_FEATURES,
+  Admin7Provider,
+  type Admin7Features,
+  getAdmin7ScopeAttributes,
+} from '@/providers/admin7-provider';
 
 /**
  * The className is used to scope the styles of the app to the app's namespace.
@@ -11,14 +17,24 @@ export const SHADE_APP_NAMESPACES = 'shade shade-admin shade-activitypub';
 
 export interface ShadeAppProps extends React.HTMLProps<HTMLDivElement> {
   darkMode: boolean;
+  /** Hosts supply resolved milestones; standalone Shade previews use future defaults. */
+  admin7?: Admin7Features;
 }
 
-const ShadeApp: React.FC<ShadeAppProps> = ({ darkMode, className, children, ...props }) => {
+const ShadeApp: React.FC<ShadeAppProps> = ({
+  darkMode,
+  admin7 = ADMIN7_PREVIEW_FEATURES,
+  className,
+  children,
+  ...props
+}) => {
   const appClassName = clsx('shade', className);
 
   return (
-    <div className={appClassName} {...props}>
-      <ShadeProvider darkMode={darkMode}>{children}</ShadeProvider>
+    <div className={appClassName} {...props} {...getAdmin7ScopeAttributes(admin7)}>
+      <Admin7Provider features={admin7}>
+        <ShadeProvider darkMode={darkMode}>{children}</ShadeProvider>
+      </Admin7Provider>
     </div>
   );
 };

--- a/apps/shade/src/shade-scope.tsx
+++ b/apps/shade/src/shade-scope.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { getAdmin7ScopeAttributes, useAdmin7 } from '@/providers/admin7-provider';
+
+/** Carries the owning surface's design into portals without styling document.body. */
+export const ShadeScope = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const admin7 = useAdmin7();
+    return (
+      <div
+        ref={ref}
+        className={cn('shade shade-admin shade-activitypub', className)}
+        {...props}
+        {...getAdmin7ScopeAttributes(admin7)}
+      />
+    );
+  },
+);
+ShadeScope.displayName = 'ShadeScope';

--- a/apps/shade/test/unit/components/ui/design-compatibility.test.tsx
+++ b/apps/shade/test/unit/components/ui/design-compatibility.test.tsx
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ShadeApp } from '../../../../src/app';
+import { Popover, PopoverContent, PopoverTrigger } from '../../../../src/components/ui/popover';
+
+it('keeps each portaled menu in its owning design scope without changing the document', () => {
+  render(
+    <ShadeApp darkMode={false}>
+      <Popover open>
+        <PopoverTrigger>Admin 7 menu</PopoverTrigger>
+        <PopoverContent>Admin 7 content</PopoverContent>
+      </Popover>
+      <ShadeApp admin7={{ pill: false }} darkMode={false}>
+        <Popover open>
+          <PopoverTrigger>Previous menu</PopoverTrigger>
+          <PopoverContent>Previous content</PopoverContent>
+        </Popover>
+      </ShadeApp>
+    </ShadeApp>,
+  );
+
+  expect(
+    screen.getByText('Admin 7 content').closest('.shade')?.getAttribute('data-admin7-pill'),
+  ).toBe('true');
+  expect(
+    screen.getByText('Previous content').closest('.shade')?.getAttribute('data-admin7-pill'),
+  ).toBe('false');
+  expect(document.body.hasAttribute('data-admin7-pill')).toBe(false);
+});

--- a/docs/practices/feature-flags.md
+++ b/docs/practices/feature-flags.md
@@ -92,6 +92,96 @@ Keep the decision at the boundary that owns the behavior. Hiding a button does
 not protect a server endpoint, and rejecting an endpoint does not give Admin a
 usable disabled state.
 
+## Admin 7 milestones
+
+Admin 7 milestones use the existing private Labs flags and session overrides.
+Each milestone has a descriptive `admin7` key, such as `admin7Pill`, and a Labs
+label that identifies its milestone and purpose: “Admin 7 · Milestone 2 · Pill
+controls.” Keep the key stable as the implementation evolves.
+
+The [Admin 7 registry](../../apps/admin/src/admin7/features.ts) records each
+milestone's Labs key, title, description, supported surfaces, route exclusions
+and explicit `requires` dependencies. The Admin root calls
+[`useResolvedAdmin7`](../../apps/admin/src/admin7/use-resolved-admin7.ts), which
+resolves that registry against effective Labs values and the current route,
+then passes the complete result to Shade. An enabled Labs flag is a request to preview a
+milestone; the resolved value means that milestone is allowed on this screen.
+
+### Resolve once, consume by milestone
+
+Use `useAdmin7().pill` from `@tryghost/shade/app` for the pill milestone. A single `isAdmin7Design` boolean
+would conflate independent milestones as the redesign grows. Pages and shared
+controls consume the resolved milestone values rather than reading raw Labs
+flags or repeating route checks.
+
+Resolution preserves Admin's existing session overrides. Missing flags and
+loading configuration resolve to off unless a session override enables them.
+Overrides still obey surface restrictions and dependencies. Permanent permission
+checks and backend capability checks remain separate from milestone rollout;
+removing a flag must not remove those checks.
+
+Milestones are independent unless the registry explicitly declares a dependency.
+A dependent milestone requires its own flag and every prerequisite to be enabled
+and supported on the current screen. Invalid or cyclic dependencies resolve to
+off. Enabling a milestone never silently enables other toggles. Describe actual
+prerequisites in its Labs description so a disabled dependency is understandable.
+
+### Keep presentation in Shade
+
+The host supplies all resolved values at the shared application boundary:
+
+```tsx
+<ShadeApp darkMode={darkMode} admin7={admin7}>
+  <App />
+</ShadeApp>
+```
+
+Shade knows the resolved features, not Labs storage or Admin routes. Shared
+components and recipes own appearance; ordinary callers keep using `<Button>`
+without a per-button milestone prop. Pages may use `useAdmin7()` for structural
+or interaction differences that belong to that page. Keep flag checks at those
+shared boundaries rather than distributing identical classes across consumers.
+
+Isolated Shade previews default milestone values to true. Those values affect
+appearance when shared controls adopt the milestone. Admin always supplies the
+complete resolved object, so a missing production flag cannot inherit the
+preview default. Standalone hosts must explicitly choose their supported
+milestones. Shade propagates the same values into portaled menus, tooltips and
+dialogs through its scope wrapper; global attributes on `document.body` would
+allow one host to change another's design.
+
+### Pill milestone
+
+`admin7Pill` resolves to `pill`. Its scope is shared pill geometry, control and
+header styling, and the accompanying header interactions. Registering and
+resolving the flag does not itself change appearance; each adoption uses the
+resolved value to gate those changes. It has no milestone
+prerequisites. It applies to React Admin routes, excluding the editor; Ember-owned
+routes and the standalone ActivityPub preview resolve to `pill: false`. The
+embedded ActivityPub routes inherit Admin's resolved values.
+
+The CSS boundary is `data-admin7-pill`. Changes to colors, spacing, strokes and
+pressed states belong in Shade's scoped tokens, recipes or shared controls.
+Page-level differences such as action order use the same resolved `pill` value.
+
+### Review and remove a milestone
+
+For each milestone, record its scope, restrictions, dependencies and removal steps
+alongside its registry entry or focused design documentation. Keep automated
+checks concentrated on the rollout boundary: absent/off/on flags, supported
+surfaces, exclusions, real dependencies and portal isolation. Preserve existing
+behavioral coverage. Styling-only changes do not need unit, acceptance or CSS
+assertion suites. Review both designs visually; private dogfooding can exercise
+experimental interactions before they become a permanent contract.
+
+Follow the normal promotion lifecycle below. As controls adopt the pill
+milestone, make their enabled behavior the intended default. When removing the
+flag, keep those branches, remove any previous token scope and fallback props,
+and delete `pill` from the registry and Shade's temporary feature contract. Remove its Labs toggle, raw key, scope attribute and boundary-only tests.
+Ordinary component calls should then use the intended defaults. Resolve dependent
+milestones before deleting a prerequisite, and retain any permanent route,
+permission or backend requirements that still apply after rollout.
+
 ## How values are resolved
 
 For normal Labs flags, later sources in this list override earlier ones:

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -47,6 +47,7 @@ const PRIVATE_FEATURES = [
   'importMemberTier',
   'csvContentImporter',
   'adminUIRefresh',
+  'admin7Pill',
   'tagsX',
   'emailUniqueid',
   'improveSendingUI',

--- a/ghost/core/test/e2e-api/admin/config.test.js
+++ b/ghost/core/test/e2e-api/admin/config.test.js
@@ -61,6 +61,9 @@ describe('Config API', function () {
             labsValues.every((value) => typeof value === 'boolean'),
             'expected all labs flags to be booleans',
           );
+          // Fixture setup enables every registered writable flag. Keep an
+          // explicit assertion while this private rollout uses dynamic snapshots.
+          assert.equal(labs.admin7Pill, true);
         })
         .matchHeaderSnapshot({
           'content-version': anyContentVersion,


### PR DESCRIPTION
Superseded by #30682. The separate Admin 7 registry, dependency resolver, provider, and batch hook have been removed.

The shared-controls PR now targets main and uses the existing Labs hook at the Admin root, passing one `isAdmin7Pill` boolean through the existing Shade provider. #30666 contains page adoption on top of it.

There are now two review units: shared Shade controls (#30682), then Admin page adoption (#30666). This infrastructure PR should not be merged.
