### PR TITLE
Fixed scheduled newsletter publishes deadlocking on their own email

### DIFF
--- a/ghost/core/core/server/services/posts/post-scheduling.js
+++ b/ghost/core/core/server/services/posts/post-scheduling.js
@@ -3,7 +3,6 @@ const errors = require('@tryghost/errors');
 const moment = require('moment');
 const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils').default;
-const models = require('../../models');
 const api = require('../../api').endpoints;
 
 const messages = {
@@ -17,6 +16,20 @@ const messages = {
 // retrying a publish that will never happen.
 const NO_OP = { scheduledResource: null, preScheduledResource: null };
 
+// A scheduler may deliver the same job twice, and the two deliveries can
+// overlap: a persistent queue can hold two jobs for one post and fire both in
+// the same tick. Deliveries for one resource are chained so the second runs
+// only after the first has finished, finds nothing left to publish and takes
+// the no-op path instead of publishing (and emailing) again.
+//
+// This is deliberately an in-process chain rather than a database row lock.
+// Publishing creates the newsletter email outside the edit's transaction and
+// hands it to the batch sender straight away, so a row lock held across the
+// edit blocks that insert on the locked post (and on gap locks from the
+// eagerly loaded relations) until the lock wait timeout, which fails the
+// publish and stalls unrelated writes in the meantime.
+const inFlight = new Map();
+
 /**
  * Publishes scheduled resource (a post or a page at the moment of writing)
  *
@@ -28,16 +41,22 @@ const NO_OP = { scheduledResource: null, preScheduledResource: null };
  *   `scheduledResource: null` when there was nothing to publish yet
  */
 exports.publish = async (resourceType, id, force, options) => {
-  // A scheduler may deliver the same job twice, and the two deliveries can
-  // overlap. Read and edit inside one transaction with the row locked so the
-  // second delivery waits for the first to commit, then finds nothing left to
-  // publish and takes the no-op path instead of publishing (and emailing) again.
-  if (!options.transacting) {
-    return models.Base.transaction((transacting) =>
-      exports.publish(resourceType, id, force, { ...options, transacting, forUpdate: true }),
-    );
-  }
+  const key = `${resourceType}:${id}`;
+  const previous = inFlight.get(key) || Promise.resolve();
+  const current = previous.catch(() => {}).then(() => publishNow(resourceType, id, force, options));
 
+  inFlight.set(key, current);
+
+  try {
+    return await current;
+  } finally {
+    if (inFlight.get(key) === current) {
+      inFlight.delete(key);
+    }
+  }
+};
+
+const publishNow = async (resourceType, id, force, options) => {
   const publishAPostBySchedulerToleranceInMinutes =
     config.get('times').publishAPostBySchedulerToleranceInMinutes;
 
@@ -56,8 +75,8 @@ exports.publish = async (resourceType, id, force, options) => {
     throw err;
   }
 
-  // The read above is filtered to scheduled resources, so a resource that
-  // another delivery has already published normally surfaces as NotFound.
+  // The read above is filtered to scheduled resources, so a resource that an
+  // earlier delivery has already published normally surfaces as NotFound.
   // Keep an explicit check so the outcome doesn't depend on that filter.
   if (preScheduledResource.status !== 'scheduled') {
     return NO_OP;

--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -9,6 +9,7 @@ const SchedulingDefault =
 const models = require('../../../../core/server/models');
 const config = require('../../../../core/shared/config');
 const testUtils = require('../../../utils');
+const { mockManager } = require('../../../utils/e2e-framework');
 const localUtils = require('./utils');
 
 describe('Schedules API', function () {
@@ -21,13 +22,17 @@ describe('Schedules API', function () {
   });
 
   afterAll(function () {
+    mockManager.restore();
     sinon.restore();
   });
 
   beforeAll(async function () {
     await localUtils.startGhost();
+    mockManager.mockMailgun();
 
     request = supertest.agent(config.get('url'));
+
+    const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
 
     resources.push(
       testUtils.DataGenerator.forKnex.createPost({
@@ -106,6 +111,9 @@ describe('Schedules API', function () {
         published_at: moment().subtract(10, 'seconds').toDate(),
         status: 'scheduled',
         slug: 'sixth',
+        // Publishing with a newsletter creates the email, which is the path
+        // that must run exactly once when deliveries overlap
+        newsletter_id: defaultNewsletter.id,
         authors: [
           {
             id: testUtils.getExistingData().users[0].id,
@@ -246,6 +254,12 @@ describe('Schedules API', function () {
         { context: { internal: true } },
       );
       assert.equal(post.get('status'), 'published');
+
+      const emails = await models.Email.findAll({
+        filter: `post_id:'${resources[5].id}'`,
+        context: { internal: true },
+      });
+      assert.equal(emails.length, 1, 'the newsletter email is created once');
     });
 
     it('a deleted resource is a no-op, not an error', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1983

The previous commit ran the scheduled publish read and edit inside one transaction with the post row locked for update, so overlapping deliveries would serialise on the database. That lock is applied to every eagerly loaded relation of the post as well, which on MySQL means gap locks on the `emails`, `posts_authors` and similar indexes. Publishing a post with a newsletter then creates the email outside that transaction and hands it to the batch sender straight away, so the insert waits on the locked post until the InnoDB lock wait timeout and the publish fails with the transaction rolled back. Any unrelated post insert in the meantime waits on the same gap locks, which is how the email preview acceptance test timed out in CI once a file earlier in the same worker had left a listening server for the scheduler to ping.

Deliveries for one resource are now chained in process instead: the second runs after the first has finished, reads the post, finds it is no longer scheduled and takes the existing no-op path. This covers the production case of two jobs for one post firing in the same tick, and removes the row lock from the publish path entirely. The legacy overlapping-deliveries test now publishes a post with a newsletter and asserts the email is created once, which fails against the row lock.
