### PR TITLE
Added atomic member open counters and comparison mode

### DIFF
--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -89,8 +89,9 @@ Comparison retains email recount load until the incremental mode is enabled.
 
 `emailAnalytics.memberCounterMode` defaults to `off`. Its `compare` mode requires
 `batchProcessing: true`, an enabled email counter mode, and
-`memberCounterPreparation: true`. The mode is selected at boot. Automation and
-gift processing keep their existing outcome APIs.
+`memberCounterPreparation: true`; an unknown value or a missing prerequisite is
+logged at boot and leaves member counters off. The mode is selected at boot.
+Automation and gift processing keep their existing outcome APIs.
 
 Preparation maintains member recipient totals and the tracked-email denominator.
 Event ingestion locks the email, eligible recipient rows, and then members before
@@ -99,8 +100,11 @@ derived truth before recipient writes. Exact first-open transitions then update
 member open counts and rates in the recipient transaction. Multiple recipient rows
 for the same member each contribute once. Opens from untracked emails still count
 in the numerator, matching existing semantics; rates remain null below five
-tracked emails. An event for pending enrolled preparation is rejected until its
-denominator has been applied.
+tracked emails. An event that arrives before its batch's denominator was applied,
+which only an abandoned preparation or a rollback to older send code can produce,
+is stored without member increments and logged: comparison then reports the
+member drift and the shared sweep repairs it, rather than one email stalling
+every newsletter's ingestion.
 
 Comparison replaces legacy member recount writes with observe-only derived truth
 under the same member locks. It always includes opens, regardless of the fetch
@@ -111,8 +115,8 @@ candidates and legacy recount recovery remain intact.
 
 Drift logs contain member IDs and actual/expected values for differing statistics.
 `email_analytics_member_counter_comparisons` counts initialized observations by
-`statistic`; `email_analytics_member_counter_drift` adds absolute differences.
-A null-versus-numeric rate mismatch adds one. Comparison does not repair counters;
+`statistic` and `phase`; `email_analytics_member_counter_drift` adds absolute
+differences with the same labels. A null-versus-numeric rate mismatch adds one. Comparison does not repair counters;
 the shared sweep owns repair. Comparison retains historical read cost during the
 soak; removing those reads and scheduling periodic repair follow separately.
 

--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -15,9 +15,9 @@ email counters atomically with recipient transitions:
 | `incremental` | Defer recounts                          | Recount all outcomes and repair drift   |
 
 Enable `incremental` only after a comparison soak has established correctness.
-This removes email recounts from intermediate aggregation. Member statistics
-still use recomputation, including replayed members needed to recover an
-interrupted recount.
+This removes email recounts from intermediate aggregation. With member counter
+mode off, member statistics still use recomputation, including replayed members
+needed to recover an interrupted recount.
 
 The mode is selected at analytics boot. Stop and drain existing analytics
 workers before changing modes, then restart them with the same configuration.
@@ -84,3 +84,51 @@ counter lock, not the source of correctness.
 This email-only mode does not remove member history queries. Removing those
 requires initialized member counters and scheduled member reconciliation.
 Comparison retains email recount load until the incremental mode is enabled.
+
+## Newsletter member counters
+
+`emailAnalytics.memberCounterMode` defaults to `off`. Its `compare` mode requires
+`batchProcessing: true`, an enabled email counter mode, and
+`memberCounterPreparation: true`. The mode is selected at boot. Automation and
+gift processing keep their existing outcome APIs.
+
+Preparation maintains member recipient totals and the tracked-email denominator.
+Event ingestion locks the email, eligible recipient rows, and then members before
+either baseline establishes a snapshot. NULL member baselines use the shared
+derived truth before recipient writes. Exact first-open transitions then update
+member open counts and rates in the recipient transaction. Multiple recipient rows
+for the same member each contribute once. Opens from untracked emails still count
+in the numerator, matching existing semantics; rates remain null below five
+tracked emails. An event for pending enrolled preparation is rejected until its
+denominator has been applied.
+
+Comparison replaces legacy member recount writes with observe-only derived truth
+under the same member locks. It always includes opens, regardless of the fetch
+lane. NULL baselines are skipped rather than reported as drift. Only members with
+committed recipient transitions are queued for comparison; duplicate replay no
+longer needs to recover a separate member write. With member mode off, replay
+candidates and legacy recount recovery remain intact.
+
+Drift logs contain member IDs and actual/expected values for differing statistics.
+`email_analytics_member_counter_comparisons` counts initialized observations by
+`statistic`; `email_analytics_member_counter_drift` adds absolute differences.
+A null-versus-numeric rate mismatch adds one. Comparison does not repair counters;
+the shared sweep owns repair. Comparison retains historical read cost during the
+soak; removing those reads and scheduling periodic repair follow separately.
+
+For cutover, stop and drain analytics and sending workers. Complete a fresh full
+member baseline while legacy writers remain stopped; if an older partial sweep
+exists, finish it and then use `--restart` for a fresh pass under this boundary.
+Enable member preparation and comparison together when restarting workers. Email
+baseline correction remains limited to touched emails and always includes opens.
+After cutover, member event updates, preparation and the manual sweep share the
+locking protocol and can run together.
+
+For the configuration fallback, drain both kinds of worker and resolve any
+enrolled batches still awaiting application before disabling member preparation
+and member counter mode together. Legacy member recomputation then resumes.
+Stop counter sweeps while legacy writers run; re-enable only after another
+drained baseline. The current sending code honors persisted enrollment, but an
+older send binary may not, so unresolved enrolled preparation must be reconciled
+before a binary rollback. Keep this fallback until the fleet rollout and retained
+aggregation paths have been decided.

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -25,7 +25,6 @@ import type DomainEvents from '@tryghost/domain-events';
 import { Queries } from './lib/queries';
 import { NewsletterEmailCounters } from './newsletter-email-counters';
 import { NewsletterMemberCounters } from './newsletter-member-counters';
-import { IncorrectUsageError } from '@tryghost/errors';
 import { StartEmailAnalyticsJobEvent } from './events/start-email-analytics-job-event';
 import { StartAutomationEmailAnalyticsJobEvent } from './events/start-automation-email-analytics-job-event';
 import { AUTOMATION_EMAIL_TAG } from '../member-welcome-emails/constants';
@@ -80,6 +79,40 @@ export function resolveEmailCounterMode(
   return mode;
 }
 
+const MemberCounterMode = z.enum(['off', 'compare']);
+type MemberCounterMode = z.infer<typeof MemberCounterMode>;
+
+/**
+ * Member counters build on batched email counters and preparation accounting.
+ * Like the email mode, a mismatch is logged and leaves the mode off rather
+ * than stopping the site from booting.
+ */
+export function resolveMemberCounterMode(
+  config: Pick<ConfigInstance, 'get'>,
+  emailCounterMode: Exclude<EmailCounterMode, 'off'> | null,
+): Exclude<MemberCounterMode, 'off'> | null {
+  const configured: unknown = config.get('emailAnalytics:memberCounterMode') ?? 'off';
+  const parsed = MemberCounterMode.safeParse(configured);
+  if (!parsed.success) {
+    logging.warn(
+      `[EmailAnalytics] Ignoring unknown emailAnalytics.memberCounterMode ${JSON.stringify(configured)}; member counters are off`,
+    );
+    return null;
+  }
+  const mode = parsed.data;
+  if (mode === 'off') {
+    return null;
+  }
+  if (!emailCounterMode || config.get('emailAnalytics:memberCounterPreparation') !== true) {
+    logging.warn(
+      `[EmailAnalytics] emailAnalytics.memberCounterMode ${mode} requires batched email counters and emailAnalytics.memberCounterPreparation; member counters are off`,
+    );
+    return null;
+  }
+  logging.info(`[EmailAnalytics] Newsletter member counter mode: ${mode}`);
+  return mode;
+}
+
 export const init = ({
   automationsApi,
   config,
@@ -119,24 +152,9 @@ export const init = ({
   const emailCounters = emailCounterMode
     ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient, mode: emailCounterMode })
     : null;
-  const memberCounterMode = config.get('emailAnalytics:memberCounterMode') ?? 'off';
-  if (memberCounterMode !== 'off' && memberCounterMode !== 'compare') {
-    throw new IncorrectUsageError({ message: 'Unknown member counter mode' });
-  }
-  if (
-    memberCounterMode === 'compare' &&
-    (config.get('emailAnalytics:batchProcessing') !== true ||
-      !emailCounters ||
-      config.get('emailAnalytics:memberCounterPreparation') !== true)
-  ) {
-    throw new IncorrectUsageError({
-      message: 'Member counters require batched email counters and member counter preparation',
-    });
-  }
-  const memberCounters =
-    memberCounterMode === 'compare'
-      ? new NewsletterMemberCounters(db.knex, { prometheusClient })
-      : null;
+  const memberCounters = resolveMemberCounterMode(config, emailCounterMode)
+    ? new NewsletterMemberCounters(db.knex, { prometheusClient })
+    : null;
 
   const newsletterEmailEventProcessor = new EmailEventProcessor({
     domainEvents,

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -24,6 +24,8 @@ import type { EmailRecipientFailure, EmailSpamComplaintEvent, Email } from '../.
 import type DomainEvents from '@tryghost/domain-events';
 import { Queries } from './lib/queries';
 import { NewsletterEmailCounters } from './newsletter-email-counters';
+import { NewsletterMemberCounters } from './newsletter-member-counters';
+import { IncorrectUsageError } from '@tryghost/errors';
 import { StartEmailAnalyticsJobEvent } from './events/start-email-analytics-job-event';
 import { StartAutomationEmailAnalyticsJobEvent } from './events/start-automation-email-analytics-job-event';
 import { AUTOMATION_EMAIL_TAG } from '../member-welcome-emails/constants';
@@ -117,12 +119,31 @@ export const init = ({
   const emailCounters = emailCounterMode
     ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient, mode: emailCounterMode })
     : null;
+  const memberCounterMode = config.get('emailAnalytics:memberCounterMode') ?? 'off';
+  if (memberCounterMode !== 'off' && memberCounterMode !== 'compare') {
+    throw new IncorrectUsageError({ message: 'Unknown member counter mode' });
+  }
+  if (
+    memberCounterMode === 'compare' &&
+    (config.get('emailAnalytics:batchProcessing') !== true ||
+      !emailCounters ||
+      config.get('emailAnalytics:memberCounterPreparation') !== true)
+  ) {
+    throw new IncorrectUsageError({
+      message: 'Member counters require batched email counters and member counter preparation',
+    });
+  }
+  const memberCounters =
+    memberCounterMode === 'compare'
+      ? new NewsletterMemberCounters(db.knex, { prometheusClient })
+      : null;
 
   const newsletterEmailEventProcessor = new EmailEventProcessor({
     domainEvents,
     db,
     eventStorage: new NewsletterEmailEventStorage({
       emailCounters,
+      memberCounters,
       config,
       db,
       membersRepository,
@@ -177,6 +198,7 @@ export const init = ({
     createEventProcessor: () =>
       new NewsletterEmailAnalyticsBatchProcessor({
         emailCounters,
+        memberCounters,
         config,
         emailEventProcessor: newsletterEmailEventProcessor,
         prometheusClient,

--- a/ghost/core/core/server/services/email-analytics/lib/counter-metrics.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/counter-metrics.ts
@@ -1,0 +1,24 @@
+import logging from '@tryghost/logging';
+import type { PrometheusClient } from '@tryghost/prometheus-metrics';
+
+export type CounterMetricsClient = Pick<PrometheusClient, 'registerCounter' | 'getMetric'>;
+
+/**
+ * Increment a registered counter without letting a metrics failure interrupt
+ * the counter work that produced the observation.
+ */
+export function incrementCounter(
+  client: CounterMetricsClient | null | undefined,
+  name: string,
+  labels: Record<string, string>,
+  value: number,
+): void {
+  try {
+    const metric = client?.getMetric(name);
+    if (metric && 'inc' in metric) {
+      metric.inc(labels, value);
+    }
+  } catch (error) {
+    logging.error(`[EmailAnalytics] Error recording ${name}`, error);
+  }
+}

--- a/ghost/core/core/server/services/email-analytics/lib/transaction-with-retry.ts
+++ b/ghost/core/core/server/services/email-analytics/lib/transaction-with-retry.ts
@@ -14,10 +14,11 @@ const MAX_ATTEMPTS = 3;
 export async function transactionWithRetry<T>(
   knex: Pick<Knex, 'transaction'>,
   callback: (trx: Knex.Transaction) => Promise<T>,
+  config?: Knex.TransactionConfig,
 ): Promise<T> {
   for (let attempt = 0; ; attempt += 1) {
     try {
-      return await knex.transaction(callback);
+      return await knex.transaction(callback, config);
     } catch (error) {
       const code =
         typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined;

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -15,15 +15,24 @@ class NewsletterEmailAnalyticsBatchProcessor {
   #prometheusClient;
   #queries;
   #emailCounters;
+  #memberCounters;
 
   #lastAggregation = Date.now();
 
-  constructor({ config, emailEventProcessor, prometheusClient, queries, emailCounters = null }) {
+  constructor({
+    config,
+    emailEventProcessor,
+    prometheusClient,
+    queries,
+    emailCounters = null,
+    memberCounters = null,
+  }) {
     this.#config = config;
     this.#emailEventProcessor = emailEventProcessor;
     this.#prometheusClient = prometheusClient;
     this.#queries = queries;
     this.#emailCounters = emailCounters;
+    this.#memberCounters = memberCounters;
   }
 
   /**
@@ -58,15 +67,25 @@ class NewsletterEmailAnalyticsBatchProcessor {
           }
 
           // batchResult lists every matched member, not only those whose row will
-          // transition in the flush. Keep replayed members eligible for recount
-          // until counters are written atomically with recipient transitions: a
-          // prior run may have committed the recipient update but failed before
-          // refreshing member statistics.
-          result.merge(batchResult);
+          // transition in the flush. Without atomic member counters, keep replayed
+          // members eligible for recount: a prior run may have committed the
+          // recipient update but failed before refreshing member statistics.
+          // Atomic member mode instead queues only the exact committed transition
+          // sets below.
+          result.merge(this.#memberCounters ? { ...batchResult, memberIds: [] } : batchResult);
         }
 
         // Flush all batched updates to the database
-        await this.#emailEventProcessor.flushBatchedUpdates();
+        const transitions = await this.#emailEventProcessor.flushBatchedUpdates();
+        if (this.#memberCounters) {
+          for (const transition of transitions) {
+            result.merge({
+              memberIds: ['delivered', 'opened', 'failed'].flatMap((type) =>
+                transition[type].map((row) => row.memberId),
+              ),
+            });
+          }
+        }
       } finally {
         // The storage is shared across fetch jobs. Nothing queued for this page
         // may outlive it: a failure anywhere above leaves the cursor behind, and
@@ -338,6 +357,9 @@ class NewsletterEmailAnalyticsBatchProcessor {
    * @returns {Promise<void>}
    */
   async #aggregateMemberStatsBatch(memberIds) {
+    if (this.#memberCounters) {
+      return this.#memberCounters.compareMembers(memberIds);
+    }
     return this.#queries.aggregateMemberStatsBatch(memberIds);
   }
 }

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -72,7 +72,12 @@ class NewsletterEmailAnalyticsBatchProcessor {
           // recipient update but failed before refreshing member statistics.
           // Atomic member mode instead queues only the exact committed transition
           // sets below.
-          result.merge(this.#memberCounters ? { ...batchResult, memberIds: [] } : batchResult);
+          if (this.#memberCounters) {
+            // emailIds is a getter, so a spread of the result would drop it
+            result.merge({ ...batchResult, emailIds: batchResult.emailIds, memberIds: [] });
+          } else {
+            result.merge(batchResult);
+          }
         }
 
         // Flush all batched updates to the database

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
@@ -5,6 +5,7 @@ import type { PrometheusClient } from '@tryghost/prometheus-metrics';
 import { z } from 'zod';
 import { DbCount } from '../../lib/db-types/count';
 import { transactionWithRetry } from './lib/transaction-with-retry';
+import { incrementCounter } from './lib/counter-metrics';
 
 const events = ['delivered', 'opened', 'failed'] as const;
 type Event = (typeof events)[number];
@@ -303,13 +304,6 @@ export class NewsletterEmailCounters {
   }
 
   #inc(name: string, labels: Record<string, string>, value: number): void {
-    try {
-      const metric = this.#prometheusClient?.getMetric(name);
-      if (metric && 'inc' in metric) {
-        metric.inc(labels, value);
-      }
-    } catch (error) {
-      logging.error(`[EmailAnalytics] Error recording ${name}`, error);
-    }
+    incrementCounter(this.#prometheusClient, name, labels, value);
   }
 }

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-counters.ts
@@ -79,6 +79,11 @@ export class NewsletterEmailCounters {
     });
   }
 
+  /** Acquire before recipient and member locks, without establishing a snapshot. */
+  async lock(trx: Knex.Transaction, emailId: string): Promise<void> {
+    await trx('emails').where('id', emailId).forUpdate().first('id');
+  }
+
   /**
    * Lock the email row and, on the first touch per process, replace its
    * counters with recounted truth. Must precede recipient locks, within a

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -48,6 +48,92 @@ export class NewsletterMemberCounters {
     this.#knex = knex;
   }
 
+  /** Lock before either baseline reads history, and before recipient writes. */
+  async prepareEventMembers(
+    trx: Knex.Transaction,
+    emailId: string,
+    recipients: { member_id: string; batch_id: string }[],
+  ): Promise<Map<string, MemberCounts>> {
+    if (!recipients.length) {
+      return new Map();
+    }
+    // These locking reads must also precede the first baseline snapshot. The
+    // email lock already serializes preparation and events for this email.
+    const email = await trx('emails').where('id', emailId).forShare().first();
+    const batches = await trx('email_batches')
+      .whereIn('id', [...new Set(recipients.map((row) => row.batch_id))])
+      .orderBy('id')
+      .forShare();
+    if (
+      !email ||
+      (email.preflight_email_count !== null && email.prepared_at === null) ||
+      batches.some(
+        (batch) => batch.member_counters_enabled && batch.member_counters_applied_at === null,
+      )
+    ) {
+      throw new IncorrectUsageError({
+        message: 'Recipient events require completed member counter preparation',
+        context: `Email ${emailId}`,
+      });
+    }
+    const memberIds = [...new Set(recipients.map((row) => row.member_id))];
+    const members: ({ id: string } & Omit<MemberCounts, 'email_tracked_count'> & {
+        email_tracked_count: number | null;
+      })[] = await this.#members(trx)
+      .whereIn('id', memberIds)
+      .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
+      .orderBy('id')
+      .forUpdate();
+    const uninitialized = members
+      .filter((row) => row.email_tracked_count === null)
+      .map((row) => row.id);
+    const baseline = uninitialized.length
+      ? await this.#derive(trx, uninitialized)
+      : new Map<string, MemberCounts>();
+    if (uninitialized.length) {
+      await this.#setCounts(trx, uninitialized, baseline);
+    }
+    return new Map(
+      members.map((member) => [
+        member.id,
+        member.email_tracked_count === null
+          ? (baseline.get(member.id) ?? {
+              email_count: 0,
+              email_tracked_count: 0,
+              email_opened_count: 0,
+              email_open_rate: null,
+            })
+          : { ...member, email_tracked_count: member.email_tracked_count },
+      ]),
+    );
+  }
+
+  /** Apply exact recipient transitions; multiple recipients may share a member. */
+  async incrementOpened(
+    trx: Knex.Transaction,
+    transitions: { memberId: string }[],
+    baseline: Map<string, MemberCounts>,
+  ): Promise<void> {
+    const totals = new Map<string, MemberCounts>();
+    for (const { memberId } of transitions) {
+      const current = totals.get(memberId) ?? baseline.get(memberId);
+      if (!current) {
+        continue;
+      }
+      const opened = Number(current.email_opened_count) + 1;
+      const tracked = Number(current.email_tracked_count);
+      totals.set(memberId, {
+        ...current,
+        email_opened_count: opened,
+        email_open_rate:
+          tracked >= MIN_EMAIL_COUNT_FOR_OPEN_RATE ? Math.round((opened / tracked) * 100) : null,
+      });
+    }
+    if (totals.size) {
+      await this.#setCounts(trx, [...totals.keys()], totals);
+    }
+  }
+
   /** Apply only explicitly enrolled, frozen batches, atomically with their marker. */
   async applyPreparedBatch(batchId: string): Promise<boolean> {
     const owner = await this.#knex('email_batches').where('id', batchId).first('email_id');

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -3,7 +3,9 @@ import { IncorrectUsageError } from '@tryghost/errors';
 import DatabaseInfo from '@tryghost/database-info';
 import ObjectID from 'bson-objectid';
 import { z } from 'zod';
+import { DbBoolean } from '../../lib/db-types/boolean';
 import { DbCount } from '../../lib/db-types/count';
+import { DbDate } from '../../lib/db-types/date';
 import { deriveOpenRate } from './lib/open-rate';
 import { transactionWithRetry } from './lib/transaction-with-retry';
 import logging from '@tryghost/logging';
@@ -37,6 +39,15 @@ const DbMemberCounters = z.object({
   email_open_rate: DbCount.nullable(),
 });
 type DbMemberCounters = z.output<typeof DbMemberCounters>;
+// Preparation state read before member increments; the models own the rows.
+const DbEmailPreparation = z.object({
+  preflight_email_count: DbCount.nullable(),
+  prepared_at: DbDate.nullable(),
+});
+const DbBatchPreparation = z.object({
+  member_counters_enabled: DbBoolean,
+  member_counters_applied_at: DbDate.nullable(),
+});
 const MEMBER_COMPARISONS_METRIC = 'email_analytics_member_counter_comparisons';
 const MEMBER_DRIFT_METRIC = 'email_analytics_member_counter_drift';
 const MEMBER_COUNTER_COLUMNS = [
@@ -183,11 +194,17 @@ export class NewsletterMemberCounters {
     }
     // These locking reads must also precede the first baseline snapshot. The
     // email lock already serializes preparation and events for this email.
-    const email = await trx('emails').where('id', emailId).forShare().first();
-    const batches = await trx('email_batches')
+    const emailRow = await trx('emails')
+      .where('id', emailId)
+      .forShare()
+      .first('preflight_email_count', 'prepared_at');
+    const email = emailRow ? DbEmailPreparation.parse(emailRow) : null;
+    const batchRows: unknown[] = await trx('email_batches')
       .whereIn('id', [...new Set(recipients.map((row) => row.batch_id))])
       .orderBy('id')
-      .forShare();
+      .forShare()
+      .select('member_counters_enabled', 'member_counters_applied_at');
+    const batches = batchRows.map((row) => DbBatchPreparation.parse(row));
     if (
       !email ||
       (email.preflight_email_count !== null && email.prepared_at === null) ||

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { DbCount } from '../../lib/db-types/count';
 import { deriveOpenRate } from './lib/open-rate';
 import logging from '@tryghost/logging';
-import type { PrometheusClient } from '@tryghost/prometheus-metrics';
+import { incrementCounter, type CounterMetricsClient } from './lib/counter-metrics';
 
 export type MemberSweepPage = { afterId?: string; throughId?: string; limit?: number };
 export type MemberSweepResult = { afterId: string | undefined; processed: number };
@@ -27,6 +27,17 @@ const DerivedRow = z.object({
 type MemberDrift = Partial<
   Record<keyof MemberCounts, { actual: number | null; expected: number | null }>
 >;
+// Projection of the members counter columns; the Bookshelf model owns the row.
+const DbMemberCounters = z.object({
+  id: z.string(),
+  email_count: DbCount,
+  email_tracked_count: DbCount.nullable(),
+  email_opened_count: DbCount,
+  email_open_rate: DbCount.nullable(),
+});
+type DbMemberCounters = z.output<typeof DbMemberCounters>;
+const MEMBER_COMPARISONS_METRIC = 'email_analytics_member_counter_comparisons';
+const MEMBER_DRIFT_METRIC = 'email_analytics_member_counter_drift';
 const MEMBER_COUNTER_COLUMNS = [
   'email_count',
   'email_tracked_count',
@@ -54,27 +65,25 @@ export type MemberSweepCheckpoint = z.infer<typeof checkpointSchema>;
 /** Shared derived truth for initialization, repair and rollback re-baselining. */
 export class NewsletterMemberCounters {
   readonly #knex: Knex;
-  readonly #prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
+  readonly #prometheusClient: CounterMetricsClient | null;
 
   constructor(
     knex: Knex,
-    {
-      prometheusClient = null,
-    }: {
-      prometheusClient?: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
-    } = {},
+    { prometheusClient = null }: { prometheusClient?: CounterMetricsClient | null } = {},
   ) {
     this.#knex = knex;
     this.#prometheusClient = prometheusClient;
+    // `phase` matches the email counter metrics, so a later repair phase can
+    // be told apart from observe-only comparison without changing the series.
     prometheusClient?.registerCounter({
-      name: 'email_analytics_member_counter_comparisons',
+      name: MEMBER_COMPARISONS_METRIC,
       help: 'Number of initialized newsletter member counter comparisons',
-      labelNames: ['statistic'],
+      labelNames: ['statistic', 'phase'],
     });
     prometheusClient?.registerCounter({
-      name: 'email_analytics_member_counter_drift',
+      name: MEMBER_DRIFT_METRIC,
       help: 'Sum of absolute member counter differences; null rate mismatches count as one',
-      labelNames: ['statistic'],
+      labelNames: ['statistic', 'phase'],
     });
   }
 
@@ -86,12 +95,7 @@ export class NewsletterMemberCounters {
     }
     this.#validateLimit(ids.length);
     const comparisons = await this.#knex.transaction(async (trx) => {
-      const members: ({ id: string } & MemberCounts)[] = await this.#members(trx)
-        .whereIn('id', ids)
-        .whereNotNull('email_tracked_count')
-        .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
-        .orderBy('id')
-        .forUpdate();
+      const members = await this.#lockMembers(trx, ids, { initializedOnly: true });
       if (!members.length) {
         return new Map<string, MemberDrift>();
       }
@@ -123,33 +127,42 @@ export class NewsletterMemberCounters {
         `[EmailAnalytics] Newsletter member counter drift: ${JSON.stringify(drift.map(([memberId, differences]) => ({ memberId, differences })))}`,
       );
     }
-    try {
-      for (const differences of comparisons.values()) {
-        for (const statistic of MEMBER_COUNTER_COLUMNS) {
-          const observations = this.#prometheusClient?.getMetric(
-            'email_analytics_member_counter_comparisons',
+    for (const differences of comparisons.values()) {
+      for (const statistic of MEMBER_COUNTER_COLUMNS) {
+        const labels = { statistic, phase: 'comparison' };
+        incrementCounter(this.#prometheusClient, MEMBER_COMPARISONS_METRIC, labels, 1);
+        const difference = differences[statistic];
+        if (difference) {
+          incrementCounter(
+            this.#prometheusClient,
+            MEMBER_DRIFT_METRIC,
+            labels,
+            difference.actual === null || difference.expected === null
+              ? 1
+              : Math.abs(difference.actual - difference.expected),
           );
-          const driftMetric = this.#prometheusClient?.getMetric(
-            'email_analytics_member_counter_drift',
-          );
-          if (observations && 'inc' in observations) {
-            observations.inc({ statistic });
-          }
-          const difference = differences[statistic];
-          if (driftMetric && 'inc' in driftMetric && difference) {
-            driftMetric.inc(
-              { statistic },
-              difference.actual === null || difference.expected === null
-                ? 1
-                : Math.abs(difference.actual - difference.expected),
-            );
-          }
         }
       }
-    } catch (error) {
-      logging.error('Error recording newsletter member counter comparison', error);
     }
     return comparisons;
+  }
+
+  /** Lock member counter rows in primary-key order and validate them. */
+  async #lockMembers(
+    trx: Knex.Transaction,
+    memberIds: string[],
+    { initializedOnly = false } = {},
+  ): Promise<DbMemberCounters[]> {
+    const query = this.#members(trx)
+      .whereIn('id', memberIds)
+      .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
+      .orderBy('id')
+      .forUpdate();
+    if (initializedOnly) {
+      query.whereNotNull('email_tracked_count');
+    }
+    const rows: unknown[] = await query;
+    return rows.map((row) => DbMemberCounters.parse(row));
   }
 
   /** Lock before either baseline reads history, and before recipient writes. */
@@ -175,19 +188,18 @@ export class NewsletterMemberCounters {
         (batch) => batch.member_counters_enabled && batch.member_counters_applied_at === null,
       )
     ) {
-      throw new IncorrectUsageError({
-        message: 'Recipient events require completed member counter preparation',
-        context: `Email ${emailId}`,
-      });
+      // Only a rollback to older send code, or an abandoned preparation, can
+      // produce events before a batch's denominator was applied. Failing here
+      // would stall every newsletter's ingestion on one email, so record the
+      // recipient facts without member increments and let comparison report
+      // the drift and the shared sweep repair it.
+      logging.error(
+        `[EmailAnalytics] Skipping member counters for email ${emailId}: recipient events arrived before member counter preparation completed`,
+      );
+      return new Map();
     }
     const memberIds = [...new Set(recipients.map((row) => row.member_id))];
-    const members: ({ id: string } & Omit<MemberCounts, 'email_tracked_count'> & {
-        email_tracked_count: number | null;
-      })[] = await this.#members(trx)
-      .whereIn('id', memberIds)
-      .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
-      .orderBy('id')
-      .forUpdate();
+    const members = await this.#lockMembers(trx, memberIds);
     const uninitialized = members
       .filter((row) => row.email_tracked_count === null)
       .map((row) => row.id);
@@ -300,13 +312,7 @@ export class NewsletterMemberCounters {
       for (const row of recipients) {
         deltas.set(row.member_id, (deltas.get(row.member_id) ?? 0) + 1);
       }
-      const members: ({ id: string } & Omit<MemberCounts, 'email_tracked_count'> & {
-          email_tracked_count: number | null;
-        })[] = await this.#members(trx)
-        .whereIn('id', [...deltas.keys()])
-        .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
-        .orderBy('id')
-        .forUpdate();
+      const members = await this.#lockMembers(trx, [...deltas.keys()]);
       const uninitialized = members
         .filter((row) => row.email_tracked_count === null)
         .map((row) => row.id);

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -5,6 +5,7 @@ import ObjectID from 'bson-objectid';
 import { z } from 'zod';
 import { DbCount } from '../../lib/db-types/count';
 import { deriveOpenRate } from './lib/open-rate';
+import { transactionWithRetry } from './lib/transaction-with-retry';
 import logging from '@tryghost/logging';
 import { incrementCounter, type CounterMetricsClient } from './lib/counter-metrics';
 
@@ -94,33 +95,39 @@ export class NewsletterMemberCounters {
       return new Map();
     }
     this.#validateLimit(ids.length);
-    const comparisons = await this.#knex.transaction(async (trx) => {
-      const members = await this.#lockMembers(trx, ids, { initializedOnly: true });
-      if (!members.length) {
-        return new Map<string, MemberDrift>();
-      }
-      const truth = await this.#derive(
-        trx,
-        members.map((member) => member.id),
-      );
-      const result = new Map<string, MemberDrift>();
-      for (const member of members) {
-        const expected = truth.get(member.id) ?? {
-          email_count: 0,
-          email_tracked_count: 0,
-          email_opened_count: 0,
-          email_open_rate: null,
-        };
-        const differences: MemberDrift = {};
-        for (const column of MEMBER_COUNTER_COLUMNS) {
-          if (member[column] !== expected[column]) {
-            differences[column] = { actual: member[column], expected: expected[column] };
-          }
+    // Observe-only, so a lock wait against batch preparation can retry the
+    // whole rolled-back transaction as the email counter comparison does.
+    const comparisons = await transactionWithRetry(
+      this.#knex,
+      async (trx) => {
+        const members = await this.#lockMembers(trx, ids, { initializedOnly: true });
+        if (!members.length) {
+          return new Map<string, MemberDrift>();
         }
-        result.set(member.id, differences);
-      }
-      return result;
-    }, this.#transactionConfig());
+        const truth = await this.#derive(
+          trx,
+          members.map((member) => member.id),
+        );
+        const result = new Map<string, MemberDrift>();
+        for (const member of members) {
+          const expected = truth.get(member.id) ?? {
+            email_count: 0,
+            email_tracked_count: 0,
+            email_opened_count: 0,
+            email_open_rate: null,
+          };
+          const differences: MemberDrift = {};
+          for (const column of MEMBER_COUNTER_COLUMNS) {
+            if (member[column] !== expected[column]) {
+              differences[column] = { actual: member[column], expected: expected[column] };
+            }
+          }
+          result.set(member.id, differences);
+        }
+        return result;
+      },
+      this.#transactionConfig(),
+    );
     const drift = [...comparisons].filter(([, differences]) => Object.keys(differences).length);
     if (drift.length) {
       logging.warn(

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -5,6 +5,8 @@ import ObjectID from 'bson-objectid';
 import { z } from 'zod';
 import { DbCount } from '../../lib/db-types/count';
 import { deriveOpenRate } from './lib/open-rate';
+import logging from '@tryghost/logging';
+import type { PrometheusClient } from '@tryghost/prometheus-metrics';
 
 export type MemberSweepPage = { afterId?: string; throughId?: string; limit?: number };
 export type MemberSweepResult = { afterId: string | undefined; processed: number };
@@ -22,6 +24,15 @@ const DerivedRow = z.object({
   email_tracked_count: DbCount,
   email_opened_count: DbCount,
 });
+type MemberDrift = Partial<
+  Record<keyof MemberCounts, { actual: number | null; expected: number | null }>
+>;
+const MEMBER_COUNTER_COLUMNS = [
+  'email_count',
+  'email_tracked_count',
+  'email_opened_count',
+  'email_open_rate',
+] as const;
 const MAX_SWEEP_PAGE_SIZE = 5000;
 const UPDATE_CHUNK_SIZE = 1000;
 const SWEEP_JOB_NAME = 'email-analytics-member-reconciliation';
@@ -43,9 +54,102 @@ export type MemberSweepCheckpoint = z.infer<typeof checkpointSchema>;
 /** Shared derived truth for initialization, repair and rollback re-baselining. */
 export class NewsletterMemberCounters {
   readonly #knex: Knex;
+  readonly #prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
 
-  constructor(knex: Knex) {
+  constructor(
+    knex: Knex,
+    {
+      prometheusClient = null,
+    }: {
+      prometheusClient?: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
+    } = {},
+  ) {
     this.#knex = knex;
+    this.#prometheusClient = prometheusClient;
+    prometheusClient?.registerCounter({
+      name: 'email_analytics_member_counter_comparisons',
+      help: 'Number of initialized newsletter member counter comparisons',
+      labelNames: ['statistic'],
+    });
+    prometheusClient?.registerCounter({
+      name: 'email_analytics_member_counter_drift',
+      help: 'Sum of absolute member counter differences; null rate mismatches count as one',
+      labelNames: ['statistic'],
+    });
+  }
+
+  /** Observe initialized counters against the same opens-inclusive derived truth. */
+  async compareMembers(memberIds: string[]): Promise<Map<string, MemberDrift>> {
+    const ids = [...new Set(memberIds)];
+    if (!ids.length) {
+      return new Map();
+    }
+    this.#validateLimit(ids.length);
+    const comparisons = await this.#knex.transaction(async (trx) => {
+      const members: ({ id: string } & MemberCounts)[] = await this.#members(trx)
+        .whereIn('id', ids)
+        .whereNotNull('email_tracked_count')
+        .select('id', 'email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate')
+        .orderBy('id')
+        .forUpdate();
+      if (!members.length) {
+        return new Map<string, MemberDrift>();
+      }
+      const truth = await this.#derive(
+        trx,
+        members.map((member) => member.id),
+      );
+      const result = new Map<string, MemberDrift>();
+      for (const member of members) {
+        const expected = truth.get(member.id) ?? {
+          email_count: 0,
+          email_tracked_count: 0,
+          email_opened_count: 0,
+          email_open_rate: null,
+        };
+        const differences: MemberDrift = {};
+        for (const column of MEMBER_COUNTER_COLUMNS) {
+          if (member[column] !== expected[column]) {
+            differences[column] = { actual: member[column], expected: expected[column] };
+          }
+        }
+        result.set(member.id, differences);
+      }
+      return result;
+    }, this.#transactionConfig());
+    const drift = [...comparisons].filter(([, differences]) => Object.keys(differences).length);
+    if (drift.length) {
+      logging.warn(
+        `[EmailAnalytics] Newsletter member counter drift: ${JSON.stringify(drift.map(([memberId, differences]) => ({ memberId, differences })))}`,
+      );
+    }
+    try {
+      for (const differences of comparisons.values()) {
+        for (const statistic of MEMBER_COUNTER_COLUMNS) {
+          const observations = this.#prometheusClient?.getMetric(
+            'email_analytics_member_counter_comparisons',
+          );
+          const driftMetric = this.#prometheusClient?.getMetric(
+            'email_analytics_member_counter_drift',
+          );
+          if (observations && 'inc' in observations) {
+            observations.inc({ statistic });
+          }
+          const difference = differences[statistic];
+          if (driftMetric && 'inc' in driftMetric && difference) {
+            driftMetric.inc(
+              { statistic },
+              difference.actual === null || difference.expected === null
+                ? 1
+                : Math.abs(difference.actual - difference.expected),
+            );
+          }
+        }
+      }
+    } catch (error) {
+      logging.error('Error recording newsletter member counter comparison', error);
+    }
+    return comparisons;
   }
 
   /** Lock before either baseline reads history, and before recipient writes. */
@@ -125,8 +229,7 @@ export class NewsletterMemberCounters {
       totals.set(memberId, {
         ...current,
         email_opened_count: opened,
-        email_open_rate:
-          tracked >= MIN_EMAIL_COUNT_FOR_OPEN_RATE ? Math.round((opened / tracked) * 100) : null,
+        email_open_rate: deriveOpenRate(opened, tracked),
       });
     }
     if (totals.size) {
@@ -475,17 +578,11 @@ export class NewsletterMemberCounters {
     memberIds: string[],
     counts: Map<string, MemberCounts>,
   ): Promise<void> {
-    const columns = [
-      'email_count',
-      'email_tracked_count',
-      'email_opened_count',
-      'email_open_rate',
-    ] as const;
     // Bound the statement size: a full page carries four CASE ladders.
     for (let start = 0; start < memberIds.length; start += UPDATE_CHUNK_SIZE) {
       const chunk = memberIds.slice(start, start + UPDATE_CHUNK_SIZE);
       const updates: Record<string, Knex.Raw> = {};
-      for (const column of columns) {
+      for (const column of MEMBER_COUNTER_COLUMNS) {
         const bindings: (string | number | null)[] = [];
         const cases = chunk.map((memberId) => {
           bindings.push(

--- a/ghost/core/core/server/services/email-service/README.md
+++ b/ghost/core/core/server/services/email-service/README.md
@@ -378,9 +378,9 @@ explicit error rather than being overwritten; pass `--restart` to replace it.
 Drain legacy analytics and preparation writers before manually initializing or
 re-baselining. The sweep's live concurrency guarantee requires every counter
 writer to acquire member locks before establishing its recipient snapshot.
-Legacy recounts and recipient creation do not follow this protocol. The later
-incremental-ingestion integration must establish that boundary before allowing
-periodic repair alongside live ingestion. MySQL pages explicitly use repeatable
+Legacy recounts and recipient creation do not follow this protocol. The member
+counter comparison mode establishes that boundary for live ingestion; ongoing
+sweep cadence remains separate. MySQL pages explicitly use repeatable
 read; multiple metadata and recipient reads share the same snapshot.
 
 `emailAnalytics.memberCounterPreparation` defaults to false and requires batched
@@ -394,8 +394,8 @@ new enrollment has been disabled. Historical batches remain opted out.
 Keep this flag off with legacy analytics workers. For isolated preparation testing,
 stop analytics jobs first: legacy recounts include pending recipient rows and do
 not coordinate with these increments. Enabling preparation with live analytics
-requires the subsequent member-event counter integration and a drained-worker
-cutover. The flag does not itself enable that integration.
+requires [member counter comparison mode](../email-analytics/README.md#newsletter-member-counters)
+and a drained-worker cutover. The flag does not itself enable that integration.
 
 Application locks the email, batch, persisted recipient rows and then members in
 primary-key order, before its first consistent read. Uninitialized members use the

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -359,11 +359,8 @@ class NewsletterEmailEventStorage {
       const transitioned = await transactionWithRetry(
         this.#db.knex,
         async (trx) => {
-          if (this.#memberCounters) {
-            await this.#emailCounters.lock(trx, emailId);
-          } else {
-            await this.#emailCounters?.prepare(trx, emailId);
-          }
+          // Email lock first; the email baseline is taken after every lock below.
+          await this.#emailCounters?.lock(trx, emailId);
           const query = trx('email_recipients');
           if (DatabaseInfo.isMySQL(trx)) {
             // Lock in primary-key order, rather than whichever secondary index
@@ -388,10 +385,8 @@ class NewsletterEmailEventStorage {
           const memberBaseline = this.#memberCounters
             ? await this.#memberCounters.prepareEventMembers(trx, emailId, recipients)
             : null;
-          if (this.#memberCounters) {
-            // Both baselines now share a snapshot established after member locks.
-            await this.#emailCounters.prepare(trx, emailId);
-          }
+          // Both baselines share a snapshot established after every lock.
+          await this.#emailCounters?.prepare(trx, emailId);
           const result = { emailId, delivered: [], opened: [], failed: [] };
           // The locked set, not an affected-row count, determines which members
           // transitioned. Dependent counter writes must use this same transaction.

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -13,6 +13,7 @@ class NewsletterEmailEventStorage {
   #prometheusClient;
   #pendingUpdates;
   #emailCounters;
+  #memberCounters;
 
   constructor({
     config,
@@ -22,6 +23,7 @@ class NewsletterEmailEventStorage {
     emailSuppressionList,
     prometheusClient,
     emailCounters = null,
+    memberCounters = null,
   }) {
     this.#config = config;
     this.#db = db;
@@ -30,6 +32,10 @@ class NewsletterEmailEventStorage {
     this.#emailSuppressionList = emailSuppressionList;
     this.#prometheusClient = prometheusClient;
     this.#emailCounters = emailCounters;
+    this.#memberCounters = memberCounters;
+    if (memberCounters && !emailCounters) {
+      throw new errors.IncorrectUsageError({ message: 'Member counters require email counters' });
+    }
 
     // Initialize pending updates for batched processing
     this.#pendingUpdates = {
@@ -350,69 +356,85 @@ class NewsletterEmailEventStorage {
     const transitions = [];
     for (const emailId of Array.from(groups.keys()).sort()) {
       const updates = groups.get(emailId);
-      const transitioned = await transactionWithRetry(this.#db.knex, async (trx) => {
-        await this.#emailCounters?.prepare(trx, emailId);
-        const query = trx('email_recipients');
-        if (DatabaseInfo.isMySQL(trx)) {
-          // Lock in primary-key order, rather than whichever secondary index
-          // the optimizer chooses. Sorting the IN list alone is insufficient.
-          query.fromRaw('?? FORCE INDEX (PRIMARY)', ['email_recipients']);
-        }
-        const recipients = await query
-          .select('id', 'member_id', 'delivered_at', 'opened_at', 'failed_at')
-          .where('email_id', emailId)
-          .where(function () {
-            for (const [type, pending] of Object.entries(updates)) {
-              if (pending.size) {
-                this.orWhere(function () {
-                  this.whereIn('id', Array.from(pending.keys()).sort()).whereNull(`${type}_at`);
-                });
+      const transitioned = await transactionWithRetry(
+        this.#db.knex,
+        async (trx) => {
+          if (this.#memberCounters) {
+            await this.#emailCounters.lock(trx, emailId);
+          } else {
+            await this.#emailCounters?.prepare(trx, emailId);
+          }
+          const query = trx('email_recipients');
+          if (DatabaseInfo.isMySQL(trx)) {
+            // Lock in primary-key order, rather than whichever secondary index
+            // the optimizer chooses. Sorting the IN list alone is insufficient.
+            query.fromRaw('?? FORCE INDEX (PRIMARY)', ['email_recipients']);
+          }
+          const recipients = await query
+            .select('id', 'member_id', 'batch_id', 'delivered_at', 'opened_at', 'failed_at')
+            .where('email_id', emailId)
+            .where(function () {
+              for (const [type, pending] of Object.entries(updates)) {
+                if (pending.size) {
+                  this.orWhere(function () {
+                    this.whereIn('id', Array.from(pending.keys()).sort()).whereNull(`${type}_at`);
+                  });
+                }
               }
-            }
-          })
-          .orderBy('id')
-          .forUpdate();
+            })
+            .orderBy('id')
+            .forUpdate();
 
-        const result = { emailId, delivered: [], opened: [], failed: [] };
-        // The locked set, not an affected-row count, determines which members
-        // transitioned. Dependent counter writes must use this same transaction.
-        for (const [type, pending] of Object.entries(updates)) {
-          const eligible = recipients.filter(
-            (row) => pending.has(row.id) && row[`${type}_at`] === null,
-          );
-          if (!eligible.length) {
-            continue;
+          const memberBaseline = this.#memberCounters
+            ? await this.#memberCounters.prepareEventMembers(trx, emailId, recipients)
+            : null;
+          if (this.#memberCounters) {
+            // Both baselines now share a snapshot established after member locks.
+            await this.#emailCounters.prepare(trx, emailId);
           }
-          const bindings = eligible.flatMap(({ id }) => [id, pending.get(id).timestamp]);
-          const affected = await trx('email_recipients')
-            .whereIn(
-              'id',
-              eligible.map(({ id }) => id),
-            )
-            .whereNull(`${type}_at`)
-            .update({
-              [`${type}_at`]: trx.raw(
-                `CASE id ${eligible.map(() => 'WHEN ? THEN ?').join(' ')} END`,
-                bindings,
-              ),
-            });
-          if (affected !== eligible.length) {
-            // Only possible without row locks (e.g. SQLite): another writer
-            // changed a locked-set row between the read and the guarded update.
-            // Fail loudly rather than report a transition that did not happen.
-            throw new errors.InternalServerError({
-              message: `Email recipient ${type} transitions changed during flush`,
-              context: `email ${emailId}: expected ${eligible.length}, updated ${affected}`,
-            });
+          const result = { emailId, delivered: [], opened: [], failed: [] };
+          // The locked set, not an affected-row count, determines which members
+          // transitioned. Dependent counter writes must use this same transaction.
+          for (const [type, pending] of Object.entries(updates)) {
+            const eligible = recipients.filter(
+              (row) => pending.has(row.id) && row[`${type}_at`] === null,
+            );
+            if (!eligible.length) {
+              continue;
+            }
+            const bindings = eligible.flatMap(({ id }) => [id, pending.get(id).timestamp]);
+            const affected = await trx('email_recipients')
+              .whereIn(
+                'id',
+                eligible.map(({ id }) => id),
+              )
+              .whereNull(`${type}_at`)
+              .update({
+                [`${type}_at`]: trx.raw(
+                  `CASE id ${eligible.map(() => 'WHEN ? THEN ?').join(' ')} END`,
+                  bindings,
+                ),
+              });
+            if (affected !== eligible.length) {
+              // Only possible without row locks (e.g. SQLite): another writer
+              // changed a locked-set row between the read and the guarded update.
+              // Fail loudly rather than report a transition that did not happen.
+              throw new errors.InternalServerError({
+                message: `Email recipient ${type} transitions changed during flush`,
+                context: `email ${emailId}: expected ${eligible.length}, updated ${affected}`,
+              });
+            }
+            result[type] = eligible.map(({ id, member_id: memberId }) => ({
+              recipientId: id,
+              memberId,
+            }));
           }
-          result[type] = eligible.map(({ id, member_id: memberId }) => ({
-            recipientId: id,
-            memberId,
-          }));
-        }
-        await this.#emailCounters?.increment(trx, emailId, result);
-        return result;
-      });
+          await this.#emailCounters?.increment(trx, emailId, result);
+          await this.#memberCounters?.incrementOpened(trx, result.opened, memberBaseline);
+          return result;
+        },
+        this.#transactionConfig(),
+      );
       this.#emailCounters?.committed(emailId);
       if (
         transitioned.delivered.length ||
@@ -428,6 +450,14 @@ class NewsletterEmailEventStorage {
       }
     }
     return transitions;
+  }
+
+  #transactionConfig() {
+    // Member baselines read several tables after taking member locks; keep
+    // those reads on one snapshot.
+    return this.#memberCounters && DatabaseInfo.isMySQL(this.#db.knex)
+      ? { isolationLevel: 'repeatable read' }
+      : undefined;
   }
 }
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -302,6 +302,7 @@
     "enabled": true,
     "batchProcessing": false,
     "memberCounterPreparation": false,
+    "memberCounterMode": "off",
     "metrics": {
       "openThroughput": {
         "enabled": false,

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -10,6 +10,13 @@ import { NewsletterMemberCounters } from '../../../../core/server/services/email
 import { NewsletterEmailCounters } from '../../../../core/server/services/email-analytics/newsletter-email-counters';
 
 const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
+const EmailEventProcessor = require('../../../../core/server/services/email-service/email-event-processor');
+const {
+  NewsletterEmailAnalyticsBatchProcessor,
+} = require('../../../../core/server/services/email-analytics/newsletter-email-analytics-batch-processor');
+const {
+  EventProcessingResult,
+} = require('../../../../core/server/services/email-analytics/event-processing-result');
 
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
@@ -188,6 +195,103 @@ describe('Newsletter member counter baselines through MySQL', () => {
     emailRecipientId: target.recipientId,
     memberId: id(1),
     timestamp: new Date('2026-09-10T12:00:00Z'),
+  });
+
+  it('compares opens-inclusive member truth without repairing deliberately incorrect counters', async () => {
+    const observations = { inc: sinon.stub() };
+    const differences = { inc: sinon.stub() };
+    counters = new NewsletterMemberCounters(db.knex, {
+      prometheusClient: {
+        registerCounter: sinon.stub(),
+        getMetric: sinon
+          .stub()
+          .callsFake((name) =>
+            name === 'email_analytics_member_counter_comparisons' ? observations : differences,
+          ),
+      },
+    });
+    for (let n = 0; n < 5; n++) {
+      await recipient({ opened: n === 0 });
+    }
+    await counters.sweepPage({ throughId: id(1) });
+    assert.deepEqual(await counters.compareMembers([id(1), id(2)]), new Map([[id(1), {}]]));
+    await db
+      .knex('members')
+      .where('id', id(1))
+      .update({ email_opened_count: 4, email_open_rate: 80 });
+    assert.deepEqual(
+      await counters.compareMembers([id(1)]),
+      new Map([
+        [
+          id(1),
+          {
+            email_opened_count: { actual: 4, expected: 1 },
+            email_open_rate: { actual: 80, expected: 20 },
+          },
+        ],
+      ]),
+    );
+    assert.equal((await stats()).email_opened_count, 4);
+    sinon.assert.callCount(observations.inc, 8);
+    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_opened_count' }, 3);
+    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_open_rate' }, 60);
+    await db.knex('members').where('id', id(1)).update({ email_open_rate: null });
+    await counters.compareMembers([id(1)]);
+    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_open_rate' }, 1);
+  });
+
+  it('uses member comparison for a missing-lane open and skips duplicate member recount work', async () => {
+    const target = await recipient();
+    const emailCounters = new NewsletterEmailCounters({ knex: db.knex });
+    const config = { get: () => true };
+    const storage = new NewsletterEmailEventStorage({
+      config,
+      db,
+      models,
+      emailCounters,
+      memberCounters: counters,
+    });
+    const queries = { aggregateEmailStats: sinon.stub(), aggregateMemberStatsBatch: sinon.stub() };
+    const compare = sinon.spy(counters, 'compareMembers');
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config,
+      queries,
+      emailCounters,
+      memberCounters: counters,
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: storage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const result = new EventProcessingResult();
+    const events = [
+      {
+        type: 'opened',
+        emailId: target.emailId,
+        recipientEmail: 'member-counter-1@example.com',
+        timestamp: new Date(),
+      },
+    ];
+    await processor.processBatch(events, result, {});
+    assert.deepEqual(result.memberIds, [id(1)]);
+    await processor.aggregate({
+      processingResult: result,
+      includeOpenedEvents: false,
+      isFinal: true,
+    });
+    sinon.assert.notCalled(queries.aggregateMemberStatsBatch);
+    sinon.assert.calledOnceWithExactly(compare, [id(1)]);
+    assert.deepEqual(await compare.firstCall.returnValue, new Map([[id(1), {}]]));
+    await processor.processBatch(events, result, {});
+    assert.deepEqual(result.memberIds, []);
+    await processor.aggregate({
+      processingResult: result,
+      includeOpenedEvents: false,
+      isFinal: true,
+    });
+    sinon.assert.calledOnce(compare);
+    assert.equal((await stats()).email_opened_count, 1);
   });
 
   it('counts multiple opened recipient rows for one member, including untracked emails', async () => {

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { NewsletterMemberCounters } from '../../../../core/server/services/email-analytics/newsletter-member-counters';
 import { NewsletterEmailCounters } from '../../../../core/server/services/email-analytics/newsletter-email-counters';
 
+const logging = require('@tryghost/logging');
 const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
 const EmailEventProcessor = require('../../../../core/server/services/email-service/email-event-processor');
 const {
@@ -153,7 +154,7 @@ describe('Newsletter member counter baselines through MySQL', () => {
     assert.equal((await db.knex('emails').where('id', target.emailId).first()).opened_count, 1);
   });
 
-  it('rejects an event before enrolled preparation has applied its member denominator', async () => {
+  it('stores an event that precedes enrolled preparation without member increments', async () => {
     const target = await recipient({ enrolled: true });
     await counters.sweepPage({ throughId: id(3) });
     const storage = new NewsletterEmailEventStorage({
@@ -169,16 +170,28 @@ describe('Newsletter member counter baselines through MySQL', () => {
       memberId: id(1),
       timestamp: new Date(),
     });
-    await assert.rejects(storage.flushBatchedUpdates(), /preparation/i);
-    assert.equal(
+    const error = sinon.stub(logging, 'error');
+    try {
+      // Only an abandoned preparation or an older send binary can produce this;
+      // failing the flush would stall every newsletter's ingestion on it
+      assert.equal((await storage.flushBatchedUpdates()).length, 1);
+    } finally {
+      error.restore();
+    }
+    sinon.assert.calledWithMatch(error, /before member counter preparation completed/);
+    assert.notEqual(
       (await db.knex('email_recipients').where('id', target.recipientId).first()).opened_at,
       null,
     );
+    // The pending enrolled batch stays outside derived truth, so nothing drifts
     assert.equal((await stats()).email_opened_count, 0);
-    await counters.applyPreparedBatch(target.batchId);
-    await storage.flushBatchedUpdates();
-    assert.equal((await stats()).email_tracked_count, 1);
-    assert.equal((await stats()).email_opened_count, 1);
+    assert.deepEqual((await counters.compareMembers([id(1)])).get(id(1)), {});
+    // Applying the batch afterwards is refused, as before, because events preceded it
+    await assert.rejects(
+      counters.applyPreparedBatch(target.batchId),
+      (caught: Error & { retryable?: boolean }) =>
+        /preceded member counter application/.test(caught.message) && caught.retryable === false,
+    );
   });
 
   function eventStorage(database = db) {
@@ -233,11 +246,23 @@ describe('Newsletter member counter baselines through MySQL', () => {
     );
     assert.equal((await stats()).email_opened_count, 4);
     sinon.assert.callCount(observations.inc, 8);
-    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_opened_count' }, 3);
-    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_open_rate' }, 60);
+    sinon.assert.calledWithExactly(
+      differences.inc,
+      { statistic: 'email_opened_count', phase: 'comparison' },
+      3,
+    );
+    sinon.assert.calledWithExactly(
+      differences.inc,
+      { statistic: 'email_open_rate', phase: 'comparison' },
+      60,
+    );
     await db.knex('members').where('id', id(1)).update({ email_open_rate: null });
     await counters.compareMembers([id(1)]);
-    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_open_rate' }, 1);
+    sinon.assert.calledWithExactly(
+      differences.inc,
+      { statistic: 'email_open_rate', phase: 'comparison' },
+      1,
+    );
   });
 
   it('uses member comparison for a missing-lane open and skips duplicate member recount work', async () => {
@@ -315,7 +340,7 @@ describe('Newsletter member counter baselines through MySQL', () => {
     assert.equal((await stats(2)).email_tracked_count, null);
   });
 
-  it('rolls back recipient, email and member updates together and retries the retained events', async () => {
+  it('rolls back recipient, email and member updates together and applies them on replay', async () => {
     const target = await recipient();
     const storage = eventStorage();
     await storage.handleOpened(openEvent(target));
@@ -333,6 +358,8 @@ describe('Newsletter member counter baselines through MySQL', () => {
     } finally {
       await db.knex.raw('DROP TRIGGER member_event_failure');
     }
+    // The failed page is discarded; the caller replays it
+    await storage.handleOpened(openEvent(target));
     await storage.flushBatchedUpdates();
     assert.equal((await stats()).email_opened_count, 1);
   });

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -7,6 +7,9 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import path from 'node:path';
 import { NewsletterMemberCounters } from '../../../../core/server/services/email-analytics/newsletter-member-counters';
+import { NewsletterEmailCounters } from '../../../../core/server/services/email-analytics/newsletter-email-counters';
+
+const NewsletterEmailEventStorage = require('../../../../core/server/services/email-service/newsletter-email-event-storage');
 
 const models = require('../../../../core/server/models');
 const db: { knex: Knex } = require('../../../../core/server/data/db');
@@ -110,6 +113,195 @@ describe('Newsletter member counter baselines through MySQL', () => {
       .knex('members')
       .where('id', id(member))
       .first('email_count', 'email_tracked_count', 'email_opened_count', 'email_open_rate');
+
+  it('initializes member history and commits a new open exactly once with its recipient', async () => {
+    for (let n = 0; n < 5; n++) {
+      await recipient();
+    }
+    const target = await recipient();
+    const storage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db,
+      models,
+      emailCounters: new NewsletterEmailCounters({ knex: db.knex }),
+      memberCounters: counters,
+    });
+    const event = {
+      emailId: target.emailId,
+      emailRecipientId: target.recipientId,
+      memberId: id(1),
+      timestamp: new Date('2026-09-10T12:00:00Z'),
+    };
+    await storage.handleOpened(event);
+    await storage.flushBatchedUpdates();
+    assert.deepEqual(await stats(), {
+      email_count: 6,
+      email_tracked_count: 6,
+      email_opened_count: 1,
+      email_open_rate: 17,
+    });
+    await storage.handleOpened(event);
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+    assert.equal((await stats()).email_opened_count, 1);
+    assert.equal((await db.knex('emails').where('id', target.emailId).first()).opened_count, 1);
+  });
+
+  it('rejects an event before enrolled preparation has applied its member denominator', async () => {
+    const target = await recipient({ enrolled: true });
+    await counters.sweepPage({ throughId: id(3) });
+    const storage = new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db,
+      models,
+      emailCounters: new NewsletterEmailCounters({ knex: db.knex }),
+      memberCounters: counters,
+    });
+    await storage.handleOpened({
+      emailId: target.emailId,
+      emailRecipientId: target.recipientId,
+      memberId: id(1),
+      timestamp: new Date(),
+    });
+    await assert.rejects(storage.flushBatchedUpdates(), /preparation/i);
+    assert.equal(
+      (await db.knex('email_recipients').where('id', target.recipientId).first()).opened_at,
+      null,
+    );
+    assert.equal((await stats()).email_opened_count, 0);
+    await counters.applyPreparedBatch(target.batchId);
+    await storage.flushBatchedUpdates();
+    assert.equal((await stats()).email_tracked_count, 1);
+    assert.equal((await stats()).email_opened_count, 1);
+  });
+
+  function eventStorage(database = db) {
+    return new NewsletterEmailEventStorage({
+      config: { get: () => true },
+      db: database,
+      models,
+      emailCounters: new NewsletterEmailCounters({ knex: database.knex }),
+      memberCounters: counters,
+    });
+  }
+  const openEvent = (target: { emailId: string; recipientId: string }) => ({
+    emailId: target.emailId,
+    emailRecipientId: target.recipientId,
+    memberId: id(1),
+    timestamp: new Date('2026-09-10T12:00:00Z'),
+  });
+
+  it('counts multiple opened recipient rows for one member, including untracked emails', async () => {
+    for (let n = 0; n < 5; n++) {
+      await recipient({ opened: n === 0 });
+    }
+    const target = await recipient({ tracked: false });
+    const copyId = ObjectID().toHexString();
+    const copy = await db.knex('email_recipients').where('id', target.recipientId).first();
+    await db.knex('email_recipients').insert({ ...copy, id: copyId });
+    const storage = eventStorage();
+    await storage.handleOpened({ ...openEvent(target), memberId: id(2) });
+    await storage.handleOpened(openEvent({ ...target, recipientId: copyId }));
+    await storage.flushBatchedUpdates();
+    assert.deepEqual(await stats(), {
+      email_count: 7,
+      email_tracked_count: 5,
+      email_opened_count: 3,
+      email_open_rate: 60,
+    });
+    assert.equal((await stats(2)).email_tracked_count, null);
+  });
+
+  it('rolls back recipient, email and member updates together and retries the retained events', async () => {
+    const target = await recipient();
+    const storage = eventStorage();
+    await storage.handleOpened(openEvent(target));
+    await db.knex.raw(
+      "CREATE TRIGGER member_event_failure BEFORE UPDATE ON members FOR EACH ROW BEGIN IF NEW.email_opened_count = 1 THEN SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected member event failure'; END IF; END",
+    );
+    try {
+      await assert.rejects(storage.flushBatchedUpdates(), /injected member event failure/);
+      assert.equal((await stats()).email_tracked_count, null);
+      assert.equal(
+        (await db.knex('email_recipients').where('id', target.recipientId).first()).opened_at,
+        null,
+      );
+      assert.equal((await db.knex('emails').where('id', target.emailId).first()).opened_count, 0);
+    } finally {
+      await db.knex.raw('DROP TRIGGER member_event_failure');
+    }
+    await storage.flushBatchedUpdates();
+    assert.equal((await stats()).email_opened_count, 1);
+  });
+
+  it('replays safely after an actual member event commit loses its acknowledgement', async () => {
+    const target = await recipient();
+    let loseAcknowledgement = true;
+    const uncertainKnex = new Proxy(db.knex, {
+      get(targetKnex, property) {
+        if (property === 'transaction') {
+          return async (
+            callback: (trx: Knex.Transaction) => Promise<unknown>,
+            config?: Knex.TransactionConfig,
+          ) => {
+            const result = await db.knex.transaction(callback, config);
+            if (loseAcknowledgement) {
+              loseAcknowledgement = false;
+              throw Object.assign(new Error('lost member event acknowledgement'), {
+                code: 'ECONNRESET',
+              });
+            }
+            return result;
+          };
+        }
+        return Reflect.get(targetKnex, property);
+      },
+    });
+    const storage = eventStorage({ knex: uncertainKnex });
+    await storage.handleOpened(openEvent(target));
+    await assert.rejects(storage.flushBatchedUpdates(), /lost member event acknowledgement/);
+    assert.equal((await stats()).email_opened_count, 1);
+    assert.deepEqual(await storage.flushBatchedUpdates(), []);
+    const restarted = eventStorage();
+    await restarted.handleOpened(openEvent(target));
+    await restarted.flushBatchedUpdates();
+    assert.equal((await stats()).email_opened_count, 1);
+    assert.equal((await db.knex('emails').where('id', target.emailId).first()).opened_count, 1);
+  });
+
+  it('establishes both baselines after waiting for the member lock', async () => {
+    const history = await recipient();
+    const target = await recipient();
+    const blocker = await db.knex.transaction();
+    await blocker('members').where('id', id(1)).forUpdate().first();
+    let reached!: () => void;
+    const waiting = new Promise<void>((resolve) => {
+      reached = resolve;
+    });
+    const listener = (query: Knex.Sql) => {
+      if (query.sql.includes('members') && query.sql.includes('for update')) {
+        reached();
+      }
+    };
+    db.knex.on('query', listener);
+    const storage = eventStorage();
+    await storage.handleOpened(openEvent(target));
+    const flushing = storage.flushBatchedUpdates();
+    try {
+      await waiting;
+      await blocker('email_recipients')
+        .where('id', history.recipientId)
+        .update({ opened_at: new Date() });
+      await blocker.commit();
+      await flushing;
+      assert.equal((await stats()).email_opened_count, 2);
+    } finally {
+      db.knex.removeListener('query', listener);
+      if (!blocker.isCompleted()) {
+        await blocker.rollback();
+      }
+      await flushing;
+    }
+  });
 
   it('derives legacy and applied facts, excluding pending enrollment and discardable preparation', async () => {
     for (let n = 0; n < 4; n++) {

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -248,13 +248,18 @@ describe('email analytics service', function () {
     [true, 'compare', false, 'compare'],
     [true, 'compare', true, 'unknown'],
   ])(
-    'rejects incompatible member mode configuration (%s, %s, %s, %s)',
+    'keeps member counters off for incompatible configuration (%s, %s, %s, %s)',
     function (batch, email, preparation, member) {
       config.get.withArgs('emailAnalytics:batchProcessing').returns(batch);
       config.get.withArgs('emailAnalytics:emailCounterMode').returns(email);
       config.get.withArgs('emailAnalytics:memberCounterPreparation').returns(preparation);
       config.get.withArgs('emailAnalytics:memberCounterMode').returns(member);
-      expect(() => init(dependencies)).toThrow(/member counter/i);
+      const registerCounter = sinon.stub();
+      dependencies.prometheusClient = { registerCounter, getMetric: sinon.stub() };
+      // A counter flag mismatch must not stop Ghost from booting
+      init(dependencies);
+      const names = registerCounter.args.map(([definition]) => definition.name);
+      expect(names).not.toContain('email_analytics_member_counter_comparisons');
     },
   );
 });

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -228,4 +228,33 @@ describe('email analytics service', function () {
       }),
     );
   });
+
+  it('enables member comparison only with batched email counters and preparation accounting', function () {
+    config.get.withArgs('emailAnalytics:batchProcessing').returns(true);
+    config.get.withArgs('emailAnalytics:emailCounterMode').returns('compare');
+    config.get.withArgs('emailAnalytics:memberCounterMode').returns('compare');
+    config.get.withArgs('emailAnalytics:memberCounterPreparation').returns(true);
+    const registerCounter = sinon.stub();
+    dependencies.prometheusClient = { registerCounter, getMetric: sinon.stub() };
+    init(dependencies);
+    const names = registerCounter.args.map(([definition]) => definition.name);
+    expect(names).toContain('email_analytics_member_counter_comparisons');
+    expect(names).toContain('email_analytics_member_counter_drift');
+  });
+
+  it.each([
+    [false, 'compare', true, 'compare'],
+    [true, 'off', true, 'compare'],
+    [true, 'compare', false, 'compare'],
+    [true, 'compare', true, 'unknown'],
+  ])(
+    'rejects incompatible member mode configuration (%s, %s, %s, %s)',
+    function (batch, email, preparation, member) {
+      config.get.withArgs('emailAnalytics:batchProcessing').returns(batch);
+      config.get.withArgs('emailAnalytics:emailCounterMode').returns(email);
+      config.get.withArgs('emailAnalytics:memberCounterPreparation').returns(preparation);
+      config.get.withArgs('emailAnalytics:memberCounterMode').returns(member);
+      expect(() => init(dependencies)).toThrow(/member counter/i);
+    },
+  );
 });

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-email-analytics-batch-processor.test.js
@@ -610,6 +610,51 @@ describe('NewsletterEmailAnalyticsBatchProcessor', function () {
           });
         });
 
+        it(`keeps email IDs and queues only transitioned members with member counters in ${modeLabel} mode`, async function () {
+          if (!batchProcessing) {
+            return;
+          }
+          const emailEventProcessor = {
+            batchGetRecipients: sinon.stub().resolves(new Map()),
+            flushBatchedUpdates: sinon.stub().resolves([
+              {
+                emailId: 'email-1',
+                delivered: [{ recipientId: 'r-1', memberId: 'member-1' }],
+                opened: [],
+                failed: [],
+              },
+            ]),
+            discardBatchedUpdates: sinon.stub(),
+            handleDelivered: sinon
+              .stub()
+              .resolves({ emailId: 'email-1', emailRecipientId: 'r-1', memberId: 'member-1' })
+              .onSecondCall()
+              .resolves({ emailId: 'email-1', emailRecipientId: 'r-2', memberId: 'member-2' }),
+          };
+          const processor = new NewsletterEmailAnalyticsBatchProcessor({
+            config: createMockConfig(),
+            emailEventProcessor,
+            emailCounters: { incremental: false },
+            memberCounters: {},
+          });
+          const result = new EventProcessingResult();
+
+          await processor.processBatch(
+            [
+              { type: 'delivered', emailId: 'email-1', timestamp: new Date(1) },
+              { type: 'delivered', emailId: 'email-1', timestamp: new Date(2) },
+            ],
+            result,
+            {},
+          );
+
+          assert.equal(result.delivered, 2);
+          // Email counter comparison and repair depend on the touched email IDs
+          assert.deepEqual(result.emailIds, ['email-1']);
+          // Only the committed transition's member is queued; the replayed one is not
+          assert.deepEqual(result.memberIds, ['member-1']);
+        });
+
         it(`verifies batch methods called correctly in ${modeLabel} mode`, async function () {
           const emailEventProcessor = {
             batchGetRecipients: sinon.stub().resolves(new Map()),


### PR DESCRIPTION
Member open rates currently require repeated scans of each affected member's recipient history. The preparation stack now supplies a reliable denominator; this adds member open increments to the same transaction as recipient facts and email counters, with an observe-only comparison mode for rollout.

```text
one email transaction
  lock email → eligible recipients → members
  initialize missing member and email baselines
  write exact recipient transitions
  increment email totals + member opens
  commit together

comparison checkpoint
  compare only members with committed transitions
  derive truth with opens included, regardless of fetch lane
  report differences without replacing counters
```

A replay has no member increments or comparison candidates because the original transaction already committed both facts and counters. Legacy mode still recounts replayed members so it can recover a crash between recipient writes and a recount. Missing-lane opens contribute to both the counter and its source-of-truth comparison.

Uninitialized members use PR 4's shared preparation-aware baseline. The email and member locks precede the first consistent read, so initialization cannot use an older snapshot after waiting for another transaction. The numerator counts opened recipient rows, including untracked emails, and the existing minimum tracked-email threshold and rounding remain unchanged.

`emailAnalytics.memberCounterMode` defaults to `off`. Its new `compare` mode requires batched ingestion, email counters and member counter preparation. Cutover requires draining legacy analytics and preparation workers and completing a fresh shared baseline. Configuration fallback must first resolve enrolled, unapplied batches. The README describes these boundaries and the limits of binary rollback.

Comparison deliberately keeps a history scan for changed members while we validate correctness. The following PR moves repair to the bounded periodic sweep and removes this comparison from ordinary ingestion. Automation and gift storage paths are outside this change.

Validation:

- 261 MySQL newsletter/preparation tests passed across 13 files in a serial run; 700 email-service/analytics unit tests passed in UTC. Core/test types and focused lint passed. An earlier parallel run timed out in four database-reset hooks before test assertions; the serial rerun passed without code changes.
- MySQL regressions cover atomic rollback, lost commit acknowledgement and replay after restart, initialization races, multiple recipient rows per member, untracked opens, missing-lane comparison, and detection of deliberately incorrect counters without repair.
- Five independent slice reviews and a refreshed accumulated review found no remaining high-confidence issues. The accumulated review identified a legacy preparation cutover bug, now corrected in parent PR #30676.
- Full `pnpm check` stops at 452 existing unrelated formatting files.

An isolated synthetic benchmark processed 5,000 opens against about 1.99 million historical recipient rows, using email incremental counters in both arms. The member comparison path reduced handler reads by 46.7% with fresh events, 73.0% with half duplicates, and 99.4% with all duplicates. Exact transitions, final email totals and independent joined member truth matched in every run. Comparison still scans changed members’ history; the following reconciliation PR removes that cost from ingestion. The harness disables commit flushing and binary logging, so these are read-cost comparisons, not production write-latency claims.

This PR uses `jonatan-ber-3934-member-counter-base` as its review base: it combines member preparation #30676 with the independent email counter/final reconciliation stack #30674 and #30675. This keeps the member-event diff reviewable on its own while those dependencies are in review. Retarget after the parent stacks land.

ref https://linear.app/ghost/issue/BER-3934/add-incremental-email-and-member-analytics-counters

The updated base includes the schema PR's serialization correction: the internal tracked-email denominator stays out of comment reaction/report responses. The rebase changes only that two-file fix; counter and reconciliation behavior is unchanged.
