### PR TITLE
Added bounded periodic member reconciliation

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -534,6 +534,14 @@ async function initBackgroundServices({ config }) {
   }
 
   try {
+    const emailAnalytics = require('./server/services/email-analytics');
+    await emailAnalytics.memberReconciliation.schedule(jobsService);
+  } catch (err) {
+    const logging = require('@tryghost/logging');
+    logging.error(err);
+  }
+
+  try {
     const updateCheck = require('./server/services/update-check');
     await updateCheck.scheduleJobs(jobsService);
   } catch (err) {

--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -136,3 +136,16 @@ drained baseline. The current sending code honors persisted enrollment, but an
 older send binary may not, so unresolved enrolled preparation must be reconciled
 before a binary rollback. Keep this fallback until the fleet rollout and retained
 aggregation paths have been decided.
+
+## Member sweep cadence and repair observations
+
+The shared sweep accepts a restart delay measured from its persisted completion
+at `jobs.finished_at`. This delay survives process recreation. It applies only
+to completed sweeps; an interrupted pass resumes immediately from its checkpoint.
+The manual CLI retains immediate explicit `--restart` behavior.
+
+Sweep observations use the same opens-inclusive truth as comparison. Initialized
+members contribute comparison and drift metrics only after the counter page and
+checkpoint commit. Drift logs identify repairs and include a bounded sample of
+affected members. First-use initialization is excluded from drift measurements.
+A failed page reports no successful repair and leaves the checkpoint unchanged.

--- a/ghost/core/core/server/services/email-analytics/README.md
+++ b/ghost/core/core/server/services/email-analytics/README.md
@@ -87,7 +87,8 @@ Comparison retains email recount load until the incremental mode is enabled.
 
 ## Newsletter member counters
 
-`emailAnalytics.memberCounterMode` defaults to `off`. Its `compare` mode requires
+`emailAnalytics.memberCounterMode` defaults to `off`. Its `compare` and
+`incremental` modes require
 `batchProcessing: true`, an enabled email counter mode, and
 `memberCounterPreparation: true`; an unknown value or a missing prerequisite is
 logged at boot and leaves member counters off. The mode is selected at boot.
@@ -118,12 +119,16 @@ Drift logs contain member IDs and actual/expected values for differing statistic
 `statistic` and `phase`; `email_analytics_member_counter_drift` adds absolute
 differences with the same labels. A null-versus-numeric rate mismatch adds one. Comparison does not repair counters;
 the shared sweep owns repair. Comparison retains historical read cost during the
-soak; removing those reads and scheduling periodic repair follow separately.
+soak. After a successful soak, `incremental` keeps the atomic writes and removes
+member comparison from every fetch aggregation, including final aggregation.
+Email final reconciliation continues according to its own mode.
 
 For cutover, stop and drain analytics and sending workers. Complete a fresh full
 member baseline while legacy writers remain stopped; if an older partial sweep
 exists, finish it and then use `--restart` for a fresh pass under this boundary.
-Enable member preparation and comparison together when restarting workers. Email
+Enable member preparation and comparison together when restarting workers. Move
+to incremental mode only after the comparison and reconciliation rollout gates
+are met. Email
 baseline correction remains limited to touched emails and always includes opens.
 After cutover, member event updates, preparation and the manual sweep share the
 locking protocol and can run together.
@@ -149,3 +154,51 @@ members contribute comparison and drift metrics only after the counter page and
 checkpoint commit. Drift logs identify repairs and include a bounded sample of
 affected members. First-use initialization is excluded from drift measurements.
 A failed page reports no successful repair and leaves the checkpoint unchanged.
+
+The jobs service always registers a dedicated member repair queue with
+concurrency one; only member incremental mode schedules work on it. The
+recurring job runs independently of event fetching every five minutes, with
+randomized seconds and minute offsets. Analytics and its background-jobs flag
+must both be enabled for scheduling. The queue serializes deliveries, so ticks
+that arrive while a page is running would drain the moment it ends; the handler
+skips a tick while a page is running, any tick sooner than four and a half
+minutes after the previous page started, and any tick within a minute of its
+end, so pages never run back to back. The jobs shutdown lifecycle waits for an
+in-flight page up to the server shutdown timeout; a page that outlives it is
+rolled back by the connection teardown and resumes from the persisted
+checkpoint. Failed pages
+surface through job failure reporting and resume on a later tick. The registered
+handler is inert in other modes, including older queued deliveries. Scheduling is
+per process: every Ghost process with background jobs enabled ticks on its own
+schedule, and the checkpoint row lock serializes their pages, so the cadence
+below describes a single process.
+
+`emailAnalytics.memberReconciliationBatchSize` defaults to 5,000 and accepts
+integers from 1 to 5,000. Each invocation runs one page. Completed sweeps pause
+for `emailAnalytics.memberReconciliationPauseHours` (default six) before restarting.
+A zero pause requests continuous passes; unfinished passes do not wait for this
+completion pause. An unusable value is logged at boot and leaves scheduled repair
+off rather than stopping the site. Change these settings at boot and tune pages
+from observed transaction time and lock contention. When background jobs are
+disabled, periodic repair does not run; operators must arrange the shared manual
+sweep.
+
+For 800,000 members with the defaults, scheduler arithmetic suggests roughly
+20 hours between full passes, including the completion pause. A measured maximum
+24-hour reconciliation age is the proposed rollout target, not a production
+guarantee: failures, downtime, page duration and contention can extend it. Reduce
+page size if locks interfere with ingestion, then reassess pause and cadence
+against that target before enabling incremental mode.
+
+The structured `email-analytics.member-reconciliation` log reports the persisted
+checkpoint's cumulative member count, last ID and completion state after each
+page; during the completion pause the handler reports nothing, although the
+jobs service still logs each delivery. Use the checkpoint row's
+`finished_at` to measure successful full-pass age
+and its `updated_at` to track progress. The jobs service records invocation timing
+and failures; member drift observations identify corrections after commit.
+
+Legacy sequential/batched recomputation and compare mode remain supported and
+covered. Their eventual retirement, fleet/Core defaults and rollback window remain
+explicit pre-merge decisions for this reconciliation PR. No scheduling-lane priority
+or production flag changes are included here.

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -25,6 +25,7 @@ import type DomainEvents from '@tryghost/domain-events';
 import { Queries } from './lib/queries';
 import { NewsletterEmailCounters } from './newsletter-email-counters';
 import { NewsletterMemberCounters } from './newsletter-member-counters';
+import { NewsletterMemberReconciliation } from './newsletter-member-reconciliation';
 import { StartEmailAnalyticsJobEvent } from './events/start-email-analytics-job-event';
 import { StartAutomationEmailAnalyticsJobEvent } from './events/start-automation-email-analytics-job-event';
 import { AUTOMATION_EMAIL_TAG } from '../member-welcome-emails/constants';
@@ -79,7 +80,7 @@ export function resolveEmailCounterMode(
   return mode;
 }
 
-const MemberCounterMode = z.enum(['off', 'compare']);
+const MemberCounterMode = z.enum(['off', 'compare', 'incremental']);
 type MemberCounterMode = z.infer<typeof MemberCounterMode>;
 
 /**
@@ -112,6 +113,9 @@ export function resolveMemberCounterMode(
   logging.info(`[EmailAnalytics] Newsletter member counter mode: ${mode}`);
   return mode;
 }
+
+/** Boot-owned recurring repair; configured by init() and registered with the jobs service. */
+export const memberReconciliation = new NewsletterMemberReconciliation();
 
 export const init = ({
   automationsApi,
@@ -152,9 +156,22 @@ export const init = ({
   const emailCounters = emailCounterMode
     ? new NewsletterEmailCounters({ knex: db.knex, prometheusClient, mode: emailCounterMode })
     : null;
-  const memberCounters = resolveMemberCounterMode(config, emailCounterMode)
-    ? new NewsletterMemberCounters(db.knex, { prometheusClient })
+  const memberCounterMode = resolveMemberCounterMode(config, emailCounterMode);
+  const memberCounters = memberCounterMode
+    ? new NewsletterMemberCounters(db.knex, { prometheusClient, mode: memberCounterMode })
     : null;
+
+  memberReconciliation.configure({
+    counters: memberCounters,
+    enabled:
+      memberCounterMode === 'incremental' &&
+      Boolean(config.get('emailAnalytics:enabled')) &&
+      Boolean(config.get('backgroundJobs:emailAnalytics')),
+    settings: {
+      batchSize: config.get('emailAnalytics:memberReconciliationBatchSize'),
+      pauseHours: config.get('emailAnalytics:memberReconciliationPauseHours'),
+    },
+  });
 
   const newsletterEmailEventProcessor = new EmailEventProcessor({
     domainEvents,

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -304,6 +304,12 @@ class NewsletterEmailAnalyticsBatchProcessor {
     }
     const emailAggregationTimeMs = Date.now() - emailAggregationStart;
 
+    // Exact member increments already committed with recipient facts. Periodic
+    // reconciliation uses the shared bounded sweep outside the fetch loop.
+    if (this.#memberCounters?.mode === 'incremental') {
+      return { emailAggregationTimeMs, memberAggregationTimeMs: 0 };
+    }
+
     const memberMetric = this.#prometheusClient?.getMetric(AGGREGATE_MEMBER_STATS_METRIC_NAME);
 
     const memberAggregationStart = Date.now();

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -77,13 +77,18 @@ export type MemberSweepCheckpoint = z.infer<typeof checkpointSchema>;
 /** Shared derived truth for initialization, repair and rollback re-baselining. */
 export class NewsletterMemberCounters {
   readonly #knex: Knex;
+  readonly mode: 'compare' | 'incremental';
   readonly #prometheusClient: CounterMetricsClient | null;
 
   constructor(
     knex: Knex,
-    { prometheusClient = null }: { prometheusClient?: CounterMetricsClient | null } = {},
+    {
+      prometheusClient = null,
+      mode = 'compare',
+    }: { prometheusClient?: CounterMetricsClient | null; mode?: 'compare' | 'incremental' } = {},
   ) {
     this.#knex = knex;
+    this.mode = mode;
     this.#prometheusClient = prometheusClient;
     // `phase` matches the email counter metrics, so a later repair phase can
     // be told apart from observe-only comparison without changing the series.
@@ -127,7 +132,14 @@ export class NewsletterMemberCounters {
             email_opened_count: 0,
             email_open_rate: null,
           };
-          result.set(member.id, this.#differences(member, expected));
+          // #lockMembers only returned initialized members, so the denominator is set
+          result.set(
+            member.id,
+            this.#differences(
+              { ...member, email_tracked_count: member.email_tracked_count ?? 0 },
+              expected,
+            ),
+          );
         }
         return result;
       },
@@ -149,6 +161,9 @@ export class NewsletterMemberCounters {
 
   /** Publish observations only after the enclosing transaction is acknowledged. */
   #recordComparisons(comparisons: Map<string, MemberDrift>, phase: 'comparison' | 'repair'): void {
+    if (comparisons.size === 0) {
+      return;
+    }
     const drift = [...comparisons].filter(([, differences]) => Object.keys(differences).length);
     if (drift.length) {
       logging.warn(
@@ -466,8 +481,11 @@ export class NewsletterMemberCounters {
       if (state.complete && !restart) {
         // Check the persisted completion time under the checkpoint lock. A process
         // restart must not reset cadence, and an unfinished sweep must keep moving.
+        if (startAnotherAfterMs === undefined) {
+          return state;
+        }
         const finishedAt = job.finished_at ? new Date(job.finished_at).getTime() : 0;
-        if (startAnotherAfterMs === undefined || Date.now() < finishedAt + startAnotherAfterMs) {
+        if (Date.now() < finishedAt + startAnotherAfterMs) {
           return { ...state, paused: true };
         }
         Object.assign(state, initial);
@@ -572,9 +590,7 @@ export class NewsletterMemberCounters {
     if (throughId !== undefined) {
       members.where('id', '<=', throughId);
     }
-    const rows: ({ id: string } & Omit<MemberCounts, 'email_tracked_count'> & {
-        email_tracked_count: number | null;
-      })[] = await members;
+    const rows = ((await members) as unknown[]).map((row) => DbMemberCounters.parse(row));
     if (rows.length === 0) {
       return { afterId, processed: 0 };
     }

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-counters.ts
@@ -127,28 +127,42 @@ export class NewsletterMemberCounters {
             email_opened_count: 0,
             email_open_rate: null,
           };
-          const differences: MemberDrift = {};
-          for (const column of MEMBER_COUNTER_COLUMNS) {
-            if (member[column] !== expected[column]) {
-              differences[column] = { actual: member[column], expected: expected[column] };
-            }
-          }
-          result.set(member.id, differences);
+          result.set(member.id, this.#differences(member, expected));
         }
         return result;
       },
       this.#transactionConfig(),
     );
+    this.#recordComparisons(comparisons, 'comparison');
+    return comparisons;
+  }
+
+  #differences(actual: MemberCounts, expected: MemberCounts): MemberDrift {
+    const differences: MemberDrift = {};
+    for (const column of MEMBER_COUNTER_COLUMNS) {
+      if (actual[column] !== expected[column]) {
+        differences[column] = { actual: actual[column], expected: expected[column] };
+      }
+    }
+    return differences;
+  }
+
+  /** Publish observations only after the enclosing transaction is acknowledged. */
+  #recordComparisons(comparisons: Map<string, MemberDrift>, phase: 'comparison' | 'repair'): void {
     const drift = [...comparisons].filter(([, differences]) => Object.keys(differences).length);
     if (drift.length) {
       logging.warn(
-        `[EmailAnalytics] Newsletter member counter drift: ${JSON.stringify(drift.map(([memberId, differences]) => ({ memberId, differences })))}`,
+        `[EmailAnalytics] Newsletter member counter drift: ${JSON.stringify({
+          phase,
+          members: drift.length,
+          sample: drift.slice(0, 20).map(([memberId, differences]) => ({ memberId, differences })),
+        })}`,
       );
     }
-    for (const differences of comparisons.values()) {
-      for (const statistic of MEMBER_COUNTER_COLUMNS) {
-        const labels = { statistic, phase: 'comparison' };
-        incrementCounter(this.#prometheusClient, MEMBER_COMPARISONS_METRIC, labels, 1);
+    for (const statistic of MEMBER_COUNTER_COLUMNS) {
+      const labels = { statistic, phase };
+      incrementCounter(this.#prometheusClient, MEMBER_COMPARISONS_METRIC, labels, comparisons.size);
+      for (const [, differences] of drift) {
         const difference = differences[statistic];
         if (difference) {
           incrementCounter(
@@ -162,7 +176,6 @@ export class NewsletterMemberCounters {
         }
       }
     }
-    return comparisons;
   }
 
   /** Lock member counter rows in primary-key order and validate them. */
@@ -395,11 +408,26 @@ export class NewsletterMemberCounters {
   async runSweepPage({
     limit = MAX_SWEEP_PAGE_SIZE,
     restart = false,
+    startAnotherAfterMs,
   }: {
     limit?: number;
+    /** Abandon any existing checkpoint, complete or not, and begin a fresh sweep. */
     restart?: boolean;
-  } = {}): Promise<MemberSweepCheckpoint> {
+    /**
+     * Continue an unfinished sweep; once one completes, begin another only after
+     * this pause has passed since its completion. Undefined never begins another.
+     */
+    startAnotherAfterMs?: number;
+  } = {}): Promise<MemberSweepCheckpoint & { paused?: boolean }> {
     this.#validateLimit(limit);
+    if (
+      startAnotherAfterMs !== undefined &&
+      (!Number.isSafeInteger(startAnotherAfterMs) || startAnotherAfterMs < 0)
+    ) {
+      throw new IncorrectUsageError({
+        message: 'Member sweep pause must be a nonnegative integer of milliseconds',
+      });
+    }
     // Outside the page transaction: this range lookup must not establish its
     // recipient snapshot before the member locks. New members are initialized
     // by preparation; a later full sweep will also visit them.
@@ -424,7 +452,8 @@ export class NewsletterMemberCounters {
       })
       .onConflict('name')
       .ignore();
-    return this.#knex.transaction(async (trx) => {
+    const comparisons = new Map<string, MemberDrift>();
+    const checkpoint = await this.#knex.transaction(async (trx) => {
       const job = await trx('jobs').where('name', SWEEP_JOB_NAME).forUpdate().first();
       if (!job) {
         throw this.#nonRetryable(
@@ -433,16 +462,27 @@ export class NewsletterMemberCounters {
         );
       }
       const state = restart ? initial : this.#parseCheckpoint(job.metadata);
+      let starting = restart;
       if (state.complete && !restart) {
-        return state;
+        // Check the persisted completion time under the checkpoint lock. A process
+        // restart must not reset cadence, and an unfinished sweep must keep moving.
+        const finishedAt = job.finished_at ? new Date(job.finished_at).getTime() : 0;
+        if (startAnotherAfterMs === undefined || Date.now() < finishedAt + startAnotherAfterMs) {
+          return { ...state, paused: true };
+        }
+        Object.assign(state, initial);
+        starting = true;
       }
-      const starting = restart;
       if (state.throughId !== null) {
-        const page = await this.#sweepPage(trx, {
-          afterId: state.afterId ?? undefined,
-          throughId: state.throughId,
-          limit,
-        });
+        const page = await this.#sweepPage(
+          trx,
+          {
+            afterId: state.afterId ?? undefined,
+            throughId: state.throughId,
+            limit,
+          },
+          comparisons,
+        );
         state.afterId = page.afterId ?? null;
         state.processed += page.processed;
         state.complete = page.processed === 0 || state.afterId === state.throughId;
@@ -458,6 +498,8 @@ export class NewsletterMemberCounters {
         });
       return state;
     }, this.#transactionConfig());
+    this.#recordComparisons(comparisons, 'repair');
+    return checkpoint;
   }
 
   #parseCheckpoint(metadata: unknown): MemberSweepCheckpoint {
@@ -490,10 +532,13 @@ export class NewsletterMemberCounters {
     limit = MAX_SWEEP_PAGE_SIZE,
   }: MemberSweepPage = {}): Promise<MemberSweepResult> {
     this.#validateLimit(limit);
-    return this.#knex.transaction(
-      (trx) => this.#sweepPage(trx, { afterId, throughId, limit }),
+    const comparisons = new Map<string, MemberDrift>();
+    const page = await this.#knex.transaction(
+      (trx) => this.#sweepPage(trx, { afterId, throughId, limit }, comparisons),
       this.#transactionConfig(),
     );
+    this.#recordComparisons(comparisons, 'repair');
+    return page;
   }
 
   #validateLimit(limit: number): void {
@@ -511,23 +556,48 @@ export class NewsletterMemberCounters {
   async #sweepPage(
     trx: Knex.Transaction,
     { afterId, throughId, limit }: MemberSweepPage & { limit: number },
+    comparisons: Map<string, MemberDrift>,
   ): Promise<MemberSweepResult> {
     // Lock before the first consistent read. Event and preparation increments
     // must take the same member locks before changing recipient-derived totals.
     // An IN-list's input order alone would not establish InnoDB lock order.
-    const members = this.#members(trx).select('id').orderBy('id').limit(limit).forUpdate();
+    const members = this.#members(trx)
+      .select('id', ...MEMBER_COUNTER_COLUMNS)
+      .orderBy('id')
+      .limit(limit)
+      .forUpdate();
     if (afterId !== undefined) {
       members.where('id', '>', afterId);
     }
     if (throughId !== undefined) {
       members.where('id', '<=', throughId);
     }
-    const rows: { id: string }[] = await members;
+    const rows: ({ id: string } & Omit<MemberCounts, 'email_tracked_count'> & {
+        email_tracked_count: number | null;
+      })[] = await members;
     if (rows.length === 0) {
       return { afterId, processed: 0 };
     }
     const memberIds = rows.map((row) => row.id);
-    await this.#setCounts(trx, memberIds, await this.#derive(trx, memberIds));
+    const truth = await this.#derive(trx, memberIds);
+    for (const member of rows) {
+      // A NULL denominator denotes initialization, not drift.
+      if (member.email_tracked_count !== null) {
+        comparisons.set(
+          member.id,
+          this.#differences(
+            { ...member, email_tracked_count: member.email_tracked_count },
+            truth.get(member.id) ?? {
+              email_count: 0,
+              email_tracked_count: 0,
+              email_opened_count: 0,
+              email_open_rate: null,
+            },
+          ),
+        );
+      }
+    }
+    await this.#setCounts(trx, memberIds, truth);
     return { afterId: memberIds.at(-1), processed: rows.length };
   }
 

--- a/ghost/core/core/server/services/email-analytics/newsletter-member-reconciliation.ts
+++ b/ghost/core/core/server/services/email-analytics/newsletter-member-reconciliation.ts
@@ -1,0 +1,154 @@
+import logging from '@tryghost/logging';
+import { z } from 'zod';
+import { Job } from '../jobs-service/job';
+import type { JobsService } from '../jobs-service/jobs-service';
+import type { NewsletterMemberCounters } from './newsletter-member-counters';
+
+export class ReconcileNewsletterMembersJob extends Job {
+  static type = 'email-analytics-member-reconciliation';
+}
+
+const MAX_BATCH_SIZE = 5000;
+const TICK_INTERVAL_MS = 5 * 60 * 1000;
+// The queue serializes deliveries, so ticks that arrive while a page is running
+// drain the moment it ends. Skip any tick sooner than the schedule would have
+// delivered it, and leave a gap after each page, so pages never run back to back.
+const MIN_PAGE_SPACING_MS = TICK_INTERVAL_MS - 30 * 1000;
+const MIN_GAP_AFTER_PAGE_MS = 60 * 1000;
+const ReconciliationSettings = z.object({
+  batchSize: z.number().int().min(1).max(MAX_BATCH_SIZE).default(MAX_BATCH_SIZE),
+  pauseHours: z.number().finite().min(0).default(6),
+});
+export type ReconciliationSettings = z.output<typeof ReconciliationSettings>;
+
+/**
+ * Config is boundary data: an unusable page size or pause is logged and
+ * leaves scheduled repair off rather than stopping the site from booting.
+ */
+export function resolveReconciliationSettings(configured: {
+  batchSize?: unknown;
+  pauseHours?: unknown;
+}): ReconciliationSettings | null {
+  const parsed = ReconciliationSettings.safeParse({
+    batchSize: configured.batchSize ?? undefined,
+    pauseHours: configured.pauseHours ?? undefined,
+  });
+  if (!parsed.success) {
+    logging.warn(
+      `[EmailAnalytics] Ignoring unusable member reconciliation settings ${JSON.stringify(configured)}: batch size must be 1 to ${MAX_BATCH_SIZE} and the pause a non-negative number of hours; scheduled member repair is off`,
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+/**
+ * Boot-owned recurring use of the same sweep that initializes member counters.
+ * Constructed at module scope like the analytics wrappers and configured by
+ * init(), so registering and scheduling never depend on call order.
+ */
+export class NewsletterMemberReconciliation {
+  #counters: Pick<NewsletterMemberCounters, 'runSweepPage'> | null = null;
+  #enabled = false;
+  #settings: ReconciliationSettings = ReconciliationSettings.parse({});
+  #running = false;
+  #lastPageStartedAt = -Infinity;
+  #lastPageEndedAt = -Infinity;
+
+  configure({
+    counters,
+    enabled,
+    settings,
+  }: {
+    counters: Pick<NewsletterMemberCounters, 'runSweepPage'> | null;
+    enabled: boolean;
+    settings: { batchSize?: unknown; pauseHours?: unknown };
+  }): void {
+    const resolved = resolveReconciliationSettings(settings);
+    this.#counters = counters;
+    this.#settings = resolved ?? this.#settings;
+    this.#enabled = enabled && Boolean(counters) && resolved !== null;
+    if (enabled && !this.#enabled) {
+      logging.warn('[EmailAnalytics] Scheduled member counter repair is off');
+    } else if (this.#enabled) {
+      logging.info(
+        `[EmailAnalytics] Scheduled member counter repair: pages of ${this.#settings.batchSize} members, ${this.#settings.pauseHours} hour pause after each full pass`,
+      );
+    }
+  }
+
+  get enabled(): boolean {
+    return this.#enabled;
+  }
+
+  get settings(): ReconciliationSettings {
+    return this.#settings;
+  }
+
+  register(jobs: Pick<JobsService, 'handle'>): void {
+    // Retain a no-op handler when disabled so an older queued delivery cannot
+    // run counter repairs alongside legacy writers after a configuration change.
+    jobs.handle(
+      ReconcileNewsletterMembersJob,
+      async () => {
+        if (!this.#enabled || !this.#counters) {
+          return;
+        }
+        const now = Date.now();
+        if (this.#running) {
+          logging.info(
+            '[EmailAnalytics] Skipping member reconciliation tick: a page is still running',
+          );
+          return;
+        }
+        if (
+          now < this.#lastPageStartedAt + MIN_PAGE_SPACING_MS ||
+          now < this.#lastPageEndedAt + MIN_GAP_AFTER_PAGE_MS
+        ) {
+          logging.info(
+            '[EmailAnalytics] Skipping member reconciliation tick: a page ran too recently',
+          );
+          return;
+        }
+        this.#running = true;
+        this.#lastPageStartedAt = now;
+        try {
+          const checkpoint = await this.#counters.runSweepPage({
+            limit: this.#settings.batchSize,
+            // Fractional hours are allowed; the sweep wants whole milliseconds.
+            startAnotherAfterMs: Math.round(this.#settings.pauseHours * 60 * 60 * 1000),
+          });
+          if (checkpoint.paused) {
+            return;
+          }
+          logging.info(
+            {
+              system: {
+                event: 'email-analytics.member-reconciliation',
+                members_processed: checkpoint.processed,
+                complete: checkpoint.complete,
+                after_id: checkpoint.afterId,
+              },
+            },
+            '[EmailAnalytics] Member reconciliation checkpoint',
+          );
+        } finally {
+          this.#running = false;
+          this.#lastPageEndedAt = Date.now();
+        }
+      },
+      { queue: 'newsletter-member-reconciliation', concurrency: 1 },
+    );
+  }
+
+  async schedule(jobs: Pick<JobsService, 'scheduleRecurring'>): Promise<void> {
+    if (!this.#enabled) {
+      return;
+    }
+    const seconds = Math.floor(Math.random() * 60);
+    const minutes = Math.floor(Math.random() * 5);
+    await jobs.scheduleRecurring(new ReconcileNewsletterMembersJob(), {
+      cron: `${seconds} ${minutes}/5 * * * *`,
+    });
+  }
+}

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -144,7 +144,13 @@ class EmailServiceWrapper {
       getRequiredUrlRelations,
       batchCreationConcurrency,
       memberCounterPreparation,
-      memberCounters: new NewsletterMemberCounters(db.knex),
+      memberCounters: new NewsletterMemberCounters(db.knex, {
+        // Sending never reads the mode today; keep it consistent with analytics.
+        mode:
+          configService.get('emailAnalytics:memberCounterMode') === 'incremental'
+            ? 'incremental'
+            : 'compare',
+      }),
     });
     const sendingStatusService = new SendingStatusService({ knex: db.knex });
 

--- a/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
+++ b/ghost/core/core/server/services/jobs-service/register-job-handlers.ts
@@ -13,6 +13,7 @@ import type MentionController from '../mentions/mention-controller';
 import type MentionSendingService from '../mentions/mention-sending-service';
 import ProcessWebmentionJob from '../mentions/process-webmention-job';
 import SendWebmentionsJob from '../mentions/send-webmentions-job';
+import { memberReconciliation } from '../email-analytics';
 
 const updateCheck = require('../update-check');
 
@@ -47,6 +48,9 @@ export default function registerJobHandlers({
   jobsService.handle(CleanTokensJob, async () => {
     await memberJobs.cleanTokens();
   });
+
+  // Periodic member counter repair; inert unless email analytics enabled it.
+  memberReconciliation.register(jobsService);
 
   jobsService.handle(CleanExpiredCompedJob, async () => {
     await memberJobs.cleanExpiredComped();

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -303,6 +303,8 @@
     "batchProcessing": false,
     "memberCounterPreparation": false,
     "memberCounterMode": "off",
+    "memberReconciliationBatchSize": 5000,
+    "memberReconciliationPauseHours": 6,
     "metrics": {
       "openThroughput": {
         "enabled": false,

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -245,7 +245,13 @@ describe('Newsletter member counter baselines through MySQL', () => {
       ]),
     );
     assert.equal((await stats()).email_opened_count, 4);
+    // Each comparison counts the members observed once per statistic
     sinon.assert.callCount(observations.inc, 8);
+    sinon.assert.calledWithExactly(
+      observations.inc,
+      { statistic: 'email_count', phase: 'comparison' },
+      1,
+    );
     sinon.assert.calledWithExactly(
       differences.inc,
       { statistic: 'email_opened_count', phase: 'comparison' },
@@ -317,6 +323,70 @@ describe('Newsletter member counter baselines through MySQL', () => {
     });
     sinon.assert.calledOnce(compare);
     assert.equal((await stats()).email_opened_count, 1);
+  });
+
+  it('keeps incremental ingestion free of member history scans and repairs drift in the shared sweep', async () => {
+    const target = await recipient();
+    counters = new NewsletterMemberCounters(db.knex, { mode: 'incremental' });
+    await counters.sweepPage({ throughId: id(3) });
+    const emailCounters = new NewsletterEmailCounters({ knex: db.knex, mode: 'incremental' });
+    const config = { get: () => true };
+    const storage = new NewsletterEmailEventStorage({
+      config,
+      db,
+      models,
+      emailCounters,
+      memberCounters: counters,
+    });
+    const compare = sinon.spy(counters, 'compareMembers');
+    const processor = new NewsletterEmailAnalyticsBatchProcessor({
+      config,
+      queries: {},
+      emailCounters,
+      memberCounters: counters,
+      emailEventProcessor: new EmailEventProcessor({
+        db,
+        eventStorage: storage,
+        domainEvents: { dispatch() {} },
+      }),
+    });
+    const historyReads: string[] = [];
+    const capture = (query: unknown) => {
+      const sql = sqlOf(query);
+      if (/group by.*member_id/i.test(sql)) {
+        historyReads.push(sql);
+      }
+    };
+    db.knex.on('query', capture);
+    try {
+      const result = new EventProcessingResult();
+      await processor.processBatch(
+        [
+          {
+            type: 'opened',
+            emailId: target.emailId,
+            recipientEmail: 'member-counter-1@example.com',
+            timestamp: new Date(),
+          },
+        ],
+        result,
+        {},
+      );
+      await processor.aggregate({
+        processingResult: result,
+        includeOpenedEvents: false,
+        isFinal: true,
+      });
+      sinon.assert.notCalled(compare);
+      assert.deepEqual(historyReads, []);
+      assert.equal((await stats()).email_opened_count, 1);
+      await db.knex('members').where('id', id(1)).update({ email_opened_count: 7 });
+      await counters.runSweepPage({ limit: 1 });
+      assert.equal((await stats()).email_opened_count, 1);
+      assert.equal(historyReads.length, 1);
+    } finally {
+      db.knex.off('query', capture);
+    }
   });
 
   it('counts multiple opened recipient rows for one member, including untracked emails', async () => {
@@ -613,7 +683,11 @@ describe('Newsletter member counter baselines through MySQL', () => {
     }
     await counters.runSweepPage({ limit: 1 });
     assert.equal((await stats()).email_opened_count, 1);
-    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_opened_count' }, 6);
+    sinon.assert.calledWithExactly(
+      differences.inc,
+      { statistic: 'email_opened_count', phase: 'repair' },
+      6,
+    );
     sinon.assert.callCount(observations.inc, 4);
   });
 
@@ -623,8 +697,11 @@ describe('Newsletter member counter baselines through MySQL', () => {
     const completed = await counters.runSweepPage();
     assert.equal(completed.complete, true);
     await db.knex('members').where('id', id(1)).update({ email_opened_count: 7 });
-    const options = { limit: 1, restart: true, restartAfterMs: 6 * 60 * 60 * 1000 };
-    assert.deepEqual(await new NewsletterMemberCounters(db.knex).runSweepPage(options), completed);
+    const options = { limit: 1, startAnotherAfterMs: 6 * 60 * 60 * 1000 };
+    assert.deepEqual(await new NewsletterMemberCounters(db.knex).runSweepPage(options), {
+      ...completed,
+      paused: true,
+    });
     assert.equal((await stats()).email_opened_count, 7);
 
     clock.setSystemTime(new Date('2030-01-01T06:00:00Z'));

--- a/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
+++ b/ghost/core/test/integration/services/email-service/newsletter-member-counters.test.ts
@@ -581,6 +581,63 @@ describe('Newsletter member counter baselines through MySQL', () => {
     assert.equal((await db.knex('jobs').where('id', job.id).first()).status, 'finished');
   });
 
+  it('reports repaired drift only after the member page and checkpoint commit', async () => {
+    const observations = { inc: sinon.stub() };
+    const differences = { inc: sinon.stub() };
+    counters = new NewsletterMemberCounters(db.knex, {
+      prometheusClient: {
+        registerCounter: sinon.stub(),
+        getMetric: sinon
+          .stub()
+          .callsFake((name) =>
+            name === 'email_analytics_member_counter_comparisons' ? observations : differences,
+          ),
+      },
+    });
+    await recipient({ opened: true });
+    await counters.sweepPage({ throughId: id(1) });
+    await db.knex('members').where('id', id(1)).update({ email_opened_count: 7 });
+    await db.knex.raw(
+      "CREATE TRIGGER member_counter_repair_report_failure BEFORE UPDATE ON jobs FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected repair checkpoint failure'",
+    );
+    try {
+      await assert.rejects(
+        counters.runSweepPage({ limit: 1 }),
+        /injected repair checkpoint failure/,
+      );
+      assert.equal((await stats()).email_opened_count, 7);
+      sinon.assert.notCalled(differences.inc);
+      sinon.assert.notCalled(observations.inc);
+    } finally {
+      await db.knex.raw('DROP TRIGGER member_counter_repair_report_failure');
+    }
+    await counters.runSweepPage({ limit: 1 });
+    assert.equal((await stats()).email_opened_count, 1);
+    sinon.assert.calledWithExactly(differences.inc, { statistic: 'email_opened_count' }, 6);
+    sinon.assert.callCount(observations.inc, 4);
+  });
+
+  it('waits after a completed sweep across recreation, then resumes bounded repair pages', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2030-01-01T00:00:00Z'), toFake: ['Date'] });
+    await recipient({ opened: true });
+    const completed = await counters.runSweepPage();
+    assert.equal(completed.complete, true);
+    await db.knex('members').where('id', id(1)).update({ email_opened_count: 7 });
+    const options = { limit: 1, restart: true, restartAfterMs: 6 * 60 * 60 * 1000 };
+    assert.deepEqual(await new NewsletterMemberCounters(db.knex).runSweepPage(options), completed);
+    assert.equal((await stats()).email_opened_count, 7);
+
+    clock.setSystemTime(new Date('2030-01-01T06:00:00Z'));
+    const restarted = await new NewsletterMemberCounters(db.knex).runSweepPage(options);
+    assert.equal(restarted.processed, 1);
+    assert.equal(restarted.afterId, id(1));
+    assert.equal(restarted.complete, false);
+    assert.equal((await stats()).email_opened_count, 1);
+    const next = await new NewsletterMemberCounters(db.knex).runSweepPage(options);
+    assert.equal(next.processed, 2);
+    assert.equal(next.afterId, id(2));
+  });
+
   it('rolls member updates back when persisting the checkpoint fails', async () => {
     await recipient();
     await db.knex.raw(

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -6,6 +6,7 @@ import {
   gifts,
   init,
   newsletters,
+  memberReconciliation,
 } from '../../../../../core/server/services/email-analytics';
 import { GIFT_DELIVERY_EMAIL_TAG } from '../../../../../core/server/services/gifts/constants';
 import { AUTOMATION_EMAIL_TAG } from '../../../../../core/server/services/member-welcome-emails/constants';
@@ -209,6 +210,54 @@ describe('email analytics service', function () {
     },
   );
 
+  it.each([
+    ['incremental', true, true, true],
+    ['compare', true, true, false],
+    ['off', true, true, false],
+    ['incremental', false, true, false],
+    ['incremental', true, false, false],
+  ])(
+    'gates scheduled member repair with mode=%s analytics=%s jobs=%s',
+    async (mode, analytics, background, scheduled) => {
+      config.get.withArgs('emailAnalytics:batchProcessing').returns(true);
+      config.get.withArgs('emailAnalytics:emailCounterMode').returns('incremental');
+      config.get.withArgs('emailAnalytics:memberCounterPreparation').returns(true);
+      config.get.withArgs('emailAnalytics:memberCounterMode').returns(mode);
+      config.get.withArgs('emailAnalytics:enabled').returns(analytics);
+      config.get.withArgs('backgroundJobs:emailAnalytics').returns(background);
+      init(dependencies);
+      const jobs = { scheduleRecurring: sinon.stub().resolves() };
+      await memberReconciliation.schedule(jobs);
+      expect(jobs.scheduleRecurring.callCount).toBe(scheduled ? 1 : 0);
+    },
+  );
+
+  it('passes the configured reconciliation page size and pause to the scheduled repair', function () {
+    config.get.withArgs('emailAnalytics:batchProcessing').returns(true);
+    config.get.withArgs('emailAnalytics:emailCounterMode').returns('incremental');
+    config.get.withArgs('emailAnalytics:memberCounterPreparation').returns(true);
+    config.get.withArgs('emailAnalytics:memberCounterMode').returns('incremental');
+    config.get.withArgs('emailAnalytics:enabled').returns(true);
+    config.get.withArgs('backgroundJobs:emailAnalytics').returns(true);
+    config.get.withArgs('emailAnalytics:memberReconciliationBatchSize').returns(500);
+    config.get.withArgs('emailAnalytics:memberReconciliationPauseHours').returns(1);
+    init(dependencies);
+    expect(memberReconciliation.enabled).toBe(true);
+    expect(memberReconciliation.settings).toEqual({ batchSize: 500, pauseHours: 1 });
+  });
+
+  it('keeps scheduled repair off with an unusable page size instead of failing boot', function () {
+    config.get.withArgs('emailAnalytics:batchProcessing').returns(true);
+    config.get.withArgs('emailAnalytics:emailCounterMode').returns('incremental');
+    config.get.withArgs('emailAnalytics:memberCounterPreparation').returns(true);
+    config.get.withArgs('emailAnalytics:memberCounterMode').returns('incremental');
+    config.get.withArgs('emailAnalytics:enabled').returns(true);
+    config.get.withArgs('backgroundJobs:emailAnalytics').returns(true);
+    config.get.withArgs('emailAnalytics:memberReconciliationBatchSize').returns(10000);
+    init(dependencies);
+    expect(memberReconciliation.enabled).toBe(false);
+  });
+
   it('registers Prometheus metrics for member stat aggregation', function () {
     const registerCounter = sinon.stub();
 
@@ -247,6 +296,9 @@ describe('email analytics service', function () {
     [true, 'off', true, 'compare'],
     [true, 'compare', false, 'compare'],
     [true, 'compare', true, 'unknown'],
+    [false, 'incremental', true, 'incremental'],
+    [true, 'off', true, 'incremental'],
+    [true, 'incremental', false, 'incremental'],
   ])(
     'keeps member counters off for incompatible configuration (%s, %s, %s, %s)',
     function (batch, email, preparation, member) {

--- a/ghost/core/test/unit/server/services/email-analytics/newsletter-member-reconciliation.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/newsletter-member-reconciliation.test.ts
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import logging from '@tryghost/logging';
+import type {
+  JobsBackendBase,
+  JobEnvelope,
+  JobsStartOptions,
+  RecurringSchedule,
+  JobRouting,
+} from '@tryghost/adapter-base-jobs';
+import { JobsService } from '../../../../../core/server/services/jobs-service/jobs-service';
+import InMemoryJobsBackend from '../../../../../core/server/adapters/jobs/InMemoryJobsBackend';
+import { deferred } from '../../../../utils/deferred';
+import {
+  NewsletterMemberReconciliation,
+  ReconcileNewsletterMembersJob,
+  resolveReconciliationSettings,
+} from '../../../../../core/server/services/email-analytics/newsletter-member-reconciliation';
+
+class Backend implements JobsBackendBase {
+  readonly requiredFns = ['start', 'enqueue', 'scheduleRecurring', 'shutdown'] as const;
+  options?: JobsStartOptions;
+  recurring?: { envelope: JobEnvelope; schedule: RecurringSchedule; routing?: JobRouting };
+  start(options: JobsStartOptions) {
+    this.options = options;
+  }
+  enqueue() {}
+  shutdown() {}
+  scheduleRecurring(envelope: JobEnvelope, schedule: RecurringSchedule, routing?: JobRouting) {
+    this.recurring = { envelope, schedule, routing };
+  }
+}
+
+const quiet = { info() {}, error() {} };
+
+function configured(
+  counters: Pick<NewsletterMemberReconciliation, never> & { runSweepPage: sinon.SinonStub },
+  settings: { batchSize?: unknown; pauseHours?: unknown } = {},
+  enabled = true,
+) {
+  const reconciliation = new NewsletterMemberReconciliation();
+  reconciliation.configure({ counters, enabled, settings });
+  return reconciliation;
+}
+
+describe('Newsletter member reconciliation', () => {
+  afterEach(() => sinon.restore());
+
+  it.each([
+    { batchSize: 0 },
+    { batchSize: 5001 },
+    { batchSize: 1.5 },
+    { pauseHours: -1 },
+    { pauseHours: Infinity },
+  ])('keeps scheduled repair off for unusable settings instead of throwing: %j', (invalid) => {
+    const warn = sinon.stub(logging, 'warn');
+    assert.equal(resolveReconciliationSettings(invalid), null);
+    sinon.assert.calledWithMatch(warn, /unusable member reconciliation settings/);
+    const reconciliation = configured({ runSweepPage: sinon.stub() }, invalid);
+    assert.equal(reconciliation.enabled, false);
+  });
+
+  it('defaults to full pages and a six hour pause', () => {
+    assert.deepEqual(resolveReconciliationSettings({}), { batchSize: 5000, pauseHours: 6 });
+    assert.deepEqual(resolveReconciliationSettings({ batchSize: null, pauseHours: undefined }), {
+      batchSize: 5000,
+      pauseHours: 6,
+    });
+  });
+
+  it('stays off without counters even when asked to enable', () => {
+    const reconciliation = new NewsletterMemberReconciliation();
+    reconciliation.configure({ counters: null, enabled: true, settings: {} });
+    assert.equal(reconciliation.enabled, false);
+  });
+
+  it('does not schedule or execute old queued work when disabled', async () => {
+    const backend = new Backend();
+    const jobs = new JobsService({ backend, logging: quiet });
+    const counters = { runSweepPage: sinon.stub() };
+    const reconciliation = configured(counters, {}, false);
+    reconciliation.register(jobs);
+    await jobs.start();
+    await reconciliation.schedule(jobs);
+    assert.equal(backend.recurring, undefined);
+    await backend.options!.processor({ type: ReconcileNewsletterMembersJob.type, payload: '{}' });
+    sinon.assert.notCalled(counters.runSweepPage);
+  });
+
+  it('propagates a failed page and retries the persisted sweep on the next delivery', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2030-01-01T00:00:00Z'), toFake: ['Date'] });
+    const backend = new Backend();
+    const jobs = new JobsService({ backend, logging: quiet });
+    const counters = { runSweepPage: sinon.stub() };
+    counters.runSweepPage.onFirstCall().rejects(new Error('failed sweep page'));
+    counters.runSweepPage
+      .onSecondCall()
+      .resolves({ processed: 1, complete: false, afterId: 'member-1' });
+    const reconciliation = configured(counters);
+    reconciliation.register(jobs);
+    await jobs.start();
+    await reconciliation.schedule(jobs);
+    await assert.rejects(
+      backend.options!.processor(backend.recurring!.envelope),
+      /failed sweep page/,
+    );
+    // The next scheduled delivery, one interval later, retries the page
+    clock.tick(5 * 60 * 1000);
+    await backend.options!.processor(backend.recurring!.envelope);
+    sinon.assert.calledTwice(counters.runSweepPage);
+    assert.deepEqual(counters.runSweepPage.firstCall.args, counters.runSweepPage.secondCall.args);
+  });
+
+  it('skips ticks that queued behind a long page instead of running pages back to back', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2030-01-01T00:00:00Z'), toFake: ['Date'] });
+    const info = sinon.stub(logging, 'info');
+    const jobs = new JobsService({ backend: new InMemoryJobsBackend(), logging: quiet });
+    const started = deferred();
+    const release = deferred();
+    const skipped = deferred();
+    let skips = 0;
+    info.withArgs(sinon.match(/Skipping member reconciliation tick/)).callsFake(() => {
+      skips += 1;
+      if (skips === 2) {
+        skipped.done();
+      }
+    });
+    const counters = {
+      runSweepPage: sinon.stub().callsFake(async () => {
+        started.done();
+        await release.promise;
+        return { processed: 1, complete: false, afterId: 'member-1' };
+      }),
+    };
+    const reconciliation = configured(counters);
+    reconciliation.register(jobs);
+    await jobs.start();
+    try {
+      // A slow page: two more ticks arrive and queue behind it in the single lane
+      await jobs.dispatch(new ReconcileNewsletterMembersJob());
+      await started.promise;
+      await jobs.dispatch(new ReconcileNewsletterMembersJob());
+      await jobs.dispatch(new ReconcileNewsletterMembersJob());
+      clock.tick(7 * 60 * 1000);
+      release.done();
+      // Both queued deliveries run once the page ends and are skipped by the
+      // handler itself, within a minute of the page's end
+      await skipped.promise;
+      await jobs.shutdown();
+      sinon.assert.calledOnce(counters.runSweepPage);
+
+      // The next real interval runs again
+      const again = new JobsService({ backend: new InMemoryJobsBackend(), logging: quiet });
+      reconciliation.register(again);
+      await again.start();
+      clock.tick(5 * 60 * 1000);
+      counters.runSweepPage.resolves({ processed: 1, complete: false, afterId: 'member-2' });
+      await again.dispatch(new ReconcileNewsletterMembersJob());
+      await again.shutdown();
+      sinon.assert.calledTwice(counters.runSweepPage);
+    } finally {
+      release.done();
+      clock.restore();
+    }
+  });
+
+  it('skips a tick that arrives sooner than an interval after a quick page', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2030-01-01T00:00:00Z'), toFake: ['Date'] });
+    const backend = new Backend();
+    const jobs = new JobsService({ backend, logging: quiet });
+    const counters = {
+      runSweepPage: sinon.stub().resolves({ processed: 1, complete: false, afterId: 'member-1' }),
+    };
+    const reconciliation = configured(counters);
+    reconciliation.register(jobs);
+    await jobs.start();
+    await reconciliation.schedule(jobs);
+    const deliver = () => backend.options!.processor(backend.recurring!.envelope);
+    await deliver();
+    // A page that finished long enough ago still keeps the schedule's spacing
+    clock.tick(2 * 60 * 1000);
+    await deliver();
+    sinon.assert.calledOnce(counters.runSweepPage);
+    clock.tick(3 * 60 * 1000);
+    await deliver();
+    sinon.assert.calledTwice(counters.runSweepPage);
+  });
+
+  it('rounds a fractional pause to whole milliseconds for the sweep', async () => {
+    const jobs = new JobsService({ backend: new InMemoryJobsBackend(), logging: quiet });
+    const counters = {
+      runSweepPage: sinon.stub().resolves({ processed: 0, complete: true, afterId: undefined }),
+    };
+    const reconciliation = configured(counters, { pauseHours: 1 / 3 });
+    reconciliation.register(jobs);
+    await jobs.start();
+    await jobs.dispatch(new ReconcileNewsletterMembersJob());
+    await jobs.shutdown();
+    sinon.assert.calledOnce(counters.runSweepPage);
+    assert.equal(
+      Number.isSafeInteger(counters.runSweepPage.firstCall.args[0].startAnotherAfterMs),
+      true,
+    );
+    assert.equal(counters.runSweepPage.firstCall.args[0].startAnotherAfterMs, 1200000);
+  });
+
+  it('does not report a paused checkpoint as progress', async () => {
+    const backend = new Backend();
+    const jobs = new JobsService({ backend, logging: quiet });
+    const counters = {
+      runSweepPage: sinon.stub().resolves({
+        processed: 3,
+        complete: true,
+        afterId: 'member-3',
+        paused: true,
+      }),
+    };
+    const reconciliation = configured(counters);
+    reconciliation.register(jobs);
+    await jobs.start();
+    await reconciliation.schedule(jobs);
+    const info = sinon.stub(logging, 'info');
+    await backend.options!.processor(backend.recurring!.envelope);
+    sinon.assert.neverCalledWithMatch(info, sinon.match.has('system'));
+  });
+
+  it('lets the jobs service drain an in-flight member page during shutdown', async () => {
+    const jobs = new JobsService({ backend: new InMemoryJobsBackend(), logging: quiet });
+    const started = deferred();
+    const release = deferred();
+    const counters = {
+      runSweepPage: sinon.stub().callsFake(async () => {
+        started.done();
+        await release.promise;
+        return { processed: 1, complete: false, afterId: 'member-1' };
+      }),
+    };
+    const reconciliation = configured(counters);
+    reconciliation.register(jobs);
+    await jobs.start();
+    try {
+      await jobs.dispatch(new ReconcileNewsletterMembersJob());
+      await started.promise;
+      let drained = false;
+      const shutdown = jobs.shutdown().then(() => {
+        drained = true;
+      });
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      assert.equal(drained, false);
+      release.done();
+      await shutdown;
+      assert.equal(drained, true);
+      sinon.assert.calledOnce(counters.runSweepPage);
+    } finally {
+      release.done();
+      await jobs.shutdown();
+    }
+  });
+
+  it('schedules bounded sweep work in its own single-worker queue', async () => {
+    const backend = new Backend();
+    const jobs = new JobsService({ backend, logging: quiet });
+    const counters = {
+      runSweepPage: sinon.stub().resolves({ processed: 2, complete: false, afterId: 'member-2' }),
+    };
+    const reconciliation = configured(counters, { batchSize: 2, pauseHours: 6 });
+    reconciliation.register(jobs);
+    await jobs.start();
+    await reconciliation.schedule(jobs);
+    assert.ok(backend.recurring);
+    assert.deepEqual(backend.recurring.routing, { queue: 'newsletter-member-reconciliation' });
+    assert.deepEqual(backend.options?.queues, {
+      'newsletter-member-reconciliation': { concurrency: 1 },
+    });
+    assert.match(backend.recurring.schedule.cron, /^\d+ [0-4]\/5 \* \* \* \*$/);
+    await backend.options!.processor(backend.recurring.envelope);
+    sinon.assert.calledOnceWithExactly(counters.runSweepPage, {
+      limit: 2,
+      startAnotherAfterMs: 6 * 60 * 60 * 1000,
+    });
+  });
+});


### PR DESCRIPTION
Member comparison currently scans recipient history during ingestion, even though member increments already commit with recipient facts. This adds an opt-in `incremental` mode that removes those scans and uses the existing bounded sweep for periodic repair.

```text
fetch an event page
  commit recipient facts + email/member counters together
  finish email reconciliation when the fetch completes

independent recurring member job
  resume one bounded page from the shared checkpoint
  lock members → derive truth → repair counters
  commit counters + checkpoint together
  report observed drift after commit
  pause after a complete sweep, then start the next pass
```

The job uses Ghost's class-based jobs service and a dedicated queue with concurrency one. Registration happens during boot; scheduling happens after jobs start. The existing shutdown lifecycle drains an in-flight page. A failed page retains the previous checkpoint and a later delivery resumes it. Disabled modes keep an inert handler for old queued deliveries.

Each five-minute tick processes at most `memberReconciliationBatchSize` members (default 5,000; maximum 5,000). A completed sweep waits `memberReconciliationPauseHours` (default six) before restarting. Completion timing is persisted, so restarting a process does not restart the sweep early. Unfinished sweeps continue immediately from their checkpoint. The manual CLI still supports an immediate explicit restart.

Repair shares the same opens-inclusive derivation as initialization and comparison. It records drift only for initialized members and only after the transaction is acknowledged; logs identify repaired values and include at most 20 member samples. The job reports cumulative checkpoint progress separately from invocation timing. Neither the fetch lane ordering nor its opens-first priority changes.

`memberCounterMode` remains `off` by default. `compare` retains observe-only validation; `incremental` requires the existing batched email-counter and preparation boundaries. Recurring repair additionally requires analytics and its background jobs to be enabled. The README describes drained cutover/fallback, manual repair when jobs are disabled, configuration bounds, progress signals and timing limitations.

Validation:

- 264 MySQL newsletter/preparation tests passed across 13 files; 759 email, analytics and jobs-service unit tests passed in UTC. Core/test type checks and focused lint passed.
- Regression tests prove persisted restart cadence across process recreation, rollback without successful repair metrics, bounded job routing, disabled queued deliveries, failed-page retry and shutdown drain.
- A MySQL ingestion test proves incremental mode issues no member history query and that the shared sweep subsequently repairs injected drift. Existing compare/off behavior and final email reconciliation remain covered.
- Five independent reviews of each slice and the accumulated PR found no remaining high-confidence issues.
- Full `pnpm check` stops at 452 existing unrelated formatting files.

An isolated synthetic benchmark processes 5,000 opens against about 1.99 million recipient rows. Incremental mode reduces ingestion handler reads from 2,139,004 to 40,609 with fresh events (98.1%), and from 1,081,715 to 33,109 with half duplicates (96.9%). All-duplicate comparison already skips member history, so both modes use 25,549 reads. Separately, a persisted 5,000-member sweep repairs injected drift using 2,005,269 reads; that periodic cost is outside ingestion and must be included in workload estimates. All independent correctness checks passed. Commit flushing and binary logging are disabled in the harness, so these support read-cost comparisons rather than production write-latency claims.

Stacked on member event counters #30683, which combines member preparation #30676 with email counters and final reconciliation #30674/#30675. **Before merging this reconciliation PR, decide the fleet/Core default, retained fallback modes and rollback/retirement window.** The implementation retains and tests the existing fallback while that decision is outstanding.

ref https://linear.app/ghost/issue/BER-3935/replace-per-cycle-analytics-recompute-with-bounded-reconciliation

The updated base includes the schema PR's serialization correction: the internal tracked-email denominator stays out of comment reaction/report responses. The rebase changes only that two-file fix; counter and reconciliation behavior is unchanged.
