### PR TITLE
Added email analytics ingestion lag to Debug

### DIFF
--- a/apps/ember-admin/app/components/posts/debug.hbs
+++ b/apps/ember-admin/app/components/posts/debug.hbs
@@ -329,7 +329,7 @@
                         <td colspan="2"><hr></td>
                     </tr>
                     <tr>
-                        <td>Analytics Latest running:</td>
+                        <td>Analytics Delivery/failures running:</td>
                         <td class="gh-email-debug-settings-icon">
                             {{#if (and this.analyticsStatus this.analyticsStatus.latest this.analyticsStatus.latest.running) }}
                                 <span class="check">{{svg-jar "check-2"}}</span>
@@ -349,6 +349,47 @@
                     <tr>
                         <td>Last event time:</td>
                         <td>{{ this.analyticsStatus.latest.lastEventTimestamp }}</td>
+                    </tr>
+                    <tr>
+                        <td>Fetched through:</td>
+                        <td>{{ this.analyticsStatus.latest.fetchedThrough }}</td>
+                    </tr>
+                    <tr>
+                        <td>Ingestion lag:</td>
+                        <td>{{ this.analyticsStatus.latest.lag }} (includes a 1-minute buffer)</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2"><hr></td>
+                    </tr>
+                    <tr>
+                        <td>Analytics Opens running:</td>
+                        <td class="gh-email-debug-settings-icon">
+                            {{#if (and this.analyticsStatus this.analyticsStatus.latestOpened this.analyticsStatus.latestOpened.running) }}
+                                <span class="check">{{svg-jar "check-2"}}</span>
+                            {{else}}
+                                <span class="x">{{svg-jar "close"}}</span>
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Last started:</td>
+                        <td>{{ this.analyticsStatus.latestOpened.lastStarted }}</td>
+                    </tr>
+                    <tr>
+                        <td>Fetching from:</td>
+                        <td>{{ this.analyticsStatus.latestOpened.lastBegin }}</td>
+                    </tr>
+                    <tr>
+                        <td>Last event time:</td>
+                        <td>{{ this.analyticsStatus.latestOpened.lastEventTimestamp }}</td>
+                    </tr>
+                    <tr>
+                        <td>Fetched through:</td>
+                        <td>{{ this.analyticsStatus.latestOpened.fetchedThrough }}</td>
+                    </tr>
+                    <tr>
+                        <td>Ingestion lag:</td>
+                        <td>{{ this.analyticsStatus.latestOpened.lag }} (includes a 1-minute buffer)</td>
                     </tr>
                     <tr>
                         <td colspan="2"><hr></td>
@@ -374,6 +415,14 @@
                     <tr>
                         <td>Last event time:</td>
                         <td>{{ this.analyticsStatus.missing.lastEventTimestamp }}</td>
+                    </tr>
+                    <tr>
+                        <td>Fetched through:</td>
+                        <td>{{ this.analyticsStatus.missing.fetchedThrough }}</td>
+                    </tr>
+                    <tr>
+                        <td>Ingestion lag:</td>
+                        <td>{{ this.analyticsStatus.missing.lag }} (rechecks events at least 30 minutes old)</td>
                     </tr>
                     <tr>
                         <td colspan="2"><hr></td>

--- a/apps/ember-admin/app/components/posts/debug.hbs
+++ b/apps/ember-admin/app/components/posts/debug.hbs
@@ -356,7 +356,7 @@
                     </tr>
                     <tr>
                         <td>Ingestion lag:</td>
-                        <td>{{ this.analyticsStatus.latest.lag }} (includes a 1-minute buffer)</td>
+                        <td>{{ this.analyticsStatus.latest.lag }}</td>
                     </tr>
                     <tr>
                         <td colspan="2"><hr></td>
@@ -389,7 +389,7 @@
                     </tr>
                     <tr>
                         <td>Ingestion lag:</td>
-                        <td>{{ this.analyticsStatus.latestOpened.lag }} (includes a 1-minute buffer)</td>
+                        <td>{{ this.analyticsStatus.latestOpened.lag }}</td>
                     </tr>
                     <tr>
                         <td colspan="2"><hr></td>
@@ -422,7 +422,7 @@
                     </tr>
                     <tr>
                         <td>Ingestion lag:</td>
-                        <td>{{ this.analyticsStatus.missing.lag }} (rechecks events at least 30 minutes old)</td>
+                        <td>{{ this.analyticsStatus.missing.lag }}</td>
                     </tr>
                     <tr>
                         <td colspan="2"><hr></td>

--- a/apps/ember-admin/app/components/posts/debug.js
+++ b/apps/ember-admin/app/components/posts/debug.js
@@ -270,18 +270,20 @@ export default class Debug extends Component {
         this.analyticsStatus = result;
 
         // Parse dates
-        for (const type of Object.keys(result)) {
+        for (const type of ['latest', 'latestOpened', 'missing', 'scheduled']) {
             if (!result[type]) {
                 result[type] = {};
             }
             let object = result[type];
-            for (const key of ['lastStarted', 'lastBegin', 'lastEventTimestamp']) {
+            for (const key of ['lastStarted', 'lastBegin', 'lastEventTimestamp', 'fetchedThrough']) {
                 if (object[key]) {
                     object[key] = moment.utc(object[key]).format('DD MMM, YYYY, HH:mm:ss.SSS [UTC]');
                 } else {
                     object[key] = 'N/A';
                 }
             }
+
+            object.lag = this.formatIngestionLag(object.lagSeconds);
 
             if (object.schedule) {
                 object = object.schedule;
@@ -294,6 +296,20 @@ export default class Debug extends Component {
                 }
             }
         }
+    }
+
+    formatIngestionLag(seconds) {
+        if (!Number.isFinite(seconds) || seconds < 0) {
+            return 'N/A';
+        }
+        const duration = moment.duration(seconds, 'seconds');
+        return [
+            [Math.floor(duration.asDays()), 'd'],
+            [duration.hours(), 'h'],
+            [duration.minutes(), 'm'],
+            [duration.seconds(), 's']
+        ].filter(([value, unit]) => value > 0 || unit === 's')
+            .map(([value, unit]) => `${value}${unit}`).join(' ');
     }
 
     @action

--- a/apps/ember-admin/app/components/posts/debug.js
+++ b/apps/ember-admin/app/components/posts/debug.js
@@ -308,8 +308,8 @@ export default class Debug extends Component {
             [duration.hours(), 'h'],
             [duration.minutes(), 'm'],
             [duration.seconds(), 's']
-        ].filter(([value, unit]) => value > 0 || unit === 's')
-            .map(([value, unit]) => `${value}${unit}`).join(' ');
+        ].filter(([value]) => value > 0)
+            .map(([value, unit]) => `${value}${unit}`).join(' ') || '0s';
     }
 
     @action

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -16,6 +16,8 @@ export type FetchData = {
   /** The begin time used during the last fetch */
   lastBegin?: Date;
   lastEventTimestamp?: Date;
+  /** End of the last successfully fetched window, or its safe cursor when capped. */
+  fetchedThrough?: Date | null;
   /** Set to quit the job early */
   canceled?: boolean;
 };
@@ -153,11 +155,21 @@ export class EmailAnalyticsService {
   }
 
   getStatus() {
+    const measuredAt = new Date();
+    const withLag = <T extends FetchData>(data: T) =>
+      Object.assign(data, {
+        fetchedThrough: data.fetchedThrough ?? null,
+        lagSeconds: data.fetchedThrough
+          ? Math.max(0, Math.floor((measuredAt.getTime() - data.fetchedThrough.getTime()) / 1000))
+          : null,
+        measuredAt,
+      });
+
     return {
-      latest: this.#fetchLatestNonOpenedData,
-      missing: this.#fetchMissingData,
-      scheduled: this.#fetchScheduledData,
-      latestOpened: this.#fetchLatestOpenedData,
+      latest: withLag(this.#fetchLatestNonOpenedData),
+      missing: withLag(this.#fetchMissingData),
+      scheduled: withLag(this.#fetchScheduledData),
+      latestOpened: withLag(this.#fetchLatestOpenedData),
     };
   }
 
@@ -543,6 +555,7 @@ export class EmailAnalyticsService {
       }
     };
 
+    let fetchedThrough: Date | undefined;
     try {
       const fetchResult = await this.#fetchEvents({
         batchHandler: processBatch,
@@ -551,6 +564,12 @@ export class EmailAnalyticsService {
         maxEvents,
         events: eventTypes,
       });
+
+      // A void result means fetching was skipped (for example, Mailgun is not configured).
+      // Empty successful windows still establish progress through their requested end.
+      if (fetchResult) {
+        fetchedThrough = fetchResult.safeCursor ?? end;
+      }
 
       if (
         fetchResult?.safeCursor &&
@@ -616,6 +635,10 @@ export class EmailAnalyticsService {
 
     if (error) {
       throw error;
+    }
+
+    if (fetchedThrough && !fetchData.canceled) {
+      fetchData.fetchedThrough = fetchedThrough;
     }
 
     return {

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -155,20 +155,19 @@ export class EmailAnalyticsService {
   }
 
   getStatus() {
-    const measuredAt = new Date();
+    const now = Date.now();
     const withLag = <T extends FetchData>(data: T) =>
       Object.assign(data, {
         fetchedThrough: data.fetchedThrough ?? null,
         lagSeconds: data.fetchedThrough
-          ? Math.max(0, Math.floor((measuredAt.getTime() - data.fetchedThrough.getTime()) / 1000))
+          ? Math.max(0, Math.floor((now - data.fetchedThrough.getTime()) / 1000))
           : null,
-        measuredAt,
       });
 
     return {
       latest: withLag(this.#fetchLatestNonOpenedData),
       missing: withLag(this.#fetchMissingData),
-      scheduled: withLag(this.#fetchScheduledData),
+      scheduled: this.#fetchScheduledData,
       latestOpened: withLag(this.#fetchLatestOpenedData),
     };
   }
@@ -637,7 +636,7 @@ export class EmailAnalyticsService {
       throw error;
     }
 
-    if (fetchedThrough && !fetchData.canceled) {
+    if (fetchedThrough) {
       fetchData.fetchedThrough = fetchedThrough;
     }
 

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -75,28 +75,22 @@ describe('EmailAnalyticsService', function () {
           running: false,
           fetchedThrough: null,
           lagSeconds: null,
-          measuredAt: new Date(),
         },
         latestOpened: {
           jobName: 'email-analytics-latest-opened',
           running: false,
           fetchedThrough: null,
           lagSeconds: null,
-          measuredAt: new Date(),
         },
         missing: {
           jobName: 'email-analytics-missing',
           running: false,
           fetchedThrough: null,
           lagSeconds: null,
-          measuredAt: new Date(),
         },
         scheduled: {
           jobName: 'email-analytics-scheduled',
           running: false,
-          fetchedThrough: null,
-          lagSeconds: null,
-          measuredAt: new Date(),
         },
       });
     });
@@ -159,7 +153,6 @@ describe('EmailAnalyticsService', function () {
 
       clock.tick(90_000);
       assert.equal(service.getStatus().latest.lagSeconds, 150);
-      assert.deepEqual(service.getStatus().latest.measuredAt, new Date());
     });
 
     it('uses the safe cursor when a domain hits its event limit', async function () {
@@ -240,6 +233,24 @@ describe('EmailAnalyticsService', function () {
       assert.equal(service.getStatus().latestOpened.lagSeconds, 1500);
       assert.equal(service.getStatus().latest.lagSeconds, 60);
       assert.equal(service.getStatus().missing.lagSeconds, null);
+    });
+
+    it('reports scheduled refetch progress without wall-clock lag', async function () {
+      const begin = new Date(2023, 0, 1);
+      const end = new Date(2023, 0, 8);
+      const safeCursor = new Date(2023, 0, 2);
+      const fetchEvents = sinon.stub().callsFake(async ({ batchHandler }) => {
+        await batchHandler([{ timestamp: safeCursor }]);
+        return { safeCursor };
+      });
+      const service = createService({ fetchEvents });
+      await service.schedule({ begin, end });
+      await service.fetchScheduled({ maxEvents: 1 });
+
+      const { scheduled } = service.getStatus();
+      assert.deepEqual(scheduled.schedule, { begin, end });
+      assert.deepEqual(scheduled.fetchedThrough, safeCursor);
+      assert.equal(Object.hasOwn(scheduled, 'lagSeconds'), false);
     });
 
     it('reports the missing-events recovery window separately', async function () {

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -73,18 +73,30 @@ describe('EmailAnalyticsService', function () {
         latest: {
           jobName: 'email-analytics-latest-others',
           running: false,
+          fetchedThrough: null,
+          lagSeconds: null,
+          measuredAt: new Date(),
         },
         latestOpened: {
           jobName: 'email-analytics-latest-opened',
           running: false,
+          fetchedThrough: null,
+          lagSeconds: null,
+          measuredAt: new Date(),
         },
         missing: {
           jobName: 'email-analytics-missing',
           running: false,
+          fetchedThrough: null,
+          lagSeconds: null,
+          measuredAt: new Date(),
         },
         scheduled: {
           jobName: 'email-analytics-scheduled',
           running: false,
+          fetchedThrough: null,
+          lagSeconds: null,
+          measuredAt: new Date(),
         },
       });
     });
@@ -131,6 +143,111 @@ describe('EmailAnalyticsService', function () {
         },
       ]);
       assert.deepEqual(setJobMetadata.secondCall.args, ['custom-scheduled', null]);
+    });
+  });
+
+  describe('ingestion lag', function () {
+    it('advances through an empty successful window and measures lag using the server clock', async function () {
+      const fetchEvents = sinon.stub().resolves({});
+      const service = createService({ fetchEvents });
+      await service.fetchLatestNonOpenedEvents();
+
+      const end = fetchEvents.firstCall.args[0].end;
+      assert.deepEqual(service.getStatus().latest.fetchedThrough, end);
+      assert.equal(service.getStatus().latest.lagSeconds, 60);
+      assert.equal(service.getStatus().latest.lastEventTimestamp, undefined);
+
+      clock.tick(90_000);
+      assert.equal(service.getStatus().latest.lagSeconds, 150);
+      assert.deepEqual(service.getStatus().latest.measuredAt, new Date());
+    });
+
+    it('uses the safe cursor when a domain hits its event limit', async function () {
+      const safeCursor = new Date(Date.now() - 25 * 60_000);
+      const service = createService({ fetchEvents: sinon.stub().resolves({ safeCursor }) });
+      await service.fetchLatestNonOpenedEvents({ maxEvents: 100 });
+
+      assert.deepEqual(service.getStatus().latest.fetchedThrough, safeCursor);
+      assert.equal(service.getStatus().latest.lagSeconds, 1500);
+    });
+
+    it('advances past the newest event when the window is exhausted', async function () {
+      const timestamp = new Date(Date.now() - 7 * 60_000);
+      const processor = createStubEventProcessor();
+      processor.processBatch.callsFake(async (_events, _result, data) => {
+        data.lastEventTimestamp = timestamp;
+      });
+      const fetchEvents = sinon.stub().callsFake(async ({ batchHandler }) => {
+        await batchHandler([{ timestamp }]);
+        return {};
+      });
+      const service = createService({ fetchEvents, createEventProcessor: () => processor });
+      await service.fetchLatestNonOpenedEvents();
+
+      assert.equal(service.getStatus().latest.lagSeconds, 60);
+      assert.ok(
+        service.getStatus().latest.fetchedThrough! > service.getStatus().latest.lastEventTimestamp!,
+      );
+    });
+
+    it('keeps progress unknown when fetching is skipped', async function () {
+      const service = createService({ fetchEvents: sinon.stub().resolves() });
+      await service.fetchLatestNonOpenedEvents();
+
+      assert.equal(service.getStatus().latest.fetchedThrough, null);
+      assert.equal(service.getStatus().latest.lagSeconds, null);
+    });
+
+    it('keeps the previous progress after a partially processed fetch fails', async function () {
+      const fetchEvents = sinon.stub().resolves({});
+      const service = createService({ fetchEvents });
+      await service.fetchLatestNonOpenedEvents();
+      const fetchedThrough = service.getStatus().latest.fetchedThrough;
+      clock.tick(60_000);
+      fetchEvents.callsFake(async ({ batchHandler }) => {
+        await batchHandler([{ timestamp: new Date() }]);
+        throw new Error('Mailgun unavailable');
+      });
+
+      await assert.rejects(service.fetchLatestNonOpenedEvents(), /Mailgun unavailable/);
+      assert.deepEqual(service.getStatus().latest.fetchedThrough, fetchedThrough);
+      assert.equal(service.getStatus().latest.lagSeconds, 120);
+    });
+
+    it('does not publish progress before processing and final aggregation succeed', async function () {
+      const processor = createStubEventProcessor();
+      const fetchEvents = sinon.stub().callsFake(async () => {
+        assert.equal(service.getStatus().latest.fetchedThrough, null);
+        return {};
+      });
+      const service = createService({ fetchEvents, createEventProcessor: () => processor });
+      processor.aggregate.rejects(new Error('Aggregation failed'));
+
+      await assert.rejects(service.fetchLatestNonOpenedEvents(), /Aggregation failed/);
+      assert.equal(service.getStatus().latest.fetchedThrough, null);
+      assert.equal(service.getStatus().latest.lagSeconds, null);
+    });
+
+    it('reports opens and delivery progress independently', async function () {
+      const safeCursor = new Date(Date.now() - 25 * 60_000);
+      const fetchEvents = sinon.stub();
+      fetchEvents.onFirstCall().resolves({ safeCursor });
+      fetchEvents.onSecondCall().resolves({});
+      const service = createService({ fetchEvents });
+      await service.fetchLatestOpenedEvents();
+      await service.fetchLatestNonOpenedEvents();
+
+      assert.equal(service.getStatus().latestOpened.lagSeconds, 1500);
+      assert.equal(service.getStatus().latest.lagSeconds, 60);
+      assert.equal(service.getStatus().missing.lagSeconds, null);
+    });
+
+    it('reports the missing-events recovery window separately', async function () {
+      const service = createService({ fetchEvents: sinon.stub().resolves({}) });
+      await service.fetchMissing();
+
+      assert.equal(service.getStatus().missing.lagSeconds, 1800);
+      assert.equal(service.getStatus().latest.lagSeconds, null);
     });
   });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3921/

Added server-calculated ingestion lag and UTC fetched-through timestamps to the analytics Debug overview, with separate delivery/failure, opens and recovery sections.

Progress advances through empty completed windows and uses the safe cursor when fetching hits an event limit. Failed fetches preserve previous progress. Unknown progress displays N/A, including on older backends. Scheduled refetches expose progress without wall-clock lag.
