### PR TITLE
Added selectable Mailgun Logs analytics ingestion

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -471,6 +471,9 @@ export class EmailAnalyticsService {
     // Track cumulative event counts separately since processingResult gets reset during intermediate aggregations
     const cumulativeResult = new EventProcessingResult();
     let error: unknown = null;
+    // A fetcher that stops early returns the cursor it covered; the window past
+    // it was never read, so the cursor must not skip ahead afterwards.
+    let capped = false;
 
     const aggregate = async (isFinal: boolean): Promise<void> => {
       if (!eventProcessor.aggregate) {
@@ -553,6 +556,7 @@ export class EmailAnalyticsService {
         events: eventTypes,
       });
 
+      capped = Boolean(fetchResult?.safeCursor);
       if (
         fetchResult?.safeCursor &&
         (!fetchData.lastEventTimestamp || fetchResult.safeCursor < fetchData.lastEventTimestamp)
@@ -600,7 +604,7 @@ export class EmailAnalyticsService {
         'finished',
         new Date(fetchData.lastEventTimestamp.getTime()),
       );
-      if (eventCount < maxEvents) {
+      if (eventCount < maxEvents && !capped) {
         // Consumed everything in the window — advance to avoid re-fetching same batch
         fetchData.lastEventTimestamp = new Date(fetchData.lastEventTimestamp.getTime() + 1000);
       }

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -65,6 +65,8 @@ export type EmailAnalyticsFetchResult = {
   memberAggregationTimeMs: number;
   /** The processing result with event breakdown */
   result: EventProcessingResult;
+  /** Whether the fetcher stopped before reading the whole window */
+  capped: boolean;
 };
 
 type FetchEvents = (options: {
@@ -91,6 +93,7 @@ function createEmptyResult(): EmailAnalyticsFetchResult {
     emailAggregationTimeMs: 0,
     memberAggregationTimeMs: 0,
     result: new EventProcessingResult(),
+    capped: false,
   };
 }
 
@@ -417,7 +420,11 @@ export class EmailAnalyticsService {
       end,
       maxEvents,
     });
-    if (fetchResult.eventCount === 0 || this.#fetchScheduledData.canceled) {
+    // A capped fetch can deliver nothing while the rest of the window is unread.
+    if (
+      (fetchResult.eventCount === 0 && !fetchResult.capped) ||
+      this.#fetchScheduledData.canceled
+    ) {
       this.#clearScheduledData();
     }
 
@@ -557,9 +564,15 @@ export class EmailAnalyticsService {
       });
 
       capped = Boolean(fetchResult?.safeCursor);
+      // Everything before a capped cursor was processed or irrelevant. Keep the
+      // earlier of it and the last processed event, except when nothing was
+      // processed: then the cursor must still move past the covered records or
+      // a window of filtered records would be re-read on every fetch.
       if (
         fetchResult?.safeCursor &&
-        (!fetchData.lastEventTimestamp || fetchResult.safeCursor < fetchData.lastEventTimestamp)
+        (eventCount === 0 ||
+          !fetchData.lastEventTimestamp ||
+          fetchResult.safeCursor < fetchData.lastEventTimestamp)
       ) {
         fetchData.lastEventTimestamp = fetchResult.safeCursor;
       }
@@ -631,6 +644,7 @@ export class EmailAnalyticsService {
       emailAggregationTimeMs,
       memberAggregationTimeMs,
       result: cumulativeResult,
+      capped,
     };
   }
 }

--- a/ghost/core/core/server/services/email-analytics/fetch-mailgun-events.ts
+++ b/ghost/core/core/server/services/email-analytics/fetch-mailgun-events.ts
@@ -1,5 +1,7 @@
 // @ts-expect-error This module lacks type definitions.
 import MailgunClient from '../lib/mailgun-client';
+import { fetchMailgunLogs } from './fetch-mailgun-logs';
+import { IncorrectUsageError } from '@tryghost/errors';
 
 const DEFAULT_EVENT_FILTER = 'delivered OR opened OR failed OR unsubscribed OR complained';
 const PAGE_LIMIT = 300;
@@ -29,6 +31,24 @@ export async function fetchMailgunEvents({
   end,
   events,
 }: FetchMailgunEventsOptions) {
+  const source = config.get('emailAnalytics:fetchSource') ?? 'events';
+  if (source !== 'events' && source !== 'logs') {
+    throw new IncorrectUsageError({
+      message: 'Invalid emailAnalytics.fetchSource; expected events or logs',
+    });
+  }
+  if (source === 'logs') {
+    return fetchMailgunLogs({
+      config,
+      settings,
+      tags,
+      events: events ?? DEFAULT_EVENT_FILTER.split(' OR '),
+      begin,
+      end,
+      maxEvents,
+      batchHandler: (page) => batchHandler(page),
+    });
+  }
   const mailgunClient = new MailgunClient({ config, settings });
   const mailgunOptions = {
     limit: PAGE_LIMIT,

--- a/ghost/core/core/server/services/email-analytics/fetch-mailgun-logs.ts
+++ b/ghost/core/core/server/services/email-analytics/fetch-mailgun-logs.ts
@@ -1,0 +1,71 @@
+import logging from '@tryghost/logging';
+import { InternalServerError } from '@tryghost/errors';
+import { getMailgunConfig, getMailgunDomains, type ConfigReader } from '../lib/mailgun-config';
+import { MailgunLogsClient, type MailgunAnalyticsEvent } from './mailgun-logs-client';
+
+export async function fetchMailgunLogs({
+  config,
+  settings,
+  tags,
+  events,
+  begin,
+  end,
+  batchHandler,
+  maxEvents = Infinity,
+}: {
+  config: ConfigReader;
+  settings: ConfigReader;
+  tags: string[];
+  events: string[];
+  begin?: Date;
+  end?: Date;
+  maxEvents?: number;
+  batchHandler: (events: MailgunAnalyticsEvent[]) => Promise<void> | void;
+}): Promise<{ safeCursor?: Date } | void> {
+  const mailgun = getMailgunConfig(config, settings);
+  if (!mailgun) {
+    logging.warn('Mailgun is not configured');
+    return;
+  }
+  const client = new MailgunLogsClient(mailgun);
+  // Fix the provider window at fetch start so long runs retain the sliding retry overlap.
+  const windowEnd = new Date(Math.min(end?.getTime() ?? Infinity, Date.now()));
+  const windowBegin = begin ?? new Date(windowEnd.getTime() - 24 * 60 * 60 * 1000);
+  let safeCursor: Date | undefined;
+  // Keep callbacks serial: all domains share the active lane's processor state.
+  for (const domain of getMailgunDomains(config, mailgun.domain)) {
+    let token: string | undefined;
+    const seenTokens = new Set<string>();
+    let eventCount = 0;
+    do {
+      const page = await client.getPage({
+        domain,
+        tags,
+        events,
+        begin: windowBegin,
+        end: windowEnd,
+        token,
+      });
+      if (!page.empty && page.next) {
+        if (seenTokens.has(page.next)) {
+          throw new InternalServerError({ message: 'Invalid Mailgun Logs pagination' });
+        }
+        seenTokens.add(page.next);
+      }
+      if (page.items.length) {
+        await batchHandler(page.items);
+        eventCount += page.items.length;
+        const last = page.items[page.items.length - 1].timestamp;
+        // Re-cover the boundary on the next fetch, but finish begin-time ties to make progress.
+        if (eventCount >= maxEvents && last > windowBegin) {
+          if (!safeCursor || last < safeCursor) {
+            safeCursor = last;
+          }
+          break;
+        }
+      }
+      token = page.empty ? undefined : page.next;
+    } while (token);
+  }
+  return { safeCursor };
+}

--- a/ghost/core/core/server/services/email-analytics/fetch-mailgun-logs.ts
+++ b/ghost/core/core/server/services/email-analytics/fetch-mailgun-logs.ts
@@ -1,7 +1,10 @@
 import logging from '@tryghost/logging';
-import { InternalServerError } from '@tryghost/errors';
 import { getMailgunConfig, getMailgunDomains, type ConfigReader } from '../lib/mailgun-config';
 import { MailgunLogsClient, type MailgunAnalyticsEvent } from './mailgun-logs-client';
+
+// A domain whose pages keep paging without matching events still bounds its
+// work: raw records count toward the budget, and pages are capped outright.
+const MAX_PAGES_PER_DOMAIN = 1000;
 
 export async function fetchMailgunLogs({
   config,
@@ -32,40 +35,82 @@ export async function fetchMailgunLogs({
   const windowEnd = new Date(Math.min(end?.getTime() ?? Infinity, Date.now()));
   const windowBegin = begin ?? new Date(windowEnd.getTime() - 24 * 60 * 60 * 1000);
   let safeCursor: Date | undefined;
+  const cap = (at: Date) => {
+    if (!safeCursor || at < safeCursor) {
+      safeCursor = at;
+    }
+  };
   // Keep callbacks serial: all domains share the active lane's processor state.
   for (const domain of getMailgunDomains(config, mailgun.domain)) {
+    const prefix = `[MailgunLogs fetch ${domain}]`;
     let token: string | undefined;
     const seenTokens = new Set<string>();
     let eventCount = 0;
-    do {
-      const page = await client.getPage({
-        domain,
-        tags,
-        events,
-        begin: windowBegin,
-        end: windowEnd,
-        token,
-      });
-      if (!page.empty && page.next) {
-        if (seenTokens.has(page.next)) {
-          throw new InternalServerError({ message: 'Invalid Mailgun Logs pagination' });
+    let rawCount = 0;
+    let skipped = 0;
+    let pages = 0;
+    let status = 'exhausted';
+    // Everything the provider returned up to this timestamp was either
+    // processed or irrelevant, so a capped cursor may safely rest here.
+    let covered: Date | undefined;
+    try {
+      do {
+        const page = await client.getPage({
+          domain,
+          tags,
+          events,
+          begin: windowBegin,
+          end: windowEnd,
+          token,
+        });
+        pages += 1;
+        rawCount += page.rawCount;
+        skipped += page.skipped;
+        if (page.lastTimestamp && (!covered || page.lastTimestamp > covered)) {
+          covered = page.lastTimestamp;
         }
-        seenTokens.add(page.next);
-      }
-      if (page.items.length) {
-        await batchHandler(page.items);
-        eventCount += page.items.length;
-        const last = page.items[page.items.length - 1].timestamp;
+        if (page.items.length) {
+          await batchHandler(page.items);
+          eventCount += page.items.length;
+        }
         // Re-cover the boundary on the next fetch, but finish begin-time ties to make progress.
-        if (eventCount >= maxEvents && last > windowBegin) {
-          if (!safeCursor || last < safeCursor) {
-            safeCursor = last;
+        const budgetSpent = eventCount >= maxEvents || rawCount >= maxEvents;
+        if (budgetSpent && covered && covered > windowBegin) {
+          cap(covered);
+          status = 'capped';
+          break;
+        }
+        if (!page.next) {
+          break;
+        }
+        // A provider that echoes the last token has nothing more; one that
+        // repeats an earlier token must not skip anything. The page was still
+        // delivered, and the cursor rests on what the domain covered so far.
+        const repeated = seenTokens.has(page.next);
+        seenTokens.add(page.next);
+        if (repeated || pages >= MAX_PAGES_PER_DOMAIN) {
+          logging.warn(
+            repeated
+              ? `${prefix}: repeated pagination token after ${pages} pages`
+              : `${prefix}: stopped after ${pages} pages`,
+          );
+          if (covered && covered > windowBegin) {
+            cap(covered);
+            status = 'capped';
           }
           break;
         }
-      }
-      token = page.empty ? undefined : page.next;
-    } while (token);
+        // An empty page can still carry a token; the page and record budgets
+        // bound how far a domain keeps paging without matching events.
+        token = page.next;
+      } while (token);
+    } catch (error) {
+      logging.error(`${prefix}: Error fetching logs after ${eventCount} events in ${pages} pages`);
+      throw error;
+    }
+    logging.info(
+      `${prefix}: Processed ${eventCount} events in ${pages} pages (${rawCount} records, ${skipped} skipped). Status: ${status}. Cursor: ${safeCursor?.toISOString() ?? 'none'}`,
+    );
   }
   return { safeCursor };
 }

--- a/ghost/core/core/server/services/email-analytics/mailgun-ingestion.md
+++ b/ghost/core/core/server/services/email-analytics/mailgun-ingestion.md
@@ -1,0 +1,69 @@
+# Mailgun analytics ingestion
+
+`emailAnalytics.fetchSource` selects the provider API for newsletter, automation,
+and gift analytics. It defaults to `events`; `logs` opts into the Logs API.
+An unknown value fails the fetch. This setting does not change event-lane
+scheduling, processor selection, or counter modes.
+
+Both sources use the same configuration resolver: `bulkEmail.mailgun` takes
+precedence as a whole, otherwise all three Mailgun settings must exist. Each
+fetch resolves current credentials and queries the primary sending domain plus
+a distinct configured fallback domain. The base URL determines the API region.
+
+## Logs contract
+
+The Logs adapter uses `POST /v1/analytics/logs` with account-level credentials,
+an explicit domain filter, and a separate AND condition for every required tag.
+Subaccounts are excluded. Responses are checked again for the domain, tags,
+event type, and exact time window before reaching a processor. Malformed pages
+or unverifiable event provenance fail the fetch rather than advancing its cursor.
+
+Logs timestamps are ISO strings. The adapter normalizes them into the existing
+event shape, accepts object or JSON-string user variables, and retains the
+message-ID fallback and delivery-error limits. Records without either email
+identity are skipped, as with Events. Nullable headers are supported.
+
+Logs pages contain at most 100 events. Opaque pagination tokens stay in request
+bodies with the original filters and window; they are never followed as URLs.
+A filtered-only page can still have more matching events behind it. Repeated
+tokens fail the fetch. Requests disable automatic retries and redirects, time
+out after 60 seconds, and expose sanitized failures with an optional HTTP
+`status`. Request latency and HTTP status use `mailgun-get-events` with
+`source: logs`.
+
+## Progress and retry boundaries
+
+Domains and page callbacks run serially because they share one lane's processor
+state. The end of the window is fixed at the earlier of the requested end and
+fetch start. API date bounds round outward to whole seconds; local filtering
+retains exact millisecond boundaries. With no begin, the adapter uses a one-day
+window ending at that fixed end; normal scheduled ingestion supplies both bounds.
+
+The per-domain event budget is a soft cap. Paging continues through events tied
+at begin so the cursor can progress. When domains cap at different times, the
+adapter returns their earliest capped timestamp. The existing analytics service
+retains overlap at that boundary and publishes progress only after processing.
+A provider or callback failure rejects the fetch; the service resets its
+in-memory cursor to begin so every domain is retried. Tokens are never persisted.
+
+## Source compatibility
+
+Changing sources retains the same stored timestamp cursors and processors.
+Finish the active fetch before changing configuration, and retain the existing
+overlap/recheck windows when switching in either direction. No counter migration
+or historical backfill is needed for this setting.
+
+Offline tests compare normalized Events and Logs fixtures for all three email
+consumers, enforce account/domain/tag isolation, and exercise capped domains,
+ties, filtered pages, and failures. They do not establish live provider parity
+or a throughput improvement. Before opting in, verify that the configured key
+can read account Logs (a domain sending key is insufficient), that the configured
+region and primary/fallback domains are visible, and that representative identical
+windows return equivalent matching events through both APIs. Include boundary
+timestamps, opens, failures, unsubscribes, complaints, and domain warming.
+
+The [Mailgun Logs reference](https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/logs)
+describes the provider contract. Its request schema marks `duration` required,
+while its explicit start/end example and official SDK omit it; this adapter uses
+explicit start/end. Confirm this request shape against the account before enablement.
+The Events path remains available for fallback while compatibility is established.

--- a/ghost/core/core/server/services/email-analytics/mailgun-ingestion.md
+++ b/ghost/core/core/server/services/email-analytics/mailgun-ingestion.md
@@ -16,19 +16,35 @@ The Logs adapter uses `POST /v1/analytics/logs` with account-level credentials,
 an explicit domain filter, and a separate AND condition for every required tag.
 Subaccounts are excluded. Responses are checked again for the domain, tags,
 event type, and exact time window before reaching a processor. Malformed pages
-or unverifiable event provenance fail the fetch rather than advancing its cursor.
+fail the fetch rather than advancing its cursor.
 
-Logs timestamps are ISO strings. The adapter normalizes them into the existing
-event shape, accepts object or JSON-string user variables, and retains the
-message-ID fallback and delivery-error limits. Records without either email
-identity are skipped, as with Events. Nullable headers are supported.
+Logs timestamps are ISO strings. The adapter validates each page and record at
+the boundary, normalizes them into the existing event shape, accepts object or
+JSON-string user variables, and retains the message-ID fallback and
+delivery-error limits. A record the adapter cannot read, or a matching record
+without a recipient or either email identity, is skipped and counted in a
+warning rather than failing the page: one unreadable line must not stall every
+lane's cursor, and a provider change must not silence a lane without a trace. Nullable headers are supported. Records from other domains,
+tags or event types are dropped after the response is read, so the account-level
+query cannot misattribute events. Subaccounts are excluded from the query; a
+sending domain hosted in a subaccount returns no events.
 
-Logs pages contain at most 100 events. Opaque pagination tokens stay in request
-bodies with the original filters and window; they are never followed as URLs.
-A filtered-only page can still have more matching events behind it. Repeated
-tokens fail the fetch. Requests disable automatic retries and redirects, time
-out after 60 seconds, and expose sanitized failures with an optional HTTP
-`status`. Request latency and HTTP status use `mailgun-get-events` with
+The Logs endpoint is derived from the configured base URL by replacing its
+trailing `/v3` with `/v1/analytics/logs`, so a proxy prefix is preserved. The
+adapter requests 100 records per page; the provider's maximum is undocumented.
+Opaque pagination tokens stay in request bodies with the original filters and
+window; they are never followed as URLs. A page with no records but a token is
+followed. Records the provider returns count toward the per-domain budget even
+when they are filtered out, and a domain stops after 1,000 pages, so a domain
+cannot page through an account window without bound; when either bound is hit,
+the cursor rests on the latest record covered so far, which was either processed
+or irrelevant, and the service does not advance a capped cursor past what was
+read. A repeated token ends the domain after delivering its page and rests the
+cursor the same way. Requests disable automatic retries and
+redirects, time out after 60 seconds, and expose sanitized failures with an
+optional HTTP `status`; a 401 or 403 says the key must be able to read account
+logs. Each domain logs a processed/records/skipped summary with its status and
+cursor. Request latency and HTTP status use `mailgun-get-events` with
 `source: logs`.
 
 ## Progress and retry boundaries

--- a/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
+++ b/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 const request: (
   url: string,
   options: Record<string, unknown>,
-) => Promise<{ body: unknown; statusCode?: number }> = require('@tryghost/request');
+) => Promise<{ body: unknown; statusCode?: unknown }> = require('@tryghost/request');
 
 type LogPageOptions = {
   domain: string;
@@ -79,6 +79,13 @@ type LogsItem = z.output<typeof LogsItem>;
 function record(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Only a plausible HTTP status reaches metrics; anything else is unknown. */
+function httpStatus(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599
+    ? value
     : undefined;
 }
 
@@ -166,20 +173,15 @@ export class MailgunLogsClient {
       body = response.body;
       metrics.metric('mailgun-get-events', {
         value: Date.now() - startedAt,
-        statusCode: response.statusCode ?? 200,
+        statusCode: httpStatus(response.statusCode) ?? 200,
         source: 'logs',
       });
     } catch (error) {
       // The request wrapper copies credentials/options onto transport errors.
       // Never attach or rethrow that error into analytics logging.
-      const statusCode = record(record(error)?.response)?.statusCode ?? record(error)?.statusCode;
-      const status =
-        typeof statusCode === 'number' &&
-        Number.isInteger(statusCode) &&
-        statusCode >= 100 &&
-        statusCode <= 599
-          ? statusCode
-          : undefined;
+      const status = httpStatus(
+        record(record(error)?.response)?.statusCode ?? record(error)?.statusCode,
+      );
       metrics.metric('mailgun-get-events', {
         value: Date.now() - startedAt,
         statusCode: status,

--- a/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
+++ b/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
@@ -1,11 +1,13 @@
-import { InternalServerError } from '@tryghost/errors';
+import { IncorrectUsageError, InternalServerError } from '@tryghost/errors';
+import logging from '@tryghost/logging';
 import metrics from '@tryghost/metrics';
+import { z } from 'zod';
 
 // @tryghost/request has no type declarations. Keep its untrusted response at the boundary.
 const request: (
   url: string,
   options: Record<string, unknown>,
-) => Promise<{ body: unknown }> = require('@tryghost/request');
+) => Promise<{ body: unknown; statusCode?: number }> = require('@tryghost/request');
 
 type LogPageOptions = {
   domain: string;
@@ -27,8 +29,55 @@ export type MailgunAnalyticsEvent = {
   error: { code?: number | string; message: string; enhancedCode: string | null } | null;
 };
 
+export type MailgunLogsPage = {
+  /** Normalized events for the requested domain, tags, types and window. */
+  items: MailgunAnalyticsEvent[];
+  next?: string;
+  /** Records the provider returned before filtering, including unreadable ones. */
+  rawCount: number;
+  /** Provider records that could not be read and were skipped. */
+  skipped: number;
+  /** Latest timestamp among readable provider records, filtered or not. */
+  lastTimestamp?: Date;
+};
+
+// Boundary data: the provider owns these shapes, so read only what ingestion
+// needs and tolerate extra fields. Records that do not fit are skipped, never
+// fatal: one unreadable line must not stall every lane's cursor.
+const LogsPage = z.object({
+  items: z.array(z.unknown()),
+  pagination: z.object({ next: z.string().nullish() }).passthrough(),
+});
+const codeValue = z.union([z.string(), z.number()]);
+const LogsItem = z.object({
+  id: z.string(),
+  event: z.string(),
+  '@timestamp': z.string(),
+  recipient: z.string().optional(),
+  severity: z.string().optional(),
+  domain: z.object({ name: z.string() }).passthrough(),
+  tags: z.array(z.string()).nullish(),
+  'user-variables': z.unknown().optional(),
+  message: z
+    .object({ headers: z.object({ 'message-id': z.string().optional() }).passthrough().nullish() })
+    .passthrough()
+    .nullish(),
+  'delivery-status': z
+    .object({
+      code: codeValue.optional(),
+      message: z.string().optional(),
+      description: z.string().optional(),
+      'enhanced-code': codeValue.optional(),
+    })
+    .passthrough()
+    .nullish(),
+});
+type LogsItem = z.output<typeof LogsItem>;
+
+// Plain property access rather than a Zod record: transport errors are class
+// instances, which Zod rejects, and only their own fields are read here.
 function record(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
 }
@@ -41,19 +90,35 @@ function equality(attribute: string, value: string) {
   return { attribute, comparator: '=', values: [{ label: value, value }] };
 }
 
+/**
+ * The Events base URL points at `/v3` on the regional host, possibly behind a
+ * proxy prefix. Logs live under `/v1/analytics/logs` on the same host and prefix.
+ */
+export function resolveLogsUrl(baseUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new IncorrectUsageError({ message: 'Mailgun base URL is not a valid absolute URL' });
+  }
+  const prefix = url.pathname.replace(/\/+$/, '').replace(/\/v3$/, '');
+  url.pathname = `${prefix}/v1/analytics/logs`;
+  url.search = '';
+  url.hash = '';
+  return url.href;
+}
+
 /** Logs pages use opaque tokens and the same normalized event shape as Events. */
 export class MailgunLogsClient {
   readonly #url: string;
   readonly #apiKey: string;
 
   constructor({ baseUrl, apiKey }: { baseUrl: string; apiKey: string }) {
-    this.#url = new URL('/v1/analytics/logs', new URL(baseUrl).origin).href;
+    this.#url = resolveLogsUrl(baseUrl);
     this.#apiKey = apiKey;
   }
 
-  async getPage(
-    options: LogPageOptions,
-  ): Promise<{ items: MailgunAnalyticsEvent[]; next?: string; empty: boolean }> {
+  async getPage(options: LogPageOptions): Promise<MailgunLogsPage> {
     if (
       !options.domain.trim() ||
       options.tags.length === 0 ||
@@ -101,7 +166,7 @@ export class MailgunLogsClient {
       body = response.body;
       metrics.metric('mailgun-get-events', {
         value: Date.now() - startedAt,
-        statusCode: 200,
+        statusCode: response.statusCode ?? 200,
         source: 'logs',
       });
     } catch (error) {
@@ -120,67 +185,77 @@ export class MailgunLogsClient {
         statusCode: status,
         source: 'logs',
       });
+      const rejected = status === 401 || status === 403;
       throw Object.assign(
         new InternalServerError({
-          message: 'Mailgun Logs request failed',
-          code: 'MAILGUN_LOGS_REQUEST_FAILED',
+          message: rejected
+            ? `Mailgun Logs request was rejected (status ${status}): the configured API key must be able to read account logs, which a domain sending key cannot`
+            : `Mailgun Logs request failed${status ? ` (status ${status})` : ''}`,
+          context: `Sending domain ${options.domain}`,
+          code: rejected ? 'MAILGUN_LOGS_REQUEST_REJECTED' : 'MAILGUN_LOGS_REQUEST_FAILED',
         }),
         { status },
       );
     }
-    const page = record(body);
-    const pagination = record(page?.pagination);
-    if (
-      !page ||
-      !Array.isArray(page.items) ||
-      !pagination ||
-      (pagination.next !== undefined &&
-        pagination.next !== null &&
-        typeof pagination.next !== 'string')
-    ) {
-      throw new InternalServerError({ message: 'Invalid Mailgun Logs page' });
+    const page = LogsPage.safeParse(body);
+    if (!page.success) {
+      throw new InternalServerError({
+        message: 'Invalid Mailgun Logs page',
+        context: `Sending domain ${options.domain}`,
+      });
     }
-    const items = page.items
-      .filter((value) => {
-        const item = record(value);
-        const domain = record(item?.domain)?.name;
-        const tags = item?.tags;
-        if (
-          !item ||
-          typeof domain !== 'string' ||
-          !Array.isArray(tags) ||
-          !tags.every((tag) => typeof tag === 'string') ||
-          typeof item.event !== 'string'
-        ) {
-          throw new InternalServerError({ message: 'Invalid Mailgun Logs event provenance' });
-        }
-        return (
-          domain === options.domain &&
-          options.tags.every((tag) => tags.includes(tag)) &&
-          options.events.includes(item.event)
-        );
-      })
-      .map((item) => this.#normalize(item))
-      .filter(
-        (item): item is MailgunAnalyticsEvent =>
-          item !== undefined && item.timestamp >= options.begin && item.timestamp <= options.end,
+    const items: MailgunAnalyticsEvent[] = [];
+    let skipped = 0;
+    let lastTimestamp: Date | undefined;
+    for (const value of page.data.items) {
+      const item = LogsItem.safeParse(value);
+      const timestamp = item.success ? new Date(item.data['@timestamp']) : new Date(NaN);
+      if (!item.success || !Number.isFinite(timestamp.getTime())) {
+        skipped += 1;
+        continue;
+      }
+      // The request end is rounded up to a whole second, so a record can sit
+      // just past the window; it must not count as covered.
+      if (timestamp > options.end) {
+        continue;
+      }
+      if (!lastTimestamp || timestamp > lastTimestamp) {
+        lastTimestamp = timestamp;
+      }
+      const tags = item.data.tags ?? [];
+      if (
+        item.data.domain.name !== options.domain ||
+        !options.tags.every((tag) => tags.includes(tag)) ||
+        !options.events.includes(item.data.event) ||
+        timestamp < options.begin
+      ) {
+        continue;
+      }
+      const normalized = this.#normalize(item.data, timestamp);
+      if (normalized) {
+        items.push(normalized);
+      } else {
+        // A matching record without a recipient or any email identity cannot be
+        // attributed; count it so a provider change does not fail silently.
+        skipped += 1;
+      }
+    }
+    if (skipped) {
+      logging.warn(
+        `[MailgunLogsClient] Skipped ${skipped} unreadable or unattributable Mailgun Logs record(s) for domain ${options.domain}`,
       );
-    const next = pagination.next;
+    }
     return {
       items,
-      next: typeof next === 'string' ? next : undefined,
-      empty: page.items.length === 0,
+      next: page.data.pagination.next ?? undefined,
+      rawCount: page.data.items.length,
+      skipped,
+      lastTimestamp,
     };
   }
 
-  #normalize(value: unknown): MailgunAnalyticsEvent | undefined {
-    const item = record(value);
-    if (!item) {
-      throw new InternalServerError({ message: 'Invalid Mailgun Logs event' });
-    }
-    const headers = record(record(item.message)?.headers);
-    const providerId =
-      typeof headers?.['message-id'] === 'string' ? headers['message-id'] : undefined;
+  #normalize(item: LogsItem, timestamp: Date): MailgunAnalyticsEvent | undefined {
+    const providerId = item.message?.headers?.['message-id'];
     const rawVariables = item['user-variables'];
     let variables: Record<string, unknown> | undefined;
     try {
@@ -194,17 +269,7 @@ export class MailgunLogsClient {
     if ((!providerId && !emailId) || typeof item.recipient !== 'string') {
       return undefined;
     }
-    const timestamp = new Date(typeof item['@timestamp'] === 'string' ? item['@timestamp'] : NaN);
-    if (
-      !Number.isFinite(timestamp.getTime()) ||
-      typeof item.id !== 'string' ||
-      typeof item.event !== 'string'
-    ) {
-      throw new InternalServerError({
-        message: 'Invalid Mailgun Logs event identity or timestamp',
-      });
-    }
-    const delivery = record(item['delivery-status']);
+    const delivery = item['delivery-status'];
     const message = delivery?.message || delivery?.description;
     const enhanced = delivery?.['enhanced-code'];
     return {
@@ -214,19 +279,13 @@ export class MailgunLogsClient {
       emailId,
       providerId,
       timestamp,
-      severity: typeof item.severity === 'string' ? item.severity : undefined,
+      severity: item.severity,
       error:
         typeof message === 'string'
           ? {
-              code:
-                typeof delivery?.code === 'string' || typeof delivery?.code === 'number'
-                  ? delivery.code
-                  : undefined,
+              code: delivery?.code,
               message: message.substring(0, 2000),
-              enhancedCode:
-                typeof enhanced === 'string' || typeof enhanced === 'number'
-                  ? String(enhanced).substring(0, 50)
-                  : null,
+              enhancedCode: enhanced !== undefined ? String(enhanced).substring(0, 50) : null,
             }
           : null,
     };

--- a/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
+++ b/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
@@ -1,0 +1,222 @@
+import { InternalServerError } from '@tryghost/errors';
+
+// @tryghost/request has no type declarations. Keep its untrusted response at the boundary.
+const request: (
+  url: string,
+  options: Record<string, unknown>,
+) => Promise<{ body: unknown }> = require('@tryghost/request');
+
+type LogPageOptions = {
+  domain: string;
+  tags: string[];
+  events: string[];
+  begin: Date;
+  end: Date;
+  token?: string;
+};
+
+export type MailgunAnalyticsEvent = {
+  id: string;
+  type: string;
+  recipientEmail: string;
+  emailId?: string;
+  providerId?: string;
+  timestamp: Date;
+  severity?: string;
+  error: { code?: number | string; message: string; enhancedCode: string | null } | null;
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function rfc2822(time: number): string {
+  return `${new Date(time).toUTCString().slice(0, 25)} -0000`;
+}
+
+function equality(attribute: string, value: string) {
+  return { attribute, comparator: '=', values: [{ label: value, value }] };
+}
+
+/** Logs pages use opaque tokens and the same normalized event shape as Events. */
+export class MailgunLogsClient {
+  readonly #url: string;
+  readonly #apiKey: string;
+
+  constructor({ baseUrl, apiKey }: { baseUrl: string; apiKey: string }) {
+    this.#url = new URL('/v1/analytics/logs', new URL(baseUrl).origin).href;
+    this.#apiKey = apiKey;
+  }
+
+  async getPage(
+    options: LogPageOptions,
+  ): Promise<{ items: MailgunAnalyticsEvent[]; next?: string; empty: boolean }> {
+    if (
+      !options.domain.trim() ||
+      options.tags.length === 0 ||
+      options.tags.some((tag) => !tag.trim()) ||
+      options.events.length === 0 ||
+      options.events.some((event) => !event.trim()) ||
+      !Number.isFinite(options.begin.getTime()) ||
+      !Number.isFinite(options.end.getTime()) ||
+      options.begin > options.end
+    ) {
+      throw new InternalServerError({
+        message: 'Invalid Mailgun Logs request filters or time window',
+      });
+    }
+    let body: unknown;
+    try {
+      const response = await request(this.#url, {
+        method: 'POST',
+        username: 'api',
+        password: this.#apiKey,
+        responseType: 'json',
+        followRedirect: false,
+        retry: { limit: 0 },
+        timeout: { request: 60000 },
+        json: {
+          start: rfc2822(Math.floor(options.begin.getTime() / 1000) * 1000),
+          end: rfc2822(Math.ceil(options.end.getTime() / 1000) * 1000),
+          events: options.events,
+          include_subaccounts: false,
+          include_totals: false,
+          filter: {
+            AND: [
+              equality('domain', options.domain),
+              ...options.tags.map((tag) => equality('tag', tag)),
+            ],
+          },
+          pagination: {
+            sort: 'timestamp:asc',
+            limit: 100,
+            ...(options.token ? { token: options.token } : {}),
+          },
+        },
+      });
+      body = response.body;
+    } catch (error) {
+      // The request wrapper copies credentials/options onto transport errors.
+      // Never attach or rethrow that error into analytics logging.
+      const statusCode = record(record(error)?.response)?.statusCode ?? record(error)?.statusCode;
+      const status =
+        typeof statusCode === 'number' &&
+        Number.isInteger(statusCode) &&
+        statusCode >= 100 &&
+        statusCode <= 599
+          ? statusCode
+          : undefined;
+      throw Object.assign(
+        new InternalServerError({
+          message: 'Mailgun Logs request failed',
+          code: 'MAILGUN_LOGS_REQUEST_FAILED',
+        }),
+        { status },
+      );
+    }
+    const page = record(body);
+    const pagination = record(page?.pagination);
+    if (
+      !page ||
+      !Array.isArray(page.items) ||
+      !pagination ||
+      (pagination.next !== undefined &&
+        pagination.next !== null &&
+        typeof pagination.next !== 'string')
+    ) {
+      throw new InternalServerError({ message: 'Invalid Mailgun Logs page' });
+    }
+    const items = page.items
+      .filter((value) => {
+        const item = record(value);
+        const domain = record(item?.domain)?.name;
+        const tags = item?.tags;
+        if (
+          !item ||
+          typeof domain !== 'string' ||
+          !Array.isArray(tags) ||
+          !tags.every((tag) => typeof tag === 'string') ||
+          typeof item.event !== 'string'
+        ) {
+          throw new InternalServerError({ message: 'Invalid Mailgun Logs event provenance' });
+        }
+        return (
+          domain === options.domain &&
+          options.tags.every((tag) => tags.includes(tag)) &&
+          options.events.includes(item.event)
+        );
+      })
+      .map((item) => this.#normalize(item))
+      .filter(
+        (item): item is MailgunAnalyticsEvent =>
+          item !== undefined && item.timestamp >= options.begin && item.timestamp <= options.end,
+      );
+    const next = pagination.next;
+    return {
+      items,
+      next: typeof next === 'string' ? next : undefined,
+      empty: page.items.length === 0,
+    };
+  }
+
+  #normalize(value: unknown): MailgunAnalyticsEvent | undefined {
+    const item = record(value);
+    if (!item) {
+      throw new InternalServerError({ message: 'Invalid Mailgun Logs event' });
+    }
+    const headers = record(record(item.message)?.headers);
+    const providerId =
+      typeof headers?.['message-id'] === 'string' ? headers['message-id'] : undefined;
+    const rawVariables = item['user-variables'];
+    let variables: Record<string, unknown> | undefined;
+    try {
+      variables = record(
+        typeof rawVariables === 'string' ? JSON.parse(rawVariables) : rawVariables,
+      );
+    } catch {
+      variables = undefined;
+    }
+    const emailId = typeof variables?.['email-id'] === 'string' ? variables['email-id'] : undefined;
+    if ((!providerId && !emailId) || typeof item.recipient !== 'string') {
+      return undefined;
+    }
+    const timestamp = new Date(typeof item['@timestamp'] === 'string' ? item['@timestamp'] : NaN);
+    if (
+      !Number.isFinite(timestamp.getTime()) ||
+      typeof item.id !== 'string' ||
+      typeof item.event !== 'string'
+    ) {
+      throw new InternalServerError({
+        message: 'Invalid Mailgun Logs event identity or timestamp',
+      });
+    }
+    const delivery = record(item['delivery-status']);
+    const message = delivery?.message || delivery?.description;
+    const enhanced = delivery?.['enhanced-code'];
+    return {
+      id: item.id,
+      type: item.event,
+      recipientEmail: item.recipient,
+      emailId,
+      providerId,
+      timestamp,
+      severity: typeof item.severity === 'string' ? item.severity : undefined,
+      error:
+        typeof message === 'string'
+          ? {
+              code:
+                typeof delivery?.code === 'string' || typeof delivery?.code === 'number'
+                  ? delivery.code
+                  : undefined,
+              message: message.substring(0, 2000),
+              enhancedCode:
+                typeof enhanced === 'string' || typeof enhanced === 'number'
+                  ? String(enhanced).substring(0, 50)
+                  : null,
+            }
+          : null,
+    };
+  }
+}

--- a/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
+++ b/ghost/core/core/server/services/email-analytics/mailgun-logs-client.ts
@@ -1,4 +1,5 @@
 import { InternalServerError } from '@tryghost/errors';
+import metrics from '@tryghost/metrics';
 
 // @tryghost/request has no type declarations. Keep its untrusted response at the boundary.
 const request: (
@@ -68,6 +69,7 @@ export class MailgunLogsClient {
       });
     }
     let body: unknown;
+    const startedAt = Date.now();
     try {
       const response = await request(this.#url, {
         method: 'POST',
@@ -97,6 +99,11 @@ export class MailgunLogsClient {
         },
       });
       body = response.body;
+      metrics.metric('mailgun-get-events', {
+        value: Date.now() - startedAt,
+        statusCode: 200,
+        source: 'logs',
+      });
     } catch (error) {
       // The request wrapper copies credentials/options onto transport errors.
       // Never attach or rethrow that error into analytics logging.
@@ -108,6 +115,11 @@ export class MailgunLogsClient {
         statusCode <= 599
           ? statusCode
           : undefined;
+      metrics.metric('mailgun-get-events', {
+        value: Date.now() - startedAt,
+        statusCode: status,
+        source: 'logs',
+      });
       throw Object.assign(
         new InternalServerError({
           message: 'Mailgun Logs request failed',

--- a/ghost/core/core/server/services/lib/mailgun-client.js
+++ b/ghost/core/core/server/services/lib/mailgun-client.js
@@ -3,6 +3,7 @@ const debug = require('@tryghost/debug');
 const logging = require('@tryghost/logging');
 const metrics = require('@tryghost/metrics');
 const errors = require('@tryghost/errors');
+const { getMailgunConfig, getMailgunDomains } = require('./mailgun-config');
 
 const DEFAULT_BATCH_SIZE = 1000;
 
@@ -220,13 +221,10 @@ module.exports = class MailgunClient {
    * @returns {string[]}
    */
   #getDomainsToFetch(mailgunConfig) {
-    const domains = [mailgunConfig.domain];
-
-    const fallbackDomain = this.#config.get('hostSettings:managedEmail:fallbackDomain');
-    if (fallbackDomain && fallbackDomain !== mailgunConfig.domain) {
-      domains.push(fallbackDomain);
+    const domains = getMailgunDomains(this.#config, mailgunConfig.domain);
+    if (domains.length > 1) {
       logging.info(
-        `[MailgunClient] Domain warming enabled, fetching from both primary (${mailgunConfig.domain}) and fallback (${fallbackDomain}) domains`,
+        `[MailgunClient] Domain warming enabled, fetching from both primary (${mailgunConfig.domain}) and fallback (${domains[1]}) domains`,
       );
     }
 
@@ -404,27 +402,7 @@ module.exports = class MailgunClient {
   }
 
   #getConfig() {
-    const bulkEmailConfig = this.#config.get('bulkEmail');
-    const bulkEmailSetting = {
-      apiKey: this.#settings.get('mailgun_api_key'),
-      domain: this.#settings.get('mailgun_domain'),
-      baseUrl: this.#settings.get('mailgun_base_url'),
-    };
-
-    const hasMailgunConfig = !!bulkEmailConfig?.mailgun;
-    const hasMailgunSetting = !!(
-      bulkEmailSetting &&
-      bulkEmailSetting.apiKey &&
-      bulkEmailSetting.baseUrl &&
-      bulkEmailSetting.domain
-    );
-
-    if (!hasMailgunConfig && !hasMailgunSetting) {
-      return null;
-    }
-
-    const mailgunConfig = hasMailgunConfig ? bulkEmailConfig.mailgun : bulkEmailSetting;
-    return mailgunConfig;
+    return getMailgunConfig(this.#config, this.#settings);
   }
 
   /**

--- a/ghost/core/core/server/services/lib/mailgun-config.ts
+++ b/ghost/core/core/server/services/lib/mailgun-config.ts
@@ -1,0 +1,28 @@
+export type ConfigReader = { get: (key: string) => unknown };
+
+type MailgunConfig = { apiKey: string; baseUrl: string; domain: string };
+
+/** Config takes precedence as a whole; settings are used only when all three exist. */
+export function getMailgunConfig(
+  config: ConfigReader,
+  settings: ConfigReader,
+): MailgunConfig | null {
+  const bulkEmailConfig = config.get('bulkEmail') as { mailgun?: MailgunConfig } | undefined;
+  const bulkEmailSetting = {
+    apiKey: settings.get('mailgun_api_key') as string,
+    domain: settings.get('mailgun_domain') as string,
+    baseUrl: settings.get('mailgun_base_url') as string,
+  };
+  if (bulkEmailConfig?.mailgun) {
+    return bulkEmailConfig.mailgun;
+  }
+  return bulkEmailSetting.apiKey && bulkEmailSetting.domain && bulkEmailSetting.baseUrl
+    ? bulkEmailSetting
+    : null;
+}
+
+/** During domain warming, both sources still contain events for the same site. */
+export function getMailgunDomains(config: ConfigReader, primary: string): string[] {
+  const fallback = config.get('hostSettings:managedEmail:fallbackDomain') as string | undefined;
+  return fallback && fallback !== primary ? [primary, fallback] : [primary];
+}

--- a/ghost/core/core/server/services/lib/mailgun-config.ts
+++ b/ghost/core/core/server/services/lib/mailgun-config.ts
@@ -1,28 +1,55 @@
+import logging from '@tryghost/logging';
+import { z } from 'zod';
+
 export type ConfigReader = { get: (key: string) => unknown };
 
-type MailgunConfig = { apiKey: string; baseUrl: string; domain: string };
+const MailgunConfig = z.object({
+  apiKey: z.string().min(1),
+  baseUrl: z.string().min(1),
+  domain: z.string().min(1),
+});
+type MailgunConfig = z.output<typeof MailgunConfig>;
+// Only the Mailgun block is read here; the rest of `bulkEmail` belongs to sending.
+const BulkEmailConfig = z.object({ mailgun: z.unknown().optional() });
+const OptionalString = z.string().optional().nullable();
+// An unexpected type in config or settings counts as absent rather than throwing.
+const optionalString = (value: unknown): string | undefined => {
+  const parsed = OptionalString.safeParse(value);
+  return parsed.success ? (parsed.data ?? undefined) : undefined;
+};
 
-/** Config takes precedence as a whole; settings are used only when all three exist. */
+/**
+ * Config takes precedence as a whole: a present `bulkEmail.mailgun` block is
+ * used even when settings are complete, and an invalid block disables Mailgun
+ * rather than silently falling back to settings. Settings are used only when
+ * all three values exist.
+ */
 export function getMailgunConfig(
   config: ConfigReader,
   settings: ConfigReader,
 ): MailgunConfig | null {
-  const bulkEmailConfig = config.get('bulkEmail') as { mailgun?: MailgunConfig } | undefined;
-  const bulkEmailSetting = {
-    apiKey: settings.get('mailgun_api_key') as string,
-    domain: settings.get('mailgun_domain') as string,
-    baseUrl: settings.get('mailgun_base_url') as string,
-  };
-  if (bulkEmailConfig?.mailgun) {
-    return bulkEmailConfig.mailgun;
+  const bulkEmail = BulkEmailConfig.safeParse(config.get('bulkEmail'));
+  if (bulkEmail.success && bulkEmail.data.mailgun !== undefined) {
+    const configured = MailgunConfig.safeParse(bulkEmail.data.mailgun);
+    if (!configured.success) {
+      logging.warn(
+        '[Mailgun] Ignoring invalid bulkEmail.mailgun config: apiKey, baseUrl and domain must be non-empty strings',
+      );
+      return null;
+    }
+    return configured.data;
   }
-  return bulkEmailSetting.apiKey && bulkEmailSetting.domain && bulkEmailSetting.baseUrl
-    ? bulkEmailSetting
-    : null;
+  const setting = (key: string) => optionalString(settings.get(key));
+  const fromSettings = MailgunConfig.safeParse({
+    apiKey: setting('mailgun_api_key'),
+    domain: setting('mailgun_domain'),
+    baseUrl: setting('mailgun_base_url'),
+  });
+  return fromSettings.success ? fromSettings.data : null;
 }
 
 /** During domain warming, both sources still contain events for the same site. */
 export function getMailgunDomains(config: ConfigReader, primary: string): string[] {
-  const fallback = config.get('hostSettings:managedEmail:fallbackDomain') as string | undefined;
+  const fallback = optionalString(config.get('hostSettings:managedEmail:fallbackDomain'));
   return fallback && fallback !== primary ? [primary, fallback] : [primary];
 }

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -299,6 +299,7 @@
   "enableTipsAndDonations": true,
   "emailAnalytics": {
     "enabled": true,
+    "fetchSource": "events",
     "batchProcessing": false,
     "metrics": {
       "openThroughput": {

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.ts
@@ -76,6 +76,7 @@ describe('EmailAnalyticsServiceWrapper', function () {
         emailAggregationTimeMs: 300,
         memberAggregationTimeMs: 200,
         result: new EventProcessingResult(),
+        capped: false,
       },
       2000,
     );

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -844,6 +844,39 @@ describe('EmailAnalyticsService', function () {
         );
       });
 
+      it('does not advance the cursor past a capped fetch that read fewer events than its budget', async function () {
+        const lastEventTimestamp = new Date(Date.now() - 10_000);
+        const setJobTimestamp = sinon.stub().resolves();
+        const eventProcessor = createStubEventProcessor();
+        eventProcessor.processBatch.callsFake(async (_events, _result, fetchData) => {
+          fetchData.lastEventTimestamp = lastEventTimestamp;
+        });
+        const service = createService({
+          queries: {
+            getLastEventTimestamp: sinon.stub().resolves(),
+            setJobTimestamp,
+            setJobStatus: sinon.stub().resolves(),
+          },
+          // A Logs fetch can stop on its record or page budget before the event
+          // budget is spent; the window after its cursor was never read.
+          fetchEvents: async ({ batchHandler }: { batchHandler: BatchHandler }) => {
+            await batchHandler([1]);
+            return { safeCursor: new Date(lastEventTimestamp.getTime() + 500) };
+          },
+          createEventProcessor: () => eventProcessor,
+        });
+
+        await service.fetchLatestOpenedEvents({ maxEvents: 10 });
+
+        sinon.assert.calledWithExactly(
+          setJobTimestamp,
+          JOB_NAMES.latestOpened,
+          'finished',
+          lastEventTimestamp,
+        );
+        assert.deepEqual(service.getStatus().latestOpened.lastEventTimestamp, lastEventTimestamp);
+      });
+
       it('resumes from a capped sending domain until all of its events are processed', async function () {
         const newerDomainTimestamp = new Date(Date.now() - 70_000);
         const fallbackTimestamps = [

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -499,6 +499,44 @@ describe('EmailAnalyticsService', function () {
         assert.equal(result.eventCount, 0);
       });
 
+      it('keeps the schedule when a capped fetch delivered no events', async function () {
+        const scheduledBegin = new Date(Date.now() - 2 * 60 * 60 * 1000);
+        const setJobMetadata = sinon.stub().resolves();
+        const fetchBegins: Date[] = [];
+        service = createService({
+          queries: {
+            setJobTimestamp: sinon.stub().resolves(),
+            setJobStatus: sinon.stub().resolves(),
+            setJobMetadata,
+          },
+          // A Logs fetch can spend its record budget on filtered records and
+          // stop before the end of the window without delivering anything
+          fetchEvents: async ({ begin }: { begin: Date }) => {
+            fetchBegins.push(begin);
+            return { safeCursor: new Date(begin.getTime() + 30 * 60 * 1000) };
+          },
+          createEventProcessor: createStubEventProcessor,
+        });
+        await service.schedule({ begin: scheduledBegin, end: new Date() });
+        setJobMetadata.resetHistory();
+
+        const result = await service.fetchScheduled({ maxEvents: 100 });
+        // A resumed schedule must move past the covered records as well
+        await service.fetchScheduled({ maxEvents: 100 });
+
+        assert.equal(result.eventCount, 0);
+        assert.equal(result.capped, true);
+        sinon.assert.neverCalledWith(setJobMetadata, JOB_NAMES.scheduled, null);
+        assert.deepEqual(fetchBegins, [
+          scheduledBegin,
+          new Date(scheduledBegin.getTime() + 30 * 60 * 1000),
+        ]);
+        assert.deepEqual(
+          service.getStatus().scheduled.lastEventTimestamp,
+          new Date(scheduledBegin.getTime() + 60 * 60 * 1000),
+        );
+      });
+
       it('resets fetchScheduledData when no events are fetched', async function () {
         service = createService({
           queries: {

--- a/ghost/core/test/unit/server/services/email-analytics/fetch-mailgun-logs.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/fetch-mailgun-logs.test.ts
@@ -1,0 +1,342 @@
+import assert from 'node:assert/strict';
+import nock from 'nock';
+import sinon from 'sinon';
+import { fetchMailgunEvents } from '../../../../../core/server/services/email-analytics/fetch-mailgun-events';
+import type { MailgunAnalyticsEvent } from '../../../../../core/server/services/email-analytics/mailgun-logs-client';
+// @ts-expect-error This module lacks type definitions.
+import MailgunClient from '../../../../../core/server/services/lib/mailgun-client';
+
+const begin = new Date('2026-09-01T12:00:00.250Z');
+const end = new Date('2026-09-01T14:00:00.750Z');
+const mailgun = {
+  domain: 'primary.example.com',
+  baseUrl: 'https://api.eu.mailgun.net/v3',
+  apiKey: 'test-key',
+};
+const read = (values: Record<string, unknown>) => ({ get: (key: string) => values[key] });
+const settings = read({});
+const config = read({ bulkEmail: { mailgun }, 'emailAnalytics:fetchSource': 'logs' });
+
+function event(id: string, domain = mailgun.domain, time = '2026-09-01T13:00:00Z') {
+  return {
+    id,
+    event: 'opened',
+    '@timestamp': time,
+    domain: { name: domain },
+    tags: ['bulk-email'],
+    recipient: 'member@example.com',
+    'user-variables': '{"email-id":"email-1"}',
+  };
+}
+
+describe('fetchMailgunEvents with Logs selected', () => {
+  beforeAll(() => nock.disableNetConnect());
+  afterAll(() => nock.enableNetConnect());
+  afterEach(() => {
+    nock.cleanAll();
+    sinon.restore();
+  });
+
+  it.each(['bulk-email', 'automation-email', 'gift-delivery'])(
+    'preserves normalized Events parity and all-tag isolation for %s',
+    async (tag) => {
+      const eventTypes = ['delivered', 'opened', 'failed', 'unsubscribed', 'complained'];
+      const events = eventTypes.map((type) => ({
+        ...event(type),
+        event: type,
+        tags: [tag, 'site-tag'],
+        'user-variables': { 'email-id': 'email-1' },
+        message: { headers: { 'message-id': 'provider-1' } },
+      }));
+      const scope = nock('https://api.eu.mailgun.net')
+        .post('/v1/analytics/logs', (body) => {
+          assert.deepEqual(body.events, eventTypes);
+          assert.deepEqual(
+            body.filter.AND.slice(1).map(
+              (item: { values: { value: string }[] }) => item.values[0].value,
+            ),
+            [tag, 'site-tag'],
+          );
+          return true;
+        })
+        .reply(200, { items: events, pagination: {} });
+      const normalized: MailgunAnalyticsEvent[] = [];
+      await fetchMailgunEvents({
+        config,
+        settings,
+        tags: [tag, 'site-tag'],
+        begin,
+        end,
+        batchHandler: (items: MailgunAnalyticsEvent[]) => {
+          normalized.push(...items);
+        },
+      });
+      const legacy = new MailgunClient({ config, settings });
+      assert.deepEqual(
+        normalized,
+        events.map((item) =>
+          legacy.normalizeEvent({
+            ...item,
+            timestamp: new Date(item['@timestamp']).getTime() / 1000,
+          }),
+        ),
+      );
+      scope.done();
+    },
+  );
+
+  it('rejects an unknown source instead of silently selecting a different API', async () => {
+    await assert.rejects(
+      fetchMailgunEvents({
+        config: read({ 'emailAnalytics:fetchSource': 'unknown' }),
+        settings,
+        tags: ['bulk-email'],
+        batchHandler: () => {},
+      }),
+      /Invalid emailAnalytics.fetchSource/,
+    );
+  });
+
+  it.each([false, true])(
+    'uses current settings unless config overrides them as a whole: %s',
+    async (override) => {
+      const configured = read({
+        'emailAnalytics:fetchSource': 'logs',
+        ...(override ? { bulkEmail: { mailgun } } : {}),
+      });
+      const stored = read({
+        mailgun_api_key: 'settings-key',
+        mailgun_domain: 'settings.example.com',
+        mailgun_base_url: 'https://api.mailgun.net/v3',
+      });
+      const domain = override ? mailgun.domain : 'settings.example.com';
+      const scope = nock(override ? 'https://api.eu.mailgun.net' : 'https://api.mailgun.net')
+        .post('/v1/analytics/logs', (body) => body.filter.AND[0].values[0].value === domain)
+        .basicAuth({ user: 'api', pass: override ? 'test-key' : 'settings-key' })
+        .reply(200, { items: [], pagination: {} });
+      await fetchMailgunEvents({
+        config: configured,
+        settings: stored,
+        tags: ['bulk-email'],
+        begin,
+        end,
+        batchHandler: () => assert.fail('Unexpected events'),
+      });
+      scope.done();
+    },
+  );
+
+  it('fetches a duplicate fallback domain only once and continues past filtered-only pages', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, {
+        items: [event('other-site', 'different.example.com')],
+        pagination: { next: 'next' },
+      })
+      .post('/v1/analytics/logs', (body) => body.pagination.token === 'next')
+      .reply(200, { items: [event('ours')], pagination: {} });
+    const ids: string[] = [];
+    await fetchMailgunEvents({
+      config: read({
+        bulkEmail: { mailgun },
+        'emailAnalytics:fetchSource': 'logs',
+        'hostSettings:managedEmail:fallbackDomain': mailgun.domain,
+      }),
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      batchHandler: (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+      },
+    });
+    assert.deepEqual(ids, ['ours']);
+    scope.done();
+  });
+
+  it('propagates processing failure before requesting another page or domain', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, { items: [event('one')], pagination: { next: 'next' } });
+    const later = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, { items: [], pagination: {} });
+    const failure = new Error('Processing failed');
+    await assert.rejects(
+      fetchMailgunEvents({
+        config,
+        settings,
+        tags: ['bulk-email'],
+        begin,
+        end,
+        batchHandler: () => {
+          throw failure;
+        },
+      }),
+      (error) => error === failure,
+    );
+    assert.equal(later.isDone(), false);
+    scope.done();
+  });
+
+  it('propagates a later-domain failure so the caller can retry the full window', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, { items: [event('primary')], pagination: {} })
+      .post('/v1/analytics/logs')
+      .reply(503, {});
+    const ids: string[] = [];
+    await assert.rejects(
+      fetchMailgunEvents({
+        config: read({
+          bulkEmail: { mailgun },
+          'emailAnalytics:fetchSource': 'logs',
+          'hostSettings:managedEmail:fallbackDomain': 'fallback.example.com',
+        }),
+        settings,
+        tags: ['bulk-email'],
+        begin,
+        end,
+        batchHandler: (items: MailgunAnalyticsEvent[]) => {
+          ids.push(...items.map((item) => item.id));
+        },
+      }),
+      /Mailgun Logs request failed/,
+    );
+    assert.deepEqual(ids, ['primary']);
+    scope.done();
+  });
+
+  it('does not make a request when credentials are absent', async () => {
+    const result = await fetchMailgunEvents({
+      config: read({ 'emailAnalytics:fetchSource': 'logs' }),
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      batchHandler: () => assert.fail('Unexpected events'),
+    });
+    assert.equal(result, undefined);
+  });
+
+  it('freezes the end at fetch start across every page of a long run', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2026-09-01T13:30:00Z'), toFake: ['Date'] });
+    const pages = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => body.end === 'Tue, 01 Sep 2026 13:30:00 -0000')
+      .reply(200, { items: [event('first')], pagination: { next: 'next' } })
+      .post('/v1/analytics/logs', (body) => body.end === 'Tue, 01 Sep 2026 13:30:00 -0000')
+      .reply(200, {
+        items: [event('too-new', mailgun.domain, '2026-09-01T13:45:00Z')],
+        pagination: {},
+      });
+    const ids: string[] = [];
+    await fetchMailgunEvents({
+      config,
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      batchHandler: (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+        clock.setSystemTime(end);
+      },
+    });
+    assert.deepEqual(ids, ['first']);
+    pages.done();
+  });
+
+  it('rejects repeated pagination tokens before delivering the repeated page', async () => {
+    const pages = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .twice()
+      .reply(200, { items: [event('same')], pagination: { next: 'repeated' } });
+    const ids: string[] = [];
+    await assert.rejects(
+      fetchMailgunEvents({
+        config,
+        settings,
+        tags: ['bulk-email'],
+        begin,
+        end,
+        batchHandler: (items: MailgunAnalyticsEvent[]) => {
+          ids.push(...items.map((item) => item.id));
+        },
+      }),
+      /Invalid Mailgun Logs pagination/,
+    );
+    assert.deepEqual(ids, ['same']);
+    pages.done();
+  });
+
+  it('finishes begin-time ties and returns the earliest capped cursor across sending domains', async () => {
+    const fallback = 'fallback.example.com';
+    const primaryFirst = nock('https://api.eu.mailgun.net')
+      .post(
+        '/v1/analytics/logs',
+        (body) => body.filter.AND[0].values[0].value === mailgun.domain && !body.pagination.token,
+      )
+      .reply(200, {
+        items: [event('tie', mailgun.domain, begin.toISOString())],
+        pagination: { next: 'primary-two' },
+      });
+    const primarySecond = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => body.pagination.token === 'primary-two')
+      .reply(200, { items: [event('primary')], pagination: { next: 'primary-three' } });
+    const fallbackFirst = nock('https://api.eu.mailgun.net')
+      .post(
+        '/v1/analytics/logs',
+        (body) => body.filter.AND[0].values[0].value === fallback && !body.pagination.token,
+      )
+      .reply(200, {
+        items: [event('fallback', fallback, '2026-09-01T12:30:00Z')],
+        pagination: { next: 'fallback-two' },
+      });
+    const ids: string[] = [];
+    const result = await fetchMailgunEvents({
+      config: read({
+        bulkEmail: { mailgun },
+        'emailAnalytics:fetchSource': 'logs',
+        'hostSettings:managedEmail:fallbackDomain': fallback,
+      }),
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      events: ['opened'],
+      maxEvents: 1,
+      batchHandler: (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+      },
+    });
+    assert.deepEqual(ids, ['tie', 'primary', 'fallback']);
+    assert.deepEqual(result, { safeCursor: new Date('2026-09-01T12:30:00Z') });
+    primaryFirst.done();
+    primarySecond.done();
+    fallbackFirst.done();
+  });
+
+  it('uses the configured Logs endpoint and delivers normalized pages in order', async () => {
+    const first = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => !body.pagination.token)
+      .reply(200, { items: [event('one')], pagination: { next: 'page-two' } });
+    const second = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => body.pagination.token === 'page-two')
+      .reply(200, { items: [event('two')], pagination: {} });
+    const ids: string[] = [];
+    const result = await fetchMailgunEvents({
+      config,
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      events: ['opened'],
+      batchHandler: async (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+      },
+    });
+    assert.deepEqual(ids, ['one', 'two']);
+    assert.deepEqual(result, { safeCursor: undefined });
+    first.done();
+    second.done();
+  });
+});

--- a/ghost/core/test/unit/server/services/email-analytics/fetch-mailgun-logs.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/fetch-mailgun-logs.test.ts
@@ -47,6 +47,16 @@ describe('fetchMailgunEvents with Logs selected', () => {
         tags: [tag, 'site-tag'],
         'user-variables': { 'email-id': 'email-1' },
         message: { headers: { 'message-id': 'provider-1' } },
+        ...(type === 'failed'
+          ? {
+              severity: 'permanent',
+              'delivery-status': {
+                code: 550,
+                message: 'Mailbox unavailable',
+                'enhanced-code': '5.1.1',
+              },
+            }
+          : {}),
       }));
       const scope = nock('https://api.eu.mailgun.net')
         .post('/v1/analytics/logs', (body) => {
@@ -245,27 +255,86 @@ describe('fetchMailgunEvents with Logs selected', () => {
     pages.done();
   });
 
-  it('rejects repeated pagination tokens before delivering the repeated page', async () => {
+  it('stops at a repeated pagination token after delivering its page and rests the cursor on covered events', async () => {
     const pages = nock('https://api.eu.mailgun.net')
-      .post('/v1/analytics/logs')
-      .twice()
-      .reply(200, { items: [event('same')], pagination: { next: 'repeated' } });
+      .post('/v1/analytics/logs', (body) => !body.pagination.token)
+      .reply(200, { items: [event('first')], pagination: { next: 'repeated' } });
+    const echoed = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => body.pagination.token === 'repeated')
+      .reply(200, {
+        items: [event('second', mailgun.domain, '2026-09-01T13:05:00Z')],
+        pagination: { next: 'repeated' },
+      });
     const ids: string[] = [];
-    await assert.rejects(
-      fetchMailgunEvents({
-        config,
-        settings,
-        tags: ['bulk-email'],
-        begin,
-        end,
-        batchHandler: (items: MailgunAnalyticsEvent[]) => {
-          ids.push(...items.map((item) => item.id));
-        },
-      }),
-      /Invalid Mailgun Logs pagination/,
-    );
-    assert.deepEqual(ids, ['same']);
+    const result = await fetchMailgunEvents({
+      config,
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      batchHandler: (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+      },
+    });
+    // The echoed page may hold new events, so it is delivered before stopping
+    assert.deepEqual(ids, ['first', 'second']);
+    // The next fetch resumes from the covered timestamp rather than skipping the window
+    assert.deepEqual(result, { safeCursor: new Date('2026-09-01T13:05:00Z') });
     pages.done();
+    echoed.done();
+  });
+
+  it('continues past an empty page that still carries a token', async () => {
+    const first = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => !body.pagination.token)
+      .reply(200, { items: [], pagination: { next: 'second' } });
+    const second = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => body.pagination.token === 'second')
+      .reply(200, { items: [event('later')], pagination: {} });
+    const ids: string[] = [];
+    const result = await fetchMailgunEvents({
+      config,
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      batchHandler: (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+      },
+    });
+    assert.deepEqual(ids, ['later']);
+    assert.deepEqual(result, { safeCursor: undefined });
+    first.done();
+    second.done();
+  });
+
+  it('counts filtered records toward the budget and caps at the last covered timestamp', async () => {
+    // Every record belongs to another site's tag, so nothing is delivered, but
+    // the domain must not page through the whole account window unbounded.
+    const first = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => !body.pagination.token)
+      .reply(200, {
+        items: [
+          { ...event('other-1', mailgun.domain, '2026-09-01T12:30:00Z'), tags: ['other-site'] },
+          { ...event('other-2', mailgun.domain, '2026-09-01T12:45:00Z'), tags: ['other-site'] },
+        ],
+        pagination: { next: 'second' },
+      });
+    const ids: string[] = [];
+    const result = await fetchMailgunEvents({
+      config,
+      settings,
+      tags: ['bulk-email'],
+      begin,
+      end,
+      maxEvents: 2,
+      batchHandler: (items: MailgunAnalyticsEvent[]) => {
+        ids.push(...items.map((item) => item.id));
+      },
+    });
+    assert.deepEqual(ids, []);
+    assert.deepEqual(result, { safeCursor: new Date('2026-09-01T12:45:00Z') });
+    first.done();
   });
 
   it('finishes begin-time ties and returns the earliest capped cursor across sending domains', async () => {

--- a/ghost/core/test/unit/server/services/email-analytics/mailgun-logs-client.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/mailgun-logs-client.test.ts
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import nock from 'nock';
+import { MailgunLogsClient } from '../../../../../core/server/services/email-analytics/mailgun-logs-client';
+
+const begin = new Date('2026-09-10T12:00:00.250Z');
+const end = new Date('2026-09-10T14:00:00.750Z');
+const timestamp = new Date('2026-09-10T13:00:00.500Z');
+const filter = (attribute: string, value: string) => ({
+  attribute,
+  comparator: '=',
+  values: [{ label: value, value }],
+});
+
+function event(overrides = {}) {
+  return {
+    id: 'event-1',
+    event: 'opened',
+    '@timestamp': timestamp.toISOString(),
+    recipient: 'member@example.com',
+    domain: { name: 'mail.example.com' },
+    tags: ['bulk-email', 'site-tag'],
+    message: { headers: { 'message-id': 'message-1@mail.example.com' } },
+    'user-variables': JSON.stringify({ 'email-id': 'email-1' }),
+    ...overrides,
+  };
+}
+
+const pageOptions = {
+  domain: 'mail.example.com',
+  tags: ['bulk-email', 'site-tag'],
+  events: ['opened'],
+  begin,
+  end,
+};
+
+const client = () =>
+  new MailgunLogsClient({ apiKey: 'test-api-key', baseUrl: 'https://api.eu.mailgun.net/v3' });
+
+describe('Mailgun Logs API client', () => {
+  beforeAll(() => nock.disableNetConnect());
+  afterAll(() => nock.enableNetConnect());
+  afterEach(() => nock.cleanAll());
+
+  it.each([
+    { domain: '' },
+    { tags: [] },
+    { tags: [''] },
+    { events: [] },
+    { begin: new Date(NaN) },
+    { end: new Date('2026-09-10T11:00:00Z') },
+  ])('rejects invalid filters or time windows before making a request: %j', async (options) => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, { items: [], pagination: {} });
+    await assert.rejects(
+      client().getPage({ ...pageOptions, ...options }),
+      /Invalid Mailgun Logs request/,
+    );
+    assert.equal(scope.isDone(), false);
+  });
+
+  it('preserves the HTTP status for rate handling without leaking transport credentials or response bodies', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(429, { message: 'private-provider-response' });
+    await assert.rejects(client().getPage(pageOptions), (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal((error as Error & { status?: number }).status, 429);
+      const serialized = JSON.stringify(error);
+      for (const secret of [
+        'test-api-key',
+        'private-provider-response',
+        'password',
+        'authorization',
+      ]) {
+        assert.equal(serialized.includes(secret), false);
+      }
+      assert.equal('cause' in error, false);
+      return true;
+    });
+    scope.done();
+  });
+
+  it.each([
+    { items: [] },
+    { items: [event()], pagination: { next: 42 } },
+    { items: [event({ domain: null })], pagination: {} },
+    { items: [event({ tags: null })], pagination: {} },
+    { items: [event({ '@timestamp': 'invalid' })], pagination: {} },
+    { items: [null], pagination: {} },
+  ])('rejects malformed pages rather than treating them as exhausted: %j', async (body) => {
+    const scope = nock('https://api.eu.mailgun.net').post('/v1/analytics/logs').reply(200, body);
+    await assert.rejects(client().getPage(pageOptions), /Invalid Mailgun Logs/);
+    scope.done();
+  });
+
+  it('keeps domain, all-tag, event-type and exact timestamp boundaries on the response', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, {
+        items: [
+          event({ id: 'before', '@timestamp': '2026-09-10T12:00:00.100Z' }),
+          event({ id: 'other-domain', domain: { name: 'other.example.com' } }),
+          event({ id: 'missing-site-tag', tags: ['bulk-email'] }),
+          event({ id: 'wrong-type', event: 'delivered' }),
+          event(),
+          event({ id: 'after', '@timestamp': '2026-09-10T14:00:00.900Z' }),
+        ],
+        pagination: { next: 'next-page' },
+      });
+    const page = await client().getPage(pageOptions);
+    assert.deepEqual(
+      page.items.map((item) => item.id),
+      ['event-1'],
+    );
+    assert.equal(page.next, 'next-page');
+    assert.equal(page.empty, false);
+    scope.done();
+  });
+
+  it('keeps opaque pagination tokens in the body and continues past filtered-only pages', async () => {
+    const token = 'https://untrusted.example/opaque-token';
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', (body) => {
+        assert.equal(body.pagination.token, token);
+        assert.deepEqual(body.filter.AND, [
+          filter('domain', 'mail.example.com'),
+          filter('tag', 'bulk-email'),
+          filter('tag', 'site-tag'),
+        ]);
+        assert.deepEqual(body.events, ['opened']);
+        return true;
+      })
+      .reply(200, {
+        items: [event({ domain: { name: 'other.example.com' } })],
+        pagination: { next: 'another-token' },
+      });
+    assert.deepEqual(await client().getPage({ ...pageOptions, token }), {
+      items: [],
+      next: 'another-token',
+      empty: false,
+    });
+    scope.done();
+  });
+
+  it('normalizes nullable headers, both user-variable encodings, provider fallback and delivery errors', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, {
+        items: [
+          event({
+            id: 'nullable',
+            message: { headers: null },
+            'user-variables': { 'email-id': 'email-object' },
+          }),
+          event({ id: 'fallback', 'user-variables': 'invalid-json' }),
+          event({ id: 'unmappable', message: { headers: null }, 'user-variables': null }),
+          event({
+            id: 'failed',
+            event: 'failed',
+            severity: 'permanent',
+            'delivery-status': { code: 550, description: 'x'.repeat(2001), 'enhanced-code': 512 },
+          }),
+        ],
+        pagination: { next: null },
+      });
+    const page = await client().getPage({ ...pageOptions, events: ['opened', 'failed'] });
+    assert.deepEqual(
+      page.items.map((item) => [item.id, item.emailId, item.providerId]),
+      [
+        ['nullable', 'email-object', undefined],
+        ['fallback', undefined, 'message-1@mail.example.com'],
+        ['failed', 'email-1', 'message-1@mail.example.com'],
+      ],
+    );
+    assert.deepEqual(page.items[2].error, {
+      code: 550,
+      message: 'x'.repeat(2000),
+      enhancedCode: '512',
+    });
+    assert.equal(page.items[2].severity, 'permanent');
+    assert.equal(page.next, undefined);
+    scope.done();
+  });
+
+  it('requests an isolated Logs page in the configured region and normalizes its event', async () => {
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs', {
+        start: 'Thu, 10 Sep 2026 12:00:00 -0000',
+        end: 'Thu, 10 Sep 2026 14:00:01 -0000',
+        events: ['opened'],
+        include_subaccounts: false,
+        include_totals: false,
+        filter: {
+          AND: [
+            filter('domain', 'mail.example.com'),
+            filter('tag', 'bulk-email'),
+            filter('tag', 'site-tag'),
+          ],
+        },
+        pagination: { sort: 'timestamp:asc', limit: 100 },
+      })
+      .basicAuth({ user: 'api', pass: 'test-api-key' })
+      .reply(200, { items: [event()], pagination: { next: 'opaque-next-token' } });
+    const page = await client().getPage(pageOptions);
+    assert.deepEqual(page, {
+      items: [
+        {
+          id: 'event-1',
+          type: 'opened',
+          recipientEmail: 'member@example.com',
+          emailId: 'email-1',
+          providerId: 'message-1@mail.example.com',
+          timestamp,
+          severity: undefined,
+          error: null,
+        },
+      ],
+      next: 'opaque-next-token',
+      empty: false,
+    });
+    scope.done();
+  });
+});

--- a/ghost/core/test/unit/server/services/email-analytics/mailgun-logs-client.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/mailgun-logs-client.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 import nock from 'nock';
+import sinon from 'sinon';
+import metrics from '@tryghost/metrics';
 import { MailgunLogsClient } from '../../../../../core/server/services/email-analytics/mailgun-logs-client';
 
 const begin = new Date('2026-09-10T12:00:00.250Z');
@@ -39,7 +41,31 @@ const client = () =>
 describe('Mailgun Logs API client', () => {
   beforeAll(() => nock.disableNetConnect());
   afterAll(() => nock.enableNetConnect());
-  afterEach(() => nock.cleanAll());
+  afterEach(() => {
+    nock.cleanAll();
+    sinon.restore();
+  });
+
+  it.each([200, 429])(
+    'records request timing and safe HTTP status for a %i response',
+    async (statusCode) => {
+      const metric = sinon.stub(metrics, 'metric');
+      const scope = nock('https://api.eu.mailgun.net')
+        .post('/v1/analytics/logs')
+        .reply(statusCode, { items: [], pagination: {} });
+      if (statusCode === 200) {
+        await client().getPage(pageOptions);
+      } else {
+        await assert.rejects(client().getPage(pageOptions));
+      }
+      sinon.assert.calledOnceWithExactly(metric, 'mailgun-get-events', {
+        value: sinon.match.number,
+        statusCode,
+        source: 'logs',
+      });
+      scope.done();
+    },
+  );
 
   it.each([
     { domain: '' },

--- a/ghost/core/test/unit/server/services/email-analytics/mailgun-logs-client.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/mailgun-logs-client.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import nock from 'nock';
 import sinon from 'sinon';
 import metrics from '@tryghost/metrics';
-import { MailgunLogsClient } from '../../../../../core/server/services/email-analytics/mailgun-logs-client';
+import logging from '@tryghost/logging';
+import {
+  MailgunLogsClient,
+  resolveLogsUrl,
+} from '../../../../../core/server/services/email-analytics/mailgun-logs-client';
 
 const begin = new Date('2026-09-10T12:00:00.250Z');
 const end = new Date('2026-09-10T14:00:00.750Z');
@@ -107,17 +111,69 @@ describe('Mailgun Logs API client', () => {
     scope.done();
   });
 
-  it.each([
-    { items: [] },
-    { items: [event()], pagination: { next: 42 } },
-    { items: [event({ domain: null })], pagination: {} },
-    { items: [event({ tags: null })], pagination: {} },
-    { items: [event({ '@timestamp': 'invalid' })], pagination: {} },
-    { items: [null], pagination: {} },
-  ])('rejects malformed pages rather than treating them as exhausted: %j', async (body) => {
-    const scope = nock('https://api.eu.mailgun.net').post('/v1/analytics/logs').reply(200, body);
-    await assert.rejects(client().getPage(pageOptions), /Invalid Mailgun Logs/);
+  it.each([{ items: [] }, { items: [event()], pagination: { next: 42 } }, { pagination: {} }])(
+    'rejects malformed pages rather than treating them as exhausted: %j',
+    async (body) => {
+      const scope = nock('https://api.eu.mailgun.net').post('/v1/analytics/logs').reply(200, body);
+      await assert.rejects(client().getPage(pageOptions), /Invalid Mailgun Logs page/);
+      scope.done();
+    },
+  );
+
+  it('skips unreadable records with a warning instead of failing the page', async () => {
+    const warn = sinon.stub(logging, 'warn');
+    const scope = nock('https://api.eu.mailgun.net')
+      .post('/v1/analytics/logs')
+      .reply(200, {
+        items: [
+          event({ domain: null }),
+          event({ '@timestamp': 'invalid' }),
+          null,
+          event({ tags: null }),
+          event({ id: 'unattributable', recipient: null, 'user-variables': {} }),
+          event({ id: 'readable', '@timestamp': end.toISOString() }),
+        ],
+        pagination: { next: 'more' },
+      });
+    const page = await client().getPage(pageOptions);
+    // An untagged record is readable but does not match the requested tags
+    assert.deepEqual(
+      page.items.map((item) => item.id),
+      ['readable'],
+    );
+    assert.equal(page.rawCount, 6);
+    // A matching record without a recipient counts as skipped too
+    assert.equal(page.skipped, 4);
+    assert.deepEqual(page.lastTimestamp, end);
+    sinon.assert.calledWithMatch(
+      warn,
+      /Skipped 4 unreadable or unattributable Mailgun Logs record/,
+    );
     scope.done();
+  });
+
+  it('explains a rejected key without leaking credentials', async () => {
+    const scope = nock('https://api.eu.mailgun.net').post('/v1/analytics/logs').reply(401, {});
+    await assert.rejects(client().getPage(pageOptions), (error: Error & { status?: number }) => {
+      assert.equal(error.status, 401);
+      assert.match(error.message, /must be able to read account logs/);
+      assert.equal(JSON.stringify(error).includes('test-api-key'), false);
+      return true;
+    });
+    scope.done();
+  });
+
+  it.each([
+    ['https://api.eu.mailgun.net/v3', 'https://api.eu.mailgun.net/v1/analytics/logs'],
+    ['https://api.mailgun.net/v3/', 'https://api.mailgun.net/v1/analytics/logs'],
+    ['https://proxy.example.com/mailgun/v3', 'https://proxy.example.com/mailgun/v1/analytics/logs'],
+    ['https://api.mailgun.net', 'https://api.mailgun.net/v1/analytics/logs'],
+  ])('derives the Logs endpoint from the base URL %s', (baseUrl, expected) => {
+    assert.equal(resolveLogsUrl(baseUrl), expected);
+  });
+
+  it('rejects an invalid base URL when constructed', () => {
+    assert.throws(() => new MailgunLogsClient({ apiKey: 'k', baseUrl: 'not a url' }), /base URL/);
   });
 
   it('keeps domain, all-tag, event-type and exact timestamp boundaries on the response', async () => {
@@ -140,7 +196,9 @@ describe('Mailgun Logs API client', () => {
       ['event-1'],
     );
     assert.equal(page.next, 'next-page');
-    assert.equal(page.empty, false);
+    assert.equal(page.skipped, 0);
+    // A record past the exact end is not covered: the request end is rounded up
+    assert.deepEqual(page.lastTimestamp, new Date('2026-09-10T13:00:00.500Z'));
     scope.done();
   });
 
@@ -164,7 +222,9 @@ describe('Mailgun Logs API client', () => {
     assert.deepEqual(await client().getPage({ ...pageOptions, token }), {
       items: [],
       next: 'another-token',
-      empty: false,
+      rawCount: 1,
+      skipped: 0,
+      lastTimestamp: timestamp,
     });
     scope.done();
   });
@@ -243,7 +303,9 @@ describe('Mailgun Logs API client', () => {
         },
       ],
       next: 'opaque-next-token',
-      empty: false,
+      rawCount: 1,
+      skipped: 0,
+      lastTimestamp: timestamp,
     });
     scope.done();
   });

--- a/ghost/core/test/unit/server/services/lib/mailgun-config.test.ts
+++ b/ghost/core/test/unit/server/services/lib/mailgun-config.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import logging from '@tryghost/logging';
+import {
+  getMailgunConfig,
+  getMailgunDomains,
+} from '../../../../../core/server/services/lib/mailgun-config';
+
+const read = (values: Record<string, unknown>) => ({ get: (key: string) => values[key] });
+const mailgun = {
+  apiKey: 'key',
+  baseUrl: 'https://api.mailgun.net/v3',
+  domain: 'primary.example.com',
+};
+const settings = read({
+  mailgun_api_key: 'settings-key',
+  mailgun_domain: 'settings.example.com',
+  mailgun_base_url: 'https://api.eu.mailgun.net/v3',
+});
+
+describe('Mailgun config', () => {
+  afterEach(() => sinon.restore());
+
+  it('prefers a complete config block over settings', () => {
+    assert.deepEqual(getMailgunConfig(read({ bulkEmail: { mailgun } }), settings), mailgun);
+  });
+
+  it('disables Mailgun with a warning for an invalid config block instead of using settings', () => {
+    const warn = sinon.stub(logging, 'warn');
+    const config = read({ bulkEmail: { mailgun: { ...mailgun, baseUrl: '' } } });
+    assert.equal(getMailgunConfig(config, settings), null);
+    sinon.assert.calledWithMatch(warn, /invalid bulkEmail.mailgun config/);
+  });
+
+  it('uses settings only when all three values exist', () => {
+    assert.deepEqual(getMailgunConfig(read({}), settings), {
+      apiKey: 'settings-key',
+      domain: 'settings.example.com',
+      baseUrl: 'https://api.eu.mailgun.net/v3',
+    });
+    assert.equal(
+      getMailgunConfig(read({ bulkEmail: {} }), read({ mailgun_api_key: 'settings-key' })),
+      null,
+    );
+    assert.equal(getMailgunConfig(read({}), read({})), null);
+  });
+
+  it('treats unexpected setting and config types as absent', () => {
+    assert.equal(
+      getMailgunConfig(
+        read({}),
+        read({ mailgun_api_key: 42, mailgun_domain: 'd', mailgun_base_url: 'u' }),
+      ),
+      null,
+    );
+    assert.deepEqual(
+      getMailgunDomains(
+        read({ 'hostSettings:managedEmail:fallbackDomain': 42 }),
+        'primary.example.com',
+      ),
+      ['primary.example.com'],
+    );
+  });
+
+  it('adds a distinct fallback sending domain', () => {
+    assert.deepEqual(getMailgunDomains(read({}), 'primary.example.com'), ['primary.example.com']);
+    assert.deepEqual(
+      getMailgunDomains(
+        read({ 'hostSettings:managedEmail:fallbackDomain': 'primary.example.com' }),
+        'primary.example.com',
+      ),
+      ['primary.example.com'],
+    );
+    assert.deepEqual(
+      getMailgunDomains(
+        read({ 'hostSettings:managedEmail:fallbackDomain': 'fallback.example.com' }),
+        'primary.example.com',
+      ),
+      ['primary.example.com', 'fallback.example.com'],
+    );
+  });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3936/raise-mailgun-event-fetch-throughput-concurrent-paging-logs-api

We need a compatible Logs API path before we can evaluate Mailgun fetch throughput improvements. This adds an opt-in adapter while keeping Events as the default, so we can compare provider behavior independently of counter rollout and scheduling changes.

```text
fetchMailgunEvents
  resolve current credentials + primary/fallback domains
  fetchSource
    events (default) → existing Events client
    logs            → isolated Logs pages + opaque tokens
  normalized events → existing newsletter / automation / gift processors
```

Logs requests keep the configured region, explicit domain filter, every required tag, event types and fixed time window. Response checks reinforce those boundaries. Normalization preserves email/provider IDs and failure details, including nullable Logs headers and JSON-string user variables. HTTP errors retain a safe status for later rate handling without carrying request credentials into logs.

Paging stays serial within the active lane. Each domain has a soft event budget; begin-time ties continue until the cursor can progress, and the earliest capped-domain timestamp constrains the shared cursor. Filtered-only pages continue, repeated tokens fail, and processing or provider failures propagate to the existing full-window retry path. Opens-first scheduling is unchanged.

This PR is stacked on #30668, which supplies the cursor failure handling used here. It does not depend on the member preparation or counter stack. The following fetch PR adds bounded prefetch and backoff. Suppression cleanup is outside this performance scope: its events run in a separate fetch loop that is not performance sensitive. Durability and correctness will be revisited when the ongoing durable background jobs work is available.

`emailAnalytics.fetchSource` defaults to `events`; `logs` opts in. Switching sources retains the timestamp cursors and overlap windows. [Mailgun integration documentation](https://github.com/TryGhost/Ghost/blob/jonatan-ber-3936-mailgun-logs-adapter/ghost/core/core/server/services/email-analytics/mailgun-ingestion.md) describes the contract and fallback.

Validation: 253 tests across shared analytics and the legacy Mailgun client, Core/test typechecks, focused lint, and checks of the new documentation passed. Tests intercept HTTP and compare normalized Events/Logs fixtures for newsletter, automation and gift tags; they cover isolation, domain warming, capped cursors, ties, token loops, fixed windows and failures. Five independent review passes cover each slice, followed by an accumulated review.

`pnpm check` remains blocked by 452 existing unrelated formatting files. The full docs check finds an existing missing `#stripe-webhooks` heading linked from `e2e/README.md`. No live Mailgun calls, production enablement or throughput improvement are claimed. Before opting in, verify account Logs read permission, region/domain visibility and matching-window parity against Events. The provider schema's `duration` requirement conflicts with its explicit start/end example and SDK; the adapter follows the latter and that request shape remains a live compatibility gate.
