### PR TITLE
Added indexed availability for deferred outbox work

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.64/2026-09-10-17-21-19-add-outbox-available-at.js
+++ b/ghost/core/core/server/data/migrations/versions/6.64/2026-09-10-17-21-19-add-outbox-available-at.js
@@ -1,0 +1,20 @@
+const {
+  combineNonTransactionalMigrations,
+  createAddColumnMigration,
+  createNonTransactionalMigration,
+} = require('../../utils');
+const { addIndex, dropIndex } = require('../../../schema/commands');
+
+const columns = ['event_type', 'status', 'available_at', 'id'];
+
+module.exports = combineNonTransactionalMigrations(
+  createAddColumnMigration('outbox', 'available_at', { type: 'dateTime', nullable: true }),
+  createNonTransactionalMigration(
+    async (knex) => {
+      await addIndex('outbox', columns, knex);
+    },
+    async (knex) => {
+      await dropIndex('outbox', columns, knex);
+    },
+  ),
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -2040,8 +2040,12 @@ module.exports = {
     updated_at: { type: 'dateTime', nullable: true },
     retry_count: { type: 'integer', nullable: false, unsigned: true, defaultTo: 0 },
     last_retry_at: { type: 'dateTime', nullable: true },
+    available_at: { type: 'dateTime', nullable: true },
     message: { type: 'string', maxlength: 2000, nullable: true },
-    '@@INDEXES@@': [['event_type', 'status', 'created_at']],
+    '@@INDEXES@@': [
+      ['event_type', 'status', 'created_at'],
+      ['event_type', 'status', 'available_at', 'id'],
+    ],
   },
   email_design_settings: {
     id: { type: 'string', maxlength: 24, nullable: false, primary: true },

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = '83816146af992ec6a8df98956c3e6bd9';
+  const currentSchemaHash = '9f0b9c4a2bff838e21b5cf3bce9b3634';
   const currentFixturesHash = '5718e0d4eb037f159c312369e949829a';
   const currentSettingsHash = '6ea42a00cca61a1ba87f66eb6e25a78a';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3936/raise-mailgun-event-fetch-throughput-concurrent-paging-logs-api

Remote suppression cleanup needs durable retry scheduling so Mailgun delays do not hold up event ingestion. This is the schema foundation: it adds a nullable `outbox.available_at` timestamp and an index for selecting due work within an event type and status.

```text
outbox
  event_type + status + available_at + id → bounded selection of due work
  existing payload / status / created-at index → retained
```

Existing rows receive NULL and their payloads are preserved. The migration uses idempotent nontransactional helpers and removes the dependent index before dropping the column on rollback. It adds no producer or worker; the following PR will commit local unsubscribe/complaint safety state with cleanup intents and process them with retries, lease recovery and shutdown draining. Keeping this foundation separate lets us review the database change on its own.

Stacked on #30690 as the next part of the ingestion performance stack. The schema has no logical dependency on prefetch or counter modes. Adding the index can still take time on an existing outbox; no claim is made from the small test database about production DDL duration.

Validation: schema integrity, Core/test types and focused lint pass. Manual MySQL CLI initialization, rollback to 6.63 and forward migration to 6.64 preserved an existing payload and verified the nullable field and index order; the temporary database was removed. SQLite up/up/down/down/up and all four migration integration tests pass. Five independent review passes found no high-confidence issues.

The full unit run is not green: unrelated untracked suites fail and the runner reports source-map parsing errors. A separate tracked-only run reported 8,687 passing tests but still exited with 64 source-map errors. The migration-specific checks above pass. The earlier full repository check also stops on 452 unrelated formatting files.
