### PR TITLE
Added durable Mailgun suppression cleanup engine

### DIFF
--- a/ghost/core/core/server/services/email-suppression-list/suppression-cleanup-client.ts
+++ b/ghost/core/core/server/services/email-suppression-list/suppression-cleanup-client.ts
@@ -1,0 +1,88 @@
+import type { SuppressionCleanupRequest } from './suppression-cleanup-repository';
+import { InternalServerError } from '@tryghost/errors';
+import {
+  parseMailgunRateLimit,
+  type MailgunRateLimitState,
+} from '../email-analytics/mailgun-rate-limit';
+
+// @tryghost/request has no declarations; isolate its response at this boundary.
+const request: (
+  url: string,
+  options: Record<string, unknown>,
+) => Promise<{ statusCode: number; headers?: unknown }> = require('@tryghost/request');
+type Target = Pick<SuppressionCleanupRequest, 'apiOrigin' | 'domain' | 'kind' | 'email'>;
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function failed(status: number | undefined, rateLimit?: MailgunRateLimitState): Error {
+  return Object.assign(
+    new InternalServerError({
+      message: 'Mailgun suppression cleanup request failed',
+      code: 'MAILGUN_SUPPRESSION_REQUEST_FAILED',
+    }),
+    { status, rateLimit },
+  );
+}
+
+export class SuppressionCleanupClient {
+  readonly #origin: string;
+  readonly #apiKey: string;
+
+  constructor({ baseUrl, apiKey }: { baseUrl: string; apiKey: string }) {
+    this.#origin = new URL(baseUrl).origin;
+    this.#apiKey = apiKey;
+  }
+
+  async remove(
+    target: Target,
+    signal?: AbortSignal,
+  ): Promise<{ status: 'removed' | 'absent'; rateLimit?: MailgunRateLimitState }> {
+    if (target.apiOrigin !== this.#origin) {
+      throw new InternalServerError({
+        message: 'Mailgun suppression cleanup API origin changed',
+        code: 'MAILGUN_SUPPRESSION_ORIGIN_CHANGED',
+      });
+    }
+    let response: Awaited<ReturnType<typeof request>>;
+    try {
+      response = await request(
+        `${this.#origin}/v3/${encodeURIComponent(target.domain)}/${target.kind}/${encodeURIComponent(target.email)}`,
+        {
+          method: 'DELETE',
+          username: 'api',
+          password: this.#apiKey,
+          signal,
+          followRedirect: false,
+          retry: { limit: 0 },
+          timeout: { request: 10000 },
+        },
+      );
+    } catch (error) {
+      const failedResponse = record(record(error)?.response);
+      const statusCode = failedResponse?.statusCode ?? record(error)?.statusCode;
+      const status =
+        typeof statusCode === 'number' &&
+        Number.isInteger(statusCode) &&
+        statusCode >= 100 &&
+        statusCode <= 599
+          ? statusCode
+          : undefined;
+      const rateLimit = parseMailgunRateLimit(failedResponse?.headers ?? record(error)?.headers);
+      if (status === 404) {
+        return { status: 'absent', rateLimit };
+      }
+      // Transport errors retain credentials, recipient addresses and response bodies.
+      throw failed(status, rateLimit);
+    }
+    const rateLimit = parseMailgunRateLimit(response.headers);
+    // Got resolves 3xx when redirects are disabled; that is not a confirmed deletion.
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw failed(response.statusCode, rateLimit);
+    }
+    return { status: 'removed', rateLimit };
+  }
+}

--- a/ghost/core/core/server/services/email-suppression-list/suppression-cleanup-repository.ts
+++ b/ghost/core/core/server/services/email-suppression-list/suppression-cleanup-repository.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto';
+import type { Knex } from 'knex';
+
+export type SuppressionCleanupRequest = {
+  kind: 'complaints' | 'unsubscribes';
+  email: string;
+  domain: string;
+  apiOrigin: string;
+  eventId: string;
+  eventTimestamp: string;
+};
+
+export type SuppressionCleanupClaim = {
+  id: string;
+  attempt: number;
+  payload: string;
+};
+
+const EVENT_TYPE = 'email-suppression-cleanup';
+const LEASE_MS = 10 * 60 * 1000;
+
+function timestamp(date: Date, roundUp = false): string {
+  const seconds = roundUp ? Math.ceil(date.getTime() / 1000) : Math.floor(date.getTime() / 1000);
+  return new Date(seconds * 1000).toISOString().slice(0, 19).replace('T', ' ');
+}
+
+export class SuppressionCleanupRepository {
+  readonly #knex: Knex;
+
+  constructor(knex: Knex) {
+    this.#knex = knex;
+  }
+
+  /** The caller commits local safety state and this intent in the same transaction. */
+  async enqueue(
+    request: SuppressionCleanupRequest,
+    trx: Knex.Transaction,
+    now = new Date(),
+  ): Promise<boolean> {
+    const id = createHash('sha256')
+      .update(
+        JSON.stringify([
+          EVENT_TYPE,
+          request.apiOrigin,
+          request.domain,
+          request.kind,
+          request.email,
+          request.eventId,
+          request.eventTimestamp,
+        ]),
+      )
+      .digest('hex')
+      .slice(0, 24);
+    try {
+      await trx('outbox').insert({
+        id,
+        event_type: EVENT_TYPE,
+        payload: JSON.stringify(request),
+        status: 'pending',
+        created_at: timestamp(now),
+        available_at: timestamp(now),
+        retry_count: 0,
+      });
+    } catch (error) {
+      const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined;
+      const sqliteDuplicate =
+        code === 'SQLITE_CONSTRAINT' &&
+        error instanceof Error &&
+        error.message.endsWith('UNIQUE constraint failed: outbox.id');
+      if (code === 'ER_DUP_ENTRY' || code === 'SQLITE_CONSTRAINT_PRIMARYKEY' || sqliteDuplicate) {
+        return false;
+      }
+      throw error;
+    }
+    return true;
+  }
+
+  async claim(now = new Date()): Promise<SuppressionCleanupClaim | null> {
+    // Range gap locks under REPEATABLE READ can deadlock concurrent status moves.
+    const mysql = this.#knex.client.config.client === 'mysql2';
+    return this.#knex.transaction(
+      async (trx) => {
+        let row: { id: string; payload: string; retry_count: number } | undefined;
+        // Recover expired workers first; a steady stream of new work must not starve recovery.
+        for (const status of ['processing', 'pending']) {
+          const query = trx('outbox')
+            .where({ event_type: EVENT_TYPE, status })
+            .where((eligible) =>
+              eligible.whereNull('available_at').orWhere('available_at', '<=', timestamp(now)),
+            )
+            .orderBy('available_at')
+            .orderBy('id')
+            .forUpdate()
+            .first();
+          // Skip locked index entries, including entries being moved between statuses.
+          row = await (mysql ? query.skipLocked() : query);
+          if (row) {
+            break;
+          }
+        }
+        if (!row) {
+          return null;
+        }
+        const attempt = Number(row.retry_count) + 1;
+        await trx('outbox')
+          .where('id', row.id)
+          .update({
+            status: 'processing',
+            retry_count: attempt,
+            last_retry_at: timestamp(now),
+            updated_at: timestamp(now),
+            available_at: timestamp(new Date(now.getTime() + LEASE_MS), true),
+          });
+        return { id: row.id, attempt, payload: row.payload };
+      },
+      mysql ? { isolationLevel: 'read committed' } : undefined,
+    );
+  }
+
+  async complete(claim: SuppressionCleanupClaim, now = new Date()): Promise<boolean> {
+    const count = await this.#knex('outbox')
+      .where({
+        id: claim.id,
+        event_type: EVENT_TYPE,
+        status: 'processing',
+        retry_count: claim.attempt,
+      })
+      .update({
+        status: 'completed',
+        available_at: null,
+        updated_at: timestamp(now),
+        message: null,
+      });
+    return count > 0;
+  }
+
+  async retry(
+    claim: SuppressionCleanupClaim,
+    availableAt: Date,
+    code: string,
+    now = new Date(),
+  ): Promise<boolean> {
+    const count = await this.#knex('outbox')
+      .where({
+        id: claim.id,
+        event_type: EVENT_TYPE,
+        status: 'processing',
+        retry_count: claim.attempt,
+      })
+      .update({
+        status: 'pending',
+        available_at: timestamp(availableAt, true),
+        updated_at: timestamp(now),
+        message: code,
+      });
+    return count > 0;
+  }
+
+  async fail(claim: SuppressionCleanupClaim, code: string, now = new Date()): Promise<boolean> {
+    const count = await this.#knex('outbox')
+      .where({
+        id: claim.id,
+        event_type: EVENT_TYPE,
+        status: 'processing',
+        retry_count: claim.attempt,
+      })
+      .update({ status: 'failed', available_at: null, updated_at: timestamp(now), message: code });
+    return count > 0;
+  }
+}

--- a/ghost/core/core/server/services/email-suppression-list/suppression-cleanup-worker.ts
+++ b/ghost/core/core/server/services/email-suppression-list/suppression-cleanup-worker.ts
@@ -1,0 +1,216 @@
+import type {
+  SuppressionCleanupRepository,
+  SuppressionCleanupRequest,
+} from './suppression-cleanup-repository';
+import type { SuppressionCleanupClient } from './suppression-cleanup-client';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const validator: { isEmail(value: string): boolean } = require('@tryghost/validator');
+const { isFQDN }: { isFQDN(value: string): boolean } = require('validator');
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function retryHint(value: unknown, limited: boolean): number {
+  const state = record(value);
+  // MySQL DATETIME cannot persist dates beyond year 9999; discard malformed hints.
+  const deadline = (time: unknown) =>
+    typeof time === 'number' && Number.isSafeInteger(time) && time > 0 && time <= 253402300799000
+      ? time
+      : 0;
+  return Math.max(
+    deadline(state?.retryAt),
+    limited || state?.remaining === 0 ? deadline(state?.resetAt) : 0,
+  );
+}
+
+function parseRequest(payload: string): SuppressionCleanupRequest | null {
+  try {
+    const value: unknown = JSON.parse(payload);
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+    const data = value as Record<string, unknown>;
+    if (
+      (data.kind !== 'complaints' && data.kind !== 'unsubscribes') ||
+      typeof data.email !== 'string' ||
+      data.email.length > 191 ||
+      !validator.isEmail(data.email) ||
+      typeof data.domain !== 'string' ||
+      !isFQDN(data.domain) ||
+      typeof data.apiOrigin !== 'string' ||
+      new URL(data.apiOrigin).origin !== data.apiOrigin ||
+      !['https:', 'http:'].includes(new URL(data.apiOrigin).protocol) ||
+      typeof data.eventId !== 'string' ||
+      !data.eventId ||
+      typeof data.eventTimestamp !== 'string' ||
+      !Number.isFinite(Date.parse(data.eventTimestamp))
+    ) {
+      return null;
+    }
+    return {
+      kind: data.kind,
+      email: data.email,
+      domain: data.domain,
+      apiOrigin: data.apiOrigin,
+      eventId: data.eventId,
+      eventTimestamp: data.eventTimestamp,
+    };
+  } catch {
+    return null;
+  }
+}
+
+type RunResult = { completed: number; retrying: number; failed: number };
+
+type Dependencies = {
+  repository: Pick<SuppressionCleanupRepository, 'claim' | 'complete' | 'retry' | 'fail'>;
+  enabled: () => boolean;
+  client: () => Pick<SuppressionCleanupClient, 'remove'> | null;
+};
+
+export class SuppressionCleanupWorker {
+  readonly #deps: Dependencies;
+  readonly #controller = new AbortController();
+  #active?: Promise<RunResult>;
+  #resumeAt = 0;
+  #nextRequestAt = 0;
+
+  constructor(deps: Dependencies) {
+    this.#deps = deps;
+  }
+
+  run(): Promise<RunResult> {
+    if (!this.#active) {
+      this.#active = this.#drain().finally(() => {
+        this.#active = undefined;
+      });
+    }
+    return this.#active;
+  }
+
+  stop(): void {
+    this.#controller.abort();
+  }
+
+  async shutdown(): Promise<void> {
+    this.stop();
+    await this.#active;
+  }
+
+  async #drain(): Promise<RunResult> {
+    const result = { completed: 0, retrying: 0, failed: 0 };
+    const startedAt = performance.now();
+    const signal = this.#controller.signal;
+    for (
+      let processed = 0;
+      processed < 250 &&
+      performance.now() - startedAt < 30000 &&
+      this.#deps.enabled() &&
+      !signal.aborted;
+      processed++
+    ) {
+      if (Date.now() < this.#resumeAt) {
+        return result;
+      }
+      // Pace before claiming so a provider wait never holds a row lease.
+      while (performance.now() < this.#nextRequestAt) {
+        const waitMs = Math.ceil(this.#nextRequestAt - performance.now());
+        if (performance.now() - startedAt + waitMs >= 30000) {
+          return result;
+        }
+        try {
+          await delay(waitMs, undefined, { signal });
+        } catch (error) {
+          if (signal.aborted) {
+            return result;
+          }
+          throw error;
+        }
+      }
+      if (signal.aborted || !this.#deps.enabled() || performance.now() - startedAt >= 30000) {
+        return result;
+      }
+      const client = this.#deps.client();
+      if (!client) {
+        return result;
+      }
+      const claim = await this.#deps.repository.claim();
+      if (!claim) {
+        return result;
+      }
+      if (signal.aborted || !this.#deps.enabled() || performance.now() - startedAt >= 30000) {
+        result.retrying += Number(
+          await this.#deps.repository.retry(
+            claim,
+            new Date(Math.floor(Date.now() / 1000) * 1000),
+            'CANCELED',
+          ),
+        );
+        return result;
+      }
+      const request = parseRequest(claim.payload);
+      if (!request) {
+        result.failed += Number(await this.#deps.repository.fail(claim, 'INVALID_PAYLOAD'));
+        continue;
+      }
+      try {
+        const outcome = await client.remove(request, signal);
+        this.#resumeAt = Math.max(this.#resumeAt, retryHint(outcome.rateLimit, false));
+      } catch (error) {
+        if (signal.aborted) {
+          result.retrying += Number(
+            await this.#deps.repository.retry(
+              claim,
+              new Date(Math.floor(Date.now() / 1000) * 1000),
+              'CANCELED',
+            ),
+          );
+          return result;
+        }
+        const rawStatus = record(error)?.status;
+        const status =
+          typeof rawStatus === 'number' &&
+          Number.isInteger(rawStatus) &&
+          rawStatus >= 100 &&
+          rawStatus <= 599
+            ? rawStatus
+            : undefined;
+        const code =
+          record(error)?.code === 'MAILGUN_SUPPRESSION_ORIGIN_CHANGED'
+            ? 'API_ORIGIN_CHANGED'
+            : status
+              ? `HTTP_${status}`
+              : 'TRANSPORT_ERROR';
+        const backoff = Math.min(
+          3600000,
+          30000 * 2 ** Math.min(claim.attempt - 1, 7) * (1 + Math.random() * 0.25),
+        );
+        const availableAt = Math.max(
+          Date.now() + backoff,
+          retryHint(record(error)?.rateLimit, status === 429),
+        );
+        if (status === 429) {
+          this.#resumeAt = Math.max(this.#resumeAt, availableAt);
+        }
+        if (claim.attempt >= 20) {
+          result.failed += Number(
+            await this.#deps.repository.fail(claim, `RETRY_EXHAUSTED_${code}`),
+          );
+          continue;
+        }
+        result.retrying += Number(
+          await this.#deps.repository.retry(claim, new Date(availableAt), code),
+        );
+        continue;
+      } finally {
+        this.#nextRequestAt = performance.now() + 100;
+      }
+      result.completed += Number(await this.#deps.repository.complete(claim));
+    }
+    return result;
+  }
+}

--- a/ghost/core/test/integration/services/suppression-cleanup-client.test.ts
+++ b/ghost/core/test/integration/services/suppression-cleanup-client.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import nock from 'nock';
+import { SuppressionCleanupClient } from '../../../core/server/services/email-suppression-list/suppression-cleanup-client';
+
+const target = {
+  kind: 'complaints' as const,
+  email: 'member+tag@example.com',
+  domain: 'sending.example.com',
+  apiOrigin: 'https://api.eu.mailgun.net',
+};
+const client = () =>
+  new SuppressionCleanupClient({
+    baseUrl: 'https://api.eu.mailgun.net/v3',
+    apiKey: 'test-api-key',
+  });
+
+describe('Suppression cleanup HTTP client', () => {
+  beforeAll(() => nock.disableNetConnect());
+  afterAll(() => nock.enableNetConnect());
+  afterEach(() => nock.cleanAll());
+
+  it('deletes the exact address on the original sending domain with current credentials', async () => {
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+      .basicAuth({ user: 'api', pass: 'test-api-key' })
+      .reply(200, { message: 'Spam complaint has been removed' });
+    assert.equal((await client().remove(target)).status, 'removed');
+    scope.done();
+  });
+
+  it('treats an already absent unsubscribe as successfully cleaned up', async () => {
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/unsubscribes/member%2Btag%40example.com')
+      .reply(404, { message: 'Address not found' });
+    assert.equal((await client().remove({ ...target, kind: 'unsubscribes' })).status, 'absent');
+    scope.done();
+  });
+
+  it('exposes a retryable status and safe quota hints without retaining request secrets', async () => {
+    const resetAt = Date.now() + 10000;
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+      .reply(
+        429,
+        { message: 'private-provider-detail' },
+        {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(resetAt),
+          'x-private': 'private-header',
+        },
+      );
+    await assert.rejects(client().remove(target), (error: unknown) => {
+      const failure = error as Error & { status?: number; rateLimit?: unknown };
+      assert.equal(failure.status, 429);
+      assert.deepEqual(failure.rateLimit, { remaining: 0, resetAt });
+      const serialized = JSON.stringify(error) + failure.message;
+      for (const secret of [
+        'test-api-key',
+        target.email,
+        'private-provider-detail',
+        'private-header',
+      ]) {
+        assert.equal(serialized.includes(secret), false);
+      }
+      assert.equal('options' in failure, false);
+      assert.equal('response' in failure, false);
+      assert.equal('cause' in failure, false);
+      return true;
+    });
+    scope.done();
+  });
+
+  it('refuses to move a queued deletion to a newly configured API origin', async () => {
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+      .reply(200, {});
+    await assert.rejects(client().remove({ ...target, apiOrigin: 'https://api.mailgun.net' }), {
+      code: 'MAILGUN_SUPPRESSION_ORIGIN_CHANGED',
+    });
+    assert.equal(scope.isDone(), false);
+  });
+
+  it.each([401, 403, 500])(
+    'exposes HTTP %i without retrying inside the transport',
+    async (status) => {
+      const scope = nock(target.apiOrigin)
+        .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+        .reply(status, 'private failure');
+      await assert.rejects(client().remove(target), {
+        status,
+        code: 'MAILGUN_SUPPRESSION_REQUEST_FAILED',
+      });
+      scope.done();
+    },
+  );
+
+  it('does not follow redirects on a destructive request', async () => {
+    const destination = nock('https://untrusted.example.com').delete('/redirected').reply(200, {});
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+      .reply(302, '', { location: 'https://untrusted.example.com/redirected' });
+    await assert.rejects(client().remove(target), { status: 302 });
+    scope.done();
+    assert.equal(destination.isDone(), false);
+  });
+
+  it('cancels an active request without exposing its transport error', async () => {
+    const controller = new AbortController();
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+      .delay(1000)
+      .reply(200, {});
+    scope.on('request', () => controller.abort());
+    await assert.rejects(client().remove(target, controller.signal), (error: unknown) => {
+      const failure = error as Error & { status?: number; code?: string };
+      assert.equal(failure.code, 'MAILGUN_SUPPRESSION_REQUEST_FAILED');
+      assert.equal(failure.status, undefined);
+      assert.equal(JSON.stringify(error).includes('test-api-key'), false);
+      return true;
+    });
+    scope.done();
+  });
+
+  it('retains success quota hints so the worker can pace the next request', async () => {
+    const resetAt = Date.now() + 10000;
+    const scope = nock(target.apiOrigin)
+      .delete('/v3/sending.example.com/complaints/member%2Btag%40example.com')
+      .reply(200, {}, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(resetAt) });
+    assert.deepEqual((await client().remove(target)).rateLimit, { remaining: 0, resetAt });
+    scope.done();
+  });
+});

--- a/ghost/core/test/integration/services/suppression-cleanup-repository-sqlite.test.ts
+++ b/ghost/core/test/integration/services/suppression-cleanup-repository-sqlite.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import createKnex, { type Knex } from 'knex';
+import { SuppressionCleanupRepository } from '../../../core/server/services/email-suppression-list/suppression-cleanup-repository';
+
+const { createTable } = require('../../../core/server/data/schema/commands');
+const request = {
+  kind: 'complaints' as const,
+  email: 'member@example.com',
+  domain: 'sending.example.com',
+  apiOrigin: 'https://api.eu.mailgun.net',
+  eventId: 'mailgun-event-1',
+  eventTimestamp: '2026-09-01T12:00:00.000Z',
+};
+
+describe('SuppressionCleanupRepository', () => {
+  let knex: Knex;
+  let repository: SuppressionCleanupRepository;
+  const now = new Date('2026-09-10T12:00:00Z');
+
+  beforeEach(async () => {
+    knex = createKnex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await createTable('outbox', knex);
+    repository = new SuppressionCleanupRepository(knex);
+  });
+
+  afterEach(async () => {
+    await knex.destroy();
+  });
+
+  it('makes a committed intent available for one worker claim', async () => {
+    await knex.transaction(async (trx) => {
+      assert.equal(await repository.enqueue(request, trx, now), true);
+    });
+    const claim = await repository.claim(now);
+    assert.ok(claim);
+    assert.deepEqual(JSON.parse(claim.payload), request);
+    assert.equal(claim.attempt, 1);
+    assert.equal(await repository.claim(now), null);
+  });
+
+  it('deduplicates a replay so the producer can skip reapplying local state', async () => {
+    const first = await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const replay = await knex.transaction((trx) => repository.enqueue({ ...request }, trx, now));
+    assert.equal(first, true);
+    assert.equal(replay, false);
+    assert.ok(await repository.claim(now));
+    assert.equal(await repository.claim(now), null);
+  });
+
+  it('reclaims an expired lease after a worker crash with a new attempt number', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const first = await repository.claim(now);
+    assert.ok(first);
+    assert.equal(await repository.claim(new Date(now.getTime() + 599999)), null);
+    const recovered = await repository.claim(new Date(now.getTime() + 600000));
+    assert.ok(recovered);
+    assert.equal(recovered.id, first.id);
+    assert.equal(recovered.attempt, 2);
+    assert.deepEqual(JSON.parse(recovered.payload), request);
+  });
+
+  it('allows completion only by the current lease owner', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const first = await repository.claim(now);
+    const later = new Date(now.getTime() + 600000);
+    const recovered = await repository.claim(later);
+    assert.ok(first && recovered);
+    assert.equal(await repository.complete(first, later), false);
+    assert.equal(await repository.complete(recovered, later), true);
+    assert.equal(await repository.claim(new Date(later.getTime() + 600000)), null);
+    assert.equal(await knex.transaction((trx) => repository.enqueue(request, trx, later)), false);
+  });
+
+  it('persists a retry deadline without rounding provider hints down', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const claim = await repository.claim(now);
+    assert.ok(claim);
+    assert.equal(
+      await repository.retry(claim, new Date(now.getTime() + 1500), 'HTTP_429', now),
+      true,
+    );
+    assert.equal(await repository.complete(claim, now), false);
+    assert.equal(await repository.claim(new Date(now.getTime() + 1499)), null);
+    const retried = await repository.claim(new Date(now.getTime() + 2000));
+    assert.ok(retried);
+    assert.equal(retried.attempt, 2);
+  });
+
+  it('returns malformed payloads to the worker for failure handling instead of wedging selection', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    await knex('outbox').update({ payload: '{broken' });
+    const claim = await repository.claim(now);
+    assert.ok(claim);
+    assert.equal(claim.payload, '{broken');
+  });
+
+  it('quarantines an invalid item without blocking subsequent work', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const claim = await repository.claim(now);
+    assert.ok(claim);
+    assert.equal(await repository.fail(claim, 'INVALID_PAYLOAD', now), true);
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'next-event' }, trx, now),
+    );
+    const next = await repository.claim(now);
+    assert.ok(next);
+    assert.notEqual(next.id, claim.id);
+    assert.equal(await repository.retry(claim, now, 'RETRY', now), false);
+  });
+
+  it('rolls back intent reservation so a replay can safely apply local state', async () => {
+    await assert.rejects(
+      knex.transaction(async (trx) => {
+        assert.equal(await repository.enqueue(request, trx, now), true);
+        throw new Error('local safety update failed');
+      }),
+      /local safety update failed/,
+    );
+    assert.equal(await repository.claim(now), null);
+    assert.equal(await knex.transaction((trx) => repository.enqueue(request, trx, now)), true);
+  });
+
+  it('rejects retry and failure writes from an expired owner after reclamation', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const old = await repository.claim(now);
+    const later = new Date(now.getTime() + 600000);
+    const current = await repository.claim(later);
+    assert.ok(old && current);
+    assert.equal(await repository.retry(old, now, 'HTTP_429', later), false);
+    assert.equal(await repository.fail(old, 'INVALID_PAYLOAD', later), false);
+    assert.equal(await repository.complete(current, later), true);
+  });
+
+  it('claims due work while another item is deferred and ignores unrelated event types', async () => {
+    await knex('outbox').insert({
+      id: 'unrelated',
+      event_type: 'another-service',
+      status: 'pending',
+      payload: '{}',
+      created_at: '2026-01-01 00:00:00',
+    });
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const delayed = await repository.claim(now);
+    assert.ok(delayed);
+    await repository.retry(delayed, new Date(now.getTime() + 60000), 'HTTP_429', now);
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'due-now' }, trx, now),
+    );
+    const due = await repository.claim(now);
+    assert.ok(due);
+    assert.equal(JSON.parse(due.payload).eventId, 'due-now');
+    assert.equal(await repository.claim(now), null);
+  });
+
+  it('keeps different provider events, domains and suppression kinds distinct', async () => {
+    const distinct = [
+      request,
+      { ...request, eventId: 'another-event' },
+      { ...request, domain: 'fallback.example.com' },
+      { ...request, kind: 'unsubscribes' as const },
+    ];
+    for (const item of distinct) {
+      assert.equal(await knex.transaction((trx) => repository.enqueue(item, trx, now)), true);
+    }
+    const ids = new Set<string>();
+    for (const _item of distinct) {
+      const claim = await repository.claim(now);
+      assert.ok(claim);
+      ids.add(claim.id);
+    }
+    assert.equal(ids.size, distinct.length);
+  });
+});

--- a/ghost/core/test/integration/services/suppression-cleanup-repository.test.ts
+++ b/ghost/core/test/integration/services/suppression-cleanup-repository.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import type { Knex } from 'knex';
+import { SuppressionCleanupRepository } from '../../../core/server/services/email-suppression-list/suppression-cleanup-repository';
+
+const { agentProvider } = require('../../utils/e2e-framework');
+const { knex }: { knex: Knex } = require('../../../core/server/data/db');
+
+const request = {
+  kind: 'complaints' as const,
+  email: 'member@example.com',
+  domain: 'sending.example.com',
+  apiOrigin: 'https://api.eu.mailgun.net',
+  eventId: 'mailgun-event-1',
+  eventTimestamp: '2026-09-01T12:00:00.000Z',
+};
+const now = new Date('2026-09-10T12:00:00Z');
+
+describe('Suppression cleanup repository on MySQL', () => {
+  const repository = new SuppressionCleanupRepository(knex);
+
+  beforeAll(async () => {
+    await agentProvider.getAdminAPIAgent();
+  });
+  afterEach(async () => {
+    await knex('outbox').where('event_type', 'email-suppression-cleanup').delete();
+  });
+
+  it('gives concurrent workers distinct claims without losing queued work', async () => {
+    for (let index = 0; index < 4; index++) {
+      await knex.transaction((trx) =>
+        repository.enqueue({ ...request, eventId: `event-${index}` }, trx, now),
+      );
+    }
+    const claims = (
+      await Promise.all(Array.from({ length: 8 }, () => repository.claim(now)))
+    ).filter((claim) => claim !== null);
+    assert.equal(claims.length, 4);
+    assert.equal(new Set(claims.map((claim) => claim.id)).size, 4);
+    assert.ok(claims.every((claim) => claim.attempt === 1));
+  });
+
+  it('allows another worker to claim due work while the oldest row is locked', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'later' }, trx, new Date(now.getTime() + 1000)),
+    );
+    const oldest = await knex('outbox')
+      .where('event_type', 'email-suppression-cleanup')
+      .orderBy('available_at')
+      .first();
+    const transaction = await knex.transaction();
+    let pending: ReturnType<typeof repository.claim> | undefined;
+    try {
+      await transaction('outbox').where('id', oldest.id).forUpdate().first();
+      pending = repository.claim(new Date(now.getTime() + 1000));
+      const claim = await pending;
+      assert.ok(claim);
+      assert.notEqual(claim.id, oldest.id);
+      assert.equal(JSON.parse(claim.payload).eventId, 'later');
+    } finally {
+      await transaction.rollback();
+      await pending;
+    }
+  });
+
+  it('reserves the intent exactly once across concurrent producer transactions', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        knex.transaction((trx) => repository.enqueue(request, trx, now)),
+      ),
+    );
+    assert.equal(results.filter(Boolean).length, 1);
+    assert.ok(await repository.claim(now));
+    assert.equal(await repository.claim(now), null);
+  });
+
+  it('does not expose an uncommitted intent and makes a rolled-back event replayable', async () => {
+    const transaction = await knex.transaction();
+    try {
+      await repository.enqueue(request, transaction, now);
+      assert.equal(await repository.claim(now), null);
+    } finally {
+      await transaction.rollback();
+    }
+    assert.equal(await repository.claim(now), null);
+    assert.equal(await knex.transaction((trx) => repository.enqueue(request, trx, now)), true);
+  });
+
+  it('fences the expired worker after reclaiming a crashed attempt', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, now));
+    const first = await repository.claim(now);
+    const later = new Date(now.getTime() + 600000);
+    const second = await repository.claim(later);
+    assert.ok(first && second);
+    assert.equal(second.id, first.id);
+    assert.equal(second.attempt, 2);
+    assert.equal(await repository.complete(first, later), false);
+    assert.equal(await repository.retry(first, later, 'HTTP_429', later), false);
+    assert.equal(await repository.fail(first, 'INVALID_PAYLOAD', later), false);
+    assert.equal(await repository.complete(second, later), true);
+  });
+});

--- a/ghost/core/test/integration/services/suppression-cleanup-worker.test.ts
+++ b/ghost/core/test/integration/services/suppression-cleanup-worker.test.ts
@@ -1,0 +1,439 @@
+import assert from 'node:assert/strict';
+import createKnex, { type Knex } from 'knex';
+import sinon from 'sinon';
+import nock from 'nock';
+import { SuppressionCleanupRepository } from '../../../core/server/services/email-suppression-list/suppression-cleanup-repository';
+import { SuppressionCleanupWorker } from '../../../core/server/services/email-suppression-list/suppression-cleanup-worker';
+import { SuppressionCleanupClient } from '../../../core/server/services/email-suppression-list/suppression-cleanup-client';
+
+const { createTable } = require('../../../core/server/data/schema/commands');
+const request = {
+  kind: 'complaints' as const,
+  email: 'member@example.com',
+  domain: 'sending.example.com',
+  apiOrigin: 'https://api.eu.mailgun.net',
+  eventId: 'provider-event-1',
+  eventTimestamp: '2026-09-01T12:00:00.000Z',
+};
+
+describe('Suppression cleanup worker', () => {
+  let knex: Knex;
+  let repository: SuppressionCleanupRepository;
+
+  beforeAll(() => nock.disableNetConnect());
+  afterAll(() => nock.enableNetConnect());
+
+  beforeEach(async () => {
+    knex = createKnex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await createTable('outbox', knex);
+    repository = new SuppressionCleanupRepository(knex);
+  });
+  afterEach(async () => {
+    await knex.destroy();
+  });
+
+  it('drains committed work and does not repeat a completed cleanup', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    const removed: unknown[] = [];
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async (target) => {
+          removed.push(target);
+          return { status: 'removed' as const };
+        },
+      }),
+    });
+    await worker.run();
+    await worker.run();
+    assert.deepEqual(removed, [request]);
+    assert.equal(await repository.claim(), null);
+  });
+
+  it.each([
+    '{broken',
+    'null',
+    JSON.stringify({ ...request, email: '' }),
+    JSON.stringify({ ...request, kind: '../complaints' }),
+    JSON.stringify({ ...request, domain: '..' }),
+  ])(
+    'quarantines malformed work without deleting a broader target or blocking valid work: %s',
+    async (payload) => {
+      await knex.transaction((trx) => repository.enqueue(request, trx));
+      await knex('outbox').update({ payload });
+      const valid = { ...request, eventId: 'valid-event' };
+      await knex.transaction((trx) => repository.enqueue(valid, trx));
+      const removed: unknown[] = [];
+      const worker = new SuppressionCleanupWorker({
+        repository,
+        enabled: () => true,
+        client: () => ({
+          remove: async (target) => {
+            removed.push(target);
+            return { status: 'removed' as const };
+          },
+        }),
+      });
+      await worker.run();
+      assert.deepEqual(removed, [valid]);
+      assert.equal(await repository.claim(new Date(Date.now() + 600000)), null);
+    },
+  );
+
+  it('persists provider backoff so a new worker cannot retry the same item early', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    const retryAt = Date.now() + 120000;
+    let attempts = 0;
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          attempts += 1;
+          throw Object.assign(new Error('request failed'), {
+            status: 429,
+            rateLimit: { remaining: 0, resetAt: retryAt },
+          });
+        },
+      }),
+    });
+    await worker.run();
+    assert.equal(attempts, 1);
+    assert.equal(await repository.claim(new Date(retryAt - 1)), null);
+    const retry = await repository.claim(new Date(retryAt + 1000));
+    assert.ok(retry);
+    assert.equal(retry.attempt, 2);
+  });
+
+  it.each(['limited', 'exhausted-quota'])(
+    'shares %s cooldown across items and worker runs',
+    async (outcome) => {
+      await knex.transaction((trx) => repository.enqueue(request, trx));
+      await knex.transaction((trx) =>
+        repository.enqueue({ ...request, eventId: 'second-event' }, trx),
+      );
+      let attempts = 0;
+      const rateLimit = { remaining: 0, resetAt: Date.now() + 120000 };
+      const worker = new SuppressionCleanupWorker({
+        repository,
+        enabled: () => true,
+        client: () => ({
+          remove: async () => {
+            attempts += 1;
+            if (outcome === 'limited') {
+              throw Object.assign(new Error('limited'), { status: 429, rateLimit });
+            }
+            return { status: 'removed' as const, rateLimit };
+          },
+        }),
+      });
+      await worker.run();
+      await worker.run();
+      assert.equal(attempts, 1);
+      assert.ok(await repository.claim());
+    },
+  );
+
+  it('leaves exhausted retries visible as failed work instead of retrying forever', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    await knex('outbox').update({ retry_count: 19 });
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          throw Object.assign(new Error('private-provider-error'), { status: 500 });
+        },
+      }),
+    });
+    await worker.run();
+    assert.equal(await repository.claim(new Date(Date.now() + 86400000)), null);
+    const stored = await knex('outbox').first();
+    assert.equal(stored.status, 'failed');
+    assert.equal(stored.message, 'RETRY_EXHAUSTED_HTTP_500');
+  });
+
+  it('aborts and drains an active removal on shutdown, leaving the intent immediately retryable', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    let started!: () => void;
+    const requested = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let release: (() => void) | undefined;
+    let attempts = 0;
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async (_target, signal) => {
+          attempts += 1;
+          started();
+          return new Promise<never>((_resolve, reject) => {
+            release = () => reject(new Error('aborted transport'));
+            signal?.addEventListener('abort', release, { once: true });
+          });
+        },
+      }),
+    });
+    const running = worker.run();
+    running.catch(() => {});
+    await requested;
+    try {
+      await worker.shutdown();
+      await running;
+      const recovered = await repository.claim();
+      assert.ok(recovered);
+      assert.equal(recovered.attempt, 2);
+      await worker.run();
+      assert.equal(attempts, 1);
+    } finally {
+      release?.();
+      await running.catch(() => {});
+    }
+  });
+
+  it('bounds one invocation even when every queued item is malformed', async () => {
+    await knex('outbox').insert(
+      Array.from({ length: 251 }, (_value, index) => ({
+        id: String(index).padStart(24, '0'),
+        event_type: 'email-suppression-cleanup',
+        payload: '{}',
+        status: 'pending',
+        created_at: '2026-09-01 00:00:00',
+      })),
+    );
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          assert.fail('invalid item reached the provider');
+        },
+      }),
+    });
+    const result = await worker.run();
+    assert.deepEqual(result, { completed: 0, retrying: 0, failed: 250 });
+    assert.ok(await repository.claim());
+  });
+
+  it('stops starting work after thirty seconds even before reaching the item cap', async () => {
+    for (let index = 0; index < 4; index++) {
+      await knex.transaction((trx) =>
+        repository.enqueue({ ...request, eventId: `event-${index}` }, trx),
+      );
+    }
+    let elapsed = 0;
+    const realNow = performance.now.bind(performance);
+    const clock = sinon.stub(performance, 'now').callsFake(() => realNow() + elapsed);
+    try {
+      const worker = new SuppressionCleanupWorker({
+        repository,
+        enabled: () => true,
+        client: () => ({
+          remove: async () => {
+            elapsed += 11000;
+            return { status: 'removed' as const };
+          },
+        }),
+      });
+      assert.deepEqual(await worker.run(), { completed: 3, retrying: 0, failed: 0 });
+      assert.ok(await repository.claim());
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('paces serial requests explicitly instead of issuing a burst', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'second-event' }, trx),
+    );
+    const starts: number[] = [];
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          starts.push(performance.now());
+          return { status: 'removed' as const };
+        },
+      }),
+    });
+    await worker.run();
+    assert.equal(starts.length, 2);
+    assert.ok(
+      starts[1] - starts[0] >= 100,
+      `requests started only ${starts[1] - starts[0]}ms apart`,
+    );
+  });
+
+  it('honors a quota reset even when the current item has exhausted its retries', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx, new Date(Date.now() - 10000)));
+    await knex('outbox').update({ retry_count: 19 });
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'fresh-event' }, trx),
+    );
+    let attempts = 0;
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          attempts += 1;
+          throw Object.assign(new Error('limited'), {
+            status: 429,
+            rateLimit: { resetAt: Date.now() + 120000 },
+          });
+        },
+      }),
+    });
+    assert.deepEqual(await worker.run(), { completed: 0, retrying: 0, failed: 1 });
+    assert.equal(attempts, 1);
+    assert.ok(await repository.claim());
+  });
+
+  it.each([false, true])(
+    'keeps work unclaimed when disabled or credentials are unavailable (enabled=%s)',
+    async (enabled) => {
+      await knex.transaction((trx) => repository.enqueue(request, trx));
+      const worker = new SuppressionCleanupWorker({
+        repository,
+        enabled: () => enabled,
+        client: () => {
+          assert.equal(enabled, true, 'disabled worker looked up credentials');
+          return null;
+        },
+      });
+      assert.deepEqual(await worker.run(), { completed: 0, retrying: 0, failed: 0 });
+      assert.equal((await repository.claim())?.attempt, 1);
+    },
+  );
+
+  it('releases a claim when disabled while the database claim is in flight', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    let enabled = true;
+    const originalClaim = repository.claim.bind(repository);
+    const claim = sinon.stub(repository, 'claim').callsFake(async () => {
+      const claimed = await originalClaim();
+      enabled = false;
+      return claimed;
+    });
+    try {
+      const worker = new SuppressionCleanupWorker({
+        repository,
+        enabled: () => enabled,
+        client: () => ({
+          remove: async () => {
+            assert.fail('disabled worker called provider');
+          },
+        }),
+      });
+      assert.deepEqual(await worker.run(), { completed: 0, retrying: 1, failed: 0 });
+      assert.equal((await originalClaim())?.attempt, 2);
+    } finally {
+      claim.restore();
+    }
+  });
+
+  it('coalesces overlapping job deliveries into one serial drain', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'second-event' }, trx),
+    );
+    let active = 0;
+    let maximum = 0;
+    let removed = 0;
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          active += 1;
+          maximum = Math.max(maximum, active);
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+          });
+          active -= 1;
+          removed += 1;
+          return { status: 'removed' as const };
+        },
+      }),
+    });
+    const first = worker.run();
+    const second = worker.run();
+    assert.equal(first, second);
+    await Promise.all([first, second]);
+    assert.equal(maximum, 1);
+    assert.equal(removed, 2);
+  });
+
+  it('stops during pacing without reserving the next item', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    await knex.transaction((trx) =>
+      repository.enqueue({ ...request, eventId: 'second-event' }, trx),
+    );
+    let notify!: () => void;
+    const firstRequest = new Promise<void>((resolve) => {
+      notify = resolve;
+    });
+    let removed = 0;
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          removed += 1;
+          notify();
+          return { status: 'removed' as const };
+        },
+      }),
+    });
+    const running = worker.run();
+    await firstRequest;
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    await worker.shutdown();
+    await running;
+    assert.equal(removed, 1);
+    assert.equal((await repository.claim())?.attempt, 1);
+  });
+
+  it('backs off a transport failure without persisting its raw message', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    const startedAt = Date.now();
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () => ({
+        remove: async () => {
+          throw new Error('private-request-credentials');
+        },
+      }),
+    });
+    assert.deepEqual(await worker.run(), { completed: 0, retrying: 1, failed: 0 });
+    assert.equal(await repository.claim(new Date(startedAt + 29000)), null);
+    assert.equal((await repository.claim(new Date(startedAt + 40000)))?.attempt, 2);
+    assert.equal((await knex('outbox').first()).message, 'TRANSPORT_ERROR');
+  });
+
+  it('retains a safe diagnostic for an API origin mismatch', async () => {
+    await knex.transaction((trx) => repository.enqueue(request, trx));
+    const worker = new SuppressionCleanupWorker({
+      repository,
+      enabled: () => true,
+      client: () =>
+        new SuppressionCleanupClient({
+          baseUrl: 'https://api.mailgun.net/v3',
+          apiKey: 'test-api-key',
+        }),
+    });
+    assert.deepEqual(await worker.run(), { completed: 0, retrying: 1, failed: 0 });
+    assert.equal((await knex('outbox').first()).message, 'API_ORIGIN_CHANGED');
+  });
+});


### PR DESCRIPTION
Remote complaint/unsubscribe cleanup currently waits on Mailgun inside event ingestion. This adds the durable queue engine that will let ingestion commit local safety state and hand remote cleanup to a separate worker. The following PR adds that producer transaction and boot/scheduling integration; this foundation does not activate cleanup by itself.

```mermaid
stateDiagram-v2
    Pending --> Processing: Claim due item and commit lease
    Processing --> Completed: DELETE returns 2xx or 404
    Processing --> Pending: Persist backoff or release on shutdown
    Processing --> Failed: Invalid payload or 20 failed attempts
    Processing --> Processing: Recover expired lease with new owner
```

- Reserve a deterministic provider-event identity inside the caller's transaction. Replay returns an existing reservation so the producer can avoid reapplying an old unsubscribe. MySQL claims use READ COMMITTED and SKIP LOCKED; ten-minute leases and attempt-fenced writes protect reclaimed work from stale workers.
- Delete the exact encoded address on its original sending domain, using current credentials only when the API origin still matches. Requests time out after ten seconds, reject redirects, and expose sanitized HTTP status and numeric quota hints.
- Run at most 250 claims or 30 seconds before starting more work, with at least 100ms between requests. Exponential backoff starts at 30 seconds and caps at one hour; provider deadlines can extend it. Final-attempt 429 responses still pause the rest of the queue. Shutdown aborts the active request, drains it, and releases interrupted work for retry.

Retry deadlines persist in the outbox; the shared endpoint cooldown lasts for the worker's process. Completed reservations remain as replay protection. Failed rows retain a fixed diagnostic code for inspection. The integration PR must preserve these records and commit local protection before making cleanup eligible.

Validation: all 48 integration tests pass across MySQL, SQLite, and intercepted HTTP. Core/test type checks, focused lint, and commit hooks pass. Five independent review passes ran for each slice and the accumulated PR. Tests caught and verified fixes for concurrent-claim deadlocks, resolved 3xx responses being mistaken for deletion, and quota hints being lost on the final retry.

`pnpm check` still stops on the existing 452 unrelated formatting failures. No live Mailgun requests or production enablement were used; these tests establish behavior, not a production throughput claim.

Stack base: #30691 (outbox availability schema), following #30690 (bounded fetching). This PR contains three reviewable commits: repository, HTTP client, and worker.

ref https://linear.app/ghost/issue/BER-3936/raise-mailgun-event-fetch-throughput-concurrent-paging-logs-api
