### PR TITLE
Fixed free members subscribing to paid-only newsletters

### DIFF
--- a/ghost/core/core/server/services/members/account-service.ts
+++ b/ghost/core/core/server/services/members/account-service.ts
@@ -45,9 +45,23 @@ interface MemberBreadService {
   ): Promise<Record<string, unknown> | null>;
 }
 
+interface Newsletter {
+  id: string;
+}
+
+interface MemberModel {
+  get(attribute: string): unknown;
+  related(relation: 'newsletters'): { map<T>(fn: (newsletter: Newsletter) => T): T[] };
+}
+
 interface MemberRepository {
+  get(data: { id: string }, options: Record<string, unknown>): Promise<MemberModel | null>;
   update(data: Record<string, unknown>, options: Record<string, unknown>): Promise<unknown>;
   update(data: Record<string, unknown>, options: Record<string, unknown>): Promise<unknown>;
+}
+
+interface NewslettersService {
+  getAll(options: { filter: string; columns: string[] }): Promise<Newsletter[]>;
 }
 
 interface EmailSuppressionList {
@@ -69,6 +83,7 @@ export interface MemberAccountServiceDeps {
   members: MemberRepository;
   emailSuppressionList: EmailSuppressionList;
   metafieldValues: MetafieldValues;
+  newslettersService: NewslettersService;
 }
 
 export class MemberAccountService {
@@ -76,17 +91,20 @@ export class MemberAccountService {
   #members: MemberRepository;
   #emailSuppressionList: EmailSuppressionList;
   #metafieldValues: MetafieldValues;
+  #newslettersService: NewslettersService;
 
   constructor({
     memberBREADService,
     members,
     emailSuppressionList,
     metafieldValues,
+    newslettersService,
   }: MemberAccountServiceDeps) {
     this.#memberBREADService = memberBREADService;
     this.#members = members;
     this.#emailSuppressionList = emailSuppressionList;
     this.#metafieldValues = metafieldValues;
+    this.#newslettersService = newslettersService;
   }
 
   /** Everything a member is shown about themselves. */
@@ -110,7 +128,12 @@ export class MemberAccountService {
             MEMBERS,
           );
 
-    await this.#members.update(_.pick(data, WRITABLE_FIELDS), {
+    const changes = _.pick(data, WRITABLE_FIELDS);
+    if (Array.isArray(changes.newsletters) && changes.newsletters.length > 0) {
+      changes.newsletters = await this.#withoutNewPaidNewsletters(changes.newsletters, memberId);
+    }
+
+    await this.#members.update(changes, {
       id: memberId,
       withRelated: WRITE_RELATIONS,
     });
@@ -128,6 +151,27 @@ export class MemberAccountService {
     // Ghost now holds, which is not always what they sent. Setting the older
     // `subscribed` flag, for one, is stored as a list of newsletters.
     return this.read(memberId);
+  }
+
+  /** Paid-only newsletters are for paying members: a free member keeps any they have but can't add one. */
+  async #withoutNewPaidNewsletters(requested: Array<{ id?: string }>, memberId: string) {
+    const member = await this.#members.get({ id: memberId }, { withRelated: ['newsletters'] });
+    if (!member || member.get('status') !== 'free') {
+      return requested;
+    }
+
+    const paidNewsletters = await this.#newslettersService.getAll({
+      filter: 'visibility:-members',
+      columns: ['id'],
+    });
+    const paidIds = new Set<string | undefined>(paidNewsletters.map((newsletter) => newsletter.id));
+    const currentIds = new Set<string | undefined>(
+      member.related('newsletters').map((newsletter) => newsletter.id),
+    );
+
+    return requested.filter(
+      (newsletter) => !paidIds.has(newsletter?.id) || currentIds.has(newsletter?.id),
+    );
   }
 
   /**

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -810,7 +810,9 @@ module.exports = class RouterController {
 
     if (metadata.newsletters) {
       metadata.newsletters = JSON.stringify(
-        await this._validateNewsletters(JSON.parse(metadata.newsletters)),
+        await this._validateNewsletters(JSON.parse(metadata.newsletters), {
+          allowPaid: type === 'subscription',
+        }),
       );
     }
 
@@ -1097,7 +1099,9 @@ module.exports = class RouterController {
       labels: req.body.labels,
       name: req.body.name,
       reqIp: req.ip ?? undefined,
-      newsletters: await this._validateNewsletters(req.body?.newsletters ?? []),
+      newsletters: await this._validateNewsletters(req.body?.newsletters ?? [], {
+        allowPaid: Boolean(giftToken),
+      }),
       attribution: await this._memberAttributionService.getAttribution(req.body.urlHistory),
       ...(giftToken ? { giftToken } : {}),
     };
@@ -1146,9 +1150,11 @@ module.exports = class RouterController {
    * Validates the newsletters in the request body
    * @param {object[]} requestedNewsletters
    * @param {string} requestedNewsletters[].name
+   * @param {object} [options]
+   * @param {boolean} [options.allowPaid] Keep paid-only newsletters, for signups that won't be free members
    * @returns {Promise<object[] | undefined>} The validated newsletters
    */
-  async _validateNewsletters(requestedNewsletters) {
+  async _validateNewsletters(requestedNewsletters, { allowPaid = false } = {}) {
     if (!requestedNewsletters || requestedNewsletters.length === 0) {
       return undefined;
     }
@@ -1169,7 +1175,7 @@ module.exports = class RouterController {
     );
     const matchedNewsletters = await this._newslettersService.getAll({
       filter: `name:[${requestedNewsletterNamesFilter}]`,
-      columns: ['id', 'name', 'status'],
+      columns: ['id', 'name', 'status', 'visibility'],
     });
 
     // Check for invalid newsletters
@@ -1195,8 +1201,10 @@ module.exports = class RouterController {
       });
     }
 
+    // Free members only get members-visibility newsletters, matching the default signup path
     return matchedNewsletters
       .filter((newsletter) => newsletter.status === 'active')
+      .filter((newsletter) => allowPaid || newsletter.visibility === 'members')
       .map((newsletter) => ({ id: newsletter.id }));
   }
 

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -366,6 +366,7 @@ module.exports = function MembersAPI({
     members: users,
     emailSuppressionList,
     metafieldValues: metafields.values,
+    newslettersService,
   });
 
   async function getMemberIdentity(transientId) {

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -384,13 +384,9 @@ const updateMemberNewsletters = async function updateMemberNewsletters(req, res)
       'enable_comment_notifications',
       'enable_updates_and_announcements',
     );
-    const options = {
-      id: memberData.id,
-      withRelated: ['newsletters'],
-    };
-
-    const updatedMember = await membersService.api.members.update(data, options);
-    const updatedMemberData = _.pick(updatedMember.toJSON(), [
+    // Via the account service, which decides what a member may change about themselves
+    const updatedMember = await membersService.api.account.edit(data, memberData.id);
+    const updatedMemberData = _.pick(updatedMember, [
       'uuid',
       'email',
       'name',

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -118,6 +118,47 @@ describe('Comments API', function () {
       member = await models.Member.findOne({ id: member.id }, { require: true });
       assert.equal(member.get('enable_updates_and_announcements'), false);
     });
+
+    it('does not let a free member add a paid-only newsletter', async function () {
+      const member = await models.Member.findOne(
+        { id: fixtureManager.get('members', 0).id },
+        { require: true, withRelated: ['newsletters'] },
+      );
+      assert.equal(member.get('status'), 'free', 'This test requires a free member');
+      const current = member.related('newsletters').models.map((n) => ({ id: n.id }));
+
+      const paidOnly = await models.Newsletter.add(
+        {
+          name: 'Paid-only newsletter',
+          visibility: 'paid',
+          subscribe_on_signup: false,
+          sort_order: 100,
+        },
+        { context: { internal: true } },
+      );
+
+      try {
+        sinon.stub(settingsHelpers, 'getMembersValidationKey').returns('test');
+        const hmac = crypto.createHmac('sha256', 'test').update(member.get('uuid')).digest('hex');
+
+        await membersAgent
+          .put(`/api/member/newsletters/?uuid=${member.get('uuid')}&key=${hmac}`)
+          .body({ newsletters: [...current, { id: paidOnly.id }] })
+          .expectStatus(200);
+
+        const after = await models.Member.findOne(
+          { id: member.id },
+          { require: true, withRelated: ['newsletters'] },
+        );
+        const ids = after.related('newsletters').models.map((n) => n.id);
+        assert.ok(!ids.includes(paidOnly.id), 'the paid-only newsletter is not added');
+        for (const { id } of current) {
+          assert.ok(ids.includes(id), 'the existing newsletters are kept');
+        }
+      } finally {
+        await models.Newsletter.destroy({ id: paidOnly.id, context: { internal: true } });
+      }
+    });
   });
 
   describe('when authenticated', function () {

--- a/ghost/core/test/unit/server/services/members/account-service.test.ts
+++ b/ghost/core/test/unit/server/services/members/account-service.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { MemberAccountService } from '../../../../../core/server/services/members/account-service';
+
+describe('Unit - members/account-service', function () {
+  describe('edit', function () {
+    let members: { get: sinon.SinonStub; update: sinon.SinonStub };
+    let newslettersService: { getAll: sinon.SinonStub };
+    let service: MemberAccountService;
+
+    const memberWith = (status: string, newsletterIds: string[]) => ({
+      get: (key: string) => (key === 'status' ? status : undefined),
+      related: () => newsletterIds.map((id) => ({ id })),
+    });
+
+    beforeEach(function () {
+      members = { get: sinon.stub(), update: sinon.stub().resolves() };
+      newslettersService = { getAll: sinon.stub().resolves([{ id: 'paid' }]) };
+      service = new MemberAccountService({
+        memberBREADService: { read: sinon.stub().resolves({ id: 'member' }) },
+        members,
+        emailSuppressionList: { removeEmail: sinon.stub() },
+        metafieldValues: {
+          unwrapWire: sinon.stub(),
+          planWrite: sinon.stub(),
+          applyWrite: sinon.stub(),
+        },
+        newslettersService,
+      });
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('stops a free member adding a paid-only newsletter', async function () {
+      members.get.resolves(memberWith('free', []));
+
+      await service.edit({ newsletters: [{ id: 'free' }, { id: 'paid' }] }, 'member');
+
+      assert.deepEqual(members.update.firstCall.args[0].newsletters, [{ id: 'free' }]);
+      sinon.assert.calledOnceWithExactly(newslettersService.getAll, {
+        filter: 'visibility:-members',
+        columns: ['id'],
+      });
+    });
+
+    it('lets a free member keep a paid-only newsletter they already have', async function () {
+      members.get.resolves(memberWith('free', ['paid']));
+
+      await service.edit({ newsletters: [{ id: 'free' }, { id: 'paid' }] }, 'member');
+
+      assert.deepEqual(members.update.firstCall.args[0].newsletters, [
+        { id: 'free' },
+        { id: 'paid' },
+      ]);
+    });
+
+    it('lets a paying member add a paid-only newsletter', async function () {
+      members.get.resolves(memberWith('paid', []));
+
+      await service.edit({ newsletters: [{ id: 'paid' }] }, 'member');
+
+      assert.deepEqual(members.update.firstCall.args[0].newsletters, [{ id: 'paid' }]);
+      sinon.assert.notCalled(newslettersService.getAll);
+    });
+
+    it('skips the lookup when newsletters are not being changed', async function () {
+      await service.edit({ name: 'New name' }, 'member');
+
+      sinon.assert.notCalled(members.get);
+      assert.deepEqual(members.update.firstCall.args[0], { name: 'New name' });
+    });
+  });
+});

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -142,8 +142,8 @@ describe('RouterController', function () {
         getAll: sinon.stub(),
       };
       newslettersServiceStub.getAll.resolves([
-        { id: 'abc123', name: 'Newsletter 1', status: 'active' },
-        { id: 'def456', name: 'Newsletter 2', status: 'active' },
+        { id: 'abc123', name: 'Newsletter 1', status: 'active', visibility: 'members' },
+        { id: 'def456', name: 'Newsletter 2', status: 'active', visibility: 'paid' },
       ]);
       const routerController = new RouterController({
         tiersService,
@@ -1985,16 +1985,19 @@ describe('RouterController', function () {
             id: 'abc123',
             name: 'Newsletter 1',
             status: 'active',
+            visibility: 'members',
           },
           {
             id: 'def456',
             name: 'Newsletter 2',
             status: 'active',
+            visibility: 'members',
           },
           {
             id: 'ghi789',
             name: 'Newsletter 3',
             status: 'active',
+            visibility: 'members',
           },
         ];
 
@@ -2011,7 +2014,7 @@ describe('RouterController', function () {
         newslettersServiceStub.getAll
           .withArgs({
             filter: `name:[${newsletterNamesFilter}]`,
-            columns: ['id', 'name', 'status'],
+            columns: ['id', 'name', 'status', 'visibility'],
           })
           .resolves(newsletters);
 
@@ -2044,7 +2047,7 @@ describe('RouterController', function () {
         newslettersServiceStub.getAll
           .withArgs({
             filter: `name:['${INVALID_NEWSLETTER_NAME}']`,
-            columns: ['id', 'name', 'status'],
+            columns: ['id', 'name', 'status', 'visibility'],
           })
           .resolves([]);
 
@@ -2086,7 +2089,7 @@ describe('RouterController', function () {
         newslettersServiceStub.getAll
           .withArgs({
             filter: `name:[${newsletterNames}]`,
-            columns: ['id', 'name', 'status'],
+            columns: ['id', 'name', 'status', 'visibility'],
           })
           .resolves(newsletters);
 
@@ -2097,6 +2100,48 @@ describe('RouterController', function () {
         await assert.rejects(controller.sendMagicLink(req, res), {
           message: `Cannot subscribe to archived newsletters Newsletter 2`,
         });
+      });
+
+      it('drops paid-only newsletters for free signups', async function () {
+        req.body.newsletters = [{ name: 'Free Newsletter' }, { name: 'Paid Newsletter' }];
+
+        const controller = createRouterController({
+          newslettersService: {
+            getAll: sinon.stub().resolves([
+              { id: 'abc123', name: 'Free Newsletter', status: 'active', visibility: 'members' },
+              { id: 'def456', name: 'Paid Newsletter', status: 'active', visibility: 'paid' },
+            ]),
+          },
+        });
+
+        await controller.sendMagicLink(req, res);
+
+        sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
+        assert.deepEqual(sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters, [
+          { id: 'abc123' },
+        ]);
+      });
+
+      it('keeps paid-only newsletters for gift signups', async function () {
+        req.body.newsletters = [{ name: 'Paid Newsletter' }];
+        req.body.giftToken = 'gift-token-123';
+
+        const controller = createRouterController({
+          newslettersService: {
+            getAll: sinon
+              .stub()
+              .resolves([
+                { id: 'def456', name: 'Paid Newsletter', status: 'active', visibility: 'paid' },
+              ]),
+          },
+        });
+
+        await controller.sendMagicLink(req, res);
+
+        sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
+        assert.deepEqual(sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters, [
+          { id: 'def456' },
+        ]);
       });
     });
 
@@ -2355,9 +2400,9 @@ describe('RouterController', function () {
         getAll: sinon.stub(),
       };
       newslettersServiceStub.getAll.resolves([
-        { id: 'abc123', name: 'Newsletter 1', status: 'active' },
-        { id: 'def456', name: 'Newsletter 2', status: 'active' },
-        { id: 'ghi789', name: 'Newsletter 3', status: 'active' },
+        { id: 'abc123', name: 'Newsletter 1', status: 'active', visibility: 'members' },
+        { id: 'def456', name: 'Newsletter 2', status: 'active', visibility: 'members' },
+        { id: 'ghi789', name: 'Newsletter 3', status: 'active', visibility: 'members' },
       ]);
       routerController = new RouterController({
         tiersService,
@@ -2379,6 +2424,30 @@ describe('RouterController', function () {
       ];
       const result = await routerController._validateNewsletters(requestedNewsletters);
       assert.deepEqual(result, [{ id: 'abc123' }, { id: 'def456' }, { id: 'ghi789' }]);
+    });
+
+    it('drops paid-only newsletters by default', async function () {
+      newslettersServiceStub.getAll.resolves([
+        { id: 'abc123', name: 'Newsletter 1', status: 'active', visibility: 'members' },
+        { id: 'def456', name: 'Newsletter 2', status: 'active', visibility: 'paid' },
+      ]);
+      const result = await routerController._validateNewsletters([
+        { name: 'Newsletter 1' },
+        { name: 'Newsletter 2' },
+      ]);
+      assert.deepEqual(result, [{ id: 'abc123' }]);
+    });
+
+    it('keeps paid-only newsletters when allowPaid is set', async function () {
+      newslettersServiceStub.getAll.resolves([
+        { id: 'abc123', name: 'Newsletter 1', status: 'active', visibility: 'members' },
+        { id: 'def456', name: 'Newsletter 2', status: 'active', visibility: 'paid' },
+      ]);
+      const result = await routerController._validateNewsletters(
+        [{ name: 'Newsletter 1' }, { name: 'Newsletter 2' }],
+        { allowPaid: true },
+      );
+      assert.deepEqual(result, [{ id: 'abc123' }, { id: 'def456' }]);
     });
 
     it('returns undefined if newsletters is an empty array', async function () {

--- a/ghost/core/test/unit/server/services/members/middleware.test.js
+++ b/ghost/core/test/unit/server/services/members/middleware.test.js
@@ -271,18 +271,10 @@ describe('Members Service Middleware', function () {
         enable_comment_notifications: false,
         status: 'free',
       };
-      sinon.stub(membersService, 'api').get(() => {
-        return {
-          members: {
-            update: sinon.stub().resolves({
-              ...req.member,
-              toJSON: () => JSON.stringify(req.member),
-            }),
-          },
-        };
-      });
+      const edit = sinon.stub().resolves(req.member);
+      sinon.stub(membersService, 'api').get(() => ({ account: { edit } }));
       await membersMiddleware.updateMemberNewsletters(req, res);
-      // the stubbing of the api is difficult to test with the current design, so we just check that the response is sent
+      sinon.assert.calledOnceWithExactly(edit, req.body, 'test');
       sinon.assert.calledOnce(res.json);
     });
 
@@ -299,8 +291,8 @@ describe('Members Service Middleware', function () {
       };
       sinon.stub(membersService, 'api').get(() => {
         return {
-          members: {
-            update: sinon.stub().rejects(new Error('Test Error')),
+          account: {
+            edit: sinon.stub().rejects(new Error('Test Error')),
           },
         };
       });


### PR DESCRIPTION
Newsletters with `visibility: paid` are meant for paying members. The default signup path already respects that (`getSubscribeOnSignupNewsletters` filters to `visibility:members`), but explicitly requested newsletters didn't:

- **Signup** (`POST /members/api/send-magic-link`): `_validateNewsletters` checked existence and archived status, not visibility.
- **Unsubscribe link** (`PUT /members/api/member/newsletters`) and **account** (`PUT /members/api/member/`): newsletter IDs went straight to the member repository.

The email segmenter already excludes free members from paid newsletters (`status:-free`), so nothing was delivered. But the subscriptions were recorded, and subscriber counts were wrong.

### Changes

- `_validateNewsletters` now selects `visibility` and drops non-`members` newsletters unless `allowPaid` is set. Subscription checkouts and gift signups pass it. Plain signups don't. Paid-only newsletters are dropped rather than rejected: Portal lists every active newsletter regardless of visibility, so a pre-ticked paid one would otherwise fail the whole signup.
- `MemberAccountService.edit` drops newly added paid-only newsletters for free members and keeps any they already have (for example, ones added by staff). `updateMemberNewsletters` now goes through `account.edit` as well, so both self-service paths share the rule.

### Testing

- Unit: `_validateNewsletters`, `sendMagicLink` (free vs gift signup), subscription checkout, the new `account-service.test.ts`, and middleware routing.
- E2E: a free member can't add a paid-only newsletter through the unsubscribe-link endpoint. This runs the real `visibility:-members` query. The `send-magic-link` and members `middleware` e2e suites pass.

### Out of scope

`visibility: paid` still has no Admin UI and no `isIn` validation, and Portal doesn't hide paid-only newsletters from free members. Those belong to finishing the paid-newsletters feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
