### PR TITLE
🐛 Fixed settings import overwriting protected core settings

### DIFF
--- a/ghost/core/core/server/data/exporter/exporter.js
+++ b/ghost/core/core/server/data/exporter/exporter.js
@@ -26,7 +26,8 @@ const getSettingsTableData = function getSettingsTableData(settingsData) {
   return (
     settingsData &&
     settingsData.filter((setting) => {
-      return !SETTING_KEYS_BLOCKLIST.includes(setting.key);
+      // core settings hold instance secrets and are never imported, so never export them
+      return setting.group !== 'core' && !SETTING_KEYS_BLOCKLIST.includes(setting.key);
     })
   );
 };

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -105,7 +105,8 @@ const TABLES_ALLOWLIST = [
   'snippets',
 ];
 
-// NOTE: these are settings keys which should never end up in the export file
+// NOTE: these are non-core settings keys which should never end up in the export file
+//       (the whole core group is always excluded)
 const SETTING_KEYS_BLOCKLIST = [
   'stripe_connect_publishable_key',
   'stripe_connect_secret_key',
@@ -113,12 +114,8 @@ const SETTING_KEYS_BLOCKLIST = [
   'stripe_secret_key',
   'stripe_publishable_key',
   'stripe_billing_portal_configuration_id',
-  'members_stripe_webhook_id',
-  'members_stripe_webhook_secret',
   'email_verification_required',
   'indexnow_api_key',
-  'machine_payments_secret',
-  'machine_payments_deposit_address',
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/importer/importers/data/settings-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/settings-importer.js
@@ -9,6 +9,11 @@ const keyTypeMapper = require('../../../../api/endpoints/utils/serializers/input
 const { WRITABLE_KEYS_ALLOWLIST } = require('../../../../../shared/labs');
 
 const labsDefaults = JSON.parse(defaultSettings.labs.labs.defaultValue);
+const defaultSettingsGroups = Object.fromEntries(
+  Object.entries(defaultSettings).flatMap(([group, settings]) =>
+    Object.keys(settings).map((key) => [key, group]),
+  ),
+);
 const ignoredSettings = [
   'slack_url',
   'members_from_address',
@@ -183,9 +188,10 @@ class SettingsImporter extends BaseImporter {
       return data;
     });
 
-    // Remove core and theme data types
+    // Remove core and theme data types, using the schema's group rather than the file's
     this.dataToImport = _.filter(this.dataToImport, (data) => {
-      return ['core', 'theme'].indexOf(data.group) === -1;
+      const group = defaultSettingsGroups[data.key] ?? data.group;
+      return ['core', 'theme'].indexOf(group) === -1;
     });
 
     const newIsPrivate = _.find(this.dataToImport, { key: 'is_private' });

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -175,7 +175,14 @@ describe('Exporter', function () {
       'members_stripe_webhook_secret',
       'machine_payments_secret',
       'machine_payments_deposit_address',
+      'admin_session_secret',
+      'theme_session_secret',
+      'members_email_auth_secret',
+      'members_private_key',
+      'ghost_private_key',
     ];
+
+    assert.equal(_.filter(exportData.data.settings, { group: 'core' }).length, 0);
 
     excludedSettings.forEach((settingKey) => {
       assert.equal(_.find(exportData.data.settings, { key: settingKey }), undefined);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -206,14 +206,17 @@ describe('Exporter', function () {
       } = require('../../../../../core/server/data/exporter/table-lists.js');
       const defaultSettings = require('../../../../../core/server/data/schema/default-settings/default-settings.json');
 
-      const totalKeysLength = Object.keys(defaultSettings).reduce((acc, curr) => {
-        return acc + Object.keys(defaultSettings[curr]).length;
-      }, 0);
+      // core settings are always excluded from exports
+      const nonCoreKeysLength = Object.keys(defaultSettings)
+        .filter((group) => group !== 'core')
+        .reduce((acc, curr) => {
+          return acc + Object.keys(defaultSettings[curr]).length;
+        }, 0);
 
       // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
       //       This is a reminder to think about the importer/exporter scenarios ;)
-      const allowedKeysLength = 113;
-      assert.equal(totalKeysLength, SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
+      const allowedKeysLength = 99;
+      assert.equal(nonCoreKeysLength, SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
     });
   });
 });

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -137,6 +137,41 @@ describe('SettingsImporter', function () {
       assert.equal(siteUuid, undefined);
     });
 
+    it('Removes core settings even when the import file labels them with another group', function () {
+      const fakeSettings = [
+        {
+          key: 'admin_session_secret',
+          value: 'imported-secret',
+          group: 'site',
+          type: 'string',
+        },
+        {
+          key: 'machine_payments_secret',
+          value: 'imported-secret',
+          group: 'site',
+          type: 'string',
+        },
+        {
+          key: 'title',
+          value: 'Imported title',
+          group: 'site',
+          type: 'string',
+        },
+      ];
+
+      const importer = new SettingsImporter(
+        { settings: fakeSettings },
+        { dataKeyToImport: 'settings' },
+      );
+
+      importer.beforeImport();
+
+      assert.deepEqual(
+        importer.dataToImport.map((setting) => setting.key),
+        ['title'],
+      );
+    });
+
     it('Adds a problem if the existing data is_private is false, and new data is_private is true', function () {
       const fakeSettings = [
         {


### PR DESCRIPTION
no ref

## Why

The settings importer is meant to drop every `core` setting (session secrets, private keys, `db_hash` and similar), but the filter checked the `group` field supplied in the import file. Only files that omit `group` get it derived from the key, so a file that relabels a core key as `site` could overwrite it.

Exports were also including the whole `core` group. Those settings are never imported, so exporting them only put instance secrets (`admin_session_secret`, `members_private_key`, `ghost_private_key`, etc.) into files that get emailed to support and handed to migration tools.

## What

- **Importer:** the core/theme filter now looks up each key's group in the schema's `default-settings.json` and only falls back to the file's `group` for unknown keys (which `Settings.edit` can't write anyway). I didn't use `settings-key-group-mapper` because it has no entry for 7 of the 18 core keys, including `machine_payments_secret`, `members_stripe_webhook_secret` and `site_uuid`.
- **Exporter:** the `core` group is always excluded. The four blocklist entries that were core keys are removed as redundant. The blocklist count test now counts only non-core keys.
- **Tests:** added an importer unit test with relabelled core keys, including one the mapper doesn't know about. The exporter integration test now asserts no core settings are exported.

DB backups use the same exporter, so they no longer contain core settings either. Nothing lost: restoring a backup goes through the importer, which already drops them.

Thanks to @zachariahchow-gvt for the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
