### PR TITLE
Changed signed member link checks to use constant-time comparison

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
+++ b/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
@@ -5,6 +5,7 @@ const { settingsHelpers } = proxy;
 const urlUtils = require('../../../../shared/url-utils').default;
 const logging = require('@tryghost/logging');
 const crypto = require('crypto');
+const { timingSafeStringEqual } = require('../../../../shared/timing-safe-string-equal');
 
 module.exports = async function unsubscribeController(req, res) {
   debug('unsubscribeController');
@@ -42,7 +43,7 @@ module.exports = async function unsubscribeController(req, res) {
       }
       const membersKey = settingsHelpers.getMembersValidationKey();
       const memberHmac = crypto.createHmac('sha256', membersKey).update(query.uuid).digest('hex');
-      if (memberHmac !== query.key) {
+      if (!timingSafeStringEqual(memberHmac, query.key)) {
         logging.warn('[List-Unsubscribe] Unsubscribe failed due to invalid key for ' + query.uuid);
         return res.status(400).end();
       }

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -12,6 +12,7 @@ const onHeaders = require('on-headers');
 const tiersService = require('../tiers/service');
 const config = require('../../../shared/config');
 const settingsHelpers = require('../settings-helpers');
+const { timingSafeStringEqual } = require('../../../shared/timing-safe-string-equal');
 
 const messages = {
   missingUuid: 'Missing uuid.',
@@ -237,7 +238,7 @@ const authMemberByUuid = async function authMemberByUuid(req, res, next) {
       .createHmac('sha256', settingsHelpers.getMembersValidationKey())
       .update(uuid)
       .digest('hex');
-    if (memberHmac !== key) {
+    if (!timingSafeStringEqual(memberHmac, key)) {
       throw new errors.UnauthorizedError({
         message: tpl(messages.invalidKey),
       });

--- a/ghost/core/core/server/services/members/request-integrity-token-provider.js
+++ b/ghost/core/core/server/services/members/request-integrity-token-provider.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { timingSafeStringEqual } = require('../../../shared/timing-safe-string-equal');
 
 class RequestIntegrityTokenProvider {
   #themeSecret;
@@ -45,7 +46,7 @@ class RequestIntegrityTokenProvider {
     hmac.update(`${timestamp.toString()}:${nonce}`);
     const expectedHmac = hmac.digest('hex');
 
-    if (expectedHmac !== hmacDigest) {
+    if (!timingSafeStringEqual(expectedHmac, hmacDigest)) {
       // HMAC mismatch
       return false;
     }

--- a/ghost/core/core/shared/timing-safe-string-equal.ts
+++ b/ghost/core/core/shared/timing-safe-string-equal.ts
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+
+/**
+ * Compares a value Ghost computed (an HMAC digest, say) with one taken from a
+ * request, without the response time revealing how much of it matched.
+ * Anything that is not a string never matches: a query param repeated in the
+ * URL arrives as an array, and that is as wrong as a bad key.
+ */
+export function timingSafeStringEqual(expected: string, provided: unknown): boolean {
+  if (typeof provided !== 'string') {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected);
+  const providedBuffer = Buffer.from(provided);
+
+  // crypto.timingSafeEqual throws when the lengths differ. The digests compared
+  // here have a fixed, public length, so returning early gives nothing away.
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expectedBuffer, providedBuffer);
+}

--- a/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
+++ b/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
@@ -68,5 +68,14 @@ describe('RequestIntegrityTokenProvider', function () {
 
       assert.equal(result, false);
     });
+
+    it('should fail to verify a token with a truncated signature', function () {
+      const token = tokenProvider.create();
+      const truncatedToken = token.slice(0, -1);
+
+      const result = tokenProvider.validate(truncatedToken);
+
+      assert.equal(result, false);
+    });
   });
 });

--- a/ghost/core/test/unit/shared/timing-safe-string-equal.test.ts
+++ b/ghost/core/test/unit/shared/timing-safe-string-equal.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { timingSafeStringEqual } from '../../../core/shared/timing-safe-string-equal';
+
+describe('timingSafeStringEqual', function () {
+  const digest = 'a'.repeat(64);
+
+  it('matches an identical string', function () {
+    assert.equal(timingSafeStringEqual(digest, 'a'.repeat(64)), true);
+  });
+
+  it('rejects a string of the same length that differs', function () {
+    assert.equal(timingSafeStringEqual(digest, `${'a'.repeat(63)}b`), false);
+  });
+
+  it('rejects a string of a different length without throwing', function () {
+    assert.equal(timingSafeStringEqual(digest, 'a'.repeat(63)), false);
+    assert.equal(timingSafeStringEqual(digest, 'a'.repeat(65)), false);
+    assert.equal(timingSafeStringEqual(digest, ''), false);
+  });
+
+  it('rejects a string with the same number of characters but a different byte length', function () {
+    assert.equal(timingSafeStringEqual(digest, `${'a'.repeat(63)}é`), false);
+  });
+
+  it('rejects values that are not strings', function () {
+    assert.equal(timingSafeStringEqual(digest, undefined), false);
+    assert.equal(timingSafeStringEqual(digest, null), false);
+    assert.equal(timingSafeStringEqual(digest, [digest]), false);
+    assert.equal(timingSafeStringEqual(digest, { key: digest }), false);
+  });
+});


### PR DESCRIPTION
no ref

The uuid + key check behind newsletter management, feedback and one-click unsubscribe links, and the request integrity token check, compared the HMAC we computed with the request's value using `!==`. That stops at the first differing character, so response timing can in principle reveal how much of a guess was right. It isn't practically exploitable over a network, but signatures should be compared in constant time, as the single-use token provider and admin toolbar already do.

The comparison lives in one small shared helper so the length check and the non-string case (a repeated query param arrives as an array) are handled the same way at every call site, frontend and server alike.

Thanks to @ka3n1x for reporting this.