### PR TITLE
Avoided Unicode normalization with timing-safe equality checks

### DIFF
--- a/ghost/core/core/shared/timing-safe-string-equal.ts
+++ b/ghost/core/core/shared/timing-safe-string-equal.ts
@@ -11,8 +11,8 @@ export function timingSafeStringEqual(expected: string, provided: unknown): bool
     return false;
   }
 
-  const expectedBuffer = Buffer.from(expected);
-  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected, 'utf16le');
+  const providedBuffer = Buffer.from(provided, 'utf16le');
 
   // crypto.timingSafeEqual throws when the lengths differ. The digests compared
   // here have a fixed, public length, so returning early gives nothing away.

--- a/ghost/core/test/unit/shared/timing-safe-string-equal.test.ts
+++ b/ghost/core/test/unit/shared/timing-safe-string-equal.test.ts
@@ -12,6 +12,10 @@ describe('timingSafeStringEqual', function () {
     assert.equal(timingSafeStringEqual(digest, `${'a'.repeat(63)}b`), false);
   });
 
+  it('rejects distinct strings that UTF-8 encodes identically', function () {
+    assert.equal(timingSafeStringEqual('\udc69', '\udc6a'), false);
+  });
+
   it('rejects a string of a different length without throwing', function () {
     assert.equal(timingSafeStringEqual(digest, 'a'.repeat(63)), false);
     assert.equal(timingSafeStringEqual(digest, 'a'.repeat(65)), false);


### PR DESCRIPTION
ref 866096c3d5a8c68c1b40386035ff96f7b2c5271b

When doing timing-safe equality checks with strings, you need to use UTF-16. All other encodings supported by `Buffer.from()`—including the default—can lose information.

`utf8`, which is the default encoding for `Buffer.from()`, normalizes lone surrogates. For example:

```javascript
const a = Buffer.from('\udc69');
const b = Buffer.from('\udc6a');
a.equals(b)
// => true
```

Note that none of the other [supported character encodings][0] work here.

[0]: https://nodejs.org/docs/latest-v22.x/api/buffer.html#buffers-and-character-encodings
