### PR TITLE
Changed the dev CLI to load without tsx in a built tree

### DIFF
--- a/ghost/core/core/cli/command.js
+++ b/ghost/core/core/cli/command.js
@@ -5,14 +5,19 @@
 //
 // tsx is a devDependency. In a built tree (the production image, or CI after a
 // build) it is absent but also unnecessary, because tsc has already emitted a
-// .js beside every .ts - the same situation MigratorConfig.js handles the same
-// way. Any other failure to load it is still an error.
+// .js beside every .ts - the same situation MigratorConfig.js handles. Only the
+// direct lookup is allowed to fail: resolving first and requiring outside the
+// guard means a tsx that is installed but broken still throws.
+let tsxLoader;
 try {
-  require('tsx/cjs');
+  tsxLoader = require.resolve('tsx/cjs');
 } catch (err) {
   if (err.code !== 'MODULE_NOT_FOUND') {
     throw err;
   }
+}
+if (tsxLoader) {
+  require(tsxLoader);
 }
 
 const cli = require('@tryghost/pretty-cli');

--- a/ghost/core/core/cli/command.js
+++ b/ghost/core/core/cli/command.js
@@ -2,8 +2,18 @@
 // repl, timetravel) can require TypeScript modules directly. These commands run
 // via bare `node index.js <command>`, which — unlike `pnpm dev` (nodemon
 // --import=tsx) or the production build (tsc) — has no TS resolution otherwise.
-// They are restricted to development/local environments, where tsx is available.
-require('tsx/cjs');
+//
+// tsx is a devDependency. In a built tree (the production image, or CI after a
+// build) it is absent but also unnecessary, because tsc has already emitted a
+// .js beside every .ts - the same situation MigratorConfig.js handles the same
+// way. Any other failure to load it is still an error.
+try {
+  require('tsx/cjs');
+} catch (err) {
+  if (err.code !== 'MODULE_NOT_FOUND') {
+    throw err;
+  }
+}
 
 const cli = require('@tryghost/pretty-cli');
 const logging = cli.ui.log;

--- a/ghost/core/test/unit/cli/command.test.ts
+++ b/ghost/core/test/unit/cli/command.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const COMMAND_MODULE = path.resolve(__dirname, '../../../core/cli/command.js');
+
+// Loads core/cli/command.js in a child process with `tsx/cjs` resolving to
+// `resolveTo` (a path), to nothing (`null`: the module is absent, as in a
+// built tree), or untouched (`undefined`: the real one). Module resolution is
+// process-wide state, so a child process keeps each case isolated. The script
+// runs from a file rather than `-e` because the CLI framework reads its
+// program name from process.argv[1].
+function loadCommandWith(tmpDir: string, resolveTo: string | null | undefined) {
+  const script = `
+    const Module = require('node:module');
+    const resolveTo = ${JSON.stringify(resolveTo)};
+    if (resolveTo !== undefined) {
+      const original = Module._resolveFilename;
+      Module._resolveFilename = function (request, ...rest) {
+        if (request === 'tsx/cjs') {
+          if (resolveTo === null) {
+            const err = new Error("Cannot find module 'tsx/cjs'");
+            err.code = 'MODULE_NOT_FOUND';
+            throw err;
+          }
+          return resolveTo;
+        }
+        return original.call(this, request, ...rest);
+      };
+    }
+    require(${JSON.stringify(COMMAND_MODULE)});
+  `;
+  const scriptPath = path.join(tmpDir, 'load-command.js');
+  fs.writeFileSync(scriptPath, script);
+  return spawnSync(process.execPath, [scriptPath], { encoding: 'utf8' });
+}
+
+describe('CLI Command module', function () {
+  let tmpDir: string;
+
+  beforeAll(function () {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-cli-command-'));
+  });
+
+  afterAll(function () {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads with the installed tsx loader', function () {
+    const result = loadCommandWith(tmpDir, undefined);
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('loads when tsx is absent, as in a built tree', function () {
+    const result = loadCommandWith(tmpDir, null);
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('still fails when tsx is installed but cannot load', function () {
+    // A tsx whose own dependency is missing: the MODULE_NOT_FOUND comes from
+    // inside the loader, not from looking it up, and must not be swallowed.
+    const brokenLoader = path.join(tmpDir, 'broken-tsx-cjs.js');
+    fs.writeFileSync(brokenLoader, "require('ghost-test-missing-tsx-dependency');\n");
+
+    const result = loadCommandWith(tmpDir, brokenLoader);
+    assert.notEqual(result.status, 0, 'a broken loader should not be ignored');
+    assert.match(result.stderr, /Cannot find module 'ghost-test-missing-tsx-dependency'/);
+  });
+});


### PR DESCRIPTION
no ref

**Why:** `node index.js generate-data` (and `repl`, `timetravel`) registered the tsx loader unconditionally at the top of `core/cli/command.js`, so the command could not even load in the production image, where `tsx` is a pruned devDependency:

```
Error: Cannot find module 'tsx/cjs'
Require stack:
- /home/ghost/core/cli/command.js
- /home/ghost/index.js
```

**What:** the loader is now optional in the same spirit as `MigratorConfig.js`, but narrower: `require.resolve('tsx/cjs')` runs inside the guard and only a `MODULE_NOT_FOUND` from that direct lookup is ignored; the resolved path is then `require`d outside the guard, so a tsx that is installed but cannot load (a dependency of its own missing) still throws. In a built tree the hook is not needed anyway: `tsc` has already emitted a `.js` beside every `.ts` the seeders use, and the image prune keeps those.

**Why it matters:** the Pro performance benchmark (Ghost-Moya) seeds its database by running the image's own `generate-data`, so the dataset always matches the schema of the exact build under test. This is the one thing that stopped that working. The `checkEnv()` guard is unchanged — the command still refuses to run outside `development`/`local`.

**Test:** `test/unit/cli/command.test.ts` loads the module in a child process (module resolution is process-wide state) for three cases: the real loader, no loader (as in a built tree), and a loader whose own dependency is missing, which must still fail.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFrJCpRwGG2oiEsFazuCfP