### PR TITLE
Fixed password reset hanging when the notification email fails

### DIFF
--- a/ghost/core/core/server/api/endpoints/authentication.js
+++ b/ghost/core/core/server/api/endpoints/authentication.js
@@ -155,7 +155,16 @@ const controller = {
         frame.data.password_reset[0].email,
         api.settings,
       );
-      return auth.passwordreset.sendResetNotification(token, api.mail);
+
+      // Fire-and-forget, matching the welcome-email pattern above: sending is
+      // usually a slow network call, and a slow/misconfigured mail transport
+      // must not hang this response (or the /session signin request that
+      // calls this same query for a locked-out user).
+      auth.passwordreset.sendResetNotification(token, api.mail).catch((err) => {
+        logging.error(err);
+      });
+
+      return {};
     },
   },
 

--- a/ghost/core/test/e2e-api/admin/authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/authentication.test.js
@@ -108,6 +108,29 @@ describe('Authentication API', function () {
 
       await waitUntil(() => assert.equal(sendMailStub.calledOnce, true));
     });
+
+    it('does not hang the request while the mail transport is still sending', async function () {
+      const user = await fixtureManager.get('users', 0);
+      const mailService = require('../../../core/server/services/mail');
+      let sendMailStarted = false;
+      mailService.GhostMailer.prototype.sendMail = () => {
+        sendMailStarted = true;
+        return new Promise(() => {});
+      };
+
+      const start = Date.now();
+      await agent
+        .post('authentication/password_reset')
+        .body({ password_reset: [{ email: user.email }] })
+        .expectStatus(200);
+      const elapsed = Date.now() - start;
+
+      assert.ok(
+        elapsed < 2000,
+        `expected the response before the mail transport settles, took ${elapsed}ms`,
+      );
+      await waitUntil(() => assert.equal(sendMailStarted, true));
+    });
   });
 
   describe('resetPassword', function () {

--- a/ghost/core/test/e2e-api/admin/authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/authentication.test.js
@@ -10,7 +10,25 @@ const security = require('@tryghost/security');
 const settingsCache = require('../../../core/shared/settings-cache');
 const moment = require('moment');
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const { anyErrorId } = matchers;
+
+async function waitUntil(assertion, { timeoutMs = 5000, intervalMs = 20 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      if (Date.now() > deadline) {
+        throw err;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, intervalMs);
+      });
+    }
+  }
+}
 
 describe('Authentication API', function () {
   let agent;
@@ -22,6 +40,14 @@ describe('Authentication API', function () {
   });
 
   describe('generateResetToken', function () {
+    beforeEach(function () {
+      mockMail();
+    });
+
+    afterEach(function () {
+      restore();
+    });
+
     it('Cannot generate reset token without required info', async function () {
       await agent
         .post('authentication/password_reset')
@@ -67,6 +93,20 @@ describe('Authentication API', function () {
           { id: suspendedUser.id, context: { internal: true } },
         );
       }
+    });
+
+    it('does not fail the request when the notification email fails to send', async function () {
+      const user = await fixtureManager.get('users', 0);
+      const mailService = require('../../../core/server/services/mail');
+      const sendMailStub = sinon.stub().rejects(new Error('mail transport unavailable'));
+      mailService.GhostMailer.prototype.sendMail = sendMailStub;
+
+      await agent
+        .post('authentication/password_reset')
+        .body({ password_reset: [{ email: user.email }] })
+        .expectStatus(200);
+
+      await waitUntil(() => assert.equal(sendMailStub.calledOnce, true));
     });
   });
 
@@ -144,7 +184,7 @@ describe('Authentication API', function () {
           .body({ password_reset: [{ email: user.get('email') }] })
           .expectStatus(200);
 
-        mail.assertSentEmailCount(1);
+        await waitUntil(() => mail.assertSentEmailCount(1));
         const email = mail.getSentEmail();
         const resetLink = email.text.match(/\/reset\/([^/]+)\//);
         assert.ok(resetLink, 'the email should contain a password reset link');


### PR DESCRIPTION
Closes #30525

`generateResetToken` awaited `sendResetNotification` before responding, so a slow or failing mail transport blocked the whole request instead of just failing to deliver the email. `POST /authentication/password_reset` hits this directly, and `/session` hits the same code internally when a locked-out admin tries to sign in — which is why the linked issue shows both endpoints timing out after key rotation invalidated the admin's session and forced a password reset.

Sending is now fire-and-forget with the error logged, matching how the welcome email a few lines above is already sent. Added a regression test in `authentication.test.js` that stubs the mailer to reject and asserts the request still returns 200; also switched two existing tests in the same file from a synchronous assertion to a small polling helper, since the email side effect is no longer guaranteed to finish before the response comes back.

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written an automated test to prove my change works