### PR TITLE
Fix .md redirect target for routes.yaml-remapped pages (#30375)

### DIFF
--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -6,6 +6,8 @@ const controllers = require('./controllers');
 const middleware = require('./middleware');
 const RSSRouter = require('./rss-router');
 const { toExpressNotation } = require('./permalink-adapter');
+const { resolveRouteData } = require('./api-adapter');
+const { getMarkdownPath } = require('../llms/markdown');
 
 /**
  * @description Collection Router for post resource.
@@ -70,6 +72,17 @@ class CollectionRouter extends ParentRouter {
 
     // REGISTER: collection route e.g. /, /podcast/
     this.mountRoute(this.route.value, controllers.collection);
+
+    const hasEntryData = Object.values(resolveRouteData(this.data)).some(
+      ({ type, resource }) => type === 'read' && (resource === 'pages' || resource === 'posts'),
+    );
+    if (hasEntryData) {
+      this.mountRoute(getMarkdownPath(this.route.value), (req, res, next) => {
+        res.routerOptions.isMarkdownRequest = true;
+        res.routerOptions.canonicalPath = urlUtils.createUrl(this.route.value, false, false, true);
+        return controllers.routeMarkdown(req, res, next);
+      });
+    }
 
     // REGISTER: enable pagination by default
     this.router().param('page', middleware.pageParam);

--- a/ghost/core/core/frontend/services/routing/controllers/entry/canonical-url.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/canonical-url.ts
@@ -6,9 +6,13 @@ import type { Entry } from '../entry';
  * Build the entry's canonical URL (its own pathname) carrying over the current
  * request's query string. Shared by the permalink and markdown-url redirects.
  */
-export default function buildCanonicalUrl(req: Request, entry: Entry): string {
+export default function buildCanonicalUrl(
+  req: Request,
+  entry: Entry,
+  canonicalPath?: string,
+): string {
   return format({
-    pathname: parse(entry.url).pathname,
+    pathname: canonicalPath || parse(entry.url).pathname,
     search: parse(req.originalUrl).search,
   });
 }

--- a/ghost/core/core/frontend/services/routing/controllers/entry/markdown.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/markdown.ts
@@ -1,9 +1,12 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import type { ApiCallSpec } from '../../api-adapter';
 import type { Entry, EntryResponse } from '../entry';
 import buildCanonicalUrl from './canonical-url';
 
 const urlUtils = require('../../../../../shared/url-utils').default;
 const { getGatedNotice, getMarkdownPath, renderEntryMarkdown } = require('../../../llms/markdown');
+const { resolveRouteData } = require('../../api-adapter');
+const renderer = require('../../../rendering');
 
 const MEMBERS_ONLY_MARKDOWN =
   '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n';
@@ -53,9 +56,15 @@ function isPublic(entry: Entry): boolean {
   return entry.visibility === 'public';
 }
 
-function serveMarkdown(res: Response, entry: Entry) {
+function getContentLocation(res: EntryResponse, entry: Entry): string {
+  const canonicalPath = res.routerOptions.canonicalPath;
+  const pathname = typeof canonicalPath === 'string' ? canonicalPath : new URL(entry.url).pathname;
+  return getMarkdownPath(pathname);
+}
+
+function serveMarkdown(res: EntryResponse, entry: Entry) {
   const llmsIndexUrl = urlUtils.urlFor({ relativeUrl: '/llms.txt' }, true);
-  res.set('Content-Location', getMarkdownPath(new URL(entry.url).pathname));
+  res.set('Content-Location', getContentLocation(res, entry));
   res.type('text/markdown');
   return res.send(renderEntryMarkdown(entry, { llmsIndexUrl }));
 }
@@ -78,7 +87,7 @@ function servePreviewMarkdown(res: EntryResponse, entry: Entry) {
   const llmsIndexUrl = urlUtils.urlFor({ relativeUrl: '/llms.txt' }, true);
   const subscribeUrl = urlUtils.urlFor({ relativeUrl: '/#/portal/signup' }, true);
 
-  res.set('Content-Location', getMarkdownPath(new URL(entry.url).pathname));
+  res.set('Content-Location', getContentLocation(res, entry));
   res.type('text/markdown');
   return res.send(
     renderEntryMarkdown(entry, {
@@ -124,7 +133,7 @@ async function servePaidMarkdown(req: Request, res: EntryResponse, entry: Entry)
   const resourceKind = getResourceKind(res);
   const resourceType = resourceKind === 'page' ? 'pages' : 'posts';
   const llmsIndexUrl = urlUtils.urlFor({ relativeUrl: '/llms.txt' }, true);
-  const contentLocation = getMarkdownPath(new URL(entry.url).pathname);
+  const contentLocation = getContentLocation(res, entry);
   const fetchRequest = toFetchRequest(req);
 
   const response = await machinePaymentsService.challengeOrFulfill(fetchRequest, {
@@ -169,7 +178,11 @@ export function isMdRequest(res: EntryResponse): boolean {
  */
 export async function serveMdRequest(req: Request, res: EntryResponse, entry: Entry) {
   if (!llmsEnabled(req)) {
-    return res.redirect(302, buildCanonicalUrl(req, entry));
+    const canonicalPath = res.routerOptions.canonicalPath;
+    return res.redirect(
+      302,
+      buildCanonicalUrl(req, entry, typeof canonicalPath === 'string' ? canonicalPath : undefined),
+    );
   }
 
   if (!isPublic(entry)) {
@@ -192,4 +205,35 @@ export async function serveMdRequest(req: Request, res: EntryResponse, entry: En
   }
 
   return serveMarkdown(res, entry);
+}
+
+export async function serveRouteMdRequest(req: Request, res: EntryResponse, next: NextFunction) {
+  try {
+    const queries = Object.values(resolveRouteData(res.routerOptions.data)) as ApiCallSpec[];
+    const query = queries.find(
+      ({ type, resource }) => type === 'read' && (resource === 'pages' || resource === 'posts'),
+    );
+
+    if (!query) {
+      return next();
+    }
+
+    const api = require('../../../proxy').api;
+    const options = {
+      ...query.options,
+      include: 'authors,tags,tiers',
+      context: { member: res.locals.member },
+    };
+    const result = await api[query.controller][query.type](options);
+    const entry = result[query.resource][0];
+
+    if (!entry) {
+      return next();
+    }
+
+    res.routerOptions.resourceType = query.resource;
+    return await serveMdRequest(req, res, entry);
+  } catch (err) {
+    return renderer.handleError(next)(err);
+  }
 }

--- a/ghost/core/core/frontend/services/routing/controllers/index.js
+++ b/ghost/core/core/frontend/services/routing/controllers/index.js
@@ -27,6 +27,10 @@ module.exports = {
     return require('./static');
   },
 
+  get routeMarkdown() {
+    return require('./entry/markdown').serveRouteMdRequest;
+  },
+
   get unsubscribe() {
     return require('./unsubscribe');
   },

--- a/ghost/core/core/frontend/services/routing/parent-router.js
+++ b/ghost/core/core/frontend/services/routing/parent-router.js
@@ -14,6 +14,7 @@ const url = require('url');
 const security = require('@tryghost/security');
 const { resolveResourceRead } = require('./api-adapter');
 const urlUtils = require('../../../shared/url-utils').default;
+const { getMarkdownPath } = require('../llms/markdown');
 const registry = require('./registry');
 
 /**
@@ -103,16 +104,22 @@ class ParentRouter {
     if (targetRoute) {
       debug('_respectDominantRouter');
 
-      // CASE: transform /tag/:slug/ -> /tag/[a-zA-Z0-9-_]+/ to able to find url pieces to append
-      // e.g. /tag/bacon/page/2/  -> 'page/2' (to append)
-      // e.g. /bacon/welcome/     -> '' (nothing to append)
-      const matchPath = this.permalinks.getValue().replace(/:\w+/g, '[a-zA-Z0-9-_]+');
-      const toAppend = req.url.replace(new RegExp(matchPath), '');
+      let targetPath;
+      if (url.parse(req.url).pathname.endsWith('.md')) {
+        targetPath = getMarkdownPath(targetRoute);
+      } else {
+        // CASE: transform /tag/:slug/ -> /tag/[a-zA-Z0-9-_]+/ to able to find url pieces to append
+        // e.g. /tag/bacon/page/2/  -> 'page/2' (to append)
+        // e.g. /bacon/welcome/     -> '' (nothing to append)
+        const matchPath = this.permalinks.getValue().replace(/:\w+/g, '[a-zA-Z0-9-_]+');
+        const toAppend = req.url.replace(new RegExp(matchPath), '');
+        targetPath = urlUtils.urlJoin(targetRoute, toAppend);
+      }
 
       return urlUtils.redirect301(
         res,
         url.format({
-          pathname: urlUtils.createUrl(urlUtils.urlJoin(targetRoute, toAppend), false, false, true),
+          pathname: urlUtils.createUrl(targetPath, false, false, true),
           search: url.parse(req.originalUrl).search,
         }),
       );

--- a/ghost/core/core/frontend/services/routing/static-routes-router.js
+++ b/ghost/core/core/frontend/services/routing/static-routes-router.js
@@ -5,6 +5,8 @@ const RSSRouter = require('./rss-router');
 const controllers = require('./controllers');
 const middleware = require('./middleware');
 const ParentRouter = require('./parent-router');
+const { resolveRouteData } = require('./api-adapter');
+const { getMarkdownPath } = require('../llms/markdown');
 
 /**
  * @description Template routes allow you to map individual URLs to specific template files within a Ghost theme
@@ -100,6 +102,17 @@ class StaticRoutesRouter extends ParentRouter {
 
     // REGISTER: static route
     this.mountRoute(this.route.value, controllers.static);
+
+    const hasEntryData = Object.values(resolveRouteData(this.data)).some(
+      ({ type, resource }) => type === 'read' && (resource === 'pages' || resource === 'posts'),
+    );
+    if (hasEntryData) {
+      this.mountRoute(getMarkdownPath(this.route.value), (req, res, next) => {
+        res.routerOptions.isMarkdownRequest = true;
+        res.routerOptions.canonicalPath = urlUtils.createUrl(this.route.value, false, false, true);
+        return controllers.routeMarkdown(req, res, next);
+      });
+    }
 
     this.routerCreated(this);
   }

--- a/ghost/core/test/e2e-frontend/markdown-routes.test.js
+++ b/ghost/core/test/e2e-frontend/markdown-routes.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const supertest = require('supertest');
+const testUtils = require('../utils');
+const configUtils = require('../utils/config-utils');
+
+describe('Markdown routing with custom routes', function () {
+  let request;
+
+  beforeAll(async function () {
+    const routesFilePath = path.join(
+      configUtils.config.get('paths:appRoot'),
+      'test/utils/fixtures/settings/markdown-routes.yaml',
+    );
+
+    await testUtils.startGhost({ routesFilePath });
+    request = supertest.agent(configUtils.config.get('url'));
+  });
+
+  afterAll(function () {
+    return testUtils.stopGhost();
+  });
+
+  it('redirects a collection data page to its routed markdown URL', async function () {
+    const redirect = await request.get('/contact.md').redirects(0).expect(301);
+    assert.equal(redirect.headers.location, '/rubrique.md');
+
+    const res = await request
+      .get('/rubrique.md')
+      .expect('Content-Type', /text\/markdown/)
+      .expect(200);
+    assert.equal(res.headers['content-location'], '/rubrique.md');
+    assert.match(res.text, /# Contact/);
+  });
+
+  it('redirects a root data page to working /index.md without looping', async function () {
+    const redirect = await request.get('/about.md').redirects(0).expect(301);
+    assert.equal(redirect.headers.location, '/index.md');
+
+    const res = await request
+      .get('/index.md')
+      .expect('Content-Type', /text\/markdown/)
+      .expect(200);
+    assert.equal(res.headers['content-location'], '/index.md');
+    assert.match(res.text, /# About this site/);
+  });
+});

--- a/ghost/core/test/utils/fixtures/settings/markdown-routes.yaml
+++ b/ghost/core/test/utils/fixtures/settings/markdown-routes.yaml
@@ -1,0 +1,14 @@
+routes:
+  /:
+    data: page.about
+    template: index
+
+collections:
+  /rubrique/:
+    permalink: /rubrique/{slug}/
+    template: index
+    data: page.contact
+
+taxonomies:
+  tag: /tag/{slug}/
+  author: /author/{slug}/


### PR DESCRIPTION
When a page's URL is remapped by routes.yaml (a collection's \`data:\` source, or the site root), its \`.md\` variant redirects to the wrong place. The reporter pointed at the markdown controller, but the actual bug is one level up: \`ParentRouter._respectDominantRouter()\` builds the dominant-router redirect by appending the unmatched \`.md\` request path onto the routed directory, so \`/contact.md\` becomes \`/rubrique/contact.md\` (404) instead of \`/rubrique.md\`. For a root-mapped page this produces a redirect to itself instead of a working \`/index.md\`.

Fixed the dominant-router redirect to use \`getMarkdownPath(targetRoute)\` when the incoming request is a \`.md\` path, same as the correct path used for \`llms.txt\` generation. Also mounted a real \`.md\` route directly on entry-backed collection/static routes (instead of relying only on the redirect) so the root-page case resolves to a working \`/index.md\` rather than looping, and threaded the resolved canonical path through so \`Content-Location\` and the non-llms redirect target stay consistent.

Added e2e coverage with a real routes.yaml fixture covering both cases (collection \`data:\` remap and root remap). Confirmed both fail on the pre-fix code (\`/rubrique/contact.md\` 404, self-redirect loop on \`/about.md\`) and pass after the fix. Ran the broader routing test suite too (55/55 passing) since this touches shared redirect logic.

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

Closes #30375