### PR TITLE
🐛 Fixed missing audit log entries for staff token changes

### DIFF
--- a/ghost/core/test/e2e-api/admin/api-tokens.test.js
+++ b/ghost/core/test/e2e-api/admin/api-tokens.test.js
@@ -1,6 +1,8 @@
+/* global vi */
 const { agentProvider, fixtureManager } = require('../../utils/e2e-framework');
 const assert = require('node:assert/strict');
 const supertest = require('supertest');
+const models = require('../../../core/server/models');
 
 describe('Admin API', function () {
   let agent;
@@ -130,6 +132,43 @@ describe('Admin API', function () {
       it('Request to list members should succeed', async function () {
         await agent.get('members').expectStatus(200);
       });
+    });
+  });
+
+  describe('Audit log attribution', function () {
+    async function createPostAndGetActions() {
+      const { body } = await agent
+        .post('posts/')
+        .body({ posts: [{ title: 'Audit log attribution post' }] })
+        .expectStatus(201);
+      const postId = body.posts[0].id;
+
+      await agent.useStaffTokenForOwner();
+      // Actions are inserted after the transaction commits, so poll for the row
+      return vi.waitFor(async () => {
+        const { body: actionsBody } = await agent
+          .get(`actions/?filter=${encodeURIComponent(`resource_id:'${postId}'`)}&include=actor`)
+          .expectStatus(200);
+        assert.equal(actionsBody.actions.length, 1);
+        return actionsBody.actions;
+      });
+    }
+
+    it('attributes staff token changes to the user', async function () {
+      await agent.useStaffTokenForAdmin();
+      const actions = await createPostAndGetActions();
+      assert.equal(actions.length, 1);
+      assert.equal(actions[0].actor_type, 'user');
+      assert.equal(actions[0].actor.id, fixtureManager.get('users', 1).id);
+    });
+
+    it('attributes integration token changes to the integration', async function () {
+      await agent.useZapierAdminAPIKey();
+      const actions = await createPostAndGetActions();
+      const zapier = await models.Integration.findOne({ slug: 'zapier' });
+      assert.equal(actions.length, 1);
+      assert.equal(actions[0].actor_type, 'integration');
+      assert.equal(actions[0].actor.id, zapier.id);
     });
   });
 

--- a/packages/api-framework/lib/http.js
+++ b/packages/api-framework/lib/http.js
@@ -31,9 +31,12 @@ const http = (apiImpl) => {
         id: req.api_key.get('id'),
         type: req.api_key.get('type'),
       };
-      integration = {
-        id: req.api_key.get('integration_id'),
-      };
+      // Staff tokens belong to a user, not an integration
+      if (req.api_key.get('integration_id')) {
+        integration = {
+          id: req.api_key.get('integration_id'),
+        };
+      }
     }
 
     if (req.user?.id) {

--- a/packages/api-framework/test/http.test.js
+++ b/packages/api-framework/test/http.test.js
@@ -131,6 +131,34 @@ describe('HTTP', function () {
     });
   });
 
+  it('does not set an integration for staff tokens', async function () {
+    await new Promise((resolve) => {
+      req.user = { id: 'user-id' };
+      req.api_key = {
+        get(key) {
+          return {
+            id: 'api-key-id',
+            type: 'admin',
+            integration_id: null,
+            user_id: 'user-id',
+          }[key];
+        },
+      };
+
+      const apiImpl = sinon.stub().resolves({ ok: true });
+
+      res.json.callsFake(() => {
+        const frame = apiImpl.args[0][0];
+        assert.equal(frame.options.context.api_key.id, 'api-key-id');
+        assert.equal(frame.options.context.integration, null);
+        assert.equal(frame.options.context.user, 'user-id');
+        resolve();
+      });
+
+      shared.http(apiImpl)(req, res, next);
+    });
+  });
+
   it('supports async response format and statusCode function', async function () {
     await new Promise((resolve) => {
       const apiImpl = sinon.stub().resolves({ ok: true });


### PR DESCRIPTION
## Summary

Changes made with a **staff access token** were silently missing from the audit log (History). Each one logged `InternalServerError` with context `"actions.actor_id"` instead.

## Cause

`packages/api-framework/lib/http.js` built `context.integration = { id: api_key.integration_id }` for every API key. Staff tokens have a `user_id` but no `integration_id`, so they got `{ id: null }` alongside a valid `context.user`.

`getActor` (`models/base/plugins/user-type.js`) checks `context.integration` first. A truthy `{ id: null }` produced an integration actor with a null id, the `actions` insert then failed the `actor_id` NOT NULL constraint, and `actions.js` swallows insert errors after logging them.

The same truthy check misattributed staff token writes elsewhere:
- metafield `writtenBy` in `member-bread-service` recorded integration + null
- gift link actors in `gift-links.ts` did the same

## Fix

Only set `context.integration` when the key actually has an `integration_id`. Staff token requests now fall through to the user actor everywhere.

Permissions are unaffected: they load from `api_key.id` and check the key's roles, not `context.integration`. Integration keys behave exactly as before.

## Tests

- `packages/api-framework/test/http.test.js`: staff token requests get `integration: null` with `user` set.
- `ghost/core/test/e2e-api/admin/api-tokens.test.js`: a post created with a staff token records an action attributed to the user, and one created with an integration key is attributed to the integration. Verified the staff token case fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
