### PR TITLE
Limited Tinybird sync batch size by messages

### DIFF
--- a/ghost/core/core/server/services/tinybird-sync/sync-table-to-tinybird.ts
+++ b/ghost/core/core/server/services/tinybird-sync/sync-table-to-tinybird.ts
@@ -18,6 +18,7 @@ export type TinybirdSyncOptions = {
   createId: () => string;
   batchSize: number;
   maxPayloadBytes: number;
+  maxPayloadMessages: number;
   requestTimeoutMs: number;
 };
 
@@ -75,13 +76,17 @@ const toEventLine = (row: Row, siteUuid: string, type: string): string => {
   });
 };
 
-function* chunkByBytes(lines: string[], maxBytes: number): Generator<string[]> {
+function* chunkByPayloadLimits(
+  lines: string[],
+  maxBytes: number,
+  maxMessages: number,
+): Generator<string[]> {
   let current: string[] = [];
   let currentBytes = 0;
 
   for (const line of lines) {
     const bytes = Buffer.byteLength(line) + '\n'.length;
-    if (current.length && currentBytes + bytes > maxBytes) {
+    if (current.length && (currentBytes + bytes > maxBytes || current.length === maxMessages)) {
       yield current;
       current = [];
       currentBytes = 0;
@@ -181,7 +186,7 @@ export async function syncTableToTinybird(
   target: TinybirdSyncTarget,
   options: TinybirdSyncOptions,
 ): Promise<number> {
-  const { knex, siteUuid, now, createId, batchSize, maxPayloadBytes } = options;
+  const { knex, siteUuid, now, createId, batchSize, maxPayloadBytes, maxPayloadMessages } = options;
   const cutoff = toDatabaseDate(new Date(now().getTime() - SAFETY_LAG_MS));
   let cursor = await readWatermark(knex, target.table);
   let sent = 0;
@@ -193,7 +198,7 @@ export async function syncTableToTinybird(
     }
 
     const lines = rows.map((row) => toEventLine(row, siteUuid, target.table));
-    for (const chunk of chunkByBytes(lines, maxPayloadBytes)) {
+    for (const chunk of chunkByPayloadLimits(lines, maxPayloadBytes, maxPayloadMessages)) {
       await postEvents(chunk, target, options);
     }
 

--- a/ghost/core/core/server/services/tinybird-sync/tinybird-sync-service.ts
+++ b/ghost/core/core/server/services/tinybird-sync/tinybird-sync-service.ts
@@ -11,6 +11,7 @@ const BATCH_SIZE = 5000;
 // This should be a little less than the maximum, because rows are chunked by
 // JSON line, not bytes strictly.
 const MAX_PAYLOAD_BYTES = 9 * 1024 * 1024;
+const MAX_PAYLOAD_MESSAGES = 1000;
 const REQUEST_TIMEOUT_MS = 60 * 1000;
 
 type Logger = {
@@ -52,6 +53,7 @@ export function createTinybirdSyncService({
           createId,
           batchSize: BATCH_SIZE,
           maxPayloadBytes: MAX_PAYLOAD_BYTES,
+          maxPayloadMessages: MAX_PAYLOAD_MESSAGES,
           requestTimeoutMs: REQUEST_TIMEOUT_MS,
         });
         logging.info(

--- a/ghost/core/test/unit/server/services/tinybird-sync/index.test.ts
+++ b/ghost/core/test/unit/server/services/tinybird-sync/index.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import createKnex, { type Knex } from 'knex';
 import { afterEach, beforeEach, describe, it, vi } from 'vitest';
 import { createTinybirdSyncService } from '../../../../../core/server/services/tinybird-sync/tinybird-sync-service';
+import { toDatabaseDate } from '../../../../../core/server/lib/db-types/date';
 
 describe('createTinybirdSyncService', () => {
   let databases: Knex[];
@@ -55,9 +56,12 @@ describe('createTinybirdSyncService', () => {
       table.text('updated_at');
     });
     await database.schema.createTable('tinybird_syncs', (table) => {
-      table.text('table_name');
+      table.text('id');
+      table.text('table_name').unique();
       table.text('last_synced_updated_at');
       table.text('last_synced_id');
+      table.text('created_at');
+      table.text('updated_at');
     });
 
     return database;
@@ -101,6 +105,32 @@ describe('createTinybirdSyncService', () => {
         { event: 'tinybird.sync.completed', table: 'automation_run_steps', sent: 0 },
       ],
     );
+  });
+
+  it('limits Traffic Analytics requests to 1000 messages', async () => {
+    const failure = new Error('stop loop');
+    const sleep = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(failure);
+    const database = await createEmptyDatabase();
+    const updatedAt = toDatabaseDate(new Date('2026-03-01T11:50:00.000Z'));
+    await database.batchInsert(
+      'automation_runs',
+      Array.from({ length: 1001 }, (_, index) => ({
+        id: `run-${index}`,
+        automation_id: `automation-${index}`,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      })),
+      500,
+    );
+    const requests: number[] = [];
+    const fetch: typeof globalThis.fetch = async (_input, init) => {
+      requests.push(String(init?.body).split('\n').length);
+      return new Response(null, { status: 202 });
+    };
+    const { service } = createService({ knex: database, sleep, random: () => 0, fetch });
+
+    service.start();
+    await vi.waitFor(() => assert.deepEqual(requests, [1000, 1]));
   });
 
   it('does not start without complete analytics config', () => {

--- a/ghost/core/test/unit/server/services/tinybird-sync/sync-table-to-tinybird.test.ts
+++ b/ghost/core/test/unit/server/services/tinybird-sync/sync-table-to-tinybird.test.ts
@@ -126,6 +126,7 @@ describe('syncTableToTinybird', () => {
       createId: () => ObjectId().toHexString(),
       batchSize: BATCH_SIZE,
       maxPayloadBytes: MAX_PAYLOAD_BYTES,
+      maxPayloadMessages: 1000,
       requestTimeoutMs: REQUEST_TIMEOUT_MS,
       ...options,
     });
@@ -203,6 +204,7 @@ describe('syncTableToTinybird', () => {
       createId: () => ObjectId().toHexString(),
       batchSize: BATCH_SIZE,
       maxPayloadBytes: MAX_PAYLOAD_BYTES,
+      maxPayloadMessages: 1000,
       requestTimeoutMs: REQUEST_TIMEOUT_MS,
     });
 
@@ -253,6 +255,19 @@ describe('syncTableToTinybird', () => {
       requests.every(({ lines }) =>
         lines.every(({ payload }) => payload.automation_id === twoByteCharacters),
       ),
+    );
+  });
+
+  it('splits requests by maximum message count without splitting events', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      await insertRun(minutesBeforeNow(10), { id: `run-${index}` });
+    }
+
+    await sync({ maxPayloadMessages: 2 });
+
+    assert.deepEqual(
+      requests.map(({ lines }) => lines.length),
+      [2, 2, 1],
     );
   });
 


### PR DESCRIPTION
no ref

Before this change, we limited Tinybird syncs to a max number of bytes.

After this change, we limit Tinybird syncs to a max number of bytes _and_ a maximum number of messages, whichever is smaller.

This should help reduce pressure on the Traffic Analytics service, which should mitigate some of the timeouts we've been seeing.
