### PR TITLE
🐛 Fixed members being subscribed to all newsletters when choosing none

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1097,7 +1097,7 @@ module.exports = class RouterController {
       labels: req.body.labels,
       name: req.body.name,
       reqIp: req.ip ?? undefined,
-      newsletters: await this._validateNewsletters(req.body?.newsletters ?? []),
+      newsletters: await this._validateNewsletters(req.body?.newsletters),
       attribution: await this._memberAttributionService.getAttribution(req.body.urlHistory),
       ...(giftToken ? { giftToken } : {}),
     };
@@ -1149,8 +1149,13 @@ module.exports = class RouterController {
    * @returns {Promise<object[] | undefined>} The validated newsletters
    */
   async _validateNewsletters(requestedNewsletters) {
-    if (!requestedNewsletters || requestedNewsletters.length === 0) {
+    if (!requestedNewsletters) {
       return undefined;
+    }
+
+    // An explicit empty list means "no newsletters", not "the defaults"
+    if (requestedNewsletters.length === 0) {
+      return [];
     }
 
     if (requestedNewsletters.some((newsletter) => !newsletter.name)) {

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1149,7 +1149,7 @@ module.exports = class RouterController {
    * @returns {Promise<object[] | undefined>} The validated newsletters
    */
   async _validateNewsletters(requestedNewsletters) {
-    if (!requestedNewsletters) {
+    if (!requestedNewsletters || !Array.isArray(requestedNewsletters)) {
       return undefined;
     }
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -191,6 +191,45 @@ describe('RouterController', function () {
       );
     });
 
+    it('keeps an explicit empty newsletter list in the checkout metadata', async function () {
+      const routerController = new RouterController({
+        tiersService,
+        paymentsService,
+        offersAPI,
+        stripeAPIService,
+        labsService,
+        settingsCache,
+        settingsHelpers,
+        urlUtils,
+        newslettersService: { getAll: sinon.stub() },
+        emailAddressService,
+      });
+      const req = {
+        body: {
+          tierId: 'tier_123',
+          cadence: 'month',
+          metadata: {
+            newsletters: JSON.stringify([]),
+          },
+        },
+      };
+
+      await routerController.createCheckoutSession(req, {
+        writeHead: () => {},
+        end: () => {},
+      });
+
+      sinon.assert.calledOnce(getPaymentLinkSpy);
+      sinon.assert.calledWith(
+        getPaymentLinkSpy,
+        sinon.match({
+          metadata: {
+            newsletters: '[]',
+          },
+        }),
+      );
+    });
+
     it('sets ghostSignupContext to has_precheckout_magic_link when checkout creates a signup magic link', async function () {
       const magicLinkService = {
         getMagicLink: sinon
@@ -2098,6 +2137,26 @@ describe('RouterController', function () {
           message: `Cannot subscribe to archived newsletters Newsletter 2`,
         });
       });
+
+      it('keeps an explicit empty newsletter list', async function () {
+        req.body.newsletters = [];
+
+        const controller = createRouterController();
+
+        await controller.sendMagicLink(req, res);
+
+        sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
+        assert.deepEqual(sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters, []);
+      });
+
+      it('leaves newsletters unset when none are requested', async function () {
+        const controller = createRouterController();
+
+        await controller.sendMagicLink(req, res);
+
+        sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
+        assert.equal(sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters, undefined);
+      });
     });
 
     describe('gift token forwarding', function () {
@@ -2381,10 +2440,10 @@ describe('RouterController', function () {
       assert.deepEqual(result, [{ id: 'abc123' }, { id: 'def456' }, { id: 'ghi789' }]);
     });
 
-    it('returns undefined if newsletters is an empty array', async function () {
+    it('returns an empty array if newsletters is an empty array', async function () {
       const requestedNewsletters = [];
       const result = await routerController._validateNewsletters(requestedNewsletters);
-      assert.equal(result, undefined);
+      assert.deepEqual(result, []);
     });
 
     it('returns undefined if newsletters is undefined', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -2452,6 +2452,14 @@ describe('RouterController', function () {
       assert.equal(result, undefined);
     });
 
+    it('returns undefined if newsletters is not an array', async function () {
+      // A truthy, non-array object with a `length` of 0 must not be treated
+      // as an explicit empty list — only a real empty array means that.
+      const requestedNewsletters = { length: 0 };
+      const result = await routerController._validateNewsletters(requestedNewsletters);
+      assert.equal(result, undefined);
+    });
+
     it('returns undefined if any newsletter is missing a name', async function () {
       const requestedNewsletters = [{ name: 'Newsletter 1' }, { id: 'def456' }];
       const result = await routerController._validateNewsletters(requestedNewsletters);


### PR DESCRIPTION
A member reported that on a free plan, unticking every newsletter in Portal still subscribed them to all of them.

Portal's newsletter selection page sends `newsletters: []` when nothing is ticked. Theme signup forms whose only newsletter inputs are unchecked `data-members-newsletter` checkboxes also send `[]`, deliberately, to opt out of the defaults (`apps/portal/src/data-attributes.js`). The server turned that into `undefined`, which member creation treats as "not specified" and fills with every `subscribe_on_signup` newsletter.

This regressed twice:

- **Free signups** in #21862, when `_validateNewsletters` replaced passing the list through unchanged and returned `undefined` for an empty array.
- **Paid signups** in #23303, when checkout metadata started going through the same function: `"[]"` became `undefined`, was dropped from the metadata, and the Stripe webhook applied the defaults.

### Change

`_validateNewsletters` now returns `[]` for an empty list, and `undefined` only when no list was sent. The signup call site no longer turns a missing list into `[]` (`?? []`), so signups that don't send newsletters (Portal's signup and offer pages, the signup-form embed) still get the defaults.

### Testing

Unit tests for a free signup sending `[]`, a signup sending no list (still gets the defaults), and paid checkout metadata keeping `"[]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
