### PR TITLE
Added an opt-in duplicate-dependency check to validate-adapters

### DIFF
--- a/ghost/core/bin/lib/duplicate-deps.ts
+++ b/ghost/core/bin/lib/duplicate-deps.ts
@@ -16,13 +16,20 @@
 //   logger on `globalThis` under `Symbol.for('@tryghost/logging@<major>')`;
 //   `@tryghost/metrics` has no such guard and would build a second instance.
 //
-// @NOTE: `require.cache` alone would stop at the first ESM boundary. Adapters
-// may be ESM (`"type": "module"`), and while Node caches the entry point of a
-// module `require()`d that way, nothing that module goes on to `import` is
-// cached - the ESM loader keeps its own registry, which has no public equivalent
-// to `require.cache`. `collectLoadedFiles` covers that gap with the inspector,
-// which reports both formats; the CJS cache stays as the fallback for a Node
-// built without inspector support.
+// @NOTE: it takes two sources to see everything loaded, and `collectLoadedFiles`
+// unions them because neither contains the other:
+//
+// - `require.cache` stops at the first ESM boundary. Adapters may be ESM
+//   (`"type": "module"`), and while Node caches the entry point of a module
+//   `require()`d that way, nothing that module goes on to `import` is cached -
+//   the ESM loader keeps its own registry, with no public equivalent to read.
+// - The inspector reports every script V8 parsed, ESM included, but a module
+//   that is not a script is not one: `.json` and native `.node` addons never
+//   produce a `scriptParsed` event, and only `require.cache` lists them. A
+//   duplicated native addon is worth reporting precisely because it is two
+//   copies of a compiled binary.
+//
+// The CJS cache doubles as the fallback when the inspector is unavailable.
 
 import fs from 'node:fs';
 import inspector from 'node:inspector';
@@ -119,8 +126,9 @@ function parsedScriptFiles(): string[] {
 }
 
 /**
- * Every file this process has loaded: the given CommonJS cache keys, plus what
- * the inspector can see of the ESM graph they stop at.
+ * Every file this process has loaded: the given CommonJS cache keys, which alone
+ * carry the JSON and native modules, plus the scripts the inspector can see,
+ * which alone carry the ESM graph the cache stops at.
  */
 export function collectLoadedFiles(cjsCachedFiles: Iterable<string>): string[] {
   return [...new Set([...cjsCachedFiles, ...parsedScriptFiles()])];

--- a/ghost/core/bin/lib/duplicate-deps.ts
+++ b/ghost/core/bin/lib/duplicate-deps.ts
@@ -16,16 +16,18 @@
 //   logger on `globalThis` under `Symbol.for('@tryghost/logging@<major>')`;
 //   `@tryghost/metrics` has no such guard and would build a second instance.
 //
-// @NOTE: this reads `require.cache`, so what it can see stops at the first ESM
-// boundary. Adapters may be ESM (`"type": "module"`), and while Node does cache
-// the entry point of a module `require()`d that way, nothing that module goes on
-// to `import` is cached - the ESM loader keeps its own registry. So an ESM
-// adapter's dependency subgraph is invisible here, and so is an ESM dependency's
-// (which is how Ghost reaches `ghost-storage-base`). The check is a useful
-// signal, not an exhaustive one.
+// @NOTE: `require.cache` alone would stop at the first ESM boundary. Adapters
+// may be ESM (`"type": "module"`), and while Node caches the entry point of a
+// module `require()`d that way, nothing that module goes on to `import` is
+// cached - the ESM loader keeps its own registry, which has no public equivalent
+// to `require.cache`. `collectLoadedFiles` covers that gap with the inspector,
+// which reports both formats; the CJS cache stays as the fallback for a Node
+// built without inspector support.
 
 import fs from 'node:fs';
+import inspector from 'node:inspector';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /** Where a loaded file's package lives, before its manifest has been read. */
 export interface PackageLocation {
@@ -57,7 +59,7 @@ export interface DuplicateDependencyReport {
 }
 
 export interface DuplicateDependencyOptions {
-  /** Loaded file paths, i.e. `Object.keys(require.cache)`. */
+  /** Loaded file paths, i.e. `collectLoadedFiles(Object.keys(require.cache))`. */
   cachedFiles: Iterable<string>;
   /** Directories custom adapters are installed under, i.e. `adapterPaths`. */
   adapterRoots: string[];
@@ -72,6 +74,57 @@ const NODE_MODULES = 'node_modules';
 // pnpm's virtual store is the one entry directly inside a `node_modules` that
 // isn't a package: `node_modules/.pnpm/<name>@<version>/node_modules/<name>`.
 const PNPM_STORE = '.pnpm';
+
+/**
+ * The files V8 has parsed in this process, whatever their module format.
+ *
+ * Enabling the inspector's `Debugger` domain replays a `scriptParsed` event for
+ * every script already parsed, so this can run after the adapters have loaded -
+ * the same after-the-fact question `require.cache` answers, minus its blind spot
+ * for ESM. The events are delivered synchronously while the domain is enabling,
+ * so there is nothing to await.
+ *
+ * Returns nothing when the inspector is unavailable, e.g. a Node built
+ * `--without-inspector`, leaving the caller with its CommonJS cache alone.
+ */
+function parsedScriptFiles(): string[] {
+  let session: inspector.Session;
+  try {
+    session = new inspector.Session();
+    session.connect();
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  session.on('Debugger.scriptParsed', ({ params }) => {
+    // Anything with no file behind it - `node:` internals, `eval`, `data:`
+    // URLs - can't belong to a package, so it is of no interest here.
+    if (!params.url.startsWith('file://')) {
+      return;
+    }
+
+    try {
+      files.push(fileURLToPath(params.url));
+    } catch {
+      // A URL Node won't convert back to a path is not a package file either.
+    }
+  });
+
+  session.post('Debugger.enable');
+  session.post('Debugger.disable');
+  session.disconnect();
+
+  return files;
+}
+
+/**
+ * Every file this process has loaded: the given CommonJS cache keys, plus what
+ * the inspector can see of the ESM graph they stop at.
+ */
+export function collectLoadedFiles(cjsCachedFiles: Iterable<string>): string[] {
+  return [...new Set([...cjsCachedFiles, ...parsedScriptFiles()])];
+}
 
 function realpathOrNull(target: string): string | null {
   try {

--- a/ghost/core/bin/lib/duplicate-deps.ts
+++ b/ghost/core/bin/lib/duplicate-deps.ts
@@ -19,10 +19,12 @@
 // @NOTE: it takes two sources to see everything loaded, and `collectLoadedFiles`
 // unions them because neither contains the other:
 //
-// - `require.cache` stops at the first ESM boundary. Adapters may be ESM
-//   (`"type": "module"`), and while Node caches the entry point of a module
-//   `require()`d that way, nothing that module goes on to `import` is cached -
-//   the ESM loader keeps its own registry, with no public equivalent to read.
+// - `require.cache` holds no ESM file. Adapters may be ESM (`"type": "module"`),
+//   and an ESM file is absent from the cache whether it is the adapter's own
+//   entry point or something it goes on to `import` - the ESM loader keeps its
+//   own registry, with no public equivalent to read. (A CommonJS dependency
+//   `import`ed from ESM does still go through the cache, so the gap is the ESM
+//   files specifically.)
 // - The inspector reports every script V8 parsed, ESM included, but a module
 //   that is not a script is not one: `.json` and native `.node` addons never
 //   produce a `scriptParsed` event, and only `require.cache` lists them. A
@@ -30,6 +32,14 @@
 //   copies of a compiled binary.
 //
 // The CJS cache doubles as the fallback when the inspector is unavailable.
+//
+// @NOTE: in a monorepo checkout Ghost's own copy of a `workspace:*` dependency
+// resolves through a symlink to `packages/<name>`, outside any `node_modules`,
+// and `require.cache` only ever reports that resolved path - so Ghost has no
+// copy to compare against and nothing is reported. Every adapter base class is
+// such a dependency, which makes a local run of `--check-duplicate-deps` a poor
+// rehearsal: it is the installed tree built into the image, where those are
+// ordinary `node_modules` entries, that this is meant to check.
 
 import fs from 'node:fs';
 import inspector from 'node:inspector';
@@ -44,8 +54,10 @@ export interface PackageLocation {
 }
 
 /** One physical copy of a package, as loaded into the process. */
-export interface PackageCopy extends PackageLocation {
+export interface PackageCopy {
   version: string;
+  /** Absolute path of the package directory the copy was loaded from. */
+  path: string;
 }
 
 /** A package loaded from both an adapter's tree and Ghost's own. */
@@ -77,10 +89,6 @@ export interface DuplicateDependencyOptions {
 }
 
 const NODE_MODULES = 'node_modules';
-
-// pnpm's virtual store is the one entry directly inside a `node_modules` that
-// isn't a package: `node_modules/.pnpm/<name>@<version>/node_modules/<name>`.
-const PNPM_STORE = '.pnpm';
 
 /**
  * The files V8 has parsed in this process, whatever their module format.
@@ -178,31 +186,30 @@ function readVersion(packagePath: string): string {
  * `node_modules/<name>` npm gives an adapter, and the
  * `.pnpm/<name>@<version>/node_modules/<name>` pnpm's isolated layout resolves
  * to - so nothing here has to understand a particular layout's naming. Returns
- * `null` for a file that isn't inside a package at all: Ghost's own source, an
- * adapter's own `index.js`, or something sitting loose in pnpm's store.
+ * `null` for a file that isn't inside a package at all: Ghost's own source, or an
+ * adapter's own `index.js`.
  */
 export function parsePackageFromPath(filePath: string): PackageLocation | null {
   const segments = filePath.split(path.sep);
-  const lastNodeModules = segments.lastIndexOf(NODE_MODULES);
-  if (lastNodeModules === -1) {
-    return null;
-  }
+  const start = segments.lastIndexOf(NODE_MODULES) + 1;
+  const first = segments[start];
 
-  const first = segments[lastNodeModules + 1];
-  if (!first || first === PNPM_STORE) {
+  // A dot-prefixed entry is an installer's own bookkeeping directory sitting
+  // next to the packages - pnpm's virtual store, `.bin`, a cache - and npm
+  // forbids a package name from looking like one.
+  if (start === 0 || !first || first.startsWith('.')) {
     return null;
   }
 
   // Scoped packages take two segments: `@tryghost/logging`.
-  const segmentCount = first.startsWith('@') ? 2 : 1;
-  const nameSegments = segments.slice(lastNodeModules + 1, lastNodeModules + 1 + segmentCount);
-  if (nameSegments.length !== segmentCount || !nameSegments[segmentCount - 1]) {
+  const end = start + (first.startsWith('@') ? 2 : 1);
+  if (!segments[end - 1]) {
     return null;
   }
 
   return {
-    name: nameSegments.join('/'),
-    path: segments.slice(0, lastNodeModules + 1 + segmentCount).join(path.sep),
+    name: segments.slice(start, end).join('/'),
+    path: segments.slice(0, end).join(path.sep),
   };
 }
 
@@ -224,22 +231,16 @@ export function checkDuplicateDependencies({
   // roots are reached through symlinks, so compare resolved paths - never
   // specifiers - on both sides.
   const realAdapterRoots = adapterRoots.map(realpathOrNull).filter((root) => root !== null);
-  const realGhostRoots = ghostNodeModulesRoots
-    .map(realpathOrNull)
-    .filter((root) => root !== null)
-    // A Ghost root nested inside an adapter would make every adapter-installed
-    // package look like Ghost's; adapters win, so drop those.
-    .filter((root) => !realAdapterRoots.some((adapterRoot) => isInside(root, adapterRoot)));
+  const realGhostRoots = ghostNodeModulesRoots.map(realpathOrNull).filter((root) => root !== null);
 
-  const adapterPackages = new Map<string, string[]>();
+  const adapterPackages = new Map<string, Set<string>>();
   const ghostPackages = new Map<string, string>();
 
   for (const cachedFile of cachedFiles) {
     const realFile = realpathOrNull(cachedFile) ?? cachedFile;
 
     const inAdapter = realAdapterRoots.some((root) => isInside(realFile, root));
-    const inGhost = !inAdapter && realGhostRoots.some((root) => isInside(realFile, root));
-    if (!inAdapter && !inGhost) {
+    if (!inAdapter && !realGhostRoots.some((root) => isInside(realFile, root))) {
       continue;
     }
 
@@ -248,8 +249,9 @@ export function checkDuplicateDependencies({
       continue;
     }
 
-    if (inGhost) {
-      // Ghost resolves a given name to a single copy, so the first wins.
+    if (!inAdapter) {
+      // Ghost's own tree can hold more than one copy of a name; any of them is
+      // the other half of the comparison, so the first one seen will do.
       if (!ghostPackages.has(location.name)) {
         ghostPackages.set(location.name, location.path);
       }
@@ -258,11 +260,8 @@ export function checkDuplicateDependencies({
 
     // Two adapters can each bundle their own copy of the same package, so keep
     // every distinct location rather than only the first.
-    const packagePaths = adapterPackages.get(location.name) ?? [];
-    if (!packagePaths.includes(location.path)) {
-      packagePaths.push(location.path);
-    }
-    adapterPackages.set(location.name, packagePaths);
+    const packagePaths = adapterPackages.get(location.name) ?? new Set<string>();
+    adapterPackages.set(location.name, packagePaths.add(location.path));
   }
 
   // Versions are only read once both sides are known, so the manifest reads
@@ -274,11 +273,11 @@ export function checkDuplicateDependencies({
       continue;
     }
 
-    const ghost = { name, version: readVersion(ghostPath), path: ghostPath };
+    const ghost = { version: readVersion(ghostPath), path: ghostPath };
     for (const packagePath of packagePaths) {
       duplicates.push({
         name,
-        adapter: { name, version: readVersion(packagePath), path: packagePath },
+        adapter: { version: readVersion(packagePath), path: packagePath },
         ghost,
       });
     }
@@ -297,7 +296,7 @@ export function formatDuplicateReport({ duplicates, blocking }: DuplicateDepende
     return '  ok    no duplicate dependencies\n';
   }
 
-  const lines = [
+  return [
     `\n${duplicates.length} package(s) loaded from both an adapter and Ghost:\n`,
     ...duplicates.map(
       ({ name, adapter, ghost }) =>
@@ -308,17 +307,10 @@ export function formatDuplicateReport({ duplicates, blocking }: DuplicateDepende
     '\nEach duplicate is loaded into memory twice. Have the adapter declare the\n' +
       'package as a peer dependency of Ghost, or match the version Ghost ships,\n' +
       'so the install can be deduplicated.\n\n',
-  ];
-
-  if (blocking.length) {
-    lines.push(
-      `  FAIL  duplicate dependencies: ${blocking.map(({ name }) => name).join(', ')}\n`,
-      '        A second copy of these breaks `instanceof` against the base class\n' +
-        '        Ghost checks adapters with - they must resolve to a single copy.\n',
-    );
-  } else {
-    lines.push('  ok    duplicate dependencies (none of them must be a single copy)\n');
-  }
-
-  return lines.join('');
+    blocking.length
+      ? `  FAIL  duplicate dependencies: ${blocking.map(({ name }) => name).join(', ')}\n` +
+        '        A second copy of these breaks `instanceof` against the base class\n' +
+        '        Ghost checks adapters with - they must resolve to a single copy.\n'
+      : '  ok    duplicate dependencies (none of them must be a single copy)\n',
+  ].join('');
 }

--- a/ghost/core/bin/lib/duplicate-deps.ts
+++ b/ghost/core/bin/lib/duplicate-deps.ts
@@ -1,0 +1,263 @@
+// Finds packages that ended up loaded twice in one process: once from a custom
+// adapter's own `node_modules` and once from Ghost's.
+//
+// Custom adapters are installed as self-contained directories with their own
+// dependency tree (Ghost Pro deploys them to `/home/ghost/adapters/<type>/<Name>`
+// and points `paths__installedAdaptersPath` at that directory). Anything the
+// adapter does not install itself resolves by walking up to Ghost's own
+// `node_modules`, so a package the adapter *does* install is loaded a second
+// time, from a second file, as a second module instance. That:
+//
+// - breaks `instanceof`, because the adapter's base class is a different
+//   function object than the one Ghost compares against (both
+//   `adapter-manager.ts` and `bin/validate-adapters.ts` carry a name-based
+//   fallback for exactly this), and
+// - splits module-level state. `@tryghost/logging` survives it by caching its
+//   logger on `globalThis` under `Symbol.for('@tryghost/logging@<major>')`;
+//   `@tryghost/metrics` has no such guard and would build a second instance.
+//
+// @NOTE: this reads `require.cache`, so what it can see stops at the first ESM
+// boundary. Adapters may be ESM (`"type": "module"`), and while Node does cache
+// the entry point of a module `require()`d that way, nothing that module goes on
+// to `import` is cached - the ESM loader keeps its own registry. So an ESM
+// adapter's dependency subgraph is invisible here, and so is an ESM dependency's
+// (which is how Ghost reaches `ghost-storage-base`). The check is a useful
+// signal, not an exhaustive one.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Where a loaded file's package lives, before its manifest has been read. */
+export interface PackageLocation {
+  name: string;
+  /** Absolute path of the package directory the copy was loaded from. */
+  path: string;
+}
+
+/** One physical copy of a package, as loaded into the process. */
+export interface PackageCopy extends PackageLocation {
+  version: string;
+}
+
+/** A package loaded from both an adapter's tree and Ghost's own. */
+export interface DuplicateDependency {
+  name: string;
+  adapter: PackageCopy;
+  ghost: PackageCopy;
+}
+
+export interface DuplicateDependencyReport {
+  /** Every duplicate found, in name order. Informational: a duplicate costs memory. */
+  duplicates: DuplicateDependency[];
+  /**
+   * The subset that must not be duplicated - a second copy of these is a
+   * correctness problem rather than a size one, so the caller fails on them.
+   */
+  blocking: DuplicateDependency[];
+}
+
+export interface DuplicateDependencyOptions {
+  /** Loaded file paths, i.e. `Object.keys(require.cache)`. */
+  cachedFiles: Iterable<string>;
+  /** Directories custom adapters are installed under, i.e. `adapterPaths`. */
+  adapterRoots: string[];
+  /** The `node_modules` directories Ghost itself resolves from, i.e. `module.paths`. */
+  ghostNodeModulesRoots: string[];
+  /** Package names a second copy of is a failure, not a note. */
+  mustBeSingleCopy: readonly string[];
+}
+
+const NODE_MODULES = 'node_modules';
+
+// pnpm's virtual store is the one entry directly inside a `node_modules` that
+// isn't a package: `node_modules/.pnpm/<name>@<version>/node_modules/<name>`.
+const PNPM_STORE = '.pnpm';
+
+function realpathOrNull(target: string): string | null {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether `filePath` sits inside `directory`. Both are expected to be realpaths
+ * already - the caller resolves them once rather than per comparison.
+ */
+function isInside(filePath: string, directory: string): boolean {
+  const relative = path.relative(directory, filePath);
+
+  // Compare the first segment exactly rather than using startsWith('..'), so an
+  // entry whose name merely begins with dots isn't mistaken for traversal.
+  const [firstSegment] = relative.split(path.sep);
+
+  return relative !== '' && firstSegment !== '..' && !path.isAbsolute(relative);
+}
+
+/**
+ * The version a package declares, or `unknown` when it declares none and when
+ * the manifest is unreadable - a missing version is worth reporting alongside
+ * the paths rather than dropping the duplicate.
+ */
+function readVersion(packagePath: string): string {
+  try {
+    const { version } = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json'), 'utf8'));
+    return typeof version === 'string' ? version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Attribute a loaded file to the package that physically contains it: whatever
+ * the *last* `node_modules` segment of its path names.
+ *
+ * That holds whatever installer produced the tree - the flat
+ * `node_modules/<name>` npm gives an adapter, and the
+ * `.pnpm/<name>@<version>/node_modules/<name>` pnpm's isolated layout resolves
+ * to - so nothing here has to understand a particular layout's naming. Returns
+ * `null` for a file that isn't inside a package at all: Ghost's own source, an
+ * adapter's own `index.js`, or something sitting loose in pnpm's store.
+ */
+export function parsePackageFromPath(filePath: string): PackageLocation | null {
+  const segments = filePath.split(path.sep);
+  const lastNodeModules = segments.lastIndexOf(NODE_MODULES);
+  if (lastNodeModules === -1) {
+    return null;
+  }
+
+  const first = segments[lastNodeModules + 1];
+  if (!first || first === PNPM_STORE) {
+    return null;
+  }
+
+  // Scoped packages take two segments: `@tryghost/logging`.
+  const segmentCount = first.startsWith('@') ? 2 : 1;
+  const nameSegments = segments.slice(lastNodeModules + 1, lastNodeModules + 1 + segmentCount);
+  if (nameSegments.length !== segmentCount || !nameSegments[segmentCount - 1]) {
+    return null;
+  }
+
+  return {
+    name: nameSegments.join('/'),
+    path: segments.slice(0, lastNodeModules + 1 + segmentCount).join(path.sep),
+  };
+}
+
+/**
+ * Find packages loaded from both an adapter's dependency tree and Ghost's own.
+ *
+ * A file belongs to an adapter when it sits under one of the adapter search
+ * paths, and to Ghost when it sits under one of the `node_modules` directories
+ * Ghost resolves from. Adapters are checked first: `content/adapters` lives
+ * inside the Ghost installation, so the two are not mutually exclusive.
+ */
+export function checkDuplicateDependencies({
+  cachedFiles,
+  adapterRoots,
+  ghostNodeModulesRoots,
+  mustBeSingleCopy,
+}: DuplicateDependencyOptions): DuplicateDependencyReport {
+  // Node reports realpaths in `require.cache`, and pnpm's layout means the
+  // roots are reached through symlinks, so compare resolved paths - never
+  // specifiers - on both sides.
+  const realAdapterRoots = adapterRoots.map(realpathOrNull).filter((root) => root !== null);
+  const realGhostRoots = ghostNodeModulesRoots
+    .map(realpathOrNull)
+    .filter((root) => root !== null)
+    // A Ghost root nested inside an adapter would make every adapter-installed
+    // package look like Ghost's; adapters win, so drop those.
+    .filter((root) => !realAdapterRoots.some((adapterRoot) => isInside(root, adapterRoot)));
+
+  const adapterPackages = new Map<string, string[]>();
+  const ghostPackages = new Map<string, string>();
+
+  for (const cachedFile of cachedFiles) {
+    const realFile = realpathOrNull(cachedFile) ?? cachedFile;
+
+    const inAdapter = realAdapterRoots.some((root) => isInside(realFile, root));
+    const inGhost = !inAdapter && realGhostRoots.some((root) => isInside(realFile, root));
+    if (!inAdapter && !inGhost) {
+      continue;
+    }
+
+    const location = parsePackageFromPath(realFile);
+    if (!location) {
+      continue;
+    }
+
+    if (inGhost) {
+      // Ghost resolves a given name to a single copy, so the first wins.
+      if (!ghostPackages.has(location.name)) {
+        ghostPackages.set(location.name, location.path);
+      }
+      continue;
+    }
+
+    // Two adapters can each bundle their own copy of the same package, so keep
+    // every distinct location rather than only the first.
+    const packagePaths = adapterPackages.get(location.name) ?? [];
+    if (!packagePaths.includes(location.path)) {
+      packagePaths.push(location.path);
+    }
+    adapterPackages.set(location.name, packagePaths);
+  }
+
+  // Versions are only read once both sides are known, so the manifest reads
+  // cost one per reported copy rather than one per cached file.
+  const duplicates: DuplicateDependency[] = [];
+  for (const [name, packagePaths] of [...adapterPackages].sort(([a], [b]) => a.localeCompare(b))) {
+    const ghostPath = ghostPackages.get(name);
+    if (!ghostPath) {
+      continue;
+    }
+
+    const ghost = { name, version: readVersion(ghostPath), path: ghostPath };
+    for (const packagePath of packagePaths) {
+      duplicates.push({
+        name,
+        adapter: { name, version: readVersion(packagePath), path: packagePath },
+        ghost,
+      });
+    }
+  }
+
+  const singleCopy = new Set(mustBeSingleCopy);
+
+  return { duplicates, blocking: duplicates.filter(({ name }) => singleCopy.has(name)) };
+}
+
+/**
+ * Render a report for humans, in the same indented style as the adapter results.
+ */
+export function formatDuplicateReport({ duplicates, blocking }: DuplicateDependencyReport): string {
+  if (!duplicates.length) {
+    return '  ok    no duplicate dependencies\n';
+  }
+
+  const lines = [
+    `\n${duplicates.length} package(s) loaded from both an adapter and Ghost:\n`,
+    ...duplicates.map(
+      ({ name, adapter, ghost }) =>
+        `- ${name}\n` +
+        `    adapter ${adapter.version}  ${adapter.path}\n` +
+        `    ghost   ${ghost.version}  ${ghost.path}\n`,
+    ),
+    '\nEach duplicate is loaded into memory twice. Have the adapter declare the\n' +
+      'package as a peer dependency of Ghost, or match the version Ghost ships,\n' +
+      'so the install can be deduplicated.\n\n',
+  ];
+
+  if (blocking.length) {
+    lines.push(
+      `  FAIL  duplicate dependencies: ${blocking.map(({ name }) => name).join(', ')}\n`,
+      '        A second copy of these breaks `instanceof` against the base class\n' +
+        '        Ghost checks adapters with - they must resolve to a single copy.\n',
+    );
+  } else {
+    lines.push('  ok    duplicate dependencies (none of them must be a single copy)\n');
+  }
+
+  return lines.join('');
+}

--- a/ghost/core/bin/lib/duplicate-deps.ts
+++ b/ghost/core/bin/lib/duplicate-deps.ts
@@ -1,45 +1,26 @@
-// Finds packages that ended up loaded twice in one process: once from a custom
-// adapter's own `node_modules` and once from Ghost's.
+// Finds packages loaded twice in one process: once from a custom adapter's own
+// `node_modules` and once from Ghost's.
 //
-// Custom adapters are installed as self-contained directories with their own
-// dependency tree (Ghost Pro deploys them to `/home/ghost/adapters/<type>/<Name>`
-// and points `paths__installedAdaptersPath` at that directory). Anything the
-// adapter does not install itself resolves by walking up to Ghost's own
-// `node_modules`, so a package the adapter *does* install is loaded a second
-// time, from a second file, as a second module instance. That:
+// An adapter is installed as a self-contained directory with its own dependency
+// tree (Ghost Pro deploys them to `/home/ghost/adapters/<type>/<Name>`). Whatever
+// it doesn't install itself resolves by walking up to Ghost's `node_modules`, so
+// a package it *does* install becomes a second module instance - which breaks
+// `instanceof` against a base class (hence the name-based fallbacks in
+// `adapter-manager.ts` and `bin/validate-adapters.ts`) and splits module-level
+// state, as `@tryghost/metrics` would with no `globalThis` guard to save it.
 //
-// - breaks `instanceof`, because the adapter's base class is a different
-//   function object than the one Ghost compares against (both
-//   `adapter-manager.ts` and `bin/validate-adapters.ts` carry a name-based
-//   fallback for exactly this), and
-// - splits module-level state. `@tryghost/logging` survives it by caching its
-//   logger on `globalThis` under `Symbol.for('@tryghost/logging@<major>')`;
-//   `@tryghost/metrics` has no such guard and would build a second instance.
+// @NOTE: `collectLoadedFiles` unions two sources because neither contains the
+// other. `require.cache` holds no ESM file, neither an ESM adapter's entry point
+// nor anything it `import`s - though a CommonJS dependency of one does still go
+// through the cache, so the gap is ESM files specifically. The inspector reports
+// every script V8 parsed, ESM included, but `.json` and native `.node` modules
+// aren't scripts and only the cache lists them. The cache is also the fallback
+// when the inspector is unavailable.
 //
-// @NOTE: it takes two sources to see everything loaded, and `collectLoadedFiles`
-// unions them because neither contains the other:
-//
-// - `require.cache` holds no ESM file. Adapters may be ESM (`"type": "module"`),
-//   and an ESM file is absent from the cache whether it is the adapter's own
-//   entry point or something it goes on to `import` - the ESM loader keeps its
-//   own registry, with no public equivalent to read. (A CommonJS dependency
-//   `import`ed from ESM does still go through the cache, so the gap is the ESM
-//   files specifically.)
-// - The inspector reports every script V8 parsed, ESM included, but a module
-//   that is not a script is not one: `.json` and native `.node` addons never
-//   produce a `scriptParsed` event, and only `require.cache` lists them. A
-//   duplicated native addon is worth reporting precisely because it is two
-//   copies of a compiled binary.
-//
-// The CJS cache doubles as the fallback when the inspector is unavailable.
-//
-// @NOTE: in a monorepo checkout Ghost's own copy of a `workspace:*` dependency
-// resolves through a symlink to `packages/<name>`, outside any `node_modules`,
-// and `require.cache` only ever reports that resolved path - so Ghost has no
-// copy to compare against and nothing is reported. Every adapter base class is
-// such a dependency, which makes a local run of `--check-duplicate-deps` a poor
-// rehearsal: it is the installed tree built into the image, where those are
-// ordinary `node_modules` entries, that this is meant to check.
+// @NOTE: this is for the installed tree built into an image, not a local
+// checkout. Ghost's copy of a `workspace:*` dependency - every adapter base class
+// among them - resolves through a symlink to `packages/<name>`, outside any
+// `node_modules`, leaving an adapter's copy with nothing to be compared against.
 
 import fs from 'node:fs';
 import inspector from 'node:inspector';
@@ -56,7 +37,6 @@ export interface PackageLocation {
 /** One physical copy of a package, as loaded into the process. */
 export interface PackageCopy {
   version: string;
-  /** Absolute path of the package directory the copy was loaded from. */
   path: string;
 }
 
@@ -70,19 +50,16 @@ export interface DuplicateDependency {
 export interface DuplicateDependencyReport {
   /** Every duplicate found, in name order. Informational: a duplicate costs memory. */
   duplicates: DuplicateDependency[];
-  /**
-   * The subset that must not be duplicated - a second copy of these is a
-   * correctness problem rather than a size one, so the caller fails on them.
-   */
+  /** The subset that is a correctness problem rather than a size one, so the caller fails. */
   blocking: DuplicateDependency[];
 }
 
 export interface DuplicateDependencyOptions {
-  /** Loaded file paths, i.e. `collectLoadedFiles(Object.keys(require.cache))`. */
+  /** i.e. `collectLoadedFiles(Object.keys(require.cache))`. */
   cachedFiles: Iterable<string>;
   /** Directories custom adapters are installed under, i.e. `adapterPaths`. */
   adapterRoots: string[];
-  /** The `node_modules` directories Ghost itself resolves from, i.e. `module.paths`. */
+  /** Where Ghost's own dependencies resolve from, i.e. `module.paths`. */
   ghostNodeModulesRoots: string[];
   /** Package names a second copy of is a failure, not a note. */
   mustBeSingleCopy: readonly string[];
@@ -93,14 +70,10 @@ const NODE_MODULES = 'node_modules';
 /**
  * The files V8 has parsed in this process, whatever their module format.
  *
- * Enabling the inspector's `Debugger` domain replays a `scriptParsed` event for
- * every script already parsed, so this can run after the adapters have loaded -
- * the same after-the-fact question `require.cache` answers, minus its blind spot
- * for ESM. The events are delivered synchronously while the domain is enabling,
- * so there is nothing to await.
- *
- * Returns nothing when the inspector is unavailable, e.g. a Node built
- * `--without-inspector`, leaving the caller with its CommonJS cache alone.
+ * Enabling the `Debugger` domain replays a `scriptParsed` event for every script
+ * already parsed, synchronously, so this can run after the adapters have and
+ * there is nothing to await. Empty when the inspector is unavailable, e.g. a Node
+ * built `--without-inspector`.
  */
 function parsedScriptFiles(): string[] {
   let session: inspector.Session;
@@ -113,8 +86,8 @@ function parsedScriptFiles(): string[] {
 
   const files: string[] = [];
   session.on('Debugger.scriptParsed', ({ params }) => {
-    // Anything with no file behind it - `node:` internals, `eval`, `data:`
-    // URLs - can't belong to a package, so it is of no interest here.
+    // Nothing with no file behind it - `node:` internals, `eval`, `data:` URLs -
+    // can belong to a package.
     if (!params.url.startsWith('file://')) {
       return;
     }
@@ -122,7 +95,7 @@ function parsedScriptFiles(): string[] {
     try {
       files.push(fileURLToPath(params.url));
     } catch {
-      // A URL Node won't convert back to a path is not a package file either.
+      // Nor anything Node won't convert back to a path.
     }
   });
 
@@ -133,11 +106,7 @@ function parsedScriptFiles(): string[] {
   return files;
 }
 
-/**
- * Every file this process has loaded: the given CommonJS cache keys, which alone
- * carry the JSON and native modules, plus the scripts the inspector can see,
- * which alone carry the ESM graph the cache stops at.
- */
+/** Every file this process has loaded, from both of the sources above. */
 export function collectLoadedFiles(cjsCachedFiles: Iterable<string>): string[] {
   return [...new Set([...cjsCachedFiles, ...parsedScriptFiles()])];
 }
@@ -150,25 +119,18 @@ function realpathOrNull(target: string): string | null {
   }
 }
 
-/**
- * Whether `filePath` sits inside `directory`. Both are expected to be realpaths
- * already - the caller resolves them once rather than per comparison.
- */
+/** Whether `filePath` sits inside `directory`. Both are expected to be realpaths. */
 function isInside(filePath: string, directory: string): boolean {
   const relative = path.relative(directory, filePath);
 
-  // Compare the first segment exactly rather than using startsWith('..'), so an
-  // entry whose name merely begins with dots isn't mistaken for traversal.
+  // Match the first segment exactly, so a name that merely begins with dots
+  // isn't taken for traversal the way startsWith('..') would take it.
   const [firstSegment] = relative.split(path.sep);
 
   return relative !== '' && firstSegment !== '..' && !path.isAbsolute(relative);
 }
 
-/**
- * The version a package declares, or `unknown` when it declares none and when
- * the manifest is unreadable - a missing version is worth reporting alongside
- * the paths rather than dropping the duplicate.
- */
+/** The version a package declares, or `unknown` - better reported than dropped. */
 function readVersion(packagePath: string): string {
   try {
     const { version } = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json'), 'utf8'));
@@ -180,23 +142,18 @@ function readVersion(packagePath: string): string {
 
 /**
  * Attribute a loaded file to the package that physically contains it: whatever
- * the *last* `node_modules` segment of its path names.
- *
- * That holds whatever installer produced the tree - the flat
- * `node_modules/<name>` npm gives an adapter, and the
- * `.pnpm/<name>@<version>/node_modules/<name>` pnpm's isolated layout resolves
- * to - so nothing here has to understand a particular layout's naming. Returns
- * `null` for a file that isn't inside a package at all: Ghost's own source, or an
- * adapter's own `index.js`.
+ * the *last* `node_modules` segment of its path names. That holds for any
+ * installer's layout, npm's flat `node_modules/<name>` and pnpm's
+ * `.pnpm/<name>@<version>/node_modules/<name>` alike. `null` when the file is in
+ * no package: Ghost's own source, or an adapter's own `index.js`.
  */
 export function parsePackageFromPath(filePath: string): PackageLocation | null {
   const segments = filePath.split(path.sep);
   const start = segments.lastIndexOf(NODE_MODULES) + 1;
   const first = segments[start];
 
-  // A dot-prefixed entry is an installer's own bookkeeping directory sitting
-  // next to the packages - pnpm's virtual store, `.bin`, a cache - and npm
-  // forbids a package name from looking like one.
+  // A dot-prefixed entry is an installer's own directory - pnpm's store, `.bin`,
+  // a cache - and npm forbids a package name from looking like one.
   if (start === 0 || !first || first.startsWith('.')) {
     return null;
   }
@@ -216,10 +173,8 @@ export function parsePackageFromPath(filePath: string): PackageLocation | null {
 /**
  * Find packages loaded from both an adapter's dependency tree and Ghost's own.
  *
- * A file belongs to an adapter when it sits under one of the adapter search
- * paths, and to Ghost when it sits under one of the `node_modules` directories
- * Ghost resolves from. Adapters are checked first: `content/adapters` lives
- * inside the Ghost installation, so the two are not mutually exclusive.
+ * Adapters are checked first: `content/adapters` lives inside the Ghost
+ * installation, so the two sides are not mutually exclusive.
  */
 export function checkDuplicateDependencies({
   cachedFiles,
@@ -227,9 +182,8 @@ export function checkDuplicateDependencies({
   ghostNodeModulesRoots,
   mustBeSingleCopy,
 }: DuplicateDependencyOptions): DuplicateDependencyReport {
-  // Node reports realpaths in `require.cache`, and pnpm's layout means the
-  // roots are reached through symlinks, so compare resolved paths - never
-  // specifiers - on both sides.
+  // Compare resolved paths on both sides, never specifiers: `require.cache`
+  // reports realpaths, and pnpm reaches these roots through symlinks.
   const realAdapterRoots = adapterRoots.map(realpathOrNull).filter((root) => root !== null);
   const realGhostRoots = ghostNodeModulesRoots.map(realpathOrNull).filter((root) => root !== null);
 
@@ -250,7 +204,7 @@ export function checkDuplicateDependencies({
     }
 
     if (!inAdapter) {
-      // Ghost's own tree can hold more than one copy of a name; any of them is
+      // Ghost's tree can hold more than one copy of a name, and any of them is
       // the other half of the comparison, so the first one seen will do.
       if (!ghostPackages.has(location.name)) {
         ghostPackages.set(location.name, location.path);
@@ -258,14 +212,13 @@ export function checkDuplicateDependencies({
       continue;
     }
 
-    // Two adapters can each bundle their own copy of the same package, so keep
-    // every distinct location rather than only the first.
+    // Two adapters can each bundle their own copy, so keep every location.
     const packagePaths = adapterPackages.get(location.name) ?? new Set<string>();
     adapterPackages.set(location.name, packagePaths.add(location.path));
   }
 
-  // Versions are only read once both sides are known, so the manifest reads
-  // cost one per reported copy rather than one per cached file.
+  // Reading versions only once both sides are known costs one manifest read per
+  // reported copy, rather than one per cached file.
   const duplicates: DuplicateDependency[] = [];
   for (const [name, packagePaths] of [...adapterPackages].sort(([a], [b]) => a.localeCompare(b))) {
     const ghostPath = ghostPackages.get(name);
@@ -288,9 +241,7 @@ export function checkDuplicateDependencies({
   return { duplicates, blocking: duplicates.filter(({ name }) => singleCopy.has(name)) };
 }
 
-/**
- * Render a report for humans, in the same indented style as the adapter results.
- */
+/** Render a report in the same indented style as the adapter results. */
 export function formatDuplicateReport({ duplicates, blocking }: DuplicateDependencyReport): string {
   if (!duplicates.length) {
     return '  ok    no duplicate dependencies\n';

--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -82,7 +82,7 @@ function reportDuplicateDeps(): boolean {
     // of the comparison rather than an adapter tree.
     adapterRoots: adapterPaths.filter((adapterPath) => adapterPath !== ''),
     ghostNodeModulesRoots: module.paths,
-    mustBeSingleCopy: baseClassPackages,
+    mustBeSingleCopy: Object.values(baseClassPackages),
   });
 
   process.stdout.write(formatDuplicateReport(report));

--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -12,7 +12,11 @@
 // present at build time
 
 import { parseArgs } from 'node:util';
-import { checkDuplicateDependencies, formatDuplicateReport } from './lib/duplicate-deps';
+import {
+  checkDuplicateDependencies,
+  collectLoadedFiles,
+  formatDuplicateReport,
+} from './lib/duplicate-deps';
 import { adapterPaths } from '../core/server/services/adapter-manager/adapter-paths';
 import {
   baseClasses,
@@ -65,15 +69,15 @@ function validate(spec: string): void {
  * Report the packages the loaded adapters brought a second copy of, and say
  * whether any of them must be a single copy.
  *
- * Runs on `require.cache`, so it has to happen after the adapters have been
- * loaded. `module.paths` is where Ghost's own dependencies resolve from - the
+ * Runs on what the process has already loaded, so it has to happen after the
+ * adapters have. `module.paths` is where Ghost's own dependencies resolve from - the
  * `node_modules` directories Node searches from this script upwards, which in a
  * Ghost Pro image reaches the `/home/ghost/node_modules` an adapter's
  * unbundled dependencies fall back to as well.
  */
 function reportDuplicateDeps(): boolean {
   const report = checkDuplicateDependencies({
-    cachedFiles: Object.keys(require.cache),
+    cachedFiles: collectLoadedFiles(Object.keys(require.cache)),
     // The blank entry means "Ghost's own node_modules", which is the other side
     // of the comparison rather than an adapter tree.
     adapterRoots: adapterPaths.filter((adapterPath) => adapterPath !== ''),

--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -2,8 +2,8 @@
 
 // Checks that custom adapters load and implement everything their base class
 // requires. Ghost only verifies an adapter fully on first use (`getAdapter`), so a
-// missing method on a storage adapter otherwise surfaces at first upload; run this
-// at image build time to fail the build instead.
+// missing method on a storage adapter otherwise surfaces at first upload - run
+// this at image build time to fail the build instead.
 //
 // Usage: bin/validate-adapters.js [--check-duplicate-deps] <type>:<AdapterClassName> ...
 //   e.g. bin/validate-adapters.js cache:Redis sso:ProSSO storage:S3Storage
@@ -66,14 +66,10 @@ function validate(spec: string): void {
 }
 
 /**
- * Report the packages the loaded adapters brought a second copy of, and say
- * whether any of them must be a single copy.
- *
- * Runs on what the process has already loaded, so it has to happen after the
- * adapters have. `module.paths` is where Ghost's own dependencies resolve from - the
- * `node_modules` directories Node searches from this script upwards, which in a
- * Ghost Pro image reaches the `/home/ghost/node_modules` an adapter's
- * unbundled dependencies fall back to as well.
+ * Report the packages the loaded adapters brought a second copy of. Reads what the
+ * process has already loaded, so it has to run after the adapters have. In a Ghost
+ * Pro image `module.paths` reaches the `/home/ghost/node_modules` that an adapter's
+ * unbundled dependencies fall back to, which is the other side of the comparison.
  */
 function reportDuplicateDeps(): boolean {
   const report = checkDuplicateDependencies({
@@ -90,10 +86,7 @@ function reportDuplicateDeps(): boolean {
   return report.blocking.length > 0;
 }
 
-/**
- * `parseArgs` is strict, so an unknown or malformed option throws rather than
- * being taken for an adapter name.
- */
+/** `parseArgs` is strict, so a bad option throws instead of passing for a name. */
 function parseCliArgs(argv: string[]) {
   try {
     return parseArgs({
@@ -132,10 +125,9 @@ function main(argv: string[]): void {
     }
   }
 
-  // Off unless asked for: adapters also resolve out of content/adapters, where
-  // a self-hosted adapter may legitimately bundle its own dependencies, and
-  // that must not fail anyone's build. Only the image build that installs
-  // adapters into a dedicated directory opts in.
+  // Off unless asked for: a self-hosted adapter in content/adapters may
+  // legitimately bundle its own dependencies, and that must not fail anyone's
+  // build. Only the image build installing adapters itself opts in.
   const duplicatesBlocked = values['check-duplicate-deps'] && reportDuplicateDeps();
 
   if (failures.length) {

--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -5,15 +5,21 @@
 // missing method on a storage adapter otherwise surfaces at first upload; run this
 // at image build time to fail the build instead.
 //
-// Usage: bin/validate-adapters.js <type>:<AdapterClassName> ...
+// Usage: bin/validate-adapters.js [--check-duplicate-deps] <type>:<AdapterClassName> ...
 //   e.g. bin/validate-adapters.js cache:Redis sso:ProSSO storage:S3Storage
 //
 // Adapters are named explicitly rather than read from config, which may not be
 // present at build time
 
+import { checkDuplicateDependencies, formatDuplicateReport } from './lib/duplicate-deps';
 import { adapterPaths } from '../core/server/services/adapter-manager/adapter-paths';
-import { baseClasses } from '../core/server/services/adapter-manager/base-classes';
+import {
+  baseClasses,
+  baseClassPackages,
+} from '../core/server/services/adapter-manager/base-classes';
 import { loadAdapterClass } from '../core/server/services/adapter-manager/utils';
+
+const DUPLICATE_DEPS_FLAG = '--check-duplicate-deps';
 
 type AdapterType = keyof typeof baseClasses;
 
@@ -56,9 +62,43 @@ function validate(spec: string): void {
   }
 }
 
-function main(specs: string[]): void {
-  if (!specs.length) {
-    process.stderr.write('Usage: bin/validate-adapters.js <type>:<AdapterClassName> ...\n');
+/**
+ * Report the packages the loaded adapters brought a second copy of, and say
+ * whether any of them must be a single copy.
+ *
+ * Runs on `require.cache`, so it has to happen after the adapters have been
+ * loaded. `module.paths` is where Ghost's own dependencies resolve from - the
+ * `node_modules` directories Node searches from this script upwards, which in a
+ * Ghost Pro image reaches the `/home/ghost/node_modules` an adapter's
+ * unbundled dependencies fall back to as well.
+ */
+function reportDuplicateDeps(): boolean {
+  const report = checkDuplicateDependencies({
+    cachedFiles: Object.keys(require.cache),
+    // The blank entry means "Ghost's own node_modules", which is the other side
+    // of the comparison rather than an adapter tree.
+    adapterRoots: adapterPaths.filter((adapterPath) => adapterPath !== ''),
+    ghostNodeModulesRoots: module.paths,
+    mustBeSingleCopy: baseClassPackages,
+  });
+
+  process.stdout.write(formatDuplicateReport(report));
+
+  return report.blocking.length > 0;
+}
+
+function main(argv: string[]): void {
+  const flags = argv.filter((arg) => arg.startsWith('--'));
+  const specs = argv.filter((arg) => !arg.startsWith('--'));
+
+  const unknownFlags = flags.filter((flag) => flag !== DUPLICATE_DEPS_FLAG);
+  if (!specs.length || unknownFlags.length) {
+    if (unknownFlags.length) {
+      process.stderr.write(`Unknown option(s): ${unknownFlags.join(', ')}\n`);
+    }
+    process.stderr.write(
+      `Usage: bin/validate-adapters.js [${DUPLICATE_DEPS_FLAG}] <type>:<AdapterClassName> ...\n`,
+    );
     process.exit(1);
   }
 
@@ -74,11 +114,20 @@ function main(specs: string[]): void {
     }
   }
 
+  // Off unless asked for: adapters also resolve out of content/adapters, where
+  // a self-hosted adapter may legitimately bundle its own dependencies, and
+  // that must not fail anyone's build. Only the image build that installs
+  // adapters into a dedicated directory opts in.
+  const duplicatesBlocked = flags.includes(DUPLICATE_DEPS_FLAG) && reportDuplicateDeps();
+
   if (failures.length) {
     process.stderr.write(`\n${failures.length} of ${specs.length} adapter(s) failed validation:\n`);
     for (const { spec, message } of failures) {
       process.stderr.write(`- ${spec}: ${message}\n`);
     }
+  }
+
+  if (failures.length || duplicatesBlocked) {
     process.exit(1);
   }
 

--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -11,6 +11,7 @@
 // Adapters are named explicitly rather than read from config, which may not be
 // present at build time
 
+import { parseArgs } from 'node:util';
 import { checkDuplicateDependencies, formatDuplicateReport } from './lib/duplicate-deps';
 import { adapterPaths } from '../core/server/services/adapter-manager/adapter-paths';
 import {
@@ -18,8 +19,6 @@ import {
   baseClassPackages,
 } from '../core/server/services/adapter-manager/base-classes';
 import { loadAdapterClass } from '../core/server/services/adapter-manager/utils';
-
-const DUPLICATE_DEPS_FLAG = '--check-duplicate-deps';
 
 type AdapterType = keyof typeof baseClasses;
 
@@ -87,20 +86,35 @@ function reportDuplicateDeps(): boolean {
   return report.blocking.length > 0;
 }
 
-function main(argv: string[]): void {
-  const flags = argv.filter((arg) => arg.startsWith('--'));
-  const specs = argv.filter((arg) => !arg.startsWith('--'));
+/**
+ * `parseArgs` is strict, so an unknown or malformed option throws rather than
+ * being taken for an adapter name.
+ */
+function parseCliArgs(argv: string[]) {
+  try {
+    return parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        'check-duplicate-deps': { type: 'boolean', default: false },
+      },
+    });
+  } catch (err) {
+    process.stderr.write(`${(err as Error).message}\n`);
+    return null;
+  }
+}
 
-  const unknownFlags = flags.filter((flag) => flag !== DUPLICATE_DEPS_FLAG);
-  if (!specs.length || unknownFlags.length) {
-    if (unknownFlags.length) {
-      process.stderr.write(`Unknown option(s): ${unknownFlags.join(', ')}\n`);
-    }
+function main(argv: string[]): void {
+  const parsed = parseCliArgs(argv);
+  if (!parsed?.positionals.length) {
     process.stderr.write(
-      `Usage: bin/validate-adapters.js [${DUPLICATE_DEPS_FLAG}] <type>:<AdapterClassName> ...\n`,
+      'Usage: bin/validate-adapters.js [--check-duplicate-deps] <type>:<AdapterClassName> ...\n',
     );
     process.exit(1);
   }
+
+  const { values, positionals: specs } = parsed;
 
   const failures: { spec: string; message: string }[] = [];
 
@@ -118,7 +132,7 @@ function main(argv: string[]): void {
   // a self-hosted adapter may legitimately bundle its own dependencies, and
   // that must not fail anyone's build. Only the image build that installs
   // adapters into a dedicated directory opts in.
-  const duplicatesBlocked = flags.includes(DUPLICATE_DEPS_FLAG) && reportDuplicateDeps();
+  const duplicatesBlocked = values['check-duplicate-deps'] && reportDuplicateDeps();
 
   if (failures.length) {
     process.stderr.write(`\n${failures.length} of ${specs.length} adapter(s) failed validation:\n`);

--- a/ghost/core/core/server/services/adapter-manager/base-classes.ts
+++ b/ghost/core/core/server/services/adapter-manager/base-classes.ts
@@ -10,8 +10,7 @@ import type { BaseClassMap } from './adapter-manager';
 
 /**
  * The base class every adapter of a given type must extend. Also read by
- * bin/validate-adapters.js, which checks adapter implementations at build time -
- * keep this the only place the mapping is declared.
+ * bin/validate-adapters.js, so keep this the only place the mapping is declared.
  */
 export const baseClasses = {
   storage: StorageBase,
@@ -24,18 +23,14 @@ export const baseClasses = {
 } satisfies BaseClassMap;
 
 /**
- * The package each base class above is imported from, keyed by adapter type so
- * that `satisfies` makes the compiler demand one entry per type in
- * `baseClasses` - a new adapter type can't be added without naming its package.
+ * The package each base class above is imported from. An adapter that installs
+ * one of these itself gets a second copy of the base class - a different function
+ * object, so `instanceof` fails and Ghost falls back to comparing class names.
+ * bin/validate-adapters.js fails a build on such a duplicate, where a duplicate
+ * of any other package is only reported.
  *
- * An adapter that installs one of these itself gets a second copy of the base
- * class, which is a different function object - so `instanceof` fails and
- * Ghost has to fall back to comparing class names. bin/validate-adapters.js
- * uses this list to fail a build on such a duplicate, where a duplicate of any
- * other package is only reported.
- *
- * The names have to match the imports at the top of this file; a unit test keeps
- * the two in sync.
+ * Keyed by adapter type so `satisfies` demands an entry per type in
+ * `baseClasses`; a unit test keeps the names matching the imports above.
  */
 export const baseClassPackages = {
   storage: 'ghost-storage-base',

--- a/ghost/core/core/server/services/adapter-manager/base-classes.ts
+++ b/ghost/core/core/server/services/adapter-manager/base-classes.ts
@@ -22,3 +22,25 @@ export const baseClasses = {
   'route-settings': RouteSettingsStoreBase,
   jobs: JobsBackendBase,
 } satisfies BaseClassMap;
+
+/**
+ * The packages the base classes above are imported from.
+ *
+ * An adapter that installs one of these itself gets a second copy of the base
+ * class, which is a different function object - so `instanceof` fails and
+ * Ghost has to fall back to comparing class names. bin/validate-adapters.js
+ * uses this list to fail a build on such a duplicate, where a duplicate of any
+ * other package is only reported.
+ *
+ * Derived from the imports at the top of this file; a unit test keeps the two
+ * in sync.
+ */
+export const baseClassPackages = [
+  'ghost-storage-base',
+  '@tryghost/adapter-base-scheduling',
+  '@tryghost/adapter-base-sso',
+  '@tryghost/adapter-base-cache',
+  '@tryghost/adapter-base-redirects',
+  '@tryghost/adapter-base-route-settings',
+  '@tryghost/adapter-base-jobs',
+] as const;

--- a/ghost/core/core/server/services/adapter-manager/base-classes.ts
+++ b/ghost/core/core/server/services/adapter-manager/base-classes.ts
@@ -24,7 +24,9 @@ export const baseClasses = {
 } satisfies BaseClassMap;
 
 /**
- * The packages the base classes above are imported from.
+ * The package each base class above is imported from, keyed by adapter type so
+ * that `satisfies` makes the compiler demand one entry per type in
+ * `baseClasses` - a new adapter type can't be added without naming its package.
  *
  * An adapter that installs one of these itself gets a second copy of the base
  * class, which is a different function object - so `instanceof` fails and
@@ -32,15 +34,15 @@ export const baseClasses = {
  * uses this list to fail a build on such a duplicate, where a duplicate of any
  * other package is only reported.
  *
- * Derived from the imports at the top of this file; a unit test keeps the two
- * in sync.
+ * The names have to match the imports at the top of this file; a unit test keeps
+ * the two in sync.
  */
-export const baseClassPackages = [
-  'ghost-storage-base',
-  '@tryghost/adapter-base-scheduling',
-  '@tryghost/adapter-base-sso',
-  '@tryghost/adapter-base-cache',
-  '@tryghost/adapter-base-redirects',
-  '@tryghost/adapter-base-route-settings',
-  '@tryghost/adapter-base-jobs',
-] as const;
+export const baseClassPackages = {
+  storage: 'ghost-storage-base',
+  scheduling: '@tryghost/adapter-base-scheduling',
+  sso: '@tryghost/adapter-base-sso',
+  cache: '@tryghost/adapter-base-cache',
+  redirects: '@tryghost/adapter-base-redirects',
+  'route-settings': '@tryghost/adapter-base-route-settings',
+  jobs: '@tryghost/adapter-base-jobs',
+} satisfies Record<keyof typeof baseClasses, string>;

--- a/ghost/core/test/unit/bin/duplicate-deps.test.ts
+++ b/ghost/core/test/unit/bin/duplicate-deps.test.ts
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  checkDuplicateDependencies,
+  formatDuplicateReport,
+  parsePackageFromPath,
+} from '../../../bin/lib/duplicate-deps';
+
+/**
+ * Write a package into a `node_modules` directory and return the path of the
+ * file a `require()` of it would end up caching.
+ */
+function writePackage(nodeModules: string, name: string, version: string): string {
+  const packagePath = path.join(nodeModules, ...name.split('/'));
+  fs.mkdirSync(packagePath, { recursive: true });
+  fs.writeFileSync(path.join(packagePath, 'package.json'), JSON.stringify({ name, version }));
+  fs.writeFileSync(path.join(packagePath, 'index.js'), 'module.exports = {};\n');
+
+  return path.join(packagePath, 'index.js');
+}
+
+/**
+ * The same, but in pnpm's isolated layout - the real files live in the virtual
+ * store and the name at the root of `node_modules` is only a symlink to them,
+ * which is how Ghost's own dependencies are installed.
+ */
+function writePnpmPackage(nodeModules: string, name: string, version: string): string {
+  const storeDirName = `${name.replace('/', '+')}@${version}`;
+  const store = path.join(nodeModules, '.pnpm', storeDirName, 'node_modules');
+  const indexPath = writePackage(store, name, version);
+
+  const linkPath = path.join(nodeModules, ...name.split('/'));
+  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+  fs.symlinkSync(path.dirname(indexPath), linkPath, 'dir');
+
+  return indexPath;
+}
+
+describe('bin/lib/duplicate-deps', function () {
+  describe('parsePackageFromPath', function () {
+    it('attributes a file to the package directory that contains it', function () {
+      assert.deepEqual(
+        parsePackageFromPath('/home/ghost/adapters/storage/S3Storage/node_modules/lodash/index.js'),
+        {
+          name: 'lodash',
+          path: '/home/ghost/adapters/storage/S3Storage/node_modules/lodash',
+        },
+      );
+    });
+
+    it("reads a scoped package out of pnpm's store layout, peer suffix and all", function () {
+      // The store directory name is never parsed - the package is whatever the
+      // last `node_modules` segment names - so pnpm's encoding of the scope
+      // (`+`) and of peer dependencies (`_`) doesn't have to be understood.
+      assert.deepEqual(
+        parsePackageFromPath(
+          '/home/ghost/node_modules/.pnpm/@tryghost+metrics@1.0.3_pg@8.11.0/node_modules/@tryghost/metrics/lib/index.js',
+        ),
+        {
+          name: '@tryghost/metrics',
+          path: '/home/ghost/node_modules/.pnpm/@tryghost+metrics@1.0.3_pg@8.11.0/node_modules/@tryghost/metrics',
+        },
+      );
+    });
+
+    it('attributes a nested dependency to the package that physically contains it', function () {
+      assert.deepEqual(
+        parsePackageFromPath(
+          '/home/ghost/node_modules/.pnpm/outer@1.0.0/node_modules/outer/node_modules/inner/index.js',
+        ),
+        {
+          name: 'inner',
+          path: '/home/ghost/node_modules/.pnpm/outer@1.0.0/node_modules/outer/node_modules/inner',
+        },
+      );
+    });
+
+    it('returns null for a file that is not inside a package', function () {
+      assert.equal(parsePackageFromPath('/home/ghost/current/core/server/boot.js'), null);
+      assert.equal(parsePackageFromPath('/home/ghost/adapters/storage/S3Storage/index.js'), null);
+      assert.equal(parsePackageFromPath('/home/ghost/node_modules/.pnpm/lock.yaml'), null);
+    });
+  });
+
+  describe('checkDuplicateDependencies', function () {
+    let tmpDir: string;
+    let ghostNodeModules: string;
+    let adapterRoot: string;
+    let adapterNodeModules: string;
+
+    // Two trees, the way Ghost Pro installs them: Ghost's own dependencies in
+    // pnpm's isolated layout, and a self-contained adapter directory carrying
+    // whatever it installed for itself.
+    beforeEach(function () {
+      tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-duplicate-deps-')));
+      ghostNodeModules = path.join(tmpDir, 'ghost', 'node_modules');
+      adapterRoot = path.join(tmpDir, 'adapters');
+      adapterNodeModules = path.join(adapterRoot, 'storage', 'S3Storage', 'node_modules');
+      fs.mkdirSync(ghostNodeModules, { recursive: true });
+      fs.mkdirSync(adapterNodeModules, { recursive: true });
+    });
+
+    afterEach(function () {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function check(cachedFiles: string[], mustBeSingleCopy: string[] = ['ghost-storage-base']) {
+      return checkDuplicateDependencies({
+        cachedFiles,
+        adapterRoots: [adapterRoot],
+        ghostNodeModulesRoots: [ghostNodeModules],
+        mustBeSingleCopy,
+      });
+    }
+
+    it("reports nothing when the adapter shares Ghost's copy of every package", function () {
+      const sharedBase = writePnpmPackage(ghostNodeModules, 'ghost-storage-base', '1.1.0');
+      const sharedLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
+      const adapterOwn = writePackage(adapterNodeModules, 'aws-sdk', '2.1.0');
+
+      const report = check([sharedBase, sharedLodash, adapterOwn]);
+
+      assert.deepEqual(report.duplicates, []);
+      assert.deepEqual(report.blocking, []);
+    });
+
+    it('reports a package the adapter brought its own copy of, without blocking', function () {
+      const ghostLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
+      const adapterLodash = writePackage(adapterNodeModules, 'lodash', '4.17.21');
+
+      const report = check([ghostLodash, adapterLodash]);
+
+      assert.deepEqual(report.duplicates, [
+        {
+          name: 'lodash',
+          adapter: {
+            name: 'lodash',
+            version: '4.17.21',
+            path: path.join(adapterNodeModules, 'lodash'),
+          },
+          ghost: {
+            name: 'lodash',
+            version: '4.17.20',
+            path: path.dirname(ghostLodash),
+          },
+        },
+      ]);
+      assert.deepEqual(report.blocking, []);
+    });
+
+    it('blocks on a duplicate of a package that must be a single copy', function () {
+      const ghostBase = writePnpmPackage(ghostNodeModules, 'ghost-storage-base', '1.1.0');
+      const adapterBase = writePackage(adapterNodeModules, 'ghost-storage-base', '1.1.0');
+      const adapterLodash = writePackage(adapterNodeModules, 'lodash', '4.17.21');
+      const ghostLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
+
+      const report = check([ghostBase, adapterBase, ghostLodash, adapterLodash]);
+
+      // Reported in name order, and the identical version still counts: two
+      // copies of the base class are still two function objects.
+      assert.deepEqual(
+        report.duplicates.map(({ name }) => name),
+        ['ghost-storage-base', 'lodash'],
+      );
+      assert.deepEqual(
+        report.blocking.map(({ name }) => name),
+        ['ghost-storage-base'],
+      );
+      assert.equal(
+        report.blocking[0].adapter.path,
+        path.join(adapterNodeModules, 'ghost-storage-base'),
+      );
+      assert.equal(report.blocking[0].ghost.path, path.dirname(ghostBase));
+    });
+
+    it('resolves symlinks before deciding which tree a file came from', function () {
+      // Requiring `lodash` from Ghost caches pnpm's store path, but an adapter
+      // requiring it through the root symlink could surface the link path -
+      // both are the same copy and must not look like a duplicate.
+      const ghostLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
+      const throughSymlink = path.join(ghostNodeModules, 'lodash', 'index.js');
+
+      const report = check([throughSymlink]);
+
+      assert.deepEqual(report.duplicates, []);
+      assert.equal(
+        parsePackageFromPath(fs.realpathSync(throughSymlink))?.path,
+        path.dirname(ghostLodash),
+      );
+    });
+
+    it("treats an adapter installed inside the Ghost directory as the adapter's tree", function () {
+      // content/adapters lives inside the installation, so an adapter path and
+      // Ghost's root are not mutually exclusive - the adapter has to win.
+      const contentAdapters = path.join(tmpDir, 'ghost', 'content', 'adapters');
+      const contentAdapterNodeModules = path.join(
+        contentAdapters,
+        'cache',
+        'Redis',
+        'node_modules',
+      );
+      fs.mkdirSync(contentAdapterNodeModules, { recursive: true });
+
+      const ghostIoredis = writePnpmPackage(ghostNodeModules, 'ioredis', '5.3.0');
+      const adapterIoredis = writePackage(contentAdapterNodeModules, 'ioredis', '5.4.0');
+
+      const report = checkDuplicateDependencies({
+        cachedFiles: [ghostIoredis, adapterIoredis],
+        adapterRoots: [contentAdapters],
+        ghostNodeModulesRoots: [ghostNodeModules],
+        mustBeSingleCopy: [],
+      });
+
+      assert.equal(report.duplicates.length, 1);
+      assert.equal(report.duplicates[0].adapter.version, '5.4.0');
+      assert.equal(report.duplicates[0].ghost.version, '5.3.0');
+    });
+
+    it('reports a copy whose manifest cannot be read as an unknown version', function () {
+      const ghostLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
+      const adapterLodash = path.join(adapterNodeModules, 'lodash', 'index.js');
+      fs.mkdirSync(path.dirname(adapterLodash), { recursive: true });
+      fs.writeFileSync(adapterLodash, 'module.exports = {};\n');
+
+      const report = check([ghostLodash, adapterLodash]);
+
+      assert.equal(report.duplicates.length, 1);
+      assert.equal(report.duplicates[0].adapter.version, 'unknown');
+      assert.equal(report.duplicates[0].ghost.version, '4.17.20');
+    });
+
+    it('ignores adapter paths that do not exist', function () {
+      const ghostLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
+
+      const report = checkDuplicateDependencies({
+        cachedFiles: [ghostLodash],
+        adapterRoots: [path.join(tmpDir, 'nope'), adapterRoot],
+        ghostNodeModulesRoots: [ghostNodeModules],
+        mustBeSingleCopy: [],
+      });
+
+      assert.deepEqual(report.duplicates, []);
+    });
+  });
+
+  describe('formatDuplicateReport', function () {
+    const duplicate = {
+      name: 'ghost-storage-base',
+      adapter: {
+        name: 'ghost-storage-base',
+        version: '1.1.0',
+        path: '/home/ghost/adapters/storage/S3Storage/node_modules/ghost-storage-base',
+      },
+      ghost: {
+        name: 'ghost-storage-base',
+        version: '1.1.1',
+        path: '/home/ghost/node_modules/ghost-storage-base',
+      },
+    };
+
+    it('says so when there is nothing to report', function () {
+      const output = formatDuplicateReport({ duplicates: [], blocking: [] });
+
+      assert.match(output, /^ {2}ok {4}no duplicate dependencies\n$/);
+    });
+
+    it('names both copies, and passes when none of them must be a single copy', function () {
+      const output = formatDuplicateReport({ duplicates: [duplicate], blocking: [] });
+
+      assert.match(output, /1 package\(s\) loaded from both an adapter and Ghost/);
+      assert.match(output, /adapter 1\.1\.0 {2}\/home\/ghost\/adapters/);
+      assert.match(output, /ghost {3}1\.1\.1 {2}\/home\/ghost\/node_modules/);
+      assert.ok(!output.includes('FAIL'));
+    });
+
+    it('marks a blocking duplicate as a failure', function () {
+      const output = formatDuplicateReport({ duplicates: [duplicate], blocking: [duplicate] });
+
+      assert.match(output, / {2}FAIL {2}duplicate dependencies: ghost-storage-base\n/);
+    });
+  });
+});

--- a/ghost/core/test/unit/bin/duplicate-deps.test.ts
+++ b/ghost/core/test/unit/bin/duplicate-deps.test.ts
@@ -86,7 +86,13 @@ describe('bin/lib/duplicate-deps', function () {
     it('returns null for a file that is not inside a package', function () {
       assert.equal(parsePackageFromPath('/home/ghost/current/core/server/boot.js'), null);
       assert.equal(parsePackageFromPath('/home/ghost/adapters/storage/S3Storage/index.js'), null);
+    });
+
+    it("returns null for an installer's own directories, which are not packages", function () {
+      // npm forbids a package name starting with a dot, so the whole class of
+      // them can be skipped without enumerating each installer's layout.
       assert.equal(parsePackageFromPath('/home/ghost/node_modules/.pnpm/lock.yaml'), null);
+      assert.equal(parsePackageFromPath('/home/ghost/node_modules/.bin/knex-migrator'), null);
     });
   });
 
@@ -173,16 +179,8 @@ describe('bin/lib/duplicate-deps', function () {
       assert.deepEqual(report.duplicates, [
         {
           name: 'lodash',
-          adapter: {
-            name: 'lodash',
-            version: '4.17.21',
-            path: path.join(adapterNodeModules, 'lodash'),
-          },
-          ghost: {
-            name: 'lodash',
-            version: '4.17.20',
-            path: path.dirname(ghostLodash),
-          },
+          adapter: { version: '4.17.21', path: path.join(adapterNodeModules, 'lodash') },
+          ghost: { version: '4.17.20', path: path.dirname(ghostLodash) },
         },
       ]);
       assert.deepEqual(report.blocking, []);
@@ -287,15 +285,10 @@ describe('bin/lib/duplicate-deps', function () {
     const duplicate = {
       name: 'ghost-storage-base',
       adapter: {
-        name: 'ghost-storage-base',
         version: '1.1.0',
         path: '/home/ghost/adapters/storage/S3Storage/node_modules/ghost-storage-base',
       },
-      ghost: {
-        name: 'ghost-storage-base',
-        version: '1.1.1',
-        path: '/home/ghost/node_modules/ghost-storage-base',
-      },
+      ghost: { version: '1.1.1', path: '/home/ghost/node_modules/ghost-storage-base' },
     };
 
     it('says so when there is nothing to report', function () {

--- a/ghost/core/test/unit/bin/duplicate-deps.test.ts
+++ b/ghost/core/test/unit/bin/duplicate-deps.test.ts
@@ -2,11 +2,17 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   checkDuplicateDependencies,
+  collectLoadedFiles,
   formatDuplicateReport,
   parsePackageFromPath,
 } from '../../../bin/lib/duplicate-deps';
+
+// The fixture below lives outside the project, so the test runner leaves this
+// import to Node and the file is loaded the way an ESM adapter would be.
+const nativeImport = (specifier: string) => import(/* @vite-ignore */ specifier);
 
 /**
  * Write a package into a `node_modules` directory and return the path of the
@@ -81,6 +87,38 @@ describe('bin/lib/duplicate-deps', function () {
       assert.equal(parsePackageFromPath('/home/ghost/current/core/server/boot.js'), null);
       assert.equal(parsePackageFromPath('/home/ghost/adapters/storage/S3Storage/index.js'), null);
       assert.equal(parsePackageFromPath('/home/ghost/node_modules/.pnpm/lock.yaml'), null);
+    });
+  });
+
+  describe('collectLoadedFiles', function () {
+    it('keeps the CommonJS cache it is given, without duplicating entries', function () {
+      const files = collectLoadedFiles([
+        '/home/ghost/a.js',
+        '/home/ghost/a.js',
+        '/home/ghost/b.js',
+      ]);
+
+      assert.deepEqual(
+        files.filter((file) => file.startsWith('/home/ghost/')),
+        ['/home/ghost/a.js', '/home/ghost/b.js'],
+      );
+    });
+
+    it('sees an ESM module, which the CommonJS cache never contains', async function () {
+      const tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-esm-deps-')));
+      const modulePath = path.join(tmpDir, 'adapter.mjs');
+      fs.writeFileSync(modulePath, 'export const loaded = true;\n');
+
+      try {
+        await nativeImport(pathToFileURL(modulePath).href);
+
+        assert.ok(
+          collectLoadedFiles([]).includes(modulePath),
+          'expected the imported ESM file to be reported as loaded',
+        );
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/ghost/core/test/unit/bin/duplicate-deps.test.ts
+++ b/ghost/core/test/unit/bin/duplicate-deps.test.ts
@@ -10,14 +10,11 @@ import {
   parsePackageFromPath,
 } from '../../../bin/lib/duplicate-deps';
 
-// The fixture below lives outside the project, so the test runner leaves this
-// import to Node and the file is loaded the way an ESM adapter would be.
+// The fixture lives outside the project, so the runner leaves this import to Node
+// and the file loads the way an ESM adapter would.
 const nativeImport = (specifier: string) => import(/* @vite-ignore */ specifier);
 
-/**
- * Write a package into a `node_modules` directory and return the path of the
- * file a `require()` of it would end up caching.
- */
+/** Write a package, returning the file path a `require()` of it would cache. */
 function writePackage(nodeModules: string, name: string, version: string): string {
   const packagePath = path.join(nodeModules, ...name.split('/'));
   fs.mkdirSync(packagePath, { recursive: true });
@@ -28,9 +25,8 @@ function writePackage(nodeModules: string, name: string, version: string): strin
 }
 
 /**
- * The same, but in pnpm's isolated layout - the real files live in the virtual
- * store and the name at the root of `node_modules` is only a symlink to them,
- * which is how Ghost's own dependencies are installed.
+ * The same in pnpm's isolated layout, how Ghost's own dependencies are installed:
+ * the files live in the virtual store and the root name is only a symlink to them.
  */
 function writePnpmPackage(nodeModules: string, name: string, version: string): string {
   const storeDirName = `${name.replace('/', '+')}@${version}`;
@@ -57,8 +53,7 @@ describe('bin/lib/duplicate-deps', function () {
     });
 
     it("reads a scoped package out of pnpm's store layout, peer suffix and all", function () {
-      // The store directory name is never parsed - the package is whatever the
-      // last `node_modules` segment names - so pnpm's encoding of the scope
+      // The store directory name is never parsed, so pnpm's encoding of the scope
       // (`+`) and of peer dependencies (`_`) doesn't have to be understood.
       assert.deepEqual(
         parsePackageFromPath(
@@ -89,8 +84,8 @@ describe('bin/lib/duplicate-deps', function () {
     });
 
     it("returns null for an installer's own directories, which are not packages", function () {
-      // npm forbids a package name starting with a dot, so the whole class of
-      // them can be skipped without enumerating each installer's layout.
+      // npm forbids a leading dot in a package name, so the whole class of them
+      // goes without enumerating each installer's layout.
       assert.equal(parsePackageFromPath('/home/ghost/node_modules/.pnpm/lock.yaml'), null);
       assert.equal(parsePackageFromPath('/home/ghost/node_modules/.bin/knex-migrator'), null);
     });
@@ -134,9 +129,8 @@ describe('bin/lib/duplicate-deps', function () {
     let adapterRoot: string;
     let adapterNodeModules: string;
 
-    // Two trees, the way Ghost Pro installs them: Ghost's own dependencies in
-    // pnpm's isolated layout, and a self-contained adapter directory carrying
-    // whatever it installed for itself.
+    // Two trees, the way Ghost Pro installs them: Ghost's dependencies in pnpm's
+    // isolated layout, and a self-contained adapter directory beside them.
     beforeEach(function () {
       tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-duplicate-deps-')));
       ghostNodeModules = path.join(tmpDir, 'ghost', 'node_modules');
@@ -194,8 +188,8 @@ describe('bin/lib/duplicate-deps', function () {
 
       const report = check([ghostBase, adapterBase, ghostLodash, adapterLodash]);
 
-      // Reported in name order, and the identical version still counts: two
-      // copies of the base class are still two function objects.
+      // Name order, and the identical version still counts: two copies of the
+      // base class are still two function objects.
       assert.deepEqual(
         report.duplicates.map(({ name }) => name),
         ['ghost-storage-base', 'lodash'],
@@ -212,9 +206,8 @@ describe('bin/lib/duplicate-deps', function () {
     });
 
     it('resolves symlinks before deciding which tree a file came from', function () {
-      // Requiring `lodash` from Ghost caches pnpm's store path, but an adapter
-      // requiring it through the root symlink could surface the link path -
-      // both are the same copy and must not look like a duplicate.
+      // Ghost caches pnpm's store path, but an adapter requiring the same copy
+      // through the root symlink could surface the link path instead.
       const ghostLodash = writePnpmPackage(ghostNodeModules, 'lodash', '4.17.20');
       const throughSymlink = path.join(ghostNodeModules, 'lodash', 'index.js');
 
@@ -228,8 +221,8 @@ describe('bin/lib/duplicate-deps', function () {
     });
 
     it("treats an adapter installed inside the Ghost directory as the adapter's tree", function () {
-      // content/adapters lives inside the installation, so an adapter path and
-      // Ghost's root are not mutually exclusive - the adapter has to win.
+      // content/adapters lives inside the installation, so the two aren't
+      // mutually exclusive - the adapter has to win.
       const contentAdapters = path.join(tmpDir, 'ghost', 'content', 'adapters');
       const contentAdapterNodeModules = path.join(
         contentAdapters,

--- a/ghost/core/test/unit/server/services/adapter-manager/base-classes.test.ts
+++ b/ghost/core/test/unit/server/services/adapter-manager/base-classes.test.ts
@@ -10,11 +10,10 @@ const sourcePath = path.join(
 
 describe('base-classes', function () {
   it('names exactly the packages the base classes are imported from', function () {
-    // bin/validate-adapters.js fails a build when an adapter ships its own copy
-    // of one of these, so a name drifting out of step with the imports would
-    // silently stop covering a base class. Both live in this one file, so the
-    // imports are the source of truth. (That every adapter type has an entry at
-    // all is enforced by the compiler, not here.)
+    // bin/validate-adapters.js fails a build when an adapter ships its own copy of
+    // one of these, so a name drifting from the imports would silently stop
+    // covering a base class. Both live in this file, so the imports win. (That
+    // every type has an entry at all is the compiler's job, not this test's.)
     const source = fs.readFileSync(sourcePath, 'utf8');
     const imported = [...source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)';$/gm)]
       .map(([, specifier]) => specifier)

--- a/ghost/core/test/unit/server/services/adapter-manager/base-classes.test.ts
+++ b/ghost/core/test/unit/server/services/adapter-manager/base-classes.test.ts
@@ -1,10 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  baseClasses,
-  baseClassPackages,
-} from '../../../../../core/server/services/adapter-manager/base-classes';
+import { baseClassPackages } from '../../../../../core/server/services/adapter-manager/base-classes';
 
 const sourcePath = path.join(
   __dirname,
@@ -12,17 +9,17 @@ const sourcePath = path.join(
 );
 
 describe('base-classes', function () {
-  it('lists exactly the packages the base classes are imported from', function () {
+  it('names exactly the packages the base classes are imported from', function () {
     // bin/validate-adapters.js fails a build when an adapter ships its own copy
-    // of one of these, so the list drifting out of step with the imports would
+    // of one of these, so a name drifting out of step with the imports would
     // silently stop covering a base class. Both live in this one file, so the
-    // imports are the source of truth.
+    // imports are the source of truth. (That every adapter type has an entry at
+    // all is enforced by the compiler, not here.)
     const source = fs.readFileSync(sourcePath, 'utf8');
     const imported = [...source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)';$/gm)]
       .map(([, specifier]) => specifier)
       .filter((specifier) => !specifier.startsWith('.'));
 
-    assert.deepEqual([...baseClassPackages], imported);
-    assert.equal(baseClassPackages.length, Object.keys(baseClasses).length);
+    assert.deepEqual(Object.values(baseClassPackages).sort(), imported.sort());
   });
 });

--- a/ghost/core/test/unit/server/services/adapter-manager/base-classes.test.ts
+++ b/ghost/core/test/unit/server/services/adapter-manager/base-classes.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  baseClasses,
+  baseClassPackages,
+} from '../../../../../core/server/services/adapter-manager/base-classes';
+
+const sourcePath = path.join(
+  __dirname,
+  '../../../../../core/server/services/adapter-manager/base-classes.ts',
+);
+
+describe('base-classes', function () {
+  it('lists exactly the packages the base classes are imported from', function () {
+    // bin/validate-adapters.js fails a build when an adapter ships its own copy
+    // of one of these, so the list drifting out of step with the imports would
+    // silently stop covering a base class. Both live in this one file, so the
+    // imports are the source of truth.
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const imported = [...source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)';$/gm)]
+      .map(([, specifier]) => specifier)
+      .filter((specifier) => !specifier.startsWith('.'));
+
+    assert.deepEqual([...baseClassPackages], imported);
+    assert.equal(baseClassPackages.length, Object.keys(baseClasses).length);
+  });
+});


### PR DESCRIPTION
no ref

Custom adapters are installed as self-contained directories with their own
node_modules, so anything an adapter installs itself is loaded a second time
alongside Ghost's copy. That is invisible today, and it has consequences: two
copies of a base class break `instanceof` (both the adapter manager and this
script already carry a name-based fallback for it), and two copies of a package
with module-level state behave differently - @tryghost/logging survives it by
caching on globalThis, @tryghost/metrics would build a second instance.

`--check-duplicate-deps` inspects require.cache after the named adapters have
loaded and reports every package resolved from both an adapter's tree and
Ghost's own. Reporting and failing are separated: a duplicate usually only
costs memory, so failing a build over one would block a release for an
optimisation regression. Only the packages the base classes come from fail the
run, since a second copy of those is a correctness problem.

The flag defaults to off because adapters also resolve out of content/adapters,
where a self-hosted adapter may legitimately bundle its own dependencies. The
downstream image build that installs adapters into a dedicated directory is the
only caller, and opts in there.